### PR TITLE
[SR-6706] Swift should complain about weak references to classes that don't support them

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -553,7 +553,7 @@ protected:
     NumRequirementsInSignature : 16
   );
 
-  SWIFT_INLINE_BITFIELD(ClassDecl, NominalTypeDecl, 1+2+1+2+1+6+1+1+1,
+  SWIFT_INLINE_BITFIELD(ClassDecl, NominalTypeDecl, 1+2+1+2+1+6+1+1+1+1,
     /// Whether this class requires all of its instance variables to
     /// have in-class initializers.
     RequiresStoredPropertyInits : 1,
@@ -581,7 +581,11 @@ protected:
     AncestryComputed : 1,
 
     HasMissingDesignatedInitializers : 1,
-    HasMissingVTableEntries : 1
+    HasMissingVTableEntries : 1,
+
+    /// Whether instances of this class are incompatible
+    /// with weak and unowned references.
+    IsIncompatibleWithWeakReferences : 1
   );
 
   SWIFT_INLINE_BITFIELD(StructDecl, NominalTypeDecl, 1,
@@ -3858,6 +3862,17 @@ public:
 
   void setHasMissingVTableEntries(bool newValue = true) {
     Bits.ClassDecl.HasMissingVTableEntries = newValue;
+  }
+
+  /// Returns true if this class cannot be used with weak or unowned
+  /// references.
+  /// 
+  /// Note that this is true if this class or any of its ancestor classes
+  /// are marked incompatible.
+  bool isIncompatibleWithWeakReferences() const;
+
+  void setIsIncompatibleWithWeakReferences(bool newValue = true) {
+    Bits.ClassDecl.IsIncompatibleWithWeakReferences = newValue;
   }
 
   /// Find a method of a class that overrides a given method.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3565,6 +3565,9 @@ ERROR(invalid_ownership_protocol_type,none,
       "%0 must not be applied to non-class-bound %1; "
       "consider adding a protocol conformance that has a class bound",
       (ReferenceOwnership, Type))
+ERROR(invalid_ownership_incompatible_class,none,
+      "%0 is incompatible with %1 references",
+      (Type, ReferenceOwnership))
 ERROR(invalid_ownership_with_optional,none,
       "%0 variable cannot have optional type", (ReferenceOwnership))
 ERROR(invalid_ownership_not_optional,none,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3691,6 +3691,7 @@ ClassDecl::ClassDecl(SourceLoc ClassLoc, Identifier Name, SourceLoc NameLoc,
   Bits.ClassDecl.AncestryComputed = 0;
   Bits.ClassDecl.HasMissingDesignatedInitializers = 0;
   Bits.ClassDecl.HasMissingVTableEntries = 0;
+  Bits.ClassDecl.IsIncompatibleWithWeakReferences = 0;
 }
 
 bool ClassDecl::hasResilientMetadata() const {
@@ -3772,6 +3773,16 @@ bool ClassDecl::hasMissingDesignatedInitializers() const {
 bool ClassDecl::hasMissingVTableEntries() const {
   (void)getMembers();
   return Bits.ClassDecl.HasMissingVTableEntries;
+}
+
+bool ClassDecl::isIncompatibleWithWeakReferences() const {
+  if (Bits.ClassDecl.IsIncompatibleWithWeakReferences) {
+    return true;
+  }
+  if (auto superclass = getSuperclassDecl()) {
+    return superclass->isIncompatibleWithWeakReferences();
+  }
+  return false;
 }
 
 bool ClassDecl::inheritsSuperclassInitializers(LazyResolver *resolver) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4692,6 +4692,9 @@ namespace {
   }
 #include "InferredAttributes.def"
 
+      if (decl->isArcWeakrefUnavailable())
+        result->setIsIncompatibleWithWeakReferences();
+
       result->setMemberLoader(&Impl, 0);
       result->addImplicitDestructor();
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -41,7 +41,7 @@ namespace {
   template<typename ...ArgTypes>
   void diagnoseAndRemoveAttr(TypeChecker &TC, Decl *D, DeclAttribute *attr,
                              ArgTypes &&...Args) {
-    assert(!D->hasClangNode() && "Clang imported propagated a bogus attribute");
+    assert(!D->hasClangNode() && "Clang importer propagated a bogus attribute");
     if (!D->hasClangNode()) {
       SourceLoc loc = attr->getLocation();
       assert(loc.isValid() && "Diagnosing attribute with invalid location");
@@ -1433,9 +1433,9 @@ void AttributeChecker::visitNSCopyingAttr(NSCopyingAttr *attr) {
   assert(VD->getOverriddenDecl() == nullptr &&
          "Can't have value with storage that is an override");
 
-  // Check the type.  It must be must be [unchecked]optional, weak, a normal
+  // Check the type.  It must be an [unchecked]optional, weak, a normal
   // class, AnyObject, or classbound protocol.
-  // must conform to the NSCopying protocol.
+  // It must conform to the NSCopying protocol.
   
 }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -32,7 +32,6 @@
 #include "swift/Sema/IDETypeChecking.h"
 #include "clang/Basic/CharInfo.h"
 #include "llvm/Support/Debug.h"
-#include "clang/Basic/CharInfo.h"
 
 using namespace swift;
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2678,6 +2678,15 @@ void TypeChecker::checkReferenceOwnershipAttr(VarDecl *var,
     attr->setInvalid();
   }
 
+  ClassDecl *underlyingClass = underlyingType->getClassOrBoundGenericClass();
+  if (underlyingClass && underlyingClass->isIncompatibleWithWeakReferences()) {
+    diagnose(attr->getLocation(),
+             diag::invalid_ownership_incompatible_class,
+             underlyingType, ownershipKind)
+      .fixItRemove(attr->getRange());
+    attr->setInvalid();
+  }
+
   auto PDC = dyn_cast<ProtocolDecl>((var->getDeclContext()));
   if (PDC && !PDC->isObjC()) {
     // Ownership does not make sense in protocols, except for "weak" on

--- a/test/Sema/Inputs/diag_ownership_incompatibility.h
+++ b/test/Sema/Inputs/diag_ownership_incompatibility.h
@@ -1,0 +1,5 @@
+@import Foundation;
+
+__attribute__((objc_arc_weak_reference_unavailable))
+@interface NoWeakClass : NSObject
+@end

--- a/test/Sema/diag_ownership_incompatibility.swift
+++ b/test/Sema/diag_ownership_incompatibility.swift
@@ -1,3 +1,5 @@
+// REQUIRES: objc_interop
+
 // RUN: %target-typecheck-verify-swift -enable-objc-interop -import-objc-header %S/Inputs/diag_ownership_incompatibility.h
 
 class C {

--- a/test/Sema/diag_ownership_incompatibility.swift
+++ b/test/Sema/diag_ownership_incompatibility.swift
@@ -1,0 +1,25 @@
+// RUN: %target-typecheck-verify-swift -enable-objc-interop -import-objc-header %S/Inputs/diag_ownership_incompatibility.h
+
+class C {
+  weak var weakVar: NoWeakClass? = nil // expected-error {{'NoWeakClass' is incompatible with 'weak' references}}
+  unowned var unownedVar = NoWeakClass() // expected-error {{'NoWeakClass' is incompatible with 'unowned' references}}
+}
+
+_ = C()
+
+weak var weakVar: NoWeakClass? = nil // expected-error {{'NoWeakClass' is incompatible with 'weak' references}}
+unowned var unownedVar = NoWeakClass() // expected-error {{'NoWeakClass' is incompatible with 'unowned' references}}
+
+// Subclasses are also incompatible.
+
+class SwiftNoWeakClass: NoWeakClass { }
+
+class D {
+  weak var weakVar: SwiftNoWeakClass? = nil // expected-error {{'SwiftNoWeakClass' is incompatible with 'weak' references}}
+  unowned var unownedVar = SwiftNoWeakClass() // expected-error {{'SwiftNoWeakClass' is incompatible with 'unowned' references}}
+}
+
+_ = D()
+
+weak var weakSwiftVar: SwiftNoWeakClass? = nil // expected-error {{'SwiftNoWeakClass' is incompatible with 'weak' references}}
+unowned var unownedSwiftVar = SwiftNoWeakClass() // expected-error {{'SwiftNoWeakClass' is incompatible with 'unowned' references}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
This pull requests adds diagnostics similar to Clang when attempting to create weak or unowned references of types that do not support them (NSFont, NSWindow, etc.). This is indicated with the `objc_arc_weak_reference_unavailable` Clang attribute.

 I thought about limiting this to only run on macOS since in practice this only affects macOS targets. (The only classes affected are from the macOS SDK). I've left it for completion's sake since someone could add the attribute to their own Objective-C class if they so choose..

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-6706](https://bugs.swift.org/browse/SR-6706).