### PR TITLE
[Parser] Make sure to add implicit parens to call for prefix/postfix operators when needed

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -785,7 +785,17 @@ swift::decomposeArgType(Type type, ArrayRef<Identifier> argumentLabels) {
                                             parenTy->getParameterFlags()));
     return result;
   }
-    
+
+  // If `Void` has been explicitly specified, resulting decomposition
+  // should be empty, just like empty tuple would be.
+  case TypeKind::NameAlias: {
+    auto &ctx = type->getASTContext();
+    auto *typealias = cast<NameAliasType>(type.getPointer());
+    if (typealias->getDecl() == ctx.getVoidDecl())
+      return result;
+    break;
+  }
+
   default:
     // Default behavior below; inject the argument as the sole parameter.
     break;

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -464,7 +464,7 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
 }
 
 static Expr *formUnaryArgument(ASTContext &context, Expr *argument) {
-  if (isa<ParenExpr>(argument) || isa<TupleExpr>(argument))
+  if (isa<ParenExpr>(argument))
     return argument;
 
   auto *arg = new (context)

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -463,6 +463,17 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
   return sub;
 }
 
+static Expr *formUnaryArgument(ASTContext &context, Expr *argument) {
+  if (isa<ParenExpr>(argument) || isa<TupleExpr>(argument))
+    return argument;
+
+  auto *arg = new (context)
+      ParenExpr(argument->getStartLoc(), argument, argument->getEndLoc(),
+                /*hasTrailingClosure*/ false);
+  arg->setImplicit();
+  return arg;
+}
+
 /// parseExprUnary
 ///
 ///   expr-unary(Mode):
@@ -538,8 +549,8 @@ ParserResult<Expr> Parser::parseExprUnary(Diag<> Message, bool isExprBasic) {
     }
   }
 
-  return makeParserResult(
-      new (Context) PrefixUnaryExpr(Operator, SubExpr.get()));
+  return makeParserResult(new (Context) PrefixUnaryExpr(
+      Operator, formUnaryArgument(Context, SubExpr.get())));
 }
 
 /// expr-keypath-swift:
@@ -1330,8 +1341,9 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
         break;
 
       Expr *oper = parseExprOperator();
-      Result =
-          makeParserResult(new (Context) PostfixUnaryExpr(oper, Result.get()));
+
+      Result = makeParserResult(new (Context) PostfixUnaryExpr(
+          oper, formUnaryArgument(Context, Result.get())));
       SyntaxContext->createNodeInPlace(SyntaxKind::PostfixUnaryExpr);
       continue;
     }

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -140,7 +140,7 @@ struct Weak<T: class> { // expected-error {{'class' constraint can only appear o
 }
 
 let x: () = ()
-!() // expected-error {{missing argument for parameter #1 in call}}
+!() // expected-error {{cannot convert value of type '()' to expected argument type 'Bool'}}
 !(()) // expected-error {{cannot convert value of type '()' to expected argument type 'Bool'}}
 !(x) // expected-error {{cannot convert value of type '()' to expected argument type 'Bool'}}
 !x // expected-error {{cannot convert value of type '()' to expected argument type 'Bool'}}

--- a/validation-test/compiler_crashers_2_fixed/0165-rdar40722855.swift
+++ b/validation-test/compiler_crashers_2_fixed/0165-rdar40722855.swift
@@ -1,0 +1,24 @@
+// RUN: %target-typecheck-verify-swift
+
+postfix operator %
+postfix func % (_: Any) {}
+
+prefix operator ~
+prefix func ~ (_: Any) {}
+
+func foo(_: String) -> Void {}
+func foo(_: Int) -> Void {}
+
+_ = foo("answer")% // Ok
+_ = ~foo(42)       // Ok
+
+class A {
+  func bar(_: Int) {}
+}
+
+extension A {
+  func bar(_ qux: String) {
+    bar(qux)% // Ok
+    ~bar(qux) // Ok
+  }
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Currently when call involving prefix/postfix operator is formed we
don't wrap argument in implicit parens (like we do with other calls)
when user didn't provide any explicitly, this is bad because
argument-to-parameter matcher requires multiple special cases to handle
such behavior, so let's start wrapping arguments in implicit parens instead.

Resolves: rdar://problem/40722855
Resolves: [SR-7840](https://bugs.swift.org/browse/SR-7840)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
