### PR TITLE
Now that the representations of addresses and values are merged, we can

### DIFF
--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -355,6 +355,8 @@ public:
     if (representationKind == RK_DirectAddress)
       return aux.directAddress_objectID;
     assert(representationKind == RK_DerivedAddress);
+    assert(aux.derivedAddress_numEntries != 0 &&
+           "should always have space for the object ID");
     return value.derivedAddress[0];
   }
 


### PR DESCRIPTION
Now that the representations of addresses and values are merged, we can
merge the code paths to compute them.  This also strengthens an assertion
than hongm@ recently hit where we'd change address values when unknowns
were computed.  Now we can just return unknown.
