### PR TITLE
Make sure artificial subclasses work with '===' and casting

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -593,7 +593,7 @@ swift::swift_getObjCClassFromMetadata(const Metadata *theMetadata) {
 
   // Otherwise, the input should already be a Swift class object.
   auto theClass = cast<ClassMetadata>(theMetadata);
-  assert(theClass->isTypeMetadata() && !theClass->isArtificialSubclass());
+  assert(theClass->isTypeMetadata());
   return theClass;
 }
 

--- a/test/Interpreter/SDK/KVO.swift
+++ b/test/Interpreter/SDK/KVO.swift
@@ -55,3 +55,20 @@ foo.addObserver(foo, forKeyPath: "foo", options: [], context: &kvoContext)
 let bar = foo.foo
 // CHECK-NEXT: 0
 print(bar)
+
+let fooClass: AnyClass = object_getClass(foo)!
+precondition(fooClass !== Foo.self, "no KVO subclass?")
+precondition(fooClass is Foo.Type, "improper KVO subclass")
+precondition(!(fooClass is Observer.Type), "improper KVO subclass")
+
+let fooClassAsObject: AnyObject = fooClass
+precondition(fooClassAsObject !== Foo.self, "no KVO subclass?")
+precondition(fooClassAsObject is Foo.Type, "improper KVO subclass")
+precondition(!(fooClassAsObject is Observer.Type), "improper KVO subclass")
+
+let fooClassAsAny: Any = fooClass
+precondition(fooClassAsAny is Foo.Type, "improper KVO subclass")
+precondition(!(fooClassAsAny is Observer.Type), "improper KVO subclass")
+
+// CHECK-NEXT: class metadata checks okay
+print("class metadata checks okay")


### PR DESCRIPTION
Dynamic subclasses aren't *really* valid Swift type metadata, but they can still be used as values of type AnyClass. Make sure we don't assert when that happens.

No intended functionality change.