### PR TITLE
[Foundation] Remove unused NSRange slice variable

### DIFF
--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -198,7 +198,6 @@ internal final class _DataStorage {
                 var buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: range.count, alignment: MemoryLayout<UInt>.alignment)
                 defer { buffer.deallocate() }
 
-                let sliceRange = NSRange(location: range.lowerBound - _offset, length: range.count)
                 var enumerated = 0
                 d.enumerateBytes { (ptr, byteRange, stop) in
                     if byteRange.upperBound - _offset < range.lowerBound {


### PR DESCRIPTION
Delete unused variable left over after previous refactoring.