### PR TITLE
[SIL] Relax verification for debug scopes with inlined call sites.

### DIFF
--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -4676,6 +4676,12 @@ public:
         continue;
       }
 
+      // If a scope has an inlined call site, skip it.
+      // TODO: Inlined call sites should be verified to ensure that the inliner
+      // handles scopes correctly.
+      if (DS->InlinedCallSite)
+        continue;
+
       // Otherwise, we're allowed to re-enter a scope only if
       // the scope is an ancestor of the scope we're currently leaving.
       auto isAncestorScope = [](const SILDebugScope *Cur,


### PR DESCRIPTION
If a debug scope has an inline call site, skip it during verification.
Eventually, `verifyDebugScopeHoles` should verify inline call sites as well to ensure that the inliner handles scopes correctly.

Addresses verification issues brought up in https://github.com/apple/swift/pull/17797: performance inlining at `-Onone` caused debug scope verification to fail.