### PR TITLE
Fixed a bug in building `GraphFunctionBody::outputs`, where the lowering of nested conditional SESE regions did not set that vector field

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -133,6 +133,28 @@ namespace {
     ///     live-in values used within the loop (with no SILArgument specified).
     SmallVector<std::pair<SILArgument*, TF_Output>, 4> outputs;
 
+    /// Track whether `outputs` have been set, and if yes who set them. This
+    /// helps maintain the following invariants:
+    /// 1. When `outputs` are read, the enum value must not be NONE.
+    /// 2. When `outputs` are set in any context other than lowering a
+    /// conditional SESE region, it can only be set exactly once. e.g. each
+    /// graph function can have at most one return or branch inst.
+    /// 3. When `outputs` are set when lowering a conditional SESE region, it
+    /// can be set again in another context. e.g. if we are lowering a sequence
+    /// of conditional SESE regions into the same graph function.
+    enum OutputSetter {
+      /// `outputs` are not yet set.
+      NONE,
+
+      /// `outputs` are set in some context other than lowering a conditional
+      /// region. e.g. When lowering a branch or a return inst.
+      NOT_COND_REGION,
+
+      /// `outputs` are set in the context of lowering a conditional
+      /// region.
+      COND_REGION,
+    } outputSetter = NONE;
+
     /// If this graph has any side-effecting operations, this is the most
     /// recently emitted operation that had side effects.  Otherwise, it is
     /// null.
@@ -2199,8 +2221,10 @@ visitUncheckedRefCastInst(UncheckedRefCastInst *inst) {
 
 GLStatus TFGraphLowering::visitReturnInst(ReturnInst *inst) {
   auto &graphFn = getCurrentGraphFunction();
-  assert(graphFn.outputs.empty() &&
-         "Should only have one return per graph function");
+  assert(graphFn.outputSetter != GraphFunctionBody::NOT_COND_REGION &&
+         "Should only have one return / exitbranch per graph function");
+  graphFn.outputs.clear();
+  graphFn.outputSetter = GraphFunctionBody::NOT_COND_REGION;
 
   // The return is either using a single value or a tuple of values (which
   // could be empty).  These become the results of the graph.
@@ -2223,11 +2247,13 @@ GLStatus TFGraphLowering::visitReturnInst(ReturnInst *inst) {
 }
 
 GLStatus TFGraphLowering::visitBranchInst(BranchInst *inst) {
-  if (inst->getNumArgs() == 0) return GLStatus::Success;
-
   auto &graphFn = getCurrentGraphFunction();
-  assert(graphFn.outputs.empty() &&
-         "Should only have one exit branch per graph function");
+  assert(graphFn.outputSetter != GraphFunctionBody::NOT_COND_REGION &&
+         "Should only have one return / exit branch per graph function");
+  graphFn.outputs.clear();
+  graphFn.outputSetter = GraphFunctionBody::NOT_COND_REGION;
+
+  if (inst->getNumArgs() == 0) return GLStatus::Success;
 
   auto destBB = inst->getDestBB();
 
@@ -2418,6 +2444,7 @@ GLStatus TFGraphLowering::lowerWhileLoopRegion(WhileLoopSESERegion *r) {
   // have all of the live inputs added as inputs to the function.  XLA While
   // loops require a T->T function, so we need to add the live inputs as outputs
   // as well.
+  assert(loopBodyFn.outputSetter != GraphFunctionBody::NONE);
   assert(loopBodyFn.outputs.size() == headerBB->getArguments().size() &&
          "loop body result values didn't get lowered properly");
 
@@ -2487,6 +2514,8 @@ GLStatus TFGraphLowering::lowerWhileLoopRegion(WhileLoopSESERegion *r) {
     }
 
     // The result of the function is our condition value.
+    assert(graphFn.outputSetter == GraphFunctionBody::NONE);
+    graphFn.outputSetter = GraphFunctionBody::NOT_COND_REGION;
     graphFn.outputs.push_back({ /*SILArgument*/nullptr, condValue });
   });
   if (S != GLStatus::Success) return S;
@@ -2574,6 +2603,10 @@ GLStatus TFGraphLowering::lowerConditionalRegion(ConditionalSESERegion *r) {
     if (auto trueRegion = r->getTrue()) {
       S = lowerRegion(trueRegion);
       if (S != GLStatus::Success) return;
+    } else {
+      auto &graphFn = functionStack.back();
+      assert(graphFn.outputSetter == GraphFunctionBody::NONE);
+      graphFn.outputSetter = GraphFunctionBody::NOT_COND_REGION;
     }
   });
   if (S != GLStatus::Success) return S;
@@ -2584,6 +2617,10 @@ GLStatus TFGraphLowering::lowerConditionalRegion(ConditionalSESERegion *r) {
     if (auto falseRegion = r->getFalse()) {
       S = lowerRegion(falseRegion);
       if (S != GLStatus::Success) return;
+    } else {
+      auto &graphFn = functionStack.back();
+      assert(graphFn.outputSetter == GraphFunctionBody::NONE);
+      graphFn.outputSetter = GraphFunctionBody::NOT_COND_REGION;
     }
   });
   if (S != GLStatus::Success) return S;
@@ -2663,6 +2700,8 @@ GLStatus TFGraphLowering::lowerConditionalRegion(ConditionalSESERegion *r) {
   // being filled in by the conditional region.  That said, the lists could
   // be in different orders.  Canonicalize the false region to match the true
   // region, and keep track of the output types for later consumption.
+  assert(trueCodeFn.outputSetter != GraphFunctionBody::NONE);
+  assert(falseCodeFn.outputSetter != GraphFunctionBody::NONE);
   assert(trueCodeFn.outputs.size() == falseCodeFn.outputs.size() &&
          "True and false region should produce same set of result values");
   for (unsigned i = 0, e = trueCodeFn.outputs.size(); i != e; ++i) {
@@ -2727,9 +2766,16 @@ GLStatus TFGraphLowering::lowerConditionalRegion(ConditionalSESERegion *r) {
 
   // Remember each of the results so that any references to the SIL BBArguments
   // that got defined end up referring to this node.
-  for (int i = 0, e = trueCodeFn.outputs.size(); i != e; ++i)
-    addValueMapping({trueCodeFn.outputs[i].first, 0}, {result, i});
-
+  // Also set the graph function outputs. Note they may have been set by the
+  // lowering of a prior conditional region.
+  assert(graphFn.outputSetter != GraphFunctionBody::NOT_COND_REGION);
+  graphFn.outputs.clear();
+  graphFn.outputSetter = GraphFunctionBody::COND_REGION;
+  for (int i = 0, e = trueCodeFn.outputs.size(); i != e; ++i) {
+      TF_Output outputNode = {result, i};
+      addValueMapping({trueCodeFn.outputs[i].first, 0}, outputNode);
+      graphFn.outputs.push_back({trueCodeFn.outputs[i].first, outputNode});
+  }
   return GLStatus::Success;
 }
 
@@ -3010,7 +3056,7 @@ bool TFGraphLowering::buildGraphFunction(
     const GraphFunctionBody &graphBody, StringRef funcName,
     bool &hasSideEffects, SmallVectorImpl<TF_DataType> *inputTypes,
     SmallVectorImpl<TF_DataType> *outputTypes) {
-
+  assert(graphBody.outputSetter != GraphFunctionBody::NONE);
   // Inform our callers whether this function contains side effects or not.
   hasSideEffects = graphBody.controlDependenceValue != nullptr;
 

--- a/test/TensorFlowRuntime/loops.swift
+++ b/test/TensorFlowRuntime/loops.swift
@@ -44,6 +44,28 @@ LoopsTests.testAllBackends("simpleCounterLoop_ab") {
   expectEqual(98, a.scalar)
 }
 
+LoopsTests.testAllBackends("SR8164") {
+  func SR8164(count: Int32, expectedVal: Int32) {
+    var a = Tensor<Int32>(count)
+    let b = Tensor<Int32>(count)
+    if (count == 100) {
+      a += b
+    } else {
+      if (count <= 50) {
+        a -= b
+      } else {
+        a += b
+      }
+    }
+    a -= b
+    expectEqualWithScalarTensor(expectedVal, a)
+  }
+
+  SR8164(count: 100, expectedVal: 100)
+  SR8164(count: 30, expectedVal: -30)
+  SR8164(count: 70, expectedVal: 70)
+}
+
 // FIXME: Compiler bug (b/73607740)
 // error: internal error generating TensorFlow graph:
 // GraphGen cannot lower a 'send' to the host yet


### PR DESCRIPTION
One example test case is:
```
public func foo(count :Int32) {
  var a = Tensor<Int32>(count)
  var b = Tensor<Int32>(count)
  if (count == 100) {
    a += b
  } else {
    if (count <= 50) {
      a -= b
    } else {
      a *= b
    }
  }
  a -= b
  _hostOp(a)
}
```

Its CFG is:

```
[sequence
  {condition Header: bb0
    block bb1
    {condition Header: bb2
      block bb4
      block bb3}}
  block bb5]
```
Before this patch, the above CFG is processed as follows:
- When lowering the outer true body (`bb1`, with `a += b`), its graph function has an output element for the updated `a`
- When lowering the outer false body (`{bb2, bb3, bb4}`, aka  the inner conditional SESE region):
  - When lowering the inner true body (`bb4`, with `a -= b`): its graph function has an output element for the updated `a`
  - When lowering the inner false body (`bb3`, with `a *= b`): its graph function has an output element for the updated `a`
  - When completing the lowering of the inner conditional SESE region  in `TFGraphLowering::lowerConditionalRegion()`, at the end of it, its graph function has **no** output elements, even though each of its `trueCodeFn` and `falseCodeFn` has an output element as described above -- **that's the source of bug**.
- When completing the lowering of the outer conditional SESE region, we then hit the assertion on `trueCodeFn.outputs.size() == falseCodeFn.outputs.size()`, because `trueCodeFn` has 1 elem, and `falseCodeFn` has none.

The solution is to track the reads and writes of `GraphFunctionBody::outputs` more rigorously via
an enum field `GraphFunctionBody::OutputSetter`. Before this patch, we check
whether `outputs` have been set via `outputs.empty()`, but some graph functions
could have an empty output, so this is not sufficient. Also, the check was not
done in all contexts where `outputs` are written to.

This bug was reported in https://bugs.swift.org/browse/SR-8164, and is also blocking https://github.com/apple/swift/pull/17698. The latter PR contained an initial fix, which is now superceded by this PR.
