### PR TITLE
[AccessEnforcement] DEBUG is now called LLVM_DEBUG. NFCI.

### DIFF
--- a/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
@@ -624,8 +624,8 @@ struct AccessEnforcementOpts : public SILFunctionTransform {
     if (F->empty())
       return;
 
-    DEBUG(llvm::dbgs() << "Running local AccessEnforcementOpts on "
-                       << F->getName() << "\n");
+    LLVM_DEBUG(llvm::dbgs() << "Running local AccessEnforcementOpts on "
+                            << F->getName() << "\n");
 
     PostOrderFunctionInfo *PO = getAnalysis<PostOrderAnalysis>()->get(F);
     AccessedStorageAnalysis *ASA = getAnalysis<AccessedStorageAnalysis>();

--- a/lib/SILOptimizer/Transforms/AccessEnforcementWMO.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementWMO.cpp
@@ -216,9 +216,9 @@ void GlobalAccessRemoval::recordAccess(SILInstruction *beginAccess,
   if (!decl || module.isVisibleExternally(decl))
     return;
 
-  DEBUG(if (!hasNoNestedConflict) llvm::dbgs()
-        << "Nested conflict on " << decl->getName() << " at" << *beginAccess
-        << "\n");
+  LLVM_DEBUG(if (!hasNoNestedConflict) llvm::dbgs()
+             << "Nested conflict on " << decl->getName() << " at"
+             << *beginAccess << "\n");
 
   auto accessLocIter = disjointAccessMap.find(decl);
   if (accessLocIter != disjointAccessMap.end()) {
@@ -250,14 +250,14 @@ void GlobalAccessRemoval::removeNonreentrantAccess() {
       continue;
 
     VarDecl *decl = declAndInfo.first;
-    DEBUG(llvm::dbgs() << "Eliminating all formal access on " << decl->getName()
-                       << "\n");
+    LLVM_DEBUG(llvm::dbgs() << "Eliminating all formal access on "
+                            << decl->getName() << "\n");
     assert(!module.isVisibleExternally(decl));
     (void)decl;
 
     // Non-deterministic iteration, only used to set a flag.
     for (BeginAccessInst *beginAccess : info.beginAccessSet) {
-      DEBUG(llvm::dbgs() << "  Disabling access marker " << *beginAccess);
+      LLVM_DEBUG(llvm::dbgs() << "  Disabling access marker " << *beginAccess);
       beginAccess->setEnforcement(SILAccessEnforcement::Static);
     }
   }


### PR DESCRIPTION
@bob-wilson / @atrick let me know if this is reasonable to you. I would like to unblock master-next and get the corresponding lldb branch in some usable state.