### PR TITLE
Use @inlinable instead of @_inlineable in TensorFlow module.

### DIFF
--- a/stdlib/public/TensorFlow/DataTypes.swift
+++ b/stdlib/public/TensorFlow/DataTypes.swift
@@ -320,7 +320,7 @@ extension BFloat16 : AccelerableByTensorFlow {
   public static func _getScalar(_ handle: TensorHandle<BFloat16>) -> BFloat16? {
     return _TFGetScalarImpl(handle)
   }
-  @_inlineable @inline(__always)
+  @inlinable @inline(__always)
   public static func _makeScalarTensor(
     _ scalar: BFloat16
   ) -> TensorHandle<BFloat16> {

--- a/stdlib/public/TensorFlow/Utilities.swift
+++ b/stdlib/public/TensorFlow/Utilities.swift
@@ -276,13 +276,13 @@ public func _hostOp<Scalar>(_ x: Tensor<Scalar>) {
 ///
 /// TODO: Remove these helper APIs, when we have a better shape
 /// inference/propagation design.
-@_inlineable @inline(__always)
+@inlinable @inline(__always)
 public func _scalarTensorWithShape<T>(_ x: Tensor<T>) -> Tensor<T> {
   let ret : Tensor<T> = #tfop("Identity", x, __shapes: [TensorShape()])
   return ret
 }
 
-@_inlineable @inline(__always)
+@inlinable @inline(__always)
 public func _addScalarTensorsWithShape<T>(_ x: Tensor<T>, _ y: Tensor<T>
 ) -> Tensor<T> {
   let ret : Tensor<T> = #tfop("Add", x, y, __shapes: [TensorShape()])


### PR DESCRIPTION
No more usages of `@_inlineable`/`@_versioned` exist in the TensorFlow module.