### PR TITLE
[SILGen] Output a different message for failed IUO force-unwraps

### DIFF
--- a/lib/SILGen/Conversion.h
+++ b/lib/SILGen/Conversion.h
@@ -33,6 +33,8 @@ public:
     BridgeToObjC,
 
     /// A bridging conversion to a foreign type following a force.
+    /// Although it's not reflected in the name, this is always an
+    /// implicit force cast.
     ForceAndBridgeToObjC,
 
     /// A bridging conversion from a foreign type.

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -182,7 +182,8 @@ auto SILGenFunction::emitSourceLocationArgs(SourceLoc sourceLoc,
 
 ManagedValue
 SILGenFunction::emitPreconditionOptionalHasValue(SILLocation loc,
-                                                 ManagedValue optional) {
+                                                 ManagedValue optional,
+                                                 bool isImplicitUnwrap) {
   // Generate code to the optional is present, and if not, abort with a message
   // (provided by the stdlib).
   SILBasicBlock *contBB = createBasicBlock();
@@ -217,12 +218,19 @@ SILGenFunction::emitPreconditionOptionalHasValue(SILLocation loc,
         getASTContext().getDiagnoseUnexpectedNilOptional(nullptr)) {
     auto args = emitSourceLocationArgs(loc.getSourceLoc(), loc);
     
+    auto i1Ty = SILType::getBuiltinIntegerType(1, getASTContext());
+    auto isImplicitUnwrapLiteral =
+      B.createIntegerLiteral(loc, i1Ty, isImplicitUnwrap);
+    auto isImplicitUnwrapValue =
+      ManagedValue::forUnmanaged(isImplicitUnwrapLiteral);
+    
     emitApplyOfLibraryIntrinsic(loc, diagnoseFailure, SubstitutionMap(),
                                 {
                                   args.filenameStartPointer,
                                   args.filenameLength,
                                   args.filenameIsAscii,
-                                  args.line
+                                  args.line,
+                                  isImplicitUnwrapValue
                                 },
                                 SGFContext());
   }
@@ -268,10 +276,11 @@ SILValue SILGenFunction::emitDoesOptionalHaveValue(SILLocation loc,
 
 ManagedValue SILGenFunction::emitCheckedGetOptionalValueFrom(SILLocation loc,
                                                       ManagedValue src,
+                                                      bool isImplicitUnwrap,
                                                       const TypeLowering &optTL,
                                                       SGFContext C) {
   // TODO: Make this take optTL.
-  return emitPreconditionOptionalHasValue(loc, src);
+  return emitPreconditionOptionalHasValue(loc, src, isImplicitUnwrap);
 }
 
 ManagedValue SILGenFunction::emitUncheckedGetOptionalValueFrom(
@@ -1103,7 +1112,9 @@ ManagedValue Conversion::emit(SILGenFunction &SGF, SILLocation loc,
   case ForceAndBridgeToObjC: {
     auto &tl = SGF.getTypeLowering(value.getType());
     auto sourceValueType = getBridgingSourceType().getOptionalObjectType();
-    value = SGF.emitCheckedGetOptionalValueFrom(loc, value, tl, SGFContext());
+    value = SGF.emitCheckedGetOptionalValueFrom(loc, value,
+                                                /*isImplicitUnwrap*/ true,
+                                                tl, SGFContext());
     return SGF.emitNativeToBridgedValue(loc, value, sourceValueType,
                                         getBridgingResultType(),
                                         getBridgingLoweredResultType(), C);
@@ -1438,7 +1449,11 @@ Lowering::emitPeepholedConversions(SILGenFunction &SGF, SILLocation loc,
 
     auto value = produceOrigValue(SGF, loc, SGFContext());
     auto &optTL = SGF.getTypeLowering(value.getType());
-    return SGF.emitCheckedGetOptionalValueFrom(loc, value, optTL, C);
+    // isForceUnwrap is hardcoded true because hint.isForced() is only
+    // set by implicit force unwraps.
+    return SGF.emitCheckedGetOptionalValueFrom(loc, value,
+                                               /*isForceUnwrap*/ true,
+                                               optTL, C);
   };
 
   auto getBridgingSourceType = [&] {

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -810,13 +810,15 @@ public:
   /// _diagnoseUnexpectedNilOptional if the optional has no value. Return the
   /// MangedValue resulting from the success case.
   ManagedValue emitPreconditionOptionalHasValue(SILLocation loc,
-                                                ManagedValue optional);
+                                                ManagedValue optional,
+                                                bool isImplicitUnwrap);
 
   /// \brief Emit a call to the library intrinsic _getOptionalValue
   /// given the address of the optional, which checks that an optional contains
   /// some value and either returns the value or traps if there is none.
   ManagedValue emitCheckedGetOptionalValueFrom(SILLocation loc,
                                                ManagedValue addr,
+                                               bool isImplicitUnwrap,
                                                const TypeLowering &optTL,
                                                SGFContext C);
   

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -398,7 +398,10 @@ ManagedValue Transform::transform(ManagedValue v,
   // optional or Any, force it.
   if (inputIsOptional && !outputIsOptional &&
       !outputSubstType->isExistentialType()) {
+    // isImplicitUnwrap is hardcoded false because this method is never
+    // used to generate code from a ForceValueExpr.
     v = SGF.emitCheckedGetOptionalValueFrom(Loc, v,
+                                            /*isImplicitUnwrap*/ false, 
                                             SGF.getTypeLowering(v.getType()),
                                             SGFContext());
 

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -398,10 +398,11 @@ ManagedValue Transform::transform(ManagedValue v,
   // optional or Any, force it.
   if (inputIsOptional && !outputIsOptional &&
       !outputSubstType->isExistentialType()) {
-    // isImplicitUnwrap is hardcoded false because this method is never
-    // used to generate code from a ForceValueExpr.
+    // isImplicitUnwrap is hardcoded true because the looseness in types of
+    // @objc witnesses/overrides that we're handling here only allows IUOs,
+    // not explicit Optionals.
     v = SGF.emitCheckedGetOptionalValueFrom(Loc, v,
-                                            /*isImplicitUnwrap*/ false, 
+                                            /*isImplicitUnwrap*/ true, 
                                             SGF.getTypeLowering(v.getType()),
                                             SGFContext());
 

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -299,9 +299,12 @@ public // COMPILER_INTRINSIC
 func _diagnoseUnexpectedNilOptional(_filenameStart: Builtin.RawPointer,
                                     _filenameLength: Builtin.Word,
                                     _filenameIsASCII: Builtin.Int1,
-                                    _line: Builtin.Word) {
+                                    _line: Builtin.Word,
+                                    _isImplicitUnwrap: Builtin.Int1) {
   _preconditionFailure(
-    "Unexpectedly found nil while unwrapping an Optional value",
+    Bool(_isImplicitUnwrap)
+      ? "Unexpectedly found nil while implicitly unwrapping an Optional value"
+      : "Unexpectedly found nil while unwrapping an Optional value",
     file: StaticString(_start: _filenameStart,
                        utf8CodeUnitCount: _filenameLength,
                        isASCII: _filenameIsASCII),

--- a/test/SILGen/objc_bridging_peephole.swift
+++ b/test/SILGen/objc_bridging_peephole.swift
@@ -75,7 +75,7 @@ func testNonNullMethodResult(dummy: DummyClass) {
   // CHECK-NEXT: switch_enum [[RESULT]]
   //
   // CHECK:    bb1:
-  // CHECK:      function_ref @$Ss30_diagnoseUnexpectedNilOptional14_filenameStart01_E6Length01_E7IsASCII5_lineyBp_BwBi1_BwtF
+  // CHECK:      function_ref @$Ss30_diagnoseUnexpectedNilOptional14_filenameStart01_E6Length01_E7IsASCII5_line17_isImplicitUnwrapyBp_BwBi1_BwBi1_tF
   // CHECK:    bb2([[RESULT:%.*]] : @owned $NSString):
   // CHECK:      [[BORROWED_RESULT:%.*]] = begin_borrow [[RESULT]]
   // CHECK:      [[USE:%.*]] = function_ref @$S22objc_bridging_peephole5useNSyySo8NSStringCF
@@ -86,7 +86,7 @@ func testNonNullMethodResult(dummy: DummyClass) {
   // CHECK-NEXT: [[RESULT:%.*]] = apply [[METHOD]]([[SELF]])
   // CHECK-NEXT: switch_enum [[RESULT]]
   // CHECK:    bb3:
-  // CHECK:      function_ref @$Ss30_diagnoseUnexpectedNilOptional14_filenameStart01_E6Length01_E7IsASCII5_lineyBp_BwBi1_BwtF
+  // CHECK:      function_ref @$Ss30_diagnoseUnexpectedNilOptional14_filenameStart01_E6Length01_E7IsASCII5_line17_isImplicitUnwrapyBp_BwBi1_BwBi1_tF
   // CHECK:    bb4([[RESULT:%.*]] : @owned $NSString):
   // CHECK-NEXT: [[ANYOBJECT:%.*]] = init_existential_ref [[RESULT]] : $NSString : $NSString, $AnyObject
   // CHECK-NEXT: [[BORROWED_ANYOBJECT:%.*]] = begin_borrow [[ANYOBJECT]]
@@ -104,7 +104,7 @@ func testForcedMethodResult(dummy: DummyClass) {
   // CHECK-NEXT: [[RESULT:%.*]] = apply [[METHOD]]([[SELF]])
   // CHECK-NEXT: switch_enum [[RESULT]]
   // CHECK:    bb1:
-  // CHECK:      function_ref @$Ss30_diagnoseUnexpectedNilOptional14_filenameStart01_E6Length01_E7IsASCII5_lineyBp_BwBi1_BwtF
+  // CHECK:      function_ref @$Ss30_diagnoseUnexpectedNilOptional14_filenameStart01_E6Length01_E7IsASCII5_line17_isImplicitUnwrapyBp_BwBi1_BwBi1_tF
   // CHECK:    bb2([[RESULT:%.*]] : @owned $NSString):
   // CHECK:      [[BORROWED_RESULT:%.*]] = begin_borrow [[RESULT]]
   // CHECK:      [[USE:%.*]] = function_ref @$S22objc_bridging_peephole5useNSyySo8NSStringCF
@@ -197,7 +197,7 @@ func testNonNullPropertyValue(dummy: DummyClass) {
   // CHECK:       [[RESULT:%.*]] = apply [[METHOD]]([[SELF]])
   // CHECK:       switch_enum [[RESULT]]
   // CHECK:    bb1:
-  // CHECK:      function_ref @$Ss30_diagnoseUnexpectedNilOptional14_filenameStart01_E6Length01_E7IsASCII5_lineyBp_BwBi1_BwtF
+  // CHECK:      function_ref @$Ss30_diagnoseUnexpectedNilOptional14_filenameStart01_E6Length01_E7IsASCII5_line17_isImplicitUnwrapyBp_BwBi1_BwBi1_tF
   // CHECK:    bb2([[RESULT:%.*]] : @owned $NSString):
   // CHECK:      [[BORROWED_RESULT:%.*]] = begin_borrow [[RESULT]]
   // CHECK:      [[USE:%.*]] = function_ref @$S22objc_bridging_peephole5useNSyySo8NSStringCF
@@ -208,7 +208,7 @@ func testNonNullPropertyValue(dummy: DummyClass) {
   // CHECK:      [[RESULT:%.*]] = apply [[METHOD]]([[SELF]])
   // CHECK:      switch_enum [[RESULT]]
   // CHECK:    bb3:
-  // CHECK:      function_ref @$Ss30_diagnoseUnexpectedNilOptional14_filenameStart01_E6Length01_E7IsASCII5_lineyBp_BwBi1_BwtF
+  // CHECK:      function_ref @$Ss30_diagnoseUnexpectedNilOptional14_filenameStart01_E6Length01_E7IsASCII5_line17_isImplicitUnwrapyBp_BwBi1_BwBi1_tF
   // CHECK:    bb4([[RESULT:%.*]] : @owned $NSString):
   // CHECK:      [[ANYOBJECT:%.*]] = init_existential_ref [[RESULT]] : $NSString : $NSString, $AnyObject
   // CHECK:      [[BORROWED_ANYOBJECT:%.*]] = begin_borrow [[ANYOBJECT]]
@@ -226,7 +226,7 @@ func testForcedPropertyValue(dummy: DummyClass) {
   // CHECK:      [[RESULT:%.*]] = apply [[METHOD]]([[SELF]])
   // CHECK:      switch_enum [[RESULT]]
   // CHECK:    bb1:
-  // CHECK:      function_ref @$Ss30_diagnoseUnexpectedNilOptional14_filenameStart01_E6Length01_E7IsASCII5_lineyBp_BwBi1_BwtF
+  // CHECK:      function_ref @$Ss30_diagnoseUnexpectedNilOptional14_filenameStart01_E6Length01_E7IsASCII5_line17_isImplicitUnwrapyBp_BwBi1_BwBi1_tF
   // CHECK:    bb2([[RESULT:%.*]] : @owned $NSString):
   // CHECK:      [[BORROWED_RESULT:%.*]] = begin_borrow [[RESULT]]
   // CHECK:      [[USE:%.*]] = function_ref @$S22objc_bridging_peephole5useNSyySo8NSStringCF
@@ -281,7 +281,7 @@ func testNonnullSubscriptGet(object: NonnullSubscript, index: AnyObject) {
   // CHECK:      [[RESULT:%.*]] = apply [[METHOD]]([[INDEX]], [[SELF]])
   // CHECK-NEXT: destroy_value [[INDEX]] : $AnyObject
   // CHECK-NEXT: switch_enum [[RESULT]]
-  // CHECK:      function_ref @$Ss30_diagnoseUnexpectedNilOptional14_filenameStart01_E6Length01_E7IsASCII5_lineyBp_BwBi1_BwtF
+  // CHECK:      function_ref @$Ss30_diagnoseUnexpectedNilOptional14_filenameStart01_E6Length01_E7IsASCII5_line17_isImplicitUnwrapyBp_BwBi1_BwBi1_tF
   // CHECK:    bb{{[0-9]+}}([[RESULT:%.*]] : @owned $NSString):
   // CHECK:      [[BORROWED_RESULT:%.*]] = begin_borrow [[RESULT]]
   // CHECK:      [[USE:%.*]] = function_ref @$S22objc_bridging_peephole5useNSyySo8NSStringCF
@@ -326,7 +326,7 @@ func testNullproneSubscriptGet(object: NullproneSubscript, index: AnyObject) {
   // CHECK:      [[RESULT:%.*]] = apply [[METHOD]]([[INDEX]], [[SELF]])
   // CHECK-NEXT: destroy_value [[INDEX]] : $AnyObject
   // CHECK-NEXT: switch_enum [[RESULT]]
-  // CHECK:      function_ref @$Ss30_diagnoseUnexpectedNilOptional14_filenameStart01_E6Length01_E7IsASCII5_lineyBp_BwBi1_BwtF
+  // CHECK:      function_ref @$Ss30_diagnoseUnexpectedNilOptional14_filenameStart01_E6Length01_E7IsASCII5_line17_isImplicitUnwrapyBp_BwBi1_BwBi1_tF
   // CHECK:    bb{{[0-9]+}}([[RESULT:%.*]] : @owned $NSString):
   // CHECK:      [[BORROWED_RESULT:%.*]] = begin_borrow [[RESULT]]
   // CHECK:      [[USE:%.*]] = function_ref @$S22objc_bridging_peephole5useNSyySo8NSStringCF

--- a/test/SILGen/objc_witnesses.swift
+++ b/test/SILGen/objc_witnesses.swift
@@ -43,6 +43,15 @@ extension Gizmo : Bells {
 // CHECK:   [[INIT:%[0-9]+]] = function_ref @$SSo5GizmoC{{[_0-9a-zA-Z]*}}fC : $@convention(method) (Int, @thick Gizmo.Type) -> @owned Optional<Gizmo>
 // CHECK:   [[IUO_RESULT:%[0-9]+]] = apply [[INIT]]([[I]], [[META]]) : $@convention(method) (Int, @thick Gizmo.Type) -> @owned Optional<Gizmo>
 // CHECK:   switch_enum [[IUO_RESULT]]
+// CHECK: bb1:
+// CHECK-NEXT:   [[FILESTR:%.*]] = string_literal utf8 "
+// CHECK-NEXT:   [[FILESIZ:%.*]] = integer_literal $Builtin.Word, 
+// CHECK-NEXT:   [[FILEASC:%.*]] = integer_literal $Builtin.Int1, 
+// CHECK-NEXT:   [[LINE:%.*]] = integer_literal $Builtin.Word, 
+// CHECK-NEXT:   [[COLUMN:%.*]] = integer_literal $Builtin.Word, 
+// CHECK-NEXT:   [[IMPLICIT:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK:   [[PRECOND:%.*]] = function_ref @$Ss30_diagnoseUnexpectedNilOptional{{[_0-9a-zA-Z]*}}F
+// CHECK:   apply [[PRECOND]]([[FILESTR]], [[FILESIZ]], [[FILEASC]], [[LINE]], [[IMPLICIT]])
 // CHECK: bb2([[UNWRAPPED_RESULT:%.*]] : @owned $Gizmo):
 // CHECK:   store [[UNWRAPPED_RESULT]] to [init] [[SELF]] : $*Gizmo
 

--- a/test/SILGen/optional.swift
+++ b/test/SILGen/optional.swift
@@ -101,3 +101,44 @@ func crash_on_dealloc(_ dict : [Int : [Int]] = [:]) {
   var dict = dict
   dict[1]?.append(2)
 }
+
+func use_unwrapped(_: Int) {}
+
+// CHECK-LABEL: sil hidden @$S8optional15explicit_unwrap{{[_0-9a-zA-Z]*}}F
+// CHECK:         [[FILESTR:%.*]] = string_literal utf8 "
+// CHECK-NEXT:         [[FILESIZ:%.*]] = integer_literal $Builtin.Word, 
+// CHECK-NEXT:         [[FILEASC:%.*]] = integer_literal $Builtin.Int1, 
+// CHECK-NEXT:         [[LINE:%.*]] = integer_literal $Builtin.Word, 
+// CHECK-NEXT:         [[COLUMN:%.*]] = integer_literal $Builtin.Word, 
+// CHECK-NEXT:         [[IMPLICIT:%.*]] = integer_literal $Builtin.Int1, 0
+// CHECK:         [[PRECOND:%.*]] = function_ref @$Ss30_diagnoseUnexpectedNilOptional{{[_0-9a-zA-Z]*}}F
+// CHECK:         apply [[PRECOND]]([[FILESTR]], [[FILESIZ]], [[FILEASC]], [[LINE]], [[IMPLICIT]])
+func explicit_unwrap(_ value: Int?) {
+  use_unwrapped(value!)
+}
+
+// CHECK-LABEL: sil hidden @$S8optional19explicit_iuo_unwrap{{[_0-9a-zA-Z]*}}F
+// CHECK:         [[FILESTR:%.*]] = string_literal utf8 "
+// CHECK-NEXT:         [[FILESIZ:%.*]] = integer_literal $Builtin.Word, 
+// CHECK-NEXT:         [[FILEASC:%.*]] = integer_literal $Builtin.Int1, 
+// CHECK-NEXT:         [[LINE:%.*]] = integer_literal $Builtin.Word, 
+// CHECK-NEXT:         [[COLUMN:%.*]] = integer_literal $Builtin.Word, 
+// CHECK-NEXT:         [[IMPLICIT:%.*]] = integer_literal $Builtin.Int1, 0
+// CHECK:         [[PRECOND:%.*]] = function_ref @$Ss30_diagnoseUnexpectedNilOptional{{[_0-9a-zA-Z]*}}F
+// CHECK:         apply [[PRECOND]]([[FILESTR]], [[FILESIZ]], [[FILEASC]], [[LINE]], [[IMPLICIT]])
+func explicit_iuo_unwrap(_ value: Int!) {
+  use_unwrapped(value!)
+}
+
+// CHECK-LABEL: sil hidden @$S8optional19implicit_iuo_unwrap{{[_0-9a-zA-Z]*}}F
+// CHECK:         [[FILESTR:%.*]] = string_literal utf8 "
+// CHECK-NEXT:         [[FILESIZ:%.*]] = integer_literal $Builtin.Word, 
+// CHECK-NEXT:         [[FILEASC:%.*]] = integer_literal $Builtin.Int1, 
+// CHECK-NEXT:         [[LINE:%.*]] = integer_literal $Builtin.Word, 
+// CHECK-NEXT:         [[COLUMN:%.*]] = integer_literal $Builtin.Word, 
+// CHECK-NEXT:         [[IMPLICIT:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK:         [[PRECOND:%.*]] = function_ref @$Ss30_diagnoseUnexpectedNilOptional{{[_0-9a-zA-Z]*}}F
+// CHECK:         apply [[PRECOND]]([[FILESTR]], [[FILESIZ]], [[FILEASC]], [[LINE]], [[IMPLICIT]])
+func implicit_iuo_unwrap(_ value: Int!) {
+  use_unwrapped(value)
+}

--- a/test/SILGen/optional_lvalue.swift
+++ b/test/SILGen/optional_lvalue.swift
@@ -3,8 +3,14 @@
 
 // CHECK-LABEL: sil hidden @$S15optional_lvalue07assign_a1_B0yySiSgz_SitF
 // CHECK:         [[WRITE:%.*]] = begin_access [modify] [unknown] %0 : $*Optional<Int>
+// CHECK:         [[FILESTR:%.*]] = string_literal utf8 "
+// CHECK-NEXT:         [[FILESIZ:%.*]] = integer_literal $Builtin.Word, 
+// CHECK-NEXT:         [[FILEASC:%.*]] = integer_literal $Builtin.Int1, 
+// CHECK-NEXT:         [[LINE:%.*]] = integer_literal $Builtin.Word, 
+// CHECK-NEXT:         [[COLUMN:%.*]] = integer_literal $Builtin.Word, 
+// CHECK-NEXT:         [[IMPLICIT:%.*]] = integer_literal $Builtin.Int1, 0
 // CHECK:         [[PRECOND:%.*]] = function_ref @$Ss30_diagnoseUnexpectedNilOptional{{[_0-9a-zA-Z]*}}F
-// CHECK:         apply [[PRECOND]](
+// CHECK:         apply [[PRECOND]]([[FILESTR]], [[FILESIZ]], [[FILEASC]], [[LINE]], [[IMPLICIT]])
 // CHECK:         [[PAYLOAD:%.*]] = unchecked_take_enum_data_addr [[WRITE]] : $*Optional<Int>, #Optional.some!enumelt.1
 // CHECK:         assign {{%.*}} to [[PAYLOAD]]
 func assign_optional_lvalue(_ x: inout Int?, _ y: Int) {
@@ -13,8 +19,14 @@ func assign_optional_lvalue(_ x: inout Int?, _ y: Int) {
 
 // CHECK-LABEL: sil hidden @$S15optional_lvalue011assign_iuo_B0yySiSgz_SitF
 // CHECK:         [[WRITE:%.*]] = begin_access [modify] [unknown] %0 : $*Optional<Int>
+// CHECK:         [[FILESTR:%.*]] = string_literal utf8 "
+// CHECK-NEXT:         [[FILESIZ:%.*]] = integer_literal $Builtin.Word, 
+// CHECK-NEXT:         [[FILEASC:%.*]] = integer_literal $Builtin.Int1, 
+// CHECK-NEXT:         [[LINE:%.*]] = integer_literal $Builtin.Word, 
+// CHECK-NEXT:         [[COLUMN:%.*]] = integer_literal $Builtin.Word, 
+// CHECK-NEXT:         [[IMPLICIT:%.*]] = integer_literal $Builtin.Int1, 0
 // CHECK:         [[PRECOND:%.*]] = function_ref @$Ss30_diagnoseUnexpectedNilOptional{{[_0-9a-zA-Z]*}}F
-// CHECK:         apply [[PRECOND]](
+// CHECK:         apply [[PRECOND]]([[FILESTR]], [[FILESIZ]], [[FILEASC]], [[LINE]], [[IMPLICIT]])
 // CHECK:         [[PAYLOAD:%.*]] = unchecked_take_enum_data_addr [[WRITE]] : $*Optional<Int>, #Optional.some!enumelt.1
 // CHECK:         assign {{%.*}} to [[PAYLOAD]]
 func assign_iuo_lvalue(_ x: inout Int!, _ y: Int) {
@@ -32,6 +44,14 @@ struct S {
 
 // CHECK-LABEL: sil hidden @$S15optional_lvalue011assign_iuo_B9_implicityyAA1SVSgz_SitF
 // CHECK:         [[WRITE:%.*]] = begin_access [modify] [unknown] %0 : $*Optional<S>
+// CHECK:         [[FILESTR:%.*]] = string_literal utf8 "
+// CHECK-NEXT:         [[FILESIZ:%.*]] = integer_literal $Builtin.Word, 
+// CHECK-NEXT:         [[FILEASC:%.*]] = integer_literal $Builtin.Int1, 
+// CHECK-NEXT:         [[LINE:%.*]] = integer_literal $Builtin.Word, 
+// CHECK-NEXT:         [[COLUMN:%.*]] = integer_literal $Builtin.Word, 
+// CHECK-NEXT:         [[IMPLICIT:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK:         [[PRECOND:%.*]] = function_ref @$Ss30_diagnoseUnexpectedNilOptional{{[_0-9a-zA-Z]*}}F
+// CHECK:         apply [[PRECOND]]([[FILESTR]], [[FILESIZ]], [[FILEASC]], [[LINE]], [[IMPLICIT]])
 // CHECK:         [[SOME:%.*]] = unchecked_take_enum_data_addr [[WRITE]]
 // CHECK:         [[X:%.*]] = struct_element_addr [[SOME]]
 func assign_iuo_lvalue_implicit(_ s: inout S!, _ y: Int) {

--- a/test/stdlib/OptionalTraps.swift
+++ b/test/stdlib/OptionalTraps.swift
@@ -37,5 +37,35 @@ OptionalTraps.test("UnwrapNone/Ounchecked")
   expectEqual(0, unsafeBitCast(a!, to: Int.self))
 }
 
+OptionalTraps.test("UnwrapNone/Message")
+  .skip(.custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .skip(.custom(
+    { !_isDebugAssertConfiguration() },
+    reason: "this trap may not have an error message may not be printed in -O"))
+  .code {
+  var a: AnyObject? = returnNil()
+  expectCrashLater(withMessage: 
+      "Unexpectedly found nil while unwrapping an Optional value")
+  let unwrapped: AnyObject = a!
+  _blackHole(unwrapped)
+}
+
+OptionalTraps.test("UnwrapNone/Message/Implicit")
+  .skip(.custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .skip(.custom(
+    { !_isDebugAssertConfiguration() },
+    reason: "this trap may not have an error message may not be printed in -O"))
+  .code {
+  var a: AnyObject! = returnNil()
+  expectCrashLater(withMessage: 
+      "Unexpectedly found nil while implicitly unwrapping an Optional value")
+  let unwrapped: AnyObject = a
+  _blackHole(unwrapped)
+}
+
 runAllTests()
 


### PR DESCRIPTION
Modifies SILGen and the `Swift._diagnoseUnexpectedNilOptional` call to print a slightly different message for force unwraps which were implicitly inserted by the compiler for IUOs. That is, these two lines will produce different messages:

```swift
myOptional!.foo()    // => "Fatal error: Unexpectedly found nil while unwrapping an Optional value"
myIUO.foo()    // => "Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value"
```

The message is chosen based on the presence of certain flags in the `ForceValueExpr`, not on the type of the value being unwrapped, so `myIUO!.foo()` would print the first message, not the second.

Resolves [SR-8170](https://bugs.swift.org/browse/SR-8170).