### PR TITLE
Make upperBound != 0 a precondition for RNG.next(upperBound:)

### DIFF
--- a/stdlib/public/core/Random.swift
+++ b/stdlib/public/core/Random.swift
@@ -90,13 +90,14 @@ extension RandomNumberGenerator {
   /// Returns a random value that is less than the given upper bound.
   ///
   /// - Parameter upperBound: The upper bound for the randomly generated value.
+  ///   Must be non-zero.
   /// - Returns: A random value of `T` in the range `0..<upperBound`. Every
   ///   value in the range `0..<upperBound` is equally likely to be returned.
   @inlinable
   public mutating func next<T: FixedWidthInteger & UnsignedInteger>(
     upperBound: T
   ) -> T {
-    guard upperBound != 0 else { return 0 }
+    _precondition(upperBound != 0, "upperBound cannot be zero.")
     let tmp = (T.max % upperBound) + 1
     let range = tmp == upperBound ? 0 : tmp
     var random: T = 0


### PR DESCRIPTION
The function's definition is "Returns a random value that is less than the given upper bound," which cannot possibly be satisfied with `upperBound == 0`; previously the function returned zero, which was a bug.

Resolves [SR-8143](https://bugs.swift.org/browse/SR-8143).