### PR TITLE
[4.2] Ensure that apply expressions have their "throws" bit set

### DIFF
--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -134,12 +134,6 @@ ProtocolConformanceRef::getTypeWitnessByName(Type type,
                                              ProtocolConformanceRef conformance,
                                              Identifier name,
                                              LazyResolver *resolver) {
-  // For an archetype, retrieve the nested type with the appropriate
-  // name. There are no conformance tables.
-  if (auto archetype = type->getAs<ArchetypeType>()) {
-    return archetype->getNestedType(name);
-  }
-
   // Find the named requirement.
   AssociatedTypeDecl *assocType = nullptr;
   auto members = conformance.getRequirement()->lookupDirect(name);
@@ -153,8 +147,15 @@ ProtocolConformanceRef::getTypeWitnessByName(Type type,
   if (!assocType)
     return nullptr;
 
-  if (conformance.isAbstract())
+  if (conformance.isAbstract()) {
+    // For an archetype, retrieve the nested type with the appropriate
+    // name. There are no conformance tables.
+    if (auto archetype = type->getAs<ArchetypeType>()) {
+      return archetype->getNestedType(name);
+    }
+
     return DependentMemberType::get(type, assocType);
+  }
 
   auto concrete = conformance.getConcrete();
   if (!concrete->hasTypeWitness(assocType, resolver)) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1188,6 +1188,7 @@ createDefaultConstructor(ClangImporter::Implementation &Impl,
 
   auto call = CallExpr::createImplicit(context, zeroInitializerRef, {}, {});
   call->setType(selfType);
+  call->setThrows(false);
 
   auto assign = new (context) AssignExpr(lhs, SourceLoc(), call,
                                          /*implicit*/ true);

--- a/lib/Sema/TypeCheckError.cpp
+++ b/lib/Sema/TypeCheckError.cpp
@@ -134,6 +134,9 @@ public:
         fn = conversion->getSubExpr()->getValueProvidingExpr();
       } else if (auto conversion = dyn_cast<BindOptionalExpr>(fn)) {
         fn = conversion->getSubExpr()->getValueProvidingExpr();
+      // Look through optional injections
+      } else if (auto injection = dyn_cast<InjectIntoOptionalExpr>(fn)) {
+        fn = injection->getSubExpr()->getValueProvidingExpr();
       // Look through function conversions.
       } else if (auto conversion = dyn_cast<FunctionConversionExpr>(fn)) {
         fn = conversion->getSubExpr()->getValueProvidingExpr();

--- a/test/Constraints/generic_super_constraint.swift
+++ b/test/Constraints/generic_super_constraint.swift
@@ -24,4 +24,4 @@ class IntegerClass : ExpressibleByIntegerLiteral, Equatable {
   static func ==(lhs: IntegerClass, rhs: IntegerClass) -> Bool { return true }
 }
 
-func foo<T: IntegerClass>(_ num: T) { let x =  num != 0 }
+func foo<T: IntegerClass>(_ num: T) { let _ =  num != 0 }

--- a/test/Constraints/generic_super_constraint.swift
+++ b/test/Constraints/generic_super_constraint.swift
@@ -17,3 +17,11 @@ func bar<T, U>(_ x: U, y: T) -> (Derived, Int) where U: Base<T>, U: Derived {
   // expected-error@+1{{cannot convert return expression}}
   return (x, y)
 }
+
+// SR-7551 captures a crash on this code.
+class IntegerClass : ExpressibleByIntegerLiteral, Equatable {
+  required init(integerLiteral value: Int) { }
+  static func ==(lhs: IntegerClass, rhs: IntegerClass) -> Bool { return true }
+}
+
+func foo<T: IntegerClass>(_ num: T) { let x =  num != 0 }

--- a/validation-test/compiler_crashers_2_fixed/0165-sr5427.swift
+++ b/validation-test/compiler_crashers_2_fixed/0165-sr5427.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift
+
+// Used to crash with: apply expression is not marked as throwing or
+// non-throwing
+struct SR5427 : Error {}
+func sr5427(op: (() throws -> Void)?) rethrows { try op?() }
+try? sr5427(op: { throw SR5427() })


### PR DESCRIPTION
**Explanation:** Swift's AST requires each application expression (e.g., a function call) to be annotated as to whether it can throw. When this invariant does not hold, we can get incorrect behavior (e.g., accepting invalid code) and compiler crashes in later compilation phases. Fix three related sources of the "apply expression is not marked as throwing or non-throwing" AST verifier assertion that tracks this information.
**Scope:** Affects checking that "try" is used properly. Many Swift projects use error handling to some degree, but most likely code that would be affected by this change would already have crashed the compiler.
**Risk:** Very low; the cases that have changed would manifest as assertion failures in the compiler (when assertions are enabled) or crashes later on in the compilation pipeline. There is some small risk that we could start rejecting code that was previously accepted (but shouldn't have been) and that somehow didn't crash the compiler.
**Testing:** Compiler regression tests (including a few new tests) and built a few projects that hit this issue.
**Reviewer:** @huonw and @rjmccall 
**SR / Radar:** rdar://problem/39860617, [SR-5427](https://bugs.swift.org/browse/SR-5427), [SR-7551](https://bugs.swift.org/browse/SR-7551)