### PR TITLE
[Sema] Don't make argument paren target of RebindSelfInConstructorExpr

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1099,9 +1099,11 @@ namespace {
             if (isa<IdentityExpr>(ancestor) ||
                 isa<ForceValueExpr>(ancestor) ||
                 isa<AnyTryExpr>(ancestor)) {
-              if (target)
-                target = ancestor;
-              continue;
+              if (!CallArgs.count(ancestor)) {
+                if (target)
+                  target = ancestor;
+                continue;
+              }
             }
 
             // No other expression kinds are permitted.

--- a/test/expr/postfix/dot/init_ref_delegation.swift
+++ b/test/expr/postfix/dot/init_ref_delegation.swift
@@ -338,9 +338,8 @@ class TestNestedExpr {
   }
 
   convenience init(b: Int) {
-    func use(_ x: ()) {} // expected-note {{'use' declared here}}
-    use(self.init())
-    // FIXME: rdar://41416911 // expected-error@-1 {{missing argument for parameter #1 in call}}
+    func use(_ x: ()) {}
+    use(self.init()) // expected-error {{initializer delegation ('self.init') cannot be nested in another expression}}
   }
 
   convenience init(c: Int) {
@@ -353,9 +352,8 @@ class TestNestedExpr {
   }
 
   convenience init(e: Int) {
-    func use(_ x: ()) {} // expected-note {{'use' declared here}}
-    use(self.init(fail: true)!)
-    // FIXME: rdar://41416911 // expected-error@-1 {{missing argument for parameter #1 in call}}
+    func use(_ x: ()) {}
+    use(self.init(fail: true)!) // expected-error {{initializer delegation ('self.init') cannot be nested in another expression}}
   }
 
   convenience init(f: Int) {
@@ -368,9 +366,8 @@ class TestNestedExpr {
   }
 
   convenience init(h: Int) {
-    func use(_ x: ()) {} // expected-note {{'use' declared here}}
-    use(try! self.init(error: true))
-    // FIXME: rdar://41416911 // expected-error@-1 {{missing argument for parameter #1 in call}}
+    func use(_ x: ()) {}
+    use(try! self.init(error: true)) // expected-error {{initializer delegation ('self.init') cannot be nested in another expression}}
   }
 
   convenience init(i: Int) {
@@ -400,6 +397,11 @@ class TestNestedExpr {
       // expected-error@-1 {{initializer delegation ('self.init') cannot be nested in another expression}}
     }
   }
+
+  convenience init(k: Int) {
+    func use(_ x: Any...) {}
+    use(self.init()) // expected-error {{initializer delegation ('self.init') cannot be nested in another expression}}
+  }
 }
 
 class TestNestedExprSub : TestNestedExpr {
@@ -409,9 +411,8 @@ class TestNestedExprSub : TestNestedExpr {
   }
 
   init(b: Int) {
-    func use(_ x: ()) {} // expected-note {{'use' declared here}}
-    use(super.init())
-    // FIXME: rdar://41416911 // expected-error@-1 {{missing argument for parameter #1 in call}}
+    func use(_ x: ()) {}
+    use(super.init()) // expected-error {{initializer chaining ('super.init') cannot be nested in another expression}}
   }
 
   init(c: Int) {
@@ -424,9 +425,8 @@ class TestNestedExprSub : TestNestedExpr {
   }
 
   init(e: Int) {
-    func use(_ x: ()) {} // expected-note {{'use' declared here}}
-    use(super.init(fail: true)!)
-    // FIXME: rdar://41416911 // expected-error@-1 {{missing argument for parameter #1 in call}}
+    func use(_ x: ()) {}
+    use(super.init(fail: true)!) // expected-error {{initializer chaining ('super.init') cannot be nested in another expression}}
   }
 
   init(f: Int) {
@@ -439,13 +439,17 @@ class TestNestedExprSub : TestNestedExpr {
   }
 
   init(h: Int) {
-    func use(_ x: ()) {} // expected-note {{'use' declared here}}
-    use(try! super.init(error: true))
-    // FIXME: rdar://41416911 // expected-error@-1 {{missing argument for parameter #1 in call}}
+    func use(_ x: ()) {}
+    use(try! super.init(error: true)) // expected-error {{initializer chaining ('super.init') cannot be nested in another expression}}
   }
 
   init(i: Int) {
     _ = ((), try! super.init(error: true)) // expected-error {{initializer chaining ('super.init') cannot be nested in another expression}}
+  }
+
+  init(j: Int) {
+    func use(_ x: Any...) {}
+    use(super.init()) // expected-error {{initializer chaining ('super.init') cannot be nested in another expression}}
   }
 }
 


### PR DESCRIPTION
For (previously crashing):
```swift
class A {
    init() {}

    convenience init(s: String) {
        print(self.init())
    }
}
```
target of `RebindSelfInConstructorExpr` should be call expression `self.init()` instead of paren `(self.init())`.

rdar://problem/41416911
Possibly: rdar://problem/41593987