### PR TITLE
 Introduce Import Resolution as a Frontend Action

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -108,15 +108,17 @@ NOTE(note_valid_swift_versions, none,
      "valid arguments to '-swift-version' are %0", (StringRef))
 
 ERROR(error_mode_cannot_emit_dependencies,none,
-  "this mode does not support emitting dependency files", ())
+      "this mode does not support emitting dependency files", ())
+ERROR(error_mode_cannot_emit_reference_dependencies,none,
+      "this mode does not support emitting reference dependency files", ())
 ERROR(error_mode_cannot_emit_header,none,
-  "this mode does not support emitting Objective-C headers", ())
+      "this mode does not support emitting Objective-C headers", ())
 ERROR(error_mode_cannot_emit_loaded_module_trace,none,
-  "this mode does not support emitting the loaded module trace", ())
+      "this mode does not support emitting the loaded module trace", ())
 ERROR(error_mode_cannot_emit_module,none,
-  "this mode does not support emitting modules", ())
+      "this mode does not support emitting modules", ())
 ERROR(error_mode_cannot_emit_module_doc,none,
-  "this mode does not support emitting module documentation files", ())
+      "this mode does not support emitting module documentation files", ())
 
 WARNING(emit_reference_dependencies_without_primary_file,none,
   "ignoring -emit-reference-dependencies (requires -primary-file)", ())

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -539,9 +539,13 @@ public:
 
   /// Parses the input file but does no type-checking or module imports.
   /// Note that this only supports parsing an invocation with a single file.
-  ///
-  ///
   void performParseOnly(bool EvaluateConditionals = false);
+
+  /// Parses and performs name binding on all input files.
+  ///
+  /// Like a parse-only invocation, a single file is required. Unlike a
+  /// parse-only invocation, module imports will be processed.
+  void performParseAndNameBindingOnly();
 
 private:
   SourceFile *
@@ -581,7 +585,9 @@ private:
 
   void addMainFileToModule(const ImplicitImports &implicitImports);
 
