### PR TITLE
[4.2] migrator: handle member variables change to global ones. rdar://41658300

### DIFF
--- a/include/swift/IDE/APIDigesterData.h
+++ b/include/swift/IDE/APIDigesterData.h
@@ -260,11 +260,10 @@ struct TypeMemberDiffItem: public APIDiffItem {
   Optional<uint8_t> removedIndex;
   StringRef oldTypeName;
   StringRef oldPrintedName;
-
 private:
   DeclNameViewer OldNameViewer;
   DeclNameViewer NewNameViewer;
-
+  std::string NewTypeDot;
 public:
   TypeMemberDiffItemSubKind Subkind;
 
@@ -276,7 +275,9 @@ public:
     newTypeName(newTypeName), newPrintedName(newPrintedName),
     selfIndex(selfIndex), removedIndex(removedIndex), oldTypeName(oldTypeName),
     oldPrintedName(oldPrintedName), OldNameViewer(oldPrintedName),
-    NewNameViewer(newPrintedName), Subkind(getSubKind()) {}
+    NewNameViewer(newPrintedName),
+    NewTypeDot(newTypeName.empty() ? "" : (llvm::Twine(newTypeName) + ".").str()),
+    Subkind(getSubKind()) {}
   static StringRef head();
   static void describe(llvm::raw_ostream &os);
   static void undef(llvm::raw_ostream &os);
@@ -286,6 +287,7 @@ public:
   StringRef getKey() const override { return usr; }
   const DeclNameViewer &getOldName() const { return OldNameViewer; }
   const DeclNameViewer &getNewName() const { return NewNameViewer; }
+  StringRef getNewTypeAndDot() const { return NewTypeDot; }
   APIDiffItemKind getKind() const override {
     return APIDiffItemKind::ADK_TypeMemberDiffItem;
   }

--- a/include/swift/IDE/APIDigesterData.h
+++ b/include/swift/IDE/APIDigesterData.h
@@ -276,7 +276,7 @@ public:
     selfIndex(selfIndex), removedIndex(removedIndex), oldTypeName(oldTypeName),
     oldPrintedName(oldPrintedName), OldNameViewer(oldPrintedName),
     NewNameViewer(newPrintedName),
-    NewTypeDot(newTypeName.empty() ? "" : (llvm::Twine(newTypeName) + ".").str()),
+    NewTypeDot(isNewNameGlobal() ? "" : (llvm::Twine(newTypeName) + ".").str()),
     Subkind(getSubKind()) {}
   static StringRef head();
   static void describe(llvm::raw_ostream &os);
@@ -291,6 +291,7 @@ public:
   APIDiffItemKind getKind() const override {
     return APIDiffItemKind::ADK_TypeMemberDiffItem;
   }
+  bool isNewNameGlobal() const { return newTypeName.empty(); }
 private:
   TypeMemberDiffItemSubKind getSubKind() const;
 };

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -343,8 +343,13 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
       if (MD->Subkind == TypeMemberDiffItemSubKind::SimpleReplacement) {
         bool NeedNoTypeName = isDotMember &&
           MD->oldPrintedName == MD->newPrintedName;
-        Text = (llvm::Twine(NeedNoTypeName ? "." : MD->getNewTypeAndDot()) +
-          MD->getNewName().base()).str();
+        if (NeedNoTypeName) {
+          Text = (llvm::Twine(MD->isNewNameGlobal() ? "" : ".") +
+            MD->getNewName().base()).str();
+        } else {
+          Text = (llvm::Twine(MD->getNewTypeAndDot()) +
+            MD->getNewName().base()).str();
+        }
         return true;
       }
     }
@@ -540,9 +545,15 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
           if (Item->Subkind == TypeMemberDiffItemSubKind::QualifiedReplacement) {
             bool NeedNoTypeName = isDotMember(ToReplace) &&
               Item->oldPrintedName == Item->newPrintedName;
-            Editor.replace(ToReplace,
-              (llvm::Twine(NeedNoTypeName ? "." : Item->getNewTypeAndDot()) +
-               Item->getNewName().base()).str());
+            if (NeedNoTypeName) {
+              Editor.replace(ToReplace,
+                (llvm::Twine(Item->isNewNameGlobal() ? "" : ".") +
+                Item->getNewName().base()).str());
+            } else {
+              Editor.replace(ToReplace,
+                (llvm::Twine(Item->getNewTypeAndDot()) +
+                  Item->getNewName().base()).str());
+            }
             return true;
           }
         }

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -329,7 +329,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
       if (auto *MI = dyn_cast<TypeMemberDiffItem>(Item)) {
         if (MI->Subkind == TypeMemberDiffItemSubKind::FuncRename) {
           llvm::raw_svector_ostream OS(Buffer);
-          OS << MI->newTypeName << "." << MI->newPrintedName;
+          OS << MI->getNewTypeAndDot() << MI->newPrintedName;
           return DeclNameViewer(OS.str());
         }
       }
