### PR TITLE
[SR-8178] Fix BinaryFloatingPoint.random(in:) open range returning upperBound

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -2464,7 +2464,7 @@ where Self.RawSignificand : FixedWidthInteger {
     let randFloat = delta * unitRandom + range.lowerBound
 %   if 'Closed' not in Range:
     if randFloat == range.upperBound {
-      return randFloat.nextDown
+      return Self.random(in: range, using: &generator)
     }
 %   end
     return randFloat

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -2461,7 +2461,13 @@ where Self.RawSignificand : FixedWidthInteger {
 %     end
     }
     let unitRandom = Self.init(rand) * Self.ulpOfOne / 2
-    return delta * unitRandom + range.lowerBound
+    let randFloat = delta * unitRandom + range.lowerBound
+%   if 'Closed' not in Range:
+    if randFloat == range.upperBound {
+      return randFloat.nextDown
+    }
+%   end
+    return randFloat
   }
 
   /// Returns a random value within the specified range.


### PR DESCRIPTION
The problem seemed to come from the final addition `+ range.lowerBound`.