### PR TITLE
Added support for tfops that return a tuple of tensor values

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -3243,7 +3243,8 @@ void TFFunctionPartition::balanceRetainReleaseCount(SILValue oldResult,
     // Ignore uses outside the tensor program region.
     if (DI.dominates(tensorEndPoint, user)) continue;
 
-    if(isa<DebugValueInst>(user)) continue;
+    if (isa<DebugValueInst>(user))
+      continue;
 
     if (isa<StrongRetainInst>(user)) {
       ++retainReleaseBalance;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2502,7 +2502,7 @@ namespace {
 
     // SWIFT_ENABLE_TENSORFLOW
     /// When we've type checked a #tfop expression, we do some adjustment to the
-    /// argument types.  Specifically, if an argument is a type that conforms to
+    /// argument types.  Specifically, if an argument type conforms to
     /// TensorProtocol (like Tensor or TensorElementLiteral), we use the
     /// TensorHandle that they contain instead.
     Expr *visitTFOp(ObjectLiteralExpr *expr) {

--- a/stdlib/public/TensorFlow/Tensor.swift
+++ b/stdlib/public/TensorFlow/Tensor.swift
@@ -137,10 +137,10 @@ public extension Tensor {
     let tensor = toAccelerator()
     // If the tensor is to be sent from host to TPU, the shape is specified on
     // TF CPU first, before TF CPU sends the tensor to TPU.
-    let ret : TensorHandle<Scalar> = #tfop("Identity",
-                                           tensor,
-                                           __shapes: [shape],
-                                           __device: "/device:CPU:0")
+    let ret: TensorHandle<Scalar> = #tfop("Identity",
+                                          tensor,
+                                          __shapes: [shape],
+                                          __device: "/device:CPU:0")
     return Tensor<Scalar>(handle: ret)
   }
 
@@ -160,7 +160,7 @@ public extension Tensor {
     // device first, before outfeeding the tensor to CPU, a required step for
     // sending the tensor to the host.
     let tensor: TensorHandle<Scalar> = #tfop("Identity", self, __shapes: [shape])
-    return Tensor<Scalar>(handle: tensor).toHost()
+    return Tensor(handle: tensor).toHost()
   }
 
   /// Mark memory transfer to host.

--- a/stdlib/public/TensorFlow/Tensor.swift
+++ b/stdlib/public/TensorFlow/Tensor.swift
@@ -137,10 +137,11 @@ public extension Tensor {
     let tensor = toAccelerator()
     // If the tensor is to be sent from host to TPU, the shape is specified on
     // TF CPU first, before TF CPU sends the tensor to TPU.
-    return #tfop("Identity",
-                 tensor,
-                 __shapes: [shape],
-                 __device: "/device:CPU:0")
+    let ret : TensorHandle<Scalar> = #tfop("Identity",
+                                           tensor,
+                                           __shapes: [shape],
+                                           __device: "/device:CPU:0")
+    return Tensor<Scalar>(handle: ret)
   }
 
   /// Mark memory transfer to accelerator.
@@ -158,8 +159,8 @@ public extension Tensor {
     // If the `self` tensor resides on TPU, the shape is specified on that
     // device first, before outfeeding the tensor to CPU, a required step for
     // sending the tensor to the host.
-    let tensor: Tensor<Scalar> = #tfop("Identity", self, __shapes: [shape])
-    return tensor.toHost()
+    let tensor: TensorHandle<Scalar> = #tfop("Identity", self, __shapes: [shape])
+    return Tensor<Scalar>(handle: tensor).toHost()
   }
 
   /// Mark memory transfer to host.
@@ -425,7 +426,8 @@ extension TensorElementLiteral : ExpressibleByArrayLiteral {
   public typealias ArrayLiteralElement = TensorElementLiteral<Scalar>
   @inlinable @inline(__always)
   public init(arrayLiteral elements: TensorElementLiteral<Scalar>...) {
-    tensor = #tfop("Pack", elements)
+    let handle: TensorHandle<Scalar> = #tfop("Pack", elements)
+    tensor = Tensor(handle: handle)
   }
 }
 

