### PR TITLE
[AST] Centralize storage of the overridden declarations of a declaration 

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -307,7 +307,7 @@ protected:
     NumElements : 32
   );
 
-  SWIFT_INLINE_BITFIELD(ValueDecl, Decl, 1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(ValueDecl, Decl, 1+1+1,
     AlreadyInLookupTable : 1,
 
     /// Whether we have already checked whether this declaration is a 
@@ -316,13 +316,7 @@ protected:
 
     /// Whether the decl can be accessed by swift users; for instance,
     /// a.storage for lazy var a is a decl that cannot be accessed.
-    IsUserAccessible : 1,
-
-    /// Whether the "IsObjC" bit has been computed yet.
-    IsObjCComputed : 1,
-
-    /// Whether this declaration is exposed to Objective-C.
-    IsObjC : 1
+    IsUserAccessible : 1
   );
 
   SWIFT_INLINE_BITFIELD(AbstractStorageDecl, ValueDecl, 1+1+1+1+1,
@@ -2181,6 +2175,14 @@ class ValueDecl : public Decl {
   llvm::PointerIntPair<Type, 3, OptionalEnum<AccessLevel>> TypeAndAccess;
   unsigned LocalDiscriminator = 0;
 
+  struct {
+    /// Whether the "IsObjC" bit has been computed yet.
+    unsigned isObjCComputed : 1;
+
+    /// Whether this declaration is exposed to Objective-C.
+    unsigned isObjC : 1;
+  } LazySemanticInfo;
+
 protected:
   ValueDecl(DeclKind K,
             llvm::PointerUnion<DeclContext *, ASTContext *> context,
@@ -2189,8 +2191,8 @@ protected:
     Bits.ValueDecl.AlreadyInLookupTable = false;
     Bits.ValueDecl.CheckedRedeclaration = false;
     Bits.ValueDecl.IsUserAccessible = true;
-    Bits.ValueDecl.IsObjCComputed = false;
-    Bits.ValueDecl.IsObjC = false;
+    LazySemanticInfo.isObjCComputed = false;
+    LazySemanticInfo.isObjC = false;
   }
 
   // MemberLookupTable borrows a bit from this type

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6650,7 +6650,7 @@ std::pair<DefaultArgumentKind, Type>
 getDefaultArgumentInfo(ValueDecl *source, unsigned Index);
 
 /// Display ValueDecl subclasses.
-void simple_display(llvm::raw_ostream &out, const ValueDecl *&decl);
+void simple_display(llvm::raw_ostream &out, const ValueDecl *decl);
 
 } // end namespace swift
 

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -94,8 +94,6 @@ enum class FileUnitKind {
   SerializedAST,
   /// An imported Clang module.
   ClangModule,
-  /// A derived declaration.
-  Derived,
 };
 
 enum class SourceFileKind {

--- a/include/swift/Basic/ArrayRefView.h
+++ b/include/swift/Basic/ArrayRefView.h
@@ -19,6 +19,7 @@
 #define SWIFT_BASIC_ARRAYREFVIEW_H
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/Casting.h"
 
 namespace swift {
 
@@ -151,6 +152,20 @@ public:
     return !(lhs == rhs);
   }
 };
+
+/// Helper for \c CastArrayRefView that casts the original type to the
+/// projected type.
+template<typename Projected, typename Orig>
+inline Projected *arrayRefViewCastHelper(const Orig &value) {
+  using llvm::cast_or_null;
+  return cast_or_null<Projected>(value);
+}
+
+/// An ArrayRefView that performs a cast_or_null on each element in the
+/// underlying ArrayRef.
+template<typename Orig, typename Projected>
+using CastArrayRefView =
+  ArrayRefView<Orig, Projected *, arrayRefViewCastHelper<Projected, Orig>>;
 
 } // end namespace swift
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1989,8 +1989,8 @@ CanType ValueDecl::getOverloadSignatureType() const {
 }
 
 bool ValueDecl::isObjC() const {
-  if (Bits.ValueDecl.IsObjCComputed)
-    return Bits.ValueDecl.IsObjC;
+  if (LazySemanticInfo.isObjCComputed)
+    return LazySemanticInfo.isObjC;
 
   // Fallback: look for an @objc attribute.
   // FIXME: This should become an error, eventually.
@@ -1998,15 +1998,15 @@ bool ValueDecl::isObjC() const {
 }
 
 void ValueDecl::setIsObjC(bool value) {
-  assert(!Bits.ValueDecl.IsObjCComputed || Bits.ValueDecl.IsObjC == value);
+  assert(!LazySemanticInfo.isObjCComputed || LazySemanticInfo.isObjC == value);
 
-  if (Bits.ValueDecl.IsObjCComputed) {
-    assert(Bits.ValueDecl.IsObjC == value);
+  if (LazySemanticInfo.isObjCComputed) {
+    assert(LazySemanticInfo.isObjC == value);
     return;
   }
 
-  Bits.ValueDecl.IsObjCComputed = true;
-  Bits.ValueDecl.IsObjC = value;
+  LazySemanticInfo.isObjCComputed = true;
+  LazySemanticInfo.isObjC = value;
 }
 
 bool ValueDecl::canBeAccessedByDynamicLookup() const {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2013,14 +2013,10 @@ bool ValueDecl::canBeAccessedByDynamicLookup() const {
   if (!hasName())
     return false;
 
-  // Dynamic lookup can only find @objc members.
-  if (!isObjC())
-    return false;
-
   // Dynamic lookup can only find class and protocol members, or extensions of
   // classes.
   auto nominalDC =
-    getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
+  getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
   if (!nominalDC ||
       (!isa<ClassDecl>(nominalDC) && !isa<ProtocolDecl>(nominalDC)))
     return false;
@@ -2031,10 +2027,14 @@ bool ValueDecl::canBeAccessedByDynamicLookup() const {
     return false;
 
   // Dynamic lookup can find functions, variables, and subscripts.
-  if (isa<FuncDecl>(this) || isa<VarDecl>(this) || isa<SubscriptDecl>(this))
-    return true;
+  if (!isa<FuncDecl>(this) && !isa<VarDecl>(this) && !isa<SubscriptDecl>(this))
+    return false;
 
-  return false;
+  // Dynamic lookup can only find @objc members.
+  if (!isObjC())
+    return false;
+
+  return true;
 }
 
 ArrayRef<ValueDecl *>

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5801,7 +5801,7 @@ NominalTypeDecl *TypeOrExtensionDecl::getBaseNominal() const {
 }
 bool TypeOrExtensionDecl::isNull() const { return Decl.isNull(); }
 
-void swift::simple_display(llvm::raw_ostream &out, const ValueDecl *&decl) {
+void swift::simple_display(llvm::raw_ostream &out, const ValueDecl *decl) {
   if (decl) decl->dumpRef(out);
   else out << "(null)";
 }

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -558,9 +558,6 @@ unsigned DeclContext::printContext(raw_ostream &OS, unsigned indent) const {
     case FileUnitKind::Builtin:
       OS << " Builtin";
       break;
-    case FileUnitKind::Derived:
-      OS << " derived";
-      break;
     case FileUnitKind::Source:
       OS << " file=\"" << cast<SourceFile>(this)->getFilename() << "\"";
       break;

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -835,8 +835,7 @@ lookupOperatorDeclForName(const FileUnit &File, SourceLoc Loc, Identifier Name,
 {
   switch (File.getKind()) {
   case FileUnitKind::Builtin:
-  case FileUnitKind::Derived:
-    // The Builtin module declares no operators, nor do derived units.
+    // The Builtin module declares no operators.
     return nullptr;
   case FileUnitKind::Source:
     break;

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -3227,7 +3227,6 @@ public:
       for (auto fileUnit : import.second->getFiles()) {
         switch (fileUnit->getKind()) {
         case FileUnitKind::Builtin:
-        case FileUnitKind::Derived:
         case FileUnitKind::ClangModule:
           continue;
         case FileUnitKind::Source:

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -573,7 +573,6 @@ bool IndexSwiftASTWalker::visitImports(
       switch (File->getKind()) {
       case FileUnitKind::Source:
       case FileUnitKind::Builtin:
-      case FileUnitKind::Derived:
         break;
       case FileUnitKind::SerializedAST:
         assert(!IsClangModuleOpt.hasValue() &&
@@ -1281,9 +1280,6 @@ void IndexSwiftASTWalker::getRecursiveModuleImports(
           switch (FU->getKind()) {
           case FileUnitKind::Builtin:
             Info += "builtin";
-            break;
-          case FileUnitKind::Derived:
-            Info += "derived";
             break;
           case FileUnitKind::Source:
             Info += "source, file=\"";

--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -410,7 +410,6 @@ static void addModuleDependencies(ArrayRef<ModuleDecl::ImportedModule> imports,
     for (auto *FU : mod->getFiles()) {
       switch (FU->getKind()) {
       case FileUnitKind::Source:
-      case FileUnitKind::Derived:
       case FileUnitKind::Builtin:
         break;
       case FileUnitKind::SerializedAST:

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1735,8 +1735,8 @@ void TypeChecker::completeLazyVarImplementation(VarDecl *VD) {
   if (VD->getDeclContext()->getAsClassOrClassExtensionContext())
     makeFinal(Context, Storage);
   Storage->setImplicit();
-  Storage->setAccess(AccessLevel::Private);
-  Storage->setSetterAccess(AccessLevel::Private);
+  Storage->overwriteAccess(AccessLevel::Private);
+  Storage->overwriteSetterAccess(AccessLevel::Private);
 }
 
 /// Consider add a materializeForSet accessor to the given storage

--- a/lib/Sema/TypeCheckError.cpp
+++ b/lib/Sema/TypeCheckError.cpp
@@ -134,7 +134,7 @@ public:
         fn = conversion->getSubExpr()->getValueProvidingExpr();
       } else if (auto conversion = dyn_cast<BindOptionalExpr>(fn)) {
         fn = conversion->getSubExpr()->getValueProvidingExpr();
-      // Look through optional injections
+      // Look through optional injections.
       } else if (auto injection = dyn_cast<InjectIntoOptionalExpr>(fn)) {
         fn = injection->getSubExpr()->getValueProvidingExpr();
       // Look through function conversions.

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2698,7 +2698,7 @@ ModuleFile::getDeclCheckedImpl(DeclID DID, Optional<DeclContext *> ForcedContext
       assocType->setImplicit();
 
     // Overridden associated types.
-    SmallVector<AssociatedTypeDecl *, 2> overriddenAssocTypes;
+    SmallVector<ValueDecl *, 2> overriddenAssocTypes;
     for (auto overriddenID : rawOverriddenIDs) {
       if (auto overriddenAssocType =
               dyn_cast_or_null<AssociatedTypeDecl>(getDecl(overriddenID))) {


### PR DESCRIPTION
Several kinds of declarations can override other declarations, but the
computation and storage for these “overridden” declarations was scattered in
at least 3 different places, with different resolution paths. Pull them
all together into two bits of `LazySemanticInfo` in `ValueDecl` (“have we computed
overrides?” and “are there any overrides?”), with a side table for the
actual list of overrides.

One side effect here is that the AST can now represent multiple overridden
declarations, although only associated type declarations track this
information.

Start using `LazyResolver::resolveOverriddenDecl()` more consistently, unifying
it with the separate path we had for associated type overrides. All of this
is staging for a move to the request-evaluator for overridden declaration
computation.