### PR TITLE
[Parse] Drop Swift3 support for '$', 'throws', and 'rethrows' as identifier

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -459,8 +459,7 @@ public:
   }
 
   SourceLoc consumeIdentifier(Identifier *Result = nullptr) {
-    assert(Tok.isAny(tok::identifier, tok::kw_self, tok::kw_Self,
-                     /* for Swift3 */tok::kw_throws, tok::kw_rethrows));
+    assert(Tok.isAny(tok::identifier, tok::kw_self, tok::kw_Self));
     if (Result)
       *Result = Context.getIdentifier(Tok.getText());
     return consumeToken();

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -895,13 +895,9 @@ void Lexer::lexDollarIdent() {
   }
 
   if (CurPtr == tokStart + 1) {
-    // It is always an error to see a standalone '$' when not in Swift 3
-    // compatibility mode.
-    if (!LangOpts.isSwiftVersion3()) {
-      // Offer to replace '$' with '`$`'.
-      diagnose(tokStart, diag::standalone_dollar_identifier)
-        .fixItReplaceChars(getSourceLoc(tokStart), getSourceLoc(CurPtr), "`$`");
-    }
+    // It is an error to see a standalone '$'. Offer to replace '$' with '`$`'.
+    diagnose(tokStart, diag::standalone_dollar_identifier)
+      .fixItReplaceChars(getSourceLoc(tokStart), getSourceLoc(CurPtr), "`$`");
     return formToken(tok::identifier, tokStart);
   }
 

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -778,23 +778,16 @@ void Parser::StructureMarkerRAII::diagnoseOverflow() {
 bool Parser::parseIdentifier(Identifier &Result, SourceLoc &Loc,
                              const Diagnostic &D) {
   switch (Tok.getKind()) {
-  case tok::kw_throws:
-  case tok::kw_rethrows:
-    if (!Context.isSwiftVersion3())
-      break;
-    // Swift3 accepts 'throws' and 'rethrows'
-    LLVM_FALLTHROUGH;
   case tok::kw_self:
   case tok::kw_Self:
   case tok::identifier:
     Loc = consumeIdentifier(&Result);
     return false;
   default:
-    break;
+    checkForInputIncomplete();
+    diagnose(Tok, D);
+    return true;
   }
-  checkForInputIncomplete();
-  diagnose(Tok, D);
-  return true;
 }
 
 bool Parser::parseSpecificIdentifier(StringRef expected, SourceLoc &loc,


### PR DESCRIPTION
In Swift3:
* '$' were parsed as identifier without any diagnostics. (6accc59)
* 'throws' and 'rethrows' are parsed as identifier in several places. (a176016)