### PR TITLE
Disable 'self' parameter for #gradient and #valueAndGradient.

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -26,16 +26,9 @@ enum class AutoDiffMode {
   Forward, Reverse
 };
 
-class AutoDiffIndexParameter {
-  SourceLoc Loc;
-  unsigned Index;
-
-public:
-  AutoDiffIndexParameter(SourceLoc loc, unsigned index)
-    : Loc(loc), Index(index) {}
-
-  unsigned getIndex() const { return Index; }
-  SourceLoc getLoc() const { return Loc; }
+struct AutoDiffIndexParameter {
+  SourceLoc loc;
+  unsigned index;
 };
 
 class AutoDiffParameter {

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -26,6 +26,18 @@ enum class AutoDiffMode {
   Forward, Reverse
 };
 
+class AutoDiffIndexParameter {
+  SourceLoc Loc;
+  unsigned Index;
+
+public:
+  AutoDiffIndexParameter(SourceLoc loc, unsigned index)
+    : Loc(loc), Index(index) {}
+
+  unsigned getIndex() const { return Index; }
+  SourceLoc getLoc() const { return Loc; }
+};
+
 class AutoDiffParameter {
 public:
   enum class Kind { Index, Self };

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1669,8 +1669,8 @@ ERROR(expr_expected_label,none,
 ERROR(expr_expected_function_to_differentiate,none,
       "expected a function to be differentiated", ())
 ERROR(gradient_expr_expected_parameter,none,
-      "expected a parameter, which can be the index of a function parameter "
-      "with a leading dot (e.g. '.0'), or 'self'", ())
+      "expected a parameter, which must be the index of a function parameter "
+      "with a leading dot (e.g. '.0')", ())
 ERROR(autodiff_use_wrt_not_withrespectto,none,
       "use 'wrt:' to specify parameters to differentiate with respect to", ())
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -716,11 +716,8 @@ ERROR(gradient_expr_not_a_function,none,
       (Type))
 ERROR(gradient_expr_original_func_decl_unresolved,none,
       "original function declaration could not be resolved", ())
-ERROR(gradient_expr_parameter_self_not_first,none,
-      "the 'self' parameter must be the first in the parameter list", ())
-ERROR(gradient_expr_parameter_self_not_in_instance_context,none,
-      "a 'self' parameter can only be used in an instance declaration context "
-      "where the function being differentiated is also located", ())
+ERROR(gradient_expr_parameter_self_unsupported,none,
+      "the 'self' parameter is unsupported by #gradient", ())
 ERROR(gradient_expr_parameter_indices_not_ascending,none,
       "parameter indices must be ascending", ())
 ERROR(gradient_expr_parameter_index_out_of_bounds,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -721,7 +721,7 @@ ERROR(gradient_expr_parameter_self_unsupported,none,
 ERROR(gradient_expr_parameter_indices_not_ascending,none,
       "parameter indices must be ascending", ())
 ERROR(gradient_expr_parameter_index_out_of_bounds,none,
-      "the parameter index is out of bounds for type %0, which has %1"
+      "the parameter index is out of bounds for type %0, which has %1 "
       "parameters", (Type, unsigned))
 ERROR(gradient_expr_parameter_not_value_type,none,
       "gradient parameter has non-value type %0 and thus cannot be a "

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3851,13 +3851,13 @@ public:
     OriginalExpr = newOriginal;
   }
 
-  AutoDiffParameter *getParametersData() {
-    return reinterpret_cast<AutoDiffParameter *>(this+1);
+  AutoDiffIndexParameter *getParametersData() {
+    return reinterpret_cast<AutoDiffIndexParameter *>(this+1);
   }
 
-  ArrayRef<AutoDiffParameter> getParameters() const;
+  ArrayRef<AutoDiffIndexParameter> getParameters() const;
 
-  MutableArrayRef<AutoDiffParameter> getParameters() {
+  MutableArrayRef<AutoDiffIndexParameter> getParameters() {
     return { getParametersData(), NumParameters };
   }
 
@@ -3886,7 +3886,7 @@ protected:
   explicit ReverseAutoDiffExpr(ExprKind kind, SourceLoc loc,
                                SourceLoc lParenLoc,
                                Expr *originalExpr,
-                               ArrayRef<AutoDiffParameter> parameters,
+                               ArrayRef<AutoDiffIndexParameter> parameters,
                                SourceLoc rParenLoc);
 };
 
@@ -3902,7 +3902,7 @@ class GradientExpr : public ReverseAutoDiffExpr {
 public:
   static GradientExpr *create(ASTContext &ctx, SourceLoc loc,
                               SourceLoc lParenLoc, Expr *originalExpr,
-                              ArrayRef<AutoDiffParameter> parameters,
+                              ArrayRef<AutoDiffIndexParameter> parameters,
                               SourceLoc rParenLoc);
 
   static bool classof(const Expr *E) {
@@ -3911,7 +3911,8 @@ public:
 
 private:
   explicit GradientExpr(SourceLoc loc, SourceLoc lParenLoc, Expr *originalExpr,
-                        ArrayRef<AutoDiffParameter> params, SourceLoc rParenLoc)
+                        ArrayRef<AutoDiffIndexParameter> params,
+                        SourceLoc rParenLoc)
     : ReverseAutoDiffExpr(ExprKind::Gradient, loc, lParenLoc, originalExpr,
                           params, rParenLoc) {}
 };
@@ -3929,7 +3930,7 @@ class ValueAndGradientExpr : public ReverseAutoDiffExpr {
 public:
   static ValueAndGradientExpr *create(ASTContext &ctx, SourceLoc loc,
                                       SourceLoc lParenLoc, Expr *originalExpr,
-                                      ArrayRef<AutoDiffParameter> parameters,
+                                      ArrayRef<AutoDiffIndexParameter> params,
                                       SourceLoc rParenLoc);
 
   static bool classof(const Expr *E) {
@@ -3939,7 +3940,7 @@ public:
 private:
   explicit ValueAndGradientExpr(SourceLoc loc, SourceLoc lParenLoc,
                                 Expr *originalExpr,
-                                ArrayRef<AutoDiffParameter> params,
+                                ArrayRef<AutoDiffIndexParameter> params,
                                 SourceLoc rParenLoc)
     : ReverseAutoDiffExpr(ExprKind::ValueAndGradient, loc, lParenLoc,
                           originalExpr, params, rParenLoc) {}

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1845,15 +1845,8 @@ public:
     auto parameters = E->getParameters();
     if (!parameters.empty()) {
       OS << " wrt=(";
-      interleave(parameters, [&](const AutoDiffParameter &param) {
-        switch (param.getKind()) {
-        case AutoDiffParameter::Kind::Index:
-          OS << '.' << param.getIndex();
-          break;
-        case AutoDiffParameter::Kind::Self:
-          OS << "self";
-          break;
-        }
+      interleave(parameters, [&](const AutoDiffIndexParameter &param) {
+        OS << '.' << param.getIndex();
       }, [&]{
         OS << ", ";
       });

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1846,7 +1846,7 @@ public:
     if (!parameters.empty()) {
       OS << " wrt=(";
       interleave(parameters, [&](const AutoDiffIndexParameter &param) {
-        OS << '.' << param.getIndex();
+        OS << '.' << param.index;
       }, [&]{
         OS << ", ";
       });

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1295,11 +1295,9 @@ packSingleArgument(ASTContext &ctx, SourceLoc lParenLoc, ArrayRef<Expr *> args,
 }
 
 // SWIFT_ENABLE_TENSORFLOW
-ReverseAutoDiffExpr::ReverseAutoDiffExpr(ExprKind kind, SourceLoc loc,
-                                         SourceLoc lParenLoc,
-                                         Expr *originalExpr,
-                                         ArrayRef<AutoDiffParameter> parameters,
-                                         SourceLoc rParenLoc)
+ReverseAutoDiffExpr::ReverseAutoDiffExpr(
+    ExprKind kind, SourceLoc loc, SourceLoc lParenLoc, Expr *originalExpr,
+    ArrayRef<AutoDiffIndexParameter> parameters, SourceLoc rParenLoc)
   : Expr(kind, /*Implicit=*/false), Loc(loc), LParenLoc(lParenLoc),
     OriginalExpr(originalExpr), NumParameters(parameters.size()),
     RParenLoc(rParenLoc) {
@@ -1308,10 +1306,11 @@ ReverseAutoDiffExpr::ReverseAutoDiffExpr(ExprKind kind, SourceLoc loc,
 
 GradientExpr *GradientExpr::create(ASTContext &ctx, SourceLoc loc,
                                    SourceLoc lParenLoc, Expr *originalExpr,
-                                   ArrayRef<AutoDiffParameter> parameters,
+                                   ArrayRef<AutoDiffIndexParameter> parameters,
                                    SourceLoc rParenLoc) {
   unsigned numParams = parameters.size();
-  unsigned size = sizeof(GradientExpr) + numParams * sizeof(AutoDiffParameter);
+  unsigned size =
+    sizeof(GradientExpr) + numParams * sizeof(AutoDiffIndexParameter);
   void *memory = ctx.Allocate(size, alignof(GradientExpr));
   return new (memory) GradientExpr(loc, lParenLoc, originalExpr, parameters,
                                    rParenLoc);
@@ -1321,11 +1320,11 @@ GradientExpr *GradientExpr::create(ASTContext &ctx, SourceLoc loc,
 ValueAndGradientExpr *
 ValueAndGradientExpr::create(ASTContext &ctx, SourceLoc loc,
                              SourceLoc lParenLoc, Expr *originalExpr,
-                             ArrayRef<AutoDiffParameter> parameters,
+                             ArrayRef<AutoDiffIndexParameter> parameters,
                              SourceLoc rParenLoc) {
   unsigned numParams = parameters.size();
   unsigned size =
-    sizeof(ValueAndGradientExpr) + numParams * sizeof(AutoDiffParameter);
+    sizeof(ValueAndGradientExpr) + numParams * sizeof(AutoDiffIndexParameter);
   void *memory = ctx.Allocate(size, alignof(ValueAndGradientExpr));
   return new (memory) ValueAndGradientExpr(loc, lParenLoc, originalExpr,
                                            parameters, rParenLoc);

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3713,7 +3713,7 @@ ParserResult<Expr> Parser::parseExprGradientBody(ExprKind kind) {
         if (parseUnsignedInteger(index, paramLoc,
                                  diag::gradient_expr_expected_parameter))
           return true;
-        params.push_back(AutoDiffIndexParameter(paramLoc, index));
+        params.push_back({ paramLoc, index });
         break;
       default:
         diagnose(Tok, diag::gradient_expr_expected_parameter);

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3687,7 +3687,7 @@ ParserResult<Expr> Parser::parseExprGradientBody(ExprKind kind) {
   if (originalFnParseResult.isParseError())
     return errorAndSkipToEnd();
   // If found comma, parse 'wrt:'.
-  SmallVector<AutoDiffParameter, 8> params;
+  SmallVector<AutoDiffIndexParameter, 8> params;
   if (consumeIf(tok::comma)) {
     // If 'withRespectTo' is used, make the user change it to 'wrt'.
     if (Tok.getText() == "withRespectTo") {
@@ -3713,8 +3713,7 @@ ParserResult<Expr> Parser::parseExprGradientBody(ExprKind kind) {
         if (parseUnsignedInteger(index, paramLoc,
                                  diag::gradient_expr_expected_parameter))
           return true;
-        params.push_back(
-          AutoDiffParameter::getIndexParameter(paramLoc, index));
+        params.push_back(AutoDiffIndexParameter(paramLoc, index));
         break;
       default:
         diagnose(Tok, diag::gradient_expr_expected_parameter);

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3645,7 +3645,7 @@ ParserResult<Expr> Parser::parseExprTypeOf() {
 ///   expr-gradient-param-list:
 ///     expr-gradient-param-index (',' expr-gradient-param-index)*
 ///   expr-gradient-param-index:
-///     'self' | '.' [0-9]+
+///     '.' [0-9]+
 ///
 ParserResult<Expr> Parser::parseExprGradientBody(ExprKind kind) {
   assert(Tok.is(tok::pound_gradient) || Tok.is(tok::pound_valueAndGradient));
@@ -3715,10 +3715,6 @@ ParserResult<Expr> Parser::parseExprGradientBody(ExprKind kind) {
           return true;
         params.push_back(
           AutoDiffParameter::getIndexParameter(paramLoc, index));
-        break;
-      case tok::kw_self:
-        paramLoc = consumeToken(tok::kw_self);
-        params.push_back(AutoDiffParameter::getSelfParameter(paramLoc));
         break;
       default:
         diagnose(Tok, diag::gradient_expr_expected_parameter);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2964,33 +2964,22 @@ static RValue emitGradientInst(RValueEmitter &RVE, const SGFContext &C,
   auto *origExpr = E->getOriginalExpr();
   auto origTy = origExpr->getType()->getAs<AnyFunctionType>();
   ManagedValue origVal = RVE.visit(origExpr, C).getAsSingleValue(RVE.SGF, loc);
-  auto origSILTy = origVal.getType().getAs<SILFunctionType>();
   // Lower Swift parameters to SIL parameters.
   auto diffParams = E->getParameters();
-  SmallVector<AutoDiffParameter, 4> allParamIndices;
+  SmallVector<AutoDiffIndexParameter, 4> allParamIndices;
   // If no differentiation parameters are specified, differentiation is done
   // with respect to all of original's parameters.
   if (E->getParameters().empty()) {
     for (unsigned i : range(0, origTy->getNumParams()))
-      allParamIndices.push_back(
-        AutoDiffParameter::getIndexParameter(E->getStartLoc(), i));
+      allParamIndices.push_back(AutoDiffIndexParameter(E->getStartLoc(), i));
     diffParams = allParamIndices;
   }
   SmallVector<unsigned, 8> loweredParamIndices;
   for (auto param : diffParams) {
-    switch (param.getKind()) {
-    case swift::AutoDiffParameter::Kind::Index: {
-      auto silParamIndices =
+    auto silParamIndices =
       RVE.SGF.SGM.getLoweredFunctionParameterIndex(param.getIndex(), origTy);
-      for (auto idx : silParamIndices)
-        loweredParamIndices.push_back(idx);
-      break;
-    }
-    case swift::AutoDiffParameter::Kind::Self: {
-      assert(false &&
-             "'self' parameter is unsupported by #gradient/#valueAndGradient");
-    }
-    }
+    for (auto idx : silParamIndices)
+      loweredParamIndices.push_back(idx);
   }
   auto gradInst = RVE.SGF.B.createGradient(loc, origVal.forward(RVE.SGF),
                                            /*sourceIndex*/ 0,

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2987,10 +2987,8 @@ static RValue emitGradientInst(RValueEmitter &RVE, const SGFContext &C,
       break;
     }
     case swift::AutoDiffParameter::Kind::Self: {
-      // `self` is the last parameter of the SIL function.
-      auto selfIdx = origSILTy->getNumParameters() - 1;
-      loweredParamIndices.push_back(selfIdx);
-      break;
+      assert(false &&
+             "'self' parameter is unsupported by #gradient/#valueAndGradient");
     }
     }
   }

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2971,13 +2971,13 @@ static RValue emitGradientInst(RValueEmitter &RVE, const SGFContext &C,
   // with respect to all of original's parameters.
   if (E->getParameters().empty()) {
     for (unsigned i : range(0, origTy->getNumParams()))
-      allParamIndices.push_back(AutoDiffIndexParameter(E->getStartLoc(), i));
+      allParamIndices.push_back({ E->getStartLoc(), i });
     diffParams = allParamIndices;
   }
   SmallVector<unsigned, 8> loweredParamIndices;
   for (auto param : diffParams) {
     auto silParamIndices =
-      RVE.SGF.SGM.getLoweredFunctionParameterIndex(param.getIndex(), origTy);
+      RVE.SGF.SGM.getLoweredFunctionParameterIndex(param.index, origTy);
     for (auto idx : silParamIndices)
       loweredParamIndices.push_back(idx);
   }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2446,8 +2446,7 @@ namespace {
           diffParamTypes.push_back(gradParam.getType());
       } else {
         for (auto &param : expr->getParameters())
-          if (param.getKind() == AutoDiffParameter::Kind::Index)
-            diffParamTypes.push_back(gradParams[param.getIndex()].getType());
+          diffParamTypes.push_back(gradParams[param.getIndex()].getType());
       }
       for (auto &paramTy : diffParamTypes) {
         if (!(TC.isCompatibleWithScalarAutoDiff(paramTy, dc) ||

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2446,7 +2446,7 @@ namespace {
           diffParamTypes.push_back(gradParam.getType());
       } else {
         for (auto &param : expr->getParameters())
-          diffParamTypes.push_back(gradParams[param.getIndex()].getType());
+          diffParamTypes.push_back(gradParams[param.index].getType());
       }
       for (auto &paramTy : diffParamTypes) {
         if (!(TC.isCompatibleWithScalarAutoDiff(paramTy, dc) ||

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2445,8 +2445,6 @@ namespace {
         for (auto &gradParam : gradParams)
           diffParamTypes.push_back(gradParam.getType());
       } else {
-        // Check only index parameters. 'self' parameters are already checked in
-        // CSGen.
         for (auto &param : expr->getParameters())
           if (param.getKind() == AutoDiffParameter::Kind::Index)
             diffParamTypes.push_back(gradParams[param.getIndex()].getType());

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1302,43 +1302,34 @@ namespace {
       else {
         int lastIndex = -1;
         for (auto &param : GE->getParameters()) {
-          switch (param.getKind()) {
-          case AutoDiffParameter::Kind::Index: {
-            auto index = param.getIndex();
-            // Indices must be ascending.
-            if (lastIndex >= (int)index) {
-              TC.diagnose(param.getLoc(),
-                          diag::gradient_expr_parameter_indices_not_ascending);
-              return nullptr;
-            }
-            // Indices cannot exceed the number of parameters in the original
-            // function.
-            if (index >= originalParams.size()) {
-              TC.diagnose(param.getLoc(),
-                          diag::gradient_expr_parameter_index_out_of_bounds,
-                          originalTy, originalParams.size());
-              return nullptr;
-            }
-            // The parameter cannot be a reference object or a protocol
-            // existential.
-            auto paramTy = originalParams[index].getType();
-            if (paramTy->isAnyClassReferenceType() ||
-                paramTy->isExistentialType()) {
-              TC.diagnose(param.getLoc(),
-                          diag::gradient_expr_parameter_not_value_type,
-                          paramTy);
-              return nullptr;
-            }
-            lastIndex = index;
-            diffParamTypes.push_back(paramTy);
-            break;
-          }
-          case AutoDiffParameter::Kind::Self:
-            // The 'self' parameter is unsupported by #gradient.
+          auto index = param.getIndex();
+          llvm::errs() << "CSGEN PARAMETER INDEX: " << param.getIndex() << "\n";
+          // Indices must be ascending.
+          if (lastIndex >= (int)index) {
             TC.diagnose(param.getLoc(),
-                        diag::gradient_expr_parameter_self_unsupported);
+                        diag::gradient_expr_parameter_indices_not_ascending);
             return nullptr;
           }
+          // Indices cannot exceed the number of parameters in the original
+          // function.
+          if (index >= originalParams.size()) {
+            TC.diagnose(param.getLoc(),
+                        diag::gradient_expr_parameter_index_out_of_bounds,
+                        originalTy, originalParams.size());
+            return nullptr;
+          }
+          // The parameter cannot be a reference object or a protocol
+          // existential.
+          auto paramTy = originalParams[index].getType();
+          if (paramTy->isAnyClassReferenceType() ||
+              paramTy->isExistentialType()) {
+            TC.diagnose(param.getLoc(),
+                        diag::gradient_expr_parameter_not_value_type,
+                        paramTy);
+            return nullptr;
+          }
+          lastIndex = index;
+          diffParamTypes.push_back(paramTy);
         }
       }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1302,18 +1302,17 @@ namespace {
       else {
         int lastIndex = -1;
         for (auto &param : GE->getParameters()) {
-          auto index = param.getIndex();
-          llvm::errs() << "CSGEN PARAMETER INDEX: " << param.getIndex() << "\n";
+          auto index = param.index;
           // Indices must be ascending.
           if (lastIndex >= (int)index) {
-            TC.diagnose(param.getLoc(),
+            TC.diagnose(param.loc,
                         diag::gradient_expr_parameter_indices_not_ascending);
             return nullptr;
           }
           // Indices cannot exceed the number of parameters in the original
           // function.
           if (index >= originalParams.size()) {
-            TC.diagnose(param.getLoc(),
+            TC.diagnose(param.loc,
                         diag::gradient_expr_parameter_index_out_of_bounds,
                         originalTy, originalParams.size());
             return nullptr;
@@ -1323,8 +1322,7 @@ namespace {
           auto paramTy = originalParams[index].getType();
           if (paramTy->isAnyClassReferenceType() ||
               paramTy->isExistentialType()) {
-            TC.diagnose(param.getLoc(),
-                        diag::gradient_expr_parameter_not_value_type,
+            TC.diagnose(param.loc, diag::gradient_expr_parameter_not_value_type,
                         paramTy);
             return nullptr;
           }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1333,44 +1333,11 @@ namespace {
             diffParamTypes.push_back(paramTy);
             break;
           }
-          case AutoDiffParameter::Kind::Self: {
-            // Self must come first in the parameter list.
-            if (lastIndex != -1) {
-              TC.diagnose(param.getLoc(),
-                          diag::gradient_expr_parameter_self_not_first);
-              return nullptr;
-            }
-            // To use 'self', #gradient must be located in an instance type
-            // context.
-            auto *method = CurDC->getInnermostMethodContext();
-            // Must be within an instance method to use 'self'.
-            if (!method || !method->isInstanceMember()) {
-              TC.diagnose(param.getLoc(),
-                    diag::gradient_expr_parameter_self_not_in_instance_context);
-              return nullptr;
-            }
-            // 'self' cannot be a reference or existential type.
-            auto *selfDecl = method->getImplicitSelfDecl();
-            auto selfTy = selfDecl->getType();
-            if (selfTy->isAnyClassReferenceType() ||
-                selfTy->isExistentialType()) {
-              TC.diagnose(param.getLoc(),
-                        diag::gradient_expr_parameter_not_value_type, selfTy);
-              return nullptr;
-            }
-            // 'self' type must conform to either FloatingPoint or
-            // VectorNumeric.
-            if (!(TC.isCompatibleWithScalarAutoDiff(selfTy, CurDC) ||
-                  TC.isCompatibleWithVectorAutoDiff(selfTy, CurDC))) {
-              TC.diagnose(param.getLoc(),
-                          diag::gradient_expr_parameter_not_differentiable,
-                          selfTy);
-              return nullptr;
-            }
-            // Collect the type.
-            diffParamTypes.push_back(selfTy);
-            break;
-          }
+          case AutoDiffParameter::Kind::Self:
+            // The 'self' parameter is unsupported by #gradient.
+            TC.diagnose(param.getLoc(),
+                        diag::gradient_expr_parameter_self_unsupported);
+            return nullptr;
           }
         }
       }

--- a/test/AutoDiff/gradient_expr_parse.swift
+++ b/test/AutoDiff/gradient_expr_parse.swift
@@ -3,10 +3,10 @@
 #gradient(foo, withRespectTo:) // expected-error {{use 'wrt:' to specify parameters to differentiate with respect to}}
 
 #gradient(foo) // okay
-#gradient(foo, wrt: 1) // expected-error {{expected a parameter, which can be }}
-#gradient(foo, wrt: 0) // expected-error {{expected a parameter, which can be }}
-#gradient(foo, wrt: .0) // okay
-#gradient(foo, wrt: .0, .1, self) // okay
+#gradient(foo, wrt: 1) // expected-error {{expected a parameter, which must be }}
+#gradient(foo, wrt: 0) // expected-error {{expected a parameter, which must be }}
+#gradient(foo, wrt: .0, self) // expected-error {{expected a parameter, which must be }}
+#gradient(foo, wrt: .0, .1) // okay
 
 #valueAndGradient(foo, wrt: .0, .1) // okay
 

--- a/test/AutoDiff/gradient_expr_type_checking.swift
+++ b/test/AutoDiff/gradient_expr_type_checking.swift
@@ -15,9 +15,6 @@ let _: (Float, Float) -> (value: Float, gradient: (Float, Float)) = #valueAndGra
 let _: (Float, Float) -> Float = #gradient(foo, wrt: .0) // ok
 let _: (Float, Float) -> (value: Float, gradient: Float)
   = #valueAndGradient(foo, wrt: .0) // ok
-let _: (Float, Float) -> (Float, Float) = #gradient(foo, wrt: self, .0) // expected-error {{a 'self' parameter can only be used in an instance declaration}}
-let _: (Float, Float) -> (Float, Float) = #gradient(foo, wrt: self, .0) // expected-error {{a 'self' parameter can only be used in an instance declaration}}
-let _: (Float, Float) -> (Float, Float) = #gradient(foo, wrt: .0, self) // expected-error {{the 'self' parameter must be the first}}
 let _: (Float, Float) -> (Float, Float) = #gradient(foo, wrt: .0, .1) // ok
 let _: (Float, Float) -> (Float, Float, Float) = #gradient(foo, wrt: .0, .1, .2) // expected-error {{the parameter index is out of bounds for type}}
 
@@ -32,14 +29,9 @@ struct S {
 
   func b() {
     let _: (Float) -> Float = #gradient(a) // ok
-    let _: (Float) -> S = #gradient(a, wrt: self) // expected-error {{gradient parameter has non-differentiable type 'S'}}
   }
 
   static func c(_ x: Float) -> Float {}
-
-  static func d() -> Float {
-    let _: (Float) -> S = #gradient(c, wrt: self) // expected-error {{a 'self' parameter can only be used in an instance declaration context}}
-  }
 }
 
 let s = S()


### PR DESCRIPTION
Disable differentiation with respect to 'self' for #gradient and #valueAndGradient.
'self' in the parameter list is ad-hoc and out of place.

The same "diff w.r.t. self" functionality can be generalized and represented
more naturally as dataflow AD, using a differential operator on an output
variable w.r.t input variables.