### PR TITLE
Fix debug scope verification.

### DIFF
--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -4781,6 +4781,14 @@ public:
       // map and go on.
       auto *DS = SI.getDebugScope();
       assert(DS && "Each instruction should have a debug scope");
+
+      // SWIFT_ENABLE_TENSORFLOW
+      // If debug scope has an inlined call site, skip it.
+      // TODO: Inlined call sites should be verified to ensure that the inliner
+      // handles scopes correctly.
+      if (DS->InlinedCallSite)
+        continue;
+
       if (!AlreadySeenScopes.count(DS)) {
         AlreadySeenScopes.insert(DS);
         LastSeenScope = DS;

--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -275,9 +275,6 @@ void TFDeabstraction::inlineCalls() {
   auto &module = fn.getModule();
   module.invalidateSILLoaderCaches();
 
-  if (!inlinedCallees.empty())
-    fn.setOptimizationMode(OptimizationMode::ForSpeed);
-
   // Now that we've inlined some functions, clean them up to avoid burning
   // compile time in later passes.  We do this with a simple linear scan,
   // because functions that reference each other have already been flattened
@@ -296,7 +293,6 @@ void TFDeabstraction::inlineCalls() {
     //
     // TODO: Build infra to find unused witness tables and remove them.
     if (callee->getRefCount() != 0) {
-      callee->setOptimizationMode(OptimizationMode::ForSpeed);
       continue;
     }
 

--- a/test/TensorFlow/debug_scope.swift
+++ b/test/TensorFlow/debug_scope.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -emit-sil %s -verify
+
+// This test checks that deabstraction passes debug scope verification with -Onone.
+// Prior to https://github.com/apple/swift/pull/17797, this test failed with:
+// SIL verification failed: Basic block contains a non-contiguous lexical scope at -Onone: DS == LastSeenScope
+
+import TensorFlow
+func test() {
+  _ = Tensor(1)
+}


### PR DESCRIPTION
Debug scope verification was enabled by default in https://github.com/apple/swift/commit/f917c9355764dc6d9308ccf2801776c62e032612.

This caused verification errors as a result of deabstraction inlining.
It's stated that `verifyDebugScopeHoles` should not be run when inlining is performed because scopes are moved around.

A simple patch is to relax debug scope verification so that only instructions with no inlined call site are checked.

Addresses [SR-8114](https://bugs.swift.org/browse/SR-8114).
Currently, since debug scope verification is enabled, any `Tensor` program compiled with `-Onone` fails verification.