### PR TITLE
[libSyntax] Syntax colouring based on the syntax tree

### DIFF
--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_AST_IDENTIFIER_H
 #define SWIFT_AST_IDENTIFIER_H
 
+#include "swift/Basic/EditorPlaceholder.h"
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/ADT/PointerUnion.h"
@@ -125,7 +126,7 @@ public:
   }
 
   static bool isEditorPlaceholder(StringRef name) {
-    return name.startswith("<#");
+    return swift::isEditorPlaceholder(name);
   }
 
   bool isEditorPlaceholder() const {

--- a/include/swift/Basic/EditorPlaceholder.h
+++ b/include/swift/Basic/EditorPlaceholder.h
@@ -46,6 +46,8 @@ struct EditorPlaceholderData {
 Optional<EditorPlaceholderData>
   parseEditorPlaceholder(StringRef PlaceholderText);
 
+/// Checks if an identifier with the given text is an editor placeholder
+bool isEditorPlaceholder(StringRef IdentifierText);
 } // end namespace swift
 
 #endif // SWIFT_BASIC_EDITORPLACEHOLDER_H

--- a/include/swift/Syntax/CMakeLists.txt
+++ b/include/swift/Syntax/CMakeLists.txt
@@ -8,6 +8,7 @@ set(generated_include_sources
     SyntaxKind.h.gyb
     SyntaxNodes.h.gyb
     SyntaxBuilders.h.gyb
+    SyntaxClassifier.h.gyb
     SyntaxFactory.h.gyb
     SyntaxVisitor.h.gyb
     Trivia.h.gyb)

--- a/include/swift/Syntax/Serialization/SyntaxDeserialization.h
+++ b/include/swift/Syntax/Serialization/SyntaxDeserialization.h
@@ -156,8 +156,15 @@ template <> struct MappingTraits<swift::RC<swift::RawSyntax>> {
       in.mapRequired("trailingTrivia", trailingTrivia);
       swift::SourcePresence presence;
       in.mapRequired("presence", presence);
-      value = swift::RawSyntax::make(tokenKind, text, leadingTrivia,
-                                     trailingTrivia, presence, nullptr);
+      /// FIXME: This is a workaround for existing bug from llvm yaml parser
+      /// which would raise error when deserializing number with trailing
+      /// character like "1\n". See https://bugs.llvm.org/show_bug.cgi?id=15505
+      StringRef nodeIdString;
+      in.mapRequired("id", nodeIdString);
+      unsigned nodeId = std::atoi(nodeIdString.data());
+      value =
+          swift::RawSyntax::make(tokenKind, text, leadingTrivia, trailingTrivia,
+                                 presence, /*Arena=*/nullptr, nodeId);
     } else {
       swift::SyntaxKind kind;
       in.mapRequired("kind", kind);
@@ -165,7 +172,14 @@ template <> struct MappingTraits<swift::RC<swift::RawSyntax>> {
       in.mapRequired("layout", layout);
       swift::SourcePresence presence;
       in.mapRequired("presence", presence);
-      value = swift::RawSyntax::make(kind, layout, presence, nullptr);
+      /// FIXME: This is a workaround for existing bug from llvm yaml parser
+      /// which would raise error when deserializing number with trailing
+      /// character like "1\n". See https://bugs.llvm.org/show_bug.cgi?id=15505
+      StringRef nodeIdString;
+      in.mapRequired("id", nodeIdString);
+      unsigned nodeId = std::atoi(nodeIdString.data());
+      value = swift::RawSyntax::make(kind, layout, presence, /*Arena=*/nullptr,
+                                     nodeId);
     }
   }
 };

--- a/include/swift/Syntax/Serialization/SyntaxSerialization.h
+++ b/include/swift/Syntax/Serialization/SyntaxSerialization.h
@@ -141,6 +141,8 @@ struct ObjectTraits<syntax::RawSyntax> {
     }
     auto presence = value.getPresence();
     out.mapRequired("presence", presence);
+    auto nodeId = value.getId();
+    out.mapRequired("id", nodeId);
   }
 };
 

--- a/include/swift/Syntax/Syntax.h
+++ b/include/swift/Syntax/Syntax.h
@@ -84,6 +84,9 @@ public:
   /// Get the shared raw syntax.
   RC<RawSyntax> getRaw() const;
 
+  /// Get an ID for this node that is stable across incremental parses
+  unsigned getId() const { return getRaw()->getId(); }
+
   /// Get the number of child nodes in this piece of syntax, not including
   /// tokens.
   size_t getNumChildren() const;

--- a/include/swift/Syntax/SyntaxClassifier.h.gyb
+++ b/include/swift/Syntax/SyntaxClassifier.h.gyb
@@ -1,0 +1,118 @@
+%{
+  # -*- mode: C++ -*-
+  from gyb_syntax_support import *
+  NODE_MAP = create_node_map()
+  # Ignore the following admonition; it applies to the resulting .h file only
+}%
+//// Automatically Generated From SyntaxClassifier.h.gyb.
+//// Do Not Edit Directly!
+//===----------- SyntaxClassifier.h - SyntaxClassifier definitions --------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SYNTAX_CLASSIFIER_H
+#define SWIFT_SYNTAX_CLASSIFIER_H
+
+#include "swift/Syntax/SyntaxVisitor.h"
+#include <stack>
+
+namespace swift {
+namespace syntax {
+
+
+/// A classification that determines which color a token should be colored in
+/// for syntax coloring.
+enum class SyntaxClassification {
+  None,
+  Keyword,
+  Identifier,
+  DollarIdentifier,
+  IntegerLiteral,
+  FloatingLiteral,
+  StringLiteral,
+  /// Marks the parens for a string interpolation.
+  StringInterpolationAnchor,
+  TypeIdentifier,
+  /// #if/#else/#endif occurrence.
+  BuildConfigKeyword,
+  /// An identifier in a #if condition.
+  BuildConfigId,
+  /// #-keywords like #warning, #sourceLocation
+  PoundDirectiveKeyword,
+  /// Any occurrence of '@<attribute-name>' anywhere.
+  Attribute,
+  /// An editor placeholder string <#like this#>.
+  EditorPlaceholder,
+  ObjectLiteral
+};
+
+
+class SyntaxClassifier: public SyntaxVisitor {
+  struct ContextStackEntry {
+    /// The classification all identifiers shall inherit
+    SyntaxClassification Classification;
+    /// If set to \c true, all tokens will be forced to receive the above
+    /// classification, overriding their context-free classification
+    bool ForceClassification;
+
+    ContextStackEntry(SyntaxClassification Classification,
+                      bool ForceClassification)
+      : Classification(Classification),
+        ForceClassification(ForceClassification) {}
+  };
+
+  std::map<unsigned, SyntaxClassification> ClassifiedTokens;
+  /// The top classification of this stack determines the color of identifiers
+  std::stack<ContextStackEntry, llvm::SmallVector<ContextStackEntry, 16>> ContextStack;
+
+  template<typename T>
+  void visit(T Node, SyntaxClassification Classification,
+             bool ForceClassification) {
+    ContextStack.emplace(Classification, ForceClassification);
+    visit(Node);
+    ContextStack.pop();
+  }
+
+  template<typename T>
+  void visit(llvm::Optional<T> OptNode) {
+    if (OptNode.hasValue()) {
+      static_cast<SyntaxVisitor *>(this)->visit(OptNode.getValue());
+    }
+  }
+
+  virtual void visit(TokenSyntax TokenNode) override;
+
+  virtual void visit(Syntax Node) override {
+    SyntaxVisitor::visit(Node);
+  }
+
+% for node in SYNTAX_NODES:
+%   if is_visitable(node):
+  virtual void visit(${node.name} Node) override;
+%   end
+% end
+
+public:
+  std::map<unsigned, SyntaxClassification> classify(Syntax Node) {
+    // Clean up the environment
+    ContextStack = std::stack<ContextStackEntry, llvm::SmallVector<ContextStackEntry, 16>>();
+    ContextStack.push({SyntaxClassification::None, false});
+    ClassifiedTokens.clear();
+
+    Node.accept(*this);
+
+    return ClassifiedTokens;
+  }
+};
+} // namespace syntax
+} // namespace swift
+
+#endif // SWIFT_SYNTAX_CLASSIFIER_H

