### PR TITLE
[Parse] Drop Swift3 support for conditional compilation condition

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1504,15 +1504,6 @@ ERROR(unsupported_platform_condition_argument,none,
       (StringRef))
 ERROR(unsupported_conditional_compilation_expression_type,none,
       "invalid conditional compilation expression", ())
-WARNING(swift3_unsupported_conditional_compilation_expression_type,none,
-        "ignoring invalid conditional compilation expression, "
-        "which will be rejected in future version of Swift", ())
-WARNING(swift3_conditional_compilation_expression_compound,none,
-        "ignoring parentheses in compound name, "
-        "which will be rejected in future version of Swift", ())
-WARNING(swift3_conditional_compilation_expression_precedence,none,
-        "future version of Swift have different rule for evaluating condition; "
-        "add parentheses to make the condition compatible with Swift4", ())
 ERROR(unsupported_conditional_compilation_integer,none,
       "'%0' is not a valid conditional compilation expression, use '%1'",
       (StringRef, StringRef))


### PR DESCRIPTION
In Swift3:
* `#if A is B` was warning
* `#if A(foo:)` was warning
* `#if A || B && C` has different meaning from Swift4+ and was diagnosed with migration support fix-it.