### PR TITLE
Sema: Check availability of key path components [4.2]

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -6949,12 +6949,17 @@ static bool diagnoseKeyPathComponents(ConstraintSystem &CS, KeyPathExpr *KPE,
 
         // Drop non-property, non-type candidates.
         if (!isa<VarDecl>(result.getValueDecl()) &&
-            !isa<TypeDecl>(result.getValueDecl()))
+            !isa<TypeDecl>(result.getValueDecl()) &&
+            !isa<SubscriptDecl>(result.getValueDecl()))
           return false;
 
         return true;
       });
     }
+
+    // If all results were unavailable, fail.
+    if (!lookup)
+      break;
 
     // If we *still* have more than one result, fail.
     if (lookup.size() > 1) {

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2307,8 +2307,7 @@ public:
       }
     }
     if (auto KP = dyn_cast<KeyPathExpr>(E)) {
-      walkKeyPath(KP);
-      return skipChildren();
+      maybeDiagKeyPath(KP);
     }
     if (auto A = dyn_cast<AssignExpr>(E)) {
       walkAssignExpr(A);
@@ -2406,7 +2405,7 @@ private:
 
   /// Walk a keypath expression, checking all of its components for
   /// availability.
-  void walkKeyPath(KeyPathExpr *KP) {
+  void maybeDiagKeyPath(KeyPathExpr *KP) {
     for (auto &component : KP->getComponents()) {
       switch (component.getKind()) {
       case KeyPathExpr::Component::Kind::Property:

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2306,6 +2306,10 @@ public:
         maybeDiagStorageAccess(S->getDecl().getDecl(), S->getSourceRange(), DC);
       }
     }
+    if (auto KP = dyn_cast<KeyPathExpr>(E)) {
+      walkKeyPath(KP);
+      return skipChildren();
+    }
     if (auto A = dyn_cast<AssignExpr>(E)) {
       walkAssignExpr(A);
       return skipChildren();
@@ -2399,7 +2403,32 @@ private:
     // Diagnose for appropriate accessors, given the access context.
     maybeDiagStorageAccess(D, E->getSourceRange(), DC);
   }
-  
+
+  /// Walk a keypath expression, checking all of its components for
+  /// availability.
+  void walkKeyPath(KeyPathExpr *KP) {
+    for (auto &component : KP->getComponents()) {
+      switch (component.getKind()) {
+      case KeyPathExpr::Component::Kind::Property:
+      case KeyPathExpr::Component::Kind::Subscript: {
+        auto *decl = component.getDeclRef().getDecl();
+        auto loc = component.getLoc();
+        SourceRange range(loc, loc);
+        diagAvailability(decl, range, nullptr);
+        break;
+      }
+
+      case KeyPathExpr::Component::Kind::Invalid:
+      case KeyPathExpr::Component::Kind::UnresolvedProperty:
+      case KeyPathExpr::Component::Kind::UnresolvedSubscript:
+      case KeyPathExpr::Component::Kind::OptionalChain:
+      case KeyPathExpr::Component::Kind::OptionalWrap:
+      case KeyPathExpr::Component::Kind::OptionalForce:
+        break;
+      }
+    }
+  }
+
   /// Walk an inout expression, checking for availability.
   void walkInOutExpr(InOutExpr *E) {
     walkInContext(E, E->getSubExpr(), MemberAccessContext::InOut);

--- a/test/attr/attr_inlinable.swift
+++ b/test/attr/attr_inlinable.swift
@@ -251,3 +251,13 @@ public struct PublicFixedStructWithInit {
   var x = internalGlobal // expected-error {{let 'internalGlobal' is internal and cannot be referenced from a property initializer in a '@_fixed_layout' type}}
   var y = publicGlobal // OK
 }
+
+public struct KeypathStruct {
+  var x: Int
+  // expected-note@-1 {{var 'x' is not '@usableFromInline' or public}}
+
+  @inlinable public func usesKeypath() {
+    _ = \KeypathStruct.x
+    // expected-error@-1 {{var 'x' is internal and cannot be referenced from an '@inlinable' function}}
+  }
+}

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -44,6 +44,24 @@ struct C<T> {
   subscript<X>(noHashableConstraint sub: X) -> X { get { return sub } set { } }
 }
 
+struct Unavailable {
+  @available(*, unavailable)
+  var unavailableProperty: Int
+  // expected-note@-1 {{'unavailableProperty' has been explicitly marked unavailable here}}
+
+  @available(*, unavailable)
+  subscript(x: Sub) -> Int { get { } set { } }
+  // expected-note@-1 {{'subscript' has been explicitly marked unavailable here}}
+}
+
+struct Deprecated {
+  @available(*, deprecated)
+  var deprecatedProperty: Int
+
+  @available(*, deprecated)
+  subscript(x: Sub) -> Int { get { } set { } }
+}
+
 extension Array where Element == A {
   var property: Prop { fatalError() }
 }
@@ -178,6 +196,12 @@ func testKeyPath(sub: Sub, optSub: OptSub,
   let _ = \C<Int>.[sub]
   let _ = \C<Int>.[noHashableConstraint: sub]
   let _ = \C<Int>.[noHashableConstraint: nonHashableSub] // expected-error{{subscript index of type 'NonHashableSub' in a key path must be Hashable}}
+
+  let _ = \Unavailable.unavailableProperty // expected-error {{'unavailableProperty' is unavailable}}
+  let _ = \Unavailable.[sub] // expected-error {{'subscript' is unavailable}}
+
+  let _ = \Deprecated.deprecatedProperty // expected-warning {{'deprecatedProperty' is deprecated}}
+  let _ = \Deprecated.[sub] // expected-warning {{'subscript' is deprecated}}
 }
 
 func testKeyPathInGenericContext<H: Hashable, X>(hashable: H, anything: X) {

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -495,6 +495,33 @@ func testImplicitConversionInSubscriptIndex() {
   _ = \BassSubscript.["hello"] // expected-error{{must be Hashable}}
 }
 
+// Crash in diagnostics
+struct AmbiguousSubscript {
+  subscript(sub: Sub) -> Int { get { } set { } }
+  // expected-note@-1 {{'subscript' declared here}}
+
+  subscript(y y: Sub) -> Int { get { } set { } }
+  // expected-note@-1 {{'subscript(y:)' declared here}}
+}
+
+func useAmbiguousSubscript(_ sub: Sub) {
+  let _: PartialKeyPath<AmbiguousSubscript> = \.[sub]
+  // expected-error@-1 {{ambiguous reference to member 'subscript'}}
+}
+
+struct BothUnavailableSubscript {
+  @available(*, unavailable)
+  subscript(sub: Sub) -> Int { get { } set { } }
+
+  @available(*, unavailable)
+  subscript(y y: Sub) -> Int { get { } set { } }
+}
+
+func useBothUnavailableSubscript(_ sub: Sub) {
+  let _: PartialKeyPath<BothUnavailableSubscript> = \.[sub]
+  // expected-error@-1 {{type of expression is ambiguous without more context}}
+}
+
 // SR-6106
 func sr6106() {
   class B {}

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -62,6 +62,11 @@ struct Deprecated {
   subscript(x: Sub) -> Int { get { } set { } }
 }
 
+@available(*, deprecated)
+func getDeprecatedSub() -> Sub {
+  return Sub()
+}
+
 extension Array where Element == A {
   var property: Prop { fatalError() }
 }
@@ -202,6 +207,8 @@ func testKeyPath(sub: Sub, optSub: OptSub,
 
   let _ = \Deprecated.deprecatedProperty // expected-warning {{'deprecatedProperty' is deprecated}}
   let _ = \Deprecated.[sub] // expected-warning {{'subscript' is deprecated}}
+
+  let _ = \A.[getDeprecatedSub()] // expected-warning {{'getDeprecatedSub()' is deprecated}}
 }
 
 func testKeyPathInGenericContext<H: Hashable, X>(hashable: H, anything: X) {


### PR DESCRIPTION
* Description: We weren't checking availability for keypath components. This could result in runtime crashes if you reference selectors that don't exist  yet, or linker errors if you reference private things from an inlinable function body.

* Origination: This was an issue ever since keypaths were introduced in Swift 4.0.

* Tested: New tests added.

* Risk: Pretty low, because the availability checking code itself is well-exercised. The main risk is source compatibility issues, but impacted code was not completely valid in the first place anyway.

* Bugs: Fixes <https://bugs.swift.org/browse/SR-7406> / <rdar://problem/39319212>.

* Reviewed by: @jckarter 