### PR TITLE
Update doc comments for #gradient and #valueAndGradient.

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3894,9 +3894,9 @@ protected:
 /// differentiated function that computes the gradient (or vector-Jacobian
 /// products) with respect to specified parameters.
 /// Examples:
-///   #gradient(of: baz)
-///   #gradient(of: bar, withRespectTo: .0, .1)
-///   #gradient(of: foo(_:_:), withRespectTo: .0)
+///   #gradient(baz)
+///   #gradient(bar, wrt: .0, .1)
+///   #gradient(foo(_:_:), wrt: .0)
 ///
 class GradientExpr : public ReverseAutoDiffExpr {
 public:
@@ -3921,9 +3921,9 @@ private:
 /// the gradient (or vector-Jacobian products) with respect to specified
 /// parameters.
 /// Examples:
-///   #valueAndGradient(of: baz)
-///   #valueAndGradient(of: bar, withRespectTo: .0, .1)
-///   #valueAndGradient(of: foo(_:_:), withRespectTo: .0)
+///   #valueAndGradient(baz)
+///   #valueAndGradient(bar, wrt: .0, .1)
+///   #valueAndGradient(foo(_:_:), wrt: .0)
 ///
 class ValueAndGradientExpr : public ReverseAutoDiffExpr {
 public:

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3691,10 +3691,10 @@ ParserResult<Expr> Parser::parseExprGradientBody(ExprKind kind) {
   if (consumeIf(tok::comma)) {
     // If 'withRespectTo' is used, make the user change it to 'wrt'.
     if (Tok.getText() == "withRespectTo") {
-      SourceRange withRespectToRange(Tok.getLoc(), Tok.getRange().getStart());
+      SourceRange withRespectToRange(Tok.getLoc());
       diagnose(Tok, diag::gradient_expr_use_wrt_not_withrespectto)
-          .highlight(withRespectToRange)
-          .fixItReplace(withRespectToRange, "wrt");
+        .highlight(withRespectToRange)
+        .fixItReplace(withRespectToRange, "wrt");
       return errorAndSkipToEnd();
     }
     // Parse 'wrt' ':'.

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3686,15 +3686,18 @@ ParserResult<Expr> Parser::parseExprGradientBody(ExprKind kind) {
     return makeParserCodeCompletionResult<Expr>();
   if (originalFnParseResult.isParseError())
     return errorAndSkipToEnd();
-  // If found comma, parse 'withRespectTo:'.
+  // If found comma, parse 'wrt:'.
   SmallVector<AutoDiffParameter, 8> params;
   if (consumeIf(tok::comma)) {
-    // Parse 'wrt' ':'.
     // If 'withRespectTo' is used, make the user change it to 'wrt'.
     if (Tok.getText() == "withRespectTo") {
-      diagnose(Tok, diag::gradient_expr_use_wrt_not_withrespectto);
+      SourceRange withRespectToRange(Tok.getLoc(), Tok.getRange().getEnd());
+      diagnose(Tok, diag::gradient_expr_use_wrt_not_withrespectto)
+          .highlight(withRespectToRange)
+          .fixItReplace(withRespectToRange, "wrt:");
       return errorAndSkipToEnd();
     }
+    // Parse 'wrt' ':'.
     if (parseSpecificIdentifier("wrt",
                                 diag::expr_expected_label,
                                 exprName, "wrt:") ||

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3691,10 +3691,10 @@ ParserResult<Expr> Parser::parseExprGradientBody(ExprKind kind) {
   if (consumeIf(tok::comma)) {
     // If 'withRespectTo' is used, make the user change it to 'wrt'.
     if (Tok.getText() == "withRespectTo") {
-      SourceRange withRespectToRange(Tok.getLoc(), Tok.getRange().getEnd());
+      SourceRange withRespectToRange(Tok.getLoc(), Tok.getRange().getStart());
       diagnose(Tok, diag::gradient_expr_use_wrt_not_withrespectto)
           .highlight(withRespectToRange)
-          .fixItReplace(withRespectToRange, "wrt:");
+          .fixItReplace(withRespectToRange, "wrt");
       return errorAndSkipToEnd();
     }
     // Parse 'wrt' ':'.


### PR DESCRIPTION
The `#gradient` syntax was changed in https://github.com/apple/swift/pull/17470.
The `of:` label was removed and `withRespectTo:` was renamed to `wrt:`.

Add fixit to replace `withRespectTo` with `wrt`.