### PR TITLE
[AST] Choose an implied conformance source next to the type, if possible.

### DIFF
--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -661,6 +661,19 @@ ConformanceLookupTable::Ordering ConformanceLookupTable::compareConformances(
              : Ordering::After;
   }
 
+  // If one of the conformances comes from the same file as the type
+  // declaration, pick that one; this is so that conformance synthesis works if
+  // there's any implied conformance in the same file as the type.
+  auto NTD =
+      lhs->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
+  auto typeSF = NTD->getParentSourceFile();
+  if (typeSF) {
+    if (typeSF == lhsSF)
+      return Ordering::Before;
+    if (typeSF == rhsSF)
+      return Ordering::After;
+  }
+
   // Otherwise, pick the earlier file unit.
   auto lhsFileUnit
     = dyn_cast<FileUnit>(lhs->getDeclContext()->getModuleScopeContext());

--- a/test/Sema/Inputs/enum_conformance_synthesis_other.swift
+++ b/test/Sema/Inputs/enum_conformance_synthesis_other.swift
@@ -23,3 +23,9 @@ enum GenericOtherFileNonconforming<T> {
 // expected-note@-1 {{type declared here}}
     case A(T)
 }
+
+protocol ImplierOther: Equatable {}
+extension ImpliedMain: ImplierMain {}
+enum ImpliedOther: ImplierOther {
+    case a(Int)
+}

--- a/test/Sema/Inputs/struct_equatable_hashable_other.swift
+++ b/test/Sema/Inputs/struct_equatable_hashable_other.swift
@@ -22,3 +22,7 @@ struct GenericOtherFileNonconforming<T> {
 // expected-note@-1{{type declared here}}
     let v: T
 }
+
+protocol ImplierOther: Equatable {}
+extension ImpliedMain: ImplierOther {}
+struct ImpliedOther: ImplierOther {}

--- a/test/Sema/enum_conformance_synthesis.swift
+++ b/test/Sema/enum_conformance_synthesis.swift
@@ -314,6 +314,18 @@ extension UnusedGenericDeriveExtension: Hashable {}
 extension GenericOtherFileNonconforming: Equatable where T: Equatable {}
 // expected-error@-1{{implementation of 'Equatable' cannot be automatically synthesized in an extension in a different file to the type}}
 
+// rdar://problem/41852654
+
+// There is a conformance to Equatable (or at least, one that implies Equatable)
+// in the same file as the type, so the synthesis is okay. Both orderings are
+// tested, to catch choosing extensions based on the order of the files, etc.
+protocol ImplierMain: Equatable {}
+enum ImpliedMain: ImplierMain {
+  case a(Int)
+}
+extension ImpliedOther: ImplierMain {}
+
+
 // FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected error produced: invalid redeclaration of 'hashValue'
 // <unknown>:0: error: unexpected note produced: candidate has non-matching type '(Foo, Foo) -> Bool'

--- a/test/Sema/enum_conformance_synthesis.swift
+++ b/test/Sema/enum_conformance_synthesis.swift
@@ -1,6 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-// RUN: %target-swift-frontend -typecheck -verify -primary-file %t/main.swift %S/Inputs/enum_conformance_synthesis_other.swift -verify-ignore-unknown -swift-version 4
+// RUN: %target-swift-frontend -typecheck -verify -primary-file %s %S/Inputs/enum_conformance_synthesis_other.swift -verify-ignore-unknown -swift-version 4
 
 var hasher = Hasher()
 
@@ -8,12 +6,14 @@ enum Foo: CaseIterable {
   case A, B
 }
 
-if Foo.A == .B { }
-var aHash: Int = Foo.A.hashValue
-Foo.A.hash(into: &hasher)
-_ = Foo.allCases
+func foo() {
+  if Foo.A == .B { }
+  var _: Int = Foo.A.hashValue
+  Foo.A.hash(into: &hasher)
+  _ = Foo.allCases
 
-Foo.A == Foo.B // expected-warning {{result of operator '==' is unused}}
+  Foo.A == Foo.B // expected-warning {{result of operator '==' is unused}}
+}
 
 enum Generic<T>: CaseIterable {
   case A, B
@@ -25,10 +25,12 @@ enum Generic<T>: CaseIterable {
   }
 }
 
