### PR TITLE
[Runtime] Fix a warning about casting away constness in _swift_getClassOfAllocated.

### DIFF
--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -120,7 +120,8 @@ public:
 #if SWIFT_HAS_OPAQUE_ISAS
     // The ISA is opaque so masking it will not return a pointer.  We instead
     // need to call the objc runtime to get the class.
-    return reinterpret_cast<const ClassMetadata*>(object_getClass((id)object));
+    id idObject = reinterpret_cast<id>(const_cast<void *>(object));
+    return reinterpret_cast<const ClassMetadata*>(object_getClass(idObject));
 #else
     // Load the isa field.
     uintptr_t bits = *reinterpret_cast<const uintptr_t*>(object);


### PR DESCRIPTION
rdar://problem/40625756