@@ -343,7 +343,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
       if (MD->Subkind == TypeMemberDiffItemSubKind::SimpleReplacement) {
         bool NeedNoTypeName = isDotMember &&
           MD->oldPrintedName == MD->newPrintedName;
-        Text = (llvm::Twine(NeedNoTypeName ? "" : MD->newTypeName) + "." +
+        Text = (llvm::Twine(NeedNoTypeName ? "." : MD->getNewTypeAndDot()) +
           MD->getNewName().base()).str();
         return true;
       }
@@ -541,7 +541,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
             bool NeedNoTypeName = isDotMember(ToReplace) &&
               Item->oldPrintedName == Item->newPrintedName;
             Editor.replace(ToReplace,
-              (llvm::Twine(NeedNoTypeName ? "" : Item->newTypeName) + "." +
+              (llvm::Twine(NeedNoTypeName ? "." : Item->getNewTypeAndDot()) +
                Item->getNewName().base()).str());
             return true;
           }
@@ -710,8 +710,8 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
       return false;
 
     if (Item->Subkind == TypeMemberDiffItemSubKind::GlobalFuncToStaticProperty) {
-      Editor.replace(Call->getSourceRange(), (llvm::Twine(Item->newTypeName) +
-        "." + Item->getNewName().base()).str());
+      Editor.replace(Call->getSourceRange(),
+        (llvm::Twine(Item->getNewTypeAndDot()) + Item->getNewName().base()).str());
       return true;
     }
     if (*Item->selfIndex)

--- a/test/Migrator/Inputs/Cities.swift
+++ b/test/Migrator/Inputs/Cities.swift
@@ -11,6 +11,7 @@ open class Cities {
   open func maroochy(x: Int?, y: Int?) {}
   public struct CityKind {
     public static let Town = 1
+    public static let Village = 1
   }
 }
 

--- a/test/Migrator/Inputs/qualified.json
+++ b/test/Migrator/Inputs/qualified.json
@@ -55,4 +55,12 @@
     "NewPrintedName": "orderedMemberSame",
     "NewTypeName": "NewFooComparisonResult.Nested"
   },
+  {
+    "DiffItemKind": "TypeMemberDiffItem",
+    "Usr": "c:@E@FooComparisonResult@FooOrderedMovedToGlobal",
+    "OldPrintedName": "orderedMovedToGlobal",
+    "OldTypeName": "FooComparisonResult",
+    "NewPrintedName": "orderedMovedToGlobal",
+    "NewTypeName": ""
+  },
 ]

