### PR TITLE
Re-enable @differentiable for FloatingPoint functions.

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -1845,7 +1845,7 @@ extension FloatingPoint {
   @inlinable // FIXME(sil-serialize-all)
   @_transparent
   /// SWIFT_ENABLE_TENSORFLOW
-  // @differentiable(reverse, withRespectTo: (self), adjoint: _adjointSquareRoot)
+  @differentiable(reverse, withRespectTo: (self), adjoint: _adjointSquareRoot)
   public func squareRoot( ) -> Self {
     var lhs = self
     lhs.formSquareRoot( )
@@ -1876,9 +1876,9 @@ extension FloatingPoint {
   @inlinable // FIXME(sil-serialize-all)
   @_transparent
   /// SWIFT_ENABLE_TENSORFLOW
-  // @differentiable(
-  //   reverse, withRespectTo: (self, .0, .1), adjoint: _adjointAddingProduct
-  // )
+  @differentiable(
+    reverse, withRespectTo: (self, .0, .1), adjoint: _adjointAddingProduct
+  )
   public func addingProduct(_ lhs: Self, _ rhs: Self) -> Self {
     var addend = self
     addend.addProduct(lhs, rhs)

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1732,7 +1732,7 @@ extension ${Self} {
   @inlinable // FIXME(sil-serialize-all)
   @_transparent
   /// SWIFT_ENABLE_TENSORFLOW
-  // @differentiable(reverse, adjoint: _adjointAdd)
+  @differentiable(reverse, adjoint: _adjointAdd)
   public static func + (lhs: ${Self}, rhs: ${Self}) -> ${Self} {
     var lhs = lhs
     lhs += rhs
@@ -1742,7 +1742,7 @@ extension ${Self} {
   @inlinable // FIXME(sil-serialize-all)
   @_transparent
   /// SWIFT_ENABLE_TENSORFLOW
-  // @differentiable(reverse, adjoint: _adjointSubtract)
+  @differentiable(reverse, adjoint: _adjointSubtract)
   public static func - (lhs: ${Self}, rhs: ${Self}) -> ${Self} {
     var lhs = lhs
     lhs -= rhs
@@ -1752,7 +1752,7 @@ extension ${Self} {
   @inlinable // FIXME(sil-serialize-all)
   @_transparent
   /// SWIFT_ENABLE_TENSORFLOW
-  // @differentiable(reverse, adjoint: _adjointMultiply)
+  @differentiable(reverse, adjoint: _adjointMultiply)
   public static func * (lhs: ${Self}, rhs: ${Self}) -> ${Self} {
     var lhs = lhs
     lhs *= rhs
@@ -1762,7 +1762,7 @@ extension ${Self} {
   @inlinable // FIXME(sil-serialize-all)
   @_transparent
   /// SWIFT_ENABLE_TENSORFLOW
-  // @differentiable(reverse, adjoint: _adjointDivide)
+  @differentiable(reverse, adjoint: _adjointDivide)
   public static func / (lhs: ${Self}, rhs: ${Self}) -> ${Self} {
     var lhs = lhs
     lhs /= rhs


### PR DESCRIPTION
`@differentiable` was temporarily disabled because it didn't have libSyntax
support, causing stdlib compilation to fail.

libSyntax support was added in https://github.com/apple/swift/pull/17428 so
`@differentiable` should be re-enabled.