### PR TITLE
Removed the tf_tensor_to_i1 magic function

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -282,6 +282,10 @@ private:
   /// serialization.
   bool WasDeserializedCanonical = false;
 
+  /// SWIFT_ENABLE_TENSORFLOW
+  /// True if this function is to be lowered to Accelerator.
+  bool isAcceleratorFn;
+
   SILFunction(SILModule &module, SILLinkage linkage, StringRef mangledName,
               CanSILFunctionType loweredType, GenericEnvironment *genericEnv,
               Optional<SILLocation> loc, IsBare_t isBareSILFunction,
@@ -289,7 +293,9 @@ private:
               ProfileCounter entryCount, IsThunk_t isThunk,
               SubclassScope classSubclassScope, Inline_t inlineStrategy,
               EffectsKind E, SILFunction *insertBefore,
-              const SILDebugScope *debugScope);
+              const SILDebugScope *debugScope,
+              /// SWIFT_ENABLE_TENSORFLOW
+              bool isAcceleratorFn = false);
 
   static SILFunction *
   create(SILModule &M, SILLinkage linkage, StringRef name,
@@ -301,7 +307,9 @@ private:
          Inline_t inlineStrategy = InlineDefault,
          EffectsKind EffectsKindAttr = EffectsKind::Unspecified,
          SILFunction *InsertBefore = nullptr,
-         const SILDebugScope *DebugScope = nullptr);
+         const SILDebugScope *DebugScope = nullptr,
+         /// SWIFT_ENABLE_TENSORFLOW
+         bool isAcceleratorFn = false);
 
 public:
   ~SILFunction();
@@ -882,6 +890,9 @@ public:
   //===--------------------------------------------------------------------===//
   // Miscellaneous
   //===--------------------------------------------------------------------===//
+
+  /// SWIFT_ENABLE_TENSORFLOW
+  bool getIsAcceleratorFn() const { return isAcceleratorFn; }
 
   /// verify - Run the IR verifier to make sure that the SILFunction follows
   /// invariants.

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -542,7 +542,9 @@ public:
       IsTransparent_t isTransparent, IsSerialized_t isSerialized,
       ProfileCounter entryCount = ProfileCounter(),
       IsThunk_t isThunk = IsNotThunk,
