### PR TITLE
SIL: Fix regression with unowned capture of generic parameter

### DIFF
--- a/test/SILGen/unowned.swift
+++ b/test/SILGen/unowned.swift
@@ -159,3 +159,12 @@ struct Unowned<T: AnyObject> {
 }
 func takesUnownedStruct(_ z: Unowned<C>) {}
 // CHECK-LABEL: sil hidden @$S7unowned18takesUnownedStructyyAA0C0VyAA1CCGF : $@convention(thin) (@guaranteed Unowned<C>) -> ()
+
+// Make sure we don't crash here
+struct UnownedGenericCapture<T : AnyObject> {
+  var object: T
+
+  func f() -> () -> () {
+    return { [unowned object] in _ = object }
+  }
+}


### PR DESCRIPTION
This fixes a regression from https://github.com/apple/swift/pull/16237.