### PR TITLE
IDE: Index references from keypaths [4.2]

### DIFF
--- a/test/Index/roles.swift
+++ b/test/Index/roles.swift
@@ -483,3 +483,18 @@ final class FinalClass {
   func foo() {}
   // CHECK: [[@LINE-1]]:8 | instance-method/Swift | {{.*}} | Def,RelChild | rel: 1
 }
+
+struct StructWithKeypath {
+  var x: Int = 0
+
+  subscript(idx: Int) -> Int { get { } set { } }
+}
+
+_ = \StructWithKeypath.x
+// CHECK: [[@LINE-1]]:24 | instance-property/Swift | x | s:14swift_ide_test17StructWithKeypathV1xSivp | Ref,Read | rel: 0
+// CHECK: [[@LINE-2]]:24 | instance-method/acc-get/Swift | getter:x | s:14swift_ide_test17StructWithKeypathV1xSivg | Ref,Call,Impl | rel: 0
+
+_ = \StructWithKeypath.[0]
+// CHECK: [[@LINE-1]]:24 | instance-property/subscript/Swift | subscript(_:) | s:14swift_ide_test17StructWithKeypathVyS2icip | Ref,Read | rel: 0
+// CHECK: [[@LINE-2]]:24 | instance-method/acc-get/Swift | getter:subscript(_:) | s:14swift_ide_test17StructWithKeypathVyS2icig | Ref,Call,Impl | rel: 0
+


### PR DESCRIPTION
* Description: The indexer used to ignore references to properties and subscripts from keypaths.

* Origination: Broken since keypaths were originally introduced in Swift 4.0.

* Risk: Low.

* Tested: New tests added.

* Reviewed by: @jckarter  

* Bug: rdar://problem/41912937