--- a/include/swift/Syntax/SyntaxVisitor.h.gyb
+++ b/include/swift/Syntax/SyntaxVisitor.h.gyb
@@ -42,7 +42,7 @@ struct SyntaxVisitor {
 
   virtual void visitPre(Syntax node) {}
   virtual void visitPost(Syntax node) {}
-  void visit(Syntax node);
+  virtual void visit(Syntax node);
 
   void visitChildren(Syntax node) {
     for (unsigned i = 0, e = node.getNumChildren(); i != e; ++i) {

--- a/lib/Basic/EditorPlaceholder.cpp
+++ b/lib/Basic/EditorPlaceholder.cpp
@@ -78,3 +78,7 @@ swift::parseEditorPlaceholder(StringRef PlaceholderText) {
 
   return PHDataTyped;
 }
+
+bool swift::isEditorPlaceholder(StringRef IdentifierText) {
+  return IdentifierText.startswith("<#");
+}

--- a/lib/Syntax/CMakeLists.txt
+++ b/lib/Syntax/CMakeLists.txt
@@ -14,5 +14,6 @@ add_swift_library(swiftSyntax STATIC
   RawSyntax.cpp
   Syntax.cpp
   SyntaxArena.cpp
+  SyntaxClassifier.cpp.gyb
   SyntaxData.cpp
   UnknownSyntax.cpp)

--- a/lib/Syntax/RawSyntax.cpp
+++ b/lib/Syntax/RawSyntax.cpp
@@ -67,10 +67,19 @@ static void dumpTokenKind(llvm::raw_ostream &OS, tok Kind) {
 
 } // end of anonymous namespace
 
+unsigned RawSyntax::NextFreeNodeId = 1;
+
 RawSyntax::RawSyntax(SyntaxKind Kind, ArrayRef<RC<RawSyntax>> Layout,
-                     SourcePresence Presence, bool ManualMemory) {
+                     SourcePresence Presence, bool ManualMemory,
+                     llvm::Optional<unsigned> NodeId) {
   assert(Kind != SyntaxKind::Token &&
          "'token' syntax node must be constructed with dedicated constructor");
+  if (NodeId.hasValue()) {
+    this->NodeId = NodeId.getValue();
+    NextFreeNodeId = std::max(this->NodeId + 1, NextFreeNodeId);
+  } else {
+    this->NodeId = NextFreeNodeId++;
+  }
   Bits.Common.Kind = unsigned(Kind);
   Bits.Common.Presence = unsigned(Presence);
   Bits.Common.ManualMemory = unsigned(ManualMemory);
@@ -92,7 +101,14 @@ RawSyntax::RawSyntax(SyntaxKind Kind, ArrayRef<RC<RawSyntax>> Layout,
 RawSyntax::RawSyntax(tok TokKind, OwnedString Text,
                      ArrayRef<TriviaPiece> LeadingTrivia,
                      ArrayRef<TriviaPiece> TrailingTrivia,
-                     SourcePresence Presence, bool ManualMemory) {
+                     SourcePresence Presence, bool ManualMemory,
+                     llvm::Optional<unsigned> NodeId) {
+  if (NodeId.hasValue()) {
+    this->NodeId = NodeId.getValue();
+    NextFreeNodeId = std::max(this->NodeId + 1, NextFreeNodeId);
+  } else {
+    this->NodeId = NextFreeNodeId++;
+  }
   Bits.Common.Kind = unsigned(SyntaxKind::Token);
   Bits.Common.Presence = unsigned(Presence);
   Bits.Common.ManualMemory = unsigned(ManualMemory);
@@ -126,25 +142,28 @@ RawSyntax::~RawSyntax() {
 }
 
 RC<RawSyntax> RawSyntax::make(SyntaxKind Kind, ArrayRef<RC<RawSyntax>> Layout,
-                              SourcePresence Presence, SyntaxArena *Arena) {
+                              SourcePresence Presence, SyntaxArena *Arena,
+                              llvm::Optional<unsigned> NodeId) {
   auto size = totalSizeToAlloc<RC<RawSyntax>, OwnedString, TriviaPiece>(
       Layout.size(), 0, 0);
   void *data = Arena ? Arena->AllocateRawSyntax(size, alignof(RawSyntax))
                      : ::operator new(size);
-  return RC<RawSyntax>(new (data)
-                           RawSyntax(Kind, Layout, Presence, bool(Arena)));
+  return RC<RawSyntax>(
+      new (data) RawSyntax(Kind, Layout, Presence, bool(Arena), NodeId));
 }
 
 RC<RawSyntax> RawSyntax::make(tok TokKind, OwnedString Text,
                               ArrayRef<TriviaPiece> LeadingTrivia,
                               ArrayRef<TriviaPiece> TrailingTrivia,
-                              SourcePresence Presence, SyntaxArena *Arena) {
+                              SourcePresence Presence, SyntaxArena *Arena,
+                              llvm::Optional<unsigned> NodeId) {
   auto size = totalSizeToAlloc<RC<RawSyntax>, OwnedString, TriviaPiece>(
       0, 1, LeadingTrivia.size() + TrailingTrivia.size());
   void *data = Arena ? Arena->AllocateRawSyntax(size, alignof(RawSyntax))
                      : ::operator new(size);
-  return RC<RawSyntax>(new (data) RawSyntax(
-      TokKind, Text, LeadingTrivia, TrailingTrivia, Presence, bool(Arena)));
+  return RC<RawSyntax>(new (data) RawSyntax(TokKind, Text, LeadingTrivia,
+                                            TrailingTrivia, Presence,
+                                            bool(Arena), NodeId));
 }
 
 RC<RawSyntax> RawSyntax::append(RC<RawSyntax> NewLayoutElement) const {

--- a/lib/Syntax/SyntaxArena.cpp
+++ b/lib/Syntax/SyntaxArena.cpp
@@ -29,9 +29,6 @@ struct SyntaxArena::Implementation {
   /// List of pointers to the allocated RawSyntax
   std::vector<RawSyntax *> AllocatedRawSyntaxList;
 
-  /// Cached Tokens.
-  llvm::FoldingSet<RawSyntaxCacheNode> CachedTokens;
-
   Implementation() = default;
   void *Allocate(size_t size, size_t alignment) {
     return Allocator.Allocate(size, alignment);
@@ -125,38 +122,6 @@ RC<RawSyntax> RawSyntax::getToken(SyntaxArena &Arena, tok TokKind,
                                   llvm::ArrayRef<TriviaPiece> LeadingTrivia,
                                   llvm::ArrayRef<TriviaPiece> TrailingTrivia) {
 
-  // Determine whether this token is worth to cache.
-  if (
-      // Is string_literal with >16 length.
-      (TokKind == tok::string_literal && Text.size() > 16) ||
-      // Has leading comment trivia et al.
-      any_of(LeadingTrivia,
-             [](const syntax::TriviaPiece &T) { return T.getText().size(); }) ||
-      // Has trailing comment trivia et al.
-      any_of(TrailingTrivia,
-             [](const syntax::TriviaPiece &T) { return T.getText().size(); })) {
-
-    // Do not use cache.
-    return RawSyntax::make(TokKind, Text, LeadingTrivia, TrailingTrivia,
-                           SourcePresence::Present, &Arena);
-  }
-
-  // This node is cacheable. Get or create.
-  auto &CachedTokens = Arena.Impl.CachedTokens;
-
-  llvm::FoldingSetNodeID ID;
-  RawSyntax::Profile(ID, TokKind, Text, LeadingTrivia, TrailingTrivia);
-
-  void *insertPos = nullptr;
-  if (auto existing = CachedTokens.FindNodeOrInsertPos(ID, insertPos))
-    // Found in the cache. Just return it.
-    return existing->get();
-
-  // Could not found in the cache. Create it.
-  auto Raw = RawSyntax::make(TokKind, Text, LeadingTrivia, TrailingTrivia,
-                             SourcePresence::Present, &Arena);
-  auto IDRef = ID.Intern(Arena.getAllocator());
-  auto CacheNode = new (Arena) RawSyntaxCacheNode(Raw.get(), IDRef);
-  CachedTokens.InsertNode(CacheNode, insertPos);
-  return Raw;
+  return RawSyntax::make(TokKind, Text, LeadingTrivia, TrailingTrivia,
+                         SourcePresence::Present, &Arena);
 }

--- a/lib/Syntax/SyntaxClassifier.cpp.gyb
+++ b/lib/Syntax/SyntaxClassifier.cpp.gyb
@@ -1,0 +1,159 @@
+%{
+  from gyb_syntax_support import *
+  # -*- mode: C++ -*-
+  # Ignore the following admonition; it applies to the resulting .cpp file only
+}%
+//// Automatically Generated From SyntaxClassifier.cpp.gyb.
+//// Do Not Edit Directly!
+//===----- SyntaxClassifier.cpp - Syntax Classifier implementations -------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the Syntax Classifier, which walks the syntax tree and
+// creates a classification table for all tokens in the syntax tree, mapping it
+// to a \c SyntaxClassification by its ID.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Basic/EditorPlaceholder.h"
+#include "swift/Syntax/SyntaxClassifier.h"
+
+using namespace swift;
+using namespace swift::syntax;
+
+% for node in SYNTAX_NODES:
+%   if is_visitable(node):
+void SyntaxClassifier::visit(${node.name} Node) {
+%     if node.is_unknown() or node.is_syntax_collection():
+  SyntaxVisitor::visit(Node);
+%     else:
+%       for child in node.children:
+%         if child.classification:
+  visit(Node.get${child.name}(), SyntaxClassification::${child.classification}, ${"true" if child.force_classification else "false"});
+%         else:
+  visit(Node.get${child.name}());
+%         end
+%       end
+%     end
+}
+%   end
+% end
+
+/// Returns the SyntaxClassficiation a token node should receive if it is not
+/// inside a special context. Returns \c None if the token has no context-free
+/// classification and should always inherit from the context.
+llvm::Optional<SyntaxClassification>
+getContextFreeClassificationForToken(TokenSyntax TokenNode) {
+  switch (TokenNode.getTokenKind()) {
+#define KEYWORD(KW) case tok::kw_##KW: return SyntaxClassification::Keyword;
+#define POUND_KEYWORD(KW) case tok::pound_##KW: return SyntaxClassification::Keyword;
+#define POUND_OBJECT_LITERAL(KW, desc, proto) case tok::pound_##KW: return SyntaxClassification::ObjectLiteral;
+#define POUND_DIRECTIVE_KEYWORD(KW) case tok::pound_##KW: return SyntaxClassification::PoundDirectiveKeyword;
+#define POUND_COND_DIRECTIVE_KEYWORD(KW) case tok::pound_##KW: return SyntaxClassification::BuildConfigKeyword;
+#include "swift/Syntax/TokenKinds.def"
+  // Punctuators
+  case tok::l_paren:
+  case tok::r_paren:
+  case tok::l_brace:
+  case tok::r_brace:
+  case tok::l_square:
+  case tok::r_square:
+  case tok::l_angle:
+  case tok::r_angle:
+  case tok::period:
+  case tok::period_prefix:
+  case tok::comma:
+  case tok::colon:
+  case tok::semi:
+  case tok::equal:
+  case tok::pound:
+  case tok::amp_prefix:
+  case tok::arrow:
+  case tok::backtick:
+  case tok::backslash:
+  case tok::exclaim_postfix:
+  case tok::question_postfix:
+  case tok::question_infix:
+  case tok::sil_dollar:
+  case tok::sil_exclamation:
+    return SyntaxClassification::None;
+  case tok::string_quote:
+  case tok::multiline_string_quote:
+    return SyntaxClassification::StringLiteral;
+  case tok::at_sign:
+    return SyntaxClassification::Attribute;
+
+  // Literals
+  case tok::integer_literal:
+    return SyntaxClassification::IntegerLiteral;
+  case tok::floating_literal:
+    return SyntaxClassification::FloatingLiteral;
+  case tok::string_literal:
+    return SyntaxClassification::StringLiteral;
+
+  // Miscelaneous
+  case tok::identifier: {
+    if (isEditorPlaceholder(TokenNode.getText())) {
+      return SyntaxClassification::EditorPlaceholder;
+    } else {
+      return llvm::None;
+    }
+  }
+  case tok::unknown:
+    if (TokenNode.getText().startswith("\"")) {
+      // Unterminated string literal
+      return SyntaxClassification::StringLiteral;
+    } else {
+      return SyntaxClassification::None;
+    }
+    break;
+  case tok::eof:
+  case tok::code_complete:
+  case tok::oper_binary_unspaced:
+  case tok::oper_binary_spaced:
+  case tok::oper_postfix:
+  case tok::oper_prefix:
+    return SyntaxClassification::None;
+  case tok::dollarident:
+    return SyntaxClassification::DollarIdentifier;
+  case tok::sil_local_name:
+    return SyntaxClassification::None;
+  case tok::comment:
+    llvm_unreachable("Comments should be in trivia");
+  case tok::contextual_keyword:
+    return SyntaxClassification::Keyword;
+  case tok::string_segment:
+    return SyntaxClassification::StringLiteral;
+  case tok::string_interpolation_anchor:
+    return SyntaxClassification::StringInterpolationAnchor;
+  case tok::NUM_TOKENS:
+    llvm_unreachable("");
+  }
+}
+
+void SyntaxClassifier::visit(TokenSyntax TokenNode) {
+  SyntaxClassification Classification = ContextStack.top().Classification;
+  bool ForceClassification = ContextStack.top().ForceClassification;
+  if (!ForceClassification) {
+    auto NativeClassification = getContextFreeClassificationForToken(TokenNode);
+    if (NativeClassification.hasValue()) {
+      Classification = NativeClassification.getValue();
+    }
+    if (Classification == SyntaxClassification::None &&
+        TokenNode.getTokenKind() == tok::identifier) {
+      Classification = SyntaxClassification::Identifier;
+    }
+  }
+
+  assert(ClassifiedTokens.count(TokenNode.getId()) == 0 &&
+         "Token already classified");
+  ClassifiedTokens[TokenNode.getId()] = Classification;
+}

--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-ide-test -syntax-coloring -source-filename %s | %FileCheck %s
-// RUN: %target-swift-ide-test -syntax-coloring -typecheck -source-filename %s | %FileCheck %s
+// RUN: %target-swift-ide-test -syntax-coloring -typecheck -source-filename %s | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-OLD
+// RUN: %target-swift-ide-test -syntax-coloring -force-libsyntax-based-processing -source-filename %s | %FileCheck %s --check-prefix CHECK -check-prefix CHECK-NEW
 // XFAIL: broken_std_regex
 
 #line 17 "abc.swift"
@@ -15,7 +16,8 @@ func foo() {
 enum List<T> {
   case Nil
   // rdar://21927124
-  // CHECK: <attr-builtin>indirect</attr-builtin> <kw>case</kw> Cons(T, List)
+  // CHECK-OLD: <attr-builtin>indirect</attr-builtin> <kw>case</kw> Cons(T, List)
+  // CHECK-NEW: <attr-builtin>indirect</attr-builtin> <kw>case</kw> Cons(<type>T</type>, <type>List</type>)
   indirect case Cons(T, List)
 }
 
@@ -91,13 +93,14 @@ class Attributes {
 // CHECK: <attr-builtin>@IBOutlet</attr-builtin> <kw>var</kw> v0: <type>Int</type>
   @IBOutlet var v0: Int
 
-// CHECK: <attr-builtin>@IBOutlet</attr-builtin> <attr-id>@IBOutlet</attr-id> <kw>var</kw> {{(<attr-builtin>)?}}v1{{(</attr-builtin>)?}}: <type>String</type>
+// CHECK-OLD: <attr-builtin>@IBOutlet</attr-builtin> <attr-id>@IBOutlet</attr-id> <kw>var</kw> v1: <type>String</type>
+// CHECK-NEW: <attr-builtin>@IBOutlet</attr-builtin> <attr-builtin>@IBOutlet</attr-builtin> <kw>var</kw> v1: <type>String</type>
   @IBOutlet @IBOutlet var v1: String
 
-// CHECK: <attr-builtin>@objc</attr-builtin> <attr-builtin>@IBOutlet</attr-builtin> <kw>var</kw> {{(<attr-builtin>)?}}v2{{(</attr-builtin>)?}}: <type>String</type>
+// CHECK: <attr-builtin>@objc</attr-builtin> <attr-builtin>@IBOutlet</attr-builtin> <kw>var</kw> v2: <type>String</type>
   @objc @IBOutlet var v2: String
 
-// CHECK: <attr-builtin>@IBOutlet</attr-builtin> <attr-builtin>@objc</attr-builtin> <kw>var</kw> {{(<attr-builtin>)?}}v3{{(</attr-builtin>)?}}: <type>String</type>
+// CHECK: <attr-builtin>@IBOutlet</attr-builtin> <attr-builtin>@objc</attr-builtin> <kw>var</kw> v3: <type>String</type>
   @IBOutlet @objc var v3: String
 
 // CHECK: <attr-builtin>@available</attr-builtin>(*, unavailable) <kw>func</kw> f1() {}
@@ -163,18 +166,22 @@ func foo(n: Float) -> Int {
 }
 
 ///- returns: single-line, no space
-// CHECK: ///- <doc-comment-field>returns</doc-comment-field>: single-line, no space
+// CHECK-OLD: ///- <doc-comment-field>returns</doc-comment-field>: single-line, no space
+// CHECK-NEW: <doc-comment-line>///- returns: single-line, no space</doc-comment-line>
 
 /// - returns: single-line, 1 space
-// CHECK: /// - <doc-comment-field>returns</doc-comment-field>: single-line, 1 space
+// CHECK-OLD: /// - <doc-comment-field>returns</doc-comment-field>: single-line, 1 space
+// CHECK-NEW: <doc-comment-line>/// - returns: single-line, 1 space</doc-comment-line>
 
 ///  - returns: single-line, 2 spaces
-// CHECK: ///  - <doc-comment-field>returns</doc-comment-field>: single-line, 2 spaces
+// CHECK-OLD: ///  - <doc-comment-field>returns</doc-comment-field>: single-line, 2 spaces
+// CHECK-NEW: <doc-comment-line>///  - returns: single-line, 2 spaces</doc-comment-line>
 
 ///       - returns: single-line, more spaces
-// CHECK: ///       - <doc-comment-field>returns</doc-comment-field>: single-line, more spaces
+// CHECK-OLD: ///       - <doc-comment-field>returns</doc-comment-field>: single-line, more spaces
+// CHECK-NEW: <doc-comment-line>///       - returns: single-line, more spaces</doc-comment-line>
 
-// CHECK: <kw>protocol</kw> Prot {
+// CHECK: <kw>protocol</kw> Prot
 protocol Prot {
   // CHECK: <kw>typealias</kw> Blarg
   typealias Blarg
@@ -260,7 +267,8 @@ func f(x: Int) -> Int {
    )
    """
 
-  // CHECK: <str>"</str>\<anchor>(</anchor><int>1</int><anchor>)</anchor>\<anchor>(</anchor><int>1</int><anchor>)</anchor><str>"</str>
+  // CHECK-OLD: <str>"</str>\<anchor>(</anchor><int>1</int><anchor>)</anchor>\<anchor>(</anchor><int>1</int><anchor>)</anchor><str>"</str>
+  // CHECK-NEW: <str>"</str>\<anchor>(</anchor><int>1</int><anchor>)</anchor><str></str>\<anchor>(</anchor><int>1</int><anchor>)</anchor><str>"</str>
   "\(1)\(1)"
 }
 
@@ -311,7 +319,8 @@ func test3(o: AnyObject) {
 
 // CHECK: <kw>func</kw> test4(<kw>inout</kw> a: <type>Int</type>) {{{$}}
 func test4(inout a: Int) {
-  // CHECK: <kw>if</kw> <kw>#available</kw> (<kw>OSX</kw> >= <float>10.10</float>, <kw>iOS</kw> >= <float>8.01</float>) {<kw>let</kw> OSX = <str>"iOS"</str>}}{{$}}
+  // CHECK-OLD: <kw>if</kw> <kw>#available</kw> (<kw>OSX</kw> >= <float>10.10</float>, <kw>iOS</kw> >= <float>8.01</float>) {<kw>let</kw> OSX = <str>"iOS"</str>}}{{$}}
+  // CHECK-NEW: <kw>if</kw> <kw>#available</kw> (OSX >= <float>10.10</float>, iOS >= <float>8.01</float>) {<kw>let</kw> OSX = <str>"iOS"</str>}}{{$}}
   if #available (OSX >= 10.10, iOS >= 8.01) {let OSX = "iOS"}}
 
 // CHECK: <kw>func</kw> test4b(a: <kw>inout</kw> <type>Int</type>) {{{$}}
@@ -348,13 +357,19 @@ func test_defer() {
 //    FIXME:   blah blah
 // Something something, FIXME: blah
 
-// CHECK: <comment-line>// <comment-marker>FIXME: blah.</comment-marker></comment-line>
-// CHECK: <comment-line>//    <comment-marker>FIXME:   blah blah</comment-marker></comment-line>
-// CHECK: <comment-line>// Something something, <comment-marker>FIXME: blah</comment-marker></comment-line>
+// CHECK-OLD: <comment-line>// <comment-marker>FIXME: blah.</comment-marker></comment-line>
+// CHECK-OLD: <comment-line>//    <comment-marker>FIXME:   blah blah</comment-marker></comment-line>
+// CHECK-OLD: <comment-line>// Something something, <comment-marker>FIXME: blah</comment-marker></comment-line>
+// CHECK-NEW: <comment-line>// FIXME: blah.</comment-line>
+// CHECK-NEW: <comment-line>//    FIXME:   blah blah</comment-line>
+// CHECK-NEW: <comment-line>// Something something, FIXME: blah</comment-line>
+
+
 
 /* FIXME: blah*/
 
-// CHECK: <comment-block>/* <comment-marker>FIXME: blah*/</comment-marker></comment-block>
+// CHECK-OLD: <comment-block>/* <comment-marker>FIXME: blah*/</comment-marker></comment-block>
+// CHECK-NEW: <comment-block>/* FIXME: blah*/</comment-block>
 
 /*
  * FIXME: blah
@@ -362,7 +377,8 @@ func test_defer() {
  */
 
 // CHECK: <comment-block>/*
-// CHECK:  * <comment-marker>FIXME: blah</comment-marker>
+// CHECK-OLD:  * <comment-marker>FIXME: blah</comment-marker>
+// CHECK-NEW:  * FIXME: blah
 // CHECK:  * Blah, blah.
 // CHECK:  */</comment-block>
 
@@ -370,13 +386,17 @@ func test_defer() {
 // TTODO: blah.
 // MARK: blah.
 
-// CHECK: <comment-line>// <comment-marker>TODO: blah.</comment-marker></comment-line>
-// CHECK: <comment-line>// T<comment-marker>TODO: blah.</comment-marker></comment-line>
-// CHECK: <comment-line>// <comment-marker>MARK: blah.</comment-marker></comment-line>
+// CHECK-OLD: <comment-line>// <comment-marker>TODO: blah.</comment-marker></comment-line>
+// CHECK-OLD: <comment-line>// T<comment-marker>TODO: blah.</comment-marker></comment-line>
+// CHECK-OLD: <comment-line>// <comment-marker>MARK: blah.</comment-marker></comment-line>
+// CHECK-NEW: <comment-line>// TODO: blah.</comment-line>
+// CHECK-NEW: <comment-line>// TTODO: blah.</comment-line>
+// CHECK-NEW: <comment-line>// MARK: blah.</comment-line>
 
 // CHECK: <kw>func</kw> test5() -> <type>Int</type> {
 func test5() -> Int {
-  // CHECK: <comment-line>// <comment-marker>TODO: something, something.</comment-marker></comment-line>
+  // CHECK-OLD: <comment-line>// <comment-marker>TODO: something, something.</comment-marker></comment-line>
+  // CHECK-NEW: <comment-line>// TODO: something, something.</comment-line>
   // TODO: something, something.
   // CHECK: <kw>return</kw> <int>0</int>
   return 0
@@ -389,11 +409,15 @@ func test6<T : Prot>(x: T) {}
 /* http://whatever.com FIXME: see in http://whatever.com/fixme
   http://whatever.com */
 
-// CHECK: <comment-line>// <comment-url>http://whatever.com?ee=2&yy=1</comment-url> and <comment-url>radar://123456</comment-url></comment-line>
-// CHECK: <comment-block>/* <comment-url>http://whatever.com</comment-url> <comment-marker>FIXME: see in <comment-url>http://whatever.com/fixme</comment-url></comment-marker>
-// CHECK:  <comment-url>http://whatever.com</comment-url> */</comment-block>
+// CHECK-OLD: <comment-line>// <comment-url>http://whatever.com?ee=2&yy=1</comment-url> and <comment-url>radar://123456</comment-url></comment-line>
+// CHECK-OLD: <comment-block>/* <comment-url>http://whatever.com</comment-url> <comment-marker>FIXME: see in <comment-url>http://whatever.com/fixme</comment-url></comment-marker>
+// CHECK-OLD:  <comment-url>http://whatever.com</comment-url> */</comment-block>
+// CHECK-NEW: <comment-line>// http://whatever.com?ee=2&yy=1 and radar://123456</comment-line>
+// CHECK-NEW: <comment-block>/* http://whatever.com FIXME: see in http://whatever.com/fixme
+// CHECK-NEW:   http://whatever.com */</comment-block>
 
-// CHECK: <comment-line>// <comment-url>http://whatever.com/what-ever</comment-url></comment-line>
+// CHECK-OLD: <comment-line>// <comment-url>http://whatever.com/what-ever</comment-url></comment-line>
+// CHECK-NEW: <comment-line>// http://whatever.com/what-ever</comment-line>
 // http://whatever.com/what-ever
 
 // CHECK: <kw>func</kw> <placeholder><#test1#></placeholder> () {}
@@ -422,29 +446,52 @@ func <#test1#> () {}
 /// - seealso nope
 /// - returns: `x + y`
 func foo(x: Int, y: Int) -> Int { return x + y }
-// CHECK: <doc-comment-line>/// Brief.
-// CHECK: </doc-comment-line><doc-comment-line>///
-// CHECK: </doc-comment-line><doc-comment-line>/// Simple case.
-// CHECK: </doc-comment-line><doc-comment-line>///
-// CHECK: </doc-comment-line><doc-comment-line>/// - <doc-comment-field>parameter</doc-comment-field> x: A number
-// CHECK: </doc-comment-line><doc-comment-line>/// - <doc-comment-field>parameter</doc-comment-field> y: Another number
-// CHECK: </doc-comment-line><doc-comment-line>/// - <doc-comment-field>PaRamEteR</doc-comment-field> z-hyphen-q: Another number
-// CHECK: </doc-comment-line><doc-comment-line>/// - <doc-comment-field>parameter</doc-comment-field> : A strange number...
-// CHECK: </doc-comment-line><doc-comment-line>/// - parameternope1: Another number
-// CHECK: </doc-comment-line><doc-comment-line>/// - parameter nope2
-// CHECK: </doc-comment-line><doc-comment-line>/// - parameter: nope3
-// CHECK: </doc-comment-line><doc-comment-line>/// -parameter nope4: Another number
-// CHECK: </doc-comment-line><doc-comment-line>/// * parameter nope5: Another number
-// CHECK: </doc-comment-line><doc-comment-line>///  - parameter nope6: Another number
-// CHECK: </doc-comment-line><doc-comment-line>///  - Parameters: nope7
-// CHECK: </doc-comment-line><doc-comment-line>/// - <doc-comment-field>seealso</doc-comment-field>: yes
-// CHECK: </doc-comment-line><doc-comment-line>///   - <doc-comment-field>seealso</doc-comment-field>: yes
-// CHECK: </doc-comment-line><doc-comment-line>/// - <doc-comment-field>seealso</doc-comment-field>:
-// CHECK: </doc-comment-line><doc-comment-line>/// -seealso: nope
-// CHECK: </doc-comment-line><doc-comment-line>/// - seealso : nope
-// CHECK: </doc-comment-line><doc-comment-line>/// - seealso nope
-// CHECK: </doc-comment-line><doc-comment-line>/// - <doc-comment-field>returns</doc-comment-field>: `x + y`
-// CHECK: </doc-comment-line><kw>func</kw> foo(x: <type>Int</type>, y: <type>Int</type>) -> <type>Int</type> { <kw>return</kw> x + y }
+// CHECK-OLD: <doc-comment-line>/// Brief.
+// CHECK-OLD: </doc-comment-line><doc-comment-line>///
+// CHECK-OLD: </doc-comment-line><doc-comment-line>/// Simple case.
+// CHECK-OLD: </doc-comment-line><doc-comment-line>///
+// CHECK-OLD: </doc-comment-line><doc-comment-line>/// - <doc-comment-field>parameter</doc-comment-field> x: A number
+// CHECK-OLD: </doc-comment-line><doc-comment-line>/// - <doc-comment-field>parameter</doc-comment-field> y: Another number
+// CHECK-OLD: </doc-comment-line><doc-comment-line>/// - <doc-comment-field>PaRamEteR</doc-comment-field> z-hyphen-q: Another number
+// CHECK-OLD: </doc-comment-line><doc-comment-line>/// - <doc-comment-field>parameter</doc-comment-field> : A strange number...
+// CHECK-OLD: </doc-comment-line><doc-comment-line>/// - parameternope1: Another number
+// CHECK-OLD: </doc-comment-line><doc-comment-line>/// - parameter nope2
+// CHECK-OLD: </doc-comment-line><doc-comment-line>/// - parameter: nope3
+// CHECK-OLD: </doc-comment-line><doc-comment-line>/// -parameter nope4: Another number
+// CHECK-OLD: </doc-comment-line><doc-comment-line>/// * parameter nope5: Another number
+// CHECK-OLD: </doc-comment-line><doc-comment-line>///  - parameter nope6: Another number
+// CHECK-OLD: </doc-comment-line><doc-comment-line>///  - Parameters: nope7
+// CHECK-OLD: </doc-comment-line><doc-comment-line>/// - <doc-comment-field>seealso</doc-comment-field>: yes
+// CHECK-OLD: </doc-comment-line><doc-comment-line>///   - <doc-comment-field>seealso</doc-comment-field>: yes
+// CHECK-OLD: </doc-comment-line><doc-comment-line>/// - <doc-comment-field>seealso</doc-comment-field>:
+// CHECK-OLD: </doc-comment-line><doc-comment-line>/// -seealso: nope
+// CHECK-OLD: </doc-comment-line><doc-comment-line>/// - seealso : nope
+// CHECK-OLD: </doc-comment-line><doc-comment-line>/// - seealso nope
+// CHECK-OLD: </doc-comment-line><doc-comment-line>/// - <doc-comment-field>returns</doc-comment-field>: `x + y`
+// CHECK-OLD: </doc-comment-line><kw>func</kw> foo(x: <type>Int</type>, y: <type>Int</type>) -> <type>Int</type> { <kw>return</kw> x + y }
+// CHECK-NEW: <doc-comment-line>/// Brief.</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>///</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>/// Simple case.</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>///</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>/// - parameter x: A number</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>/// - parameter y: Another number</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>/// - PaRamEteR z-hyphen-q: Another number</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>/// - parameter : A strange number...</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>/// - parameternope1: Another number</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>/// - parameter nope2</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>/// - parameter: nope3</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>/// -parameter nope4: Another number</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>/// * parameter nope5: Another number</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>///  - parameter nope6: Another number</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>///  - Parameters: nope7</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>/// - seealso: yes</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>///   - seealso: yes</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>/// - seealso:</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>/// -seealso: nope</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>/// - seealso : nope</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>/// - seealso nope</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>/// - returns: `x + y`</doc-comment-line>
+// CHECK-NEW: <kw>func</kw> foo(x: <type>Int</type>, y: <type>Int</type>) -> <type>Int</type> { <kw>return</kw> x + y }
 
 
 /// Brief.
@@ -461,15 +508,29 @@ func foo(x: Int, y: Int) -> Int { return x + y }
 ///   - note: Not a Note field (not at top level)
 /// - returns: `x + y`
 func bar(x: Int, y: Int) -> Int { return x + y }
-// CHECK: <doc-comment-line>/// Brief.
-// CHECK: </doc-comment-line><doc-comment-line>///
-// CHECK: </doc-comment-line><doc-comment-line>/// Simple case.
-// CHECK: </doc-comment-line><doc-comment-line>///
-// CHECK: </doc-comment-line><doc-comment-line>/// - <doc-comment-field>Parameters</doc-comment-field>:
-// CHECK: </doc-comment-line><doc-comment-line>/// - x: A number
-// CHECK: </doc-comment-line><doc-comment-line>/// - y: Another number
-// CHECK: </doc-comment-line><doc-comment-line>/// - <doc-comment-field>returns</doc-comment-field>: `x + y`
-// CHECK: </doc-comment-line><kw>func</kw> bar(x: <type>Int</type>, y: <type>Int</type>) -> <type>Int</type> { <kw>return</kw> x + y }
+// CHECK-OLD: <doc-comment-line>/// Brief.
+// CHECK-OLD: </doc-comment-line><doc-comment-line>///
+// CHECK-OLD: </doc-comment-line><doc-comment-line>/// Simple case.
+// CHECK-OLD: </doc-comment-line><doc-comment-line>///
+// CHECK-OLD: </doc-comment-line><doc-comment-line>/// - <doc-comment-field>Parameters</doc-comment-field>:
+// CHECK-OLD: </doc-comment-line><doc-comment-line>/// - x: A number
+// CHECK-OLD: </doc-comment-line><doc-comment-line>/// - y: Another number
+// CHECK-OLD: </doc-comment-line><doc-comment-line>/// - <doc-comment-field>returns</doc-comment-field>: `x + y`
+// CHECK-OLD: </doc-comment-line><kw>func</kw> bar(x: <type>Int</type>, y: <type>Int</type>) -> <type>Int</type> { <kw>return</kw> x + y }
+// CHECK-NEW: <doc-comment-line>/// Brief.</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>///</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>/// Simple case.</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>///</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>/// - Parameters:</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>///   - x: A number</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>///   - y: Another number</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>///</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>///- note: NOTE1</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>///</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>/// - NOTE: NOTE2</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>///   - note: Not a Note field (not at top level)</doc-comment-line>
+// CHECK-NEW: <doc-comment-line>/// - returns: `x + y`</doc-comment-line>
+// CHECK-NEW: <kw>func</kw> bar(x: <type>Int</type>, y: <type>Int</type>) -> <type>Int</type> { <kw>return</kw> x + y }
 
 /**
   Does pretty much nothing.
@@ -488,7 +549,8 @@ func baz() {}
 // CHECK:   Does pretty much nothing.
 // CHECK:   Not a parameter list: improper indentation.
 // CHECK:     - Parameters: sdfadsf
-// CHECK:   - <doc-comment-field>WARNING</doc-comment-field>: - WARNING: Should only have one field
+// CHECK-OLD:   - <doc-comment-field>WARNING</doc-comment-field>: - WARNING: Should only have one field
+// CHECK-NEW:   - WARNING: - WARNING: Should only have one field
 // CHECK:   - $$$: Not a field.
 // CHECK:   Empty field, OK:
 // CHECK: */</doc-comment-block>
@@ -515,7 +577,9 @@ func emptyDocBlockComment3() {}
 /**/
 func malformedBlockComment(f : () throws -> ()) rethrows {}
 // CHECK: <doc-comment-block>/**/</doc-comment-block>
-// CHECK: <kw>func</kw> malformedBlockComment(f : () <kw>throws</kw> -> ()) <attr-builtin>rethrows</attr-builtin> {}
+
+// CHECK-OLD: <kw>func</kw> malformedBlockComment(f : () <kw>throws</kw> -> ()) <attr-builtin>rethrows</attr-builtin> {}
+// CHECK-NEW: <kw>func</kw> malformedBlockComment(f : () <kw>throws</kw> -> ()) <kw>rethrows</kw> {}
 
 //: playground doc comment line
 func playgroundCommentLine(f : () throws -> ()) rethrows {}
@@ -530,7 +594,8 @@ func playgroundCommentMultiLine(f : () throws -> ()) rethrows {}
 // CHECK: */</comment-block>
 
 /// [strict weak ordering](http://en.wikipedia.org/wiki/Strict_weak_order#Strict_weak_orderings)
-// CHECK: <doc-comment-line>/// [strict weak ordering](<comment-url>http://en.wikipedia.org/wiki/Strict_weak_order#Strict_weak_orderings</comment-url>
+// CHECK-OLD: <doc-comment-line>/// [strict weak ordering](<comment-url>http://en.wikipedia.org/wiki/Strict_weak_order#Strict_weak_orderings</comment-url>
+// CHECK-NEW: <doc-comment-line>/// [strict weak ordering](http://en.wikipedia.org/wiki/Strict_weak_order#Strict_weak_orderings)</doc-comment-line>
 
 func funcTakingFor(for internalName: Int) {}
 // CHECK: <kw>func</kw> funcTakingFor(for internalName: <type>Int</type>) {}
@@ -541,19 +606,24 @@ func funcTakingIn(in internalName: Int) {}
 _ = 123
 // CHECK: <int>123</int>
 _ = -123
-// CHECK: <int>-123</int>
+// CHECK-OLD: <int>-123</int>
+// CHECK-NEW: -<int>123</int>
 _ = -1
-// CHECK: <int>-1</int>
+// CHECK-OLD: <int>-1</int>
+// CHECK-NEW: -<int>1</int>
 _ = -0x123
-// CHECK: <int>-0x123</int>
+// CHECK-OLD: <int>-0x123</int>
+// CHECK-NEW: -<int>0x123</int>
 _ = -3.1e-5
-// CHECK: <float>-3.1e-5</float>
+// CHECK-OLD: <float>-3.1e-5</float>
+// CHECK-NEW: <float>3.1e-5</float>
 
 /** aaa
 
  - returns: something
  */
-// CHECK:  - <doc-comment-field>returns</doc-comment-field>: something
+// CHECK-OLD:  - <doc-comment-field>returns</doc-comment-field>: something
+// CHECK-NEW:  - returns: something
 
 let filename = #file
 // CHECK: <kw>let</kw> filename = <kw>#file</kw>
@@ -565,18 +635,24 @@ let function = #function
 // CHECK: <kw>let</kw> function = <kw>#function</kw>
 
 let image = #imageLiteral(resourceName: "cloud.png")
-// CHECK: <kw>let</kw> image = <object-literal>#imageLiteral(resourceName: "cloud.png")</object-literal>
+// CHECK-OLD: <kw>let</kw> image = <object-literal>#imageLiteral(resourceName: "cloud.png")</object-literal>
+// CHECK-NEW: <kw>let</kw> image = <object-literal>#imageLiteral</object-literal>(resourceName: <str>"cloud.png"</str>)
 let file = #fileLiteral(resourceName: "cloud.png")
-// CHECK: <kw>let</kw> file = <object-literal>#fileLiteral(resourceName: "cloud.png")</object-literal>
+// CHECK-OLD: <kw>let</kw> file = <object-literal>#fileLiteral(resourceName: "cloud.png")</object-literal>
+// CHECK-NEW: <kw>let</kw> file = <object-literal>#fileLiteral</object-literal>(resourceName: <str>"cloud.png"</str>)
 let black = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1)
-// CHECK: <kw>let</kw> black = <object-literal>#colorLiteral(red: 0, green: 0, blue: 0, alpha: 1)</object-literal>
+// CHECK-OLD: <kw>let</kw> black = <object-literal>#colorLiteral(red: 0, green: 0, blue: 0, alpha: 1)</object-literal>
+// CHECK-NEW: <kw>let</kw> black = <object-literal>#colorLiteral</object-literal>(red: <int>0</int>, green: <int>0</int>, blue: <int>0</int>, alpha: <int>1</int>)
 
 let rgb = [#colorLiteral(red: 1, green: 0, blue: 0, alpha: 1),
            #colorLiteral(red: 0, green: 1, blue: 0, alpha: 1),
            #colorLiteral(red: 0, green: 0, blue: 1, alpha: 1)]
-// CHECK: <kw>let</kw> rgb = [<object-literal>#colorLiteral(red: 1, green: 0, blue: 0, alpha: 1)</object-literal>,
-// CHECK:                     <object-literal>#colorLiteral(red: 0, green: 1, blue: 0, alpha: 1)</object-literal>,
-// CHECK:                     <object-literal>#colorLiteral(red: 0, green: 0, blue: 1, alpha: 1)</object-literal>]
+// CHECK-OLD: <kw>let</kw> rgb = [<object-literal>#colorLiteral(red: 1, green: 0, blue: 0, alpha: 1)</object-literal>,
+// CHECK-OLD:                     <object-literal>#colorLiteral(red: 0, green: 1, blue: 0, alpha: 1)</object-literal>,
+// CHECK-OLD:                     <object-literal>#colorLiteral(red: 0, green: 0, blue: 1, alpha: 1)</object-literal>]
+// CHECK-NEW: <kw>let</kw> rgb = [<object-literal>#colorLiteral</object-literal>(red: <int>1</int>, green: <int>0</int>, blue: <int>0</int>, alpha: <int>1</int>),
+// CHECK-NEW:                     <object-literal>#colorLiteral</object-literal>(red: <int>0</int>, green: <int>1</int>, blue: <int>0</int>, alpha: <int>1</int>),
+// CHECK-NEW:                     <object-literal>#colorLiteral</object-literal>(red: <int>0</int>, green: <int>0</int>, blue: <int>1</int>, alpha: <int>1</int>)]
 
 "--\"\(x) --"
 // CHECK: <str>"--\"</str>\<anchor>(</anchor>x<anchor>)</anchor><str> --"</str>
@@ -591,8 +667,8 @@ func keywordAsLabel4(_: Int) {}
 // CHECK: <kw>func</kw> keywordAsLabel4(<kw>_</kw>: <type>Int</type>) {}
 func keywordAsLabel5(_: Int, for: Int) {}
 // CHECK: <kw>func</kw> keywordAsLabel5(<kw>_</kw>: <type>Int</type>, for: <type>Int</type>) {}
-func keywordAsLabel6(if let: Int) {}
-// CHECK: <kw>func</kw> keywordAsLabel6(if <kw>let</kw>: <type>Int</type>) {}
+func keywordAsLabel6(if func: Int) {}
+// CHECK: <kw>func</kw> keywordAsLabel6(if func: <type>Int</type>) {}
 
 func foo1() {
 // CHECK: <kw>func</kw> foo1() {

--- a/test/IDE/coloring_configs.swift
+++ b/test/IDE/coloring_configs.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-ide-test -syntax-coloring -source-filename %s -D CONF | %FileCheck %s
+// RUN: %target-swift-ide-test -syntax-coloring -force-libsyntax-based-processing -source-filename %s -D CONF | %FileCheck %s
 
 // CHECK: <kw>var</kw> f : <type>Int</type>
 var f : Int

--- a/test/IDE/coloring_keywords.swift
+++ b/test/IDE/coloring_keywords.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-ide-test -syntax-coloring -source-filename %s | %FileCheck %s
+// RUN: %target-swift-ide-test -syntax-coloring -force-libsyntax-based-processing -source-filename %s | %FileCheck %s
 // RUN: %target-swift-ide-test -syntax-coloring -typecheck -source-filename %s | %FileCheck %s
 
 // CHECK: <kw>return</kw> c.return

--- a/test/IDE/coloring_unclosed_hash_if.swift
+++ b/test/IDE/coloring_unclosed_hash_if.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-ide-test -syntax-coloring -source-filename %s | %FileCheck %s
+// RUN: %target-swift-ide-test -syntax-coloring -force-libsyntax-based-processing -source-filename %s | %FileCheck %s
 // RUN: %target-swift-ide-test -syntax-coloring -typecheck -source-filename %s | %FileCheck %s
 
 // CHECK: <#kw>#if</#kw> <#id>d</#id>

--- a/test/SourceKit/SyntaxMapData/syntaxmap-edit-block-comment.swift
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-edit-block-comment.swift
@@ -1,5 +1,7 @@
 // RUN: %sourcekitd-test -req=open -print-raw-response %S/Inputs/syntaxmap-edit-block-comment.swift == -req=edit -print-raw-response %S/Inputs/syntaxmap-edit-block-comment.swift -pos=4:2 -replace=" " -length=1  == -req=edit -print-raw-response %S/Inputs/syntaxmap-edit-block-comment.swift -pos=4:2 -replace="/" -length=1 == -req=edit -print-raw-response %S/Inputs/syntaxmap-edit-block-comment.swift -pos=1:1 -replace="//" -length=2 | %sed_clean > %t.response
-// RUN: %FileCheck -input-file=%t.response %s
+// RUN: %FileCheck -input-file=%t.response %s --check-prefixes CHECK,CHECK-OLD
+// RUN: %sourcekitd-test -req=open -print-raw-response %S/Inputs/syntaxmap-edit-block-comment.swift -force-libsyntax-based-processing == -req=edit -print-raw-response %S/Inputs/syntaxmap-edit-block-comment.swift -pos=4:2 -replace=" " -length=1 -force-libsyntax-based-processing  == -req=edit -print-raw-response %S/Inputs/syntaxmap-edit-block-comment.swift -pos=4:2 -replace="/" -length=1 -force-libsyntax-based-processing == -req=edit -print-raw-response %S/Inputs/syntaxmap-edit-block-comment.swift -pos=1:1 -replace="//" -length=2 -force-libsyntax-based-processing | %sed_clean > %t.libSyntax.response
+// RUN: %FileCheck -input-file=%t.libSyntax.response %s --check-prefixes CHECK,CHECK-NEW
 
 // Initial state
 
@@ -87,12 +89,14 @@
 
 // CHECK: {{^}}{
 // CHECK-NEXT: key.offset: 0,
-// CHECK-NEXT: key.length: 3,
+// CHECK-OLD-NEXT: key.length: 3,
+// CHECK-NEW-NEXT: key.length: 2,
 // CHECK-NEXT: key.diagnostic_stage: source.diagnostic.stage.swift.parse,
 // CHECK-NEXT: key.syntaxmap: [
 // CHECK-NEXT:   {
 // CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.comment,
 // CHECK-NEXT:     key.offset: 0,
-// CHECK-NEXT:     key.length: 3
+// CHECK-OLD-NEXT:     key.length: 3
+// CHECK-NEW-NEXT:     key.length: 2
 // CHECK-NEXT:   }
 // CHECK-NEXT: ],

--- a/test/SourceKit/SyntaxMapData/syntaxmap-edit-chained-comment.swift
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-edit-chained-comment.swift
@@ -1,5 +1,7 @@
 // RUN: %sourcekitd-test -req=open -print-raw-response %S/Inputs/syntaxmap-edit-chained-comment.swift == -req=edit -print-raw-response %S/Inputs/syntaxmap-edit-chained-comment.swift -pos=1:9 -replace=" " -length=1  == -req=edit -print-raw-response %S/Inputs/syntaxmap-edit-chained-comment.swift -pos=1:9 -replace="/" -length=1 | %sed_clean > %t.response
-// RUN: %FileCheck -input-file=%t.response %s
+// RUN: %FileCheck -input-file=%t.response %s --check-prefixes CHECK,CHECK-OLD
+// RUN: %sourcekitd-test -req=open -print-raw-response %S/Inputs/syntaxmap-edit-chained-comment.swift -force-libsyntax-based-processing == -req=edit -print-raw-response %S/Inputs/syntaxmap-edit-chained-comment.swift -pos=1:9 -replace=" " -length=1 -force-libsyntax-based-processing  == -req=edit -print-raw-response %S/Inputs/syntaxmap-edit-chained-comment.swift -pos=1:9 -replace="/" -length=1 -force-libsyntax-based-processing | %sed_clean > %t.libsyntax.response
+// RUN: %FileCheck -input-file=%t.libsyntax.response %s --check-prefixes CHECK,CHECK-NEW
 
 // Initial state
 
@@ -46,7 +48,8 @@
 // CHECK-NEXT:   {
 // CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.comment,
 // CHECK-NEXT:     key.offset: 13,
-// CHECK-NEXT:     key.length: 6
+// CHECK-OLD-NEXT:     key.length: 6
+// CHECK-NEW-NEXT:     key.length: 5
 // CHECK-NEXT:   }
 // CHECK-NEXT: ],
 

--- a/test/SourceKit/SyntaxMapData/syntaxmap-edit-del.swift
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-edit-del.swift
@@ -2,3 +2,8 @@
 // RUN: diff -u %s.response %t.response
 // RUN: %sourcekitd-test -req=syntax-map -pos=4:1 -length=2 -replace="" %S/Inputs/syntaxmap-edit-del.swift | %sed_clean > %t.response2
 // RUN: diff -u %s.response2 %t.response2
+
+// RUN: %sourcekitd-test -req=syntax-map -pos=2:1 -length=2 -replace=" " %S/Inputs/syntaxmap-edit-del.swift -force-libsyntax-based-processing | %sed_clean > %t.libsyntax.response
+// RUN: diff -u %s.response %t.libsyntax.response
+// RUN: %sourcekitd-test -req=syntax-map -pos=4:1 -length=2 -replace="" %S/Inputs/syntaxmap-edit-del.swift -force-libsyntax-based-processing | %sed_clean > %t.libsyntax.response2
+// RUN: diff -u %s.response2 %t.libsyntax.response2

--- a/test/SourceKit/SyntaxMapData/syntaxmap-edit-disjoint-effect.swift
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-edit-disjoint-effect.swift
@@ -1,5 +1,7 @@
 // RUN: %sourcekitd-test -req=open -print-raw-response %S/Inputs/syntaxmap-edit-disjoint-effect.swift == -req=edit -print-raw-response %S/Inputs/syntaxmap-edit-disjoint-effect.swift -pos=1:11 -replace='(' -length=1 | %sed_clean > %t.response
 // RUN: %FileCheck -input-file=%t.response %s
+// RUN: %sourcekitd-test -req=open -print-raw-response %S/Inputs/syntaxmap-edit-disjoint-effect.swift -force-libsyntax-based-processing == -req=edit -print-raw-response %S/Inputs/syntaxmap-edit-disjoint-effect.swift -pos=1:11 -replace='(' -length=1 -force-libsyntax-based-processing | %sed_clean > %t.libsyntax.response
+// RUN: %FileCheck -input-file=%t.libsyntax.response %s
 
 // Original contents
 

--- a/test/SourceKit/SyntaxMapData/syntaxmap-edit-multiline-string.swift
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-edit-multiline-string.swift
@@ -1,5 +1,7 @@
 // RUN: %sourcekitd-test -req=open -print-raw-response %S/Inputs/syntaxmap-edit-multiline-string.swift == -req=edit -print-raw-response %S/Inputs/syntaxmap-edit-multiline-string.swift -pos=8:1 -replace='"""' -length=3 == -req=edit -print-raw-response %S/Inputs/syntaxmap-edit-multiline-string.swift -pos=6:2 -replace=')' -length=1 == -req=edit -print-raw-response %S/Inputs/syntaxmap-edit-multiline-string.swift -pos=2:10 -replace=' ' -length=1 | %sed_clean > %t.response
-// RUN: %FileCheck -input-file=%t.response %s
+// RUN: %FileCheck -input-file=%t.response %s --check-prefixes CHECK,CHECK-OLD
+// RUN: %sourcekitd-test -req=open -print-raw-response %S/Inputs/syntaxmap-edit-multiline-string.swift -force-libsyntax-based-processing == -req=edit -print-raw-response %S/Inputs/syntaxmap-edit-multiline-string.swift -pos=8:1 -replace='"""' -length=3 -force-libsyntax-based-processing == -req=edit -print-raw-response %S/Inputs/syntaxmap-edit-multiline-string.swift -pos=6:2 -replace=')' -length=1 -force-libsyntax-based-processing == -req=edit -print-raw-response %S/Inputs/syntaxmap-edit-multiline-string.swift -pos=2:10 -replace=' ' -length=1 -force-libsyntax-based-processing | %sed_clean > %t.libsyntax.response
+// RUN: %FileCheck -input-file=%t.libsyntax.response %s --check-prefixes CHECK,CHECK-NEW
 
 // Original file contents
 
@@ -50,8 +52,14 @@
 // CHECK-NEXT:   {
 // CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.string,
 // CHECK-NEXT:     key.offset: 24,
-// CHECK-NEXT:     key.length: 5
+// CHECK-OLD-NEXT:     key.length: 5
+// CHECK-NEW-NEXT:     key.length: 3
 // CHECK-NEXT:   },
+// CHECK-NEW-NEXT:   {
+// CHECK-NEW-NEXT:     key.kind: source.lang.swift.syntaxtype.string,
+// CHECK-NEW-NEXT:     key.offset: 27,
+// CHECK-NEW-NEXT:     key.length: 2
+// CHECK-NEW-NEXT:   },
 // CHECK-NEXT:   {
 // CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.string_interpolation_anchor,
 // CHECK-NEXT:     key.offset: 30,
@@ -70,8 +78,14 @@
 // CHECK-NEXT:   {
 // CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.string,
 // CHECK-NEXT:     key.offset: 35,
-// CHECK-NEXT:     key.length: 6
+// CHECK-OLD-NEXT:     key.length: 6
+// CHECK-NEW-NEXT:     key.length: 3
 // CHECK-NEXT:   },
+// CHECK-NEW-NEXT:   {
+// CHECK-NEW-NEXT:     key.kind: source.lang.swift.syntaxtype.string,
+// CHECK-NEW-NEXT:     key.offset: 38,
+// CHECK-NEW-NEXT:     key.length: 3
+// CHECK-NEW-NEXT:   },
 // CHECK-NEXT:   {
 // CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.keyword,
 // CHECK-NEXT:     key.offset: 43,
@@ -102,13 +116,15 @@
 // After adding a character after the interpolation
 // CHECK: {{^}}{
 // CHECK-NEXT: key.offset: 35,
-// CHECK-NEXT: key.length: 6,
+// CHECK-OLD-NEXT: key.length: 6,
+// CHECK-NEW-NEXT: key.length: 3,
 // CHECK-NEXT: key.diagnostic_stage: source.diagnostic.stage.swift.parse,
 // CHECK-NEXT: key.syntaxmap: [
 // CHECK-NEXT:   {
 // CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.string,
 // CHECK-NEXT:     key.offset: 35,
-// CHECK-NEXT:     key.length: 6
+// CHECK-OLD-NEXT:     key.length: 6
+// CHECK-NEW-NEXT:     key.length: 3
 // CHECK-NEXT:   }
 // CHECK-NEXT: ],
 

--- a/test/SourceKit/SyntaxMapData/syntaxmap-edit-nested-token.swift
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-edit-nested-token.swift
@@ -1,5 +1,7 @@
 // RUN: %sourcekitd-test -req=open -print-raw-response %S/Inputs/syntaxmap-edit-nested-token.swift == -req=edit -print-raw-response %S/Inputs/syntaxmap-edit-nested-token.swift -pos=10:43 -replace='impact' -length=6 | %sed_clean > %t.response
-// RUN: %FileCheck -input-file=%t.response %s
+// RUN: %FileCheck -input-file=%t.response %s --check-prefixes CHECK,CHECK-OLD
+// RUN: %sourcekitd-test -req=open -print-raw-response %S/Inputs/syntaxmap-edit-nested-token.swift -force-libsyntax-based-processing == -req=edit -print-raw-response %S/Inputs/syntaxmap-edit-nested-token.swift -pos=10:43 -replace='impact' -length=6 -force-libsyntax-based-processing | %sed_clean > %t.libsyntax.response
+// RUN: %FileCheck -input-file=%t.libsyntax.response %s --check-prefixes CHECK,CHECK-NEW
 
 // Original file contents
 
@@ -11,48 +13,61 @@
 // CHECK-NEXT:   {
 // CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
 // CHECK-NEXT:     key.offset: 0,
-// CHECK-NEXT:     key.length: 29
+// CHECK-OLD-NEXT:     key.length: 29
+// CHECK-NEW-NEXT:     key.length: 28
 // CHECK-NEXT:   },
 // CHECK-NEXT:   {
 // CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
 // CHECK-NEXT:     key.offset: 29,
-// CHECK-NEXT:     key.length: 4
+// CHECK-OLD-NEXT:     key.length: 4
+// CHECK-NEW-NEXT:     key.length: 3
 // CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
-// CHECK-NEXT:     key.offset: 33,
-// CHECK-NEXT:     key.length: 6
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment.field,
-// CHECK-NEXT:     key.offset: 39,
-// CHECK-NEXT:     key.length: 9
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
-// CHECK-NEXT:     key.offset: 48,
-// CHECK-NEXT:     key.length: 28
-// CHECK-NEXT:   },
+// CHECK-OLD-NEXT:   {
+// CHECK-OLD-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
+// CHECK-OLD-NEXT:     key.offset: 33,
+// CHECK-OLD-NEXT:     key.length: 6
+// CHECK-OLD-NEXT:   },
+// CHECK-OLD-NEXT:   {
+// CHECK-OLD-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment.field,
+// CHECK-OLD-NEXT:     key.offset: 39,
+// CHECK-OLD-NEXT:     key.length: 9
+// CHECK-OLD-NEXT:   },
+// CHECK-OLD-NEXT:   {
+// CHECK-OLD-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
+// CHECK-OLD-NEXT:     key.offset: 48,
+// CHECK-OLD-NEXT:     key.length: 28
+// CHECK-OLD-NEXT:   },
+// CHECK-NEW-NEXT:   {
+// CHECK-NEW-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
+// CHECK-NEW-NEXT:     key.offset: 33,
+// CHECK-NEW-NEXT:     key.length: 42
+// CHECK-NEW-NEXT:   },
 // CHECK-NEXT:   {
 // CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
 // CHECK-NEXT:     key.offset: 76,
-// CHECK-NEXT:     key.length: 4
+// CHECK-OLD-NEXT:     key.length: 4
+// CHECK-NEW-NEXT:     key.length: 3
 // CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
-// CHECK-NEXT:     key.offset: 80,
-// CHECK-NEXT:     key.length: 6
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment.field,
-// CHECK-NEXT:     key.offset: 86,
-// CHECK-NEXT:     key.length: 7
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
-// CHECK-NEXT:     key.offset: 93,
-// CHECK-NEXT:     key.length: 19
-// CHECK-NEXT:   },
+// CHECK-OLD-NEXT:   {
+// CHECK-OLD-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
+// CHECK-OLD-NEXT:     key.offset: 80,
+// CHECK-OLD-NEXT:     key.length: 6
+// CHECK-OLD-NEXT:   },
+// CHECK-OLD-NEXT:   {
+// CHECK-OLD-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment.field,
+// CHECK-OLD-NEXT:     key.offset: 86,
+// CHECK-OLD-NEXT:     key.length: 7
+// CHECK-OLD-NEXT:   },
+// CHECK-OLD-NEXT:   {
+// CHECK-OLD-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
+// CHECK-OLD-NEXT:     key.offset: 93,
+// CHECK-OLD-NEXT:     key.length: 19
+// CHECK-OLD-NEXT:   },
+// CHECK-NEW-NEXT:   {
+// CHECK-NEW-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
+// CHECK-NEW-NEXT:     key.offset: 80,
+// CHECK-NEW-NEXT:     key.length: 31
+// CHECK-NEW-NEXT:   },
 // CHECK-NEXT:   {
 // CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.keyword,
 // CHECK-NEXT:     key.offset: 112,
@@ -106,48 +121,61 @@
 // CHECK-NEXT:   {
 // CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
 // CHECK-NEXT:     key.offset: 221,
-// CHECK-NEXT:     key.length: 35
+// CHECK-OLD-NEXT:     key.length: 35
+// CHECK-NEW-NEXT:     key.length: 34
 // CHECK-NEXT:   },
 // CHECK-NEXT:   {
 // CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
 // CHECK-NEXT:     key.offset: 256,
-// CHECK-NEXT:     key.length: 4
+// CHECK-OLD-NEXT:     key.length: 4
+// CHECK-NEW-NEXT:     key.length: 3
 // CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
-// CHECK-NEXT:     key.offset: 260,
-// CHECK-NEXT:     key.length: 6
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment.field,
-// CHECK-NEXT:     key.offset: 266,
-// CHECK-NEXT:     key.length: 9
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
-// CHECK-NEXT:     key.offset: 275,
-// CHECK-NEXT:     key.length: 28
-// CHECK-NEXT:   },
+// CHECK-OLD-NEXT:   {
+// CHECK-OLD-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
+// CHECK-OLD-NEXT:     key.offset: 260,
+// CHECK-OLD-NEXT:     key.length: 6
+// CHECK-OLD-NEXT:   },
+// CHECK-OLD-NEXT:   {
+// CHECK-OLD-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment.field,
+// CHECK-OLD-NEXT:     key.offset: 266,
+// CHECK-OLD-NEXT:     key.length: 9
+// CHECK-OLD-NEXT:   },
+// CHECK-OLD-NEXT:   {
+// CHECK-OLD-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
+// CHECK-OLD-NEXT:     key.offset: 275,
+// CHECK-OLD-NEXT:     key.length: 28
+// CHECK-OLD-NEXT:   },
+// CHECK-NEW-NEXT:   {
+// CHECK-NEW-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
+// CHECK-NEW-NEXT:     key.offset: 260,
+// CHECK-NEW-NEXT:     key.length: 42
+// CHECK-NEW-NEXT:   },
 // CHECK-NEXT:   {
 // CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
 // CHECK-NEXT:     key.offset: 303,
-// CHECK-NEXT:     key.length: 4
+// CHECK-OLD-NEXT:     key.length: 4
+// CHECK-NEW-NEXT:     key.length: 3
 // CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
-// CHECK-NEXT:     key.offset: 307,
-// CHECK-NEXT:     key.length: 6
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment.field,
-// CHECK-NEXT:     key.offset: 313,
-// CHECK-NEXT:     key.length: 7
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
-// CHECK-NEXT:     key.offset: 320,
-// CHECK-NEXT:     key.length: 19
-// CHECK-NEXT:   },
+// CHECK-OLD-NEXT:   {
+// CHECK-OLD-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
+// CHECK-OLD-NEXT:     key.offset: 307,
+// CHECK-OLD-NEXT:     key.length: 6
+// CHECK-OLD-NEXT:   },
+// CHECK-OLD-NEXT:   {
+// CHECK-OLD-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment.field,
+// CHECK-OLD-NEXT:     key.offset: 313,
+// CHECK-OLD-NEXT:     key.length: 7
+// CHECK-OLD-NEXT:   },
+// CHECK-OLD-NEXT:   {
+// CHECK-OLD-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
+// CHECK-OLD-NEXT:     key.offset: 320,
+// CHECK-OLD-NEXT:     key.length: 19
+// CHECK-OLD-NEXT:   },
+// CHECK-NEW-NEXT:   {
+// CHECK-NEW-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
+// CHECK-NEW-NEXT:     key.offset: 307,
+// CHECK-NEW-NEXT:     key.length: 31
+// CHECK-NEW-NEXT:   },
 // CHECK-NEXT:   {
 // CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.keyword,
 // CHECK-NEXT:     key.offset: 339,

--- a/test/SourceKit/SyntaxMapData/syntaxmap-edit-remove.swift
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-edit-remove.swift
@@ -1,5 +1,7 @@
 // RUN: %sourcekitd-test -req=open -print-raw-response %S/Inputs/syntaxmap-edit-remove.swift == -req=edit -print-raw-response %S/Inputs/syntaxmap-edit-remove.swift -pos=3:3 -length=1 -replace='' == -req=edit -print-raw-response %S/Inputs/syntaxmap-edit-remove.swift -pos=2:1 -replace='' -length=1 == -req=edit -print-raw-response %S/Inputs/syntaxmap-edit-remove.swift -pos=1:9 -length=1 -replace='' | %sed_clean > %t.response
 // RUN: %FileCheck -input-file=%t.response %s
+// RUN: %sourcekitd-test -req=open -print-raw-response %S/Inputs/syntaxmap-edit-remove.swift -force-libsyntax-based-processing == -req=edit -print-raw-response %S/Inputs/syntaxmap-edit-remove.swift -pos=3:3 -length=1 -replace='' -force-libsyntax-based-processing == -req=edit -print-raw-response %S/Inputs/syntaxmap-edit-remove.swift -pos=2:1 -replace='' -length=1 -force-libsyntax-based-processing == -req=edit -print-raw-response %S/Inputs/syntaxmap-edit-remove.swift -pos=1:9 -length=1 -replace='' -force-libsyntax-based-processing | %sed_clean > %t.libsyntax.response
+// RUN: %FileCheck -input-file=%t.libsyntax.response %s
 
 // Initial state
 

--- a/test/SourceKit/SyntaxMapData/syntaxmap-edit.swift
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-edit.swift
@@ -1,2 +1,4 @@
 // RUN: %sourcekitd-test -req=syntax-map -pos=4:10 -replace="Bar" %S/Inputs/syntaxmap-edit.swift > %t.response
 // RUN: diff -u %s.response %t.response
+// RUN: %sourcekitd-test -req=syntax-map -pos=4:10 -replace="Bar" %S/Inputs/syntaxmap-edit.swift -force-libsyntax-based-processing > %t.libsyntax.response
+// RUN: diff -u %s.libsyntax.response %t.libsyntax.response

--- a/test/SourceKit/SyntaxMapData/syntaxmap-edit.swift.libsyntax.response
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-edit.swift.libsyntax.response
@@ -1,0 +1,54 @@
+{
+  key.offset: 0,
+  key.length: 114,
+  key.diagnostic_stage: source.diagnostic.stage.swift.parse,
+  key.syntaxmap: [
+    {
+      key.kind: source.lang.swift.syntaxtype.comment,
+      key.offset: 0,
+      key.length: 21
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.comment,
+      key.offset: 22,
+      key.length: 57
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 81,
+      key.length: 5
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 87,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 97,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 101,
+      key.length: 4
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
+      key.offset: 108,
+      key.length: 3
+    }
+  ]
+}
+{
+  key.offset: 87,
+  key.length: 6,
+  key.diagnostic_stage: source.diagnostic.stage.swift.parse,
+  key.syntaxmap: [
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 87,
+      key.length: 6
+    }
+  ]
+}

--- a/test/SourceKit/SyntaxMapData/syntaxmap-multiple-edits.swift
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-multiple-edits.swift
@@ -1,5 +1,7 @@
 // RUN: %sourcekitd-test -req=open -print-raw-response %S/Inputs/syntaxmap-multiple-edits.swift == -req=edit -print-raw-response -pos=6:13 -length=1 -replace=" " %S/Inputs/syntaxmap-multiple-edits.swift == -req="edit" -pos=14:1 -length=0 -replace="let y = 2" -print-raw-response %S/Inputs/syntaxmap-multiple-edits.swift == -req="edit" -pos=8:10 -length=7 -replace='Int64 = 3; let z = 2' -print-raw-response %S/Inputs/syntaxmap-multiple-edits.swift == -req="edit" -pos=4:9 -length=2 -replace='50 * 95 - 100' -print-raw-response %S/Inputs/syntaxmap-multiple-edits.swift == -req="edit" -pos=1:1 -length=0 -replace='func firstFunc(x: Int) {}' -print-raw-response %S/Inputs/syntaxmap-multiple-edits.swift | %sed_clean > %t.response
-// RUN: %FileCheck -input-file=%t.response %s
+// RUN: %FileCheck -input-file=%t.response %s --check-prefixes CHECK,CHECK-OLD
+// RUN: %sourcekitd-test -req=open -print-raw-response %S/Inputs/syntaxmap-multiple-edits.swift -force-libsyntax-based-processing == -req=edit -print-raw-response -pos=6:13 -length=1 -replace=" " %S/Inputs/syntaxmap-multiple-edits.swift -force-libsyntax-based-processing == -req="edit" -pos=14:1 -length=0 -replace="let y = 2" -print-raw-response %S/Inputs/syntaxmap-multiple-edits.swift -force-libsyntax-based-processing == -req="edit" -pos=8:10 -length=7 -replace='Int64 = 3; let z = 2' -print-raw-response %S/Inputs/syntaxmap-multiple-edits.swift -force-libsyntax-based-processing == -req="edit" -pos=4:9 -length=2 -replace='50 * 95 - 100' -print-raw-response %S/Inputs/syntaxmap-multiple-edits.swift -force-libsyntax-based-processing == -req="edit" -pos=1:1 -length=0 -replace='func firstFunc(x: Int) {}' -print-raw-response %S/Inputs/syntaxmap-multiple-edits.swift -force-libsyntax-based-processing | %sed_clean > %t.libsyntax.response
+// RUN: %FileCheck -input-file=%t.libsyntax.response %s --check-prefixes CHECK,CHECK-NEW
 
 // Initial syntax map
 
@@ -11,23 +13,29 @@
 // CHECK-NEXT:   {
 // CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
 // CHECK-NEXT:     key.offset: 2,
-// CHECK-NEXT:     key.length: 14
+// CHECK-OLD-NEXT:     key.length: 14
+// CHECK-NEW-NEXT:     key.length: 13
 // CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
-// CHECK-NEXT:     key.offset: 16,
-// CHECK-NEXT:     key.length: 6
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment.field,
-// CHECK-NEXT:     key.offset: 22,
-// CHECK-NEXT:     key.length: 4
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
-// CHECK-NEXT:     key.offset: 26,
-// CHECK-NEXT:     key.length: 19
-// CHECK-NEXT:   },
+// CHECK-OLD-NEXT:   {
+// CHECK-OLD-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
+// CHECK-OLD-NEXT:     key.offset: 16,
+// CHECK-OLD-NEXT:     key.length: 6
+// CHECK-OLD-NEXT:   },
+// CHECK-OLD-NEXT:   {
+// CHECK-OLD-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment.field,
+// CHECK-OLD-NEXT:     key.offset: 22,
+// CHECK-OLD-NEXT:     key.length: 4
+// CHECK-OLD-NEXT:   },
+// CHECK-OLD-NEXT:   {
+// CHECK-OLD-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
+// CHECK-OLD-NEXT:     key.offset: 26,
+// CHECK-OLD-NEXT:     key.length: 19
+// CHECK-OLD-NEXT:   },
+// CHECK-NEW-NEXT:   {
+// CHECK-NEW-NEXT:     key.kind: source.lang.swift.syntaxtype.doccomment,
+// CHECK-NEW-NEXT:     key.offset: 16,
+// CHECK-NEW-NEXT:     key.length: 28
+// CHECK-NEW-NEXT:   },
 // CHECK-NEXT:   {
 // CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.keyword,
 // CHECK-NEXT:     key.offset: 45,

--- a/test/SourceKit/SyntaxMapData/syntaxmap-object-literals.swift
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-object-literals.swift
@@ -1,5 +1,7 @@
 // RUN: %sourcekitd-test -req=syntax-map %s | %sed_clean > %t.response
 // RUN: diff -u %s.response %t.response
+// RUN: %sourcekitd-test -req=syntax-map %s -force-libsyntax-based-processing | %sed_clean > %t.libsyntax.response
+// RUN: diff -u %s.libsyntax.response %t.libsyntax.response
 
 let image = #imageLiteral(resourceName: "cloud.png")
 let color = #colorLiteral(red: 1, blue: 0, green: 1, alpha: 1)

--- a/test/SourceKit/SyntaxMapData/syntaxmap-object-literals.swift.libsyntax.response
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-object-literals.swift.libsyntax.response
@@ -1,0 +1,132 @@
+{
+  key.offset: 0,
+  key.length: 454,
+  key.diagnostic_stage: source.diagnostic.stage.swift.parse,
+  key.syntaxmap: [
+    {
+      key.kind: source.lang.swift.syntaxtype.comment,
+      key.offset: 0,
+      key.length: 70
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.comment,
+      key.offset: 71,
+      key.length: 39
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.comment,
+      key.offset: 111,
+      key.length: 114
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.comment,
+      key.offset: 226,
+      key.length: 59
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 287,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 291,
+      key.length: 5
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.objectliteral,
+      key.offset: 299,
+      key.length: 13
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 313,
+      key.length: 12
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.string,
+      key.offset: 327,
+      key.length: 11
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 340,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 344,
+      key.length: 5
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.objectliteral,
+      key.offset: 352,
+      key.length: 13
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 366,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.number,
+      key.offset: 371,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 374,
+      key.length: 4
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.number,
+      key.offset: 380,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 383,
+      key.length: 5
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.number,
+      key.offset: 390,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 393,
+      key.length: 5
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.number,
+      key.offset: 400,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 403,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 407,
+      key.length: 4
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.objectliteral,
+      key.offset: 414,
+      key.length: 12
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 427,
+      key.length: 12
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.string,
+      key.offset: 441,
+      key.length: 10
+    }
+  ]
+}

--- a/test/SourceKit/SyntaxMapData/syntaxmap-object-literals.swift.response
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-object-literals.swift.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 279,
+  key.length: 454,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.syntaxmap: [
     {
@@ -14,48 +14,58 @@
       key.length: 40
     },
     {
+      key.kind: source.lang.swift.syntaxtype.comment,
+      key.offset: 111,
+      key.length: 115
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.comment,
+      key.offset: 226,
+      key.length: 60
+    },
+    {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 112,
+      key.offset: 287,
       key.length: 3
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 116,
+      key.offset: 291,
       key.length: 5
     },
     {
       key.kind: source.lang.swift.syntaxtype.objectliteral,
-      key.offset: 124,
+      key.offset: 299,
       key.length: 40
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 165,
+      key.offset: 340,
       key.length: 3
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 169,
+      key.offset: 344,
       key.length: 5
     },
     {
       key.kind: source.lang.swift.syntaxtype.objectliteral,
-      key.offset: 177,
+      key.offset: 352,
       key.length: 50
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 228,
+      key.offset: 403,
       key.length: 3
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 232,
+      key.offset: 407,
       key.length: 4
     },
     {
       key.kind: source.lang.swift.syntaxtype.objectliteral,
-      key.offset: 239,
+      key.offset: 414,
       key.length: 38
     }
   ]

--- a/test/SourceKit/SyntaxMapData/syntaxmap-partial-delete.swift
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-partial-delete.swift
@@ -1,5 +1,7 @@
 // RUN: %sourcekitd-test -req=open -print-raw-response %S/Inputs/syntaxmap-partial-delete.swift == -req=edit -print-raw-response -pos=2:10 -length=2 -replace='' %S/Inputs/syntaxmap-partial-delete.swift | %sed_clean > %t.response
 // RUN: %FileCheck -input-file=%t.response %s
+// RUN: %sourcekitd-test -req=open -print-raw-response %S/Inputs/syntaxmap-partial-delete.swift -force-libsyntax-based-processing == -req=edit -print-raw-response -pos=2:10 -length=2 -replace='' %S/Inputs/syntaxmap-partial-delete.swift -force-libsyntax-based-processing | %sed_clean > %t.libsyntax.response
+// RUN: %FileCheck -input-file=%t.libsyntax.response %s
 
 // CHECK: {{^}}{
 // CHECK-NEXT: key.offset: 0,

--- a/test/SourceKit/SyntaxMapData/syntaxmap-pound-keyword.swift
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-pound-keyword.swift
@@ -1,5 +1,7 @@
 // RUN: %sourcekitd-test -req=syntax-map %s | %sed_clean > %t.response
 // RUN: diff -u %s.response %t.response
+// RUN: %sourcekitd-test -req=syntax-map %s -force-libsyntax-based-processing | %sed_clean > %t.libsyntax.response
+// RUN: diff -u %s.libsyntax.response %t.libsyntax.response
 
 let fn = #function
 let f = #file

--- a/test/SourceKit/SyntaxMapData/syntaxmap-pound-keyword.swift.libsyntax.response
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-pound-keyword.swift.libsyntax.response
@@ -6,22 +6,22 @@
     {
       key.kind: source.lang.swift.syntaxtype.comment,
       key.offset: 0,
-      key.length: 71
+      key.length: 70
     },
     {
       key.kind: source.lang.swift.syntaxtype.comment,
       key.offset: 71,
-      key.length: 40
+      key.length: 39
     },
     {
       key.kind: source.lang.swift.syntaxtype.comment,
       key.offset: 111,
-      key.length: 115
+      key.length: 114
     },
     {
       key.kind: source.lang.swift.syntaxtype.comment,
       key.offset: 226,
-      key.length: 60
+      key.length: 59
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,

--- a/test/SourceKit/SyntaxMapData/syntaxmap.swift
+++ b/test/SourceKit/SyntaxMapData/syntaxmap.swift
@@ -1,3 +1,5 @@
 // XFAIL: broken_std_regex
 // RUN: %sourcekitd-test -req=syntax-map %S/Inputs/syntaxmap.swift > %t.response
 // RUN: diff -u %s.response %t.response
+// RUN: %sourcekitd-test -req=syntax-map %S/Inputs/syntaxmap.swift -force-libsyntax-based-processing > %t.libsyntax.response
+// RUN: diff -u %s.libsyntax.response %t.libsyntax.response

--- a/test/SourceKit/SyntaxMapData/syntaxmap.swift.libsyntax.response
+++ b/test/SourceKit/SyntaxMapData/syntaxmap.swift.libsyntax.response
@@ -1,0 +1,467 @@
+{
+  key.offset: 0,
+  key.length: 1049,
+  key.diagnostic_stage: source.diagnostic.stage.swift.parse,
+  key.syntaxmap: [
+    {
+      key.kind: source.lang.swift.syntaxtype.comment,
+      key.offset: 0,
+      key.length: 21
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.comment,
+      key.offset: 22,
+      key.length: 59
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 83,
+      key.length: 5
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 89,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 99,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 103,
+      key.length: 4
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
+      key.offset: 110,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 118,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 122,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 125,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
+      key.offset: 129,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.buildconfig.keyword,
+      key.offset: 136,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.buildconfig.id,
+      key.offset: 140,
+      key.length: 4
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 145,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 149,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
+      key.offset: 153,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.buildconfig.keyword,
+      key.offset: 157,
+      key.length: 5
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 163,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 167,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
+      key.offset: 171,
+      key.length: 5
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.buildconfig.keyword,
+      key.offset: 177,
+      key.length: 6
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.comment,
+      key.offset: 185,
+      key.length: 26
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.comment,
+      key.offset: 212,
+      key.length: 48
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.comment,
+      key.offset: 261,
+      key.length: 22
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.comment,
+      key.offset: 284,
+      key.length: 23
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 309,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 313,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.string,
+      key.offset: 319,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.string,
+      key.offset: 320,
+      key.length: 12
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.string_interpolation_anchor,
+      key.offset: 333,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.number,
+      key.offset: 334,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.string_interpolation_anchor,
+      key.offset: 335,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.string,
+      key.offset: 336,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 339,
+      key.length: 4
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.placeholder,
+      key.offset: 344,
+      key.length: 9
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.doccomment,
+      key.offset: 360,
+      key.length: 22
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.doccomment,
+      key.offset: 383,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.doccomment,
+      key.offset: 387,
+      key.length: 15
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.doccomment,
+      key.offset: 403,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.doccomment,
+      key.offset: 407,
+      key.length: 17
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.doccomment,
+      key.offset: 425,
+      key.length: 14
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.doccomment,
+      key.offset: 440,
+      key.length: 7
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.doccomment,
+      key.offset: 448,
+      key.length: 32
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.doccomment,
+      key.offset: 481,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.doccomment,
+      key.offset: 485,
+      key.length: 27
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.doccomment,
+      key.offset: 513,
+      key.length: 22
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 536,
+      key.length: 4
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 541,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 545,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
+      key.offset: 548,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 553,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
+      key.offset: 556,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
+      key.offset: 564,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 570,
+      key.length: 6
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 577,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 581,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.doccomment,
+      key.offset: 586,
+      key.length: 139
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 726,
+      key.length: 4
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 731,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.comment,
+      key.offset: 741,
+      key.length: 30
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.comment,
+      key.offset: 772,
+      key.length: 16
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.comment,
+      key.offset: 789,
+      key.length: 23
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.comment,
+      key.offset: 813,
+      key.length: 35
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 850,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.number,
+      key.offset: 855,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 860,
+      key.length: 4
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 865,
+      key.length: 18
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 884,
+      key.length: 2
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 887,
+      key.length: 5
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
+      key.offset: 894,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 899,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 901,
+      key.length: 4
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 908,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 910,
+      key.length: 7
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
+      key.offset: 919,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
+      key.offset: 927,
+      key.length: 4
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 937,
+      key.length: 2
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
+      key.offset: 941,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
+      key.offset: 946,
+      key.length: 6
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 958,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 962,
+      key.length: 6
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 971,
+      key.length: 2
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
+      key.offset: 975,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
+      key.offset: 980,
+      key.length: 6
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.number,
+      key.offset: 991,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.string,
+      key.offset: 994,
+      key.length: 6
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 1004,
+      key.length: 6
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 1011,
+      key.length: 9
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 1023,
+      key.length: 6
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 1033,
+      key.length: 2
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.number,
+      key.offset: 1037,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.string,
+      key.offset: 1040,
+      key.length: 5
+    }
+  ]
+}

--- a/test/Syntax/Inputs/serialize_multiple_decls.json
+++ b/test/Syntax/Inputs/serialize_multiple_decls.json
@@ -40,7 +40,8 @@
                       "value": 1
                     }
                   ],
-                  "presence": "Present"
+                  "presence": "Present",
+                  "id": 1
                 },
                 {
                   "tokenKind": {
@@ -54,7 +55,8 @@
                       "value": 1
                     }
                   ],
-                  "presence": "Present"
+                  "presence": "Present",
+                  "id": 2
                 },
                 null,
                 null,
@@ -68,12 +70,14 @@
                       },
                       "leadingTrivia": [],
                       "trailingTrivia": [],
-                      "presence": "Present"
+                      "presence": "Present",
+                      "id": 3
                     },
                     {
                       "kind": "MemberDeclList",
                       "layout": [],
-                      "presence": "Present"
+                      "presence": "Present",
+                      "id": 4
                     },
                     {
                       "tokenKind": {
@@ -86,18 +90,22 @@
                         }
                       ],
                       "trailingTrivia": [],
-                      "presence": "Present"
+                      "presence": "Present",
+                      "id": 5
                     }
                   ],
-                  "presence": "Present"
+                  "presence": "Present",
+                  "id": 6
                 }
               ],
-              "presence": "Present"
+              "presence": "Present",
+              "id": 7
             },
             null,
             null
           ],
