### PR TITLE
Suppress a number of warnings in no-assert builds

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -654,8 +654,7 @@ void ASTMangler::appendDeclName(const ValueDecl *decl) {
     assert(((relatedEntityKind[0] >= 'a' && relatedEntityKind[0] <= 'j') ||
             (relatedEntityKind[0] >= 'A' && relatedEntityKind[0] <= 'J')) &&
            "Only [a-jA-J] are reserved for related entity kinds");
-    (void)relatedEntityKind;
-    return appendOperatorParam("L", synthesizedTypeAttr->getManglingName());
+    return appendOperatorParam("L", relatedEntityKind);
   }
 
   StringRef privateDiscriminator = getPrivateDiscriminatorIfNecessary(decl);

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -654,6 +654,7 @@ void ASTMangler::appendDeclName(const ValueDecl *decl) {
     assert(((relatedEntityKind[0] >= 'a' && relatedEntityKind[0] <= 'j') ||
             (relatedEntityKind[0] >= 'A' && relatedEntityKind[0] <= 'J')) &&
            "Only [a-jA-J] are reserved for related entity kinds");
+    (void)relatedEntityKind;
     return appendOperatorParam("L", synthesizedTypeAttr->getManglingName());
   }
 

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -934,6 +934,7 @@ public:
     void verifyChecked(DeferStmt *S) {
       auto FT = S->getTempDecl()->getInterfaceType()->castTo<AnyFunctionType>();
       assert(FT->isNoEscape() && "Defer statements must not escape");
+      (void)FT;
       verifyCheckedBase(S);
     }
 

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1544,6 +1544,7 @@ TupleExpr *TupleExpr::create(ASTContext &ctx,
   assert((Implicit || ElementNames.size() == ElementNameLocs.size() ||
           (!hasNonEmptyIdentifier(ElementNames) && ElementNameLocs.empty())) &&
          "trying to create non-implicit tuple-expr without name locations");
+  (void)hasNonEmptyIdentifier;
 
   size_t size =
       totalSizeToAlloc<Expr *, Identifier, SourceLoc>(SubExprs.size(),

--- a/lib/Basic/Unix/TaskQueue.inc
+++ b/lib/Basic/Unix/TaskQueue.inc
@@ -556,6 +556,7 @@ void TaskMonitor::verifyEvents(const short events) const {
   assert((events & POLLNVAL) == 0 && "Asked poll() to watch a closed fd");
   const short expectedEvents = POLLIN | POLLPRI | POLLHUP | POLLERR;
   assert((events & ~expectedEvents) == 0 && "Received unexpected event");
+  (void)expectedEvents;
 }
 
 void TaskMonitor::readDataIfAvailable(const short events, const int fd,

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7900,6 +7900,7 @@ recursivelySubstituteBaseType(const NormalProtocolConformance *conformance,
 
   const ProtocolDecl *proto = conformance->getProtocol();
   assert(origBase->isEqual(proto->getSelfInterfaceType()));
+  (void)proto;
   return conformance->getTypeWitness(depMemTy->getAssocType(),
                                      /*resolver=*/nullptr);
 }

--- a/lib/Driver/ToolChain.cpp
+++ b/lib/Driver/ToolChain.cpp
@@ -297,6 +297,7 @@ sortJobsToMatchCompilationInputs(ArrayRef<const Job *> unsortedJobs,
     auto R =
         jobsByInput.insert(std::make_pair(IA->getInputArg().getValue(), J));
     assert(R.second);
+    (void)R;
   }
   for (const InputPair &P : C.getInputFiles()) {
     auto I = jobsByInput.find(P.second->getValue());

--- a/lib/Frontend/FrontendInputsAndOutputs.cpp
+++ b/lib/Frontend/FrontendInputsAndOutputs.cpp
@@ -293,6 +293,7 @@ void FrontendInputsAndOutputs::setMainAndSupplementaryOutputs(
     assert(outputFiles.size() == N && "Must have one main output per primary");
     assert(supplementaryOutputs.size() == N &&
            "Must have one set of supplementary outputs per primary");
+    (void)N;
 
     unsigned i = 0;
     for (auto &input : AllInputs) {

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -874,6 +874,7 @@ namespace {
 
       auto *dc = fn.getDecl()->getDeclContext();
       assert(!isa<ExtensionDecl>(dc));
+      (void)dc;
 
       if (fn.getDecl()->getDeclContext() == getType()) {
         if (auto entry = VTable->getEntry(IGM.getSILModule(), fn)) {

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -874,9 +874,8 @@ namespace {
 
       auto *dc = fn.getDecl()->getDeclContext();
       assert(!isa<ExtensionDecl>(dc));
-      (void)dc;
 
-      if (fn.getDecl()->getDeclContext() == getType()) {
+      if (dc == getType()) {
         if (auto entry = VTable->getEntry(IGM.getSILModule(), fn)) {
           assert(entry->TheKind == SILVTable::Entry::Kind::Normal);
           auto *implFn = IGM.getAddrOfSILFunction(entry->Implementation,

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2614,6 +2614,7 @@ MetadataResponse MetadataPath::followComponent(IRGenFunction &IGF,
           return /*finished?*/ false;
         });
     assert(found && "too many conditional conformances");
+    (void)found;
 
     sourceKey.Kind =
         LocalTypeDataKind::forAbstractProtocolWitnessTable(conformingProto);

--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -1400,4 +1400,5 @@ void TypeInfo::collectMetadataForOutlining(OutliningMetadataCollector &c,
                                            SILType T) const {
   auto canType = T.getASTType();
   assert(!canType->is<ArchetypeType>() && "Did not expect an ArchetypeType");
+  (void)canType;
 }

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3956,6 +3956,7 @@ void IRGenSILFunction::visitIsEscapingClosureInst(
 
   auto fnType = operandType.getAs<SILFunctionType>();
   assert(fnType->getExtInfo().hasContext() && "Must have a closure operand");
+  (void)fnType;
 
   // This code relies on that an optional<()->()>'s tag fits in the function
   // pointer.
@@ -3963,6 +3964,7 @@ void IRGenSILFunction::visitIsEscapingClosureInst(
   assert(TI.mayHaveExtraInhabitants(IGM) &&
          "Must have extra inhabitants to be able to handle the optional "
          "closure case");
+  (void)TI;
 
   Explosion closure = getLoweredExplosion(i->getOperand());
   auto func = closure.claimNext();

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -949,6 +949,7 @@ void LargeValueVisitor::visitDeallocInst(DeallocStackInst *instr) {
     assert(pass.allocToApplyRetMap.find(opAsInstr) !=
                pass.allocToApplyRetMap.end() &&
            "Unexpected dealloc instr!");
+    (void)opAsInstr;
   }
 }
 
@@ -1377,6 +1378,7 @@ void LoadableStorageAllocation::convertApplyResults() {
                  "Expected SILFunctionType or Optional for the result type");
           assert(optionalType.is<SILFunctionType>() &&
                  "Expected a SILFunctionType inside the optional Type");
+          (void)optionalType;
         }
         continue;
       }
@@ -2018,6 +2020,8 @@ static void rewriteFunction(StructLoweringState &pass,
     assert(srcType && "Expected an address-type source");
     assert(tgtType.isAddress() && "Expected an address-type target");
     assert(srcType == tgtType && "Source and target type do not match");
+    (void)srcType;
+    (void)tgtType;
 
     SILBuilderWithScope copyBuilder(instr);
     createOutlinedCopyCall(copyBuilder, src, tgt, pass);
@@ -2406,6 +2410,7 @@ void LoadableByAddress::recreateSingleApply(SILInstruction *applyInst) {
     assert(oldYields.size() == newYields.size() &&
            oldYields.size() == oldYieldedValues.size() &&
            newYields.size() == newYieldedValues.size());
+    (void)newYields;
     for (auto i : indices(oldYields)) {
       SILValue oldValue = oldYieldedValues[i];
       SILValue newValue = newYieldedValues[i];

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -847,6 +847,7 @@ void SILParser::convertRequirements(SILFunction *F,
 
   auto *GenericEnv = F->getGenericEnvironment();
   assert(GenericEnv);
+  (void)GenericEnv;
 
   IdentTypeReprLookup PerformLookup(P);
   // Use parser lexical scopes to resolve references

--- a/lib/SIL/InstructionUtils.cpp
+++ b/lib/SIL/InstructionUtils.cpp
@@ -355,6 +355,7 @@ SILValue swift::isPartialApplyOfReabstractionThunk(PartialApplyInst *PAI) {
 static SILValue findClosureStoredIntoBlock(SILValue V) {
   auto FnType = V->getType().castTo<SILFunctionType>();
   assert(FnType->getRepresentation() == SILFunctionTypeRepresentation::Block);
+  (void)FnType;
 
   // Given a no escape block argument to a function,
   // pattern match to find the noescape closure that invoking the block

--- a/lib/SIL/SILCoverageMap.cpp
+++ b/lib/SIL/SILCoverageMap.cpp
@@ -45,6 +45,7 @@ SILCoverageMap::create(SILModule &M, StringRef Filename, StringRef Name,
 
   // Assert that this coverage map is unique.
   assert(result.second && "Duplicate coverage mapping for function");
+  (void)result;
 
   return CM;
 }

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -2122,6 +2122,7 @@ const SILConstantInfo &TypeConverter::getConstantInfo(SILDeclRef constant) {
 
   auto inserted = ConstantTypes.insert({constant, result});
   assert(inserted.second);
+  (void)inserted;
   return *result;
 }
 
@@ -2289,6 +2290,7 @@ TypeConverter::getConstantOverrideInfo(SILDeclRef derived, SILDeclRef base) {
   
   auto inserted = ConstantOverrideTypes.insert({{derived, base}, result});
   assert(inserted.second);
+  (void)inserted;
   return *result;
 }
 

--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -129,6 +129,7 @@ static bool isGuaranteedForwardingInst(SILInstruction *I) {
   return isGuaranteedForwardingValueKind(SILNodeKind(I->getKind()));
 }
 
+LLVM_ATTRIBUTE_UNUSED
 static bool isOwnershipForwardingInst(SILInstruction *I) {
   return isOwnershipForwardingValueKind(SILNodeKind(I->getKind()));
 }
@@ -154,7 +155,9 @@ class OwnershipCompatibilityUseChecker
                                    OwnershipUseCheckerResult> {
 public:
 private:
+  LLVM_ATTRIBUTE_UNUSED
   SILModule &Mod;
+
   const Operand &Op;
   SILValue BaseValue;
   ErrorBehaviorKind ErrorBehavior;

--- a/lib/SIL/SILProfiler.cpp
+++ b/lib/SIL/SILProfiler.cpp
@@ -86,6 +86,7 @@ bool doesASTRequireProfiling(SILModule &M, ASTNode N) {
 } // namespace swift
 
 /// Check that the input AST has at least been type-checked.
+LLVM_ATTRIBUTE_UNUSED
 static bool hasASTBeenTypeChecked(ASTNode N) {
   DeclContext *DC = N.getAsDeclContext();
   assert(DC && "Invalid AST node for profiling");

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -4984,6 +4984,8 @@ void SILWitnessTable::verify(const SILModule &M) const {
                "Witnesses must either have a concrete Self, or an "
                "an abstract Self that is constrained to their "
                "protocol.");
+        (void)protocol;
+        (void)witnessSelfProtocol;
       }
     }
 }

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3857,6 +3857,7 @@ CallEmission::applyEnumElementConstructor(SGFContext C) {
   }
 
   assert(substFnType->getNumResults() == 1);
+  (void)substFnType;
   ManagedValue resultMV = SGF.emitInjectEnum(
       uncurriedLoc, std::move(payload), SGF.getLoweredType(formalResultType),
       element, uncurriedContext);
@@ -5198,6 +5199,7 @@ void SILGenFunction::emitSetAccessor(SILLocation loc, SILDeclRef set,
       auto subscriptsTupleType = cast<TupleType>(subscripts.getType());
       assert(accessType.getParams().size()
               == 1 + subscriptsTupleType->getNumElements());
+      (void)subscriptsTupleType;
       SmallVector<RValue, 8> eltRVs;
       std::move(subscripts).extractElements(eltRVs);
       for (auto &elt : eltRVs)

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -219,6 +219,8 @@ ManagedValue SILGenBuilder::createConvertEscapeToNoEscape(
              SILFunctionTypeRepresentation::Thick &&
          !fnType->isNoEscape() && resultFnType->isNoEscape() &&
          "Expect a escaping to noescape conversion");
+  (void)fnType;
+  (void)resultFnType;
   SILValue fnValue = fn.getValue();
   SILValue result = createConvertEscapeToNoEscape(
       loc, fnValue, resultTy, isEscapedByUser, false);

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -901,6 +901,7 @@ static ManagedValue emitBuiltinValueToBridgeObject(SILGenFunction &SGF,
          "ValueToBridgeObject should have one sub");
   auto &fromTL = SGF.getTypeLowering(subs.getReplacementTypes()[0]);
   assert(fromTL.isTrivial() && "Expected a trivial type");
+  (void)fromTL;
 
   SILValue result = SGF.B.createValueToBridgeObject(loc, args[0].getValue());
   return SGF.emitManagedRetain(loc, result);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -4765,6 +4765,7 @@ namespace {
     void visitTupleExpr(TupleExpr *E) {
       auto *TTy = E->getType()->castTo<TupleType>();
       assert(TTy->hasLValueType() || TTy->isVoid());
+      (void)TTy;
       for (auto &elt : E->getElements()) {
         visit(elt);
       }

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -498,6 +498,7 @@ void SILGenFunction::emitArtificialTopLevel(ClassDecl *mainClass) {
     // Fix up the string parameters to have the right type.
     SILType nameArgTy = fnConv.getSILArgumentType(3);
     assert(nameArgTy == fnConv.getSILArgumentType(2));
+    (void)nameArgTy;
     auto managedName = ManagedValue::forUnmanaged(optName);
     SILValue nilValue;
     assert(optName->getType() == nameArgTy);

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -105,6 +105,7 @@ public:
             == parent->getParent()->mapTypeIntoContext(
                    SGF.getSILType(parameterInfo))
         && "argument does not have same type as specified by parameter info");
+    (void)parameterInfo;
 
     ManagedValue mv = SGF.B.createInputFunctionArgument(
         argType, loc.getAsASTNode<ValueDecl>());

--- a/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
+++ b/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
@@ -81,6 +81,7 @@ struct AddressCapture {
   bool isValid() const { return bool(site); }
 };
 
+LLVM_ATTRIBUTE_UNUSED
 raw_ostream &operator<<(raw_ostream &os, const AddressCapture &capture) {
   os << *capture.site.getInstruction() << " captures Arg #"
      << capture.calleeArgIdx;

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -516,6 +516,7 @@ void SILPassManager::execute() {
     SILTransform *Tr = Transformations[Idx];
     assert((isa<SILFunctionTransform>(Tr) || isa<SILModuleTransform>(Tr)) &&
            "Unexpected pass kind!");
+    (void)Tr;
 
     unsigned FirstFuncTrans = Idx;
     while (Idx < NumTransforms && isa<SILFunctionTransform>(Transformations[Idx]))

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -393,6 +393,7 @@ SILInstruction *PartialApplyCombiner::combine() {
             ConvertCalleeTy->getExtInfo().withNoEscape(false));
       assert(Use->get()->getType().castTo<SILFunctionType>() ==
              EscapingCalleeTy);
+      (void)EscapingCalleeTy;
       Uses.append(CFI->getUses().begin(), CFI->getUses().end());
       continue;
     }

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -808,6 +808,7 @@ static void createPropertyStoreOrCallSuperclassSetter(AccessorDecl *accessor,
                                              IsImplicit));
 }
 
+LLVM_ATTRIBUTE_UNUSED
 static bool isSynthesizedComputedProperty(AbstractStorageDecl *storage) {
   return (storage->getAttrs().hasAttribute<LazyAttr>() ||
           storage->getAttrs().hasAttribute<NSManagedAttr>());

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1497,6 +1497,7 @@ recur:
       } else {
         auto parenTy = dyn_cast<ParenType>(elementType.getPointer());
         assert(parenTy && "Associated value type is neither paren nor tuple?");
+        (void)parenTy;
         
         auto *subPattern = new (Context) AnyPattern(SourceLoc());
         elements.push_back(TuplePatternElt(Identifier(), SourceLoc(),

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1428,6 +1428,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
     assert(expectedType == getSILType(Ty, (SILValueCategory)TyCategory) &&
            "Type of a global variable does not match GlobalAddr.");
     (void)Ty;
+    (void)expectedType;
     if (OpCode == SILInstructionKind::GlobalAddrInst) {
       ResultVal = Builder.createGlobalAddr(Loc, g);
     } else {

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2433,6 +2433,7 @@ void SILSerializer::writeSILBlock(const SILModule *SILMod) {
   // FIXME: Resilience: could write out vtable for fragile classes.
   const DeclContext *assocDC = SILMod->getAssociatedContext();
   assert(assocDC && "cannot serialize SIL without an associated DeclContext");
+  (void)assocDC;
   for (const SILVTable &vt : SILMod->getVTables()) {
     if ((ShouldSerializeAll || vt.isSerialized()) &&
         SILMod->shouldSerializeEntitiesAssociatedWithDeclContext(vt.getClass()))

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3390,6 +3390,7 @@ WitnessTableCacheEntry::allocate(GenericWitnessTable *genericTable,
   size_t numRequirements =
     protocol->NumRequirements + WitnessTableFirstRequirementOffset;
   assert(numPatternWitnesses <= numRequirements);
+  (void)numRequirements;
 
   // Number of bytes for any private storage used by the conformance itself.
   size_t privateSizeInWords = genericTable->WitnessTablePrivateSizeInWords;


### PR DESCRIPTION
Lots of variables used only in asserts were warning in non-assert builds.