### PR TITLE
[4.2][stdlib] Add KeyValuePairs typealias as prep for 5.0 rename

### DIFF
--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -720,6 +720,12 @@ public struct DictionaryLiteral<Key, Value> : ExpressibleByDictionaryLiteral {
   internal let _elements: [(Key, Value)]
 }
 
+// NOTE: This will become the new name in Swift 5.0. This typealias is being
+// introduced in 4.2 in order to allow code to be migrated to the new name
+// using the old compiler, enabling warning-free compilation with both  the
+// old and new compiler. This is a swift-4.2-branch only change.
+public typealias KeyValuePairs<Key,Value> = DictionaryLiteral<Key,Value>
+
 /// `Collection` conformance that allows `DictionaryLiteral` to
 /// interoperate with the rest of the standard library.
 extension DictionaryLiteral : RandomAccessCollection {

--- a/test/stdlib/DictionaryLiteral.swift
+++ b/test/stdlib/DictionaryLiteral.swift
@@ -51,3 +51,7 @@ expectType(DictionaryLiteral<String, NSString>.self, &stringNSStringLet)
 
 var hetero: DictionaryLiteral = ["a": 1 as NSNumber, "b": "Foo" as NSString]
 expectType(DictionaryLiteral<String, NSObject>.self, &hetero)
+
+let aliased: KeyValuePairs<String,String> = strings
+expectType(DictionaryLiteral<String, String>.self, &strings)
+


### PR DESCRIPTION
Note, this is a 4.2-only PR. The 5.0 version renames the type and type aliases the old type, here: #16577. 

Adding this typealias now will allow people to make the change on code that will still compile on the (future) old compiler, allowing us to deprecate the old name in 5.0 mode.
 