-          "presence": "Present"
+          "presence": "Present",
+          "id": 8
         },
         {
           "kind": "CodeBlockItem",
@@ -123,7 +131,8 @@
                       "value": 1
                     }
                   ],
-                  "presence": "Present"
+                  "presence": "Present",
+                  "id": 9
                 },
                 {
                   "tokenKind": {
@@ -137,7 +146,8 @@
                       "value": 1
                     }
                   ],
-                  "presence": "Present"
+                  "presence": "Present",
+                  "id": 10
                 },
                 null,
                 null,
@@ -151,12 +161,14 @@
                       },
                       "leadingTrivia": [],
                       "trailingTrivia": [],
-                      "presence": "Present"
+                      "presence": "Present",
+                      "id": 11
                     },
                     {
                       "kind": "MemberDeclList",
                       "layout": [],
-                      "presence": "Present"
+                      "presence": "Present",
+                      "id": 12
                     },
                     {
                       "tokenKind": {
@@ -169,21 +181,26 @@
                         }
                       ],
                       "trailingTrivia": [],
-                      "presence": "Present"
+                      "presence": "Present",
+                      "id": 13
                     }
                   ],
-                  "presence": "Present"
+                  "presence": "Present",
+                  "id": 14
                 }
               ],
-              "presence": "Present"
+              "presence": "Present",
+              "id": 15
             },
             null,
             null
           ],
