### PR TITLE
Sema: Fix some keypath diagnostic crashers

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -7131,12 +7131,17 @@ static bool diagnoseKeyPathComponents(ConstraintSystem &CS, KeyPathExpr *KPE,
 
         // Drop non-property, non-type candidates.
         if (!isa<VarDecl>(result.getValueDecl()) &&
-            !isa<TypeDecl>(result.getValueDecl()))
+            !isa<TypeDecl>(result.getValueDecl()) &&
+            !isa<SubscriptDecl>(result.getValueDecl()))
           return false;
 
         return true;
       });
     }
+
+    // If all results were unavailable, fail.
+    if (!lookup)
+      break;
 
     // If we *still* have more than one result, fail.
     if (lookup.size() > 1) {

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -495,6 +495,33 @@ func testImplicitConversionInSubscriptIndex() {
   _ = \BassSubscript.["hello"] // expected-error{{must be Hashable}}
 }
 
+// Crash in diagnostics
+struct AmbiguousSubscript {
+  subscript(sub: Sub) -> Int { get { } set { } }
+  // expected-note@-1 {{'subscript' declared here}}
+
+  subscript(y y: Sub) -> Int { get { } set { } }
+  // expected-note@-1 {{'subscript(y:)' declared here}}
+}
+
+func useAmbiguousSubscript(_ sub: Sub) {
+  let _: PartialKeyPath<AmbiguousSubscript> = \.[sub]
+  // expected-error@-1 {{ambiguous reference to member 'subscript'}}
+}
+
+struct BothUnavailableSubscript {
+  @available(*, unavailable)
+  subscript(sub: Sub) -> Int { get { } set { } }
+
+  @available(*, unavailable)
+  subscript(y y: Sub) -> Int { get { } set { } }
+}
+
+func useBothUnavailableSubscript(_ sub: Sub) {
+  let _: PartialKeyPath<BothUnavailableSubscript> = \.[sub]
+  // expected-error@-1 {{type of expression is ambiguous without more context}}
+}
+
 // SR-6106
 func sr6106() {
   class B {}


### PR DESCRIPTION
We would crash in these cases:

- If all lookup results were subscripts
- If all results were unavailable