### PR TITLE
Fixed a bug in TFFunctionPartition::markBlock() when handling a loop.

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -1038,8 +1038,9 @@ void TFFunctionPartition::markBlock(SILBasicBlock *BB) {
       // `thisBB`, processed via `worklist`} would form a cycle, with no "escape
       // edges" to some exit block (e.g. the block containing tensor end
       // point). That would not be a valid CFG.
-      // This is a case where BB is control-dependent on itself,
-      // and we need to mark its term inst (a cond_br).
+      // When `BB` and `pred` are the same block, we know the tensor ops in the
+      // block are control-dependent on the term inst of the block (a cond_br),
+      // so we need to mark that term inst.
       // Example CFG: bb0 -> bb1 -> {bb2, bb3}; bb2 -> bb1
       // Here bb1 is the loop header, bb2 the loop body.
       // `BB` and `pred` can both be bb1, with `thisBB` being bb2.

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -1014,10 +1014,8 @@ void TFFunctionPartition::markBlock(SILBasicBlock *BB) {
       // In those cases, continue walking `pred` if we haven't processed it,
       // since it may be control-dependent on something.
       if (tensorCodeBlocks.properlyPostDominates(BB, pred)) {
-        if (!addedToList.count(pred)) {
+        if (addedToList.insert(pred).second)
           worklist.push_back(pred);
-          addedToList.insert(pred);
-        }
         continue;
       }
 

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -607,7 +607,8 @@ public final class _TensorComputation {
   /// The thread to run tensor computation in. The global config flag
   /// '_RuntimeConfig.usesSynchronousExecution' decides whether tensor
   /// computation should be synchronous: if true, this property will always be
-  /// nil.
+  /// nil. Otherwise, this property is non-nil only when the tensor computation
+  /// is on-going.
   private var pthread: pthread_t?
 
   /// Loads the TF program from a binary TF FunctionDef proto given by
@@ -764,6 +765,13 @@ public extension _TensorComputation {
       let joinStatus = pthread_join(pthread, nil)
       internalConsistencyCheck(joinStatus == 0)
       self.pthread = nil
+    } else {
+      internalConsistencyCheck(
+        _RuntimeConfig.usesSynchronousExecution,
+        """
+          finish() is called in async execution mode with pthread == nil -- \
+          Was finish() already called?
+          """)
     }
     debugLog("Done executing TF graph.")
 

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -770,8 +770,7 @@ public extension _TensorComputation {
         _RuntimeConfig.usesSynchronousExecution,
         """
           finish() is called in async execution mode with pthread == nil -- \
-          Was finish() already called?
-          """)
+          Was finish() already called?""")
     }
     debugLog("Done executing TF graph.")
 

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -767,10 +767,10 @@ public extension _TensorComputation {
       self.pthread = nil
     } else {
       internalConsistencyCheck(
-        _RuntimeConfig.usesSynchronousExecution,
-        """
+        _RuntimeConfig.usesSynchronousExecution, """
           finish() is called in async execution mode with pthread == nil -- \
-          Was finish() already called?""")
+          Was finish() already called?
+          """)
     }
     debugLog("Done executing TF graph.")
 

--- a/test/TensorFlowRuntime/loops.swift
+++ b/test/TensorFlowRuntime/loops.swift
@@ -66,6 +66,16 @@ LoopsTests.testAllBackends("SR8164") {
   SR8164(count: 70, expectedVal: 70)
 }
 
+LoopsTests.testAllBackends("SR-8191") {
+  let t = Tensor<Float>(1.0)
+  var i = 0
+  repeat {
+    let y = t + t
+    print(y)
+    i += 1
+  } while i < 10
+}
+
 // FIXME: Compiler bug (b/73607740)
 // error: internal error generating TensorFlow graph:
 // GraphGen cannot lower a 'send' to the host yet


### PR DESCRIPTION
The is an "off-by-1" error -- we need to check if `BB` **properly** post-dominates `pred`, instead of mere post-dominance, since `BB` and `pred` can be the same block, as in the test case, where the CFG is: 
```
bb0 -> bb1 -> {bb2, bb3}; bb2 -> bb1
```
Here bb1 is the loop header, bb2 the loop body.

In this case, when we run `markBlock()` over bb1, we first find bb2,
post-dominated by bb1. We then walk bb2 (pushing it to `worklist`), where we find
bb1 as its predecessor -- in that case we must mark the term inst of bb1 (a
cond_br), because all tensor ops in bb1 are control-dependent on that term inst. This way, the loop count variable gets promoted to tensor.

The comment blocks in the code and added test cases provide more context.
Resolves #50723.

Additional misc changes:
1. Renamed `visited` to `addedToList` to better reflect its semantics, and
moved around sanity check code on `numTensorSuccs` to make it clear that the
core marking logic does not depend on it.

2. Added more sanity-checking to compiler runtime, to catch incorrect code generation by the compiler like the case at hand. e.g. if `@_swift_tfc_StartTensorComputation()` is called more than once on a tensor computation handle, the runtime will crash with an error message like:
```
Fatal error: finish() is called in async execution mode with pthread == nil -- Was finish() already called?: file /usr/local/google/home/hongm/ssd_part/git/swift-base/swift/stdlib/public/TensorFlow/CompilerRuntime.swift, line 768
```