### PR TITLE
Space Engine: uninhabited types map to empty spaces

### DIFF
--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -214,6 +214,8 @@ namespace {
           Spaces({}) {}
 
       static Space forType(Type T, Identifier NameForPrinting) {
+        if (T->isStructurallyUninhabited())
+          return Space();
         return Space(T, NameForPrinting);
       }
       static Space forUnknown(bool allowedButNotRequired) {

--- a/test/Compatibility/exhaustive_switch.swift
+++ b/test/Compatibility/exhaustive_switch.swift
@@ -1184,3 +1184,23 @@ func testUnavailableCases(_ x: UnavailableCase, _ y: UnavailableCaseOSSpecific, 
   case .notYetIntroduced: break
   } // no-error
 }
+
+// The following test used to behave differently when the uninhabited enum was
+// defined in the same module as the function (as opposed to using Swift.Never).
+enum NoError {}
+extension Result where T == NoError {
+  func testUninhabited() {
+    switch self {
+    case .Error(_):
+      break
+    // No .Ok case possible because of the 'NoError'.
+    }
+
+    switch self {
+    case .Error(_):
+      break
+    case .Ok(_):
+      break // But it's okay to write one.
+    }
+  }
+}

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -1223,3 +1223,23 @@ func testUnavailableCases(_ x: UnavailableCase, _ y: UnavailableCaseOSSpecific, 
   case .notYetIntroduced: break
   } // no-error
 }
+
+// The following test used to behave differently when the uninhabited enum was
+// defined in the same module as the function (as opposed to using Swift.Never).
+enum NoError {}
+extension Result where T == NoError {
+  func testUninhabited() {
+    switch self {
+    case .Error(_):
+      break
+    // No .Ok case possible because of the 'NoError'.
+    }
+
+    switch self {
+    case .Error(_):
+      break
+    case .Ok(_):
+      break // But it's okay to write one.
+    }
+  }
+}


### PR DESCRIPTION
Without this, the compiler ended up complaining about missing cases that can't actually occur, like `Optional<Never>.some(_)`. This was a regression from Swift 4.1.

[SR-8125](https://bugs.swift.org/browse/SR-8125) / rdar://problem/41525746