### PR TITLE
Adjust several type checker perf tests to be more complex.

### DIFF
--- a/validation-test/Sema/type_checker_perf/slow/rdar19612086.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar19612086.swift
@@ -13,7 +13,10 @@ struct rdar19612086 {
   var description : String {
     return "\(i)" + Stringly(format: "%.2f", x) +
            "\(i+1)" + Stringly(format: "%.2f", x) +
-           "\(i+2)" + Stringly(format: "%.2f", x)
+           "\(i+2)" + Stringly(format: "%.2f", x) +
+           "\(i+3)" + Stringly(format: "%.2f", x) +
+           "\(i+4)" + Stringly(format: "%.2f", x) +
+           "\(i+5)" + Stringly(format: "%.2f", x)
     // expected-error@-1 {{reasonable time}}
   }
 }

--- a/validation-test/Sema/type_checker_perf/slow/rdar20859567.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar20859567.swift
@@ -9,5 +9,9 @@ struct Stringly {
 
 [Int](0..<1).map {
   // expected-error@-1 {{reasonable time}}
-  print(Stringly(format: "%d: ", $0 * 2 * 42) + ["a", "b", "c", "d", "e", "f", "g"][$0 * 2] + "," + "," + ",")
+  print(Stringly(format: "%d: ",
+      $0 * 2 * 42 +
+      $0 * 2 * 42 +
+      $0 * 2 * 42
+    ) + ["a", "b", "c", "d", "e", "f", "g"][$0 * 2] + "," + "," + ",")
 }

--- a/validation-test/Sema/type_checker_perf/slow/rdar22949523.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar22949523.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
 // REQUIRES: tools-release,no_asserts
 
-_ = [0,1,2,3].lazy.map { String($0)+"hi" }.sorted(by: { $0 > $1 })
+_ = [0,1,2,3].lazy.map { String($0)+"hi" }.sorted(by: { $0 > $1 && $1 < $0 && ($1 + $0) < 1000 })
 // expected-error@-1 {{reasonable time}}

--- a/validation-test/Sema/type_checker_perf/slow/rdar23429943.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar23429943.swift
@@ -3,5 +3,5 @@
 
 let _ = [0].reduce([Int]()) {
   // expected-error@-1 {{reasonable time}}
-  return $0.count == 0 && $1 == 0 ? [] : $0 + [$1]
+  return $0.count == 0 && ($1 == 0 || $1 == 2 || $1 == 3) ? [] : $0 + [$1]
 }

--- a/validation-test/Sema/type_checker_perf/slow/rdar23861629.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar23861629.swift
@@ -6,6 +6,6 @@ struct S { var s: String? }
 func rdar23861629(_ a: [S]) {
   _ = a.reduce("") {
     // expected-error@-1 {{reasonable time}}
-    ($0 == "") ? ($1.s ?? "") : $0 + "," + ($1.s ?? "")
+    ($0 == "") ? ($1.s ?? "") : ($0 + "," + ($1.s ?? "")) + ($1.s ?? "test") + ($1.s ?? "okay")
   }
 }

--- a/validation-test/Sema/type_checker_perf/slow/rdar31742586.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar31742586.swift
@@ -2,6 +2,6 @@
 // REQUIRES: tools-release,no_asserts
 
 func rdar31742586() -> Double {
-  return -(1 + 2) + -(3 + 4) + 5
+  return -(1 + 2) + -(3 + 4) + 5 - (-(1 + 2) + -(3 + 4) + 5)
   // expected-error@-1 {{reasonable time}}
 }

--- a/validation-test/Sema/type_checker_perf/slow/rdar32998180.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar32998180.swift
@@ -2,7 +2,8 @@
 // REQUIRES: tools-release,no_asserts
 
 func rdar32998180(value: UInt16) -> UInt16 {
-  var result = (((value >> 1) ^ (value >> 1) ^ (value >> 1) ^ (value >> 1)) & 1) << 1
+  var result = ((((value >> 1) ^ (value >> 1) ^ (value >> 1) ^ (value >> 1)) & 1) << 1)
+  | (((((value >> 1) ^ (value >> 1) ^ (value >> 1) ^ (value >> 1)) & 1) << 1) << 1)
   // expected-error@-1 {{reasonable time}}
   return result
 }


### PR DESCRIPTION
None of these failed naturally based on the limits of the "too
complex" heuristic and several were relatively closer to the time-out
threshold used in the test RUN line.

Increasing the complexity will ensure that we don't see spurious
failures on builders or on local machines.
