### PR TITLE
Completed the partitioning and lowering support for SwitchEnum

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFDevicePartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDevicePartition.cpp
@@ -270,7 +270,11 @@ class DevicePartitionCloner
 }  // end anonymous namespace
 
 void DevicePartitionCloner::visitGraphOperationInst(GraphOperationInst *inst) {
-  if (!targetOps.count(inst)) return;
+  // TODO: try and remove this special case.
+  if (inst->getName().str() == "tf_tensor_to_i1") {
+    SILClonerWithScopes::visitGraphOperationInst(inst);
+    return;
+  }
 
   // TODO: visitTensorTransferInst?
 
@@ -652,6 +656,10 @@ class DevicePartitionerImpl
   }
 
   void visitGraphOperationInst(GraphOperationInst *inst) {
+    // For this magic builtin, it will be handled in graph lowering directly.
+    if (inst->getName().str() == "tf_tensor_to_i1")
+      return;
+
     auto deviceType = GraphOperationInfo(inst).getDeviceType();
     markInstForDevice(deviceType, inst);
 

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -758,9 +758,10 @@ TF_DataType TFGraphLowering::getTensorFlowDataType(SILType type,
 // Helpers to create TensorFlow graph nodes.
 //===----------------------------------------------------------------------===//
 
-static TF_Tensor *convertValuesToTensor(ArrayRef<SingleValueInstruction*> elts,
-                                        ArrayRef<int64_t> shape,
-                                        TF_DataType dtype) {
+// TODO: remove this function once we complete the migration to graph op inst.
+static TF_Tensor *
+convertValuesToTensorLegacy(ArrayRef<SingleValueInstruction *> elts,
+                            ArrayRef<int64_t> shape, TF_DataType dtype) {
   assert(dtype != TF_DataType() && "Expected to get a type!");
   auto dtypeSize = TF_DataTypeSize(dtype);
 
@@ -785,6 +786,32 @@ static TF_Tensor *convertValuesToTensor(ArrayRef<SingleValueInstruction*> elts,
 
     // FIXME: This will need a byte swap for big endian hosts.
     memcpy(ptr, value.getRawData(), dtypeSize);
+    ptr += dtypeSize;
+  }
+
+  return tensor;
+}
+
+static TF_Tensor *convertValuesToTensor(ArrayRef<APInt> elts,
+                                        ArrayRef<int64_t> shape,
+                                        TF_DataType dtype) {
+  assert(dtype != TF_DataType() && "Expected to get a type!");
+  auto dtypeSize = TF_DataTypeSize(dtype);
+
+  // Compute the total memory size of the tensor value.
+  unsigned totalElements = 1;
+  for (auto dim : shape)
+    totalElements *= dim;
+
+  // Make an uninitialized tensor that is big enough for our value.
+  auto *tensor = TF_AllocateTensor(dtype, shape.data(), shape.size(),
+                                   dtypeSize * totalElements);
+
+  // Set up its contents, element-wise.
+  auto *ptr = (char *)TF_TensorData(tensor);
+  for (auto elt : elts) {
+    // FIXME: This will need a byte swap for big endian hosts.
+    memcpy(ptr, elt.getRawData(), dtypeSize);
     ptr += dtypeSize;
   }
 
@@ -1632,6 +1659,12 @@ bool TFGraphLowering::copyGraphFunctions(const std::vector<char> &graphDefProto,
 /// Lower a graph_op into the TensorFlow op node.
 ///
 GLStatus TFGraphLowering::visitGraphOperationInst(GraphOperationInst *inst) {
+  // If this is the magic tf_tensor_to_i1 builtin, then we completely ignore it.
+  // the only user of it are things that take conditional branches, and they
+  // handle it directly.
+  if (inst->getName().str() == "tf_tensor_to_i1")
+    return GLStatus::Success;
+
   auto &graphFn = getCurrentGraphFunction();
 
   // Decode information about the graph_op.
@@ -1794,12 +1827,32 @@ GLStatus TFGraphLowering::visitGraphOperationInst(GraphOperationInst *inst) {
       // Done with normal attributes.
       break;
     case SILTensorOpInfo::OperandClass::DType: {
-      // This integer value is a dtype.
-      auto val = attrValue.getIntegerValue();
-      TF_SetAttrType(op, name.data(), (TF_DataType)val.getLimitedValue());
+      auto swiftType = attrValue.getMetatypeValue();
+      auto tfType = convertSwiftTypeToTF(swiftType);
+      TF_SetAttrType(op, name.data(), (TF_DataType)tfType);
       break;
     }
-    case SILTensorOpInfo::OperandClass::Tensor:
+    case SILTensorOpInfo::OperandClass::Tensor: {
+      // Tensor can support two cases: an array case (not yet implemented), and
+      // a scalar case.
+      TF_DataType dtype;
+      SmallVector<APInt, 4> elements;
+      SmallVector<int64_t, 4> shape;
+      if (attrValue.getKind() != SymbolicValue::Integer) {
+        llvm_unreachable("FIXME: Tensor-typed attr is not yet handled");
+      }
+      // The scalar case is very simple, the shape of a scalar is 0d, and the
+      // data type is int32.
+      dtype = TF_INT32;
+      elements.push_back(attrValue.getIntegerValue());
+      // Set the tensor as the attribute on the graph node.
+      auto tensor = convertValuesToTensor(elements, shape, dtype);
+      TF_SetAttrTensor(op, name.c_str(), tensor, status);
+      TF_DeleteTensor(tensor);
+      if (checkStatus(inst->getLoc()))
+        return GLStatus::Error;
+      break;
+    }
     case SILTensorOpInfo::OperandClass::Shape:
     case SILTensorOpInfo::OperandClass::ShapeArray:
     case SILTensorOpInfo::OperandClass::Array:
@@ -2039,7 +2092,7 @@ GLStatus TFGraphLowering::visitTFOpInst(BuiltinInst *inst) {
       }
 
       // Set the tensor as the attribute on the graph node.
-      auto tensor = convertValuesToTensor(elements, shape, dtype);
+      auto tensor = convertValuesToTensorLegacy(elements, shape, dtype);
       TF_SetAttrTensor(op, name.c_str(), tensor, status);
       TF_DeleteTensor(tensor);
       if (checkStatus(inst->getLoc())) return GLStatus::Error;
@@ -2301,14 +2354,23 @@ GLStatus TFGraphLowering::lowerSequenceRegion(SequenceSESERegion *r) {
   return GLStatus::Success;
 }
 
-
 /// Given a conditional branch, produce the TF_Output for its branch condition.
 static TF_Output getCondition(CondBranchInst *condBr,
                               TFGraphLowering &lowering) {
   auto cond = condBr->getCondition();
-  auto tensorToI1 = cast<BuiltinInst>(cond);
-  assert(tensorToI1->getName().str() == "tf_tensor_to_i1" &&
-         tensorToI1->getNumOperands() == 1 &&
+  SILInstruction *tensorToI1 = nullptr;
+  // TODO: remove the case of BuiltinInst.
+  if (auto *builtinInst = dyn_cast<BuiltinInst>(cond)) {
+    assert(builtinInst->getName().str() == "tf_tensor_to_i1");
+    tensorToI1 = builtinInst;
+  } else {
+    auto *graphOpResult = cast<GraphOperationResult>(cond);
+    auto *graphOpInst = graphOpResult->getParent();
+    assert(graphOpInst->getNumResults() == 1);
+    assert(graphOpInst->getName().str() == "tf_tensor_to_i1");
+    tensorToI1 = graphOpInst;
+  }
+  assert(tensorToI1->getNumOperands() == 1 &&
          "unexpected branch condition in graph lowering");
   cond = tensorToI1->getOperand(0);
 

--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -1621,8 +1621,18 @@ canonicalizeOperands(GraphGlobalConfiguration &configuration) {
 /// exist.
 StringRef GraphOperationInfo::getDeviceString() const {
   auto attr = inst->getAttribute(DEVICE_ATTR);
-  assert(attr.hasValue() && "Tensor op instruction has no device string");
+  assertWithDump(attr.hasValue(), "Tensor op instruction has no device string");
   return attr.getValue().getStringValue();
+}
+
+void GraphOperationInfo::assertWithDump(bool cond,
+                                        const char *assertMsg) const {
+#ifndef NDEBUG
+  if (cond)
+    return;
+  inst->dump();
+  llvm_unreachable(assertMsg);
+#endif // NDEBUG
 }
 
 /// Decode the name of a graph_op into its TensorFlow op name and a list of
@@ -1637,14 +1647,15 @@ decodeName(SmallVectorImpl<InputMarker> &inputInfo) {
     name = name.drop_front(pos+1);
     pos = name.find(',');
     auto letter = name.substr(0, pos);
-    assert(letter.size() == 1 && "malformed graph_op instruction");
+    assertWithDump(letter.size() == 1, "malformed graph_op instruction");
     InputMarker kind;
     switch (letter[0]) {
     case 's': kind = InputMarker::IM_Scalar; break;
     case 'i': kind = InputMarker::IM_Normal; break;
     case 'L': kind = InputMarker::IM_InputList; break;
     case 'e': kind = InputMarker::IM_InputListElt; break;
-    default: assert(0 && "malformed graph_op instruction");
+    default:
+      assertWithDump(false, "malformed graph_op instruction");
     }
     inputInfo.push_back(kind);
   }

--- a/lib/SILOptimizer/Mandatory/TFUtilities.h
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.h
@@ -492,6 +492,9 @@ private:
     static Type decodeArrayElements(SILValue value,
                                     SmallVectorImpl<SILValue> &elements,
                         SmallPtrSet<SILInstruction*, 8> *arrayInsts = nullptr);
+
+  private:
+    void assertWithDump(bool cond, const char *assertMsg) const;
   };
 
   //===--------------------------------------------------------------------===//

--- a/test/TensorFlow/control_flow.swift
+++ b/test/TensorFlow/control_flow.swift
@@ -1,0 +1,76 @@
+// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -O -emit-sil %s -verify | %FileCheck %s
+
+import TensorFlow
+
+public enum Pet {
+  case bird, cat, dog, fish
+}
+
+// Enumerated all cases.
+public func weighPet(pet: Pet) {
+  var weight = Tensor<Float>(0.0)
+  switch pet {
+  case .bird: weight += 1.0
+  case .cat: weight += 5.0
+  case .dog: weight += 10.0
+  case .fish: break // no tensor code here
+  }
+  // This is needed to work-around the current TF limitation where the `If` op
+  // must produce some output tensors.
+  // FIXME: lift this restriction.
+  weight += 0.0
+  _hostOp(weight)
+}
+
+// CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}weighPet{{.*}}
+//sil {{.*}}weighPet
+//
+// CHECK:      bb0:
+// CHECK:        cond_br {{.*}}, bb1, bb6
+
+// bb1 through bb4 are the 4 enum cases. bb5 is the merge block.
+// Also, bb4 is the block for .fish, and has no tensor code.
+// CHECK:      bb1:
+// CHECK:        br bb5
+// CHECK:      bb2:
+// CHECK:        br bb5
+// CHECK:      bb3:
+// CHECK:        br bb5
+// CHECK:      bb4:
+// CHECK-NEXT:   br bb5
+// CHECK:      bb5(
+// CHECK:        return
+
+// bb6 and bb7 are the synthesized blocks that compare against enum cases 1 and
+// 2 (.cat and .dog).
+// CHECK:      bb6:
+// CHECK:        cond_br {{.*}}, bb2, bb7
+// CHECK:      bb7:
+// CHECK:        cond_br {{.*}}, bb3, bb4
+// CHECK:      } // end sil function {{.*}}weighPet
+
+public func weighPetWithDefault(pet: Pet) {
+  var weight = Tensor<Float>(1.0)
+  switch pet {
+  case .cat: weight += 5.0
+  default: weight += 3.0
+  }
+  weight += 0.0
+  _hostOp(weight)
+}
+
+public func weighPetOnlyDefault(pet: Pet) {
+  var weight = Tensor<Float>(1.0)
+  switch pet {
+  default: weight += 3.0
+  }
+  weight += 0.0
+  _hostOp(weight)
+}
+
+// Straightline code -- nice!
+// CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}weighPetOnlyDefault{{.*}}
+// CHECK:      bb0:
+// CHECK-NOT:  bb1
+// CHECK:        return
+// CHECK-NEXT: }  // end sil function

--- a/test/TensorFlowRuntime/control_flow.swift
+++ b/test/TensorFlowRuntime/control_flow.swift
@@ -25,4 +25,86 @@ ControlFlowTests.testAllBackends("testSwitchEnum") {
   testSwitchEnum(nil, 1.0)
 }
 
+
+public enum Pet {
+  case bird, cat, dog, fish
+}
+
+// Enumerated all cases.
+public func weighPet(_ pet: Pet,
+                     _ expectedVal: Float) {
+  var weight = Tensor<Float>(1.0)
+  switch pet {
+  case .bird: weight += 1.0
+  case .cat: weight += 5.0
+  case .dog: weight += 10.0
+  case .fish: break // no tensor code here
+  }
+  // This is needed to work-around the current TF limitation where the `If` op
+  // must produce some output tensors.
+  // FIXME: lift this restriction.
+  weight += 0.0
+  expectNearlyEqualWithScalarTensor(expectedVal, weight)
+}
+ControlFlowTests.testAllBackends("weighPet") {
+  weighPet(.bird, 2.0)
+  weighPet(.cat, 6.0)
+  weighPet(.dog, 11.0)
+  weighPet(.fish, 1.0)
+}
+
+public func weighPetWithDefault(_ pet: Pet,
+                                _ expectedVal: Float) {
+  var weight = Tensor<Float>(1.0)
+  switch pet {
+  case .cat: weight += 5.0
+  default: weight += 3.0
+  }
+  // This is needed to work-around the current TF limitation where the `If` op
+  // must produce some output tensors.
+  // FIXME: lift this restriction.
+  weight += 0.0
+  expectNearlyEqualWithScalarTensor(expectedVal, weight)
+}
+ControlFlowTests.testAllBackends("weighPetWithDefault") {
+  weighPetWithDefault(.cat, 6.0)
+  weighPetWithDefault(.bird, 4.0)
+  weighPetWithDefault(.dog, 4.0)
+  weighPetWithDefault(.fish, 4.0)
+}
+
+
+public enum EnumWithPayload {
+  case a(String)
+  case b(Float)
+  case c(Tensor<Float>, Tensor<Float>)
+  indirect case d(EnumWithPayload)
+}
+
+public func testEnumWithPayload(_ x: EnumWithPayload, _ expectedVal: Float) {
+  var val = Tensor<Float>(2.0)
+  switch x {
+  case .a(let x):
+    val += 1.0
+    print(x)
+  case .b(let x):
+    print(x)
+    val += Tensor<Float>(x)
+  case .c(let x, let y):
+    val *= x + y
+    print(x, y)
+  case .d(let f):
+    val += 10.0
+    print(f)
+  }
+  val += 0.0
+  expectNearlyEqualWithScalarTensor(expectedVal, val)
+}
+ControlFlowTests.testAllBackends("testEnumWithPayload") {
+  testEnumWithPayload(.a("Hello"), 3.0)
+  testEnumWithPayload(.b(3.0), 5.0)
+  testEnumWithPayload(.c(Tensor<Float>(1.0), Tensor<Float>(2.0)), 6.0)
+  testEnumWithPayload(.d(.b(3.0)), 12.0)
+}
+
 runAllTests()


### PR DESCRIPTION
This works with an arbitrary N cases, including an optional default case.

The synthesized accelerator code, involves a sequence of if/else statements over the successor blocks of the SwitchEnum inst, and uses the new GraphOpInst. It sets up the ground work for supporting other types of TermInsts.