### PR TITLE
[CSGen] Re-typecheck literal expressions with 'UnresolvedType'

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1173,7 +1173,7 @@ namespace {
 
     Type visitLiteralExpr(LiteralExpr *expr) {
       // If the expression has already been assigned a type; just use that type.
-      if (expr->getType())
+      if (expr->getType() && !expr->getType()->is<UnresolvedType>())
         return expr->getType();
 
       auto protocol = CS.getTypeChecker().getLiteralProtocol(expr);

--- a/test/IDE/complete_crashes.swift
+++ b/test/IDE/complete_crashes.swift
@@ -296,3 +296,10 @@ func test_28188259(x: ((Int) -> Void) -> Void) {
 // RDAR_28188259-DAG: Pattern/CurrModule:                 ({#_#})[#Void#]; name=(_)
 // RDAR_28188259-DAG: Keyword[self]/CurrNominal:          .self[#(_) -> ()#]; name=self
 // RDAR_28188259: End completions
+
+// rdar://problem/41224316
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=RDAR_41224316 -source-filename=%s | %FileCheck %s -check-prefix=RDAR_41224316
+func test_41224316(str: String?) {
+  _ = str == nil #^RDAR_41224316^#
+}
+// RDAR_41224316: Begin completions


### PR DESCRIPTION
`nil` literal expression from code-completion may have `UnresolvedType`.
We need to re-typecheck them.

rdar://problem/41234606
