### PR TITLE
[Runtime] Remove dependency on Compiler.h from Config.h.

### DIFF
--- a/stdlib/private/StdlibUnittest/GetOSVersion.mm
+++ b/stdlib/private/StdlibUnittest/GetOSVersion.mm
@@ -15,7 +15,7 @@
 
 #include "swift/Runtime/Config.h"
 
-SWIFT_CC(swift) LLVM_LIBRARY_VISIBILITY extern "C"
+SWIFT_CC(swift) SWIFT_RUNTIME_LIBRARY_VISIBILITY extern "C"
 const char *
 getSystemVersionPlistProperty(const char *PropertyName) {
   // This function is implemented in Objective-C because Swift does not support

--- a/stdlib/private/StdlibUnittest/InterceptTraps.cpp
+++ b/stdlib/private/StdlibUnittest/InterceptTraps.cpp
@@ -33,7 +33,7 @@ static void CrashCatcher(int Sig) {
   _exit(0);
 }
 
-SWIFT_CC(swift) LLVM_LIBRARY_VISIBILITY extern "C"
+SWIFT_CC(swift) SWIFT_RUNTIME_LIBRARY_VISIBILITY extern "C"
 void installTrapInterceptor() {
   // Disable buffering on stdout so that everything is printed before crashing.
   setbuf(stdout, 0);

--- a/stdlib/private/StdlibUnittest/OpaqueIdentityFunctions.cpp
+++ b/stdlib/private/StdlibUnittest/OpaqueIdentityFunctions.cpp
@@ -12,6 +12,6 @@
 
 #include "swift/Runtime/Config.h"
 
-SWIFT_CC(swift) LLVM_LIBRARY_VISIBILITY extern "C"
+SWIFT_CC(swift) SWIFT_RUNTIME_LIBRARY_VISIBILITY extern "C"
 void *getPointer(void *x) { return x; }
 

--- a/stdlib/private/StdlibUnittestFoundationExtras/UnavailableFoundationMethodThunks.mm
+++ b/stdlib/private/StdlibUnittestFoundationExtras/UnavailableFoundationMethodThunks.mm
@@ -13,7 +13,7 @@
 #include <Foundation/Foundation.h>
 #include "swift/Runtime/Config.h"
 
-SWIFT_CC(swift) LLVM_LIBRARY_VISIBILITY
+SWIFT_CC(swift) SWIFT_RUNTIME_LIBRARY_VISIBILITY
 extern "C" void
 NSArray_getObjects(NSArray SWIFT_NS_RELEASES_ARGUMENT *_Nonnull nsArray,
                    id *objects, NSUInteger rangeLocation,
@@ -22,7 +22,7 @@ NSArray_getObjects(NSArray SWIFT_NS_RELEASES_ARGUMENT *_Nonnull nsArray,
   SWIFT_CC_PLUSONE_GUARD([nsArray release]);
 }
 
-SWIFT_CC(swift) LLVM_LIBRARY_VISIBILITY
+SWIFT_CC(swift) SWIFT_RUNTIME_LIBRARY_VISIBILITY
 extern "C" void
 NSDictionary_getObjects(NSDictionary *_Nonnull nsDictionary,
                         id *objects, id *keys) {


### PR DESCRIPTION
The runtime doesn't really need Compiler.h. It just needs some
visibility macros which can be inlined here instead of pulling
the whole heavyweight header (including its transitive closure,
llvm-config.h). This is becoming more important now that Compiler.h
includes C++ headers (namely, <new>), and swift/Runtime/Config.h
can be included from C or Objective-C files (causing build failures).

<rdar://problem/35860874>