-      SubclassScope subclassScope = SubclassScope::NotApplicable);
+      SubclassScope subclassScope = SubclassScope::NotApplicable,
+      /// SWIFT_ENABLE_TENSORFLOW
+      bool isAcceleratorFn = false);
 
   /// \brief Return the declaration of a function, or create it if it doesn't
   /// exist.

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -265,7 +265,9 @@ SILFunction *SILModule::getOrCreateFunction(
     SILLocation loc, StringRef name, SILLinkage linkage,
     CanSILFunctionType type, IsBare_t isBareSILFunction,
     IsTransparent_t isTransparent, IsSerialized_t isSerialized,
-    ProfileCounter entryCount, IsThunk_t isThunk, SubclassScope subclassScope) {
+    ProfileCounter entryCount, IsThunk_t isThunk, SubclassScope subclassScope,
+    // SWIFT_ENABLE_TENSORFLOW
+    bool isAcceleratorFn) {
   assert(!type->isNoEscape() && "Function decls always have escaping types.");
   if (auto fn = lookUpFunction(name)) {
     assert(fn->getLoweredFunctionType() == type);
@@ -274,9 +276,11 @@ SILFunction *SILModule::getOrCreateFunction(
     return fn;
   }
 
-  auto fn = SILFunction::create(*this, linkage, name, type, nullptr, loc,
-                                isBareSILFunction, isTransparent, isSerialized,
-                                entryCount, isThunk, subclassScope);
+  auto fn = SILFunction::create(
+      *this, linkage, name, type, nullptr, loc, isBareSILFunction,
+      isTransparent, isSerialized, entryCount, isThunk, subclassScope,
+      InlineDefault, EffectsKind::Unspecified, /*InsertBefore*/ nullptr,
+      /*DebugScope*/ nullptr, isAcceleratorFn);
   fn->setDebugScope(new (*this) SILDebugScope(loc, fn));
   return fn;
 }

--- a/test/TensorFlow/control_flow.swift
+++ b/test/TensorFlow/control_flow.swift
@@ -2,6 +2,28 @@
 
 import TensorFlow
 
+// The operand of cond_br is a TensorHandle<Bool>
+public func testBoolCondForWhile() {
+  let t = Tensor<Float>(1.0)
+  var i = Tensor<Int32>(0)
+  repeat {
+    // expected-warning @+1{{value implicitly copied to the host}}
+    let y = t + t
+    print(y)
+    i += 1
+    // expected-warning @+1{{value implicitly copied to the host}}
+  } while i != Tensor<Int32>(10)
+}
+
+// TODO: currently the loop condition comparison uses scalarized(), which
+// generates send/recv, and uses Reshape. See if we can generate more efficient
+// TF code in our stdlib.
+
+// CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testBoolCondForWhile{{.*}}
+// CHECK:    bb1(
+// CHECK:      [[COND:%.*]] = builtin "__tfop_Reshape{{.*}} : $TensorHandle<Bool>
+// CHECK:      cond_br [[COND]], bb2, bb3
+
 public enum Pet {
   case bird, cat, dog, fish
 }

--- a/test/TensorFlow/integration.swift
+++ b/test/TensorFlow/integration.swift
@@ -178,8 +178,7 @@ public func test_bool_param(cond: Bool, // expected-warning {{'cond' implicitly 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}test_bool_param{{.*}}
 // CHECK: sil private @{{.*}}test_bool_param{{.*}} : $@callee_owned (TensorHandle<Builtin.Int1>, TensorHandle<Float>, TensorHandle<Float>) -> TensorHandle<Float>
 // CHECK: bb0(%0 : $TensorHandle<Builtin.Int1>, %1 : $TensorHandle<Float>, %2 : $TensorHandle<Float>):
-// CHECK: %3 = builtin "tf_tensor_to_i1"(%0 : $TensorHandle<Builtin.Int1>) : $Builtin.Int1
-// CHECK: cond_br %3, bb2, bb1
+// CHECK: cond_br %0, bb2, bb1
 
 
 // CHECK-LABEL: --- TFPartition Host Result: {{.*}}test_bool_param{{.*}}
@@ -213,8 +212,7 @@ public func test_bool_param2(cond: Bool, // expected-warning {{'cond' implicitly
 // CHECK: sil private @{{.*}}test_bool_param2{{.*}}
 // CHECK: bb0(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>, %2 : $TensorHandle<Builtin.Int1>):
 // CHECK:         builtin "__tfop_Add,$in,$in,T,__device"(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>, {{.*}}) : $TensorHandle<Float>
-// CHECK-NEXT:    [[BOOL:%.*]] = builtin "tf_tensor_to_i1"(%2 : $TensorHandle<Builtin.Int1>) : $Builtin.Int1
-// CHECK-NEXT:    cond_br [[BOOL]]
+// CHECK-NEXT:    cond_br %2
 // ...
 // CHECK: }
 
@@ -277,15 +275,13 @@ public func test_while1(maxCount: Int,  // expected-warning {{'maxCount' implici
 // CHECK-NEXT: integer_literal $Builtin.Int32, 9
 // CHECK:      builtin "__tfop_Const,dtype$dtype,value$tensor,__device"(
 // CHECK:      builtin "__tfop_Add,$in,$in,T,__device"(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>
-// CHECK-NEXT: builtin "tf_tensor_to_i1"(
 // CHECK-NEXT: cond_br {{.*}}, bb2, bb1
 
 // CHECK: bb3([[A:%.*]] : $TensorHandle<Float>, [[COUNT:%.*]] : $TensorHandle<Builtin.Int64>):
 // CHECK:       [[NEXTA:%.*]] = builtin "__tfop_Sub,$in,$in,T,__device"([[A]] : $TensorHandle<Float>, %1 : $TensorHandle<Float>, {{.*}}) : $TensorHandle<Float>
 // CHECK:       [[NEXTCOUNT:%.*]] = builtin "__tfop_Add,$in,$in,__device"([[COUNT]] : $TensorHandle<Builtin.Int64>,
 // CHECK:       [[CONDT:%.*]] = builtin "__tfop_Less,$in,$in,__device"([[NEXTCOUNT]] : $TensorHandle<Builtin.Int64>,
-// CHECK-NEXT:   [[COND:%.*]] = builtin "tf_tensor_to_i1"([[CONDT]] : $TensorHandle<Builtin.Int1>) : $Builtin.Int1
-// CHECK-NEXT:   cond_br [[COND]], bb5, bb4
+// CHECK-NEXT:   cond_br [[CONDT]], bb5, bb4
 
 // CHECK: bb5:
 // CHECK-NEXT: br bb3([[NEXTA]] : $TensorHandle<Float>, [[NEXTCOUNT]] : $TensorHandle<Builtin.Int64>)


### PR DESCRIPTION
This function appears only needed to appease SILVerifier, which requires that the `cond` operand of `cond_br` be a `Builtin.i1` type. Removing this function helps simplify the logic in the TF partition, device partition and lowering passes.

Added a field to SILFunction indicating if it's a accelerator (TF) function, so that we can customize SILVerifier behavior accordingly (and possibly other code related to SILFunction down the road).

Added a test case where the While condition is based on a `TensorHandle<Bool>` value (instead of `TensorHandle<Builtin.i1>`).