### PR TITLE
[Parse] Drop Swift3 support for misc diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -339,9 +339,6 @@ ERROR(static_func_decl_global_scope,none,
       (StaticSpellingKind))
 ERROR(func_decl_expected_arrow,none,
       "expected '->' after function parameter tuple", ())
-WARNING(swift3_operator_static_in_protocol,none,
-        "operator '%0' declared in protocol must be 'static'",
-        (StringRef))
 ERROR(operator_static_in_protocol,none,
       "operator '%0' declared in protocol must be 'static'",
       (StringRef))
@@ -434,13 +431,8 @@ ERROR(expected_operator_name_after_operator,PointsToFirstBadToken,
 ERROR(identifier_when_expecting_operator,PointsToFirstBadToken,
       "%0 is considered to be an identifier, not an operator", (Identifier))
 
-WARNING(swift3_deprecated_operator_body,PointsToFirstBadToken,
-        "operator should no longer be declared with body", ())
 ERROR(deprecated_operator_body,PointsToFirstBadToken,
       "operator should no longer be declared with body", ())
-WARNING(swift3_deprecated_operator_body_use_group,PointsToFirstBadToken,
-        "operator should no longer be declared with body; "
-        "use a precedence group instead", ())
 ERROR(deprecated_operator_body_use_group,PointsToFirstBadToken,
       "operator should no longer be declared with body; "
       "use a precedence group instead", ())
@@ -775,16 +767,10 @@ ERROR(tuple_type_multiple_labels,none,
 ERROR(expected_rangle_protocol,PointsToFirstBadToken,
       "expected '>' to complete protocol-constrained type", ())
 
-WARNING(swift3_deprecated_protocol_composition,none,
-        "'protocol<...>' composition syntax is deprecated; join the protocols using '&'", ())
 ERROR(deprecated_protocol_composition,none,
       "'protocol<...>' composition syntax has been removed; join the protocols using '&'", ())
-WARNING(swift3_deprecated_protocol_composition_single,none,
-        "'protocol<...>' composition syntax is deprecated and not needed here", ())
 ERROR(deprecated_protocol_composition_single,none,
-        "'protocol<...>' composition syntax has been removed and is not needed here", ())
-WARNING(swift3_deprecated_any_composition,none,
-        "'protocol<>' syntax is deprecated; use 'Any' instead", ())
+      "'protocol<...>' composition syntax has been removed and is not needed here", ())
 ERROR(deprecated_any_composition,none,
       "'protocol<>' syntax has been removed; use 'Any' instead", ())
 
@@ -891,8 +877,6 @@ ERROR(parameter_curry_syntax_removed,none,
 ERROR(initializer_as_typed_pattern,none,
       "unexpected initializer in pattern; did you mean to use '='?", ())
 
-WARNING(swift3_unlabeled_parameter_following_variadic_parameter,none,
-        "a parameter following a variadic parameter requires a label", ())
 ERROR(unlabeled_parameter_following_variadic_parameter,none,
       "a parameter following a variadic parameter requires a label", ())
 
@@ -1348,15 +1332,9 @@ ERROR(attr_noescape_conflicts_escaping_autoclosure,none,
 ERROR(attr_noescape_implied_by_autoclosure,none,
       "@noescape is implied by @autoclosure and should not be "
       "redundantly specified", ())
-WARNING(swift3_attr_autoclosure_escaping_deprecated,none,
-        "@autoclosure(escaping) is deprecated; use @autoclosure @escaping instead",
-        ())
 ERROR(attr_autoclosure_escaping_deprecated,none,
       "@autoclosure(escaping) has been removed; use @autoclosure @escaping instead",
       ())
-WARNING(swift3_attr_noescape_deprecated,none,
-        "@noescape is the default and is deprecated",
-        ())
 ERROR(attr_noescape_deprecated,none,
       "@noescape is the default and has been removed",
       ())

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1823,9 +1823,7 @@ bool Parser::parseTypeAttribute(TypeAttributes &Attributes, bool justChecking) {
       if (Attributes.has(TAK_noescape)) {
         diagnose(Loc, diag::attr_noescape_conflicts_escaping_autoclosure);
       } else {
-        diagnose(Loc, Context.isSwiftVersion3()
-                          ? diag::swift3_attr_autoclosure_escaping_deprecated
-                          : diag::attr_autoclosure_escaping_deprecated)
+        diagnose(Loc, diag::attr_autoclosure_escaping_deprecated)
             .fixItReplace(autoclosureEscapingParenRange, " @escaping ");
       }
       Attributes.setAttr(TAK_escaping, Loc);
@@ -1850,9 +1848,7 @@ bool Parser::parseTypeAttribute(TypeAttributes &Attributes, bool justChecking) {
     // In SIL, the polarity of @escaping is reversed.
     // @escaping is the default and @noescape is explicit.
     if (!isInSILMode()) {
-      diagnose(Loc, Context.isSwiftVersion3()
-               ? diag::swift3_attr_noescape_deprecated
-               : diag::attr_noescape_deprecated)
+      diagnose(Loc, diag::attr_noescape_deprecated)
         .fixItRemove({Attributes.AtLoc, Loc});
     }
     break;
@@ -5192,10 +5188,7 @@ Parser::parseDeclFunc(SourceLoc StaticLoc, StaticSpellingKind StaticSpelling,
     if (Flags & PD_InProtocol) {
       switch (StaticSpelling) {
       case StaticSpellingKind::None: {
-        auto Message = Context.isSwiftVersion3()
-                           ? diag::swift3_operator_static_in_protocol
-                           : diag::operator_static_in_protocol;
-        diagnose(NameLoc, Message, SimpleName.str())
+        diagnose(NameLoc, diag::operator_static_in_protocol, SimpleName.str())
             .fixItInsert(FuncLoc, "static ");
         StaticSpelling = StaticSpellingKind::KeywordStatic;
         break;
@@ -6428,15 +6421,9 @@ Parser::parseDeclOperatorImpl(SourceLoc OperatorLoc, Identifier Name,
   SourceLoc lBraceLoc;
   if (consumeIf(tok::l_brace, lBraceLoc)) {
     if (isInfix && !Tok.is(tok::r_brace)) {
-      auto message = Context.isSwiftVersion3()
-                         ? diag::swift3_deprecated_operator_body_use_group
-                         : diag::deprecated_operator_body_use_group;
-      diagnose(lBraceLoc, message);
+      diagnose(lBraceLoc, diag::deprecated_operator_body_use_group);
     } else {
-      auto message = Context.isSwiftVersion3()
-                         ? diag::swift3_deprecated_operator_body
-                         : diag::deprecated_operator_body;
-      auto Diag = diagnose(lBraceLoc, message);
+      auto Diag = diagnose(lBraceLoc, diag::deprecated_operator_body);
       if (Tok.is(tok::r_brace)) {
         SourceLoc lastGoodLoc = precedenceGroupNameLoc;
         if (lastGoodLoc.isInvalid())

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -547,11 +547,8 @@ mapParsedParameters(Parser &parser,
     // Warn when an unlabeled parameter follows a variadic parameter
     if (ellipsisLoc.isValid() && elements.back()->isVariadic() &&
         param.FirstName.empty()) {
-      auto message =
-          parser.Context.isSwiftVersion3()
-              ? diag::swift3_unlabeled_parameter_following_variadic_parameter
-              : diag::unlabeled_parameter_following_variadic_parameter;
-      parser.diagnose(param.FirstNameLoc, message);
+      parser.diagnose(param.FirstNameLoc,
+                      diag::unlabeled_parameter_following_variadic_parameter);
     }
     
     // If this parameter had an ellipsis, check whether it's the last parameter.

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -828,16 +828,13 @@ ParserResult<TypeRepr> Parser::parseOldStyleProtocolComposition() {
       replacement += TrailingContent;
     }
 
-    auto isThree = Context.isSwiftVersion3();
-#define THREEIFY(MESSAGE) (isThree ? diag::swift3_##MESSAGE : diag::MESSAGE)
     // Replace 'protocol<T1, T2>' with 'T1 & T2'
     diagnose(ProtocolLoc,
-      IsEmpty              ? THREEIFY(deprecated_any_composition) :
-      Protocols.size() > 1 ? THREEIFY(deprecated_protocol_composition) :
-                             THREEIFY(deprecated_protocol_composition_single))
+      IsEmpty              ? diag::deprecated_any_composition :
+      Protocols.size() > 1 ? diag::deprecated_protocol_composition :
+                             diag::deprecated_protocol_composition_single)
       .highlight(composition->getSourceRange())
       .fixItReplace(composition->getSourceRange(), replacement);
-#undef THREEIFY
   }
 
   return makeParserResult(Status, composition);


### PR DESCRIPTION
Several diagnostics were warning in Swift3, but errors in Swift4+

Related https://github.com/apple/swift/pull/10908
CC: @huonw 
