### PR TITLE
[SpaceEngine] Couple of minor improvements

### DIFF
--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -575,9 +575,7 @@ namespace {
             paramSpace.push_back(result);
           }
 
-          return Space::forConstructor(this->getType(), this->getHead(),
-                                       this->canDowngradeToWarning(),
-                                       paramSpace);
+          return Space::forDisjunct(paramSpace);
         }
 
         PAIRCASE (SpaceKind::UnknownCase, SpaceKind::Type):

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -607,7 +607,9 @@ namespace {
             paramSpace.push_back(result);
           }
 
-          return Space::forDisjunct(paramSpace);
+          return Space::forConstructor(this->getType(), this->getHead(),
+                                       this->canDowngradeToWarning(),
+                                       paramSpace);
         }
 
         PAIRCASE (SpaceKind::UnknownCase, SpaceKind::Type):

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -1187,6 +1187,7 @@ namespace {
             TC.diagnose(caseItem.getStartLoc(),
                           diag::redundant_particular_case)
               .highlight(caseItem.getSourceRange());
+            continue;
           } else {
             Expr *cachedExpr = nullptr;
             if (checkRedundantLiteral(caseItem.getPattern(), cachedExpr)) {
@@ -1197,6 +1198,7 @@ namespace {
               TC.diagnose(cachedExpr->getLoc(),
                           diag::redundant_particular_literal_case_here)
                 .highlight(cachedExpr->getSourceRange());
+              continue;
             }
           }
           spaces.push_back(projection);


### PR DESCRIPTION
* `Intersection` of two constructor spaces should produce a constructor space (not a disjunction);
* When it's detected that `switch` has redundant cases, don't include them into "covered" space to reduce some work done by exhaustiveness checker.
* Remove `isUseful` due to eager empty sub-space pruning

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->