### PR TITLE
Added partial support for SwitchEnum, which works when the num has exactly 2 cases, such as {some, none} in a swift optional

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -951,7 +951,10 @@ void TFFunctionPartition::markBlock(SILBasicBlock *BB) {
     return;
 
   // Walk predecessors until we find marked blocks or other blocks we are
-  // control-dependent on.  We only scan the region post dominated by BB.
+  // control-dependent on.
+  //
+  // We only scan the region post dominated by BB.  In other words, elements in
+  // worklist must be post-minated by BB.
   //
   // Note that though this is bounded, that it isn't a very efficient algorithm
   // since each block marking can walk the entire function's CFG, but it is good
@@ -967,6 +970,7 @@ void TFFunctionPartition::markBlock(SILBasicBlock *BB) {
 
   // Walk up the CFG looking for terminators we are control-dependent on.
   while (!worklist.empty()) {
+    // The basic block being processed in this loop iteration.
     auto thisBB = worklist.pop_back_val();
     assert(tensorCodeBlocks.postDominates(BB, thisBB) &&
            "Should only be scanning the region pdom'd by BB");
@@ -1002,18 +1006,36 @@ void TFFunctionPartition::markBlock(SILBasicBlock *BB) {
       // aren't control-dependent on it.  It may be control-dependent on
       // something though.
       if (numTensorSuccs == 1) {
+        assert(tensorCodeBlocks.postDominates(thisBB, pred));
+        assert(tensorCodeBlocks.postDominates(BB, pred));
         worklist.push_back(pred);
         continue;
       }
 
-      // Otherwise, check to see if BB is post-dominated by thisBB, but not by
-      // pred - in other words that it is the post dominance frontier for BB.
-      // If so, that means that the terminator in pred controls whether BB is
-      // executed, so it must be marked.
+      // Otherwise, we already know by construction that BB post-dominates
+      // thisBB -- now we check to see if BB also post-dominates pred. If not,
+      // pred is the post dominance frontier for BB, and that means that the
+      // terminator in pred controls whether BB is executed, so it must be
+      // marked.  For example, BB is control-dependent on pred in this CFG:
+      //
+      //    pred
+      //    /  \
+      //   ..  thisBB
+      //    \   |
+      //    ..  BB
+      //      \ |
+      //       ..
       if (!tensorCodeBlocks.postDominates(BB, pred)) {
         auto predTerm = pred->getTerminator();
         if (isa<BranchInst>(predTerm) || isa<CondBranchInst>(predTerm)) {
           markInstruction(*predTerm, Marking::Copy);
+          continue;
+        }
+
+        if (isa<SwitchEnumInst>(predTerm)) {
+          // We intend for `predTerm` to still run on host (and thus did not
+          // mark its parent block), but send its result to accelerator.
+          markedInstructions.insert({predTerm, Marking::Send});
           continue;
         }
 
@@ -2039,6 +2061,7 @@ class PartitionCloner : public SILClonerWithScopes<PartitionCloner> {
   // On error, returns false.
   bool finalizeOriginal();
 
+  void handleSwitchEnum(SwitchEnumInst *inst);
   void insertSend(SILInstruction &inst);
   // On error, returns false.
   bool insertReceive(SILValue value, SILLocation loc);
@@ -2127,10 +2150,10 @@ private:
   void initBlock(SILBasicBlock *BB);
   void cloneBlock(SILBasicBlock *BB);
 
-  // If the type T of `value` conforms to TensorSendableReceivable protocol,
+  // If `type` conforms to TensorSendableReceivable protocol,
   // looks up and returns the SIL function associated with T based on `fnName`.
   // Otherwise emits error diagnostics, and returns NULL.
-  SILFunction *lookupSendReceiveFunction(StringRef fnName, SILValue value,
+  SILFunction *lookupSendReceiveFunction(StringRef fnName, SILType type,
                                          SILLocation loc);
 };
 } // end anonymous namespace
@@ -2227,8 +2250,8 @@ void PartitionCloner::visitGraphOperationInst(GraphOperationInst *inst) {
     // by GraphGen.
     auto result = remapValue(inst->getOperand(0));
     auto S2TResult = inst->getResult(0);
-    if (!S2TResult->getType().getASTType()
-          ->isEqual(result->getType().getASTType())) {
+    if (!S2TResult->getType().getASTType()->isEqual(
+            result->getType().getASTType())) {
       auto &B = getBuilder();
       auto loc = remapLocation(getUserSourceLocation(inst->getDebugLocation()));
       result = B.createUncheckedRefCast(loc, result, S2TResult->getType());
@@ -2292,6 +2315,27 @@ void PartitionCloner::visitOpInst(SingleValueInstruction *inst,
   ValueMap[inst] = result;
 }
 
+/// Create the operands a const tensor inst in accelerator code via `B` at
+/// `loc`, based on the literal in `hostLiteralInst`.  Extend `opName` and
+/// `operands` with the attributes of that const tensor inst, which caller will
+/// then use to finish creating the inst.
+// TODO: migrate to the new graph op inst.
+static void createConstTensorAttrsOnAccel(
+    SingleValueInstruction *hostLiteralInst, SILLocation loc, ASTContext &ctx,
+    SILBuilder &B, std::string &opName, SmallVectorImpl<SILValue> &operands) {
+  // Literals take attributes specifying the dtype and value.
+  opName += ",dtype$dtype,value$tensor";
+
+  auto dtype = convertSwiftTypeToTF(hostLiteralInst->getType().getASTType());
+  auto dtypeCst = B.createIntegerLiteral(
+      loc, SILType::getBuiltinIntegerType(32, ctx), dtype);
+  operands.push_back(dtypeCst);
+
+  // The value attribute is specified by a clone of the literal itself.
+  auto ourCst = hostLiteralInst->clone(dtypeCst);
+  ourCst->setDebugLocation(B.getSILDebugLocation(loc));
+  operands.push_back(ourCst);
+}
 
 /// Given a primitive scalar instruction like a literal or an LLVM IR
 /// instruction (represented as a builtin), promote it to a tensor op in the
@@ -2348,19 +2392,7 @@ void PartitionCloner::visitScalarInst(SingleValueInstruction *inst) {
     opName += ",$in,$in";
     break;
   case PromotedScalarKind::Literal: {
-    // Literals take attributes specifying the dtype and value.
-    opName += ",dtype$dtype,value$tensor";
-
-    auto dtype = convertSwiftTypeToTF(inst->getType().getASTType());
-    auto dtypeCst =
-      B.createIntegerLiteral(loc, SILType::getBuiltinIntegerType(32, ctx),
-                             dtype);
-    operands.push_back(dtypeCst);
-
-    // The value attribute is specified by a clone of the literal itself.
-    auto ourCst = inst->clone(dtypeCst);
-    ourCst->setDebugLocation(B.getSILDebugLocation(loc));
-    operands.push_back(ourCst);
+    createConstTensorAttrsOnAccel(inst, loc, ctx, B, opName, operands);
     break;
   }
   case PromotedScalarKind::Conversion: {
@@ -2418,14 +2450,20 @@ static SILValue wrapInStruct(SILValue v, NominalTypeDecl *decl, SILBuilder &B,
   return B.createStruct(loc, silType, v);
 }
 
+/// `decl` is an stdlib numeric type represented by a struct wrapping an LLVM
+/// builtin type, such as $Bool, $Float and $Int64.
+static SILType getStdlibNumericTypeFromDecl(NominalTypeDecl *decl) {
+  auto type = getSingleElementDeclFieldType(decl);
+  return SILType::getPrimitiveObjectType(type);
+}
+
 /// Create a value of some standard library integer type, as specified by
 /// integerDecl.
 static SILValue createSomeIntegerValue(intmax_t value, SILBuilder &B,
                                        SILLocation loc,
                                        NominalTypeDecl *integerDecl,
                                        IntegerLiteralInst **ILI = nullptr) {
-  auto intFieldType = getSingleElementDeclFieldType(integerDecl);
-  auto intFieldSILType = SILType::getPrimitiveObjectType(intFieldType);
+  auto intFieldSILType = getStdlibNumericTypeFromDecl(integerDecl);
 
   auto literal = B.createIntegerLiteral(loc, intFieldSILType, value);
 
@@ -2681,13 +2719,13 @@ static SILValue createHostSend(SILBuilder &B, SILLocation loc, SILValue value,
 }
 
 SILFunction *PartitionCloner::lookupSendReceiveFunction(StringRef fnName,
-                                                        SILValue value,
+                                                        SILType type,
                                                         SILLocation loc) {
   auto &ctx = FP.hostFn.getASTContext();
   // If `value` is not receivable, reject the program with diagnostics.
   auto proto = ctx.getProtocol(KnownProtocolKind::TensorSendableReceivable);
   SmallVector<ProtocolConformance *, 1> conformances;
-  auto tensorValueTy = convertElementTypeToTensorValueType(value->getType());
+  auto tensorValueTy = convertElementTypeToTensorValueType(type);
   auto nominal = tensorValueTy.getASTType()->getAnyNominal();
   auto lookup =
       nominal->lookupConformance(&tensorFlowModule, proto, conformances);
@@ -2704,10 +2742,150 @@ SILFunction *PartitionCloner::lookupSendReceiveFunction(StringRef fnName,
   return fn;
 }
 
+/// The partitioned code is illustrated by the snippet below:
+///
+/// Host side:
+/// bb0:
+///   ...
+///   swich_enum %X, case ..: bb1, case ..: bb2, .., case ..: bbN
+///
+/// bb1:
+///   sendToAccelerator(0) // 0 is the case id here
+///   <other host code>
+///   br bb_merge
+///
+/// <same for bb2 through bbN, sending a different case_id each>
+///
+/// bb_merge:
+///   ...
+///
+/// Accelerator side:
+/// bb0:
+///   ...
+///   %case_id = recvFromHost()
+///   if %case_id == 0 goto bb1
+///   else if %case_id == 1 goto bb2
+///   else ...
+///
+void PartitionCloner::handleSwitchEnum(SwitchEnumInst *inst) {
+  auto &ctx = FP.hostFn.getASTContext();
+  auto intDecl = ctx.getInt64Decl();
+  auto intFieldSILType = getStdlibNumericTypeFromDecl(intDecl);
+
+  auto hostLoc = getUserSourceLocation(inst);
+  auto *createScalarTensorFn =
+      lookupSendReceiveFunction("scalar", intFieldSILType, hostLoc);
+  // If `result` were not a send'able data type like String, compiler
+  // would have rejected the program before reaching here.
+  assert(createScalarTensorFn &&
+         "At this point of compilation, scalar value must be send'able "
+         "from Swift to TensorFlow.");
+  (void)createScalarTensorFn;
+
+  SILFunction *sendFn =
+      lookupSendReceiveFunction("sendToAccelerator", intFieldSILType, hostLoc);
+  assert(sendFn && "At this point of compilation, the value must be send'able "
+                   "from Swift to TensorFlow.");
+  (void)sendFn;
+
+  // Create the host->accelerator sends in the host code.
+  for (unsigned i = 0, e = inst->getNumCases(); i != e; ++i) {
+    SILBasicBlock *caseBB = inst->getCase(i).second;
+    SILBuilder BH(caseBB); // Builder for host.
+
+    // The send is at the beginning of each caseBB.
+    BH.setInsertionPoint(&caseBB->front());
+    auto loc = caseBB->front().getLoc();
+    // `caseId` must be of a type conforming to `AccelerableByTensorFlow`, so we
+    // chose Int64 here.
+    auto caseId = createSomeIntegerValue(i, BH, loc, intDecl);
+
+    createHostSend(BH, loc, caseId, tensorComputation, nextSendID,
+                   tensorFlowModule, FP.hostFn.getModule(),
+                   createScalarTensorFn, sendFn);
+  }
+
+  // In accelerator, first recv the caseId from host, and then dispatch to the
+  // right BB. An example SIL snippet is:
+  //
+  // %caseId = builtin "__tfop_tfc.RecvFromHost,tensorId...
+  // %zeroScalarTensor = builtin "__tfop_Const,...
+  // Both operands have type $TensorHandle<Builtin.Int64>
+  // %eq = builtin "__tfop_Equal,$in,$in(%caseId, %zeroScalarTensor)
+  // %cond = builtin "tf_tensor_to_i1"(%eq : $TensorHandle<Builtin.Int1>)
+  // cond_br %cond, bb1, bb2
+  auto BA = getBuilder(); // Builder for accelerator.
+  auto loc = remapLocation(getUserSourceLocation(inst->getDebugLocation()));
+  auto acceleratorCaseId =
+      createAcceleratorReceive(BA, loc, remapType(intFieldSILType),
+                               /*isScalar*/ true, nextSendID, FP.configuration);
+
+  assert(inst->getNumCases() == 2 &&
+         "switch enums with 1 or >2 cases will be supported later.");
+  // Create a scalar const tensor 0, to compare with case id.
+  BuiltinInst *zeroConstTensor = nullptr;
+  {
+    auto *caseZero = BA.createIntegerLiteral(loc, intFieldSILType, 0);
+    SmallVector<SILValue, 4> operands;
+    std::string constOpName = "__tfop_Const";
+    createConstTensorAttrsOnAccel(caseZero, loc, ctx, BA, constOpName,
+                                  operands);
+    FP.configuration.handleDevicePlacement(
+        "Const", /*opDevice*/ getDeviceString(DeviceType::ALL), BA, loc,
+        operands, constOpName);
+    auto subMap = getSingleSubstitutionMapForElementType(
+        intFieldSILType.getASTType(), ctx);
+    auto tensorHandleInt64Ty =
+        convertElementTypeToTensorValueType(intFieldSILType);
+    zeroConstTensor = BA.createBuiltin(loc, ctx.getIdentifier(constOpName),
+                                       tensorHandleInt64Ty, subMap, operands);
+  }
+
+  // Cast to a TensorHandle<Builtin.Int1> value
+  BuiltinInst *condBrOperand = nullptr;
+  {
+    // Omit the metatype attr T for simplicity, and TF graphDef compiler can
+    // infer the type.
+    std::string equalOpName = "__tfop_Equal,$in,$in";
+    auto boolFieldSILType = getStdlibNumericTypeFromDecl(ctx.getBoolDecl());
+    auto tensorHandleI1Ty =
+        convertElementTypeToTensorValueType(boolFieldSILType);
+    SmallVector<SILValue, 4> operands = {acceleratorCaseId, zeroConstTensor};
+    FP.configuration.handleDevicePlacement(
+        "Equal", /*opDevice*/ getDeviceString(DeviceType::ALL), BA, loc,
+        operands, equalOpName);
+    auto subMap = getSingleSubstitutionMapForElementType(
+        boolFieldSILType.getASTType(), ctx);
+    auto *equalComparisonInst =
+        BA.createBuiltin(loc, ctx.getIdentifier(equalOpName), tensorHandleI1Ty,
+                         subMap, operands);
+    condBrOperand =
+        BA.createBuiltin(loc, ctx.getIdentifier("tf_tensor_to_i1"),
+                         boolFieldSILType, {}, {equalComparisonInst});
+  }
+
+  // The args for the true and false BBs are always sent from host to
+  // accelerator, so no BB args for them here.
+  BA.createCondBranch(
+      loc, condBrOperand, getOpBasicBlock(inst->getCase(0).second),
+      /*TrueArgs*/ OperandValueArrayRef(),
+      getOpBasicBlock(inst->getCase(1).second),
+      /*FalseArgs*/ OperandValueArrayRef(), ProfileCounter(), ProfileCounter());
+
+  ++nextSendID;
+}
+
 /// Insert a send of values from the specified instruction result(s) to the
 /// accelerator, and insert receives in it.
 void PartitionCloner::insertSend(SILInstruction &inst) {
-  assert(!isa<TermInst>(inst) && "Cannot insert after a terminator");
+  if (isa<TermInst>(inst)) {
+    if (auto *SEI = dyn_cast<SwitchEnumInst>(&inst)) {
+      handleSwitchEnum(SEI);
+      return;
+    }
+    inst.dump();
+    llvm_unreachable("Cannot handle the above terminator with Marking::Send");
+  }
 
   SILBuilder BH(++SILBasicBlock::iterator(&inst)); // Builder for host.
   auto BA = getBuilder();        // Builder for accelerator.
@@ -2727,15 +2905,16 @@ void PartitionCloner::insertSend(SILInstruction &inst) {
     // reference to createHostSend() below for this scalar->tensor conversion.
     SILFunction *createScalarTensorFn = nullptr;
     if (isScalar) {
-      createScalarTensorFn = lookupSendReceiveFunction("scalar", result, loc);
+      createScalarTensorFn =
+          lookupSendReceiveFunction("scalar", result->getType(), loc);
       // If `result` were not a send'able data type like String, compiler
-      // would not rejected the program before reaching here.
+      // would have rejected the program before reaching here.
       assert(createScalarTensorFn &&
              "At this point of compilation, scalar value must be send'able "
              "from Swift to TensorFlow.");
     }
     SILFunction *sendFn =
-        lookupSendReceiveFunction("sendToAccelerator", result, loc);
+        lookupSendReceiveFunction("sendToAccelerator", result->getType(), loc);
     assert(sendFn &&
            "At this point of compilation, the value must be send'able "
            "from Swift to TensorFlow.");
@@ -2750,8 +2929,8 @@ void PartitionCloner::insertSend(SILInstruction &inst) {
 bool PartitionCloner::insertReceive(SILValue value, SILLocation loc) {
   assert(value->getDefiningInstruction() || isa<SILArgument>(value) &&
          "Don't know how to receive this value");
-  SILFunction *receiveFn =
-      lookupSendReceiveFunction("receiveFromAccelerator", value, loc);
+  SILFunction *receiveFn = lookupSendReceiveFunction("receiveFromAccelerator",
+                                                     value->getType(), loc);
   // If `value` is not receivable on Swift host from TensorFlow (e.g. it is a
   // tensor resource handle), reject the program.
   if (!receiveFn) return false;

--- a/test/TensorFlow/sends_recvs.swift
+++ b/test/TensorFlow/sends_recvs.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -O -emit-sil %s -verify | %FileCheck %s
 
+// In this file, send means accelerator->host, and recv means the opposite.
+
 import TensorFlow
 
 public func test1Send() {

--- a/test/TensorFlowRuntime/control_flow.swift
+++ b/test/TensorFlowRuntime/control_flow.swift
@@ -1,0 +1,28 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize
+
+// Control flow related tests.
+
+import TensorFlow
+import TensorFlowUnittest
+import StdlibUnittest
+
+var ControlFlowTests = TestSuite("ControlFlow")
+
+@inline(never)
+public  func testSwitchEnum(_ a: Tensor<Float>?,
+                            _ expectedVal: Float) {
+  var b = Tensor<Float>(2.0)
+  if let a = a {
+    b += a
+  }
+  b -= 1.0
+  expectNearlyEqualWithScalarTensor(expectedVal, b)
+}
+ControlFlowTests.testAllBackends("testSwitchEnum") {
+  testSwitchEnum(Tensor<Float>(1.0), 2.0)
+  testSwitchEnum(nil, 1.0)
+}
+
+runAllTests()

--- a/test/TensorFlowRuntime/sends_recvs_1.swift
+++ b/test/TensorFlowRuntime/sends_recvs_1.swift
@@ -127,7 +127,7 @@ func test1RecvIntScalar() {
 SendsRecvsTests.testAllBackends("test1RecvIntScalar", test1RecvIntScalar)
 
 @inline(never)
-func atariSimFloat(_ a: Tensor<Float>) -> Tensor<Float> {
+func atariSim<T>(_ a: Tensor<T>) -> Tensor<T> {
   return a
 }
 
@@ -136,8 +136,7 @@ func test1RecvFloatTensor() {
   // One send.
   printT(a.toHost())
   // One recv.
-  var b = atariSimFloat(a).toAccelerator()
-  let b_cpu = atariSimFloat(a).toAccelerator()
+  let b_cpu = atariSim(a).toAccelerator()
   var b_tpu = _scalarTensorWithShapeOnCPU(b_cpu)
   b_tpu += a
   printT("final b = \(b_tpu.toHost())")
@@ -145,17 +144,12 @@ func test1RecvFloatTensor() {
 }
 SendsRecvsTests.testAllBackends("test1RecvFloatTensor", test1RecvFloatTensor)
 
-@inline(never)
-func atariSimInt(_ a: Tensor<Int64>) -> Tensor<Int64> {
-  return a
-}
-
 func test1RecvIntTensor() {
   let a = Tensor<Int64>(1)
   // One send.
   printT(a.toHost())
   // One recv.
-  let b_cpu = atariSimInt(a).toAccelerator()
+  let b_cpu = atariSim(a).toAccelerator()
   var b_tpu = _scalarTensorWithShapeOnCPU(b_cpu)
   b_tpu += a
   printT("final b = \(b_tpu.toHost())")


### PR DESCRIPTION
A later PR will extend the support for N cases.

The design is for host to send the switch case id (a int64 value) to accelerator
in each of the cases, and for accelerator to recv the case id, and use a
sequence of cond_br instructions to dispatch to the right basic block.

To illustrate this design with pseudo-code in SIL, host does:

```
bb0:
  ...
  switch_enum %X, bb1, bb2, ..., bbN

bb1:
  sendToAccelerator(0) // 0 is the case id here
  <other host code>
  br bb_merge

<same for bb2 through bbN, sending a different case_id each>

bb_merge:
  ...
```

Accelerator side:
```
bb0:
  ...
  %case_id = recvFromHost
  if %case_id == 0 goto bb1
  else if %case_id == 1 goto bb2
  else ...
```

When TF backend supports switch_case in the future, we can lower to switch_case
instead of a sequence of if's / cond_br's.
