### PR TITLE
[stdlib]remove _PointerFunction

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1067,8 +1067,7 @@ extension Array: RangeReplaceableCollection, ArrayProtocol {
     let newCount = oldCount + 1
     var newBuffer = _buffer._forceCreateUniqueMutableBuffer(
       countForNewBuffer: oldCount, minNewCapacity: newCount)
-    _buffer._arrayOutOfPlaceUpdate(
-      &newBuffer, oldCount, 0, _IgnorePointer())
+    _buffer._arrayOutOfPlaceUpdate(&newBuffer, oldCount, 0)
   }
 
   @inlinable

--- a/stdlib/public/core/ArrayShared.swift
+++ b/stdlib/public/core/ArrayShared.swift
@@ -203,15 +203,13 @@ extension _ArrayBufferProtocol {
     _ headCount: Int, // Count of initial source elements to copy/move
     _ newCount: Int,  // Number of new elements to insert
     _ initializeNewElements: 
-        ((UnsafeMutablePointer<Element>, _ count: Int) -> ())? = nil
+        ((UnsafeMutablePointer<Element>, _ count: Int) -> ()) = { ptr, count in
+      _sanityCheck(count == 0)
+    }
   ) {
 
     _sanityCheck(headCount >= 0)
     _sanityCheck(newCount >= 0)
-    
-    let initializeNewElements = initializeNewElements ?? { ptr, count in
-      _sanityCheck(count == 0)
-    }
 
     // Count of trailing source elements to copy/move
     let sourceCount = self.count

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -859,7 +859,7 @@ extension ArraySlice: RangeReplaceableCollection, ArrayProtocol {
     var newBuffer = _buffer._forceCreateUniqueMutableBuffer(
       countForNewBuffer: oldCount, minNewCapacity: newCount)
     _buffer._arrayOutOfPlaceUpdate(
-      &newBuffer, oldCount, 0, _IgnorePointer())
+      &newBuffer, oldCount, 0)
   }
 
   @inlinable

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -768,7 +768,7 @@ extension ContiguousArray: RangeReplaceableCollection, ArrayProtocol {
     var newBuffer = _buffer._forceCreateUniqueMutableBuffer(
       countForNewBuffer: oldCount, minNewCapacity: newCount)
     _buffer._arrayOutOfPlaceUpdate(
-      &newBuffer, oldCount, 0, _IgnorePointer())
+      &newBuffer, oldCount, 0)
   }
 
   @inlinable


### PR DESCRIPTION
The _PointerFunction protocol and related types are kind of weird and unnecessary. 