### PR TITLE
DO NOT MERGE [SR-1807] Diagnose primitive reference cycles

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5095,5 +5095,21 @@ ERROR(atomics_ordering_must_be_constant, none,
       "ordering argument must be a static method or property of %0",
       (Identifier))
 
+//------------------------------------------------------------------------------
+// Reference cycle diagnostics
+//------------------------------------------------------------------------------
+
+WARNING(warn_reference_cycle, none,
+        "implicitly capturing %0 strongly in this closure is likely to lead "
+        "to a reference cycle", (Identifier))
+NOTE(note_reference_cycle_owner, none,
+     "closure is strongly referenced by %select{%1|an object "
+     "strongly referenced by %1}0", (unsigned, Identifier))
+NOTE(note_reference_cycle_thru_call, none,
+     "closure capturing %0 is referenced as an escaping argument "
+     "to this function call", (Identifier))
+NOTE(note_capture_variable_explicitly_silence,none,
+     "capture %0 explicitly to silence this warning", (Identifier))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/test/Sema/diag_reference_cycles.swift
+++ b/test/Sema/diag_reference_cycles.swift
@@ -1,0 +1,156 @@
+// RUN: %target-typecheck-verify-swift
+
+class Test0 {
+  var closure: () -> () = { }
+  func actNow() {}
+}
+
+func test(x : Test0) {
+  x.closure = { // expected-warning {{implicitly capturing 'x' strongly in this closure is likely to lead to a reference cycle}}
+    // expected-note@-1 {{closure is strongly referenced by an object strongly referenced by 'x'}}
+    // expected-note@-2 {{capture 'x' explicitly to silence this warning}} {{16-16= [x] in}}
+    x.actNow()
+  }
+
+  x.closure = { [x] in
+    x.actNow()
+  }
+}
+
+class ClosureOwner {
+  var strongClosure: () -> () = {}
+}
+
+class Test1 {
+  var owner = ClosureOwner()
+  unowned var owner2: ClosureOwner
+  weak var owner3: ClosureOwner?
+
+  init() {
+    self.owner2 = self.owner
+    self.owner3 = self.owner
+  }
+}
+
+func test(x : Test1) {
+  x.owner.strongClosure = { // expected-warning {{implicitly capturing 'x' strongly in this closure is likely to lead to a reference cycle}}
+    // expected-note@-1 {{closure is strongly referenced by an object strongly referenced by 'x'}}
+    // expected-note@-2 {{capture 'x' explicitly to silence this warning}} {{28-28= [x] in}}
+    _ = x
+  }
+  x.owner2.strongClosure = {
+    _ = x
+  }
+  x.owner3!.strongClosure = {
+    _ = x
+  }
+
+  x.owner.strongClosure = { [x] in
+    _ = x
+  }
+  x.owner2.strongClosure = { [x] in
+    _ = x
+  }
+  x.owner3!.strongClosure = { [x] in
+    _ = x
+  }
+}
+
+func test2_helper(_ x : AnyObject) {}
+
+class Test2 {
+  var closure: () -> () = {}
+  let x: AnyObject = Test0()
+
+  func test() {
+    self.closure = { // expected-warning {{implicitly capturing 'self' strongly in this closure is likely to lead to a reference cycle}}
+      // expected-note@-1 {{closure is strongly referenced by an object strongly referenced by 'self'}}
+      // expected-note@-2 {{capture 'self' explicitly to silence this warning}} {{21-21= [self] in}}
+      test2_helper(self.x)
+    }
+
+    self.closure = { [self] in
+      test2_helper(x)
+    }
+
+    self.closure = { [self] in
+      test2_helper(self.x)
+    }
+  }
+}
+
+class Test3 {
+  func doNoEscapeClosure(_ f: () -> ()) {}
+  func doEscapingClosure(_ f: @escaping () -> ()) {}
+  func doAutoclosure(_ f: @autoclosure () -> Test3) {}
+  func doEscapingAutoclosure(_ f: @escaping @autoclosure () -> Test3) {}
+
+  func test(_ x: Test3) {
+    x.doNoEscapeClosure {
+      _ = x
+    }
+
+    x.doEscapingClosure { // expected-warning {{implicitly capturing 'x' strongly in this closure is likely to lead to a reference cycle}}
+      // expected-note@-1 {{closure capturing 'x' is referenced as an escaping argument to this function call}}
+      // expected-note@-2 {{capture 'x' explicitly to silence this warning}} {{26-26= [x] in}}
+      _ = x
+    }
+
+    x.doEscapingClosure { [x] in
+      _ = x
+    }
+
+    x.doAutoclosure(x)
+
+    x.doEscapingAutoclosure(x) // expected-warning {{implicitly capturing 'x' strongly in this closure is likely to lead to a reference cycle}}
+      // expected-note@-1 {{closure capturing 'x' is referenced as an escaping argument to this function call}}
+  }
+}
+
+class HTMLElement {
+  let name: String
+  let text: String?
+
+  // Unapplied closures escape
+  lazy var asHTML: () -> String = { // expected-warning {{implicitly capturing 'self' strongly in this closure is likely to lead to a reference cycle}}
+    // expected-note@-1 {{closure is strongly referenced by an object strongly referenced by 'self'}}
+    // expected-note@-2 {{capture 'self' explicitly to silence this warning}} {{36-36= [self] in}}
+    if let text = self.text {
+      return "<\(self.name)>\(text)</\(self.name)>"
+    } else {
+      return "<\(self.name) />"
+    }
+  }
+
+  // Unapplied closures escape
+  lazy var asHTMLNoCapture: () -> String = { [self] in
+    if let text = self.text {
+      return "<\(self.name)>\(text)</\(self.name)>"
+    } else {
+      return "<\(self.name) />"
+    }
+  }
+
+  lazy var asHTMLWeakify: () -> String = { [weak self] in // No warning
+    if let text = self!.text {
+      return "<\(self!.name)>\(text)</\(self!.name)>"
+    } else {
+      return "<\(self!.name) />"
+    }
+  }
+
+  // Immediately-applied closures are no-escape.
+  lazy var asHTMLNoEscape: String = { // No warning
+    if let text = self.text {
+      return "<\(self.name)>\(text)</\(self.name)>"
+    } else {
+      return "<\(self.name) />"
+    }
+  }()
+
+  init(name: String, text: String? = nil) {
+    self.name = name
+    self.text = text
+  }
+}
+


### PR DESCRIPTION
Repurpose the walker for diagnosing implicit 'self' usage in closures to
diagnose certain forms of reference cycles.

Around assignment expressions with closure sources, we walk to the
capture list to see if it contains the destination expression's base.

Around call expressions we walk to each argument.  If it is an escaping
closure we check its capture list to see if it contains the
destination's base expression.

This patch also works around the implicit AST nodes synthesized for 'lazy
var' declarations - these allow references to 'self' and are a major
source of reference cycles for 'class' types.

Resolves [SR-1807](https://bugs.swift.org/browse/SR-1807) and rdar://25469728