### PR TITLE
[4.2] IRGen: Correctly set and honor the "is reflectable" bit on structs.

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -700,7 +700,10 @@ namespace {
     uint16_t getKindSpecificFlags() {
       TypeContextDescriptorFlags flags;
 
-      flags.setIsReflectable(true); // struct always reflectable
+      // Structs are reflectable unless we emit them with opaque reflection
+      // metadata.
+      flags.setIsReflectable(
+                            !IGM.shouldEmitOpaqueTypeMetadataRecord(getType()));
 
       getClangImportedFlags(flags);
       return flags.getOpaqueValue();

--- a/stdlib/public/runtime/ReflectionMirror.mm
+++ b/stdlib/public/runtime/ReflectionMirror.mm
@@ -257,11 +257,21 @@ struct TupleImpl : ReflectionMirrorImpl {
 
 // Implementation for structs.
 struct StructImpl : ReflectionMirrorImpl {
+  bool isReflectable() {
+    const auto *Struct = static_cast<const StructMetadata *>(type);
+    const auto &Description = Struct->getDescription();
+    return Description->getTypeContextDescriptorFlags().isReflectable();
+  }
+
   char displayStyle() {
     return 's';
   }
   
   intptr_t count() {
+    if (!isReflectable()) {
+      return 0;
+    }
+
     auto *Struct = static_cast<const StructMetadata *>(type);
     return Struct->getDescription()->NumFields;
   }
@@ -399,11 +409,20 @@ struct EnumImpl : ReflectionMirrorImpl {
 
 // Implementation for classes.
 struct ClassImpl : ReflectionMirrorImpl {
+  bool isReflectable() {
+    const auto *Class = static_cast<const ClassMetadata *>(type);
+    const auto &Description = Class->getDescription();
+    return Description->getTypeContextDescriptorFlags().isReflectable();
+  }
+
   char displayStyle() {
     return 'c';
   }
   
   intptr_t count() {
+    if (!isReflectable())
+      return 0;
+
     auto *Clas = static_cast<const ClassMetadata*>(type);
     auto count = Clas->getDescription()->NumFields;
 

--- a/test/stdlib/Reflection_objc.swift
+++ b/test/stdlib/Reflection_objc.swift
@@ -14,6 +14,7 @@
 
 import Swift
 import Foundation
+import simd
 
 #if os(macOS)
 import AppKit
@@ -283,6 +284,11 @@ testQLO(HasAttributedQLO.self)
 testQLO(HasStringQLO.self)
 // CHECK-NEXT: HasStringQLO overboard
 // CHECK-NEXT: CanaryBase overboard
+
+// simd types get no reflection info, so should have no mirror children
+let x = float4(0)
+print("float4 has \(Mirror(reflecting: x).children.count) children")
+// CHECK-NEXT: float4 has 0 children
 
 // CHECK-LABEL: and now our song is done
 print("and now our song is done")


### PR DESCRIPTION
Explanation: Attempting to reflect a SIMD type or a struct containing a SIMD type would cause the runtime to log a bug because it was trying to find nonexistent reflection metadata for the type.

Scope: Regression from Swift 4.1

Issue: rdar://problem/41274260

Risk: Low, small fix to IRGen and the runtime

Testing: Swift CI

Reviewed by: @mikeash 