### PR TITLE
[Type checker] Minimize checking needed to compute the set of overridden declarations

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -2411,6 +2411,10 @@ static void configureDesignatedInitAttributes(TypeChecker &tc,
         ctor, {classDecl, superclassCtor}, ctx);
   }
 
+  // Wire up the overrides.
+  ctor->getAttrs().add(new (ctx) OverrideAttr(/*IsImplicit=*/true));
+  ctor->setOverriddenDecl(superclassCtor);
+
   if (superclassCtor->isObjC()) {
     // Inherit the @objc name from the superclass initializer, if it
     // has one.
@@ -2429,10 +2433,6 @@ static void configureDesignatedInitAttributes(TypeChecker &tc,
     ctor->getAttrs().add(new (ctx) RequiredAttr(/*IsImplicit=*/true));
   if (superclassCtor->isDynamic())
     ctor->getAttrs().add(new (ctx) DynamicAttr(/*IsImplicit*/true));
-
-  // Wire up the overrides.
-  ctor->getAttrs().add(new (ctx) OverrideAttr(/*IsImplicit=*/true));
-  ctor->setOverriddenDecl(superclassCtor);
 }
 
 ConstructorDecl *

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2965,6 +2965,19 @@ public:
       }
     }
 
+    if (!checkOverrides(TC, VD)) {
+      // If a property has an override attribute but does not override
+      // anything, complain.
+      auto overridden = VD->getOverriddenDecl();
+      if (auto *OA = VD->getAttrs().getAttribute<OverrideAttr>()) {
+        if (!overridden) {
+          TC.diagnose(VD, diag::property_does_not_override)
+            .highlight(OA->getLocation());
+          OA->setInvalid();
+        }
+      }
+    }
+
     TC.checkDeclAttributes(VD);
 
     triggerAccessorSynthesis(TC, VD);
@@ -3109,6 +3122,18 @@ public:
 
     AccessControlChecker::checkAccessControl(TC, SD);
     UsableFromInlineChecker::checkUsableFromInline(TC, SD);
+
+    if (!checkOverrides(TC, SD)) {
+      // If a subscript has an override attribute but does not override
+      // anything, complain.
+      if (auto *OA = SD->getAttrs().getAttribute<OverrideAttr>()) {
+        if (!SD->getOverriddenDecl()) {
+          TC.diagnose(SD, diag::subscript_does_not_override)
+            .highlight(OA->getLocation());
+          OA->setInvalid();
+        }
+      }
+    }
 
     triggerAccessorSynthesis(TC, SD);
   }
@@ -3605,6 +3630,18 @@ public:
     AccessControlChecker::checkAccessControl(TC, FD);
     UsableFromInlineChecker::checkUsableFromInline(TC, FD);
 
