### PR TITLE
IRGen: Always call metadata accessor for resilient types even when resilience bypass is enabled [4.2]

### DIFF
--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -572,8 +572,28 @@ bool irgen::isTypeMetadataAccessTrivial(IRGenModule &IGM, CanType type) {
     if (nominalDecl->isGenericContext())
       return false;
 
+    auto expansion = ResilienceExpansion::Maximal;
+
+    // Normally, if a value type is known to have a fixed layout to us, we will
+    // have emitted fully initialized metadata for it, including a payload size
+    // field for enum metadata for example, allowing the type metadata to be
+    // used in other resilience domains without initialization.
+    //
+    // However, when -enable-resilience-bypass is on, we might be using a value
+    // type from another module built with resilience enabled. In that case, the
+    // type looks like it has fixed size to us, since we're bypassing resilience,
+    // but the metadata still requires runtime initialization, so its incorrect
+    // to reference it directly.
+    //
+    // While unconditionally using minimal expansion is correct, it is not as
+    // efficient as it should be, so only do so if -enable-resilience-bypass is on.
+    //
+    // FIXME: All of this goes away once lldb supports resilience.
+    if (IGM.IRGen.Opts.EnableResilienceBypass)
+      expansion = ResilienceExpansion::Minimal;
+
     // Resiliently-sized metadata access always requires an accessor.
-    return (IGM.getTypeInfoForUnlowered(type).isFixedSize());
+    return (IGM.getTypeInfoForUnlowered(type).isFixedSize(expansion));
   }
 
   // The empty tuple type has a singleton metadata.

--- a/test/IRGen/resilience_bypass.swift
+++ b/test/IRGen/resilience_bypass.swift
@@ -4,13 +4,37 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path=%t/second.swiftmodule -module-name=second %S/Inputs/resilience_bypass/second.swift -I %t
 // RUN: %target-swift-frontend -emit-ir -enable-resilience-bypass %s -I %t | %FileCheck %s -DINT=i%target-ptrsize
 
+import first
 import second
 
 // CHECK:       define{{( protected)?}} swiftcc [[INT]] @"$S17resilience_bypass7getSizeSiyF"() {{.*}} {
 // CHECK-NEXT:  entry:
+
+// FIXME: The metadata accessor call is not necessary
+// CHECK-NEXT:    [[RESPONSE:%.*]] = call swiftcc %swift.metadata_response @"$S6second1EOMa"
+// CHECK-NEXT:    [[METADATA:%.*]] = extractvalue %swift.metadata_response [[RESPONSE]], 0
+
 // CHECK-NEXT:    ret [[INT]] {{5|9}}
 // CHECK-NEXT:  }
 
 public func getSize() -> Int {
   return MemoryLayout<E>.size
+}
+
+public func makeE(_ s: S) -> E {
+  return .b(s)
+}
+
+// CHECK:       define{{( dllexport| protected)?}} swiftcc void @"$S17resilience_bypass7makeAnyyyp5first1SVF"(
+// CHECK-NEXT:  entry:
+
+// Make sure we form the existential using the result of the metadata accessor, instead of
+// directly using the address of the metadata global.
+//
+// FIXME: The metadata global should have hidden linkage to rule out this kind of bug.
+
+// CHECK-NEXT:    [[RESPONSE:%.*]] = call swiftcc %swift.metadata_response @"$S6second1EOMa"
+
+public func makeAny(_ s: S) -> Any {
+  return makeE(s)
 }


### PR DESCRIPTION
* Description: The previous fix for rdar://problem/40034143 was incomplete, because I got the reduced test case working but the original test case was still broken. The problem is when you have a module dependency graph like `A --> B --> C` and A is built with `-enable-resilience-bypass` (ie, the LLDB REPL), B uses a type from C, and C is built with resilience enabled, then sometimes A would directly access type metadata for types defined in B, instead of going through metadata accessors. This was because to A, everything has a known size, so it thinks the metadata does not require runtime initialization; however when B was built, the size of types in C was not known, so B's types *do* require runtime initialization.

* Risk: Low, the fix only changes behavior when generating code for the LLDB REPL.

* Scope of the issue: Impacts CreateML and possibly other frameworks that use Foundation value types, which are resilient.

* Origination: New in 4.2 when we enabled resilience for stdlib and overlays.

* Bug: rdar://40034143 (re-opened)

* Reviewed by: @rjmccall 