### PR TITLE
Sema: Fix source compatibility break from relaxed witness matching rules [4.2]

### DIFF
--- a/test/Compatibility/optional_visibility.swift
+++ b/test/Compatibility/optional_visibility.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift -enable-objc-interop -swift-version 4
+
+@objc protocol Opt {
+  @objc optional func f(callback: @escaping () -> ())
+}
+
+class Conforms : Opt {
+  private func f(callback: () -> ()) {} // expected-note {{'f' declared here}}
+}
+
+func g(x: Conforms) {
+  _ = x.f(callback: {}) // expected-error {{'f' is inaccessible due to 'private' protection level}}
+}

--- a/test/decl/protocol/req/optional_visibility.swift
+++ b/test/decl/protocol/req/optional_visibility.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift -enable-objc-interop -swift-version 5
+
+@objc protocol Opt {
+  @objc optional func f(callback: @escaping () -> ())
+}
+
+class Conforms : Opt {
+  private func f(callback: () -> ()) {}
+  // expected-error@-1 {{method 'f(callback:)' must be declared internal because it matches a requirement in internal protocol 'Opt'}}
+  // expected-note@-2 {{mark the instance method as 'internal' to satisfy the requirement}}
+}
+
+func g(x: Conforms) {
+  _ = x.f(callback: {})
+}


### PR DESCRIPTION
* Description: Fix for minor source compatibility issue introduced by the fix for rdar://problem/35297911. With the new witness matching rules, a class method that was formerly not considered a witness to a requirement could now be considered a witness. If the requirement was optional, this meant that code that would compile in Swift 4.1 would not fail to compile in 4.2 because the witness was not sufficiently visible.

* Origination: Regression in 4.2.

* Scope of the issue: Only found one internal test case, probably not a widespread problem but it 's very easy to work around.

* Tested: Added new test for the hackaround which is only enabled with -swift-version 4 or 4.2, as well as the old, more consistent behavior, which is still the default in -swift-version 5

* Risk: Very low, we just ignore the witness if its not accessible, which should be fine for optional requirements and only comes up with code that already didn't compile.

* Reviewed by: @DougGregor 

* Bug: rdar://problem/39614880