+    if (!checkOverrides(TC, FD)) {
+      // If a method has an 'override' keyword but does not
+      // override anything, complain.
+      if (auto *OA = FD->getAttrs().getAttribute<OverrideAttr>()) {
+        if (!FD->getOverriddenDecl()) {
+          TC.diagnose(FD, diag::method_does_not_override)
+            .highlight(OA->getLocation());
+          OA->setInvalid();
+        }
+      }
+    }
+
     if (FD->hasBody()) {
       // Record the body.
       TC.definedFunctions.push_back(FD);
@@ -3733,6 +3770,61 @@ public:
 
   void visitConstructorDecl(ConstructorDecl *CD) {
     TC.validateDecl(CD);
+
+    // Check whether this initializer overrides an initializer in its
+    // superclass.
+    if (!checkOverrides(TC, CD)) {
+      // If an initializer has an override attribute but does not override
+      // anything or overrides something that doesn't need an 'override'
+      // keyword (e.g., a convenience initializer), complain.
+      // anything, or overrides something that complain.
+      if (auto *attr = CD->getAttrs().getAttribute<OverrideAttr>()) {
+        if (!CD->getOverriddenDecl()) {
+          TC.diagnose(CD, diag::initializer_does_not_override)
+            .highlight(attr->getLocation());
+          attr->setInvalid();
+        } else if (attr->isImplicit()) {
+          // Don't diagnose implicit attributes.
+        } else if (!overrideRequiresKeyword(CD->getOverriddenDecl())) {
+          // Special case: we are overriding a 'required' initializer, so we
+          // need (only) the 'required' keyword.
+          if (cast<ConstructorDecl>(CD->getOverriddenDecl())->isRequired()) {
+            if (CD->getAttrs().hasAttribute<RequiredAttr>()) {
+              TC.diagnose(CD, diag::required_initializer_override_keyword)
+                .fixItRemove(attr->getLocation());
+            } else {
+              TC.diagnose(CD, diag::required_initializer_override_wrong_keyword)
+                .fixItReplace(attr->getLocation(), "required");
+              CD->getAttrs().add(
+                new (TC.Context) RequiredAttr(/*IsImplicit=*/true));
+            }
+
+            TC.diagnose(findNonImplicitRequiredInit(CD->getOverriddenDecl()),
+                        diag::overridden_required_initializer_here);
+          } else {
+            // We tried to override a convenience initializer.
+            TC.diagnose(CD, diag::initializer_does_not_override)
+              .highlight(attr->getLocation());
+            TC.diagnose(CD->getOverriddenDecl(),
+                        diag::convenience_init_override_here);
+          }
+        }
+      }
+
+      // A failable initializer cannot override a non-failable one.
+      // This would normally be diagnosed by the covariance rules;
+      // however, those are disabled so that we can provide a more
+      // specific diagnostic here.
+      if (CD->getFailability() != OTK_None &&
+          CD->getOverriddenDecl() &&
+          CD->getOverriddenDecl()->getFailability() == OTK_None) {
+        TC.diagnose(CD, diag::failable_initializer_override,
+                    CD->getFullName());
+        TC.diagnose(CD->getOverriddenDecl(),
+                    diag::nonfailable_initializer_override_here,
+                    CD->getOverriddenDecl()->getFullName());
+      }
+    }
 
     // If this initializer overrides a 'required' initializer, it must itself
     // be marked 'required'.
@@ -4506,19 +4598,6 @@ void TypeChecker::validateDecl(ValueDecl *D) {
     checkDeclAttributesEarly(VD);
     validateAttributes(*this, VD);
 
-    if (!checkOverrides(*this, VD)) {
-      // If a property has an override attribute but does not override
-      // anything, complain.
-      auto overridden = VD->getOverriddenDecl();
-      if (auto *OA = VD->getAttrs().getAttribute<OverrideAttr>()) {
-        if (!overridden) {
-          diagnose(VD, diag::property_does_not_override)
-            .highlight(OA->getLocation());
-          OA->setInvalid();
-        }
-      }
-    }
-
     // Properties need some special validation logic.
     if (auto *nominalDecl = VD->getDeclContext()
             ->getAsNominalTypeOrNominalTypeExtensionContext()) {
@@ -4797,18 +4876,6 @@ void TypeChecker::validateDecl(ValueDecl *D) {
 
     // Member functions need some special validation logic.
     if (FD->getDeclContext()->isTypeContext()) {
-      if (!checkOverrides(*this, FD)) {
-        // If a method has an 'override' keyword but does not
-        // override anything, complain.
-        if (auto *OA = FD->getAttrs().getAttribute<OverrideAttr>()) {
-          if (!FD->getOverriddenDecl()) {
-            diagnose(FD, diag::method_does_not_override)
-              .highlight(OA->getLocation());
-            OA->setInvalid();
-          }
-        }
-      }
-
       if (FD->isOperator())
         checkMemberOperator(*this, FD);
 
@@ -4995,59 +5062,6 @@ void TypeChecker::validateDecl(ValueDecl *D) {
 
     validateAttributes(*this, CD);
 
-    // Check whether this initializer overrides an initializer in its
-    // superclass.
-    if (!checkOverrides(*this, CD)) {
-      // If an initializer has an override attribute but does not override
-      // anything or overrides something that doesn't need an 'override'
-      // keyword (e.g., a convenience initializer), complain.
-      // anything, or overrides something that complain.
-      if (auto *attr = CD->getAttrs().getAttribute<OverrideAttr>()) {
-        if (!CD->getOverriddenDecl()) {
-          diagnose(CD, diag::initializer_does_not_override)
-            .highlight(attr->getLocation());
-          attr->setInvalid();
-        } else if (!overrideRequiresKeyword(CD->getOverriddenDecl())) {
-          // Special case: we are overriding a 'required' initializer, so we
-          // need (only) the 'required' keyword.
-          if (cast<ConstructorDecl>(CD->getOverriddenDecl())->isRequired()) {
-            if (CD->getAttrs().hasAttribute<RequiredAttr>()) {
-              diagnose(CD, diag::required_initializer_override_keyword)
-                .fixItRemove(attr->getLocation());
-            } else {
-              diagnose(CD, diag::required_initializer_override_wrong_keyword)
-                .fixItReplace(attr->getLocation(), "required");
-              CD->getAttrs().add(
-                new (Context) RequiredAttr(/*IsImplicit=*/true));
-            }
-
-            diagnose(findNonImplicitRequiredInit(CD->getOverriddenDecl()),
-                     diag::overridden_required_initializer_here);
-          } else {
-            // We tried to override a convenience initializer.
-            diagnose(CD, diag::initializer_does_not_override)
-              .highlight(attr->getLocation());
-            diagnose(CD->getOverriddenDecl(),
-                     diag::convenience_init_override_here);
-          }
-        }
-      }
-
-      // A failable initializer cannot override a non-failable one.
-      // This would normally be diagnosed by the covariance rules;
-      // however, those are disabled so that we can provide a more
-      // specific diagnostic here.
-      if (CD->getFailability() != OTK_None &&
-          CD->getOverriddenDecl() &&
-          CD->getOverriddenDecl()->getFailability() == OTK_None) {
-        diagnose(CD, diag::failable_initializer_override,
-                 CD->getFullName());
-        diagnose(CD->getOverriddenDecl(),
-                 diag::nonfailable_initializer_override_here,
-                 CD->getOverriddenDecl()->getFullName());
-      }
-    }
-
     // An initializer is ObjC-compatible if it's explicitly @objc or a member
     // of an ObjC-compatible class.
     if (CD->getDeclContext()->isTypeContext()) {
@@ -5187,18 +5201,6 @@ void TypeChecker::validateDecl(ValueDecl *D) {
       auto &C = SD->getASTContext();
       SD->getAttrs().add(
           new (C) ImplicitlyUnwrappedOptionalAttr(/* implicit= */ true));
-    }
-
-    if (!checkOverrides(*this, SD)) {
-      // If a subscript has an override attribute but does not override
-      // anything, complain.
-      if (auto *OA = SD->getAttrs().getAttribute<OverrideAttr>()) {
-        if (!SD->getOverriddenDecl()) {
-          diagnose(SD, diag::subscript_does_not_override)
-              .highlight(OA->getLocation());
-          OA->setInvalid();
-        }
-      }
     }
 
     // Member subscripts need some special validation logic.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1454,12 +1454,17 @@ static void inferDynamic(ASTContext &ctx, ValueDecl *D) {
     (D->getOverriddenDecl() &&
      D->getOverriddenDecl()->hasClangNode());
 
+  bool overridesDyanmic =
+    (D->getOverriddenDecl() &&
+     D->getOverriddenDecl()->isDynamic());
+
   bool isNSManaged = D->getAttrs().hasAttribute<NSManagedAttr>();
 
   bool isExtension = isa<ExtensionDecl>(D->getDeclContext());
 
   // We only infer 'dynamic' in these three cases.
-  if (!isExtension && !isNSManaged && !overridesImportedMethod)
+  if (!isExtension && !isNSManaged && !overridesImportedMethod &&
+      !overridesDyanmic)
     return;
 
   // The presence of 'final' blocks the inference of 'dynamic'.

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -86,6 +86,12 @@ Type swift::getMemberTypeForComparison(ASTContext &ctx, ValueDecl *member,
     auto owningType = dc->getDeclaredInterfaceType();
     assert(owningType);
 
+    if (!derivedDecl->hasInterfaceType()) {
+      auto lazyResolver = ctx.getLazyResolver();
+      assert(lazyResolver && "Need to resolve interface type");
+      lazyResolver->resolveDeclSignature(derivedDecl);
+    }
+
     memberType = owningType->adjustSuperclassMemberDeclType(member, derivedDecl,
                                                             memberType);
     if (memberType->hasError())

--- a/test/ClangImporter/objc_override.swift
+++ b/test/ClangImporter/objc_override.swift
@@ -19,7 +19,8 @@ class SomeCellSub1 : SomeCell {
   @objc func initWithString(_ string: String) { }
 
   var isEnabled: Bool { // expected-error{{overriding declaration requires an 'override' keyword}}
-    get { return super.isEnabled }
+    // FIXE: The error that follows is a bit strange.
+    get { return super.isEnabled } // expected-error{{'@objc' getter for non-'@objc' property}}
   }
 
   @objc(enabled)

--- a/test/SourceKit/CursorInfo/cursor_overrides.swift
+++ b/test/SourceKit/CursorInfo/cursor_overrides.swift
@@ -5,11 +5,11 @@ protocol Prot {
 }
 
 class Cls : S1, Prot {
-  func meth() {}
+  override func meth() {}
 }
 
 class SubCls : Cls {
-  func meth() {}
+  override func meth() {}
 }
 
 func goo(x: SubCls) {
@@ -27,7 +27,7 @@ public protocol WithInheritedAssocType : WithAssocType {
 
 // REQUIRES: objc_interop
 // RUN: %sourcekitd-test -req=cursor -pos=16:7 %s -- -embed-bitcode -I %S/Inputs/cursor-overrides %mcp_opt %s | %FileCheck -check-prefix=CHECK1 %s
-// CHECK1: source.lang.swift.ref.function.method.instance (12:8-12:14)
+// CHECK1: source.lang.swift.ref.function.method.instance (12:17-12:23)
 // CHECK1: c:@M@cursor_overrides@objc(cs)SubCls(im)meth
 // CHECK1: (SubCls) -> () -> ()
 // CHECK1:      OVERRIDES BEGIN

--- a/test/multifile/Inputs/overrideB.swift
+++ b/test/multifile/Inputs/overrideB.swift
@@ -1,0 +1,5 @@
+class Super {
+  func bar<T>(_: Into<T>) { }
+
+  func wibble() { }
+}

--- a/test/multifile/Inputs/overrideC.swift
+++ b/test/multifile/Inputs/overrideC.swift
@@ -1,0 +1,5 @@
+class Sub: Super {
+  override func bar<T>(_: Into<T>) { }
+
+  func wibble() { }
+}

--- a/test/multifile/override.swift
+++ b/test/multifile/override.swift
@@ -1,0 +1,22 @@
+// Test that overrides in other source files get checked lazily.
+
+// Make sure the overrides are resolved... but we don't diagnose a missing
+// 'override' keyword from another source file.
+// RUN: %target-swift-frontend -typecheck -primary-file %s %S/Inputs/overrideB.swift %S/Inputs/overrideC.swift -verify
+
+// Make sure we still diagnose the missing 'override' when looking at the
+// source file where it occurs.
+// RUN: not %target-swift-frontend -typecheck %s %S/Inputs/overrideB.swift -primary-file %S/Inputs/overrideC.swift 2> %t.err
+// RUN: %FileCheck %s < %t.err
+
+// expected-no-diagnostics
+
+class Foo {
+  func foo(sub: Sub) {
+    sub.bar(Into<Int>())
+  }
+}
+
+struct Into<T> { }
+
+// CHECK: overriding declaration requires an 'override' keyword

--- a/validation-test/compiler_crashers_fixed/28780-hasinterfacetype-no-interface-type-was-set.swift
+++ b/validation-test/compiler_crashers_fixed/28780-hasinterfacetype-no-interface-type-was-set.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+
+// RUN: not %target-swift-frontend %s -emit-ir
 class a{func a:A.a:class A:a{{}func a

--- a/validation-test/compiler_crashers_fixed/28841-swift-valuedecl-getformalaccessscope-swift-declcontext-const-bool-const.swift
+++ b/validation-test/compiler_crashers_fixed/28841-swift-valuedecl-getformalaccessscope-swift-declcontext-const-bool-const.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 extension a{var f=a}class a:a


### PR DESCRIPTION
Refactor the checking of overridden declarations so we only perform the minimal work to answer the question "what declarations to this declaration override?".  Includes a healthy refactoring of the previously-monolithic `TypeChecker::checkOverrides()` into re-usable pieces that are far easier to reason about than before.