### PR TITLE
[Clang importer] Allow us to wire up overrides with generic classes.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -6393,11 +6393,10 @@ void SwiftDeclConverter::recordObjCOverride(AbstractFunctionDecl *decl) {
   if (!decl->getDeclContext()->isTypeContext())
     return;
 
-  auto classTy = decl->getDeclContext()->getDeclaredInterfaceType()
-      ->getAs<ClassType>();
-  if (!classTy)
+  auto classDecl = decl->getDeclContext()->getAsClassOrClassExtensionContext();
+  if (!classDecl)
     return;
-  auto superTy = classTy->getSuperclass();
+  auto superTy = classDecl->getSuperclass();
   if (!superTy)
     return;
   // Dig out the Objective-C superclass.

--- a/test/ClangImporter/Inputs/objc_init_generics.h
+++ b/test/ClangImporter/Inputs/objc_init_generics.h
@@ -1,0 +1,10 @@
+@import Foundation;
+
+@interface MyIntermediateClass : NSObject
+- (nonnull instancetype)initWithDouble:(double)value NS_DESIGNATED_INITIALIZER;
+@end
+
+@interface MyGenericClass<__covariant T> : MyIntermediateClass
+- (nonnull instancetype)initWithValue:(nonnull T)value;
+@end
+

--- a/test/ClangImporter/objc_init_generics.swift
+++ b/test/ClangImporter/objc_init_generics.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -import-objc-header %S/Inputs/objc_init_generics.h %s -verify
+
+// REQUIRES: objc_interop
+
+// expected-no-diagnostics
+
+import Foundation
+
+class MyConcreteClass: MyGenericClass<NSObject> {
+  // Make sure we don't complain about this "override", because MyGenericClass
+  // was getting an init() that was distinct from its superclass's init() due
+  // to a bug in the Clang importer.
+	init() {
+    super.init(value: NSObject())
+	}
+}
+


### PR DESCRIPTION
A use of "getAs<ClassType>()" when trying to wire up the overrides of
an imported Objective-C initializer meant that imported Objective-C
generic classes didn't get their overrides set properly. This could
lead to redundant initializers; use a proper accessor, since we only
need the ClassDecl anyway.

Fixes SR-8142 / rdar://problem/41591677.
