### PR TITLE
Fix typos/grammar in comments & docs

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -151,7 +151,7 @@ public:
   };
 
 private:
-  /// If non-NULL, an plug-in that should be used when performing external
+  /// If non-NULL, a plug-in that should be used when performing external
   /// lookups.
   // FIXME: Do we really need to bloat all modules with this?
   DebuggerClient *DebugClient = nullptr;

--- a/include/swift/SIL/Projection.h
+++ b/include/swift/SIL/Projection.h
@@ -78,7 +78,7 @@ bool getIntegerIndex(SILValue IndexVal, unsigned &IndexConst);
 /// TypeAlignments.h.
 ///
 /// Projection Kinds which can be represented via indices can use as many bits
-/// as they want to represent the kind. When the index value is uses at most 11
+/// as they want to represent the kind. When the index value uses at most 11
 /// bits, we represent it inline in the data structure. This is taking advantage
 /// of the fact that on most modern OSes (including Darwin), the zero page is
 /// not allocated. In the case where we have more than 11 bits of value

--- a/lib/SILOptimizer/Transforms/Outliner.cpp
+++ b/lib/SILOptimizer/Transforms/Outliner.cpp
@@ -1141,7 +1141,7 @@ class OutlinePatterns {
   llvm::DenseMap<CanType, SILDeclRef> BridgeFromObjectiveCache;
 
 public:
-  /// Try matching an outlineable pattern from the current current instruction.
+  /// Try matching an outlineable pattern from the current instruction.
   OutlinePattern *tryToMatch(SILBasicBlock::iterator CurInst) {
     if (BridgedPropertyPattern.matchInstSequence(CurInst))
       return &BridgedPropertyPattern;

--- a/utils/bug_reducer/README.md
+++ b/utils/bug_reducer/README.md
@@ -62,7 +62,7 @@ Then I invoke the bug reducer as follows:
 
 Then the bug_reducer will first attempt to reduce the passes. Then, it will
 attempt to reduce the test case by splitting the module and only optimizing part
-of it. The output will be look something like:
+of it. The output will look something like:
 
     *** Successfully Reduced file!
     *** Final File: ${FINAL_SIB_FILE}


### PR DESCRIPTION
Just some random grammar/typo corrections I came across in documentation.