### PR TITLE
[Sema] Improve error for inout on conversion

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -227,6 +227,12 @@ ERROR(cannot_subscript_nil_literal,none,
 ERROR(cannot_pass_rvalue_inout_subelement,none,
       "cannot pass immutable value as inout argument: %0",
       (StringRef))
+ERROR(cannot_pass_rvalue_inout_converted,none,
+      "inout argument could be set to a value with a type other than %0; "
+      "use a value declared as type %1 instead", (Type, Type))
+NOTE(inout_change_var_type_if_possible,none,
+      "change variable type to %1 if it doesn't need to be declared as %0",
+      (Type, Type))
 ERROR(cannot_pass_rvalue_inout,none,
       "cannot pass immutable value of type %0 as inout argument",
       (Type))

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -654,6 +654,70 @@ static bool isLoadedLValue(Expr *expr) {
   return false;
 }
 
+static void fixItChangeInoutArgType(const Expr * arg,
+                                    const Type actualType,
+                                    const Type neededType,
+                                    ConstraintSystem &CS) {
+  auto &TC = CS.getTypeChecker();
+  
+  auto *DRE = dyn_cast<DeclRefExpr>(arg);
+  if (!DRE)
+    return;
+  
+  auto *VD = dyn_cast_or_null<VarDecl>(DRE->getDecl());
+  if (!VD)
+    return;
+  
+  // Don't emit for non-local variables.
+  // (But in script-mode files, we consider module-scoped
+  // variables in the same file to be local variables.)
+  auto VDC = VD->getDeclContext();
+  bool isLocalVar = VDC->isLocalContext();
+  if (!isLocalVar && VDC->isModuleScopeContext()) {
+    auto argFile = CS.DC->getParentSourceFile();
+    auto varFile = VDC->getParentSourceFile();
+    isLocalVar = (argFile == varFile && argFile->isScriptMode());
+  }
+  if (!isLocalVar)
+    return;
+  
+  SmallString<32> scratch;
+  SourceLoc endLoc;       // Filled in if we decide to diagnose this
+  SourceLoc startLoc;     // Left invalid if we're inserting
+  
+  auto isSimpleTypelessPattern = [](Pattern *P) -> bool {
+    if (auto VP = dyn_cast_or_null<VarPattern>(P))
+      P = VP->getSubPattern();
+    return P && isa<NamedPattern>(P);
+  };
+  
+  auto typeRange = VD->getTypeSourceRangeForDiagnostics();
+  if (typeRange.isValid()) {
+    startLoc = typeRange.Start;
+    endLoc = typeRange.End;
+  } else if (isSimpleTypelessPattern(VD->getParentPattern())) {
+    endLoc = VD->getNameLoc();
+    scratch += ": ";
+  }
+  
+  if (endLoc.isInvalid())
+    return;
+  
+  scratch += neededType.getString();
+  
+  // Adjust into the location where we actually want to insert
+  endLoc = Lexer::getLocForEndOfToken(TC.Context.SourceMgr, endLoc);
+  
+  // Since we already adjusted endLoc, this will turn an insertion
+  // into a zero-character replacement.
+  if (!startLoc.isValid())
+    startLoc = endLoc;
+  
+  TC.diagnose(VD->getLoc(), diag::inout_change_var_type_if_possible,
+              actualType, neededType)
+    .fixItReplaceChars(startLoc, endLoc, scratch);
+}
+
 static void diagnoseSubElementFailure(Expr *destExpr,
                                       SourceLoc loc,
                                       ConstraintSystem &CS,
@@ -767,11 +831,24 @@ static void diagnoseSubElementFailure(Expr *destExpr,
   }
 
   if (auto *ICE = dyn_cast<ImplicitConversionExpr>(immInfo.first))
-    if (isa<LoadExpr>(ICE->getSubExpr())) {
-      TC.diagnose(loc, diagID,
-                  "implicit conversion from '" +
-                      CS.getType(ICE->getSubExpr())->getString() + "' to '" +
-                      CS.getType(ICE)->getString() + "' requires a temporary")
+    if (auto *LE = dyn_cast<LoadExpr>(ICE->getSubExpr())) {
+      Type actualType = CS.getType(LE);
+      Type neededType = CS.getType(ICE);
+      
+      if (diagID.ID == diag::cannot_pass_rvalue_inout_subelement.ID) {
+        // We have a special diagnostic with tailored wording for this
+        // common case.
+        TC.diagnose(loc, diag::cannot_pass_rvalue_inout_converted,
+                    actualType, neededType)
+          .highlight(ICE->getSourceRange());
+        
+        fixItChangeInoutArgType(LE->getSubExpr(), actualType, neededType, CS);
+      }
+      else
+        TC.diagnose(loc, diagID,
+                    "implicit conversion from '" +
+                    actualType->getString() + "' to '" +
+                    neededType->getString() + "' requires a temporary")
           .highlight(ICE->getSourceRange());
       return;
     }

--- a/test/TypeCoercion/protocols_library.swift
+++ b/test/TypeCoercion/protocols_library.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift -parse-as-library
+
+func refCoercion(_: inout CustomStringConvertible) {}
+
+// Make sure we don't add the fix-it for globals in non-script files
+var fp_2 = ""
+
+let x = refCoercion(&fp_2) // expected-error{{inout argument could be set to a value with a type other than 'String'; use a value declared as type 'CustomStringConvertible' instead}}
+
+func y() {
+  refCoercion(&fp_2) // expected-error{{inout argument could be set to a value with a type other than 'String'; use a value declared as type 'CustomStringConvertible' instead}}
+}

--- a/test/expr/capture/noescape-error.swift
+++ b/test/expr/capture/noescape-error.swift
@@ -6,6 +6,5 @@ class D {}
 func f1(f : (inout Int) -> ()) {}
 
 func f2(f : (inout Any) -> ()) {
-    // TODO: Error here is still pretty bad...
-    f1 { f(&$0) } // expected-error{{conversion from 'Int' to 'Any'}}
+    f1 { f(&$0) } // expected-error{{inout argument could be set to a value with a type other than 'Int'; use a value declared as type 'Any' instead}}
 }


### PR DESCRIPTION
When a user attempts to pass a value requiring an implicit conversion as an `inout` argument (usually a subclass instead of its superclass, or a conforming type instead of its protocol existential), the diagnostic we produce is not very clear:

```swift
func useSuper(_: inout Super) {}
var sub = Sub()
useSuper(&sub)
// error: cannot pass immutable value as inout argument: implicit conversion
//     from 'Sub' to 'Super' requires a temporary
```

This PR changes the error message:
```swift
// error: cannot pass implicitly converted value of type 'Sub' to inout argument:
//     use a temporary variable of exact type 'Super' instead
```

It leaves the existing diagnostic in place for a number of related errors involving implicit conversions (e.g. with operators, on left-hand side of assignment, etc.). I don't think that these cases should actually occur—operators apparently reject solutions with implicit conversions much earlier, and most of the others seem like solutions we'd never generate—but if they can, the old message is better than nothing.

It'd be nice to offer one or both of these fixes:
```swift
// note: make inout parameter generic if 'useSuper' cannot change its type
func useSuper<T: Super>(_: inout T) {}
```
```swift
// note: insert a temporary of type 'Super'
var temporary = sub as Super
useSuper(&temporary)
sub = temporary as! Sub
```

But the former would require us to diagnose this error higher in the AST, probably at the `CallExpr`, while the latter seems to really stretch what a fix-it can currently do.

Resolves [SR-8155](https://bugs.swift.org/browse/SR-8155). See also [SR-8148](https://bugs.swift.org/browse/SR-8148), which was closed by the user.

Tagging Joe because he griped about this diagnostic in a FIXME, and David because he reported the issue.