### PR TITLE
[Emacs support] Fix the fix for latest emacs

### DIFF
--- a/utils/swift-project-settings.el
+++ b/utils/swift-project-settings.el
@@ -114,7 +114,7 @@
 ;; project settings yet.  For example, Swift files may come up in
 ;; Fundamental mode, and C++ files won't use the swift style, unless
 ;; we do something.  This hack causes the file to be re-mode-ed.
-(ignore-errors (set-auto-mode))
+(unless (eq major-mode 'dired-mode) (set-auto-mode))
 
 (defun swift-project-comment-end ()
   "If comment-end is non-empty returns it, stripped of leading whitespace.  Returns nil otherwise"


### PR DESCRIPTION
The previous fix was wrong.  `(set-auto-mode)` fails when we are in the middle of visiting the first dired buffer.