### PR TITLE
[4.2] [Clang importer] Allow us to wire up overrides with generic classes.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -6379,11 +6379,10 @@ ConstructorDecl *SwiftDeclConverter::importConstructor(
 
 void SwiftDeclConverter::recordObjCOverride(AbstractFunctionDecl *decl) {
   // Figure out the class in which this method occurs.
-  auto classTy = decl->getDeclContext()->getDeclaredInterfaceType()
-      ->getAs<ClassType>();
-  if (!classTy)
+  auto classDecl = decl->getDeclContext()->getAsClassOrClassExtensionContext();
+  if (!classDecl)
     return;
-  auto superTy = classTy->getSuperclass();
+  auto superTy = classDecl->getSuperclass();
   if (!superTy)
     return;
   // Dig out the Objective-C superclass.

--- a/test/ClangImporter/Inputs/objc_init_generics.h
+++ b/test/ClangImporter/Inputs/objc_init_generics.h
@@ -1,0 +1,10 @@
+@import Foundation;
+
+@interface MyIntermediateClass : NSObject
+- (nonnull instancetype)initWithDouble:(double)value NS_DESIGNATED_INITIALIZER;
+@end
+
+@interface MyGenericClass<__covariant T> : MyIntermediateClass
+- (nonnull instancetype)initWithValue:(nonnull T)value;
+@end
+

--- a/test/ClangImporter/objc_init_generics.swift
+++ b/test/ClangImporter/objc_init_generics.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -import-objc-header %S/Inputs/objc_init_generics.h %s -verify
+
+// REQUIRES: objc_interop
+
+// expected-no-diagnostics
+
+import Foundation
+
+class MyConcreteClass: MyGenericClass<NSObject> {
+  // Make sure we don't complain about this "override", because MyGenericClass
+  // was getting an init() that was distinct from its superclass's init() due
+  // to a bug in the Clang importer.
+	init() {
+    super.init(value: NSObject())
+	}
+}
+


### PR DESCRIPTION
**Explanation:** Imported generic Objective-C classes could end up importing initializers
that were not considered "overrides" of their superclass initializers, which could lead to ambiguities
due to initializers with the same signature being visible in multiple superclasses (e.g., `UIViewController.init()` and `MyGenericObjCClass.init()` would both exist but be ambiguous). Ensure that overrides are set up properly to address this Swift 4.2 regression.
**Scope:** Affects the initializers of imported generic Objective-C classes.
**Risk:** Low; this will add the "overrides" relationship among imported initializers for generic classes, but does not affect other relationships.
**Testing:** Compiler regression tests, include new tests.
**Reviewer:** @jrose-apple 
**SR / Radar:** [SR-8142](https://bugs.swift.org/browse/SR-8142) / rdar://problem/41591677
