### PR TITLE
Handle stray LoadExprs in RawRepresentable fix-its

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4608,8 +4608,14 @@ static bool diagnoseRawRepresentableMismatch(CalleeCandidateInfo &CCI,
     return false;
 
   const Expr *expr = argExpr;
-  if (auto *tupleArgs = dyn_cast<TupleExpr>(argExpr))
+  if (auto *tupleArgs = dyn_cast<TupleExpr>(argExpr)) {
     expr = tupleArgs->getElement(bestMatchIndex);
+  } else if (auto *misplacedLoad = dyn_cast<LoadExpr>(argExpr)) {
+    // If there are multiple possible overloads for a single-argument call
+    // expression, the partially-typed-checked AST may have a load around the
+    // call parentheses instead of inside them.
+    expr = misplacedLoad->getSubExpr();
+  }
   expr = expr->getValueProvidingExpr();
 
   auto parameters = bestMatchCandidate->getParameters();

--- a/test/Sema/enum_raw_representable.swift
+++ b/test/Sema/enum_raw_representable.swift
@@ -168,6 +168,19 @@ func sr8150(bar: Bar) {
   // expected-error@-1 {{cannot convert value of type 'Double' to expected argument type 'Bar'}} {{18-18=Bar(rawValue: }} {{21-21=)}}
 }
 
+class SR8150Box {
+  var bar: Bar
+  init(bar: Bar) { self.bar = bar }
+}
+// Bonus problem with mutable values being passed.
+func sr8150_mutable(obj: SR8150Box) {
+  sr8150_helper1(obj.bar)
+  // expected-error@-1 {{cannot convert value of type 'Bar' to expected argument type 'Double'}} {{18-18=}} {{25-25=.rawValue}}
+
+  var bar = obj.bar
+  sr8150_helper1(bar)
+  // expected-error@-1 {{cannot convert value of type 'Bar' to expected argument type 'Double'}} {{18-18=}} {{21-21=.rawValue}}
+}
 
 struct NotEquatable { }
 


### PR DESCRIPTION
When there are multiple possible overloads for a call, the partially-type-checked argument expression might end up with a LoadExpr outside of the call ParenExpr instead of inside it. Account for this in a one- off way for the `rawValue` / `init(rawValue:)` fix-its.

Yet more [SR-8150](https://bugs.swift.org/browse/SR-8150) / rdar://problem/41725207. (Follow-up to #17714.)