### PR TITLE
[test] AnyHashable: Shorten class hierarchy tests

### DIFF
--- a/validation-test/stdlib/AnyHashable.swift.gyb
+++ b/validation-test/stdlib/AnyHashable.swift.gyb
@@ -510,14 +510,15 @@ class ${Self.full_name} : ${Super.full_name} {}
 
 AnyHashableTests.test("AnyHashable containing classes from the ${prefix} hierarchy") {
   typealias T = Int
+% bunch = 2
   let xs = [
 % for (i, (Self, _)) in enumerate(types):
 %   ConcreteSelf = Self
 %   if ConcreteSelf.is_generic:
 %     ConcreteSelf = ConcreteSelf.specialize_with({'T':'Int'})
 %   end
-    ${Self.full_name}(${len(types) + i}),
-%   for j in range(0, len(types)):
+    ${Self.full_name}(${bunch + i}),
+%   for j in range(0, bunch):
     ${Self.full_name}(${j}),
 %   end
 % end
@@ -526,7 +527,7 @@ AnyHashableTests.test("AnyHashable containing classes from the ${prefix} hierarc
     if lhs == rhs {
       return true
     }
-    let p = ${len(types) + 1}
+    let p = ${bunch + 1}
     if lhs % p == 0 || rhs % p == 0 {
       return false
     }


### PR DESCRIPTION
AnyHashable.swift.gyb is by far the longest test in debug builds of the test suite. Cut it dramatically shorter by reducing the number of equivalence classes checked in “containing classes from the `<foo>` hierarchy” tests from 16 down to 3. (It seems to me the extra test cases didn’t actually test any additional functionality.)

rdar://problem/41701421