### PR TITLE
[Type checker] Refactor override checking

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1385,7 +1385,7 @@ public:
   /// Retrieve the first attribute of the given attribute class.
   template <typename ATTR>
   const ATTR *getAttribute(bool AllowInvalid = false) const {
-    return const_cast<DeclAttributes *>(this)->getAttribute<ATTR>();
+    return const_cast<DeclAttributes *>(this)->getAttribute<ATTR>(AllowInvalid);
   }
 
   template <typename ATTR>

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1976,15 +1976,6 @@ NOTE(overridden_here,none,
 NOTE(overridden_here_can_be_objc,none,
      "add '@objc' to make this declaration overridable", ())
 
-ERROR(override_objc_type_mismatch_method,none,
-      "overriding method with selector %0 has incompatible type %1",
-      (ObjCSelector, Type))
-ERROR(override_objc_type_mismatch_subscript,none,
-      "overriding %select{|indexed |keyed }0subscript with incompatible type "
-      "%1",
-      (unsigned, Type))
-NOTE(overridden_here_with_type,none,
-     "overridden declaration here has type %0", (Type))
 ERROR(missing_override,none,
       "overriding declaration requires an 'override' keyword", ())
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -84,13 +84,8 @@ bool swift::removeOverriddenDecls(SmallVectorImpl<ValueDecl*> &decls) {
   if (decls.size() < 2)
     return false;
 
-  auto lazyResolver = decls.front()->getASTContext().getLazyResolver();
   llvm::SmallPtrSet<ValueDecl*, 8> overridden;
   for (auto decl : decls) {
-    // Compute enough information to make the overridden-declaration available.
-    if (lazyResolver)
-      lazyResolver->resolveOverriddenDecl(decl);
-
     while (auto overrides = decl->getOverriddenDecl()) {
       overridden.insert(overrides);
 
@@ -105,10 +100,6 @@ bool swift::removeOverriddenDecls(SmallVectorImpl<ValueDecl*> &decls) {
         ///        cause instead (incomplete circularity detection).
         assert(decl != overrides && "Circular class inheritance?");
         decl = overrides;
-
-        if (lazyResolver)
-          lazyResolver->resolveOverriddenDecl(decl);
-
         continue;
       }
 
@@ -1908,9 +1899,6 @@ bool DeclContext::lookupQualified(Type type,
       // If the declaration has an override, name lookup will also have
       // found the overridden method. Skip this declaration, because we
       // prefer the overridden method.
-      if (typeResolver)
-        typeResolver->resolveOverriddenDecl(decl);
-
       if (decl->getOverriddenDecl())
         continue;
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -6389,6 +6389,12 @@ ConstructorDecl *SwiftDeclConverter::importConstructor(
 }
 
 void SwiftDeclConverter::recordObjCOverride(AbstractFunctionDecl *decl) {
+  // Make sure that we always set the overriden declarations.
+  SWIFT_DEFER {
+    if (!decl->overriddenDeclsComputed())
+      (void)decl->setOverriddenDecls({ });
+  };
+
   // Figure out the class in which this method occurs.
   if (!decl->getDeclContext()->isTypeContext())
     return;
@@ -6419,6 +6425,7 @@ void SwiftDeclConverter::recordObjCOverride(AbstractFunctionDecl *decl) {
           func->getObjCSelector() != foundFunc->getObjCSelector())
         continue;
       func->setOverriddenDecl(foundFunc);
+      func->getAttrs().add(new (func->getASTContext()) OverrideAttr(true));
       return;
     }
     // Set constructor override.
@@ -6429,6 +6436,8 @@ void SwiftDeclConverter::recordObjCOverride(AbstractFunctionDecl *decl) {
         ctor->getObjCSelector() != memberCtor->getObjCSelector())
       continue;
     ctor->setOverriddenDecl(memberCtor);
+    ctor->getAttrs().add(new (ctor->getASTContext()) OverrideAttr(true));
+
     // Propagate 'required' to subclass initializers.
     if (memberCtor->isRequired() &&
         !ctor->getAttrs().hasAttribute<RequiredAttr>()) {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1644,8 +1644,10 @@ void TypeChecker::resolveOverriddenDecl(ValueDecl *VD) {
   if (isa<TypeDecl>(VD))
     return;
 
-  // FIXME: We should check for the 'override' or 'required' keywords
-  // here, to short-circuit checking in the common case.
+  // Only initializers and declarations marked with the 'override' declaration
+  // modifier can override declarations.
+  if (!isa<ConstructorDecl>(VD) && !VD->getAttrs().hasAttribute<OverrideAttr>())
+    return;
 
   // FIXME: We should perform more minimal validation.
   validateDeclForNameLookup(VD);

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -71,9 +71,8 @@ Type InheritedTypeRequest::evaluate(
     resolver = &archetypeResolver;
   }
 
-  // FIXME: Hack for calls through here when we have no type checker.
   auto lazyResolver = dc->getASTContext().getLazyResolver();
-  if (!lazyResolver) return ErrorType::get(dc->getASTContext());
+  assert(lazyResolver && "Cannot resolve inherited type at this point");
 
   TypeChecker &tc = *static_cast<TypeChecker *>(lazyResolver);
   TypeLoc &typeLoc = getTypeLoc(decl, index);

--- a/test/attr/attr_objc_override.swift
+++ b/test/attr/attr_objc_override.swift
@@ -11,8 +11,8 @@ class MixedKeywordsAndAttributes { // expected-note{{in declaration of 'MixedKey
 struct SwiftStruct { }
 
 class A {
-  @objc subscript (a: ObjCClass) -> ObjCClass { // expected-note{{overridden declaration here has type '(ObjCClass) -> ObjCClass'}}
-    get { return ObjCClass() }
+  @objc subscript (a: ObjCClass) -> ObjCClass {
+    get { return ObjCClass() }  // expected-note{{subscript getter declared here}}
   }
 
   func bar() { } // expected-note{{add '@objc' to make this declaration overridable}}{{3-3=@objc }}
@@ -25,8 +25,8 @@ extension A {
 
 class B : A {
   // Objective-C
-  @objc subscript (a: ObjCClass) -> AnyObject { // expected-error{{overriding keyed subscript with incompatible type '(ObjCClass) -> AnyObject'}}
-    get { return self }
+  @objc subscript (a: ObjCClass) -> AnyObject {
+    get { return self }  // expected-error{{subscript getter with Objective-C selector 'objectForKeyedSubscript:' conflicts with subscript getter from superclass 'A'}}
   }
 
   override func foo() { } // expected-error{{overriding non-@objc declarations from extensions is not supported}}


### PR DESCRIPTION
Break the gigantic `swift::checkOverrides()` into a few separable pieces
encapsulated in a new class, OverrideMatcher:

* Setup: establish whether we can do matching at all
* Matching: check whether we have a match based on a set of checking rules
* Checking: check that the selected override is semantically correct
* Search: apply various matching rules to try to find the overridden declaration

While here, limit the dependencies of override checking somewhat. 
Specifically, don’t ask for the type of the declaration until we’ve found
a potential overridden declaration to check against, and even then only do
it when the “simple” checks fail.