### PR TITLE
[4.2] migrator: support migration of raw representable initializer calls without explicit labels. 

### DIFF
--- a/test/Migrator/Inputs/Cities.swift
+++ b/test/Migrator/Inputs/Cities.swift
@@ -77,7 +77,8 @@ public enum FontWeight: Int {
 }
 
 public struct AwesomeCityAttribute: RawRepresentable {
-  public init?(rawValue: String) { self.rawValue = rawValue }
+  public init(rawValue: String) { self.rawValue = rawValue }
+  public init(_ rawValue: String) { self.rawValue = rawValue }
   public var rawValue: String
   public typealias RawValue = String
 }
@@ -86,6 +87,7 @@ public class Wrapper {
   public struct Attribute: RawRepresentable {
     public static let KnownAttr = Wrapper.Attribute(rawValue: "")
     public init(rawValue: String) { self.rawValue = rawValue }
+    public init(_ rawValue: String) { self.rawValue = rawValue }
     public var rawValue: String
     public typealias RawValue = String
   }

--- a/test/Migrator/string-representable.swift
+++ b/test/Migrator/string-representable.swift
@@ -49,11 +49,15 @@ class C: BarForwardDeclaredClass {}
 func revert(_ a: AwesomeCityAttribute, b: Wrapper.Attribute) {
   _ = AwesomeCityAttribute(rawValue: "somevalue")
   _ = AwesomeCityAttribute.init(rawValue: "somevalue")
+  _ = AwesomeCityAttribute("somevalue")
+  _ = AwesomeCityAttribute.init("somevalue")
   _ = a.rawValue
   _ = Wrapper.Attribute(rawValue: "somevalue")
   _ = Wrapper.Attribute.init(rawValue: "somevalue")
   _ = b.rawValue
   _ = Wrapper.Attribute.KnownAttr.rawValue
+  _ = Wrapper.Attribute("somevalue")
+  _ = Wrapper.Attribute.init("somevalue")
 }
 
 

--- a/test/Migrator/string-representable.swift.expected
+++ b/test/Migrator/string-representable.swift.expected
@@ -49,11 +49,15 @@ class C: BarForwardDeclaredClass {}
 func revert(_ a: AwesomeCityAttribute, b: Wrapper.Attribute) {
   _ = "somevalue"
   _ = "somevalue"
+  _ = "somevalue"
+  _ = "somevalue"
   _ = a
   _ = "somevalue"
   _ = "somevalue"
   _ = b
   _ = NewAttributeWrapper.NewKnownAttr
+  _ = "somevalue"
+  _ = "somevalue"
 }
 
 


### PR DESCRIPTION
Explanation: Some raw representable struct from SDK can be initialized without
explicit labels (rawValue:). When their types have been changed to type
alias, we should migrate the initializer calls to the argument alone.
Scope: Swift 4.2 migrator
Radar/SR Issue: rdar://41740103
Risk: Low
Testing: Unit tests added
Reviewer: Nathan Hawes