-          "presence": "Present"
+          "presence": "Present",
+          "id": 16
         }
       ],
-      "presence": "Present"
+      "presence": "Present",
+      "id": 19
     },
     {
       "tokenKind": {
@@ -197,8 +214,10 @@
         }
       ],
       "trailingTrivia": [],
-      "presence": "Present"
+      "presence": "Present",
+      "id": 18
     }
   ],
-  "presence": "Present"
+  "presence": "Present",
+  "id": 20
 }

--- a/test/Syntax/Inputs/serialize_struct_decl.json
+++ b/test/Syntax/Inputs/serialize_struct_decl.json
@@ -40,7 +40,8 @@
                       "value": 1
                     }
                   ],
-                  "presence": "Present"
+                  "presence": "Present",
+                  "id": 1
                 },
                 {
                   "tokenKind": {
@@ -54,7 +55,8 @@
                       "value": 1
                     }
                   ],
-                  "presence": "Present"
+                  "presence": "Present",
+                  "id": 2
                 },
                 null,
                 null,
@@ -68,7 +70,8 @@
                       },
                       "leadingTrivia": [],
                       "trailingTrivia": [],
-                      "presence": "Present"
+                      "presence": "Present",
+                      "id": 3
                     },
                     {
                       "kind": "MemberDeclList",
@@ -101,7 +104,8 @@
                                       "value": 3
                                     }
                                   ],