--- a/test/Migrator/Inputs/qualified.json
+++ b/test/Migrator/Inputs/qualified.json
@@ -33,6 +33,14 @@
   },
   {
     "DiffItemKind": "TypeMemberDiffItem",
+    "Usr": "s:6CitiesAAC8CityKindV7VillageSivpZ",
+    "OldPrintedName": "Village",
+    "OldTypeName": "Cities.CityKind",
+    "NewPrintedName": "GlobalCityKindVillage",
+    "NewTypeName": ""
+  },
+  {
+    "DiffItemKind": "TypeMemberDiffItem",
     "Usr": "s:6Cities12ToplevelTypeC",
     "OldPrintedName": "ToplevelType",
     "OldTypeName": "",

--- a/test/Migrator/mock-sdk/Bar.framework/Headers/Bar.h
+++ b/test/Migrator/mock-sdk/Bar.framework/Headers/Bar.h
@@ -55,6 +55,7 @@ typedef NS_ENUM(long, FooComparisonResult) {
   FooOrderedSame,
   FooOrderedDescending,
   FooOrderedMemberSame,
+  FooOrderedMovedToGlobal,
 };
 
 @interface BarBase

--- a/test/Migrator/qualified-replacement.swift
+++ b/test/Migrator/qualified-replacement.swift
@@ -19,6 +19,8 @@ func foo() {
   bar(.orderedMemberSame)
   bar(FooComparisonResult.orderedSame)
   bar(FooComparisonResult.orderedMemberSame)
+  bar(FooComparisonResult.orderedMovedToGlobal)
+  bar(.orderedMovedToGlobal)
 }
 
 func foo(_: ToplevelType) {}

--- a/test/Migrator/qualified-replacement.swift
+++ b/test/Migrator/qualified-replacement.swift
@@ -12,6 +12,7 @@ func foo() {
   _ = FooComparisonResult.orderedSame
   let _ : FooComparisonResult = .orderedSame
   _ = Cities.CityKind.Town
+  _ = Cities.CityKind.Village
   _ = ToplevelType()
   _ = ToplevelType(recordName: "")
   bar(.orderedSame)

--- a/test/Migrator/qualified-replacement.swift.expected
+++ b/test/Migrator/qualified-replacement.swift.expected
@@ -12,6 +12,7 @@ func foo() {
   _ = NewFooComparisonResult.NewFooOrderedSame
   let _ : FooComparisonResult = NewFooComparisonResult.NewFooOrderedSame
   _ = NewCityKind.NewTown
+  _ = GlobalCityKindVillage
   _ = ToplevelWrapper.internalType()
   _ = ToplevelWrapper.internalType(recordName: "")
   bar(NewFooComparisonResult.NewFooOrderedSame)

--- a/test/Migrator/qualified-replacement.swift.expected
+++ b/test/Migrator/qualified-replacement.swift.expected
@@ -19,6 +19,8 @@ func foo() {
   bar(.orderedMemberSame)
   bar(NewFooComparisonResult.NewFooOrderedSame)
   bar(NewFooComparisonResult.Nested.orderedMemberSame)
+  bar(orderedMovedToGlobal)
+  bar(orderedMovedToGlobal)
 }
 
 func foo(_: ToplevelWrapper.internalType) {}

--- a/test/api-digester/Outputs/apinotes-migrator-gen-revert.json
+++ b/test/api-digester/Outputs/apinotes-migrator-gen-revert.json
@@ -1,6 +1,17 @@
 [
   {
     "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Var",
+    "NodeAnnotation": "RevertSimpleStringRepresentableUpdate",
+    "ChildIndex": "0",
+    "LeftUsr": "c:@globalAttributeName",
+    "LeftComment": "AnimalAttributeName",
+    "RightUsr": "",
+    "RightComment": "String",
+    "ModuleName": "APINotesTest"
+  },
+  {
+    "DiffItemKind": "CommonDiffItem",
     "NodeKind": "TypeDecl",
     "NodeAnnotation": "RevertTypeAliasDeclToRawRepresentable",
     "ChildIndex": "0",
@@ -160,6 +171,14 @@
     "OldTypeName": "NewType",
     "NewPrintedName": "oldMember",
     "NewTypeName": "OldType"
+  },
+  {
+    "DiffItemKind": "TypeMemberDiffItem",
+    "Usr": "c:@globalAttributeName",
+    "OldPrintedName": "globalAttributeName",
+    "OldTypeName": "AnimalAttributeName",
+    "NewPrintedName": "globalAttributeName",
+    "NewTypeName": ""
   },
   {
     "DiffItemKind": "TypeMemberDiffItem",

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -2544,6 +2544,12 @@ class TypeMemberDiffFinder : public SDKNodeVisitor {
     if (nodeParent->getKind() == SDKNodeKind::DeclType &&
         diffParent->getKind() == SDKNodeKind::Root)
       TypeMemberDiffs.insert({diffNode, node});
+
+    // Move from a member variable to global variable.
+    if (nodeParent->getKind() == SDKNodeKind::Root &&
+        diffParent->getKind() == SDKNodeKind::DeclType)
+      TypeMemberDiffs.insert({diffNode, node});
+
     // Move from a member variable to another member variable
     if (nodeParent->getKind() == SDKNodeKind::DeclType &&
         diffParent->getKind() == SDKNodeKind::DeclType &&
@@ -3758,7 +3764,8 @@ static void findTypeMemberDiffs(NodePtr leftSDKRoot, NodePtr rightSDKRoot,
     // index, old printed name)
     TypeMemberDiffItem item = {
         right->getAs<SDKNodeDecl>()->getUsr(),
-        rightParent->getAs<SDKNodeDecl>()->getFullyQualifiedName(),
+        rightParent->getKind() == SDKNodeKind::Root ?
+          StringRef() : rightParent->getAs<SDKNodeDecl>()->getFullyQualifiedName(),
         right->getPrintedName(), findSelfIndex(right), None,
         leftParent->getKind() == SDKNodeKind::Root ?
           StringRef() : leftParent->getAs<SDKNodeDecl>()->getFullyQualifiedName(),


### PR DESCRIPTION
Explanation: By manually experimenting with APIs, we found a few cases of nested variables in Xcode 9 change to global variables in Xcode 10. Since the pattern migrator used to handle is only the opposite direction, we need to update the swift-api-digester and the migrator to detect and handle this category of changes. 

Scope of Issue: Swift 4.2 migrator

Risk: Very Low

Reviewed by: Nathan Hawes

Testing: Unit tests added.

Radar: rdar://41658300