### PR TITLE
[4.2] Make upperBound != 0 a precondition for RNG.next(upperBound:) (#17627)

### DIFF
--- a/stdlib/public/core/Random.swift
+++ b/stdlib/public/core/Random.swift
@@ -89,13 +89,14 @@ extension RandomNumberGenerator {
   /// Returns a random value that is less than the given upper bound.
   ///
   /// - Parameter upperBound: The upper bound for the randomly generated value.
+  ///   Must be non-zero.
   /// - Returns: A random value of `T` in the range `0..<upperBound`. Every
   ///   value in the range `0..<upperBound` is equally likely to be returned.
   @inlinable
   public mutating func next<T: FixedWidthInteger & UnsignedInteger>(
     upperBound: T
   ) -> T {
-    guard upperBound != 0 else { return 0 }
+    _precondition(upperBound != 0, "upperBound cannot be zero.")
     let tmp = (T.max % upperBound) + 1
     let range = tmp == upperBound ? 0 : tmp
     var random: T = 0


### PR DESCRIPTION
The function's definition is "Returns a random value that is less than the given upper bound," which cannot possibly be satisfied with upperBound == 0; previously the function returned zero, which was a bug.

Resolves [SR-8143](https://bugs.swift.org/browse/SR-8143) and <rdar://problem/41735302>.

Explanation: Without this change, `RNG.next(upperBound: bound)` can return a value that does not satisfy the invariant `bound < upperBound`.
Scope: Minor, but we want to be able to guarantee this invariant holds.
Issue #: https://bugs.swift.org/browse/SR-8143
Risk: Very low.
Testing: Standard regression tests. Random is a new feature, and this only fixes an error case.
Reviewer: @lorentey