### PR TITLE
[4.2] Space Engine: uninhabited types map to empty spaces

### DIFF
--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -214,6 +214,8 @@ namespace {
           Spaces({}) {}
 
       static Space forType(Type T, Identifier NameForPrinting) {
+        if (T->isStructurallyUninhabited())
+          return Space();
         return Space(T, NameForPrinting);
       }
       static Space forUnknown(bool allowedButNotRequired) {

--- a/test/Compatibility/exhaustive_switch.swift
+++ b/test/Compatibility/exhaustive_switch.swift
@@ -1184,3 +1184,23 @@ func testUnavailableCases(_ x: UnavailableCase, _ y: UnavailableCaseOSSpecific, 
   case .notYetIntroduced: break
   } // no-error
 }
+
+// The following test used to behave differently when the uninhabited enum was
+// defined in the same module as the function (as opposed to using Swift.Never).
+enum NoError {}
+extension Result where T == NoError {
+  func testUninhabited() {
+    switch self {
+    case .Error(_):
+      break
+    // No .Ok case possible because of the 'NoError'.
+    }
+
+    switch self {
+    case .Error(_):
+      break
+    case .Ok(_):
+      break // But it's okay to write one.
+    }
+  }
+}

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -1223,3 +1223,23 @@ func testUnavailableCases(_ x: UnavailableCase, _ y: UnavailableCaseOSSpecific, 
   case .notYetIntroduced: break
   } // no-error
 }
+
+// The following test used to behave differently when the uninhabited enum was
+// defined in the same module as the function (as opposed to using Swift.Never).
+enum NoError {}
+extension Result where T == NoError {
+  func testUninhabited() {
+    switch self {
+    case .Error(_):
+      break
+    // No .Ok case possible because of the 'NoError'.
+    }
+
+    switch self {
+    case .Error(_):
+      break
+    case .Ok(_):
+      break // But it's okay to write one.
+    }
+  }
+}


### PR DESCRIPTION
- **Explanation**: In adding `@unknown default`, the switch statement exhaustivity checking started complaining about missing enum cases where the payload type was uninhabited (like `Optional<Never>.some(_)`). It's clearly unnecessary for a user to have to match that case, and so this patch detects it earlier and avoids even adding the `some` case to the list of possible enum values. This may also very slightly speed up switch statement checking.

- **Scope**: Affects switch statement checking of enums when one of the case payload types is uninhabited.

- **Issue**: [SR-8125](https://bugs.swift.org/browse/SR-8125) / rdar://problem/41525746

- **Risk**: Medium-low. This does affect switch exhaustivity checking, which means we could see more "case is redundant" diagnostics in addition to removing the unwanted "missing case" diagnostic. However, the change is correct from the perspective of the algorithm.

- **Testing**: Added compiler regression tests, verified that the original project builds successfully.

- **Reviewed by**: @CodaFi, @xedin 