### PR TITLE
Migrate UnsafeMutableAudioBufferListPointer off _writeBackMutableSlice.

### DIFF
--- a/stdlib/public/SDK/CoreAudio/CMakeLists.txt
+++ b/stdlib/public/SDK/CoreAudio/CMakeLists.txt
@@ -3,7 +3,6 @@ include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
 add_swift_library(swiftCoreAudio ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   CoreAudio.swift
-  ../../../public/core/WriteBackMutableSlice.swift
 
   SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"

--- a/stdlib/public/SDK/CoreAudio/CoreAudio.swift
+++ b/stdlib/public/SDK/CoreAudio/CoreAudio.swift
@@ -136,7 +136,9 @@ public struct UnsafeMutableAudioBufferListPointer {
 extension UnsafeMutableAudioBufferListPointer
   : MutableCollection, RandomAccessCollection {
 
+  public typealias Element = AudioBuffer
   public typealias Index = Int
+  public typealias Indices = Range<Int>
 
   /// Always zero, which is the index of the first `AudioBuffer`.
   public var startIndex: Int {
@@ -149,7 +151,7 @@ extension UnsafeMutableAudioBufferListPointer
   }
 
   /// Access an indexed `AudioBuffer` (`mBuffers[i]`).
-  public subscript(index: Int) -> AudioBuffer {
+  public subscript(index: Index) -> Element {
     get {
       _precondition(index >= 0 && index < self.count,
         "subscript index out of range")
@@ -161,17 +163,5 @@ extension UnsafeMutableAudioBufferListPointer
       (_audioBuffersPointer + index).pointee = newValue
     }
   }
-
-  public subscript(bounds: Range<Int>)
-    -> Slice<UnsafeMutableAudioBufferListPointer> {
-    get {
-      return Slice(base: self, bounds: bounds)
-    }
-    set {
-      _writeBackMutableSlice(&self, bounds: bounds, slice: newValue)
-    }
-  }
-
-  public typealias Indices = Range<Int>
 }
 


### PR DESCRIPTION
The current behavior is the default you get "for free" from `MutableCollection` so there's no good reason for accessing the std lib file directly, and it requires access to std lib internals to do so.

This is the first step in removing `_writeBackMutableSlice` entirely, since it seems like it's a hangover from the days before protocol extensions that got missed.