### PR TITLE
Fixed a bug in handling the __owned keyword.

### DIFF
--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -2628,9 +2628,17 @@ TypeConverter::getLoweredFormalTypes(SILDeclRef constant,
   SmallVector<TupleTypeElt, 4> inputs;
 
   // Merge inputs and generic parameters from the uncurry levels.
+  assert (uncurryLevel <= fnType.getParams().size());
   for (;;) {
     auto canInput = fnType->getInput()->getCanonicalType();
     auto inputFlags = ParameterTypeFlags().withInOut(isa<InOutType>(canInput));
+    if (!fnType.getParams().empty()) {
+      auto oldFlags = fnType.getParams()[0].getParameterFlags();
+      // TODO: Assess whether to merge other metadata info from `oldFlags` to
+      // `inputFlags`. Merging the `Variadic` bit causes compiler crash when
+      // building stdlib.
+      inputFlags = inputFlags.withOwned(oldFlags.isOwned());
+    }
     inputs.push_back(TupleTypeElt(canInput->getInOutObjectType(), Identifier(),
                                   inputFlags));
 

--- a/test/SILGen/owned.swift
+++ b/test/SILGen/owned.swift
@@ -28,3 +28,9 @@ struct Foo {
 func oneUnnamedArgument1(_: __owned ValueAggregate) {}
 // CHECK-LABEL: sil hidden @$S5owned19oneUnnamedArgument2yyAA12RefAggregateCnF : $@convention(thin) (@owned RefAggregate) -> () {
 func oneUnnamedArgument2(_: __owned RefAggregate) {}
+
+public final class C {
+  // CHECK-LABEL: sil @{{.*}}bar{{.*}} : $@convention(method) (@owned Optional<String>, @thick C.Type) -> ()
+  public static func bar(_ x: __owned String?) {
+ }
+}


### PR DESCRIPTION
Learned about __owned from @rjmccall  at https://forums.swift.org/t/questions-on-retain-release-count-balancing-and-the-change-of-func-parameter-calling-convention-from-owned-to-guaranteed/13578/2?u=hongm, but found a bug when trying to use it.

Here's an attempt to fix the bug -- I wish the fix were more general (i.e., also cover other fields in `ParameterTypeFlags`), but wasn't able to extend it given my lack of familiarity with the code base.

When I tried setting `inputFlags` to `fnType.getParams()[0].getParameterFlags()`, and then modifying it with `withInOut(isa<InOutType>(canInput))`, I got some compiler crashes when building stdlib:

```
[17/51] Generating /usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/./lib/swift/linux/x86_64/Swift.swiftmodule
FAILED: lib/swift/linux/x86_64/Swift.swiftmodule lib/swift/linux/x86_64/Swift.swiftdoc 
cd /usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core && /usr/bin/cmake -E remove -f /usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/./lib/swift/linux/x86_64/Swift.swiftmodule && /usr/bin/cmake -E remove -f /usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/./lib/swift/linux/x86_64/Swift.swiftdoc && /usr/local/google/home/hongm/anaconda2/bin/python /usr/local/google/home/hongm/ssd_part/git/swift-master/swift/utils/line-directive @/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/HzoeI.txt -- /usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/./bin/swiftc -emit-module -o /usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/./lib/swift/linux/x86_64/Swift.swiftmodule -sdk / -target x86_64-unknown-linux-gnu -resource-dir /usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/./lib/swift -O -I /usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/./lib/swift/linux/x86_64 -module-cache-path /usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/./module-cache -no-link-objc-runtime -Xfrontend -enable-resilience -nostdimport -parse-stdlib -module-name Swift -Xfrontend -group-info-path -Xfrontend /usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/GroupInfo.json -swift-version 4 -warn-swift3-objc-inference-complete -Xfrontend -verify-syntax-tree -Xllvm -sil-inline-generics -Xllvm -sil-partial-specialization -Xfrontend -enable-sil-ownership -Xcc -DswiftCore_EXPORTS -module-link-name swiftCore -force-single-frontend-invocation -Xcc -D__SWIFT_CURRENT_DYLIB=swiftCore -parse-as-library @/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/HzoeI.txt
swift: /usr/local/google/home/hongm/ssd_part/git/swift-master/swift/include/swift/SIL/AbstractionPattern.h:774: void swift::Lowering::AbstractionPattern::rewriteType(swift::CanGenericSignature, swift::CanType): Assertion `hasSameBasicTypeStructure(OrigType, type)' failed.
#0 0x0000000003c83af4 PrintStackTraceSignalHandler(void*) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0x3c83af4)
#1 0x0000000003c81d72 llvm::sys::RunSignalHandlers() (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0x3c81d72)
#2 0x0000000003c83ca2 SignalHandler(int) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0x3c83ca2)
#3 0x00007fc9d8e830c0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x110c0)
#4 0x00007fc9d73cdfcf gsignal (/lib/x86_64-linux-gnu/libc.so.6+0x32fcf)
#5 0x00007fc9d73cf3fa abort (/lib/x86_64-linux-gnu/libc.so.6+0x343fa)
#6 0x00007fc9d73c6e37 (/lib/x86_64-linux-gnu/libc.so.6+0x2be37)
#7 0x00007fc9d73c6ee2 (/lib/x86_64-linux-gnu/libc.so.6+0x2bee2)
#8 0x0000000001175b08 swift::Lowering::TypeConverter::getLoweredFormalTypes(swift::SILDeclRef, swift::CanTypeWrapper<swift::AnyFunctionType>) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0x1175b08)
#9 0x0000000001176f4f swift::Lowering::TypeConverter::getConstantInfo(swift::SILDeclRef) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0x1176f4f)
#10 0x0000000000c8b7bb (anonymous namespace)::Callee::forDirect(swift::Lowering::SILGenFunction&, swift::SILDeclRef, swift::SubstitutionMap, swift::SILLocation) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xc8b7bb)
#11 0x0000000000c953e4 swift::ASTVisitor<(anonymous namespace)::SILGenApply, void, void, void, void, void, void>::visit(swift::Expr*) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xc953e4)
#12 0x0000000000c97cda (anonymous namespace)::SILGenApply::visitApplyExpr(swift::ApplyExpr*) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xc97cda)
#13 0x0000000000c97cda (anonymous namespace)::SILGenApply::visitApplyExpr(swift::ApplyExpr*) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xc97cda)
#14 0x0000000000c87f71 swift::Lowering::SILGenFunction::emitApplyExpr(swift::Expr*, swift::Lowering::SGFContext) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xc87f71)
#15 0x0000000000c1ec07 swift::ASTVisitor<(anonymous namespace)::RValueEmitter, swift::Lowering::RValue, void, void, void, void, void, swift::Lowering::SGFContext>::visit(swift::Expr*, swift::Lowering::SGFContext) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xc1ec07)
#16 0x0000000000c153d8 swift::Lowering::SILGenFunction::emitIgnoredExpr(swift::Expr*) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xc153d8)
#17 0x0000000000c69740 swift::ASTVisitor<(anonymous namespace)::StmtEmitter, void, void, void, void, void, void>::visit(swift::Stmt*) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xc69740)
#18 0x0000000000c6950d swift::Lowering::SILGenFunction::emitStmt(swift::Stmt*) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xc6950d)
#19 0x0000000000c36615 swift::Lowering::SILGenFunction::emitFunction(swift::FuncDecl*) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xc36615)
#20 0x0000000000bdb183 swift::Lowering::SILGenModule::emitFunction(swift::FuncDecl*)::$_1::operator()(swift::SILFunction*) const (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xbdb183)
#21 0x0000000000bd2847 swift::Lowering::SILGenModule::emitFunction(swift::FuncDecl*) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xbd2847)
#22 0x0000000000c7534c swift::ASTVisitor<SILGenExtension, void, void, void, void, void, void>::visit(swift::Decl*) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xc7534c)
#23 0x0000000000c72f9b SILGenExtension::emitExtension(swift::ExtensionDecl*) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xc72f9b)
#24 0x0000000000c72f5d swift::Lowering::SILGenModule::visitExtensionDecl(swift::ExtensionDecl*) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xc72f5d)
#25 0x0000000000bd84fb swift::Lowering::SILGenModule::emitSourceFile(swift::SourceFile*, unsigned int) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xbd84fb)
#26 0x0000000000bd9166 swift::SILModule::constructSIL(swift::ModuleDecl*, swift::SILOptions&, swift::FileUnit*, llvm::Optional<unsigned int>, bool) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xbd9166)
#27 0x0000000000bd975d swift::performSILGeneration(swift::ModuleDecl*, swift::SILOptions&, bool) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xbd975d)
#28 0x00000000004d14ff performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0x4d14ff)
#29 0x00000000004ccafa swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0x4ccafa)
#30 0x00000000004867a8 main (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0x4867a8)
#31 0x00007fc9d73bb2b1 __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x202b1)
#32 0x00000000004849ca _start (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0x4849ca)
Stack dump:
0.	Program arguments: /usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift -frontend -emit-module -filelist /tmp/sources-3ceff3 -supplementary-output-file-map /tmp/supplementaryOutputs-10081f -disable-objc-attr-requires-foundation-module -target x86_64-unknown-linux-gnu -disable-objc-interop -sdk / -I /usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/./lib/swift/linux/x86_64 -warn-swift3-objc-inference-complete -module-cache-path /usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/./module-cache -module-link-name swiftCore -nostdimport -parse-stdlib -resource-dir /usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/./lib/swift -swift-version 4 -O -enable-resilience -group-info-path /usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/GroupInfo.json -verify-syntax-tree -enable-sil-ownership -Xllvm -sil-inline-generics -Xllvm -sil-partial-specialization -Xcc -DswiftCore_EXPORTS -Xcc -D__SWIFT_CURRENT_DYLIB=swiftCore -parse-as-library -module-name Swift -o /usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/./lib/swift/linux/x86_64/Swift.swiftmodule 
1.	Contents of /tmp/sources-3ceff3:
---
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Algorithm.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ArrayBody.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ArrayBuffer.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ArrayBufferProtocol.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ArrayCast.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Array.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ArrayShared.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ArraySlice.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ArrayType.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ASCII.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Assert.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/AssertCommon.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/BidirectionalCollection.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Bool.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/BridgeObjectiveC.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/BridgeStorage.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Builtin.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/BuiltinMath.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Character.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/CharacterUnicodeScalars.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/CocoaArray.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/Codable.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Collection.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/CollectionAlgorithms.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Comparable.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/CompilerProtocols.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ContiguousArray.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ClosedRange.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ContiguousArrayBuffer.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/CString.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/CTypes.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/DebuggerSupport.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Dictionary.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/DropWhile.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Dump.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/EmptyCollection.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Equatable.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ErrorType.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Filter.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/FixedArray.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/FlatMap.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Flatten.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/FloatingPoint.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/FloatingPointParsing.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/FloatingPointTypes.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Hashable.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/AnyHashable.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/HashedCollectionsAnyHashableExtensions.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Hasher.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Hashing.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/HeapBuffer.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ICU.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Indices.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/InputStream.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/IntegerParsing.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/Integers.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Join.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/KeyPath.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/LazyCollection.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/LazySequence.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/LifetimeManager.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ManagedBuffer.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Map.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/MemoryLayout.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/UnicodeScalar.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/Mirrors.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Misc.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/MutableCollection.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/NewtypeWrapper.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/NormalizedCodeUnitIterator.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ObjectIdentifier.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Optional.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/OptionSet.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/OutputStream.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Pointer.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Policy.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/PrefixWhile.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Print.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Random.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/RandomAccessCollection.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Range.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/RangeReplaceableCollection.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ReflectionMirror.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Repeat.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/REPL.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Reverse.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/Runtime.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/RuntimeFunctionCounters.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/SipHash.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Sequence.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/SequenceAlgorithms.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/SequenceWrapper.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Set.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/SetAlgebra.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ShadowProtocols.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Shims.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Slice.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/SmallString.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/Sort.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StaticString.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/Stride.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringHashable.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/String.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringBridge.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringComparable.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringComparison.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringGuts.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringGutsVisitor.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringObject.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringProtocol.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringIndex.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringInterpolation.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringLegacy.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringRangeReplaceableCollection.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringStorage.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringSwitch.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringIndexConversions.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringNormalization.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringUnicodeScalarView.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringUTF16.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringUTF8.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringVariant.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/Substring.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/SwiftNativeNSArray.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ThreadLocalStorage.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/UIntBuffer.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/UnavailableStringAPIs.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/UnicodeEncoding.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/UnicodeParser.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Unmanaged.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/UnmanagedOpaqueString.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/UnmanagedString.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/UnsafeBitMap.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/UnsafeBufferPointer.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/UnsafeRawBufferPointer.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/UnsafePointer.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/UnsafeRawPointer.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/UTFEncoding.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/UTF8.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/UTF16.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/UTF32.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Unicode.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringGraphemeBreaking.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ValidUTF8Buffer.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/WriteBackMutableSlice.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/MigrationSupport.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Availability.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/CollectionOfOne.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/ExistentialCollection.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Mirror.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/PlaygroundDisplay.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/CommandLine.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/SliceBuffer.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/Tuple.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/UnfoldSequence.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/VarArgs.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Zip.swift
---
2.	While emitting SIL for 'next()' at /usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Algorithm.swift:146:19
3.	While silgen emitFunction SIL function "@$Ss18EnumeratedSequenceV8IteratorV4nextSi6offset_7ElementQz7elementtSgyF".
 for 'next()' at /usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Algorithm.swift:146:19
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal 6 (use -v to see invocation)
[18/51] Compiling /usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/linux/x86_64/Swift.o
FAILED: stdlib/public/core/linux/x86_64/Swift.o 
cd /usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core && /usr/local/google/home/hongm/anaconda2/bin/python /usr/local/google/home/hongm/ssd_part/git/swift-master/swift/utils/line-directive @/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/HzoeI.txt -- /usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/./bin/swiftc -c -sdk / -target x86_64-unknown-linux-gnu -resource-dir /usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/./lib/swift -O -I /usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/./lib/swift/linux/x86_64 -module-cache-path /usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/./module-cache -no-link-objc-runtime -Xfrontend -enable-resilience -nostdimport -parse-stdlib -module-name Swift -Xfrontend -group-info-path -Xfrontend /usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/GroupInfo.json -swift-version 4 -warn-swift3-objc-inference-complete -Xfrontend -verify-syntax-tree -Xllvm -sil-inline-generics -Xllvm -sil-partial-specialization -Xfrontend -enable-sil-ownership -Xcc -DswiftCore_EXPORTS -module-link-name swiftCore -force-single-frontend-invocation -Xcc -D__SWIFT_CURRENT_DYLIB=swiftCore -parse-as-library -o /usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/linux/x86_64/Swift.o @/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/HzoeI.txt
swift: /usr/local/google/home/hongm/ssd_part/git/swift-master/swift/include/swift/SIL/AbstractionPattern.h:774: void swift::Lowering::AbstractionPattern::rewriteType(swift::CanGenericSignature, swift::CanType): Assertion `hasSameBasicTypeStructure(OrigType, type)' failed.
#0 0x0000000003c83af4 PrintStackTraceSignalHandler(void*) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0x3c83af4)
#1 0x0000000003c81d72 llvm::sys::RunSignalHandlers() (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0x3c81d72)
#2 0x0000000003c83ca2 SignalHandler(int) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0x3c83ca2)
#3 0x00007f48fce530c0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x110c0)
#4 0x00007f48fb39dfcf gsignal (/lib/x86_64-linux-gnu/libc.so.6+0x32fcf)
#5 0x00007f48fb39f3fa abort (/lib/x86_64-linux-gnu/libc.so.6+0x343fa)
#6 0x00007f48fb396e37 (/lib/x86_64-linux-gnu/libc.so.6+0x2be37)
#7 0x00007f48fb396ee2 (/lib/x86_64-linux-gnu/libc.so.6+0x2bee2)
#8 0x0000000001175b08 swift::Lowering::TypeConverter::getLoweredFormalTypes(swift::SILDeclRef, swift::CanTypeWrapper<swift::AnyFunctionType>) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0x1175b08)
#9 0x0000000001176f4f swift::Lowering::TypeConverter::getConstantInfo(swift::SILDeclRef) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0x1176f4f)
#10 0x0000000000c8b7bb (anonymous namespace)::Callee::forDirect(swift::Lowering::SILGenFunction&, swift::SILDeclRef, swift::SubstitutionMap, swift::SILLocation) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xc8b7bb)
#11 0x0000000000c953e4 swift::ASTVisitor<(anonymous namespace)::SILGenApply, void, void, void, void, void, void>::visit(swift::Expr*) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xc953e4)
#12 0x0000000000c97cda (anonymous namespace)::SILGenApply::visitApplyExpr(swift::ApplyExpr*) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xc97cda)
#13 0x0000000000c97cda (anonymous namespace)::SILGenApply::visitApplyExpr(swift::ApplyExpr*) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xc97cda)
#14 0x0000000000c87f71 swift::Lowering::SILGenFunction::emitApplyExpr(swift::Expr*, swift::Lowering::SGFContext) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xc87f71)
#15 0x0000000000c1ec07 swift::ASTVisitor<(anonymous namespace)::RValueEmitter, swift::Lowering::RValue, void, void, void, void, void, swift::Lowering::SGFContext>::visit(swift::Expr*, swift::Lowering::SGFContext) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xc1ec07)
#16 0x0000000000c153d8 swift::Lowering::SILGenFunction::emitIgnoredExpr(swift::Expr*) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xc153d8)
#17 0x0000000000c69740 swift::ASTVisitor<(anonymous namespace)::StmtEmitter, void, void, void, void, void, void>::visit(swift::Stmt*) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xc69740)
#18 0x0000000000c6950d swift::Lowering::SILGenFunction::emitStmt(swift::Stmt*) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xc6950d)
#19 0x0000000000c36615 swift::Lowering::SILGenFunction::emitFunction(swift::FuncDecl*) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xc36615)
#20 0x0000000000bdb183 swift::Lowering::SILGenModule::emitFunction(swift::FuncDecl*)::$_1::operator()(swift::SILFunction*) const (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xbdb183)
#21 0x0000000000bd2847 swift::Lowering::SILGenModule::emitFunction(swift::FuncDecl*) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xbd2847)
#22 0x0000000000c7534c swift::ASTVisitor<SILGenExtension, void, void, void, void, void, void>::visit(swift::Decl*) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xc7534c)
#23 0x0000000000c72f9b SILGenExtension::emitExtension(swift::ExtensionDecl*) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xc72f9b)
#24 0x0000000000c72f5d swift::Lowering::SILGenModule::visitExtensionDecl(swift::ExtensionDecl*) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xc72f5d)
#25 0x0000000000bd84fb swift::Lowering::SILGenModule::emitSourceFile(swift::SourceFile*, unsigned int) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xbd84fb)
#26 0x0000000000bd9166 swift::SILModule::constructSIL(swift::ModuleDecl*, swift::SILOptions&, swift::FileUnit*, llvm::Optional<unsigned int>, bool) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xbd9166)
#27 0x0000000000bd975d swift::performSILGeneration(swift::ModuleDecl*, swift::SILOptions&, bool) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0xbd975d)
#28 0x00000000004d14ff performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0x4d14ff)
#29 0x00000000004ccafa swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0x4ccafa)
#30 0x00000000004867a8 main (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0x4867a8)
#31 0x00007f48fb38b2b1 __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x202b1)
#32 0x00000000004849ca _start (/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift+0x4849ca)
Stack dump:
0.	Program arguments: /usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift -frontend -c -filelist /tmp/sources-b47d57 -supplementary-output-file-map /tmp/supplementaryOutputs-4c2059 -disable-objc-attr-requires-foundation-module -target x86_64-unknown-linux-gnu -disable-objc-interop -sdk / -I /usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/./lib/swift/linux/x86_64 -warn-swift3-objc-inference-complete -module-cache-path /usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/./module-cache -module-link-name swiftCore -nostdimport -parse-stdlib -resource-dir /usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/./lib/swift -swift-version 4 -O -enable-resilience -group-info-path /usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/GroupInfo.json -verify-syntax-tree -enable-sil-ownership -Xllvm -sil-inline-generics -Xllvm -sil-partial-specialization -Xcc -DswiftCore_EXPORTS -Xcc -D__SWIFT_CURRENT_DYLIB=swiftCore -parse-as-library -module-name Swift -o /usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/linux/x86_64/Swift.o 
1.	Contents of /tmp/sources-b47d57:
---
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Algorithm.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ArrayBody.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ArrayBuffer.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ArrayBufferProtocol.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ArrayCast.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Array.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ArrayShared.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ArraySlice.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ArrayType.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ASCII.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Assert.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/AssertCommon.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/BidirectionalCollection.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Bool.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/BridgeObjectiveC.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/BridgeStorage.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Builtin.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/BuiltinMath.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Character.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/CharacterUnicodeScalars.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/CocoaArray.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/Codable.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Collection.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/CollectionAlgorithms.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Comparable.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/CompilerProtocols.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ContiguousArray.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ClosedRange.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ContiguousArrayBuffer.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/CString.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/CTypes.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/DebuggerSupport.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Dictionary.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/DropWhile.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Dump.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/EmptyCollection.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Equatable.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ErrorType.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Filter.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/FixedArray.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/FlatMap.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Flatten.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/FloatingPoint.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/FloatingPointParsing.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/FloatingPointTypes.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Hashable.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/AnyHashable.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/HashedCollectionsAnyHashableExtensions.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Hasher.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Hashing.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/HeapBuffer.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ICU.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Indices.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/InputStream.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/IntegerParsing.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/Integers.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Join.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/KeyPath.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/LazyCollection.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/LazySequence.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/LifetimeManager.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ManagedBuffer.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Map.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/MemoryLayout.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/UnicodeScalar.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/Mirrors.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Misc.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/MutableCollection.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/NewtypeWrapper.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/NormalizedCodeUnitIterator.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ObjectIdentifier.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Optional.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/OptionSet.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/OutputStream.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Pointer.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Policy.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/PrefixWhile.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Print.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Random.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/RandomAccessCollection.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Range.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/RangeReplaceableCollection.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ReflectionMirror.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Repeat.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/REPL.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Reverse.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/Runtime.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/RuntimeFunctionCounters.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/SipHash.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Sequence.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/SequenceAlgorithms.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/SequenceWrapper.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Set.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/SetAlgebra.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ShadowProtocols.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Shims.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Slice.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/SmallString.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/Sort.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StaticString.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/Stride.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringHashable.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/String.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringBridge.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringComparable.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringComparison.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringGuts.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringGutsVisitor.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringObject.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringProtocol.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringIndex.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringInterpolation.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringLegacy.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringRangeReplaceableCollection.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringStorage.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringSwitch.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringIndexConversions.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringNormalization.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringUnicodeScalarView.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringUTF16.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringUTF8.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringVariant.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/Substring.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/SwiftNativeNSArray.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ThreadLocalStorage.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/UIntBuffer.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/UnavailableStringAPIs.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/UnicodeEncoding.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/UnicodeParser.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Unmanaged.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/UnmanagedOpaqueString.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/UnmanagedString.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/UnsafeBitMap.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/UnsafeBufferPointer.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/UnsafeRawBufferPointer.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/UnsafePointer.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/UnsafeRawPointer.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/UTFEncoding.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/UTF8.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/UTF16.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/UTF32.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Unicode.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/StringGraphemeBreaking.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/ValidUTF8Buffer.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/WriteBackMutableSlice.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/MigrationSupport.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Availability.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/CollectionOfOne.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/ExistentialCollection.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Mirror.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/PlaygroundDisplay.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/CommandLine.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/SliceBuffer.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/stdlib/public/core/8/Tuple.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/UnfoldSequence.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/VarArgs.swift
/usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Zip.swift
---
2.	While emitting SIL for 'next()' at /usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Algorithm.swift:146:19
3.	While silgen emitFunction SIL function "@$Ss18EnumeratedSequenceV8IteratorV4nextSi6offset_7ElementQz7elementtSgyF".
 for 'next()' at /usr/local/google/home/hongm/ssd_part/git/swift-master/swift/stdlib/public/core/Algorithm.swift:146:19
<unknown>:0: error: unable to execute command: Aborted
<unknown>:0: error: compile command failed due to signal 6 (use -v to see invocation)
ninja: build stopped: subcommand failed.
./utils/build-script: fatal error: command terminated with a non-zero exit status 1, aborting

```