### PR TITLE
[Foundation] Handle null for Optional<T> in JSONDecoder and PropertyListDecoder.

### DIFF
--- a/stdlib/public/SDK/Foundation/Foundation.swift
+++ b/stdlib/public/SDK/Foundation/Foundation.swift
@@ -95,3 +95,18 @@ extension CVarArg where Self: _ObjectiveCBridgeable {
     return _encodeBitsAsWords(object)
   }
 }
+
+//===----------------------------------------------------------------------===//
+// Optionality Checker
+//===----------------------------------------------------------------------===//
+
+// This protocol is expected to be conformed to by Optional only.
+// It can be used to check if a type is Optional within Foundation internal scope.
+fileprivate protocol _Unwrappable {}
+
+extension Optional : _Unwrappable {}
+
+@inline(__always)
+internal func _isOptionalType<T>(_ type: T.Type) -> Bool {
+    return type is _Unwrappable.Type
+}

--- a/stdlib/public/SDK/Foundation/JSONEncoder.swift
+++ b/stdlib/public/SDK/Foundation/JSONEncoder.swift
@@ -2005,7 +2005,9 @@ extension _JSONDecoder : SingleValueDecodingContainer {
     }
 
     public func decode<T : Decodable>(_ type: T.Type) throws -> T {
-        try expectNonNull(type)
+        if !_isOptional(type) {
+            try expectNonNull(T.self)
+        }
         return try self.unbox(self.storage.topContainer, as: type)!
     }
 }

--- a/stdlib/public/SDK/Foundation/JSONEncoder.swift
+++ b/stdlib/public/SDK/Foundation/JSONEncoder.swift
@@ -2007,7 +2007,7 @@ extension _JSONDecoder : SingleValueDecodingContainer {
     public func decode<T : Decodable>(_ type: T.Type) throws -> T {
         // Not expecting NonNull for Optional, which may take null for nil case.
         if !_isOptionalType(type) {
-            try expectNonNull(T.self)
+            try expectNonNull(type)
         }
         return try self.unbox(self.storage.topContainer, as: type)!
     }
@@ -2455,19 +2455,4 @@ fileprivate extension EncodingError {
         let debugDescription = "Unable to encode \(valueDescription) directly in JSON. Use JSONEncoder.NonConformingFloatEncodingStrategy.convertToString to specify how the value should be encoded."
         return .invalidValue(value, EncodingError.Context(codingPath: codingPath, debugDescription: debugDescription))
     }
-}
-
-//===----------------------------------------------------------------------===//
-// Optionality Checker
-//===----------------------------------------------------------------------===//
-
-// This protocol is expected to be conformed to by Optional only.
-// It is used to check if a type is Optional.
-fileprivate protocol _Unwrappable {}
-
-extension Optional : _Unwrappable {}
-
-@inline(__always)
-fileprivate func _isOptionalType<T>(_ type: T.Type) -> Bool {
-    return type as? _Unwrappable.Type != nil
 }

--- a/stdlib/public/SDK/Foundation/JSONEncoder.swift
+++ b/stdlib/public/SDK/Foundation/JSONEncoder.swift
@@ -2005,7 +2005,8 @@ extension _JSONDecoder : SingleValueDecodingContainer {
     }
 
     public func decode<T : Decodable>(_ type: T.Type) throws -> T {
-        if !_isOptional(type) {
+        // Not expecting NonNull for Optional, which may take null for nil case.
+        if !_isOptionalType(type) {
             try expectNonNull(T.self)
         }
         return try self.unbox(self.storage.topContainer, as: type)!
@@ -2454,4 +2455,19 @@ fileprivate extension EncodingError {
         let debugDescription = "Unable to encode \(valueDescription) directly in JSON. Use JSONEncoder.NonConformingFloatEncodingStrategy.convertToString to specify how the value should be encoded."
         return .invalidValue(value, EncodingError.Context(codingPath: codingPath, debugDescription: debugDescription))
     }
+}
+
+//===----------------------------------------------------------------------===//
+// Optionality Checker
+//===----------------------------------------------------------------------===//
+
+// This protocol is expected to be conformed to by Optional only.
+// It is used to check if a type is Optional.
+fileprivate protocol _Unwrappable {}
+
+extension Optional : _Unwrappable {}
+
+@inline(__always)
+fileprivate func _isOptionalType<T>(_ type: T.Type) -> Bool {
+    return type as? _Unwrappable.Type != nil
 }

--- a/stdlib/public/SDK/Foundation/PlistEncoder.swift
+++ b/stdlib/public/SDK/Foundation/PlistEncoder.swift
@@ -1526,7 +1526,10 @@ extension _PlistDecoder : SingleValueDecodingContainer {
     }
 
     public func decode<T : Decodable>(_ type: T.Type) throws -> T {
-        try expectNonNull(type)
+        // Not expecting NonNull for Optional, which may take null for nil case.
+        if !_isOptionalType(type) {
+            try expectNonNull(type)
+        }
         return try self.unbox(self.storage.topContainer, as: type)!
     }
 }