--- a/stdlib/public/TensorFlow/Tensor.swift
+++ b/stdlib/public/TensorFlow/Tensor.swift
@@ -141,7 +141,7 @@ public extension Tensor {
                                           tensor,
                                           __shapes: [shape],
                                           __device: "/device:CPU:0")
-    return Tensor<Scalar>(handle: ret)
+    return Tensor(handle: ret)
   }
 
   /// Mark memory transfer to accelerator.

--- a/stdlib/public/TensorFlow/Utilities.swift
+++ b/stdlib/public/TensorFlow/Utilities.swift
@@ -271,6 +271,11 @@ public func _hostOp<Scalar>(_ x: Tensor<Scalar>) {
   print(x)
 }
 
+@inline(never)
+public func _hostOp<Scalar>(_ x: TensorHandle<Scalar>) {
+  print(Tensor(handle: x))
+}
+
 /// Some TPU ops (e.g. infeed/outfeed) require tensor shape info, which the APIs
 /// below can provide.
 ///
@@ -278,13 +283,13 @@ public func _hostOp<Scalar>(_ x: Tensor<Scalar>) {
 /// inference/propagation design.
 @inlinable @inline(__always)
 public func _scalarTensorWithShape<T>(_ x: Tensor<T>) -> Tensor<T> {
-  let ret : Tensor<T> = #tfop("Identity", x, __shapes: [TensorShape()])
-  return ret
+  let ret : TensorHandle<T> = #tfop("Identity", x, __shapes: [TensorShape()])
+  return Tensor<T>(handle: ret)
 }
 
 @inlinable @inline(__always)
 public func _addScalarTensorsWithShape<T>(_ x: Tensor<T>, _ y: Tensor<T>
 ) -> Tensor<T> {
-  let ret : Tensor<T> = #tfop("Add", x, y, __shapes: [TensorShape()])
-  return ret
+  let ret : TensorHandle<T> = #tfop("Add", x, y, __shapes: [TensorShape()])
+  return Tensor<T>(handle: ret)
 }

--- a/stdlib/public/TensorFlow/Utilities.swift
+++ b/stdlib/public/TensorFlow/Utilities.swift
@@ -283,13 +283,13 @@ public func _hostOp<Scalar>(_ x: TensorHandle<Scalar>) {
 /// inference/propagation design.
 @inlinable @inline(__always)
 public func _scalarTensorWithShape<T>(_ x: Tensor<T>) -> Tensor<T> {
-  let ret : TensorHandle<T> = #tfop("Identity", x, __shapes: [TensorShape()])
+  let ret: TensorHandle<T> = #tfop("Identity", x, __shapes: [TensorShape()])
   return Tensor<T>(handle: ret)
 }
 
 @inlinable @inline(__always)
 public func _addScalarTensorsWithShape<T>(_ x: Tensor<T>, _ y: Tensor<T>
 ) -> Tensor<T> {
-  let ret : TensorHandle<T> = #tfop("Add", x, y, __shapes: [TensorShape()])
+  let ret: TensorHandle<T> = #tfop("Add", x, y, __shapes: [TensorShape()])
   return Tensor<T>(handle: ret)
 }

--- a/test/TensorFlow/crashers.swift
+++ b/test/TensorFlow/crashers.swift
@@ -223,7 +223,7 @@ func twoHandles() -> (TensorHandle<Int32>, ResourceHandle) {
 
 public func testMultiResultUninlinable() {
   let (x1, _) = twoHandles()  // expected-warning {{value implicitly copied to the accelerator}}
-  let _ : TensorHandle<Float> = #tfop("Identity", x1)  // expected-note {{value used here}}
+  let _: TensorHandle<Float> = #tfop("Identity", x1)  // expected-note {{value used here}}
 }
 
 // Test support for copying multiple result outputs.

--- a/test/TensorFlow/crashers.swift
+++ b/test/TensorFlow/crashers.swift
@@ -154,7 +154,8 @@ public extension Tensor {
   @inlinable @inline(__always)
   func genericAttr<T : AccelerableByTensorFlow>(axis: T) -> Tensor {
     // expected-error @+1 {{op named 'ExampleOp' is not registered in TensorFlow}}
-    return #tfop("ExampleOp", handle, axis: axis, axisType: T.self)
+    let ret: TensorHandle<Scalar> = #tfop("ExampleOp", handle, axis: axis, axisType: T.self)
+    return Tensor<Scalar>(handle: ret)
   }
 }
 
@@ -222,7 +223,7 @@ func twoHandles() -> (TensorHandle<Int32>, ResourceHandle) {
 
 public func testMultiResultUninlinable() {
   let (x1, _) = twoHandles()  // expected-warning {{value implicitly copied to the accelerator}}
-  let _ : Tensor<Float> = #tfop("Identity", x1)  // expected-note {{value used here}}
+  let _ : TensorHandle<Float> = #tfop("Identity", x1)  // expected-note {{value used here}}
 }
 
 // Test support for copying multiple result outputs.
@@ -234,12 +235,57 @@ public func testMultiOutputsFnResults() -> (Tensor<Float>,  Tensor<Float>) {
   return (x.toHost(),y.toHost())
 }
 
+// expected-warning @+2{{implicitly copied to the accelerator}}
+// expected-warning @+1{{implicitly copied to the accelerator}}
+public func testMultiResultOp_tfop(x: Tensor<Float>, y: Tensor<Float>) {
+  let (loss, backprop) : (TensorHandle<Float>, TensorHandle<Float>) =
+    #tfop("SoftmaxCrossEntropyWithLogits", x, y)
+  // expected-note @-1{{value used here}}
+  // expected-note @-2{{value used here}}
+  _hostOp(loss)
+  _hostOp(backprop)
+}
+
+// expected-warning @+2{{implicitly copied to the accelerator}}
+// expected-warning @+1{{implicitly copied to the accelerator}}
+public func testMultiResultOp_rawop(x: Tensor<Float>, y: Tensor<Float>) {
+  // expected-note @+2{{value used here}}
+  // expected-note @+1{{value used here}}
+  let results = TensorFlow.Raw.softmaxCrossEntropyWithLogits(features: x, labels: y)
+  _hostOp(results.loss)
+  _hostOp(results.backprop)
+}
+
+// TODO: The sends/recvs diagnostics are not very good. Fix them.
+public func testMultiResultOp_send_recv() {
+  var x = Tensor<Float>([[1.0]])  // expected-warning {{implicitly copied to the host}}
+  // Accelerator -> Host
+  _hostOp(x)
+  x += [[2.0]]
+  // expected-warning @+2{{implicitly copied to the host}}
+  // expected-warning @+1{{implicitly copied to the host}}
+  let results = TensorFlow.Raw.softmaxCrossEntropyWithLogits(features: x, labels: x)
+  // Accelerator -> Host
+  _hostOp(results.loss)
+  // expected-note @+2{{value used here}}
+  // expected-warning @+1{{implicitly copied to the accelerator}}
+  let adjustedLoss = results.loss.scalar! + 3.0
+  // Host -> Accelerator
+  let y = Tensor<Float>(adjustedLoss)
+  _hostOp(y)
+}
+
+// CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testMultiResultOp_send_recv{{.*}}
+// CHECK:  builtin "__tfop_tfc.SendToHost
+// CHECK:  builtin "__tfop_tfc.SendToHost
+// CHECK:  builtin "__tfop_tfc.RecvFromHost
+
 var globalThing: Int32!
 
 public func testStructExtractBBArg(x: Tensor<Float>) -> Tensor<Int32> {
   _ = x.toAccelerator() + 1
-  //	%21 = argument of bb2 : $Int32                    // user: %22
-  // [Send]	  %22 = struct_extract %21 : $Int32, #Int32._value // user: %23
+  //  %21 = argument of bb2 : $Int32                    // user: %22
+  // [Send]   %22 = struct_extract %21 : $Int32, #Int32._value // user: %23
   // expected-warning @+1 {{value implicitly copied to the accelerator}}
   return Tensor<Int32>(globalThing)
 }

--- a/test/TensorFlow/dataset.swift
+++ b/test/TensorFlow/dataset.swift
@@ -3,13 +3,13 @@ import TensorFlow
 
 public func testDatasetWithFakeData() {
   TensorFlow.enableTPU(infeed: true)
-  let x: Tensor<Float> = #tfop(
+  let x: TensorHandle<Float> = #tfop(
     "tfc.makeIteratorGetNextWithDatasets",
     dataSource: "fake",
     filePath: "dummy_path",
     batchSize: 1,
     outputShapes: [TensorShape()])
-  let y = x + 1
+  let y = Tensor<Float>(handle: x) + 1
   print(y.array.scalars[0])
 }
 
@@ -27,11 +27,11 @@ public func testDatasetWithMNIST() {
     filePath: "some_path",
     batchSize: 64,
     output_shapes: [TensorShape(64,224,224,3), TensorShape(64)])
-  let images : Tensor<Float> = #tfop("Identity", images1)
-  let labels : Tensor<Int32> = #tfop("Identity", labels1)
+  let images : TensorHandle<Float> = #tfop("Identity", images1)
+  let labels : TensorHandle<Int32> = #tfop("Identity", labels1)
   // Confirm we can add more nodes to the graph.
-  let imagesMod = images + 1
-  let labelsMod = labels + 2
+  let imagesMod = Tensor<Float>(handle: images) + 1
+  let labelsMod = Tensor<Int32>(handle: labels) + 2
   print(imagesMod.array.scalars[0])
   print(labelsMod.array.scalars[0])
 }
@@ -105,10 +105,10 @@ public func model() {
   //   .Output("components: output_types")
   //   .Attr("output_types: list(type) >= 1")
   //   .Attr("output_shapes: list(shape) >= 1")
-  let one: Tensor<Float> = #tfop("IteratorGetNext",
-                                 iterator,
-                                 output_types: [Float.self],
-                                 output_shapes: [TensorShape()])
+  let one: TensorHandle<Float> = #tfop("IteratorGetNext",
+                                       iterator,
+                                       output_types: [Float.self],
+                                       output_shapes: [TensorShape()])
   _hostOp(one)
 }
 

