### PR TITLE
[Sema] Fix crash on bad inheritance clause

### DIFF
--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -956,7 +956,8 @@ void AccessControlChecker::check(Decl *D) {
           return false;
         Type ty = inherited.getType();
         if (ty->is<ProtocolCompositionType>())
-          ty = ty->getExistentialLayout().superclass;
+          if (auto superclass = ty->getExistentialLayout().superclass)
+            ty = superclass;
         return ty->getAnyNominal() == superclassDecl;
       });
       // Sanity check: we couldn't find the superclass for whatever reason
@@ -1475,7 +1476,8 @@ void UsableFromInlineChecker::check(Decl *D) {
           return false;
         Type ty = inherited.getType();
         if (ty->is<ProtocolCompositionType>())
-          ty = ty->getExistentialLayout().superclass;
+          if (auto superclass = ty->getExistentialLayout().superclass)
+            ty = superclass;
         return ty->getAnyNominal() == superclassDecl;
       });
       // Sanity check: we couldn't find the superclass for whatever reason

--- a/test/decl/inherit/inherit.swift
+++ b/test/decl/inherit/inherit.swift
@@ -1,7 +1,8 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -swift-version 5
 
-class A { }
-protocol P { }
+public class A { }
+public protocol P { }
+public protocol P1 { }
 
 // Duplicate inheritance
 class B : A, A { } // expected-error{{duplicate inheritance from 'A'}}{{12-15=}}
@@ -17,6 +18,17 @@ class C : B, A { } // expected-error{{multiple inheritance from classes 'B' and 
 
 // Superclass in the wrong position
 class D : P, A { } // expected-error{{superclass 'A' must appear first in the inheritance clause}}{{12-15=}}{{11-11=A, }}
+
+// SR-8160
+class D1 : Any, A { } // expected-error{{superclass 'A' must appear first in the inheritance clause}}{{15-18=}}{{12-12=A, }}
+
+class D2 : P & P1, A { } // expected-error{{superclass 'A' must appear first in the inheritance clause}}{{18-21=}}{{12-12=A, }}
+
+@usableFromInline
+class D3 : Any, A { } // expected-error{{superclass 'A' must appear first in the inheritance clause}}{{15-18=}}{{12-12=A, }}
+
+@usableFromInline
+class D4 : P & P1, A { } // expected-error{{superclass 'A' must appear first in the inheritance clause}}{{18-21=}}{{12-12=A, }}
 
 // Struct inheriting a class
 struct S : A { } // expected-error{{non-class type 'S' cannot inherit from class 'A'}}


### PR DESCRIPTION
When checking for the superclass type, ensure we don't use a protocol composition's superclass type if it doesn't have one.

Resolves [SR-8160](https://bugs.swift.org/browse/SR-8160).
