### PR TITLE
Remove some gratutious uses of GCC extensions from the Syntax library

### DIFF
--- a/lib/Syntax/RawSyntax.cpp
+++ b/lib/Syntax/RawSyntax.cpp
@@ -71,16 +71,16 @@ RawSyntax::RawSyntax(SyntaxKind Kind, ArrayRef<RC<RawSyntax>> Layout,
                      SourcePresence Presence, bool ManualMemory) {
   assert(Kind != SyntaxKind::Token &&
          "'token' syntax node must be constructed with dedicated constructor");
-  Bits.Kind = unsigned(Kind);
-  Bits.Presence = unsigned(Presence);
-  Bits.ManualMemory = unsigned(ManualMemory);
-  Bits.NumChildren = Layout.size();
+  Bits.Common.Kind = unsigned(Kind);
+  Bits.Common.Presence = unsigned(Presence);
+  Bits.Common.ManualMemory = unsigned(ManualMemory);
+  Bits.Layout.NumChildren = Layout.size();
 
   // Compute the text length
-  Bits.TextLength = 0;
+  Bits.Layout.TextLength = 0;
   for (const auto ChildNode : Layout) {
     if (ChildNode && !ChildNode->isMissing()) {
-      Bits.TextLength += ChildNode->getTextLength();
+      Bits.Layout.TextLength += ChildNode->getTextLength();
     }
   }
 
@@ -93,12 +93,12 @@ RawSyntax::RawSyntax(tok TokKind, OwnedString Text,
                      ArrayRef<TriviaPiece> LeadingTrivia,
                      ArrayRef<TriviaPiece> TrailingTrivia,
                      SourcePresence Presence, bool ManualMemory) {
-  Bits.Kind = unsigned(SyntaxKind::Token);
-  Bits.Presence = unsigned(Presence);
-  Bits.ManualMemory = unsigned(ManualMemory);
-  Bits.TokenKind = unsigned(TokKind);
-  Bits.NumLeadingTrivia = LeadingTrivia.size();
-  Bits.NumTrailingTrivia = TrailingTrivia.size();
+  Bits.Common.Kind = unsigned(SyntaxKind::Token);
+  Bits.Common.Presence = unsigned(Presence);
+  Bits.Common.ManualMemory = unsigned(ManualMemory);
+  Bits.Token.TokenKind = unsigned(TokKind);
+  Bits.Token.NumLeadingTrivia = LeadingTrivia.size();
+  Bits.Token.NumTrailingTrivia = TrailingTrivia.size();
 
   // Initialize token text.
   ::new (static_cast<void *>(getTrailingObjects<OwnedString>()))
@@ -109,7 +109,7 @@ RawSyntax::RawSyntax(tok TokKind, OwnedString Text,
   // Initialize trailing trivia.
   std::uninitialized_copy(TrailingTrivia.begin(), TrailingTrivia.end(),
                           getTrailingObjects<TriviaPiece>() +
-                              Bits.NumLeadingTrivia);
+                              Bits.Token.NumLeadingTrivia);
 }
 
 RawSyntax::~RawSyntax() {


### PR DESCRIPTION
Naming the bit-field structs is a significant readability improvement because it's very clear that you shouldn't touch e.g. `Bits.Token` without having checked/asserted that you're in a token case.

The assertions are all in statement context (which was obvious because the `NDEBUG` versions all included semicolons), so there's no reason not to use the traditional `do { } while (false)` trick instead of a statement-expression.

This also clears up some warnings in atypical build configurations.