### PR TITLE
[Type checker] Separate most `@objc` checking from the `TypeChecker` class.

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3973,7 +3973,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
       // Objective-C.
       Optional<ObjCReason> isObjC = shouldMarkAsObjC(*this, VD);
 
-      if (isObjC && !isRepresentableInObjC(VD, *isObjC))
+      if (isObjC && !swift::isRepresentableInObjC(VD, *isObjC))
         isObjC = None;
 
       markAsObjC(*this, VD, isObjC);
@@ -4580,7 +4580,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
       // member of an ObjC-compatible class or protocol.
       Optional<ObjCReason> isObjC = shouldMarkAsObjC(*this, SD);
 
-      if (isObjC && !isRepresentableInObjC(SD, *isObjC))
+      if (isObjC && !swift::isRepresentableInObjC(SD, *isObjC))
         isObjC = None;
       markAsObjC(*this, SD, isObjC);
 

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -928,24 +928,19 @@ static void checkObjCBridgingFunctions(ModuleDecl *mod,
   }
 }
 
-static void checkBridgedFunctions(TypeChecker &TC) {
-  if (TC.HasCheckedBridgeFunctions)
-    return;
-
-  TC.HasCheckedBridgeFunctions = true;
-
+void swift::checkBridgedFunctions(ASTContext &ctx) {
   #define BRIDGE_TYPE(BRIDGED_MOD, BRIDGED_TYPE, _, NATIVE_TYPE, OPT) \
-  Identifier ID_##BRIDGED_MOD = TC.Context.getIdentifier(#BRIDGED_MOD);\
-  if (ModuleDecl *module = TC.Context.getLoadedModule(ID_##BRIDGED_MOD)) {\
+  Identifier ID_##BRIDGED_MOD = ctx.getIdentifier(#BRIDGED_MOD);\
+  if (ModuleDecl *module = ctx.getLoadedModule(ID_##BRIDGED_MOD)) {\
     checkObjCBridgingFunctions(module, #BRIDGED_TYPE, \
     "_convert" #BRIDGED_TYPE "To" #NATIVE_TYPE, \
     "_convert" #NATIVE_TYPE "To" #BRIDGED_TYPE); \
   }
   #include "swift/SIL/BridgedTypes.def"
 
-  if (ModuleDecl *module = TC.Context.getLoadedModule(TC.Context.Id_Foundation)) {
+  if (ModuleDecl *module = ctx.getLoadedModule(ctx.Id_Foundation)) {
     checkObjCBridgingFunctions(module,
-                               TC.Context.getSwiftName(
+                               ctx.getSwiftName(
                                  KnownFoundationEntity::NSError),
                                "_convertNSErrorToError",
                                "_convertErrorToNSError");
@@ -1434,9 +1429,6 @@ void swift::markAsObjC(TypeChecker &TC, ValueDecl *D,
     attr->setInvalid();
   }
 
-  // Make sure we have the appropriate bridging operations.
-  if (!isa<DestructorDecl>(D))
-    checkBridgedFunctions(TC);
   TC.useObjectiveCBridgeableConformances(D->getInnermostDeclContext(),
                                          D->getInterfaceType());
 

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1418,7 +1418,7 @@ static bool recordOverride(TypeChecker &TC, ValueDecl *override,
   if ((base->getDeclContext()->isExtensionContext() ||
        override->getDeclContext()->isExtensionContext()) &&
       !base->isObjC() && !isKnownObjC) {
-    bool baseCanBeObjC = TC.canBeRepresentedInObjC(base);
+    bool baseCanBeObjC = canBeRepresentedInObjC(base);
     diags.diagnose(override, diag::override_decl_extension, baseCanBeObjC,
                    !base->getDeclContext()->isExtensionContext());
     if (baseCanBeObjC) {

--- a/lib/Sema/TypeCheckObjC.h
+++ b/lib/Sema/TypeCheckObjC.h
@@ -22,6 +22,7 @@
 
 namespace swift {
 
+class AbstractFunctionDecl;
 class ASTContext;
 class SubscriptDecl;
 class TypeChecker;
@@ -121,11 +122,20 @@ void markAsObjC(TypeChecker &TC, ValueDecl *D,
                 Optional<ObjCReason> isObjC,
                 Optional<ForeignErrorConvention> errorConvention = llvm::None);
 
+/// Determine whether the given function can be represented in Objective-C,
+/// and figure out its foreign error convention (if any).
+bool isRepresentableInObjC(const AbstractFunctionDecl *AFD,
+                           ObjCReason Reason,
+                           Optional<ForeignErrorConvention> &errorConvention);
+
 /// Determine whether the given variable can be represented in Objective-C.
 bool isRepresentableInObjC(const VarDecl *VD, ObjCReason Reason);
 
 /// Determine whether the given subscript can be represented in Objective-C.
 bool isRepresentableInObjC(const SubscriptDecl *SD, ObjCReason Reason);
+
+/// Check whether the given declaration can be represented in Objective-C.
+bool canBeRepresentedInObjC(const ValueDecl *decl);
 
 } // end namespace swift
 

--- a/lib/Sema/TypeCheckObjC.h
+++ b/lib/Sema/TypeCheckObjC.h
@@ -23,8 +23,10 @@
 namespace swift {
 
 class ASTContext;
+class SubscriptDecl;
 class TypeChecker;
 class ValueDecl;
+class VarDecl;
 
 using llvm::Optional;
 
@@ -118,6 +120,12 @@ Optional<ObjCReason> shouldMarkAsObjC(TypeChecker &TC,
 void markAsObjC(TypeChecker &TC, ValueDecl *D,
                 Optional<ObjCReason> isObjC,
                 Optional<ForeignErrorConvention> errorConvention = llvm::None);
+
+/// Determine whether the given variable can be represented in Objective-C.
+bool isRepresentableInObjC(const VarDecl *VD, ObjCReason Reason);
+
+/// Determine whether the given subscript can be represented in Objective-C.
+bool isRepresentableInObjC(const SubscriptDecl *SD, ObjCReason Reason);
 
 } // end namespace swift
 

--- a/lib/Sema/TypeCheckObjC.h
+++ b/lib/Sema/TypeCheckObjC.h
@@ -137,6 +137,11 @@ bool isRepresentableInObjC(const SubscriptDecl *SD, ObjCReason Reason);
 /// Check whether the given declaration can be represented in Objective-C.
 bool canBeRepresentedInObjC(const ValueDecl *decl);
 
+/// Check that specific, known bridging functions are fully type-checked.
+///
+/// NOTE: This is only here to support the --enable-source-import hack.
+void checkBridgedFunctions(ASTContext &ctx);
+
 } // end namespace swift
 
 #endif // SWIFT_SEMA_TYPE_CHECK_OBJC_H

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -17,6 +17,7 @@
 
 #include "swift/Subsystems.h"
 #include "TypeChecker.h"
+#include "TypeCheckObjC.h"
 #include "CodeSynthesis.h"
 #include "MiscDiagnostics.h"
 #include "GenericTypeResolver.h"
@@ -669,6 +670,10 @@ void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
         }
       }
     });
+
+    // Look for bridging functions. This only matters when
+    // -enable-source-import is provided.
+    checkBridgedFunctions(TC.Context);
 
     // Type check the top-level elements of the source file.
     bool hasTopLevelCode = false;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -799,9 +799,6 @@ private:
   /// The \c Swift.UnsafeMutablePointer<T> declaration.
   Optional<NominalTypeDecl *> ArrayDecl;
 
-  /// A set of types that can be mapped to C integer types.
-  llvm::DenseSet<CanType> CIntegerTypes;
-
   /// The set of expressions currently being analyzed for failures.
   llvm::DenseMap<Expr*, ExprAndConstraintSystem> DiagnosedExprs;
 
@@ -2188,7 +2185,6 @@ public:
   void resolveWitness(const NormalProtocolConformance *conformance,
                       ValueDecl *requirement) override;
 
-  bool isCIntegerType(const DeclContext *DC, Type T);
   bool isRepresentableInObjC(const AbstractFunctionDecl *AFD,
                              ObjCReason Reason,
                              Optional<ForeignErrorConvention> &errorConvention);
@@ -2196,8 +2192,6 @@ public:
   bool isRepresentableInObjC(const SubscriptDecl *SD, ObjCReason Reason);
 
   bool canBeRepresentedInObjC(const ValueDecl *decl);
-
-  void fillObjCRepresentableTypeCache(const DeclContext *DC);
 
   /// \name Resilience diagnostics
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -678,11 +678,6 @@ public:
   llvm::DenseMap<std::pair<ValueDecl*, ValueDecl*>, bool> 
     specializedOverloadComparisonCache;
   
-  // We delay validation of C and Objective-C type-bridging functions in the
-  // standard library until we encounter a declaration that requires one. This
-  // flag is set to 'true' once the bridge functions have been checked.
-  bool HasCheckedBridgeFunctions = false;
-
   /// A list of closures for the most recently type-checked function, which we
   /// will need to compute captures for.
   std::vector<AnyFunctionRef> ClosuresWithUncomputedCaptures;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -570,8 +570,6 @@ withoutContext(TypeResolutionOptions options, bool preserveSIL = false) {
   return options;
 }
 
-class ObjCReason;
-
 /// Flags that control protocol conformance checking.
 enum class ConformanceCheckFlags {
   /// Whether we're performing the check from within an expression.
@@ -790,7 +788,6 @@ private:
   Type Int8Type;
   Type UInt8Type;
   Type NSObjectType;
-  Type NSErrorType;
   Type NSNumberType;
   Type NSValueType;
   Type ObjCSelectorType;
@@ -951,7 +948,6 @@ public:
   Type getUInt8Type(DeclContext *dc);
   Type getMaxIntegerType(DeclContext *dc);
   Type getNSObjectType(DeclContext *dc);
-  Type getNSErrorType(DeclContext *dc);
   Type getObjCSelectorType(DeclContext *dc);
   Type getExceptionType(DeclContext *dc, SourceLoc loc);
   
@@ -2184,12 +2180,6 @@ public:
                           AssociatedTypeDecl *assocType) override;
   void resolveWitness(const NormalProtocolConformance *conformance,
                       ValueDecl *requirement) override;
-
-  bool isRepresentableInObjC(const AbstractFunctionDecl *AFD,
-                             ObjCReason Reason,
-                             Optional<ForeignErrorConvention> &errorConvention);
-
-  bool canBeRepresentedInObjC(const ValueDecl *decl);
 
   /// \name Resilience diagnostics
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -2188,8 +2188,6 @@ public:
   bool isRepresentableInObjC(const AbstractFunctionDecl *AFD,
                              ObjCReason Reason,
                              Optional<ForeignErrorConvention> &errorConvention);
-  bool isRepresentableInObjC(const VarDecl *VD, ObjCReason Reason);
-  bool isRepresentableInObjC(const SubscriptDecl *SD, ObjCReason Reason);
 
   bool canBeRepresentedInObjC(const ValueDecl *decl);
 

--- a/test/Parse/objc_enum.swift
+++ b/test/Parse/objc_enum.swift
@@ -16,7 +16,7 @@
   case Zim, Zang, Zung
 }
 
-@objc enum NonIntegerRawType: Float { // expected-error{{'@objc' enum raw type 'Float' is not an integer type}} expected-error {{'NonIntegerRawType' declares raw type 'Float', but does not conform to RawRepresentable and conformance could not be synthesized}}
+@objc enum NonIntegerRawType: Float { // expected-error{{'@objc' enum raw type 'Float' is not an integer type}}
   case Zim = 1.0, Zang = 1.5, Zung = 2.0
 }
 

--- a/test/decl/enum/objc_enum_multi_file.swift
+++ b/test/decl/enum/objc_enum_multi_file.swift
@@ -12,13 +12,13 @@
 }
 
 #elseif BAD_RAW_TYPE
-// BAD_RAW_TYPE: :[[@LINE+1]]:22: error: '@objc' enum raw type 'Array<Int>' is not an integer type
+// BAD_RAW_TYPE: :[[@LINE+1]]:12: error: '@objc' enum raw type 'Array<Int>' is not an integer type
 @objc enum TheEnum : Array<Int> {
   case A
 }
 
 #elseif NON_INT_RAW_TYPE
-// NON_INT_RAW_TYPE: :[[@LINE+1]]:22: error: '@objc' enum raw type 'Float' is not an integer type
+// NON_INT_RAW_TYPE: :[[@LINE+1]]:12: error: '@objc' enum raw type 'Float' is not an integer type
 @objc enum TheEnum : Float {
   case A = 0.0
 }


### PR DESCRIPTION
`@objc` checking is heavily tied into the `TypeChecker` class, but there are very few reasons why it should. Eliminate most of the dependencies on `TypeChecker`, cleaning up `@objc enum` raw type checking in the process.