### PR TITLE
[4.2] migrator: handle the composite change of updating raw-representable to type alias and rename the referenced variables simultaneously. rdar://41732485

### DIFF
--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -1052,8 +1052,10 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
   bool walkToExprPre(Expr *E) override {
     if (E->getSourceRange().isInvalid())
       return false;
-    if (handleRevertRawRepresentable(E))
-      return false;
+    if (handleRevertRawRepresentable(E)) {
+      // The name may also change, so we should keep visiting.
+      return true;
+    }
     if (handleQualifiedReplacement(E))
       return false;
     if (handleAssignDestMigration(E))

--- a/test/Migrator/Inputs/Cities.swift
+++ b/test/Migrator/Inputs/Cities.swift
@@ -84,7 +84,8 @@ public struct AwesomeCityAttribute: RawRepresentable {
 
 public class Wrapper {
   public struct Attribute: RawRepresentable {
-    public init?(rawValue: String) { self.rawValue = rawValue }
+    public static let KnownAttr = Wrapper.Attribute(rawValue: "")
+    public init(rawValue: String) { self.rawValue = rawValue }
     public var rawValue: String
     public typealias RawValue = String
   }

--- a/test/Migrator/Inputs/string-representable.json
+++ b/test/Migrator/Inputs/string-representable.json
@@ -260,4 +260,12 @@
     "RightComment": "String",
     "ModuleName": "Cities"
   },
+  {
+    "DiffItemKind": "TypeMemberDiffItem",
+    "Usr": "s:6Cities7WrapperC9AttributeV9KnownAttrAEvpZ",
+    "OldPrintedName": "KnownAttr",
+    "OldTypeName": "Wrapper.Attribute",
+    "NewPrintedName": "NewKnownAttr",
+    "NewTypeName": "NewAttributeWrapper"
+  },
 ]

--- a/test/Migrator/string-representable.swift
+++ b/test/Migrator/string-representable.swift
@@ -53,6 +53,7 @@ func revert(_ a: AwesomeCityAttribute, b: Wrapper.Attribute) {
   _ = Wrapper.Attribute(rawValue: "somevalue")
   _ = Wrapper.Attribute.init(rawValue: "somevalue")
   _ = b.rawValue
+  _ = Wrapper.Attribute.KnownAttr.rawValue
 }
 
 

--- a/test/Migrator/string-representable.swift.expected
+++ b/test/Migrator/string-representable.swift.expected
@@ -53,6 +53,7 @@ func revert(_ a: AwesomeCityAttribute, b: Wrapper.Attribute) {
   _ = "somevalue"
   _ = "somevalue"
   _ = b
+  _ = NewAttributeWrapper.NewKnownAttr
 }
 
 


### PR DESCRIPTION
- Explanation: We saw cases where rename and raw-representable reversion happen at the same time. This PR handles this composite changes.
- Scope: Swift 4.2 migrator
- Radar/SR Issue: rdar://41732485
- Risk: Very Low
- Testing: Unit test added
- Reviewer: Nathan Hawes