--- a/test/stdlib/TestPlistEncoder.swift
+++ b/test/stdlib/TestPlistEncoder.swift
@@ -68,6 +68,14 @@ class TestPropertyListEncoder : TestPropertyListEncoderSuper {
     _testRoundTrip(of: TopLevelWrapper(c), in: .xml)
   }
 
+  func testEncodingTopLevelSingleValueContainerForOptionalType() {
+    let c = CounterOptional(nil)
+    _testEncodeFailure(of: c, in: .binary)
+    _testEncodeFailure(of: c, in: .xml)
+    _testRoundTrip(of: TopLevelWrapper(c), in: .binary)
+    _testRoundTrip(of: TopLevelWrapper(c), in: .xml)
+  }
+
   // MARK: - Encoding Top-Level Structured Types
   func testEncodingTopLevelStructuredStruct() {
     // Address is a struct type with multiple fields.
@@ -424,6 +432,29 @@ fileprivate final class Counter : Codable, Equatable {
   }
 
   static func ==(_ lhs: Counter, _ rhs: Counter) -> Bool {
+    return lhs === rhs || lhs.count == rhs.count
+  }
+}
+
+/// A simple referential counter type that encodes as a single Int? value.
+fileprivate final class CounterOptional : Codable, Equatable {
+  var count: Int? = nil
+
+  init(_ def: Int?) {
+    count = def
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    count = try container.decode(Int?.self)
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(self.count)
+  }
+
+  static func ==(_ lhs: CounterOptional, _ rhs: CounterOptional) -> Bool {
     return lhs === rhs || lhs.count == rhs.count
   }
 }
@@ -805,6 +836,7 @@ PropertyListEncoderTests.test("testEncodingTopLevelStructuredStruct") { TestProp
 PropertyListEncoderTests.test("testEncodingTopLevelStructuredClass") { TestPropertyListEncoder().testEncodingTopLevelStructuredClass() }
 PropertyListEncoderTests.test("testEncodingTopLevelStructuredSingleStruct") { TestPropertyListEncoder().testEncodingTopLevelStructuredSingleStruct() }
 PropertyListEncoderTests.test("testEncodingTopLevelStructuredSingleClass") { TestPropertyListEncoder().testEncodingTopLevelStructuredSingleClass() }
+PropertyListEncoderTests.test("testEncodingTopLevelSingleValueContainerForOptionalType") { TestPropertyListEncoder().testEncodingTopLevelSingleValueContainerForOptionalType() }
 PropertyListEncoderTests.test("testEncodingTopLevelDeepStructuredType") { TestPropertyListEncoder().testEncodingTopLevelDeepStructuredType() }
 PropertyListEncoderTests.test("testEncodingClassWhichSharesEncoderWithSuper") { TestPropertyListEncoder().testEncodingClassWhichSharesEncoderWithSuper() }
 PropertyListEncoderTests.test("testEncodingTopLevelNullableType") { TestPropertyListEncoder().testEncodingTopLevelNullableType() }


### PR DESCRIPTION
This patch makes JSONDecoder and PropertyListDecoder accept null for Optional<T> values when using SingleValueDecodingContainer.

Resolves [SR-7404](https://bugs.swift.org/browse/SR-7404).