### PR TITLE
[DontMerge] [just looking for feedback on approach] @compilerEvaluable verifier in the evaluator

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -368,6 +368,11 @@ ERROR(non_borrowed_indirect_addressof,none,
       "use `withUnsafePointer` or `withUnsafeBytes` unless you're implementing "
       "`withUnsafePointer` or `withUnsafeBytes`", ())
 
+// @compilerEvaluable diagnostics
+
+ERROR(compiler_evaluable_bad_operation,none,
+      "@compilerEvaluable function contains forbidden operation", ())
+
 REMARK(opt_remark_passed, none, "%0", (StringRef))
 REMARK(opt_remark_missed, none, "%0", (StringRef))
 

--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -65,6 +65,9 @@ enum class UnknownReason {
 /// interface though.
 class SymbolicValue {
   enum RepresentationKind {
+    /// See comment on `AbstractConstant` below.
+    RK_AbstractConstant,
+
     /// This value is an alloc stack that is has not (yet) been initialized
     /// by flow-sensitive analysis.
     RK_UninitMemory,
@@ -160,6 +163,10 @@ public:
   /// independent of its concrete representation.  This is the public
   /// interface to SymbolicValue.
   enum Kind {
+    /// Only occurs when the evaluator is in AbstractInterpretationMode.
+    /// This is a value that the evaluator will certainly be able to calculate.
+    AbstractConstant,
+
     /// This is a value that isn't a constant.
     Unknown,
 
@@ -194,6 +201,12 @@ public:
   bool isConstant() const {
     auto kind = getKind();
     return kind != Unknown && kind != UninitMemory;
+  }
+
+  static SymbolicValue getAbstractConstant() {
+    SymbolicValue result;
+    result.representationKind = RK_AbstractConstant;
+    return result;
   }
 
   static SymbolicValue getUnknown(SILNode *node, UnknownReason reason) {

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -145,6 +145,11 @@ public:
   void print(llvm::raw_ostream &OS) const;
 };
 
+/// @compilerEvaluable attribute lowered to SIL. Currently has no fields, but we
+/// expect to add some fields eventually to implement
+/// @compilerEvaluable(magicBehavior).
+class SILCompilerEvaluableAttr final {};
+
 /// SILFunction - A function body that has been lowered to SIL. This consists of
 /// zero or more SIL SILBasicBlock objects that contain the SILInstruction
 /// objects making up the function.
@@ -249,6 +254,9 @@ private:
   /// The function's `[reverse_differentiable]` attributes.
   llvm::SmallVector<SILReverseDifferentiableAttr *, 4>
     ReverseDifferentiableAttrs;
+
+  /// The function's `[compiler_evaluable]` attribute.
+  SILCompilerEvaluableAttr *CompilerEvaluableAttr = nullptr;
 
   /// The function's effects attribute.
   EffectsKind EffectsKindAttr;
@@ -582,6 +590,13 @@ public:
 
   void addReverseDifferentiableAttr(SILReverseDifferentiableAttr *attr) {
     ReverseDifferentiableAttrs.push_back(attr);
+  }
+
+  SILCompilerEvaluableAttr *getCompilerEvaluableAttr() const {
+    return CompilerEvaluableAttr;
+  }
+  void setCompilerEvaluableAttr(SILCompilerEvaluableAttr *Attr) {
+    CompilerEvaluableAttr = Attr;
   }
 
   /// Get this function's optimization mode or OptimizationMode::NotSet if it is

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -130,6 +130,8 @@ PASS(DiagnoseStaticExclusivity, "diagnose-static-exclusivity",
      "Static Enforcement of Law of Exclusivity")
 PASS(DiagnoseUnreachable, "diagnose-unreachable",
      "Diagnose Unreachable Code")
+PASS(DiagnoseCompilerEvaluable, "diagnose-compiler-evaluable",
+     "Diagnose @compilerEvaluable functions")
 PASS(DiagnosticConstantPropagation, "diagnostic-constant-propagation",
      "Constants Propagation for Diagnostics")
 PASS(EagerSpecializer, "eager-specializer",

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t VERSION_MINOR = 422; // SWIFT_ENABLE_TENSORFLOW: serialize @differentiable. 
+const uint16_t VERSION_MINOR = 423; // SWIFT_ENABLE_TENSORFLOW: serialize @compilerEvaluable.
 
 using DeclIDField = BCFixed<31>;
 

--- a/lib/SIL/SILConstants.cpp
+++ b/lib/SIL/SILConstants.cpp
@@ -32,6 +32,7 @@ diagnose(ASTContext &Context, SourceLoc loc, Diag<T...> diag, U &&...args) {
 void SymbolicValue::print(llvm::raw_ostream &os, unsigned indent) const {
   os.indent(indent);
   switch (representationKind) {
+  case RK_AbstractConstant: os << "abstractconstant\n"; return;
   case RK_UninitMemory: os << "uninit\n"; return;
   case RK_Unknown: {
     std::pair<SILNode *, UnknownReason> unknown = getUnknownValue();
@@ -94,6 +95,7 @@ void SymbolicValue::dump() const {
 /// multiple forms for efficiency, but provide a simpler interface to clients.
 SymbolicValue::Kind SymbolicValue::getKind() const {
   switch (representationKind) {
+  case RK_AbstractConstant:    return AbstractConstant;
   case RK_UninitMemory: return UninitMemory;
   case RK_Unknown:      return Unknown;
   case RK_Metatype:     return Metatype;
@@ -117,6 +119,7 @@ SymbolicValue::Kind SymbolicValue::getKind() const {
 /// version.  This only works for valid constants.
 SymbolicValue SymbolicValue::cloneInto(llvm::BumpPtrAllocator &allocator) const{
   switch (getKind()) {
+  case SymbolicValue::AbstractConstant:
   case SymbolicValue::Unknown:
   case SymbolicValue::UninitMemory:
     assert(0 && "These are not constants!");

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1230,6 +1230,7 @@ public:
       });
       *this << "]";
       return;
+    case SymbolicValue::AbstractConstant:
     case SymbolicValue::UninitMemory:
     case SymbolicValue::Unknown:
       llvm_unreachable("Unimplemented SymbolicValue case");
@@ -2446,6 +2447,8 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
     OS << "[global_init] ";
   if (isWeakLinked())
     OS << "[_weakLinked] ";
+  if (getCompilerEvaluableAttr())
+    OS << "[compiler_evaluable] ";
 
   switch (getInlineStrategy()) {
     case NoInline: OS << "[noinline] "; break;

--- a/lib/SILOptimizer/Mandatory/CMakeLists.txt
+++ b/lib/SILOptimizer/Mandatory/CMakeLists.txt
@@ -19,6 +19,7 @@ set(MANDATORY_SOURCES
   Mandatory/RawSILInstLowering.cpp
   Mandatory/MandatoryOptUtils.cpp
   # SWIFT_ENABLE_TENSORFLOW
+  Mandatory/DiagnoseCompilerEvaluable.cpp
   Mandatory/TFDifferentiation.cpp
   Mandatory/TFCanonicalizeCFG.cpp
   Mandatory/TFConstExpr.cpp

--- a/lib/SILOptimizer/Mandatory/DiagnoseCompilerEvaluable.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseCompilerEvaluable.cpp
@@ -1,0 +1,54 @@
+//===--- DiagnoseCompilerEvaluable.cpp - Check @compilerEvaluable decls ---===//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// SWIFT_ENABLE_TENSORFLOW
+// Checks that @compilerEvaluable decls follow all rules for what is allowed to
+// execute at compile time.
+//
+//===----------------------------------------------------------------------===//
+
+#include "TFConstExpr.h"
+#include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/DiagnosticsSIL.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "llvm/Support/Debug.h"
+
+using namespace swift;
+
+namespace {
+
+class DiagnoseCompilerEvaluable : public SILFunctionTransform {
+public:
+  DiagnoseCompilerEvaluable() {}
+
+private:
+  void run() override {
+    auto &M = getFunction()->getModule();
+
+    if (!getFunction()->getCompilerEvaluableAttr())
+      return;
+
+    tf::ConstExprEvaluator evaluator(M);
+    auto result = evaluator.checkCompilerEvaluable(*getFunction());
+
+    if (result) {
+      M.getASTContext().Diags.diagnose(getFunction()->getLocation().getSourceLoc(), diag::compiler_evaluable_bad_operation);
+      result->emitUnknownDiagnosticNotes(getFunction()->getLocation());
+    }
+  }
+};
+
+} // end anonymous namespace
+
+SILTransform *swift::createDiagnoseCompilerEvaluable() {
+  return new DiagnoseCompilerEvaluable();
+}

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.h
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.h
@@ -26,13 +26,14 @@
 
 #include "llvm/Support/Allocator.h"
 #include "swift/Basic/LLVM.h"
+#include "swift/SIL/SILConstants.h"
 
 namespace swift {
   class SingleValueInstruction;
   class SILBuilder;
+  class SILFunction;
   class SILModule;
   class SILValue;
-  class SymbolicValue;
 
 namespace tf {
 
@@ -61,6 +62,18 @@ public:
   /// that occur after after folding them.
   void computeConstantValues(ArrayRef<SILValue> values,
                              SmallVectorImpl<SymbolicValue> &results);
+
+  /// Checks if the function only contains operations that the evaluator knows
+  /// how to fold.
+  ///
+  /// Note that this doesn't guarantee that the evaluator will fold the
+  /// operations successfully -- e.g. the evaluator might encounter overflow
+  /// traps or non-@compilerEvaluable protocol function implementations.
+  ///
+  /// Returns None if the function only has allowed operations.
+  /// Returns an Unknown SymbolicValue pointing at a disallowed operation if
+  /// there are disallowed operations.
+  llvm::Optional<SymbolicValue> checkCompilerEvaluable(SILFunction &fn);
 };
 
 } // end namespace tf

--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -1504,6 +1504,7 @@ emitConstantInst(SymbolicValue symVal, SILType type, SILLocation loc,
   assert(symVal.isConstant() && "Not a constant value");
 
   switch (symVal.getKind()) {
+  case SymbolicValue::AbstractConstant:
   case SymbolicValue::Unknown:
   case SymbolicValue::UninitMemory:
     assert(0 && "Shouldn't happen");

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -1548,6 +1548,7 @@ void TFGraphLowering::visitGraphOperationInst(GraphOperationInst *inst) {
     case SILTensorOpInfo::OperandClass::Normal:  // No modifier.
       // We add attributes based on what the type of the value is.
       switch (attrValue.getKind()) {
+      case SymbolicValue::AbstractConstant:
       case SymbolicValue::Unknown:
       case SymbolicValue::UninitMemory:
         assert(0 && "These attribute kinds cannot happen here");

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -113,6 +113,7 @@ static void addMandatoryOptPipeline(SILPassPipelinePlan &P,
   P.addSplitNonCondBrCriticalEdges();
 
   // SWIFT_ENABLE_TENSORFLOW
+  P.addDiagnoseCompilerEvaluable();
   P.addDifferentiation();
   P.addTFDeabstraction();
 }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2590,6 +2590,7 @@ compilerEvaluableAllowedInExtensionDecl(ExtensionDecl *extensionDecl) {
 }
 
 void AttributeChecker::visitCompilerEvaluableAttr(CompilerEvaluableAttr *attr) {
+#if 0
   // Check that the function is defined in an allowed context.
   // TODO(marcrasi): In many cases, we can probably generate a more informative
   // error message than just saying that it's "not allowed here". (Like "not
@@ -2643,6 +2644,7 @@ void AttributeChecker::visitCompilerEvaluableAttr(CompilerEvaluableAttr *attr) {
   // follow certain rules. We can only check these rules after the body is type
   // checked, and it's not type checked yet, so we check these rules later in
   // TypeChecker::checkFunctionBodyCompilerEvaluable().
+#endif
 }
 
 // SWIFT_ENABLE_TENSORFLOW

--- a/lib/Sema/TypeCheckCompilerEvaluable.cpp
+++ b/lib/Sema/TypeCheckCompilerEvaluable.cpp
@@ -235,6 +235,7 @@ public:
 ///
 /// The function body must already be type checked.
 void TypeChecker::checkFunctionBodyCompilerEvaluable(AbstractFunctionDecl *D) {
+#if 0
   auto compilerEvaluableAttr =
       D->getAttrs().getAttribute<CompilerEvaluableAttr>();
   if (!compilerEvaluableAttr || !compilerEvaluableAttr->isValid()) return;
@@ -247,4 +248,5 @@ void TypeChecker::checkFunctionBodyCompilerEvaluable(AbstractFunctionDecl *D) {
   if (!Checker.getCompilerEvaluable()) {
     compilerEvaluableAttr->setInvalid();
   }
+#endif
 }

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -295,6 +295,7 @@ namespace sil_block {
                      BCVBR<8>,    // number of specialize attributes
                      BCFixed<1>,  // has qualified ownership
                      BCFixed<1>,  // must be weakly referenced
+                     BCFixed<1>,  // is compiler evaluable
                      TypeIDField, // SILFunctionType
                      GenericEnvironmentIDField,
                      DeclIDField, // ClangNode owner

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -402,7 +402,8 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
       (unsigned)F.getInlineStrategy(), (unsigned)F.getOptimizationMode(),
       (unsigned)F.getEffectsKind(),
       (unsigned)numSpecAttrs, (unsigned)F.hasQualifiedOwnership(),
-      F.isWeakLinked(), FnID, genericEnvID, clangNodeOwnerID, SemanticsIDs);
+      F.isWeakLinked(), (bool)F.getCompilerEvaluableAttr(), FnID, genericEnvID,
+      clangNodeOwnerID, SemanticsIDs);
 
   if (NoBody)
     return;

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -3016,7 +3016,6 @@ ${unsafeOperationComment(x.operator)}
   /// - Parameter source: An integer to convert to this type.
   @inlinable // FIXME(sil-serialize-all)
   @inline(__always)
-  @compilerEvaluable
   public init<T : BinaryInteger>(truncatingIfNeeded source: T) {
     if Self.bitWidth <= ${word_bits} {
       self = Self.init(_truncatingBits: source._lowWord)

--- a/test/SILOptimizer/compiler_evaluable.swift
+++ b/test/SILOptimizer/compiler_evaluable.swift
@@ -1,0 +1,458 @@
+// RUN: %target-swift-frontend -emit-sil %s -verify
+
+// ----------------------------------------------------------------------------
+// Helper decls.
+// ----------------------------------------------------------------------------
+
+// expected-note @+1 {{could not fold operation}}
+let globalLet = 1
+
+// expected-note @+2 {{could not fold operation}}
+// expected-note @+1 {{could not fold operation}}
+var globalVar = 1
+
+@compilerEvaluable
+func compilerEvaluableFunc() {}
+
+func nonCompilerEvaluableFunc() {}
+
+@compilerEvaluable
+func genericCompilerEvaluable<T>(t: T) {}
+
+func genericNonCompilerEvaluable<T>(t: T) {}
+
+protocol ProtocolWithAFunction {
+  func protocolFunction() -> Int
+}
+
+@compilerEvaluable
+func autocloses(_ x: @autoclosure () -> Int) {}
+
+struct SimpleStruct {
+  let field: Int
+
+  @compilerEvaluable
+  init() {
+    field = 1
+  }
+
+  init(nonCompilerEvaluableInit: Int) {
+    field = nonCompilerEvaluableInit
+  }
+
+  @compilerEvaluable
+  static postfix func ... (x: SimpleStruct) -> SimpleStruct {
+    return x
+  }
+
+  @compilerEvaluable
+  func foo() -> Int {
+    return 1
+  }
+}
+
+struct SubscriptableStruct {
+  @compilerEvaluable
+  init() {}
+
+  @compilerEvaluable
+  subscript(x: Int) -> Int { return x }
+}
+
+enum SimpleEnum {
+  case case1
+  case case2
+}
+
+enum PayloadEnum {
+  case case1(x: Int)
+  case case2(x: Int)
+}
+
+@compilerEvaluable
+func throwingFunction() throws {}
+
+@compilerEvaluable
+func mutate(_ x: inout Int) {
+  x = 3
+}
+
+// ----------------------------------------------------------------------------
+// Actual tests.
+// ----------------------------------------------------------------------------
+
+// ----------------------------------------------------------------------------
+//   Literals.
+// ----------------------------------------------------------------------------
+
+@compilerEvaluable
+func test_nilLiteral() {
+  let _: Int? = nil
+}
+
+@compilerEvaluable
+func test_IntegerLiteral() {
+  let _ = 1
+}
+
+@compilerEvaluable
+func test_FloatLiteral() {
+  let _ = 1.0
+}
+
+@compilerEvaluable
+func test_BooleanLiteral() {
+  let _ = true
+  let _ = false
+}
+
+@compilerEvaluable
+// expected-error @+1 {{@compilerEvaluable function contains forbidden operation}}
+func test_StringLiteral() {
+  // expected-note @+1 {{could not fold operation}}
+  let _ = "hello world"
+}
+
+@compilerEvaluable
+// expected-error @+1 {{@compilerEvaluable function contains forbidden operation}}
+func test_InterpolatedStringLiteral(x: Int) {
+  // expected-note @+1 {{could not fold operation}}
+  let _ = "hello world \(x)"
+}
+
+@compilerEvaluable
+func test_MagicIdentifierLiteral() {
+  let _ = #line
+}
+
+@compilerEvaluable
+// expected-error @+1 {{@compilerEvaluable function contains forbidden operation}}
+func test_arrayLiteral() {
+  // expected-note @+1 {{could not fold operation}}
+  let _ = [1]
+}
+
+@compilerEvaluable
+// expected-error @+1 {{@compilerEvaluable function contains forbidden operation}}
+func test_dictionaryLiteral() {
+  // expected-note @+1 {{could not fold operation}}
+  let _ = [1: 2]
+}
+
+// ----------------------------------------------------------------------------
+//   DeclRefs.
+// ----------------------------------------------------------------------------
+
+@compilerEvaluable
+func test_readArg(arg: Int) {
+  let _ = arg
+}
+
+@compilerEvaluable
+func test_mutateAndReadInout(arg: inout Int) {
+  arg = 2
+  let _ = arg
+}
+
+@compilerEvaluable
+func test_readLet() {
+  let x = 1
+  let _ = x
+}
+
+@compilerEvaluable
+func test_mutateAndReadVar() {
+  var x = 1
+  x = 2
+  let _ = x
+}
+
+@compilerEvaluable
+// expected-error @+1 {{@compilerEvaluable function contains forbidden operation}}
+func test_readGlobalLet() {
+  let _ = globalLet
+}
+
+@compilerEvaluable
+// expected-error @+1 {{@compilerEvaluable function contains forbidden operation}}
+func test_readGlobalVar() {
+  let _ = globalVar
+}
+
+@compilerEvaluable
+// expected-error @+1 {{@compilerEvaluable function contains forbidden operation}}
+func test_mutateGlobalVar() {
+  globalVar = 3
+}
+
+@compilerEvaluable
+func test_refCompilerEvaluable() {
+  let _ = compilerEvaluableFunc
+}
+
+@compilerEvaluable
+// expected-error @+1 {{@compilerEvaluable function contains forbidden operation}}
+func test_refNonCompilerEvaluable() {
+  // expected-note @+1 {{could not fold operation}}
+  let _ = nonCompilerEvaluableFunc
+}
+
+@compilerEvaluable
+func test_refProtocolFunction<T: ProtocolWithAFunction>(t: T) {
+  let _ = t.protocolFunction
+}
+
+@compilerEvaluable
+func test_readOuterArg(arg: Int) {
+  func inner() {
+    let _ = arg
+  }
+  inner()
+}
+
+@compilerEvaluable
+func test_mutateAndReadOuterInout(arg: inout Int) {
+  func inner() {
+    arg = 2
+    let _ = arg
+  }
+  inner()
+}
+
+@compilerEvaluable
+func test_readOuterLet() {
+  let x = 1
+  func inner() {
+    let _ = x
+  }
+  inner()
+}
+
+@compilerEvaluable
+// expected-error @+1 {{@compilerEvaluable function contains forbidden operation}}
+func test_mutateAndReadOuterVar() {
+  // expected-note @+2 {{could not fold operation}}
+  // expected-note @+1 {{could not fold operation}}
+  var x = 1
+
+  // expected-error @+1 {{@compilerEvaluable function contains forbidden operation}}
+  func inner() {
+    x = 2
+    let _ = x
+  }
+
+  inner()
+}
+
+struct DeclRefTestStruct {
+  let structLet: Int
+  var structVar: Int
+
+  @compilerEvaluable
+  func test_readStructLet() {
+    let _ = structLet
+  }
+
+  @compilerEvaluable
+  func test_readStructVar() {
+    let _ = structVar
+  }
+
+  @compilerEvaluable
+  mutating func test_mutateStructVar() {
+    structVar = 2
+  }
+}
+
+func test_refStructSelf() {
+  let _ = SimpleStruct.self
+}
+
+func test_refStructField(s: SimpleStruct) {
+  let _ = s.field
+}
+
+// ----------------------------------------------------------------------------
+//   Calls.
+// ----------------------------------------------------------------------------
+
+@compilerEvaluable
+func test_callCompilerEvaluable() {
+  compilerEvaluableFunc()
+}
+
+@compilerEvaluable
+// expected-error @+1 {{@compilerEvaluable function contains forbidden operation}}
+func test_callNonCompilerEvaluable() {
+  // expected-note @+1 {{could not fold operation}}
+  nonCompilerEvaluableFunc()
+}
+
+@compilerEvaluable
+func test_initStructCompilerEvaluable() {
+  let _ = SimpleStruct()
+}
+
+@compilerEvaluable
+// expected-error @+1 {{@compilerEvaluable function contains forbidden operation}}
+func test_initStructNonCompilerEvaluable() {
+  // expected-note @+1 {{could not fold operation}}
+  let _ = SimpleStruct(nonCompilerEvaluableInit: 1)
+}
+
+@compilerEvaluable
+func test_initEnum() {
+  let _: SimpleEnum = .case1
+}
+
+@compilerEvaluable
+func test_initEnumWithPayload() {
+  let _: PayloadEnum = .case1(x: 2)
+}
+
+func test_callMutator() {
+  var x = 1
+  mutate(&x)
+}
+
+@compilerEvaluable
+func test_callProtocolFunction<T: ProtocolWithAFunction>(t: T) -> Int {
+  return t.protocolFunction()
+}
+
+@compilerEvaluable
+func test_callTry() throws {
+  let _ = try throwingFunction()
+}
+
+@compilerEvaluable
+func test_callTryForced() {
+  let _ = try! throwingFunction()
+}
+
+@compilerEvaluable
+func test_callTryOptional() {
+  let _ = try? throwingFunction()
+}
+
+// ----------------------------------------------------------------------------
+//   Closures.
+// ----------------------------------------------------------------------------
+
+@compilerEvaluable
+func test_makeAndCallClosure() {
+  let closure = { (i: Int) -> Int in return i + 1 }
+  let _ = closure(2)
+}
+
+@compilerEvaluable
+func test_autoclosure() {
+  autocloses(1)
+}
+
+@compilerEvaluable
+// expected-error @+1 {{@compilerEvaluable function contains forbidden operation}}
+func test_escapingClosureCapturesVar() -> () -> () {
+  // expected-note @+2 {{could not fold operation}}
+  // expected-note @+1 {{could not fold operation}}
+  var x = 1
+
+  // expected-error @+1 {{@compilerEvaluable function contains forbidden operation}}
+  func inner() {
+    x = 2
+  }
+  return inner
+}
+
+// ----------------------------------------------------------------------------
+//   Misc expressions.
+// ----------------------------------------------------------------------------
+
+@compilerEvaluable
+func test_constructTuple() {
+  let _ = (1, 2)
+  let _ = (a: 1, 2)
+}
+
+@compilerEvaluable
+func test_tupleField() {
+  let _ = (1, 2).0
+}
+
+@compilerEvaluable
+func test_bindOptional(s: SimpleStruct?) {
+  let _ = s?.field
+}
+
+@compilerEvaluable
+func test_forceOptional(x: Int?) {
+  let _ = x!
+}
+
+@compilerEvaluable
+// expected-error @+1 {{@compilerEvaluable function contains forbidden operation}}
+func test_keyPath() {
+  // expected-note @+1 {{could not fold operation}}
+  let _ = \SimpleStruct.field
+}
+
+// ----------------------------------------------------------------------------
+//   Statements.
+// ----------------------------------------------------------------------------
+
+@compilerEvaluable
+func test_if(x: Int) -> Int {
+  if (x < 0) {
+    return -1
+  } else {
+    return 1
+  }
+}
+
+@compilerEvaluable
+// expected-error @+1 {{@compilerEvaluable function contains forbidden operation}}
+func test_forbiddenAfterBranch(x: Int) -> Int {
+  if (x < 0) {
+    return -1
+  } else {
+    // expected-note @+1 {{could not fold operation}}
+    nonCompilerEvaluableFunc()
+    return 1
+  }
+}
+
+@compilerEvaluable
+func test_switchInt(x: Int) -> Int {
+  switch (x) {
+  case 1: return 1
+  case 2: return 2
+  default: return 3
+  }
+}
+
+@compilerEvaluable
+func test_switchEnum(x: SimpleEnum) -> Int {
+  switch (x) {
+  case .case1: return 1
+  case .case2: return 2
+  }
+}
+
+@compilerEvaluable
+func test_switchEnumWithPayload(x: PayloadEnum) -> Int {
+  switch (x) {
+  case .case1(let y): return y
+  case .case2(_): return 2
+  }
+}
+
+@compilerEvaluable
+// expected-error @+1 {{@compilerEvaluable function contains forbidden operation}}
+func test_whileLoop() -> Int {
+  var x = 0
+  // expected-note @+1 {{control flow loop found}}
+  while (x < 100) {
+    x += 1
+  }
+  return x
+}


### PR DESCRIPTION
This is a working (but messy) verifier that checks that the evaluator can evaluate all the functions marked @compilerEvaluable. @lattner, could you give me feedback on the approach before I clean it up and make it mergeable?

This works by propagating the `AbstractConstant` `SymbolicValue` through all the instructions in all the BBs. When it reaches an instruction it doesn't know about, it stops and emits an error. So it's pretty much an instruction whitelist, with the whitelist written alongside the implementation of the evaluator.

A nice thing about this approach is that it tells us what evaluator features we need to add for all the @compilerEvaluable functions in the stdlib to work. We just have to add a few more instructions.

Guide to the changes:
* `test/SILOptimizer/compiler_evaluable.swift` is a bunch of test cases that show you how it works.
* `SILConstants.h` has a new kind of `SymbolicValue` for the abstract interpretation
* Don't look too closely at most of `TFConstExpr.cpp`. I made a bunch of bad hacky changes to get it working. The main interesting part is lines 1574 onwards, where I teach it to look at all the branches.

Possible issues:
* Right now, this rejects all closures that capture mutable variables because it rejects `alloc_box` and `project_box` instructions. (e.g `test_mutateAndReadOuterVar`). If we want to allow those, then we probably want to verify that they get destroyed before the `@compilerEvaluable` function exits. Is that doable?
* Right now, this rejects references to non-`@compilerEvaluable` functions, so that it can be sure that all `apply` instructions are allowed. If we want to allow references to non-`@compilerEvaluable` functions, then the verifier will have to keep track of which functions are `@compilerEvaluable` and which aren't. I think this should be doable by propagating information about which `AbstractConstant`s are `@compilerEvaluable` functions.