### PR TITLE
[stdlib]Specialize remaining 4.2

### DIFF
--- a/stdlib/public/core/NormalizedCodeUnitIterator.swift
+++ b/stdlib/public/core/NormalizedCodeUnitIterator.swift
@@ -63,7 +63,11 @@ struct _NormalizedCodeUnitIterator: IteratorProtocol {
     where Source.Element == UInt16, Source.SubSequence == Source
   {
     var remaining: Int {
-      return collection.distance(from: index, to: collection.endIndex)
+      @_specialize(where Source == _UnmanagedString<UInt16>)
+      @_specialize(where Source == _UnmanagedOpaqueString)
+      get {
+        return collection.distance(from: index, to: collection.endIndex)
+      }
     }
     var collection: Source
     var index: Source.Index


### PR DESCRIPTION
Cherry-pick from https://github.com/apple/swift/commit/78e9e9062b81b8f2d1ce22daebdf9c4f9256150f for 4.2

- Explanation: Hashing some non-ascii strings got slower in Swift 4.2. This was caused by some generic code that didn't get specialized by the optimizer. This change hand specializes that code.
- Scope of Issue: The majority of strings hashed should not hit this code path, but it is a regression for some non-ascii strings.
- Origination: March 2018, we unified the hashing approaches for Darwin and Linux platforms
- Risk: Minimal
- Reviewed By: Karoy Lorentey and Michael Ilseman
- Dependencies: None
- Testing: Benchmarks and automated test suite

<rdar://problem/41734165>