### PR TITLE
Added enum support for const expr, with payloads.

### DIFF
--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -198,7 +198,7 @@ public:
 
     /// This is an enum without payload.
     Enum,
-    /// This is an enum without payload.
+    /// This is an enum with payload.
     EnumWithPayload,
 
     /// These values are generally only seen internally to the system, external

--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -198,7 +198,7 @@ public:
 
     /// This is an enum without payload.
     Enum,
-    /// This is an enum with payload.
+    /// This is an enum with payload (formally known as "associated value").
     EnumWithPayload,
 
     /// These values are generally only seen internally to the system, external
@@ -313,7 +313,7 @@ public:
 
   EnumElementDecl *getEnumValue() const;
 
-  SymbolicValue getEnumPayload() const;
+  SymbolicValue getEnumPayloadValue() const;
 
   /// Given that this is an 'Unknown' value, emit diagnostic notes providing
   /// context about what the problem is.  If there is no location for some

--- a/lib/SIL/SILConstants.cpp
+++ b/lib/SIL/SILConstants.cpp
@@ -94,7 +94,7 @@ void SymbolicValue::print(llvm::raw_ostream &os, unsigned indent) const {
     os << "enum: ";
     decl->print(os);
     os <<", payload: ";
-    getEnumPayload().print(os, indent);
+    getEnumPayloadValue().print(os, indent);
     return;
   }
   }
