### PR TITLE
Add constraints to FixedWidthInteger.Stride and .Magnitude

### DIFF
--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -1665,7 +1665,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     }
     
     public subscript<R: RangeExpression>(_ rangeExpression: R) -> Data
-        where R.Bound: FixedWidthInteger, R.Bound.Stride : SignedInteger {
+        where R.Bound: FixedWidthInteger {
         get {
             let lower = R.Bound(_sliceRange.lowerBound)
             let upper = R.Bound(_sliceRange.upperBound)

--- a/stdlib/public/SDK/Foundation/NSRange.swift
+++ b/stdlib/public/SDK/Foundation/NSRange.swift
@@ -140,7 +140,7 @@ extension NSRange {
 
 extension NSRange {
   public init<R: RangeExpression>(_ region: R)
-  where R.Bound: FixedWidthInteger, R.Bound.Stride : SignedInteger {
+  where R.Bound: FixedWidthInteger {
     let r = region.relative(to: 0..<R.Bound.max)
     self.init(location: numericCast(r.lowerBound), length: numericCast(r.count))
   }

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -2398,9 +2398,7 @@ extension BinaryFloatingPoint {
 % for Range in ['Range', 'ClosedRange']:
 %   exampleRange = '10.0..<20.0' if Range == 'Range' else '10.0...20.0'
 extension BinaryFloatingPoint
-where Self.RawSignificand : FixedWidthInteger,
-      Self.RawSignificand.Stride : SignedInteger,
-      Self.RawSignificand.Magnitude : UnsignedInteger {
+where Self.RawSignificand : FixedWidthInteger {
 
   /// Returns a random value within the specified range, using the given
   /// generator as a source for randomness.

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2271,7 +2271,8 @@ extension BinaryInteger {
 /// other arithmetic methods and operators.
 public protocol FixedWidthInteger :
   BinaryInteger, LosslessStringConvertible
-  where Magnitude : FixedWidthInteger
+  where Magnitude : FixedWidthInteger & UnsignedInteger,
+           Stride : FixedWidthInteger & SignedInteger
 {
   /// The number of bits used for the underlying binary representation of
   /// values of this type.
@@ -2531,9 +2532,7 @@ ${assignmentOperatorComment(x.operator, False)}
 % for Range in ['Range', 'ClosedRange']:
 %   exampleRange = '1..<100' if Range == 'Range' else '1...100'
 
-extension FixedWidthInteger
-where Self.Stride : SignedInteger,
-      Self.Magnitude : UnsignedInteger {
+extension FixedWidthInteger {
 
   /// Returns a random value within the specified range, using the given
   /// generator as a source for randomness.

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2272,7 +2272,7 @@ extension BinaryInteger {
 public protocol FixedWidthInteger :
   BinaryInteger, LosslessStringConvertible
   where Magnitude : FixedWidthInteger & UnsignedInteger,
-           Stride : FixedWidthInteger & SignedInteger
+        Stride : FixedWidthInteger & SignedInteger
 {
   /// The number of bits used for the underlying binary representation of
   /// values of this type.


### PR DESCRIPTION
Add the constraint that these associatedtypes themselves conform to FixedWidthInteger and to SignedInteger and UnsignedInteger, respectively. These are effectively part of the semantic requirement of the protocol already, because the requirements on .min and .max effectively force FixedWidthInteger to be twos-complement, which requires Magnitude not be Self for signed types. Also, in practice it's generally necessary to have these two constraints in order to effectively use the FixedWidthInteger protocol anyway; witness that by adding them to the protocol, we eliminate them as constraints from a number of extensions.

Resolves [SR-8156](https://bugs.swift.org/browse/SR-8156).