### PR TITLE
IRGen: Always call metadata accessor for resilient types even when resilience bypass is enabled

### DIFF
--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -561,8 +561,28 @@ bool irgen::isTypeMetadataAccessTrivial(IRGenModule &IGM, CanType type) {
     if (nominalDecl->isGenericContext())
       return false;
 
+    auto expansion = ResilienceExpansion::Maximal;
+
+    // Normally, if a value type is known to have a fixed layout to us, we will
+    // have emitted fully initialized metadata for it, including a payload size
+    // field for enum metadata for example, allowing the type metadata to be
+    // used in other resilience domains without initialization.
+    //
+    // However, when -enable-resilience-bypass is on, we might be using a value
+    // type from another module built with resilience enabled. In that case, the
+    // type looks like it has fixed size to us, since we're bypassing resilience,
+    // but the metadata still requires runtime initialization, so its incorrect
+    // to reference it directly.
+    //
+    // While unconditionally using minimal expansion is correct, it is not as
+    // efficient as it should be, so only do so if -enable-resilience-bypass is on.
+    //
+    // FIXME: All of this goes away once lldb supports resilience.
+    if (IGM.IRGen.Opts.EnableResilienceBypass)
+      expansion = ResilienceExpansion::Minimal;
+
     // Resiliently-sized metadata access always requires an accessor.
-    return (IGM.getTypeInfoForUnlowered(type).isFixedSize());
+    return (IGM.getTypeInfoForUnlowered(type).isFixedSize(expansion));
   }
 
   // The empty tuple type has a singleton metadata.

--- a/test/IRGen/resilience_bypass.swift
+++ b/test/IRGen/resilience_bypass.swift
@@ -4,13 +4,37 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path=%t/second.swiftmodule -module-name=second %S/Inputs/resilience_bypass/second.swift -I %t
 // RUN: %target-swift-frontend -emit-ir -enable-resilience-bypass %s -I %t | %FileCheck %s -DINT=i%target-ptrsize
 
+import first
 import second
 
 // CHECK:       define{{( dllexport| protected)?}} swiftcc [[INT]] @"$S17resilience_bypass7getSizeSiyF"() {{.*}} {
 // CHECK-NEXT:  entry:
+
+// FIXME: The metadata accessor call is not necessary
+// CHECK-NEXT:    [[RESPONSE:%.*]] = call swiftcc %swift.metadata_response @"$S6second1EOMa"
+// CHECK-NEXT:    [[METADATA:%.*]] = extractvalue %swift.metadata_response [[RESPONSE]], 0
+
 // CHECK-NEXT:    ret [[INT]] {{5|9}}
 // CHECK-NEXT:  }
 
 public func getSize() -> Int {
   return MemoryLayout<E>.size
+}
+
+public func makeE(_ s: S) -> E {
+  return .b(s)
+}
+
+// CHECK:       define{{( dllexport| protected)?}} swiftcc void @"$S17resilience_bypass7makeAnyyyp5first1SVF"(
+// CHECK-NEXT:  entry:
+
+// Make sure we form the existential using the result of the metadata accessor, instead of
+// directly using the address of the metadata global.
+//
+// FIXME: The metadata global should have hidden linkage to rule out this kind of bug.
+
+// CHECK-NEXT:    [[RESPONSE:%.*]] = call swiftcc %swift.metadata_response @"$S6second1EOMa"
+
+public func makeAny(_ s: S) -> Any {
+  return makeE(s)
 }


### PR DESCRIPTION
Otherwise, we might directly use uninitialized metadata, because we think
the type has a fixed size, even if it was defined in a different module
built with resilience.

Fixes <rdar://problem/40034143>, for real this time.