### PR TITLE
[Runtime] Fix warning about implicitly converting nullptr to bool in CompatibilityOverride.cpp tests.

### DIFF
--- a/unittests/runtime/CompatibilityOverride.cpp
+++ b/unittests/runtime/CompatibilityOverride.cpp
@@ -31,7 +31,7 @@ bool Ran;
     if (!EnableOverride)                                            \
       return originalImpl namedArgs;                                \
     Ran = true;                                                     \
-    return nullptr;                                                 \
+    return (ret)0;                                                  \
   }
 #include "../../stdlib/public/runtime/CompatibilityOverride.def"
 


### PR DESCRIPTION
rdar://problem/40625829