@@ -108,17 +108,26 @@ void SymbolicValue::dump() const {
 /// multiple forms for efficiency, but provide a simpler interface to clients.
 SymbolicValue::Kind SymbolicValue::getKind() const {
   switch (representationKind) {
-  case RK_UninitMemory: return UninitMemory;
-  case RK_Unknown:      return Unknown;
-  case RK_Metatype:     return Metatype;
-  case RK_Function:     return Function;
-  case RK_Aggregate:    return Aggregate;
-  case RK_Enum:         return Enum;
+  case RK_UninitMemory:
+    return UninitMemory;
+  case RK_Unknown:
+    return Unknown;
+  case RK_Metatype:
+    return Metatype;
+  case RK_Function:
+    return Function;
+  case RK_Aggregate:
+    return Aggregate;
+  case RK_Enum:
+    return Enum;
   case RK_EnumWithPayload:
     return EnumWithPayload;
-  case RK_Integer:      return Integer;
-  case RK_Float:        return Float;
-  case RK_String:       return String;
+  case RK_Integer:
+    return Integer;
+  case RK_Float:
+    return Float;
+  case RK_String:
+    return String;
   case RK_Inst:
     auto *inst = value.inst;
     if (isa<IntegerLiteralInst>(inst))
@@ -158,8 +167,8 @@ SymbolicValue SymbolicValue::cloneInto(llvm::BumpPtrAllocator &allocator) const{
   case SymbolicValue::Enum:
     return SymbolicValue::getEnum(getEnumValue());
   case SymbolicValue::EnumWithPayload:
-    return SymbolicValue::getEnumWithPayload(getEnumValue(), getEnumPayload(),
-                                             allocator);
+    return SymbolicValue::getEnumWithPayload(getEnumValue(),
+                                             getEnumPayloadValue(), allocator);
   }
 }
 
@@ -507,7 +516,7 @@ EnumElementDecl *SymbolicValue::getEnumValue() const {
   return value.enumValWithPayload->getEnumDecl();
 }
 
-SymbolicValue SymbolicValue::getEnumPayload() const {
+SymbolicValue SymbolicValue::getEnumPayloadValue() const {
   assert(representationKind == RK_EnumWithPayload);
   return value.enumValWithPayload->getPayload();
 }

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1233,6 +1233,13 @@ public:
     case SymbolicValue::Enum:
       *this << SILDeclRef(v.getEnumValue(), SILDeclRef::Kind::EnumElement);
       return;
+    case SymbolicValue::EnumWithPayload:
+      *this << "(";
+      *this << SILDeclRef(v.getEnumValue(), SILDeclRef::Kind::EnumElement);
+      *this << ", ";
+      visitSymbolicValue(v.getEnumPayload());
+      *this << ")";
+      return;
     case SymbolicValue::UninitMemory:
     case SymbolicValue::Unknown:
       llvm_unreachable("Unimplemented SymbolicValue case");

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1237,7 +1237,7 @@ public:
       *this << "(";
       *this << SILDeclRef(v.getEnumValue(), SILDeclRef::Kind::EnumElement);
       *this << ", ";
-      visitSymbolicValue(v.getEnumPayload());
+      visitSymbolicValue(v.getEnumPayloadValue());
       *this << ")";
       return;
     case SymbolicValue::UninitMemory:

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
@@ -219,6 +219,11 @@ namespace {
     /// object it is addressing and any indices into that object.
     llvm::DenseMap<SILValue, AddressValue> addressValues;
 
+    void setAddress(SILValue addr, AddressValue addrVal) {
+      assert(addr->getType().isAddress() && "values are tracked separately");
+      addressValues.insert({addr, addrVal});
+    }
+
   public:
     ConstExprFunctionState(ConstExprEvaluator &evaluator, SILFunction *fn,
                            SubstitutionMap substitutionMap,
@@ -233,14 +238,15 @@ namespace {
       calculatedValues.insert({ value, symVal });
     }
 
-    void setAddress(SILValue addr, AddressValue addrVal) {
-      assert(addr->getType().isAddress() && "values are tracked separately");
-      addressValues.insert({ addr, addrVal });
-    }
-
+    /// Invariant: Before the call, `addressValues` must not contain `addr` as a
+    /// key, unless `initialValue` is an unknown value, representing a failure in
+    /// compiler-time evaluation.
     AddressValue createMemoryObject(SILValue addr, SymbolicValue initialValue) {
+      if (!initialValue.isUnknown()) {
+        assert(!addressValues.count(addr));
+      }
       unsigned objectID = memoryObjects.size();
-      auto objectType = simplifyType(addr->getType().getSwiftRValueType());
+      auto objectType = simplifyType(addr->getType().getASTType());
       memoryObjects.push_back({initialValue, objectType});
 
       auto result = AddressValue::get(objectID);
@@ -418,10 +424,13 @@ SymbolicValue ConstExprFunctionState::computeConstantValue(SILValue value) {
   }
 
   if (auto *enumVal = dyn_cast<EnumInst>(value)) {
-    // TODO: support enums with payloads.
     if (!enumVal->hasOperand())
-      return SymbolicValue::getEnum(enumVal->getElement(),
-                                    evaluator.getAllocator());
+      return SymbolicValue::getEnum(enumVal->getElement());
+
+    auto payload = computeConstantValue(enumVal->getOperand());
+    if (payload.isConstant())
+      return SymbolicValue::getEnumWithPayload(enumVal->getElement(), payload,
+                                               evaluator.getAllocator());
   }
 
   DEBUG(llvm::dbgs() << "ConstExpr Unknown simple: " << *value << "\n");
@@ -1189,8 +1198,10 @@ ConstExprFunctionState::computeFSStore(SymbolicValue storedCst, SILValue dest) {
   return None;
 }
 
-
+/// Invariant: Before the call, `addressValues` must not contain `addr` as a
+/// key. After the call, it must do.
 AddressValue ConstExprFunctionState::computeAddressValue(SILValue addr) {
+  assert(!addressValues.count(addr));
   // If this is a struct or tuple element addressor, compute a more derived
   // address.
   if (isa<StructElementAddrInst>(addr) || isa<TupleElementAddrInst>(addr)) {
@@ -1213,6 +1224,14 @@ AddressValue ConstExprFunctionState::computeAddressValue(SILValue addr) {
   // These instructions are markers that return their first operand.
   if (auto *bai = dyn_cast<BeginAccessInst>(addr))
     return getAddressValue(bai->getOperand());
+
+  // This one returns the address of its enum payload.
+  if (auto *dai = dyn_cast<UncheckedTakeEnumDataAddrInst>(addr)) {
+    auto enumAddr = dai->getOperand();
+    auto enumVal = computeLoadResult(enumAddr);
+    if (enumVal.isConstant())
+      return createMemoryObject(addr, enumVal.getEnumPayload());
+  }
 
   DEBUG(llvm::dbgs() << "ConstExpr Unknown simple addr: " << *addr << "\n");
 
@@ -1296,6 +1315,19 @@ ConstExprFunctionState::evaluateFlowSensitive(SILInstruction *inst) {
       return stored;
 
     return computeFSStore(stored, inst->getOperand(1));
+  }
+
+  if (auto *dai = dyn_cast<UncheckedTakeEnumDataAddrInst>(inst)) {
+    auto enumVal = computeLoadResult(dai->getOperand());
+    if (!enumVal.isConstant())
+      return enumVal;
+    assert(enumVal.getKind() == SymbolicValue::EnumWithPayload);
+
+    assert(dai->getType().isAddress());
+    auto payload = computeLoadResult(dai);
+    assert(payload.isConstant());
+    (void)payload;
+    return None;
   }
 
   // Copy addr is a load + store combination.
@@ -1470,14 +1502,34 @@ evaluateAndCacheCall(SILFunction &fn, SubstitutionMap substitutionMap,
       continue;
     }
 
-    if (auto *SEAI = dyn_cast<SwitchEnumAddrInst>(inst)) {
-      auto value = state.computeLoadResult(SEAI->getOperand());
-      assert(value.getKind() == SymbolicValue::Enum);
-      auto *caseBB = SEAI->getCaseDestination(value.getEnumValue());
+    if (isa<SwitchEnumAddrInst>(inst) || isa<SwitchEnumInst>(inst)) {
+      SymbolicValue value;
+      SwitchEnumInstBase *switchInst = dyn_cast<SwitchEnumInst>(inst);
+      if (switchInst) {
+        value = state.getConstantValue(switchInst->getOperand());
+      } else {
+        switchInst = cast<SwitchEnumAddrInst>(inst);
+        value = state.computeLoadResult(switchInst->getOperand());
+      }
+      if (!value.isConstant())
+        return value;
+      assert(value.getKind() == SymbolicValue::Enum ||
+             value.getKind() == SymbolicValue::EnumWithPayload);
+      // Set up basic block arguments.
+      auto *caseBB = switchInst->getCaseDestination(value.getEnumValue());
+      if (caseBB->getNumArguments() > 0) {
+        assert(value.getKind() == SymbolicValue::EnumWithPayload);
+        // When there are multiple payload components, they form a single
+        // tuple-typed argument.
+        assert(caseBB->getNumArguments() == 1);
+        auto argument = value.getEnumPayload();
+        assert(argument.isConstant());
+        state.setValue(caseBB->getArgument(0), argument);
+      }
       nextInst = caseBB->begin();
       continue;
     }
-
+    
     DEBUG(llvm::dbgs() << "ConstExpr: Unknown Terminator: " << *inst << "\n");
 
     // TODO: Enum switches when we support enums?

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
@@ -242,9 +242,8 @@ namespace {
     /// key, unless `initialValue` is an unknown value, representing a failure in
     /// compiler-time evaluation.
     AddressValue createMemoryObject(SILValue addr, SymbolicValue initialValue) {
-      if (!initialValue.isUnknown()) {
+      if (!initialValue.isUnknown())
         assert(!addressValues.count(addr));
-      }
       unsigned objectID = memoryObjects.size();
       auto objectType = simplifyType(addr->getType().getASTType());
       memoryObjects.push_back({initialValue, objectType});
@@ -1529,7 +1528,7 @@ evaluateAndCacheCall(SILFunction &fn, SubstitutionMap substitutionMap,
       nextInst = caseBB->begin();
       continue;
     }
-    
+
     DEBUG(llvm::dbgs() << "ConstExpr: Unknown Terminator: " << *inst << "\n");
 
     // TODO: Enum switches when we support enums?

--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -1510,6 +1510,7 @@ emitConstantInst(SymbolicValue symVal, SILType type, SILLocation loc,
   case SymbolicValue::Aggregate:
   case SymbolicValue::Function:
   case SymbolicValue::Enum:
+  case SymbolicValue::EnumWithPayload:
     // TODO: Unsupported right now.
     return nullptr;
 

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -1579,6 +1579,7 @@ GLStatus TFGraphLowering::visitGraphOperationInst(GraphOperationInst *inst) {
       case SymbolicValue::Unknown:
       case SymbolicValue::UninitMemory:
       case SymbolicValue::Enum:
+      case SymbolicValue::EnumWithPayload:
         assert(0 && "These attribute kinds cannot happen here");
       case SymbolicValue::Integer: {
         auto value = attrValue.getIntegerValue();

--- a/test/SILOptimizer/pound_assert.swift
+++ b/test/SILOptimizer/pound_assert.swift
@@ -147,9 +147,31 @@ func isNil(_ x: Int?) -> Bool {
 }
 
 #assert(isNil(nil))
+#assert(!isNil(3))
 
-// TODO: support this case
-//#assert(isNil(3))
+public enum Pet {
+  case bird
+  case cat(Int)
+  case dog(Int, Int)
+  case fish
+}
+
+public func weighPet(pet: Pet) -> Int {
+  switch pet {
+  case .bird: return 3
+  case let .cat(weight): return weight
+  case let .dog(w1, w2): return w1+w2
+  default: return 1
+  }
+}
+
+#assert(weighPet(pet: .bird) == 3)
+#assert(weighPet(pet: .fish) == 1)
+#assert(weighPet(pet: .cat(2)) == 2)
+// expected-error @+1 {{assertion failed}}
+#assert(weighPet(pet: .cat(2)) == 3)
+
+#assert(weighPet(pet: .dog(9, 10)) == 19)
 
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Also:
1. Tweaked the const expr eval code a bit with more sanity checks on memory
object addresses.

2. Addressed improvement sugestions from @lattner in https://github.com/apple/swift/pull/17707.