--- a/test/TensorFlow/deabstraction_finished.swift
+++ b/test/TensorFlow/deabstraction_finished.swift
@@ -61,9 +61,9 @@ public func f(a: Tensor<Float>, idx: Tensor<Int32>) -> Tensor<Float> {
 public func testInputListArguments(a: TensorHandle<Float>, b: Tensor<Float>) -> Tensor<Float> {
   // Pack takes an input list, not multiple inputs.  Here we're checking that
   // we can pass in an array of Tensor's and an array of TensorHandle's.
-  let x: Tensor<Float> = #tfop("Pack", [a, a, a])  // expected-note {{value used here}}
-  let y: Tensor<Float> = #tfop("Pack", [b, b, b])  // expected-note {{value used here}}
-  return (x+y).toHost()
+  let x: TensorHandle<Float> = #tfop("Pack", [a, a, a])  // expected-note {{value used here}}
+  let y: TensorHandle<Float> = #tfop("Pack", [b, b, b])  // expected-note {{value used here}}
+  return (Tensor(handle: x)+Tensor(handle: y)).toHost()
 }
 
 /*

--- a/test/TensorFlow/device_placement.swift
+++ b/test/TensorFlow/device_placement.swift
@@ -3,7 +3,7 @@
 import TensorFlow
 
 public func implicitDevicePlacement() {
-  let x : Tensor<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0)
+  let x : TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0)
   _hostOp(x)
 }
 
@@ -59,7 +59,7 @@ public func explicitDeviceConfigTPU() {
 
 // This involves cross-device sends/recvs.
 public func explicitDevicePlacementGPU() {
-  let x : Tensor<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __device: "/device:GPU:0")
+  let x : TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __device: "/device:GPU:0")
   _hostOp(x)
 }
 
@@ -107,13 +107,13 @@ public func explicitDevicePlacementGPU() {
 // Instead, we check on the _Send node in the next test.
 
 public func explicitDevicePlacementAll() {
-  let x : Tensor<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __device: "/device:GPU:0")
+  let x : TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __device: "/device:GPU:0")
   // For GPU -> TPU transfer, always go through CPU first. Compiler can be
   // extended to generate this Identity op if needed.
-  let x_cpu : Tensor<Float> = #tfop("Identity", x, __shapes: [TensorShape()], __device: "/device:CPU:0")
-  let y_cpu : Tensor<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __shapes: [TensorShape()], __device: "/device:CPU:0")
+  let x_cpu : TensorHandle<Float> = #tfop("Identity", x, __shapes: [TensorShape()], __device: "/device:CPU:0")
+  let y_cpu : TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __shapes: [TensorShape()], __device: "/device:CPU:0")
   // y is sent from CPU to TPU.
-  let z_tpu : Tensor<Float> = #tfop("Add", x_cpu, y_cpu , __shapes: [TensorShape()], __device: "TPU_SYSTEM")
+  let z_tpu : TensorHandle<Float> = #tfop("Add", x_cpu, y_cpu , __shapes: [TensorShape()], __device: "TPU_SYSTEM")
   _hostOp(z_tpu)
 }
 
@@ -169,7 +169,7 @@ public func explicitDevicePlacementAll() {
 // CHECK-NEXT:       device: "/device:CPU:0"
 
 public func GPUToTPUTransfer_Unsupported() {
-  let x : Tensor<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __shapes: [TensorShape()], __device: "/device:GPU:0")
+  let x : TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __shapes: [TensorShape()], __device: "/device:GPU:0")
   // expected-error @+1 {{TPU infeed enqueue cannot run on this device}}
-  let _ : Tensor<Float> = #tfop("Identity", x, __device: "TPU_SYSTEM")
+  let _ : TensorHandle<Float> = #tfop("Identity", x, __device: "TPU_SYSTEM")
 }

--- a/test/TensorFlow/device_placement.swift
+++ b/test/TensorFlow/device_placement.swift
@@ -3,7 +3,7 @@
 import TensorFlow
 
 public func implicitDevicePlacement() {
-  let x : TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0)
+  let x: TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0)
   _hostOp(x)
 }
 
@@ -59,7 +59,7 @@ public func explicitDeviceConfigTPU() {
 
 // This involves cross-device sends/recvs.
 public func explicitDevicePlacementGPU() {
-  let x : TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __device: "/device:GPU:0")
+  let x: TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __device: "/device:GPU:0")
   _hostOp(x)
 }
 
@@ -107,13 +107,13 @@ public func explicitDevicePlacementGPU() {
 // Instead, we check on the _Send node in the next test.
 
 public func explicitDevicePlacementAll() {
-  let x : TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __device: "/device:GPU:0")
+  let x: TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __device: "/device:GPU:0")
   // For GPU -> TPU transfer, always go through CPU first. Compiler can be
   // extended to generate this Identity op if needed.
-  let x_cpu : TensorHandle<Float> = #tfop("Identity", x, __shapes: [TensorShape()], __device: "/device:CPU:0")
-  let y_cpu : TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __shapes: [TensorShape()], __device: "/device:CPU:0")
+  let x_cpu: TensorHandle<Float> = #tfop("Identity", x, __shapes: [TensorShape()], __device: "/device:CPU:0")
+  let y_cpu: TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __shapes: [TensorShape()], __device: "/device:CPU:0")
   // y is sent from CPU to TPU.
-  let z_tpu : TensorHandle<Float> = #tfop("Add", x_cpu, y_cpu , __shapes: [TensorShape()], __device: "TPU_SYSTEM")
+  let z_tpu: TensorHandle<Float> = #tfop("Add", x_cpu, y_cpu , __shapes: [TensorShape()], __device: "TPU_SYSTEM")
   _hostOp(z_tpu)
 }
 
@@ -169,7 +169,7 @@ public func explicitDevicePlacementAll() {
 // CHECK-NEXT:       device: "/device:CPU:0"
 
 public func GPUToTPUTransfer_Unsupported() {
-  let x : TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __shapes: [TensorShape()], __device: "/device:GPU:0")
+  let x: TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __shapes: [TensorShape()], __device: "/device:GPU:0")
   // expected-error @+1 {{TPU infeed enqueue cannot run on this device}}
-  let _ : TensorHandle<Float> = #tfop("Identity", x, __device: "TPU_SYSTEM")
+  let _: TensorHandle<Float> = #tfop("Identity", x, __device: "TPU_SYSTEM")
 }

--- a/test/TensorFlow/integration.swift
+++ b/test/TensorFlow/integration.swift
@@ -337,9 +337,9 @@ public func testCast(x: Tensor<Float>) -> Tensor<Int32> {
 public func testInputListArguments(a: TensorHandle<Float>, b: Tensor<Float>) -> Tensor<Float> {
   // Pack takes an input list, not multiple inputs.  Here we're checking that
   // we can pass in an array of Tensor's and an array of TensorHandle's.
-  let x: Tensor<Float> = #tfop("Pack", [a, a, a])  // expected-note {{value used here}}
-  let y: Tensor<Float> = #tfop("Pack", [b, b, b])  // expected-note {{value used here}}
-  return (x+y).toHost()
+  let x: TensorHandle<Float> = #tfop("Pack", [a, a, a])  // expected-note {{value used here}}
+  let y: TensorHandle<Float> = #tfop("Pack", [b, b, b])  // expected-note {{value used here}}
+  return (Tensor(handle: x)+Tensor(handle: y)).toHost()
 }
 
 /*

--- a/test/TensorFlow/no_copy.swift
+++ b/test/TensorFlow/no_copy.swift
@@ -237,9 +237,9 @@ public func testMultiOutputs() {
   let c = Tensor<Bool>(false)
   let (x1, y1): (TensorHandle<Float>, TensorHandle<Float>) = #tfop("Switch", d, c)
   // FIXME: Remove the uses of Identity nodes here.
-  let x : Tensor<Float> = #tfop("Identity", x1)
-  let y : Tensor<Float> = #tfop("Identity", y1)
-  print(x.array.scalars[0])
-  print(y.array.scalars[0])
+  let x : TensorHandle<Float> = #tfop("Identity", x1)
+  let y : TensorHandle<Float> = #tfop("Identity", y1)
+  _hostOp(x)
+  _hostOp(y)
 }
 

--- a/test/TensorFlow/no_copy.swift
+++ b/test/TensorFlow/no_copy.swift
@@ -55,7 +55,7 @@ public func testEmptyScalarsArray() {
  */
 
 // This tests the attributes necessary to get arrays of integers and strings going.
-public func testConvolution(x : Tensor<Float>, filter: Tensor<Float>) -> Tensor<Float> {
+public func testConvolution(x: Tensor<Float>, filter: Tensor<Float>) -> Tensor<Float> {
   return x.toAccelerator().convolved2D(withFilter: filter.toAccelerator(),
                        strides: (1, 2, 3, 4), padding: .same)
 }
@@ -134,7 +134,7 @@ public func randomUniformHoisting() -> Tensor<Float> {
 // scalar back to a tensor.  This checks to make sure that tf-partition can pull
 // this whole mess in graph without leaving anything on the host that will cause
 // a send/receive.
-public func tensorToScalarToTensor(a : Tensor<Int32>) -> Tensor<Int32> {
+public func tensorToScalarToTensor(a: Tensor<Int32>) -> Tensor<Int32> {
   let scalar = a.toAccelerator().mean()
   let b = Tensor(scalar)
   return (b+b).toHost()
@@ -237,8 +237,8 @@ public func testMultiOutputs() {
   let c = Tensor<Bool>(false)
   let (x1, y1): (TensorHandle<Float>, TensorHandle<Float>) = #tfop("Switch", d, c)
   // FIXME: Remove the uses of Identity nodes here.
-  let x : TensorHandle<Float> = #tfop("Identity", x1)
-  let y : TensorHandle<Float> = #tfop("Identity", y1)
+  let x: TensorHandle<Float> = #tfop("Identity", x1)
+  let y: TensorHandle<Float> = #tfop("Identity", y1)
   _hostOp(x)
   _hostOp(y)
 }

--- a/test/TensorFlow/sends_recvs.swift
+++ b/test/TensorFlow/sends_recvs.swift
@@ -322,7 +322,7 @@ public func test1RecvTensorCPU() {
 
 public func test1RecvTensorTPU() {
   TensorFlow.enableTPU()
-  let a_tpu_h : TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __device: "TPU_SYSTEM")
+  let a_tpu_h: TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __device: "TPU_SYSTEM")
   let a_tpu = Tensor<Float>(handle: a_tpu_h)
   // Tensor transfer for the param of atariSim(): TPU->CPU, and then CPU->host.
   let a_host = a_tpu.toHost(shape: TensorShape())
@@ -335,7 +335,7 @@ public func test1RecvTensorTPU() {
 public func test1RecvTensorTPU_ToHostNoShape_Error() {
   TensorFlow.enableTPU()
   // expected-error @+1 {{TPU outfeed dequeue supports dequeuing a single tensor -- did you specify shape?}}
-  let a_tpu_h : TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __device: "TPU_SYSTEM")
+  let a_tpu_h: TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __device: "TPU_SYSTEM")
   let a_tpu = Tensor<Float>(handle: a_tpu_h)
   // Tensor transfer for the param of atariSim(): TPU->CPU, and then CPU->host.
   let a_host = a_tpu.toHost()
@@ -347,7 +347,7 @@ public func test1RecvTensorTPU_ToHostNoShape_Error() {
 
 public func test1RecvTensorTPU_ToAcceleratorNoShape_Error() {
   TensorFlow.enableTPU()
-  let a_tpu_h : TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __device: "TPU_SYSTEM")
+  let a_tpu_h: TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __device: "TPU_SYSTEM")
   let a_tpu = Tensor<Float>(handle: a_tpu_h)
   // Tensor transfer for the param of atariSim(): TPU->CPU, and then CPU->host.
   let a_host = a_tpu.toHost(shape: TensorShape())
@@ -361,7 +361,7 @@ public func test1RecvTensorTPU_ToAcceleratorNoShape_Error() {
 // Specifying shapes for CPU<->GPU sends/recvs should not hurt.
 public func test1RecvTensorGPU_WithShapes() {
   TensorFlow.enableGPU()
-  let a_gpu_h : TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __device: "/device:CPU:0")
+  let a_gpu_h: TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __device: "/device:CPU:0")
   let a_gpu = Tensor<Float>(handle: a_gpu_h)
   // One send.
   // Tensor transfer for the param of atariSim(): GPU->CPU, and then CPU->host.

--- a/test/TensorFlow/sends_recvs.swift
+++ b/test/TensorFlow/sends_recvs.swift
@@ -322,7 +322,8 @@ public func test1RecvTensorCPU() {
 
 public func test1RecvTensorTPU() {
   TensorFlow.enableTPU()
-  let a_tpu : Tensor<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __device: "TPU_SYSTEM")
+  let a_tpu_h : TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __device: "TPU_SYSTEM")
+  let a_tpu = Tensor<Float>(handle: a_tpu_h)
   // Tensor transfer for the param of atariSim(): TPU->CPU, and then CPU->host.
   let a_host = a_tpu.toHost(shape: TensorShape())
   // For the result of atariSim(): host -> CPU, and then CPU->TPU.
@@ -334,7 +335,8 @@ public func test1RecvTensorTPU() {
 public func test1RecvTensorTPU_ToHostNoShape_Error() {
   TensorFlow.enableTPU()
   // expected-error @+1 {{TPU outfeed dequeue supports dequeuing a single tensor -- did you specify shape?}}
-  let a_tpu : Tensor<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __device: "TPU_SYSTEM")
+  let a_tpu_h : TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __device: "TPU_SYSTEM")
+  let a_tpu = Tensor<Float>(handle: a_tpu_h)
   // Tensor transfer for the param of atariSim(): TPU->CPU, and then CPU->host.
   let a_host = a_tpu.toHost()
   // For the result of atariSim(): host -> CPU, and then CPU->TPU.
@@ -345,7 +347,8 @@ public func test1RecvTensorTPU_ToHostNoShape_Error() {
 
 public func test1RecvTensorTPU_ToAcceleratorNoShape_Error() {
   TensorFlow.enableTPU()
-  let a_tpu : Tensor<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __device: "TPU_SYSTEM")
+  let a_tpu_h : TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __device: "TPU_SYSTEM")
+  let a_tpu = Tensor<Float>(handle: a_tpu_h)
   // Tensor transfer for the param of atariSim(): TPU->CPU, and then CPU->host.
   let a_host = a_tpu.toHost(shape: TensorShape())
   // For the result of atariSim(): host -> CPU, and then CPU->TPU.
@@ -358,7 +361,8 @@ public func test1RecvTensorTPU_ToAcceleratorNoShape_Error() {
 // Specifying shapes for CPU<->GPU sends/recvs should not hurt.
 public func test1RecvTensorGPU_WithShapes() {
   TensorFlow.enableGPU()
-  let a_gpu : Tensor<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __device: "/device:CPU:0")
+  let a_gpu_h : TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __device: "/device:CPU:0")
+  let a_gpu = Tensor<Float>(handle: a_gpu_h)
   // One send.
   // Tensor transfer for the param of atariSim(): GPU->CPU, and then CPU->host.
   let a_host = a_gpu.toHost(shape: TensorShape())

--- a/test/TensorFlowRuntime/sends_recvs_1.swift
+++ b/test/TensorFlowRuntime/sends_recvs_1.swift
@@ -102,7 +102,7 @@ SendsRecvsTests.testAllBackends("testSendsInALoopWithNoResultTensor",
 // Utilities.swift in TensorFlow stdlib.
 @inline(__always)
 func _scalarTensorWithShapeOnCPU<T>(_ x: Tensor<T>) -> Tensor<T> {
-  let ret : TensorHandle<T> = #tfop("Identity", x, __shapes: [TensorShape()], __device: "/device:CPU:0")
+  let ret: TensorHandle<T> = #tfop("Identity", x, __shapes: [TensorShape()], __device: "/device:CPU:0")
   return Tensor<T>(handle: ret)
 }
 

--- a/test/TensorFlowRuntime/sends_recvs_1.swift
+++ b/test/TensorFlowRuntime/sends_recvs_1.swift
@@ -102,8 +102,8 @@ SendsRecvsTests.testAllBackends("testSendsInALoopWithNoResultTensor",
 // Utilities.swift in TensorFlow stdlib.
 @inline(__always)
 func _scalarTensorWithShapeOnCPU<T>(_ x: Tensor<T>) -> Tensor<T> {
-  let ret : Tensor<T> = #tfop("Identity", x, __shapes: [TensorShape()], __device: "/device:CPU:0")
-  return ret
+  let ret : TensorHandle<T> = #tfop("Identity", x, __shapes: [TensorShape()], __device: "/device:CPU:0")
+  return Tensor<T>(handle: ret)
 }
 
 func test1RecvFloatScalar() {

--- a/utils/update-checkout-config.json
+++ b/utils/update-checkout-config.json
@@ -305,7 +305,7 @@
                 "swift-xcode-playground-support": "swift-DEVELOPMENT-SNAPSHOT-2018-06-19-a",
                 "ninja": "253e94c1fa511704baeb61cf69995bbf09ba435e",
                 "tensorflow": "9752b117ff63f204c4975cad52b5aab5c1f5e9a9",
-                "tensorflow-swift-bindings": "ce0a9e5561c0c6ce3af927bdfed51181da13aef1"
+                "tensorflow-swift-bindings": "489fcb7c4ca0ee11f3453ee7b0749a4f0742e780"
             }
         }
     }


### PR DESCRIPTION
One example is:
```
#tfop("SoftmaxCrossEntropyWithLogits", features, labels) -> (loss: TensorHandle<T>, backprop: TensorHandle<T>)
```

To do so, changed #tfop signature to never return Tensor -- most TF ops return
TensorHandle, some also return resource handles and variant handles.

This also has the benefit of:
- Simplifying the compiler code (in particular, removed code in CSApply.cpp that messes with #tfop return type)
- Simplifying the generated SIL code in some cases (when a #tfop conumes the TensorHandle output of another #tfop)

The APIs in RawOps (and other APIs in TensorFlow stdlib) will continue to consume and produce Tensor's, as Tensor is the user-facing class. The associated changes to RawOps is https://github.com/tensorflow/swift-bindings/pull/7.

Resolves [SR-8127](https://bugs.swift.org/browse/SR-8127).