-                                  "presence": "Present"
+                                  "presence": "Present",
+                                  "id": 4
                                 },
                                 {
                                   "kind": "PatternBindingList",
@@ -124,10 +128,12 @@
                                                   "value": 1
                                                 }
                                               ],
-                                              "presence": "Present"
+                                              "presence": "Present",
+                                              "id": 5
                                             }
                                           ],
-                                          "presence": "Present"
+                                          "presence": "Present",
+                                          "id": 6
                                         },
                                         {
                                           "kind": "TypeAnnotation",
@@ -143,7 +149,8 @@
                                                   "value": 1
                                                 }
                                               ],
-                                              "presence": "Present"
+                                              "presence": "Present",
+                                              "id": 7
                                             },
                                             {
                                               "kind": "SimpleTypeIdentifier",
@@ -155,30 +162,37 @@
                                                   },
                                                   "leadingTrivia": [],
                                                   "trailingTrivia": [],
-                                                  "presence": "Present"
+                                                  "presence": "Present",
+                                                  "id": 8
                                                 },
                                                 null
                                               ],
-                                              "presence": "Present"
+                                              "presence": "Present",
+                                              "id": 9
                                             }
                                           ],
-                                          "presence": "Present"
+                                          "presence": "Present",
+                                          "id": 10
                                         },
                                         null,
                                         null,
                                         null
                                       ],
