### PR TITLE
[Parse][Sema] Emit instant deallocation warning on the '=' token for PBDs

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1791,6 +1791,9 @@ public:
 class PatternBindingEntry {
   Pattern *ThePattern;
 
+  /// The location of the equal '=' token.
+  SourceLoc EqualLoc;
+
   enum class Flags {
     Checked = 1 << 0,
     Removed = 1 << 1,
@@ -1808,8 +1811,10 @@ class PatternBindingEntry {
   friend class PatternBindingInitializer;
 
 public:
-  PatternBindingEntry(Pattern *P, Expr *E, DeclContext *InitContext)
-    : ThePattern(P), InitAndFlags(E, {}), InitContext(InitContext) {}
+  PatternBindingEntry(Pattern *P, SourceLoc EqualLoc, Expr *E,
+                      DeclContext *InitContext)
+      : ThePattern(P), EqualLoc(EqualLoc), InitAndFlags(E, {}),
+        InitContext(InitContext) {}
 
   Pattern *getPattern() const { return ThePattern; }
   void setPattern(Pattern *P) { ThePattern = P; }
@@ -1822,6 +1827,12 @@ public:
   }
   SourceRange getOrigInitRange() const;
   void setInit(Expr *E);
+
+  /// Retrieve the location of the equal '=' token.
+  SourceLoc getEqualLoc() const { return EqualLoc; }
+
+  /// Set the location of the equal '=' token.
+  void setEqualLoc(SourceLoc equalLoc) { EqualLoc = equalLoc; }
 
   /// Retrieve the initializer as it was written in the source.
   Expr *getInitAsWritten() const { return InitAndFlags.getPointer(); }
@@ -1890,8 +1901,8 @@ public:
 
   static PatternBindingDecl *create(ASTContext &Ctx, SourceLoc StaticLoc,
                                     StaticSpellingKind StaticSpelling,
-                                    SourceLoc VarLoc,
-                                    Pattern *Pat, Expr *E,
+                                    SourceLoc VarLoc, Pattern *Pat,
+                                    SourceLoc EqualLoc, Expr *E,
                                     DeclContext *Parent);
 
   static PatternBindingDecl *createImplicit(ASTContext &Ctx,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -999,17 +999,15 @@ PatternBindingDecl::PatternBindingDecl(SourceLoc StaticLoc,
 
 PatternBindingDecl *
 PatternBindingDecl::create(ASTContext &Ctx, SourceLoc StaticLoc,
-                           StaticSpellingKind StaticSpelling,
-                           SourceLoc VarLoc,
-                           Pattern *Pat, Expr *E,
+                           StaticSpellingKind StaticSpelling, SourceLoc VarLoc,
+                           Pattern *Pat, SourceLoc EqualLoc, Expr *E,
                            DeclContext *Parent) {
   DeclContext *BindingInitContext = nullptr;
   if (!Parent->isLocalContext())
     BindingInitContext = new (Ctx) PatternBindingInitializer(Parent);
 
-  auto Result = create(Ctx, StaticLoc, StaticSpelling, VarLoc,
-                       PatternBindingEntry(Pat, E, BindingInitContext),
-                       Parent);
+  auto PBE = PatternBindingEntry(Pat, EqualLoc, E, BindingInitContext);
+  auto *Result = create(Ctx, StaticLoc, StaticSpelling, VarLoc, PBE, Parent);
 
   if (BindingInitContext)
     cast<PatternBindingInitializer>(BindingInitContext)->setBinding(Result, 0);
@@ -1021,7 +1019,7 @@ PatternBindingDecl *PatternBindingDecl::createImplicit(
     ASTContext &Ctx, StaticSpellingKind StaticSpelling, Pattern *Pat, Expr *E,
     DeclContext *Parent, SourceLoc VarLoc) {
   auto *Result = create(Ctx, /*StaticLoc*/ SourceLoc(), StaticSpelling, VarLoc,
-                        Pat, E, Parent);
+                        Pat, /*EqualLoc*/ SourceLoc(), E, Parent);
   Result->setImplicit();
   return Result;
 }
@@ -1069,7 +1067,8 @@ PatternBindingDecl *PatternBindingDecl::createDeserialized(
   auto PBD = ::new (D) PatternBindingDecl(StaticLoc, StaticSpelling, VarLoc,
                                           NumPatternEntries, Parent);
   for (auto &entry : PBD->getMutablePatternList()) {
-    entry = PatternBindingEntry(nullptr, nullptr, nullptr);
+    entry = PatternBindingEntry(/*Pattern*/ nullptr, /*EqualLoc*/ SourceLoc(),
+                                /*Init*/ nullptr, /*InitContext*/ nullptr);
   }
   return PBD;
 }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -148,7 +148,8 @@ createVarWithPattern(ASTContext &ctx, DeclContext *dc, Identifier name, Type ty,
   Pattern *varPattern = createTypedNamedPattern(var);
   auto *patternBinding = PatternBindingDecl::create(
       ctx, /*StaticLoc*/ SourceLoc(), StaticSpellingKind::None,
-      /*VarLoc*/ SourceLoc(), varPattern, /*InitExpr*/ nullptr, dc);
+      /*VarLoc*/ SourceLoc(), varPattern, /*EqualLoc*/ SourceLoc(),
+      /*InitExpr*/ nullptr, dc);
   if (isImplicit)
     patternBinding->setImplicit();
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4440,7 +4440,8 @@ VarDecl *Parser::parseDeclVarGetSet(Pattern *pattern,
     Pattern *pattern =
       new (Context) TypedPattern(new (Context) NamedPattern(storage),
                                  TypeLoc::withoutLoc(ErrorType::get(Context)));
-    PatternBindingEntry entry(pattern, /*init*/ nullptr, /*initDC*/ nullptr);
+    PatternBindingEntry entry(pattern, /*EqualLoc*/ SourceLoc(),
+                              /*Init*/ nullptr, /*InitContext*/ nullptr);
     auto binding = PatternBindingDecl::create(Context, StaticLoc,
                                               StaticSpellingKind::None,
                                               VarLoc, entry, CurDeclContext);
@@ -4867,7 +4868,8 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
 
     // Remember this pattern/init pair for our ultimate PatternBindingDecl. The
     // Initializer will be added later when/if it is parsed.
-    PBDEntries.push_back({pattern, nullptr, nullptr});
+    PBDEntries.push_back({pattern, /*EqualLoc*/ SourceLoc(), /*Init*/ nullptr,
+                          /*InitContext*/ nullptr});
 
     Expr *PatternInit = nullptr;
     
@@ -4912,6 +4914,8 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
 
       
       SourceLoc EqualLoc = consumeToken(tok::equal);
+      PBDEntries.back().setEqualLoc(EqualLoc);
+
       ParserResult<Expr> init = parseExpr(diag::expected_init_value);
       
       // If this Pattern binding was not supposed to have an initializer, but it

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2494,6 +2494,7 @@ parseClosureSignatureIfPresent(SmallVectorImpl<CaptureListEntry> &captureList,
       Expr *initializer;
       Identifier name;
       SourceLoc nameLoc = Tok.getLoc();
+      SourceLoc equalLoc;
       if (peekToken().isNot(tok::equal)) {
         // If this is the simple case, then the identifier is both the name and
         // the expression to capture.
@@ -2511,7 +2512,7 @@ parseClosureSignatureIfPresent(SmallVectorImpl<CaptureListEntry> &captureList,
       } else {
         // Otherwise, the name is a new declaration.
         consumeIdentifier(&name);
-        consumeToken(tok::equal);
+        equalLoc = consumeToken(tok::equal);
 
         auto ExprResult = parseExpr(diag::expected_init_capture_specifier);
         if (ExprResult.isNull())
@@ -2536,10 +2537,10 @@ parseClosureSignatureIfPresent(SmallVectorImpl<CaptureListEntry> &captureList,
 
       auto pattern = new (Context) NamedPattern(VD, /*implicit*/true);
 
-      auto *PBD = PatternBindingDecl::create(Context, /*staticloc*/SourceLoc(),
-                                             StaticSpellingKind::None,
-                                             nameLoc, pattern, initializer,
-                                             CurDeclContext);
+      auto *PBD = PatternBindingDecl::create(
+          Context, /*StaticLoc*/ SourceLoc(), StaticSpellingKind::None,
+          /*VarLoc*/ nameLoc, pattern, /*EqualLoc*/ equalLoc, initializer,
+          CurDeclContext);
 
       captureList.push_back(CaptureListEntry(VD, PBD));
     } while (HasNext);

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2175,6 +2175,7 @@ void swift::diagnoseUnownedImmediateDeallocation(TypeChecker &TC,
 
 void swift::diagnoseUnownedImmediateDeallocation(TypeChecker &TC,
                                                  const Pattern *pattern,
+                                                 SourceLoc equalLoc,
                                                  const Expr *initExpr) {
   pattern = pattern->getSemanticsProvidingPattern();
 
@@ -2190,15 +2191,13 @@ void swift::diagnoseUnownedImmediateDeallocation(TypeChecker &TC,
         const Pattern *subPattern = elt.getPattern();
         Expr *subInitExpr = TE->getElement(i);
 
-        diagnoseUnownedImmediateDeallocation(TC, subPattern, subInitExpr);
+        diagnoseUnownedImmediateDeallocation(TC, subPattern, equalLoc,
+                                             subInitExpr);
       }
     }
   } else if (auto *NP = dyn_cast<NamedPattern>(pattern)) {
-    // FIXME: Ideally the diagnostic location should be on the equals '=' token
-    // of the pattern binding rather than at the start of the initializer
-    // expression (matching the above diagnostic logic for an assignment).
     diagnoseUnownedImmediateDeallocationImpl(TC, NP->getDecl(), initExpr,
-                                             initExpr->getStartLoc(),
+                                             equalLoc,
                                              initExpr->getSourceRange());
   }
 }

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -79,6 +79,7 @@ void diagnoseUnownedImmediateDeallocation(TypeChecker &TC,
 /// emit a warning that the bound instance will be immediately deallocated.
 void diagnoseUnownedImmediateDeallocation(TypeChecker &TC,
                                           const Pattern *pattern,
+                                          SourceLoc equalLoc,
                                           const Expr *initializer);
 
 /// Attempt to fix the type of \p decl so that it's a valid override for

--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -318,9 +318,10 @@ void REPLChecker::processREPLTopLevelExpr(Expr *E) {
   Pattern *metavarPat = new (Context) NamedPattern(vd);
   metavarPat->setType(E->getType());
 
-  PatternBindingDecl *metavarBinding
-    = PatternBindingDecl::create(Context, SourceLoc(), StaticSpellingKind::None,
-                                 E->getStartLoc(), metavarPat, E, TLCD);
+  PatternBindingDecl *metavarBinding = PatternBindingDecl::create(
+      Context, /*StaticLoc*/ SourceLoc(), StaticSpellingKind::None,
+      /*VarLoc*/ E->getStartLoc(), metavarPat, /*EqualLoc*/ SourceLoc(), E,
+      TLCD);
 
   // Overwrite the body of the existing TopLevelCodeDecl.
   TLCD->setBody(BraceStmt::create(Context,
@@ -392,12 +393,11 @@ void REPLChecker::processREPLTopLevelPatternBinding(PatternBindingDecl *PBD) {
     // Create a PatternBindingDecl to bind the expression into the decl.
     Pattern *metavarPat = new (Context) NamedPattern(vd);
     metavarPat->setType(vd->getType());
-    PatternBindingDecl *metavarBinding
-      = PatternBindingDecl::create(Context, SourceLoc(),
-                                   StaticSpellingKind::None,
-                                   PBD->getStartLoc(), metavarPat,
-                                   patternEntry.getInit(), &SF);
-    
+    PatternBindingDecl *metavarBinding = PatternBindingDecl::create(
+        Context, /*StaticLoc*/ SourceLoc(), StaticSpellingKind::None,
+        /*VarLoc*/ PBD->getStartLoc(), metavarPat, /*EqualLoc*/ SourceLoc(),
+        patternEntry.getInit(), &SF);
+
     auto MVBrace = BraceStmt::create(Context, metavarBinding->getStartLoc(),
                                      ASTNode(metavarBinding),
                                      metavarBinding->getEndLoc());

--- a/test/Sema/diag_unowned_immediate_deallocation_locs.swift
+++ b/test/Sema/diag_unowned_immediate_deallocation_locs.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -typecheck %s 2>&1 | %FileCheck %s
+
+// Ensure we emit the warnings on the equal '=' tokens.
+class C {}
+
+weak var c1 = C() // CHECK: [[@LINE]]:13: warning: instance will be immediately deallocated because variable 'c1' is 'weak'
+
+weak var c2: C? = C() // CHECK: [[@LINE]]:17: warning: instance will be immediately deallocated because variable 'c2' is 'weak'
+
+weak var (c3, c4) = (C(), C())
+// CHECK: [[@LINE-1]]:19: warning: instance will be immediately deallocated because variable 'c3' is 'weak'
+// CHECK: [[@LINE-2]]:19: warning: instance will be immediately deallocated because variable 'c4' is 'weak'
+
+weak var (c5, c6): (C?, C?) = (C(), C())
+// CHECK: [[@LINE-1]]:29: warning: instance will be immediately deallocated because variable 'c5' is 'weak'
+// CHECK: [[@LINE-2]]:29: warning: instance will be immediately deallocated because variable 'c6' is 'weak'
+
+unowned let c7 = C(), c8: C = C()
+// CHECK: [[@LINE-1]]:16: warning: instance will be immediately deallocated because variable 'c7' is 'unowned'
+// CHECK: [[@LINE-2]]:29: warning: instance will be immediately deallocated because variable 'c8' is 'unowned'
+
+c1 = C() // CHECK: [[@LINE]]:4: warning: instance will be immediately deallocated because variable 'c1' is 'weak'


### PR DESCRIPTION
This is a follow-up to #14875.

Pass through the location of the equal '=' token for pattern binding decl entries, and use this location for the immediate deallocation diagnostic. Previously, we were just diagnosing on the start of the initialiser expression.

Additionally, this PR moves the call to `diagnoseUnownedImmediateDeallocation` from `typeCheckBinding` to `typeCheckPatternBinding`. This not only gives us easier access to the PBD entry, but also avoids calling the diagnostic logic for statement conditions such as `if let x = <expr>`. We currently never diagnose on these anyway, as the 'weak' and 'unowned' keywords cannot be applied to such bindings.

Is there a way to test the specific source location of a diagnostic? The diagnostic verifier appears to only currently support checking source locations for fix-its. I did try a bunch of examples locally that all worked as expected.

Resolves [SR-7340](https://bugs.swift.org/browse/SR-7340).
