### PR TITLE
Remove watchOS IO workaround

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -1268,9 +1268,6 @@ struct _ParentProcess {
       let crashOutput = crashStdout + crashStderr
       for expectedSubstring in t.crashOutputMatches {
         var found = false
-        if crashOutput.isEmpty && expectedSubstring.isEmpty {
-          found = true
-        }
         for s in crashOutput {
           if findSubstring(s, expectedSubstring) != nil {
             found = true


### PR DESCRIPTION
I believe this workaround can be removed now. 

rdar://problem/27344553