-                                      "presence": "Present"
+                                      "presence": "Present",
+                                      "id": 11
                                     }
                                   ],
-                                  "presence": "Present"
+                                  "presence": "Present",
+                                  "id": 12
                                 }
                               ],
-                              "presence": "Present"
+                              "presence": "Present",
+                              "id": 13
                             },
                             null
                           ],
-                          "presence": "Present"
+                          "presence": "Present",
+                          "id": 14
                         },
                         {
                           "kind": "MemberDeclListItem",
@@ -208,7 +222,8 @@
                                       "value": 1
                                     }
                                   ],
-                                  "presence": "Present"
+                                  "presence": "Present",
+                                  "id": 15
                                 },
                                 {
                                   "kind": "PatternBindingList",
@@ -231,10 +246,12 @@
                                                   "value": 1
                                                 }
                                               ],
-                                              "presence": "Present"
+                                              "presence": "Present",
+                                              "id": 16
                                             }
                                           ],
-                                          "presence": "Present"
+                                          "presence": "Present",
+                                          "id": 17
                                         },
                                         {
                                           "kind": "TypeAnnotation",
@@ -250,7 +267,8 @@
                                                   "value": 1
                                                 }
                                               ],
-                                              "presence": "Present"
+                                              "presence": "Present",
+                                              "id": 18
                                             },
                                             {
                                               "kind": "SimpleTypeIdentifier",
@@ -267,7 +285,8 @@
                                                       "value": 1
                                                     }
                                                   ],
-                                                  "presence": "Present"
+                                                  "presence": "Present",
+                                                  "id": 19
                                                 },
                                                 {
                                                   "kind": "GenericArgumentClause",
@@ -283,7 +302,8 @@
                                                           "value": 1
                                                         }
                                                       ],
-                                                      "presence": "Present"
+                                                      "presence": "Present",
+                                                      "id": 20
                                                     },
                                                     {
                                                       "kind": "GenericArgumentList",
@@ -306,18 +326,22 @@
                                                                       "value": 1
                                                                     }
                                                                   ],
-                                                                  "presence": "Present"
+                                                                  "presence": "Present",
+                                                                  "id": 21
                                                                 },
                                                                 null
                                                               ],
-                                                              "presence": "Present"
+                                                              "presence": "Present",
+                                                              "id": 22
                                                             },
                                                             null
                                                           ],
-                                                          "presence": "Present"
+                                                          "presence": "Present",
+                                                          "id": 23
                                                         }
                                                       ],
-                                                      "presence": "Present"
+                                                      "presence": "Present",
+                                                      "id": 24
                                                     },
                                                     {
                                                       "tokenKind": {
@@ -325,35 +349,44 @@
                                                       },
                                                       "leadingTrivia": [],
                                                       "trailingTrivia": [],
-                                                      "presence": "Present"
+                                                      "presence": "Present",
+                                                      "id": 25
                                                     }
                                                   ],
-                                                  "presence": "Present"
+                                                  "presence": "Present",
+                                                  "id": 26
                                                 }
                                               ],
-                                              "presence": "Present"
+                                              "presence": "Present",
+                                              "id": 27
                                             }
                                           ],
-                                          "presence": "Present"
+                                          "presence": "Present",
+                                          "id": 28
                                         },
                                         null,
                                         null,
                                         null
                                       ],
-                                      "presence": "Present"
+                                      "presence": "Present",
+                                      "id": 29
                                     }
                                   ],
-                                  "presence": "Present"
+                                  "presence": "Present",
+                                  "id": 30
                                 }
                               ],
-                              "presence": "Present"
+                              "presence": "Present",
+                              "id": 31
                             },
                             null
                           ],
-                          "presence": "Present"
+                          "presence": "Present",
+                          "id": 32
                         }
                       ],
-                      "presence": "Present"
+                      "presence": "Present",
+                      "id": 33
                     },
                     {
                       "tokenKind": {
@@ -370,21 +403,26 @@
                         }
                       ],
                       "trailingTrivia": [],
-                      "presence": "Present"
+                      "presence": "Present",
+                      "id": 34
                     }
                   ],
-                  "presence": "Present"
+                  "presence": "Present",
+                  "id": 35
                 }
               ],
-              "presence": "Present"
+              "presence": "Present",
+              "id": 36
             },
             null,
             null
           ],
-          "presence": "Present"
+          "presence": "Present",
+          "id": 37
         }
       ],
-      "presence": "Present"
+      "presence": "Present",
+      "id": 40
     },
     {
       "tokenKind": {
@@ -398,8 +436,10 @@
         }
       ],
       "trailingTrivia": [],
-      "presence": "Present"
+      "presence": "Present",
+      "id": 39
     }
   ],
-  "presence": "Present"
+  "presence": "Present",
+  "id": 41
 }

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -241,6 +241,10 @@ public:
   virtual bool syntaxTreeEnabled() = 0;
 
   virtual void finished() {}
