### PR TITLE
Install llbuild swift bindings

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3140,7 +3140,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 if [[ -z "${INSTALL_LLBUILD}" ]] ; then
                     continue
                 fi
-                INSTALL_TARGETS="install-swift-build-tool"
+                INSTALL_TARGETS="install-swift-build-tool install-libllbuildSwift"
                 ;;
             # Products from this here install themselves; they don't fall-through.
             lldb)


### PR DESCRIPTION
This PR installs the llbuild Swift bindings in the toolchain so they can be dynamically linked from SwiftPM.