### PR TITLE
Fixes a bug in SESERegion Builder

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
+++ b/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
@@ -213,9 +213,9 @@ SESERegionBuilder::processAcyclicRegionExcludingEnd(SILBasicBlock *startBB,
     // Analyze the successors of the branch: each of them is post dominated by
     // endBB (and any of the successors may be exactly endBB).
     auto trueRegion =
-      processAcyclicRegionExcludingEnd(condBr->getTrueBB(), endBB);
+      processAcyclicRegionExcludingEnd(condBr->getTrueBB(), postidom);
     auto falseRegion =
-      processAcyclicRegionExcludingEnd(condBr->getFalseBB(), endBB);
+      processAcyclicRegionExcludingEnd(condBr->getFalseBB(), postidom);
 
     // Finally, form our conditional region.
     auto condRegion = new ConditionalSESERegion(startBB, std::move(trueRegion),
@@ -362,6 +362,3 @@ namespace {
 SILTransform *swift::createTFXLACFGCanonicalize() {
   return new TFXLACFGCanonicalizeTestPass();
 }
-
-
-

--- a/test/TensorFlow/integration.swift
+++ b/test/TensorFlow/integration.swift
@@ -228,58 +228,23 @@ public func test_bool_param2(cond: Bool, // expected-warning {{'cond' implicitly
 // CHECK-NEXT: [[PROGRAM:%.*]] = apply [[STARTFN:%.*]](
 // CHECK: cond_br [[BOOLVAL]],
 
-public func test_multiple_ifs(status: Bool // expected-warning {{'status' implicitly copied to the accelerator}}
-) {
-  var a = Tensor<Int32>(0);
-  let b = a;
-  if (status) { // expected-note {{value used here}}
-    a += b;
+// expected-warning @+1 {{'status' implicitly copied to the accelerator}}
+public func test_multiple_ifs(status: Bool) {
+  var a = Tensor<Int32>(0)
+  let b = a
+  if status { // expected-note {{value used here}}
+    a += b
   }
-  a += b;
-  if (status) {
-    a += b;
+  a += b
+  if status {
+    a += b
   }
-  a -= b;
-  print (a)
+  a -= b
+  _hostOp(a)
 }
 
-// CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}test_multiple_ifs{{.*}}
-// CHECK: sil private @{{.*}}test_multiple_ifs{{.*}}
-// CHECK: bb0(%0 : $TensorHandle<Builtin.Int1>):
-// CHECK:      integer_literal $Builtin.Int32, 0
-// CHECK-NEXT: integer_literal $Builtin.Int32, 3
-// CHECK:      [[INIT:%.*]] = builtin "__tfop_Const,dtype$dtype,value$tensor,__device"(
-// CHECK-NEXT: [[A:%.*]] = unchecked_ref_cast [[INIT]] : $TensorHandle<Builtin.Int32> to $TensorHandle<Int32>
-// CHECK:      builtin "tf_tensor_to_i1"(%0 : $TensorHandle<Builtin.Int1>)
-// CHECK-NEXT: cond_br {{.*}}, bb2, bb1
-
-// CHECK: bb1:
-// CHECK:   br bb3([[A]] : $TensorHandle<Int32>)
-
-// CHECK: bb2:
-// CHECK:      [[B:%.*]] = builtin "__tfop_Add,$in,$in,T,__device"([[A]] : $TensorHandle<Int32>, [[A]] : $TensorHandle<Int32>, {{.*}} : $@thick Int32.Type, {{.*}} : $Builtin.RawPointer) : $TensorHandle<Int32>
-// CHECK-NEXT: br bb3([[B]] : $TensorHandle<Int32>)
-
-// CHECK: bb3([[C:%.*]] : $TensorHandle<Int32>):
-// CHECK:   [[D:%.*]] = builtin "__tfop_Add,$in,$in,T,__device"([[C]] : $TensorHandle<Int32>, [[A]] : $TensorHandle<Int32>, {{.*}} : $@thick Int32.Type, {{.*}} : $Builtin.RawPointer) : $TensorHandle<Int32>
-// CHECK:      builtin "tf_tensor_to_i1"(%0 : $TensorHandle<Builtin.Int1>)
-// CHECK-NEXT: cond_br {{.*}}, bb5, bb4
-
-// CHECK: bb4:
-// CHECK:   br bb6([[D]] : $TensorHandle<Int32>)
-
-// CHECK: bb5:
-// CHECK:   [[E:%.*]] = builtin "__tfop_Add,$in,$in,T,__device"([[D]] : $TensorHandle<Int32>, [[A]] : $TensorHandle<Int32>, {{.*}} : $@thick Int32.Type, {{.*}} : $Builtin.RawPointer) : $TensorHandle<Int32>
-// CHECK:   br bb6([[E]] : $TensorHandle<Int32>)
-
-// CHECK: bb6([[F:%.*]] : $TensorHandle<Int32>):
-// CHECK:   [[G:%.*]] = builtin "__tfop_Sub,$in,$in,T,__device"([[F]] : $TensorHandle<Int32>, [[A]] : $TensorHandle<Int32>, {{.*}} : $@thick Int32.Type, {{.*}} : $Builtin.RawPointer) : $TensorHandle<Int32>
-// CHECK-NEXT:   return [[G]] : $TensorHandle<Int32>
-// CHECK: }
-
-// ----
 // CHECK-LABEL: --- XLA CFG Canonicalize: {{.*}}test_multiple_ifs{{.*}}
-// CHECK:      [sequence
+// CHECK-NEXT: [sequence
 // CHECK-NEXT:   {condition Header: bb0
 // CHECK-NEXT:     block bb2
 // CHECK-NEXT:     block bb1}


### PR DESCRIPTION
<!-- What's in this pull request? -->
The computation of true and false regions of a conditional region should only consider nodes up to the post idom of the current startBB. Currently, it considers all the way up to the endBB, which causes duplication of the blocks in the SESE regions. 


