### PR TITLE
IndexSet.union performance improvement

### DIFF
--- a/stdlib/public/SDK/Foundation/IndexSet.swift
+++ b/stdlib/public/SDK/Foundation/IndexSet.swift
@@ -442,16 +442,23 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     
     /// Union the `IndexSet` with `other`.
     public func union(_ other: IndexSet) -> IndexSet {
-        // This algorithm is naïve but it works. We could avoid calling insert in some cases.
-        
-        var result = IndexSet()
-        for r in self.rangeView {
-            result.insert(integersIn: r)
+        var result: IndexSet
+        var dense: IndexSet
+
+        // Prepare to make a copy of the more sparse IndexSet to prefer copy over repeated inserts
+        if self.rangeView.count > other.rangeView.count {
+            result = self
+            dense = other
+        } else {
+            result = other
+            dense = self
         }
-        
-        for r in other.rangeView {
-            result.insert(integersIn: r)
+
+        // Insert each range from the less sparse IndexSet
+        dense.rangeView.forEach {
+            result.insert(integersIn: $0)
         }
+
         return result
     }
     


### PR DESCRIPTION
Improves performance of IndexSet.union by replacing a loop with a struct copy of the more sparse set. Same change as [#1603](https://github.com/apple/swift-corelibs-foundation/pull/1603) merged into swift-corelibs-foundation.