### PR TITLE
[Sema] Reject usage of @TensorFlowGraph on generic functions.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2557,6 +2557,8 @@ ERROR(tf_graph_attr_function_tensorflow_value_only,none,
       "@TensorFlowGraph can only be applied to functions whose parameters and "
       "return values are TensorFlow values or aggregates of TensorFlow "
       "values", ())
+ERROR(tf_graph_attr_no_generic_functions,none,
+      "@TensorFlowGraph cannot be applied to generic functions", ())
 
 //------------------------------------------------------------------------------
 // MARK: Type Check Expressions

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2653,6 +2653,11 @@ void AttributeChecker::visitTensorFlowGraphAttr(TensorFlowGraphAttr *attr) {
     diagnoseAndRemoveAttr(attr, diag::tf_graph_attr_top_level_only);
     return;
   }
+  // Generic functions are not supported.
+  if (FD->isGeneric()) {
+    diagnoseAndRemoveAttr(attr, diag::tf_graph_attr_no_generic_functions);
+    return;
+  }
   // Only functions taking and returning TensorFlow values are permitted.
   if (!tf::isTensorFlowValueOrAggregate(
         FD->getParameterList(0)->getType(FD->getASTContext())) ||

--- a/test/TensorFlow/attr_tensorflow_graph_sema.swift
+++ b/test/TensorFlow/attr_tensorflow_graph_sema.swift
@@ -23,6 +23,10 @@ func tensors(_ x: Tensor<Float>) -> Tensor<Int32> {} // okay
 @TensorFlowGraph
 func multiRetTensors(_ x: Tensor<Int32>) -> (Tensor<Double>, Tensor<Float>) {} // okay
 
+// expected-error @+1 {{@TensorFlowGraph cannot be applied to generic functions}}
+@TensorFlowGraph
+func generic<T>(_ x: Tensor<T>) -> Tensor<T> {}
+
 // expected-error @+1 {{@TensorFlowGraph can only be applied to functions whose parameters and return values are TensorFlow values or aggregates of TensorFlow values}}
 @TensorFlowGraph
 func wrongInput(_ x: Int32) -> ResourceHandle {}


### PR DESCRIPTION
Partitioning on generic functions won't be supported any time soon, and it's not practical (or even possible?) to have dtype-generic TensorFlow graphs. We reject the use of `@TensorFlowGraph` on generic functions.