-if Generic<Foo>.A == .B { }
-var gaHash: Int = Generic<Foo>.A.hashValue
-Generic<Foo>.A.hash(into: &hasher)
-_ = Generic<Foo>.allCases
+func generic() {
+  if Generic<Foo>.A == .B { }
+  var _: Int = Generic<Foo>.A.hashValue
+  Generic<Foo>.A.hash(into: &hasher)
+  _ = Generic<Foo>.allCases
+}
 
 func localEnum() -> Bool {
   enum Local {
@@ -47,9 +49,11 @@ func ==(x: CustomHashable, y: CustomHashable) -> Bool { // expected-note 5 {{non
   return true
 }
 
-if CustomHashable.A == .B { }
-var custHash: Int = CustomHashable.A.hashValue
-CustomHashable.A.hash(into: &hasher)
+func customHashable() {
+  if CustomHashable.A == .B { }
+  var _: Int = CustomHashable.A.hashValue
+  CustomHashable.A.hash(into: &hasher)
+}
 
 // We still synthesize conforming overloads of '==' and 'hashValue' if
 // explicit definitions don't satisfy the protocol requirements. Probably
@@ -62,11 +66,14 @@ enum InvalidCustomHashable {
 func ==(x: InvalidCustomHashable, y: InvalidCustomHashable) -> String { // expected-note 5 {{non-matching type}}
   return ""
 }
-if InvalidCustomHashable.A == .B { }
-var s: String = InvalidCustomHashable.A == .B
-s = InvalidCustomHashable.A.hashValue
-var i: Int = InvalidCustomHashable.A.hashValue
-InvalidCustomHashable.A.hash(into: &hasher)
+func invalidCustomHashable() {
+  if InvalidCustomHashable.A == .B { }
+  var s: String = InvalidCustomHashable.A == .B
+  s = InvalidCustomHashable.A.hashValue
+  _ = s
+  var _: Int = InvalidCustomHashable.A.hashValue
+  InvalidCustomHashable.A.hash(into: &hasher)
+}
 
 // Check use of an enum's synthesized members before the enum is actually declared.
 struct UseEnumBeforeDeclaration {
@@ -77,16 +84,19 @@ enum EnumToUseBeforeDeclaration {
   case A
 }
 
-// Check enums from another file in the same module.
-if FromOtherFile.A == .A {}
-let _: Int = FromOtherFile.A.hashValue
-
 func getFromOtherFile() -> AlsoFromOtherFile { return .A }
-if .A == getFromOtherFile() {}
-
 func overloadFromOtherFile() -> YetAnotherFromOtherFile { return .A }
 func overloadFromOtherFile() -> Bool { return false }
-if .A == overloadFromOtherFile() {}
+
+func useEnumBeforeDeclaration() {
+  // Check enums from another file in the same module.
+  if FromOtherFile.A == .A {}
+  let _: Int = FromOtherFile.A.hashValue
+
+  if .A == getFromOtherFile() {}
+
+  if .A == overloadFromOtherFile() {}
+}
 
 // Complex enums are not automatically Equatable, Hashable, or CaseIterable.
 enum Complex {
@@ -94,8 +104,10 @@ enum Complex {
   case B
 }
 
-if Complex.A(1) == .B { } // expected-error{{binary operator '==' cannot be applied to operands of type 'Complex' and '_'}}
-// expected-note @-1 {{overloads for '==' exist with these partially matching parameter lists: }}
+func complex() {
+  if Complex.A(1) == .B { } // expected-error{{binary operator '==' cannot be applied to operands of type 'Complex' and '_'}}
+  // expected-note @-1 {{overloads for '==' exist with these partially matching parameter lists: }}
+}
 
 // Enums with equatable payloads are equatable if they explicitly conform.
 enum EnumWithEquatablePayload: Equatable {
@@ -104,9 +116,11 @@ enum EnumWithEquatablePayload: Equatable {
   case C
 }
 
-if EnumWithEquatablePayload.A(1) == .B("x", 1) { }
-if EnumWithEquatablePayload.A(1) == .C { }
-if EnumWithEquatablePayload.B("x", 1) == .C { }
+func enumWithEquatablePayload() {
+  if EnumWithEquatablePayload.A(1) == .B("x", 1) { }
+  if EnumWithEquatablePayload.A(1) == .C { }
+  if EnumWithEquatablePayload.B("x", 1) == .C { }
+}
 
 // Enums with hashable payloads are hashable if they explicitly conform.
 enum EnumWithHashablePayload: Hashable {
@@ -115,18 +129,20 @@ enum EnumWithHashablePayload: Hashable {
   case C
 }
 
-_ = EnumWithHashablePayload.A(1).hashValue
-_ = EnumWithHashablePayload.B("x", 1).hashValue
-_ = EnumWithHashablePayload.C.hashValue
+func enumWithHashablePayload() {
+  _ = EnumWithHashablePayload.A(1).hashValue
+  _ = EnumWithHashablePayload.B("x", 1).hashValue
+  _ = EnumWithHashablePayload.C.hashValue
 
-EnumWithHashablePayload.A(1).hash(into: &hasher)
-EnumWithHashablePayload.B("x", 1).hash(into: &hasher)
-EnumWithHashablePayload.C.hash(into: &hasher)
+  EnumWithHashablePayload.A(1).hash(into: &hasher)
+  EnumWithHashablePayload.B("x", 1).hash(into: &hasher)
+  EnumWithHashablePayload.C.hash(into: &hasher)
 
-// ...and they should also inherit equatability from Hashable.
-if EnumWithHashablePayload.A(1) == .B("x", 1) { }
-if EnumWithHashablePayload.A(1) == .C { }
-if EnumWithHashablePayload.B("x", 1) == .C { }
+  // ...and they should also inherit equatability from Hashable.
+  if EnumWithHashablePayload.A(1) == .B("x", 1) { }
+  if EnumWithHashablePayload.A(1) == .C { }
+  if EnumWithHashablePayload.B("x", 1) == .C { }
+}
 
 // Enums with non-hashable payloads don't derive conformance.
 struct NotHashable {}
@@ -140,8 +156,10 @@ enum GenericHashable<T: Hashable>: Hashable {
   case A(T)
   case B
 }
-if GenericHashable<String>.A("a") == .B { }
-var genericHashableHash: Int = GenericHashable<String>.A("a").hashValue
+func genericHashable() {
+  if GenericHashable<String>.A("a") == .B { }
+  var _: Int = GenericHashable<String>.A("a").hashValue
+}
 
 // But it should be an error if the generic argument doesn't have the necessary
 // constraints to satisfy the conditions for derivation.
@@ -149,9 +167,11 @@ enum GenericNotHashable<T: Equatable>: Hashable { // expected-error 2 {{does not
   case A(T)
   case B
 }
-if GenericNotHashable<String>.A("a") == .B { }
-let _: Int = GenericNotHashable<String>.A("a").hashValue // No error. hashValue is always synthesized, even if Hashable derivation fails
-GenericNotHashable<String>.A("a").hash(into: &hasher) // expected-error {{value of type 'GenericNotHashable<String>' has no member 'hash'}}
+func genericNotHashable() {
+  if GenericNotHashable<String>.A("a") == .B { }
+  let _: Int = GenericNotHashable<String>.A("a").hashValue // No error. hashValue is always synthesized, even if Hashable derivation fails
+  GenericNotHashable<String>.A("a").hash(into: &hasher) // expected-error {{value of type 'GenericNotHashable<String>' has no member 'hash'}}
+}
 
 // An enum with no cases should not derive conformance.
 enum NoCases: Hashable {} // expected-error 2 {{does not conform}}
@@ -193,13 +213,17 @@ public enum Medicine {
 
 extension Medicine : Equatable {}
 
-public func ==(lhs: Medicine, rhs: Medicine) -> Bool { // expected-note 4 {{non-matching type}}
+public func ==(lhs: Medicine, rhs: Medicine) -> Bool { // expected-note 5 {{non-matching type}}
   return true
 }
 
 // No explicit conformance; but it can be derived, for the same-file cases.
-extension Complex : Hashable {}
-extension Complex : CaseIterable {}  // expected-error {{type 'Complex' does not conform to protocol 'CaseIterable'}}
+enum Complex2 {
+  case A(Int)
+  case B
+}
+extension Complex2 : Hashable {}
+extension Complex2 : CaseIterable {}  // expected-error {{type 'Complex2' does not conform to protocol 'CaseIterable'}}
 extension FromOtherFile: CaseIterable {} // expected-error {{cannot be automatically synthesized in an extension in a different file to the type}} expected-error {{does not conform to protocol 'CaseIterable'}}
 
 // No explicit conformance and it cannot be derived.
@@ -212,7 +236,7 @@ extension NotExplicitlyHashableAndCannotDerive : CaseIterable {} // expected-err
 // Verify that conformance (albeit manually implemented) can still be added to
 // a type in a different file.
 extension OtherFileNonconforming: Hashable {
-  static func ==(lhs: OtherFileNonconforming, rhs: OtherFileNonconforming) -> Bool { // expected-note 4 {{non-matching type}}
+  static func ==(lhs: OtherFileNonconforming, rhs: OtherFileNonconforming) -> Bool { // expected-note 5 {{non-matching type}}
     return true
   }
   var hashValue: Int { return 0 }

--- a/test/Sema/struct_equatable_hashable.swift
+++ b/test/Sema/struct_equatable_hashable.swift
@@ -1,6 +1,4 @@
-// RUN: %empty-directory(%t)
-// RUN: cp %s %t/main.swift
-// RUN: %target-swift-frontend -typecheck -verify -primary-file %t/main.swift %S/Inputs/struct_equatable_hashable_other.swift -verify-ignore-unknown -swift-version 4
+// RUN: %target-swift-frontend -typecheck -verify -primary-file %s %S/Inputs/struct_equatable_hashable_other.swift -verify-ignore-unknown -swift-version 4
 
 var hasher = Hasher()
 
@@ -9,11 +7,13 @@ struct Point: Hashable {
   let y: Int
 }
 
-if Point(x: 1, y: 2) == Point(x: 2, y: 1) { }
-let pointHash: Int = Point(x: 3, y: 5).hashValue
-Point(x: 3, y: 5).hash(into: &hasher)
+func point() {
+  if Point(x: 1, y: 2) == Point(x: 2, y: 1) { }
+  let _: Int = Point(x: 3, y: 5).hashValue
+  Point(x: 3, y: 5).hash(into: &hasher)
 
-Point(x: 1, y: 2) == Point(x: 2, y: 1) // expected-warning {{result of operator '==' is unused}}
+  Point(x: 1, y: 2) == Point(x: 2, y: 1) // expected-warning {{result of operator '==' is unused}}
+}
 
 struct Pair<T: Hashable>: Hashable {
   let first: T
@@ -24,11 +24,13 @@ struct Pair<T: Hashable>: Hashable {
   }
 }
 
-let p1 = Pair(first: "a", second: "b")
-let p2 = Pair(first: "a", second: "c")
-if p1 == p2 { }
-let _: Int = p1.hashValue
-p1.hash(into: &hasher)
+func pair() {
+  let p1 = Pair(first: "a", second: "b")
+  let p2 = Pair(first: "a", second: "c")
+  if p1 == p2 { }
+  let _: Int = p1.hashValue
+  p1.hash(into: &hasher)
+}
 
 func localStruct() -> Bool {
   struct Local: Equatable {
@@ -51,9 +53,11 @@ struct CustomHashValue: Hashable {
   static func ==(x: CustomHashValue, y: CustomHashValue) -> Bool { return true } // expected-note 3 {{non-matching type}}
 }
 
-if CustomHashValue(x: 1, y: 2) == CustomHashValue(x: 2, y: 3) { }
-let _: Int = CustomHashValue(x: 1, y: 2).hashValue
-CustomHashValue(x: 1, y: 2).hash(into: &hasher)
+func customHashValue() {
+  if CustomHashValue(x: 1, y: 2) == CustomHashValue(x: 2, y: 3) { }
+  let _: Int = CustomHashValue(x: 1, y: 2).hashValue
+  CustomHashValue(x: 1, y: 2).hash(into: &hasher)
+}
 
 
 //------------------------------------------------------------------------------
@@ -71,10 +75,11 @@ struct CustomHashInto: Hashable {
   static func ==(x: CustomHashInto, y: CustomHashInto) -> Bool { return true } // expected-note 3 {{non-matching type}}
 }
 
-if CustomHashInto(x: 1, y: 2) == CustomHashInto(x: 2, y: 3) { }
-let _: Int = CustomHashInto(x: 1, y: 2).hashValue
-CustomHashInto(x: 1, y: 2).hash(into: &hasher)
-
+func customHashInto() {
+  if CustomHashInto(x: 1, y: 2) == CustomHashInto(x: 2, y: 3) { }
+  let _: Int = CustomHashInto(x: 1, y: 2).hashValue
+  CustomHashInto(x: 1, y: 2).hash(into: &hasher)
+}
 
 // Check use of an struct's synthesized members before the struct is actually declared.
 struct UseStructBeforeDeclaration {
@@ -86,17 +91,20 @@ struct StructToUseBeforeDeclaration: Hashable {
   let v: Int
 }
 
-// Check structs from another file in the same module.
-if FromOtherFile(v: "a") == FromOtherFile(v: "b") {}
-let _: Int = FromOtherFile(v: "c").hashValue
-FromOtherFile(v: "d").hash(into: &hasher)
-
 func getFromOtherFile() -> AlsoFromOtherFile { return AlsoFromOtherFile(v: 4) }
-if AlsoFromOtherFile(v: 3) == getFromOtherFile() {}
-
 func overloadFromOtherFile() -> YetAnotherFromOtherFile { return YetAnotherFromOtherFile(v: 1.2) }
 func overloadFromOtherFile() -> Bool { return false }
-if YetAnotherFromOtherFile(v: 1.9) == overloadFromOtherFile() {}
+
+func useStructBeforeDeclaration() {
+  // Check structs from another file in the same module.
+  if FromOtherFile(v: "a") == FromOtherFile(v: "b") {}
+  let _: Int = FromOtherFile(v: "c").hashValue
+  FromOtherFile(v: "d").hash(into: &hasher)
+
+  if AlsoFromOtherFile(v: 3) == getFromOtherFile() {}
+
+  if YetAnotherFromOtherFile(v: 1.9) == overloadFromOtherFile() {}
+}
 
 
 // Even if the struct has only equatable/hashable members, it's not synthesized
@@ -106,9 +114,10 @@ struct StructWithoutExplicitConformance {
   let b: String
 }
 
-if StructWithoutExplicitConformance(a: 1, b: "b") == StructWithoutExplicitConformance(a: 2, b: "a") { } // expected-error{{binary operator '==' cannot be applied to two 'StructWithoutExplicitConformance' operands}}
-// expected-note @-1 {{overloads for '==' exist with these partially matching parameter lists: }}
-
+func structWithoutExplicitConformance() {
+  if StructWithoutExplicitConformance(a: 1, b: "b") == StructWithoutExplicitConformance(a: 2, b: "a") { } // expected-error{{binary operator '==' cannot be applied to two 'StructWithoutExplicitConformance' operands}}
+  // expected-note @-1 {{overloads for '==' exist with these partially matching parameter lists: }}
+}
 
 // Structs with non-hashable/equatable stored properties don't derive conformance.
 struct NotHashable {}
@@ -123,29 +132,34 @@ struct StructIgnoresComputedProperties: Hashable {
   static var staticComputed = NotHashable()
   var computed: NotHashable { return NotHashable() }
 }
-if StructIgnoresComputedProperties(a: 1, b: "a") == StructIgnoresComputedProperties(a: 2, b: "c") {}
-let _: Int = StructIgnoresComputedProperties(a: 3, b: "p").hashValue
-StructIgnoresComputedProperties(a: 4, b: "q").hash(into: &hasher)
+func structIgnoresComputedProperties() {
+  if StructIgnoresComputedProperties(a: 1, b: "a") == StructIgnoresComputedProperties(a: 2, b: "c") {}
+  let _: Int = StructIgnoresComputedProperties(a: 3, b: "p").hashValue
+  StructIgnoresComputedProperties(a: 4, b: "q").hash(into: &hasher)
+}
 
 // Structs should be able to derive conformances based on the conformances of
 // their generic arguments.
 struct GenericHashable<T: Hashable>: Hashable {
   let value: T
 }
-if GenericHashable<String>(value: "a") == GenericHashable<String>(value: "b") { }
-let _: Int = GenericHashable<String>(value: "c").hashValue
-GenericHashable<String>(value: "c").hash(into: &hasher)
+func genericHashable() {
+  if GenericHashable<String>(value: "a") == GenericHashable<String>(value: "b") { }
+  let _: Int = GenericHashable<String>(value: "c").hashValue
+  GenericHashable<String>(value: "c").hash(into: &hasher)
+}
 
 // But it should be an error if the generic argument doesn't have the necessary
 // constraints to satisfy the conditions for derivation.
 struct GenericNotHashable<T: Equatable>: Hashable { // expected-error 2 {{does not conform to protocol 'Hashable'}}
   let value: T
 }
-if GenericNotHashable<String>(value: "a") == GenericNotHashable<String>(value: "b") { }
-let gnh = GenericNotHashable<String>(value: "b")
-let _: Int = gnh.hashValue // No error. hashValue is always synthesized, even if Hashable derivation fails
-gnh.hash(into: &hasher) // expected-error {{value of type 'GenericNotHashable<String>' has no member 'hash'}}
-
+func genericNotHashable() {
+  if GenericNotHashable<String>(value: "a") == GenericNotHashable<String>(value: "b") { }
+  let gnh = GenericNotHashable<String>(value: "b")
+  let _: Int = gnh.hashValue // No error. hashValue is always synthesized, even if Hashable derivation fails
+  gnh.hash(into: &hasher) // expected-error {{value of type 'GenericNotHashable<String>' has no member 'hash'}}
+}
 
 // Synthesis can be from an extension...
 struct StructConformsInExtension {
@@ -158,7 +172,7 @@ public struct StructConformsAndImplementsInExtension {
   let v: Int
 }
 extension StructConformsAndImplementsInExtension : Equatable {
-  public static func ==(lhs: StructConformsAndImplementsInExtension, rhs: StructConformsAndImplementsInExtension) -> Bool {  // expected-note 2 {{non-matching type}}
+  public static func ==(lhs: StructConformsAndImplementsInExtension, rhs: StructConformsAndImplementsInExtension) -> Bool {  // expected-note 3 {{non-matching type}}
     return true
   }  
 }
@@ -175,7 +189,7 @@ struct NoStoredProperties: Hashable {}
 // Verify that conformance (albeit manually implemented) can still be added to
 // a type in a different file.
 extension OtherFileNonconforming: Hashable {
-  static func ==(lhs: OtherFileNonconforming, rhs: OtherFileNonconforming) -> Bool { // expected-note 2 {{non-matching type}}
+  static func ==(lhs: OtherFileNonconforming, rhs: OtherFileNonconforming) -> Bool { // expected-note 3 {{non-matching type}}
     return true
   }
   var hashValue: Int { return 0 }
@@ -193,8 +207,10 @@ extension StructConformsAndImplementsHashIntoInExtension: Hashable {
     hasher.combine(v)
   }
 }
-let _: Int = StructConformsAndImplementsHashIntoInExtension(v: "a").hashValue
-StructConformsAndImplementsHashIntoInExtension(v: "b").hash(into: &hasher)
+func structConformsAndImplementsHashIntoInExtension() {
+  let _: Int = StructConformsAndImplementsHashIntoInExtension(v: "a").hashValue
+  StructConformsAndImplementsHashIntoInExtension(v: "b").hash(into: &hasher)
+}
 
 struct GenericHashIntoInExtension<T: Hashable>: Equatable {
   let value: T
@@ -204,8 +220,10 @@ extension GenericHashIntoInExtension: Hashable {
     hasher.combine(value)
   }
 }
-let _: Int = GenericHashIntoInExtension<String>(value: "a").hashValue
-GenericHashIntoInExtension(value: "b").hash(into: &hasher)
+func genericHashIntoInExtension() {
+  let _: Int = GenericHashIntoInExtension<String>(value: "a").hashValue
+  GenericHashIntoInExtension(value: "b").hash(into: &hasher)
+}
 
 // Conditional conformances should be able to be synthesized
 struct GenericDeriveExtension<T> {

--- a/test/Sema/struct_equatable_hashable.swift
+++ b/test/Sema/struct_equatable_hashable.swift
@@ -253,6 +253,15 @@ extension UnusedGenericDeriveExtension: Hashable {}
 extension GenericOtherFileNonconforming: Equatable where T: Equatable {}
 // expected-error@-1{{implementation of 'Equatable' cannot be automatically synthesized in an extension in a different file to the type}}
 
+// rdar://problem/41852654
+
+// There is a conformance to Equatable (or at least, one that implies Equatable)
+// in the same file as the type, so the synthesis is okay. Both orderings are
+// tested, to catch choosing extensions based on the order of the files, etc.
+protocol ImplierMain: Equatable {}
+struct ImpliedMain: ImplierMain {}
+extension ImpliedOther: ImplierMain {}
+
 // FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected error produced: invalid redeclaration of 'hashValue'
 // <unknown>:0: error: unexpected note produced: candidate has non-matching type '(Foo, Foo) -> Bool'


### PR DESCRIPTION
If a conformance to a protocol is implied by several other
conformances (i.e. protocol P: Equatable {} and protocol Q: Equatable {} and a
type declares conformance to both P and Q), we should choose a source that's in
the same file as the type, if we can, because automatic synthesis of
conformances (for Equatable, Hashable, etc.) only works in that case.

Fixes rdar://problem/41852654.