### PR TITLE
[4.2] Add constraints to FixedWidthInteger.Stride and .Magnitude (#17716)

### DIFF
--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -1665,7 +1665,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     }
     
     public subscript<R: RangeExpression>(_ rangeExpression: R) -> Data
-        where R.Bound: FixedWidthInteger, R.Bound.Stride : SignedInteger {
+        where R.Bound: FixedWidthInteger {
         get {
             let lower = R.Bound(_sliceRange.lowerBound)
             let upper = R.Bound(_sliceRange.upperBound)

--- a/stdlib/public/SDK/Foundation/NSRange.swift
+++ b/stdlib/public/SDK/Foundation/NSRange.swift
@@ -140,7 +140,7 @@ extension NSRange {
 
 extension NSRange {
   public init<R: RangeExpression>(_ region: R)
-  where R.Bound: FixedWidthInteger, R.Bound.Stride : SignedInteger {
+  where R.Bound: FixedWidthInteger {
     let r = region.relative(to: 0..<R.Bound.max)
     self.init(location: numericCast(r.lowerBound), length: numericCast(r.count))
   }

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -2398,9 +2398,7 @@ extension BinaryFloatingPoint {
 % for Range in ['Range', 'ClosedRange']:
 %   exampleRange = '10.0..<20.0' if Range == 'Range' else '10.0...20.0'
 extension BinaryFloatingPoint
-where Self.RawSignificand : FixedWidthInteger,
-      Self.RawSignificand.Stride : SignedInteger,
-      Self.RawSignificand.Magnitude : UnsignedInteger {
+where Self.RawSignificand : FixedWidthInteger {
 
   /// Returns a random value within the specified range, using the given
   /// generator as a source for randomness.

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2271,7 +2271,8 @@ extension BinaryInteger {
 /// other arithmetic methods and operators.
 public protocol FixedWidthInteger :
   BinaryInteger, LosslessStringConvertible, _BitwiseOperations
-  where Magnitude : FixedWidthInteger
+  where Magnitude : FixedWidthInteger & UnsignedInteger,
+        Stride : FixedWidthInteger & SignedInteger
 {
   /// The number of bits used for the underlying binary representation of
   /// values of this type.
@@ -2540,9 +2541,7 @@ ${assignmentOperatorComment(x.operator, False)}
 % for Range in ['Range', 'ClosedRange']:
 %   exampleRange = '1..<100' if Range == 'Range' else '1...100'
 
-extension FixedWidthInteger
-where Self.Stride : SignedInteger,
-      Self.Magnitude : UnsignedInteger {
+extension FixedWidthInteger {
 
   /// Returns a random value within the specified range, using the given
   /// generator as a source for randomness.


### PR DESCRIPTION
* Add constraints to FixedWidthInteger.Stride and .Magnitude

Add the constraint that these associatedtypes themselves conform to FixedWidthInteger and to SignedInteger and UnsignedInteger, respectively. These are effectively part of the semantic requirement of the protocol already, because the requirements on .min and .max effectively force FixedWidthInteger to be twos-complement, which requires Magnitude not be Self for signed types. Also, in practice it's generally necessary to have these two constraints in order to effectively use the FixedWidthInteger protocol anyway; witness that by adding them to the protocol, we eliminate them as constraints from a number of extensions.

This also resolves https://bugs.swift.org/browse/SR-8156
<rdar://problem/41789616> [SR-8156]: Difficult to use random integers in generic contexts

Explanation: The primary motivation is to make it possible to use .random(in:) in generic contexts on FixedWidthInteger, without adding a pile of conformances. More generally, it brings the actual protocol more closely in-line with the documented semantics.
Scope: Adds (minor) additional requirements on any FixedWidthInteger type. These are all satisfied by all existing standard library types, and are already required by the documented semantics of FixedWidthInteger, if not explicitly by the protocol.
Issue: rdar://problem/41789616
Risk: Medium. This is an ABI change, but one that is unlikely to effect much (any?) third-party code.
Testing: Standard test suite, source compatibility test, compiler performance test (In https://github.com/apple/swift/pull/17716)
Reviewer: @lancep, @milseman, @lorentey 