+
+  // FIXME: This is just for bootstrapping incremental syntax tree parsing.
+  // Remove it once when we are able to incrementally transfer the syntax tree
+  virtual bool forceLibSyntaxBasedProcessing() = 0;
 };
 
 class OptionsDictionary {

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -37,6 +37,7 @@
 #include "swift/IDE/SyntaxModel.h"
 #include "swift/Subsystems.h"
 #include "swift/Syntax/Serialization/SyntaxSerialization.h"
+#include "swift/Syntax/SyntaxClassifier.h"
 #include "swift/Syntax/SyntaxNodes.h"
 
 #include "llvm/Support/ErrorHandling.h"
@@ -555,6 +556,122 @@ struct SwiftSyntaxMap {
 
     return true;
   }
+};
+
+class SyntaxToSyntaxMapConverter : public SyntaxVisitor {
+  SwiftSyntaxMap &SyntaxMap;
+
+  std::map<unsigned, SyntaxClassification> TokenClassifications;
+
+public:
+  SyntaxToSyntaxMapConverter(
+      SwiftSyntaxMap &SyntaxMap,
+      std::map<unsigned, SyntaxClassification> TokenClassifications)
+      : SyntaxMap(SyntaxMap), TokenClassifications(TokenClassifications) {}
+
+private:
+  void visitTrivia(Trivia Trivia, unsigned Offset) {
+    for (auto TriviaPiece : Trivia) {
+      visitTriviaPiece(TriviaPiece, Offset);
+      Offset += TriviaPiece.getTextLength();
+    }
+  }
+
+  void visitTriviaPiece(TriviaPiece TriviaPiece, unsigned Offset) {
+    llvm::Optional<SyntaxNodeKind> Kind;
+    switch (TriviaPiece.getKind()) {
+    case TriviaKind::Space:
+    case TriviaKind::Tab:
+    case TriviaKind::VerticalTab:
+    case TriviaKind::Formfeed:
+    case TriviaKind::Newline:
+    case TriviaKind::CarriageReturn:
+    case TriviaKind::CarriageReturnLineFeed:
+    case swift::syntax::TriviaKind::Backtick:
+    case TriviaKind::GarbageText:
+      Kind = llvm::None;
+      break;
+    case swift::syntax::TriviaKind::LineComment:
+      Kind = SyntaxNodeKind::CommentLine;
+      break;
+    case TriviaKind::BlockComment:
+      Kind = SyntaxNodeKind::CommentBlock;
+      break;
+    case TriviaKind::DocLineComment:
+      Kind = SyntaxNodeKind::DocCommentLine;
+      break;
+    case TriviaKind::DocBlockComment:
+      Kind = SyntaxNodeKind::DocCommentBlock;
+      break;
+    }
+    if (Kind.hasValue()) {
+      SwiftSyntaxToken Token(Offset, TriviaPiece.getTextLength(),
+                             Kind.getValue());
+      SyntaxMap.addToken(Token);
+    }
+  }
+
+  llvm::Optional<SyntaxNodeKind>
+  getKindForSyntaxClassification(SyntaxClassification Classification) const {
+    // FIXME: We should really use the same enum so that the conversion is not
+    // necessary
+    switch (Classification) {
+    case SyntaxClassification::None:
+      return llvm::None;
+    case SyntaxClassification::Keyword:
+      return SyntaxNodeKind::Keyword;
+    case SyntaxClassification::Identifier:
+      return SyntaxNodeKind::Identifier;
+    case SyntaxClassification::DollarIdentifier:
+      return SyntaxNodeKind::DollarIdent;
+    case SyntaxClassification::IntegerLiteral:
+      return SyntaxNodeKind::Integer;
+    case SyntaxClassification::FloatingLiteral:
+      return SyntaxNodeKind::Floating;
+    case SyntaxClassification::StringLiteral:
+      return SyntaxNodeKind::String;
+    case SyntaxClassification::StringInterpolationAnchor:
+      return SyntaxNodeKind::StringInterpolationAnchor;
+    case SyntaxClassification::TypeIdentifier:
+      return SyntaxNodeKind::TypeId;
+    case SyntaxClassification::BuildConfigKeyword:
+      return SyntaxNodeKind::BuildConfigKeyword;
+    case SyntaxClassification::BuildConfigId:
+      return SyntaxNodeKind::BuildConfigId;
+    case SyntaxClassification::PoundDirectiveKeyword:
+      return SyntaxNodeKind::PoundDirectiveKeyword;
+    case SyntaxClassification::Attribute:
+      return SyntaxNodeKind::AttributeBuiltin;
+    case SyntaxClassification::EditorPlaceholder:
+      return SyntaxNodeKind::EditorPlaceholder;
+    case SyntaxClassification::ObjectLiteral:
+      return SyntaxNodeKind::ObjectLiteral;
+    }
+  }
+
+  virtual void visit(TokenSyntax Token) override {
+    if (Token.isMissing())
+      return;
+
+    auto LeadingTriviaOffset =
+        Token.getAbsolutePositionWithLeadingTrivia().getOffset();
+    visitTrivia(Token.getLeadingTrivia(), LeadingTriviaOffset);
+
+    SyntaxClassification Classification = TokenClassifications[Token.getId()];
+    auto Kind = getKindForSyntaxClassification(Classification);
+    unsigned TokenStart = Token.getAbsolutePosition().getOffset();
+    unsigned TokenLength = Token.getRaw()->getTokenText().size();
+    if (Kind.hasValue() && TokenLength > 0) {
+      SwiftSyntaxToken Token(TokenStart, TokenLength, Kind.getValue());
+      SyntaxMap.addToken(Token);
+    }
+
+    auto TrailingTriviaOffset = TokenStart + TokenLength;
+    visitTrivia(Token.getTrailingTrivia(), TrailingTriviaOffset);
+  }
+
+public:
+  void writeToSyntaxMap(Syntax Node) { Node.accept(*this); }
 };
 
 struct EditorConsumerSyntaxMapEntry {
@@ -1772,8 +1889,6 @@ void SwiftEditorDocument::readSyntaxInfo(EditorConsumer &Consumer) {
 
   Impl.ParserDiagnostics = Impl.SyntaxInfo->getDiagnostics();
 
-  ide::SyntaxModelContext ModelContext(Impl.SyntaxInfo->getSourceFile());
-
   if (Consumer.syntaxTreeEnabled()) {
     std::string SyntaxContent;
     llvm::raw_string_ostream OS(SyntaxContent);
@@ -1785,11 +1900,21 @@ void SwiftEditorDocument::readSyntaxInfo(EditorConsumer &Consumer) {
 
   SwiftSyntaxMap NewMap = SwiftSyntaxMap(Impl.SyntaxMap.Tokens.size() + 16);
 
-  SwiftEditorSyntaxWalker SyntaxWalker(NewMap,
-                                       Impl.SyntaxInfo->getSourceManager(),
-                                       Consumer,
-                                       Impl.SyntaxInfo->getBufferID());
-  ModelContext.walk(SyntaxWalker);
+  if (Consumer.forceLibSyntaxBasedProcessing()) {
+    auto SyntaxTree = Impl.SyntaxInfo->getSourceFile().getSyntaxRoot();
+
+    SyntaxClassifier Classifier;
+    auto Classification = Classifier.classify(SyntaxTree);
+    SyntaxToSyntaxMapConverter Printer(NewMap, Classification);
+    Printer.writeToSyntaxMap(SyntaxTree);
+  } else {
+    ide::SyntaxModelContext ModelContext(Impl.SyntaxInfo->getSourceFile());
+
+    SwiftEditorSyntaxWalker SyntaxWalker(
+        NewMap, Impl.SyntaxInfo->getSourceManager(), Consumer,
+        Impl.SyntaxInfo->getBufferID());
+    ModelContext.walk(SyntaxWalker);
+  }
 
   bool SawChanges = true;
   if (Impl.Edited) {
@@ -2034,7 +2159,8 @@ void SwiftLangSupport::editorOpen(StringRef Name, llvm::MemoryBuffer *Buf,
                                   ArrayRef<const char *> Args) {
 
   ImmutableTextSnapshotRef Snapshot = nullptr;
-  const bool BuildSyntaxTree = Consumer.syntaxTreeEnabled();
+  const bool BuildSyntaxTree =
+      Consumer.syntaxTreeEnabled() || Consumer.forceLibSyntaxBasedProcessing();
   auto EditorDoc = EditorDocuments.getByUnresolvedName(Name);
   if (!EditorDoc) {
     EditorDoc = new SwiftEditorDocument(Name, *this);
@@ -2101,7 +2227,9 @@ void SwiftLangSupport::editorReplaceText(StringRef Name,
     Snapshot = EditorDoc->replaceText(Offset, Length, Buf,
                                       Consumer.needsSemanticInfo());
     assert(Snapshot);
-    EditorDoc->parse(Snapshot, *this, Consumer.syntaxTreeEnabled());
+    bool BuildSyntaxTree = Consumer.syntaxTreeEnabled() ||
+                           Consumer.forceLibSyntaxBasedProcessing();
+    EditorDoc->parse(Snapshot, *this, BuildSyntaxTree);
     EditorDoc->readSyntaxInfo(Consumer);
   } else {
     Snapshot = EditorDoc->getLatestSnapshot();

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -94,7 +94,7 @@ public:
 
   void parse(ImmutableTextSnapshotRef Snapshot, SwiftLangSupport &Lang,
              bool BuildSyntaxTree);
-  void readSyntaxInfo(EditorConsumer& consumer);
+  void readSyntaxInfo(EditorConsumer &consumer);
   void readSemanticInfo(ImmutableTextSnapshotRef Snapshot,
                         EditorConsumer& Consumer);
 

--- a/tools/SourceKit/tools/sourcekitd-test/Options.td
+++ b/tools/SourceKit/tools/sourcekitd-test/Options.td
@@ -127,6 +127,9 @@ def cancel_on_subsequent_request : Separate<["-"], "cancel-on-subsequent-request
 def cancel_on_subsequent_request_EQ : Joined<["-"], "cancel-on-subsequent-request=">,
   Alias<cancel_on_subsequent_request>;
 
+def force_libsyntax_based_processing : Flag<["-"], "force-libsyntax-based-processing">,
+  HelpText<"Use libSyntax to process syntactic information">;
+
 def time_request : Flag<["-"], "time-request">,
   HelpText<"Print the time taken to process the request">;
 

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -349,6 +349,10 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
       }
       break;
 
+    case OPT_force_libsyntax_based_processing:
+      ForceLibSyntaxBasedProcessing = true;
+      break;
+
     case OPT_UNKNOWN:
       llvm::errs() << "error: unknown argument: "
                    << InputArg->getAsString(ParsedArgs) << '\n'

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
@@ -107,6 +107,7 @@ struct TestOptions {
   bool timeRequest = false;
   unsigned repeatRequest = 1;
   llvm::Optional<bool> CancelOnSubsequentRequest;
+  bool ForceLibSyntaxBasedProcessing = false;
   bool parseArgs(llvm::ArrayRef<const char *> Args);
   void printHelp(bool ShowHidden) const;
 };

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -647,6 +647,8 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
     sourcekitd_request_dictionary_set_int64(Req, KeyEnableSyntaxMap, true);
     sourcekitd_request_dictionary_set_int64(Req, KeyEnableStructure, false);
     sourcekitd_request_dictionary_set_int64(Req, KeyEnableSyntaxTree, false);
+    sourcekitd_request_dictionary_set_int64(
+        Req, KeyForceLibSyntaxBasedProcessing, true);
     sourcekitd_request_dictionary_set_int64(Req, KeySyntacticOnly, !Opts.UsedSema);
     break;
 
@@ -713,6 +715,8 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
     sourcekitd_request_dictionary_set_int64(Req, KeyLength, Opts.Length);
     sourcekitd_request_dictionary_set_string(Req, KeySourceText,
                                        Opts.ReplaceText.getValue().c_str());
+    sourcekitd_request_dictionary_set_int64(
+        Req, KeyForceLibSyntaxBasedProcessing, true);
     break;
 
   case SourceKitRequest::PrintAnnotations:
@@ -1061,6 +1065,8 @@ static bool handleResponse(sourcekitd_response_t Resp, const TestOptions &Opts,
                                                 EnableSubStructure);
         sourcekitd_request_dictionary_set_int64(EdReq, KeySyntacticOnly,
                                                 !Opts.UsedSema);
+        sourcekitd_request_dictionary_set_int64(
+            EdReq, KeyForceLibSyntaxBasedProcessing, true);
 
         sourcekitd_response_t EdResp = sendRequestSync(EdReq, Opts);
         sourcekitd_response_description_dump_filedesc(EdResp, STDOUT_FILENO);

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -647,8 +647,9 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
     sourcekitd_request_dictionary_set_int64(Req, KeyEnableSyntaxMap, true);
     sourcekitd_request_dictionary_set_int64(Req, KeyEnableStructure, false);
     sourcekitd_request_dictionary_set_int64(Req, KeyEnableSyntaxTree, false);
-    sourcekitd_request_dictionary_set_int64(
-        Req, KeyForceLibSyntaxBasedProcessing, true);
+    sourcekitd_request_dictionary_set_int64(Req,
+                                            KeyForceLibSyntaxBasedProcessing,
+                                            Opts.ForceLibSyntaxBasedProcessing);
     sourcekitd_request_dictionary_set_int64(Req, KeySyntacticOnly, !Opts.UsedSema);
     break;
 
@@ -700,6 +701,9 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
   case SourceKitRequest::Open:
     sourcekitd_request_dictionary_set_uid(Req, KeyRequest, RequestEditorOpen);
     sourcekitd_request_dictionary_set_string(Req, KeyName, SemaName.c_str());
+    sourcekitd_request_dictionary_set_int64(Req,
+                                            KeyForceLibSyntaxBasedProcessing,
+                                            Opts.ForceLibSyntaxBasedProcessing);
     break;
 
   case SourceKitRequest::Close:
@@ -715,8 +719,9 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
     sourcekitd_request_dictionary_set_int64(Req, KeyLength, Opts.Length);
     sourcekitd_request_dictionary_set_string(Req, KeySourceText,
                                        Opts.ReplaceText.getValue().c_str());
-    sourcekitd_request_dictionary_set_int64(
-        Req, KeyForceLibSyntaxBasedProcessing, true);
+    sourcekitd_request_dictionary_set_int64(Req,
+                                            KeyForceLibSyntaxBasedProcessing,
+                                            Opts.ForceLibSyntaxBasedProcessing);
     break;
 
   case SourceKitRequest::PrintAnnotations:
@@ -1066,7 +1071,8 @@ static bool handleResponse(sourcekitd_response_t Resp, const TestOptions &Opts,
         sourcekitd_request_dictionary_set_int64(EdReq, KeySyntacticOnly,
                                                 !Opts.UsedSema);
         sourcekitd_request_dictionary_set_int64(
-            EdReq, KeyForceLibSyntaxBasedProcessing, true);
+            EdReq, KeyForceLibSyntaxBasedProcessing,
+            Opts.ForceLibSyntaxBasedProcessing);
 
         sourcekitd_response_t EdResp = sendRequestSync(EdReq, Opts);
         sourcekitd_response_description_dump_filedesc(EdResp, STDOUT_FILENO);

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -75,6 +75,9 @@ struct SKEditorConsumerOptions {
   bool EnableDiagnostics = false;
   bool EnableSyntaxTree = false;
   bool SyntacticOnly = false;
+  // FIXME: This is just for bootstrapping incremental syntax tree parsing.
+  // Remove it once when we are able to incrementally transfer the syntax tree
+  bool ForceLibSyntaxBasedProcessing = false;
 };
 
 } // anonymous namespace
@@ -435,6 +438,9 @@ void handleRequestImpl(sourcekitd_object_t ReqObj, ResponseReceiver Rec) {
     Req.getInt64(KeyEnableSyntaxTree, EnableSyntaxTree, /*isOptional=*/true);
     int64_t SyntacticOnly = false;
     Req.getInt64(KeySyntacticOnly, SyntacticOnly, /*isOptional=*/true);
+    int64_t ForceLibSyntaxBasedProcessing = false;
+    Req.getInt64(KeyForceLibSyntaxBasedProcessing,
+                 ForceLibSyntaxBasedProcessing, /*isOptional=*/true);
 
     SKEditorConsumerOptions Opts;
     Opts.EnableSyntaxMap = EnableSyntaxMap;
@@ -442,6 +448,7 @@ void handleRequestImpl(sourcekitd_object_t ReqObj, ResponseReceiver Rec) {
     Opts.EnableDiagnostics = EnableDiagnostics;
     Opts.EnableSyntaxTree = EnableSyntaxTree;
     Opts.SyntacticOnly = SyntacticOnly;
+    Opts.ForceLibSyntaxBasedProcessing = ForceLibSyntaxBasedProcessing;
     return Rec(editorOpen(*Name, InputBuf.get(), Opts, Args));
   }
   if (ReqUID == RequestEditorClose) {
@@ -476,6 +483,10 @@ void handleRequestImpl(sourcekitd_object_t ReqObj, ResponseReceiver Rec) {
     Req.getInt64(KeyEnableSyntaxTree, EnableSyntaxTree, /*isOptional=*/true);
     int64_t SyntacticOnly = false;
     Req.getInt64(KeySyntacticOnly, SyntacticOnly, /*isOptional=*/true);
+    int64_t ForceLibSyntaxBasedProcessing = false;
+    Req.getInt64(KeyForceLibSyntaxBasedProcessing,
+                 ForceLibSyntaxBasedProcessing,
+                 /*isOptional=*/true);
 
     SKEditorConsumerOptions Opts;
     Opts.EnableSyntaxMap = EnableSyntaxMap;
@@ -483,6 +494,7 @@ void handleRequestImpl(sourcekitd_object_t ReqObj, ResponseReceiver Rec) {
     Opts.EnableDiagnostics = EnableDiagnostics;
     Opts.EnableSyntaxTree = EnableSyntaxTree;
     Opts.SyntacticOnly = SyntacticOnly;
+    Opts.ForceLibSyntaxBasedProcessing = ForceLibSyntaxBasedProcessing;
 
     return Rec(editorReplaceText(*Name, InputBuf.get(), Offset, Length, Opts));
   }
@@ -2063,6 +2075,10 @@ public:
   void finished() override {
     if (RespReceiver)
       RespReceiver(createResponse());
+  }
+
+  virtual bool forceLibSyntaxBasedProcessing() override {
+    return Opts.ForceLibSyntaxBasedProcessing;
   }
 };
 

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -39,6 +39,7 @@
 #include "swift/IDE/Utils.h"
 #include "swift/Index/Index.h"
 #include "swift/Sema/IDETypeChecking.h"
+#include "swift/Syntax/SyntaxClassifier.h"
 #include "swift/Markup/Markup.h"
 #include "swift/Config.h"
 #include "clang/APINotes/APINotesReader.h"
@@ -425,6 +426,12 @@ Playground("playground",
            llvm::cl::desc("Whether coloring in playground"),
            llvm::cl::cat(Category),
            llvm::cl::init(false));
+
+static llvm::cl::opt<bool>
+SyntaxTreeColoring("force-libsyntax-based-processing",
+                   llvm::cl::desc("Perform syntax coloring using libSyntax"),
+                   llvm::cl::cat(Category),
+                   llvm::cl::init(false));
 
 // AST printing options.
 
@@ -950,6 +957,125 @@ public:
   }
 };
 
+class ColoredSyntaxTreePrinter : public SyntaxVisitor {
+  llvm::raw_ostream &OS;
+
+  std::map<unsigned, SyntaxClassification> TokenClassifications;
+
+  /// The name of the tag that is currently open
+  StringRef CurrentTag;
+
+  // Don't print the next newline in trivia if this flag is set.
+  // Used to skip the newline after a CHECK line
+  bool SkipNextNewline = false;
+
+public:
+  ColoredSyntaxTreePrinter(
+      llvm::raw_ostream &OS,
+      std::map<unsigned, SyntaxClassification> TokenClassifications)
+      : OS(OS), TokenClassifications(TokenClassifications) {}
+
+private:
+  void print(Trivia Trivia) {
+    for (auto TriviaPiece : Trivia) {
+      print(TriviaPiece);
+    }
+  }
+
+  /// Closes the current tag if it is different from the previous one and opens
+  /// a tag with the specified ID.
+  void recordCurrentTag(StringRef Id) {
+    if (CurrentTag != Id) {
+      if (!CurrentTag.empty()) {
+        OS << "</" << CurrentTag << ">";
+      }
+      if (!Id.empty()) {
+        OS << "<" << Id << ">";
+      }
+    }
+    CurrentTag = Id;
+  }
+
+  void print(TriviaPiece TriviaPiece) {
+    StringRef Id;
+    switch (TriviaPiece.getKind()) {
+    case TriviaKind::Space:
+    case TriviaKind::Tab:
+    case TriviaKind::VerticalTab:
+    case TriviaKind::Formfeed:
+      Id = "";
+      break;
+    case TriviaKind::Newline:
+    case TriviaKind::CarriageReturn:
+    case TriviaKind::CarriageReturnLineFeed:
+      if (SkipNextNewline) {
+        SkipNextNewline = false;
+        return;
+      }
+      Id = "";
+      break;
+    case swift::syntax::TriviaKind::Backtick:
+      Id = "";
+      break;
+    case swift::syntax::TriviaKind::LineComment:
+      // Don't print CHECK lines
+      if (TriviaPiece.getText().contains("// CHECK")) {
+        SkipNextNewline = true;
+        return;
+      }
+      Id = "comment-line";
+      break;
+    case TriviaKind::BlockComment: Id = "comment-block"; break;
+    case TriviaKind::DocLineComment: Id = "doc-comment-line"; break;
+    case TriviaKind::DocBlockComment: Id = "doc-comment-block"; break;
+    case TriviaKind::GarbageText: Id = ""; break;
+    }
+    recordCurrentTag(Id);
+    TriviaPiece.print(OS);
+  }
+
+  StringRef
+  getTagForSyntaxClassification(SyntaxClassification Classification) const {
+    switch (Classification) {
+    case SyntaxClassification::None: return "";
+    case SyntaxClassification::Keyword: return "kw";
+    case SyntaxClassification::Identifier: return "";
+    case SyntaxClassification::DollarIdentifier: return "dollar";
+    case SyntaxClassification::IntegerLiteral: return "int";
+    case SyntaxClassification::FloatingLiteral: return "float";
+    case SyntaxClassification::StringLiteral: return "str";
+    case SyntaxClassification::StringInterpolationAnchor: return "anchor";
+    case SyntaxClassification::TypeIdentifier: return "type";
+    case SyntaxClassification::BuildConfigKeyword: return "#kw";
+    case SyntaxClassification::BuildConfigId: return "#id";
+    case SyntaxClassification::PoundDirectiveKeyword: return "#kw";
+    case SyntaxClassification::Attribute: return "attr-builtin";
+    case SyntaxClassification::EditorPlaceholder: return "placeholder";
+    case SyntaxClassification::ObjectLiteral: return "object-literal";
+    }
+  }
+
+public:
+  virtual void visit(TokenSyntax Token) override {
+    if (Token.isMissing())
+      return;
+
+    print(Token.getLeadingTrivia());
+
+    SyntaxClassification Classification = TokenClassifications[Token.getId()];
+    recordCurrentTag(getTagForSyntaxClassification(Classification));
+    OS << Token.getText();
+
+    print(Token.getTrailingTrivia());
+  }
+
+  void print(Syntax Node) {
+    Node.accept(*this);
+    // Emit the last closing tag
+    recordCurrentTag("");
+  }
+};
+
 } // end anonymous namespace
 
 static int doSyntaxColoring(const CompilerInvocation &InitInvok,
@@ -984,11 +1110,18 @@ static int doSyntaxColoring(const CompilerInvocation &InitInvok,
       break;
   }
   assert(SF && "no source file?");
-  ide::SyntaxModelContext ColorContext(*SF);
-  PrintSyntaxColorWalker ColorWalker(CI.getSourceMgr(), BufID, llvm::outs(),
-                                     TerminalOutput);
-  ColorContext.walk(ColorWalker);
-  ColorWalker.finished();
+  if (options::SyntaxTreeColoring) {
+    SyntaxClassifier Classifier;
+    auto Classification = Classifier.classify(SF->getSyntaxRoot());
+    ColoredSyntaxTreePrinter Printer(llvm::outs(), Classification);
+    Printer.print(SF->getSyntaxRoot());
+  } else {
+    ide::SyntaxModelContext ColorContext(*SF);
+    PrintSyntaxColorWalker ColorWalker(CI.getSourceMgr(), BufID, llvm::outs(),
+                                       TerminalOutput);
+    ColorContext.walk(ColorWalker);
+    ColorWalker.finished();
+  }
 
   return 0;
 }

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -90,6 +90,7 @@ class NullEditorConsumer : public EditorConsumer {
   bool handleSourceText(StringRef Text) override { return false; }
   bool handleSerializedSyntaxTree(StringRef Text) override { return false; }
   bool syntaxTreeEnabled() override { return false; }
+  bool forceLibSyntaxBasedProcessing() override { return false; }
 
 public:
   bool needsSema = false;

--- a/unittests/SourceKit/SwiftLang/EditingTest.cpp
+++ b/unittests/SourceKit/SwiftLang/EditingTest.cpp
@@ -99,6 +99,7 @@ private:
   bool handleSourceText(StringRef Text) override { return false; }
   bool handleSerializedSyntaxTree(StringRef Text) override { return false; }
   bool syntaxTreeEnabled() override { return false; }
+  bool forceLibSyntaxBasedProcessing() override { return false; }
 };
 
 struct DocUpdateMutexState {

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -48,6 +48,7 @@ UID_KEYS = [
     KEY('SourceFile', 'key.sourcefile'),
     KEY('SerializedSyntaxTree', 'key.serialized_syntax_tree'),
     KEY('SourceText', 'key.sourcetext'),
+    KEY('ForceLibSyntaxBasedProcessing', 'key.forcelibsyntaxbasedprocessing'),
     KEY('EnableSyntaxMap', 'key.enablesyntaxmap'),
     KEY('EnableSyntaxTree', 'key.enablesyntaxtree'),
     KEY('EnableStructure', 'key.enablesubstructure'),

--- a/utils/gyb_syntax_support/AttributeNodes.py
+++ b/utils/gyb_syntax_support/AttributeNodes.py
@@ -25,7 +25,7 @@ ATTRIBUTE_NODES = [
          children=[
              Child('AtSignToken', kind='AtSignToken', 
                    description='The `@` sign.'),
-             Child('AttributeName', kind='Token', 
+             Child('AttributeName', kind='Token', classification='Attribute',
                    description='The name of the attribute.'),
              Child('LeftParen', kind='LeftParenToken', is_optional=True,
                    description='''

--- a/utils/gyb_syntax_support/AvailabilityNodes.py
+++ b/utils/gyb_syntax_support/AvailabilityNodes.py
@@ -63,11 +63,13 @@ AVAILABILITY_NODES = [
          certain platform to a version, e.g. `iOS 10` or `swift 3.4`.
          ''',
          children=[
-             Child('Platform', kind='IdentifierToken', description='''
-             The name of the OS on which the availability should be \
-             restricted or 'swift' if the availability should be restricted \
-             based on a Swift version.
-             '''),
+             Child('Platform', kind='IdentifierToken', 
+                   classification='Keyword',
+                   description='''
+                   The name of the OS on which the availability should be \
+                   restricted or 'swift' if the availability should be \
+                   restricted based on a Swift version.
+                   '''),
              Child('Version', kind='VersionTuple'),
          ]),
 

--- a/utils/gyb_syntax_support/Child.py
+++ b/utils/gyb_syntax_support/Child.py
@@ -9,13 +9,23 @@ class Child(object):
     restricted subset of acceptable kinds or texts.
     """
     def __init__(self, name, kind, description=None, is_optional=False,
-                 token_choices=None, text_choices=None, node_choices=None):
+                 token_choices=None, text_choices=None, node_choices=None,
+                 classification=None, force_classification=False):
+        """
+        If a classification is passed, it specifies the color identifiers in 
+        that subtree should inherit for syntax coloring. Must be a member of 
+        SyntaxClassification in SyntaxClassifier.h.gyb
+        If force_classification is also set to true, all child nodes (not only
+        identifiers) inherit the syntax classification.
+        """
         self.name = name
         self.swift_name = lowercase_first_word(name)
         self.syntax_kind = kind
         self.description = description
         self.swift_syntax_kind = lowercase_first_word(self.syntax_kind)
         self.type_name = kind_to_type(self.syntax_kind)
+        self.classification = classification
+        self.force_classification = force_classification
 
         # If the child has "token" anywhere in the kind, it's considered
         # a token node. Grab the existing reference to that token from the

--- a/utils/gyb_syntax_support/DeclNodes.py
+++ b/utils/gyb_syntax_support/DeclNodes.py
@@ -86,13 +86,14 @@ DECL_NODES = [
     #    ('#if' | '#elseif' | '#else') expr? (stmt-list | switch-case-list)
     Node('IfConfigClause', kind='Syntax',
          children=[
-             Child('PoundKeyword', kind='Token',
+             Child('PoundKeyword', kind='Token', 
+                   classification='BuildConfigId',
                    token_choices=[
                        'PoundIfToken',
                        'PoundElseifToken',
                        'PoundElseToken',
                    ]),
-             Child('Condition', kind='Expr',
+             Child('Condition', kind='Expr', classification='BuildConfigId',
                    is_optional=True),
              Child('Elements', kind='Syntax',
                    node_choices=[
@@ -110,7 +111,8 @@ DECL_NODES = [
     Node('IfConfigDecl', kind='Decl',
          children=[
              Child('Clauses', kind='IfConfigClauseList'),
-             Child('PoundEndif', kind='PoundEndifToken'),
+             Child('PoundEndif', kind='PoundEndifToken', 
+                   classification='BuildConfigId'),
          ]),
 
     Node('PoundErrorDecl', kind='Decl',
@@ -155,7 +157,7 @@ DECL_NODES = [
 
     Node('DeclModifier', kind='Syntax',
          children=[
-             Child('Name', kind='Token',
+             Child('Name', kind='Token', classification='Attribute',
                    text_choices=[
                        'class', 'convenience', 'dynamic', 'final', 'infix',
                        'lazy', 'optional', 'override', 'postfix', 'prefix',
@@ -644,6 +646,7 @@ DECL_NODES = [
                    The attributes applied to the 'operator' declaration.
                    '''),
              Child('Modifiers', kind='ModifierList', is_optional=True,
+                   classification='Attribute',
                    description='''
                    The declaration modifiers applied to the 'operator'
                    declaration.
@@ -723,7 +726,8 @@ DECL_NODES = [
          groups.
          ''',
          children=[
-             Child('HigherThanOrLowerThan', kind='IdentifierToken',
+             Child('HigherThanOrLowerThan', kind='IdentifierToken', 
+                   classification='Keyword',
                    text_choices=[
                       'higherThan', 'lowerThan',
                    ],
@@ -782,8 +786,8 @@ DECL_NODES = [
          are grouped together in the absence of grouping parentheses.
          ''',
          children=[
-             Child('AssociativityKeyword', kind='IdentifierToken',
-                   text_choices=['associativity']),
+             Child('AssociativityKeyword', kind='IdentifierToken', 
+                   classification='Keyword', text_choices=['associativity']),
              Child('Colon', kind='ColonToken'),
              Child('Value', kind='IdentifierToken',
                    text_choices=['left', 'right', 'none'],

--- a/utils/gyb_syntax_support/ExprNodes.py
+++ b/utils/gyb_syntax_support/ExprNodes.py
@@ -473,7 +473,9 @@ EXPR_NODES = [
          traits=['Parenthesized'],
          children=[
              Child('Backslash', kind='BackslashToken'),
-             Child('LeftParen', kind='LeftParenToken'),
+             Child('LeftParen', kind='LeftParenToken', 
+                   classification='StringInterpolationAnchor',
+                   force_classification=True),
              Child('Expression', kind='Expr'),
              Child('RightParen', kind='StringInterpolationAnchorToken'),
          ]),

--- a/utils/gyb_syntax_support/TypeNodes.py
+++ b/utils/gyb_syntax_support/TypeNodes.py
@@ -5,7 +5,7 @@ TYPE_NODES = [
     # simple-type-identifier -> identifier generic-argument-clause?
     Node('SimpleTypeIdentifier', kind='Type',
          children=[
-             Child('Name', kind='Token',
+             Child('Name', kind='Token', classification='TypeIdentifier',
                    token_choices=[
                        'IdentifierToken',
                        'CapitalSelfToken',
@@ -24,7 +24,7 @@ TYPE_NODES = [
                        'PeriodToken',
                        'PrefixPeriodToken',
                    ]),
-             Child('Name', kind='Token',
+             Child('Name', kind='Token', classification='TypeIdentifier',
                    token_choices=[
                        'IdentifierToken',
                        'CapitalSelfToken',

--- a/utils/incrparse_test_util.py
+++ b/utils/incrparse_test_util.py
@@ -196,6 +196,10 @@ def main():
         test_case + '.incr.swift.serialized.json'
     serialized_post_edit_filename = post_edit_file.name + '.serialized.json'
 
+    serialized_incr_no_ids_filename = serialized_incr_filename + '.noids.json'
+    serialized_post_edit_no_ids_filename = serialized_post_edit_filename + \
+        '.noids.json'
+
     try:
         # Serialise the pre-edit syntax tree
         run_command(
@@ -232,6 +236,20 @@ def main():
             ['-output-filename', serialized_incr_filename] +
             print_visual_reuse_info_args)
 
+        with open(serialized_incr_no_ids_filename, 'w+') as file:
+            subprocess.check_call(
+                ['grep'] + 
+                ['-v'] +
+                ['-e', '^ *"id": [0-9]*$'] +
+                [serialized_incr_filename], stdout=file)
+
+        with open(serialized_post_edit_no_ids_filename, 'w+') as file:
+            subprocess.check_call(
+                ['grep'] + 
+                ['-v'] +
+                ['-e', '^ *"id": [0-9]*$'] +
+                [serialized_post_edit_filename], stdout=file)
+
         if print_visual_reuse_info:
             print(incr_parse_output)
             exit(0)
@@ -247,8 +265,8 @@ def main():
         run_command(
             [
                 'diff', '-u',
-                serialized_post_edit_filename,
-                serialized_incr_filename
+                serialized_incr_no_ids_filename,
+                serialized_post_edit_no_ids_filename
             ])
     except subprocess.CalledProcessError as e:
         print('Test case "%s" of %s FAILed' % (test_case, test_file.name), 


### PR DESCRIPTION
This PR adds a way to perform syntax colouring based on the syntax tree instead of the collected tokens and then converts that syntax colouring classification to the old syntax map. As a next step, we will be able to use the incrementally created syntax map to incrementally performance syntax colouring.

This is just a temporary bootstrapping step. In the future, we want to incrementally transfer the syntax tree and perform the classification for syntax colouring on the Swift side.

The classifier is currently not able to syntax colour semantics inside comments like markers or URLs.