### PR TITLE
[stdlib] Align behavior of generic NaN conversion to that of concrete types

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -2185,7 +2185,9 @@ extension BinaryFloatingPoint {
           sign: source.sign,
           exponentBitPattern: Self.nan.exponentBitPattern,
           significandBitPattern: payload | Self.nan.significandBitPattern)
-      return payload_ == payload ? (value, true) : (value, false)
+      // We define exactness by equality after roundtripping; since NaN is never
+      // equal to itself, it can never be converted exactly.
+      return (value, false)
     }
 
     let exponent = source.exponent
@@ -2299,8 +2301,7 @@ extension BinaryFloatingPoint {
   /// exactly.
   ///
   /// If the given floating-point value cannot be represented exactly, the
-  /// result is `nil`. A value that is NaN ("not a number") cannot be
-  /// represented exactly if its payload cannot be encoded exactly.
+  /// result is `nil`.
   ///
   /// - Parameter value: A floating-point value to be converted.
   @inlinable // FIXME(sil-serialize-all)


### PR DESCRIPTION
`Double.init(exactly: Float)` checks that the converted value is "exact" by checking for equality. Therefore, NaN is never "exactly" converted.

Whether NaN should always or never be considered "exactly" NaN for the purposes of conversion has been discussed at some length. As @stephentyrone puts it, "Either behavior is weird to some people, but the current behavior is easier to explain: the initializer succeeds if the round-tripped value compares equal."

In #13782, I implemented generic floating-point conversion of NaN; that method checks for exactness by looking at the payload, which is inconsistent with the behavior of its concrete counterparts. This PR aligns the behavior for consistency.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->