-  void parseAndCheckTypes(const ImplicitImports &implicitImports);
+  void performSemaUpTo(SourceFile::ASTStage_t LimitStage);
+  void parseAndCheckTypesUpTo(const ImplicitImports &implicitImports,
+                              SourceFile::ASTStage_t LimitStage);
 
   void parseLibraryFile(unsigned BufferID,
                         const ImplicitImports &implicitImports,
@@ -600,9 +606,10 @@ private:
 
   void forEachFileToTypeCheck(llvm::function_ref<void(SourceFile &)> fn);
 
-  void parseAndTypeCheckMainFile(PersistentParserState &PersistentState,
-                                 DelayedParsingCallbacks *DelayedParseCB,
-                                 OptionSet<TypeCheckingFlags> TypeCheckOptions);
+  void parseAndTypeCheckMainFileUpTo(SourceFile::ASTStage_t LimitStage,
+                                     PersistentParserState &PersistentState,
+                                     DelayedParsingCallbacks *DelayedParseCB,
+                                     OptionSet<TypeCheckingFlags> TypeCheckOptions);
 
   void finishTypeChecking(OptionSet<TypeCheckingFlags> TypeCheckOptions);
 

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -545,7 +545,7 @@ public:
   ///
   /// Like a parse-only invocation, a single file is required. Unlike a
   /// parse-only invocation, module imports will be processed.
-  void performParseAndNameBindingOnly();
+  void performParseAndResolveImportsOnly();
 
 private:
   SourceFile *

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -296,6 +296,7 @@ public:
 
 private:
   static bool canActionEmitDependencies(ActionType);
+  static bool canActionEmitReferenceDependencies(ActionType);
   static bool canActionEmitObjCHeader(ActionType);
   static bool canActionEmitLoadedModuleTrace(ActionType);
   static bool canActionEmitModule(ActionType);

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -105,6 +105,7 @@ public:
   enum class ActionType {
     NoneAction,        ///< No specific action
     Parse,             ///< Parse only
+    NameBind,          ///< Parse and perform name-binding only
     Typecheck,         ///< Parse and type-check only
     DumpParse,         ///< Parse only and dump AST
     DumpInterfaceHash, ///< Parse and dump the interface token hash.

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -105,7 +105,7 @@ public:
   enum class ActionType {
     NoneAction,        ///< No specific action
     Parse,             ///< Parse only
-    NameBind,          ///< Parse and perform name-binding only
+    ResolveImports,    ///< Parse and resolve imports only
     Typecheck,         ///< Parse and type-check only
     DumpParse,         ///< Parse only and dump AST
     DumpInterfaceHash, ///< Parse and dump the interface token hash.

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -637,6 +637,9 @@ def fixit_all : Flag<["-"], "fixit-all">,
 def parse: Flag<["-"], "parse">,
   HelpText<"Parse input file(s)">, ModeOpt,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
+def namebind : Flag<["-"], "name-bind">,
+  HelpText<"Parse and perform name binding on input file(s)">, ModeOpt,
+  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
 def typecheck : Flag<["-"], "typecheck">,
   HelpText<"Parse and type-check input file(s)">, ModeOpt,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -637,8 +637,8 @@ def fixit_all : Flag<["-"], "fixit-all">,
 def parse: Flag<["-"], "parse">,
   HelpText<"Parse input file(s)">, ModeOpt,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
-def namebind : Flag<["-"], "name-bind">,
-  HelpText<"Parse and perform name binding on input file(s)">, ModeOpt,
+def resolve_imports : Flag<["-"], "resolve-imports">,
+  HelpText<"Parse and resolve imports in input file(s)">, ModeOpt,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
 def typecheck : Flag<["-"], "typecheck">,
   HelpText<"Parse and type-check input file(s)">, ModeOpt,

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1370,7 +1370,7 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
       OI.LinkAction = LinkKind::None;
       break;
     case options::OPT_parse:
-    case options::OPT_namebind:
+    case options::OPT_resolve_imports:
     case options::OPT_typecheck:
     case options::OPT_dump_parse:
     case options::OPT_dump_ast:

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1370,6 +1370,7 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
       OI.LinkAction = LinkKind::None;
       break;
     case options::OPT_parse:
+    case options::OPT_namebind:
     case options::OPT_typecheck:
     case options::OPT_dump_parse:
     case options::OPT_dump_ast:

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -322,8 +322,8 @@ ArgsToFrontendOptionsConverter::determineRequestedAction(const ArgList &args) {
     return FrontendOptions::ActionType::EmitImportedModules;
   if (Opt.matches(OPT_parse))
     return FrontendOptions::ActionType::Parse;
-  if (Opt.matches(OPT_namebind))
-    return FrontendOptions::ActionType::NameBind;
+  if (Opt.matches(OPT_resolve_imports))
+    return FrontendOptions::ActionType::ResolveImports;
   if (Opt.matches(OPT_typecheck))
     return FrontendOptions::ActionType::Typecheck;
   if (Opt.matches(OPT_dump_parse))

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -322,6 +322,8 @@ ArgsToFrontendOptionsConverter::determineRequestedAction(const ArgList &args) {
     return FrontendOptions::ActionType::EmitImportedModules;
   if (Opt.matches(OPT_parse))
     return FrontendOptions::ActionType::Parse;
+  if (Opt.matches(OPT_namebind))
+    return FrontendOptions::ActionType::NameBind;
   if (Opt.matches(OPT_typecheck))
     return FrontendOptions::ActionType::Typecheck;
   if (Opt.matches(OPT_dump_parse))
@@ -465,6 +467,12 @@ bool ArgsToFrontendOptionsConverter::checkUnusedSupplementaryOutputPaths()
   if (!FrontendOptions::canActionEmitDependencies(Opts.RequestedAction) &&
       Opts.InputsAndOutputs.hasDependenciesPath()) {
     Diags.diagnose(SourceLoc(), diag::error_mode_cannot_emit_dependencies);
+    return true;
+  }
+  if (!FrontendOptions::canActionEmitReferenceDependencies(Opts.RequestedAction)
+      && Opts.InputsAndOutputs.hasReferenceDependenciesPath()) {
+    Diags.diagnose(SourceLoc(),
+                   diag::error_mode_cannot_emit_reference_dependencies);
     return true;
   }
   if (!FrontendOptions::canActionEmitObjCHeader(Opts.RequestedAction) &&

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -425,7 +425,21 @@ shouldImplicityImportSwiftOnoneSupportModule(CompilerInvocation &Invocation) {
   return Invocation.getFrontendOptions().isCreatingSIL();
 }
 
+void CompilerInstance::performParseAndNameBindingOnly() {
+  performSemaUpTo(SourceFile::NameBound);
+}
+
 void CompilerInstance::performSema() {
+  performSemaUpTo(SourceFile::TypeChecked);
+}
+
+void CompilerInstance::performSemaUpTo(SourceFile::ASTStage_t LimitStage) {
+  // FIXME: A lot of the logic in `performParseOnly` is a stripped-down version
+  // of the logic in `performSemaUpTo`.  We should try to unify them over time.
+  if (LimitStage <= SourceFile::Parsed) {
+    return performParseOnly();
+  }
+
   FrontendStatsTracer tracer(Context->Stats, "perform-sema");
   Context->LoadedModules[MainModule->getName()] = getMainModule();
 
@@ -457,8 +471,9 @@ void CompilerInstance::performSema() {
   if (MainBufferID != NO_SUCH_BUFFER)
     addMainFileToModule(implicitImports);
 
-  parseAndCheckTypes(implicitImports);
+  parseAndCheckTypesUpTo(implicitImports, LimitStage);
 }
+
 
 CompilerInstance::ImplicitImports::ImplicitImports(CompilerInstance &compiler) {
   kind = compiler.Invocation.getImplicitModuleImportKind();
@@ -575,8 +590,8 @@ void CompilerInstance::addMainFileToModule(
   addAdditionalInitialImportsTo(MainFile, implicitImports);
 }
 
-void CompilerInstance::parseAndCheckTypes(
-    const ImplicitImports &implicitImports) {
+void CompilerInstance::parseAndCheckTypesUpTo(
+    const ImplicitImports &implicitImports, SourceFile::ASTStage_t limitStage) {
   FrontendStatsTracer tracer(Context->Stats, "parse-and-check-types");
   // Delayed parsing callback for the primary file, or all files
   // in non-WMO mode.
@@ -611,8 +626,8 @@ void CompilerInstance::parseAndCheckTypes(
   // In addition, the main file has parsing and type-checking
   // interwined.
   if (MainBufferID != NO_SUCH_BUFFER) {
-    parseAndTypeCheckMainFile(PersistentState, PrimaryDelayedCB.get(),
-                              TypeCheckOptions);
+    parseAndTypeCheckMainFileUpTo(limitStage, PersistentState,
+                                  PrimaryDelayedCB.get(), TypeCheckOptions);
   }
 
   assert(llvm::all_of(MainModule->getFiles(), [](const FileUnit *File) -> bool {
@@ -622,6 +637,11 @@ void CompilerInstance::parseAndCheckTypes(
     return SF->ASTStage >= SourceFile::NameBound;
   }) && "some files have not yet had their imports resolved");
   MainModule->setHasResolvedImports();
+
+  // If the limiting AST stage is name binding, we're done.
+  if (limitStage <= SourceFile::NameBound) {
+    return;
+  }
 
   const auto &options = Invocation.getFrontendOptions();
   forEachFileToTypeCheck([&](SourceFile &SF) {
@@ -720,7 +740,8 @@ bool CompilerInstance::parsePartialModulesAndLibraryFiles(
   return hadLoadError;
 }
 
-void CompilerInstance::parseAndTypeCheckMainFile(
+void CompilerInstance::parseAndTypeCheckMainFileUpTo(
+    SourceFile::ASTStage_t LimitStage,
     PersistentParserState &PersistentState,
     DelayedParsingCallbacks *DelayedParseCB,
     OptionSet<TypeCheckingFlags> TypeCheckOptions) {
@@ -747,15 +768,27 @@ void CompilerInstance::parseAndTypeCheckMainFile(
     parseIntoSourceFile(MainFile, MainFile.getBufferID().getValue(), &Done,
                         TheSILModule ? &SILContext : nullptr, &PersistentState,
                         DelayedParseCB);
+
     if (mainIsPrimary) {
-      const auto &options = Invocation.getFrontendOptions();
-      performTypeChecking(MainFile, PersistentState.getTopLevelContext(),
-                          TypeCheckOptions, CurTUElem,
-                          options.WarnLongFunctionBodies,
-                          options.WarnLongExpressionTypeChecking,
-                          options.SolverExpressionTimeThreshold,
-                          options.SwitchCheckingInvocationThreshold);
+      switch (LimitStage) {
+      case SourceFile::Parsing:
+      case SourceFile::Parsed:
+        llvm_unreachable("invalid limit stage");
+      case SourceFile::NameBound:
+        performNameBinding(MainFile, CurTUElem);
+        break;
+      case SourceFile::TypeChecked:
+        const auto &options = Invocation.getFrontendOptions();
+        performTypeChecking(MainFile, PersistentState.getTopLevelContext(),
+                            TypeCheckOptions, CurTUElem,
+                            options.WarnLongFunctionBodies,
+                            options.WarnLongExpressionTypeChecking,
+                            options.SolverExpressionTimeThreshold,
+                            options.SwitchCheckingInvocationThreshold);
+        break;
+      }
     }
+
     CurTUElem = MainFile.Decls.size();
   } while (!Done);
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -425,7 +425,7 @@ shouldImplicityImportSwiftOnoneSupportModule(CompilerInvocation &Invocation) {
   return Invocation.getFrontendOptions().isCreatingSIL();
 }
 
-void CompilerInstance::performParseAndNameBindingOnly() {
+void CompilerInstance::performParseAndResolveImportsOnly() {
   performSemaUpTo(SourceFile::NameBound);
 }
 
@@ -473,7 +473,6 @@ void CompilerInstance::performSemaUpTo(SourceFile::ASTStage_t LimitStage) {
 
   parseAndCheckTypesUpTo(implicitImports, LimitStage);
 }
-
 
 CompilerInstance::ImplicitImports::ImplicitImports(CompilerInstance &compiler) {
   kind = compiler.Invocation.getImplicitModuleImportKind();

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -184,6 +184,7 @@ FrontendOptions::suffixForPrincipalOutputFileForAction(ActionType action) {
 bool FrontendOptions::canActionEmitDependencies(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
+  case ActionType::Parse:
   case ActionType::DumpParse:
   case ActionType::DumpInterfaceHash:
   case ActionType::DumpAST:
@@ -194,7 +195,37 @@ bool FrontendOptions::canActionEmitDependencies(ActionType action) {
   case ActionType::Immediate:
   case ActionType::REPL:
     return false;
+  case ActionType::Typecheck:
+  case ActionType::MergeModules:
+  case ActionType::EmitModuleOnly:
+  case ActionType::EmitPCH:
+  case ActionType::EmitSILGen:
+  case ActionType::EmitSIL:
+  case ActionType::EmitSIBGen:
+  case ActionType::EmitSIB:
+  case ActionType::EmitIR:
+  case ActionType::EmitBC:
+  case ActionType::EmitAssembly:
+  case ActionType::EmitObject:
+  case ActionType::EmitImportedModules:
+    return true;
+  }
+}
+
+bool FrontendOptions::canActionEmitReferenceDependencies(ActionType action) {
+  switch (action) {
+  case ActionType::NoneAction:
   case ActionType::Parse:
+  case ActionType::DumpParse:
+  case ActionType::DumpInterfaceHash:
+  case ActionType::DumpAST:
+  case ActionType::EmitSyntax:
+  case ActionType::PrintAST:
+  case ActionType::DumpScopeMaps:
+  case ActionType::DumpTypeRefinementContexts:
+  case ActionType::Immediate:
+  case ActionType::REPL:
+    return false;
   case ActionType::Typecheck:
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -31,6 +31,7 @@ bool FrontendOptions::needsProperModuleName(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
   case ActionType::Parse:
+  case ActionType::NameBind:
   case ActionType::Typecheck:
   case ActionType::DumpParse:
   case ActionType::DumpAST:
@@ -65,6 +66,7 @@ bool FrontendOptions::isActionImmediate(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
   case ActionType::Parse:
+  case ActionType::NameBind:
   case ActionType::Typecheck:
   case ActionType::DumpParse:
   case ActionType::DumpAST:
@@ -134,6 +136,7 @@ FrontendOptions::suffixForPrincipalOutputFileForAction(ActionType action) {
     return StringRef();
 
   case ActionType::Parse:
+  case ActionType::NameBind:
   case ActionType::Typecheck:
   case ActionType::DumpParse:
   case ActionType::DumpInterfaceHash:
@@ -195,6 +198,7 @@ bool FrontendOptions::canActionEmitDependencies(ActionType action) {
   case ActionType::Immediate:
   case ActionType::REPL:
     return false;
+  case ActionType::NameBind:
   case ActionType::Typecheck:
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
@@ -216,6 +220,7 @@ bool FrontendOptions::canActionEmitReferenceDependencies(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
   case ActionType::Parse:
+  case ActionType::NameBind:
   case ActionType::DumpParse:
   case ActionType::DumpInterfaceHash:
   case ActionType::DumpAST:
@@ -258,6 +263,7 @@ bool FrontendOptions::canActionEmitObjCHeader(ActionType action) {
   case ActionType::REPL:
     return false;
   case ActionType::Parse:
+  case ActionType::NameBind:
   case ActionType::Typecheck:
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
@@ -288,6 +294,7 @@ bool FrontendOptions::canActionEmitLoadedModuleTrace(ActionType action) {
   case ActionType::Immediate:
   case ActionType::REPL:
     return false;
+  case ActionType::NameBind:
   case ActionType::Typecheck:
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
@@ -309,6 +316,7 @@ bool FrontendOptions::canActionEmitModule(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
   case ActionType::Parse:
+  case ActionType::NameBind:
   case ActionType::Typecheck:
   case ActionType::DumpParse:
   case ActionType::DumpInterfaceHash:
@@ -343,6 +351,7 @@ bool FrontendOptions::canActionEmitModuleDoc(ActionType action) {
 bool FrontendOptions::doesActionProduceOutput(ActionType action) {
   switch (action) {
   case ActionType::Parse:
+  case ActionType::NameBind:
   case ActionType::Typecheck:
   case ActionType::DumpParse:
   case ActionType::DumpAST:
@@ -388,6 +397,7 @@ bool FrontendOptions::doesActionProduceTextualOutput(ActionType action) {
     return false;
 
   case ActionType::Parse:
+  case ActionType::NameBind:
   case ActionType::Typecheck:
   case ActionType::DumpParse:
   case ActionType::DumpInterfaceHash:

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -31,7 +31,7 @@ bool FrontendOptions::needsProperModuleName(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
   case ActionType::Parse:
-  case ActionType::NameBind:
+  case ActionType::ResolveImports:
   case ActionType::Typecheck:
   case ActionType::DumpParse:
   case ActionType::DumpAST:
@@ -66,7 +66,7 @@ bool FrontendOptions::isActionImmediate(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
   case ActionType::Parse:
-  case ActionType::NameBind:
+  case ActionType::ResolveImports:
   case ActionType::Typecheck:
   case ActionType::DumpParse:
   case ActionType::DumpAST:
@@ -136,7 +136,7 @@ FrontendOptions::suffixForPrincipalOutputFileForAction(ActionType action) {
     return StringRef();
 
   case ActionType::Parse:
-  case ActionType::NameBind:
+  case ActionType::ResolveImports:
   case ActionType::Typecheck:
   case ActionType::DumpParse:
   case ActionType::DumpInterfaceHash:
@@ -198,7 +198,7 @@ bool FrontendOptions::canActionEmitDependencies(ActionType action) {
   case ActionType::Immediate:
   case ActionType::REPL:
     return false;
-  case ActionType::NameBind:
+  case ActionType::ResolveImports:
   case ActionType::Typecheck:
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
@@ -220,7 +220,7 @@ bool FrontendOptions::canActionEmitReferenceDependencies(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
   case ActionType::Parse:
-  case ActionType::NameBind:
+  case ActionType::ResolveImports:
   case ActionType::DumpParse:
   case ActionType::DumpInterfaceHash:
   case ActionType::DumpAST:
@@ -263,7 +263,7 @@ bool FrontendOptions::canActionEmitObjCHeader(ActionType action) {
   case ActionType::REPL:
     return false;
   case ActionType::Parse:
-  case ActionType::NameBind:
+  case ActionType::ResolveImports:
   case ActionType::Typecheck:
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
@@ -294,7 +294,7 @@ bool FrontendOptions::canActionEmitLoadedModuleTrace(ActionType action) {
   case ActionType::Immediate:
   case ActionType::REPL:
     return false;
-  case ActionType::NameBind:
+  case ActionType::ResolveImports:
   case ActionType::Typecheck:
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
@@ -316,7 +316,7 @@ bool FrontendOptions::canActionEmitModule(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
   case ActionType::Parse:
-  case ActionType::NameBind:
+  case ActionType::ResolveImports:
   case ActionType::Typecheck:
   case ActionType::DumpParse:
   case ActionType::DumpInterfaceHash:
@@ -351,7 +351,7 @@ bool FrontendOptions::canActionEmitModuleDoc(ActionType action) {
 bool FrontendOptions::doesActionProduceOutput(ActionType action) {
   switch (action) {
   case ActionType::Parse:
-  case ActionType::NameBind:
+  case ActionType::ResolveImports:
   case ActionType::Typecheck:
   case ActionType::DumpParse:
   case ActionType::DumpAST:
@@ -397,7 +397,7 @@ bool FrontendOptions::doesActionProduceTextualOutput(ActionType action) {
     return false;
 
   case ActionType::Parse:
-  case ActionType::NameBind:
+  case ActionType::ResolveImports:
   case ActionType::Typecheck:
   case ActionType::DumpParse:
   case ActionType::DumpInterfaceHash:

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -898,8 +898,8 @@ static bool performCompile(CompilerInstance &Instance,
   if (FrontendOptions::shouldActionOnlyParse(Action)) {
     Instance.performParseOnly(/*EvaluateConditionals*/
                     Action == FrontendOptions::ActionType::EmitImportedModules);
-  } else if (Action == FrontendOptions::ActionType::NameBind) {
-    Instance.performParseAndNameBindingOnly();
+  } else if (Action == FrontendOptions::ActionType::ResolveImports) {
+    Instance.performParseAndResolveImportsOnly();
   } else {
     Instance.performSema();
   }
@@ -922,7 +922,7 @@ static bool performCompile(CompilerInstance &Instance,
   (void)emitMakeDependenciesIfNeeded(Context.Diags,
                                      Instance.getDependencyTracker(), opts);
 
-  if (Action == FrontendOptions::ActionType::NameBind)
+  if (Action == FrontendOptions::ActionType::ResolveImports)
     return Context.hadError();
 
   if (observer)

--- a/test/Driver/options.swift
+++ b/test/Driver/options.swift
@@ -36,6 +36,8 @@
 // PARSE_NO_REFERENCE_DEPS: error: this mode does not support emitting reference dependency files{{$}}
 // RUN: not %target-swift-frontend -dump-ast -emit-reference-dependencies %s 2>&1 | %FileCheck -check-prefix=DUMP_NO_REFERENCE_DEPS %s
 // DUMP_NO_REFERENCE_DEPS: error: this mode does not support emitting reference dependency files{{$}}
+// RUN: not %target-swift-frontend -resolve-imports -emit-reference-dependencies %s 2>&1 | %FileCheck -check-prefix=RESOLVE_IMPORTS_NO_REFERENCE_DEPS %s
+// RESOLVE_IMPORTS_NO_REFERENCE_DEPS: error: this mode does not support emitting reference dependency files{{$}}
 
 // Should not fail with non-zero exit code.
 // RUN: %target-swift-frontend -emit-silgen %S/Inputs/invalid-module-name.swift > /dev/null

--- a/test/Driver/options.swift
+++ b/test/Driver/options.swift
@@ -27,8 +27,15 @@
 // RUN: not %target-swift-frontend -typecheck -emit-module %s 2>&1 | %FileCheck -check-prefix=PARSE_NO_MODULE %s
 // PARSE_NO_MODULE: error: this mode does not support emitting modules{{$}}
 
+// RUN: not %target-swift-frontend -parse -emit-dependencies %s 2>&1 | %FileCheck -check-prefix=PARSE_NO_DEPS %s
+// PARSE_NO_DEPS: error: this mode does not support emitting dependency files{{$}}
 // RUN: not %target-swift-frontend -dump-ast -emit-dependencies %s 2>&1 | %FileCheck -check-prefix=DUMP_NO_DEPS %s
 // DUMP_NO_DEPS: error: this mode does not support emitting dependency files{{$}}
+
+// RUN: not %target-swift-frontend -parse -emit-reference-dependencies %s 2>&1 | %FileCheck -check-prefix=PARSE_NO_REFERENCE_DEPS %s
+// PARSE_NO_REFERENCE_DEPS: error: this mode does not support emitting reference dependency files{{$}}
+// RUN: not %target-swift-frontend -dump-ast -emit-reference-dependencies %s 2>&1 | %FileCheck -check-prefix=DUMP_NO_REFERENCE_DEPS %s
+// DUMP_NO_REFERENCE_DEPS: error: this mode does not support emitting reference dependency files{{$}}
 
 // Should not fail with non-zero exit code.
 // RUN: %target-swift-frontend -emit-silgen %S/Inputs/invalid-module-name.swift > /dev/null

--- a/test/Frontend/dependencies.swift
+++ b/test/Frontend/dependencies.swift
@@ -2,7 +2,7 @@
 
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -emit-dependencies-path - -name-bind %S/../Inputs/empty\ file.swift | %FileCheck -check-prefix=CHECK-BASIC %s
+// RUN: %target-swift-frontend -emit-dependencies-path - -resolve-imports %S/../Inputs/empty\ file.swift | %FileCheck -check-prefix=CHECK-BASIC %s
 // RUN: %target-swift-frontend -emit-reference-dependencies-path - -typecheck -primary-file %S/../Inputs/empty\ file.swift | %FileCheck -check-prefix=CHECK-BASIC-YAML %s
 
 // RUN: %target-swift-frontend -emit-dependencies-path %t.d -emit-reference-dependencies-path %t.swiftdeps -typecheck -primary-file %S/../Inputs/empty\ file.swift
@@ -38,7 +38,7 @@
 // CHECK-MULTIPLE-OUTPUTS: Swift.swiftmodule
 // CHECK-MULTIPLE-OUTPUTS-NOT: :
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-dependencies-path - -name-bind %s | %FileCheck -check-prefix=CHECK-IMPORT %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-dependencies-path - -resolve-imports %s | %FileCheck -check-prefix=CHECK-IMPORT %s
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-reference-dependencies-path - -typecheck -primary-file %s | %FileCheck -check-prefix=CHECK-IMPORT-YAML %s
 
 // CHECK-IMPORT-LABEL: - :

--- a/test/Frontend/dependencies.swift
+++ b/test/Frontend/dependencies.swift
@@ -2,7 +2,7 @@
 
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -emit-dependencies-path - -typecheck %S/../Inputs/empty\ file.swift | %FileCheck -check-prefix=CHECK-BASIC %s
+// RUN: %target-swift-frontend -emit-dependencies-path - -name-bind %S/../Inputs/empty\ file.swift | %FileCheck -check-prefix=CHECK-BASIC %s
 // RUN: %target-swift-frontend -emit-reference-dependencies-path - -typecheck -primary-file %S/../Inputs/empty\ file.swift | %FileCheck -check-prefix=CHECK-BASIC-YAML %s
 
 // RUN: %target-swift-frontend -emit-dependencies-path %t.d -emit-reference-dependencies-path %t.swiftdeps -typecheck -primary-file %S/../Inputs/empty\ file.swift
@@ -38,7 +38,7 @@
 // CHECK-MULTIPLE-OUTPUTS: Swift.swiftmodule
 // CHECK-MULTIPLE-OUTPUTS-NOT: :
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-dependencies-path - -typecheck %s | %FileCheck -check-prefix=CHECK-IMPORT %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-dependencies-path - -name-bind %s | %FileCheck -check-prefix=CHECK-IMPORT %s
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-reference-dependencies-path - -typecheck -primary-file %s | %FileCheck -check-prefix=CHECK-IMPORT-YAML %s
 
 // CHECK-IMPORT-LABEL: - :


### PR DESCRIPTION
Add <strike>Name Binding</strike> Import Resolution as a frontend action to make computing dependencies cheaper by no longer going through the type checker.  Also includes corrections and additions to the diagnostics for misuse of `-emit-reference-dependencies` and `-emit-dependencies` when in parse-only contexts.