### PR TITLE
[constexpr] Reenable ptrtoint/inttoptr now that we have the address representation straightened out

### DIFF
--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -397,21 +397,19 @@ struct SymbolicValueMemoryObject {
   void setValue(SymbolicValue newValue) { value = newValue; }
 
   /// Create a new memory object whose overall type is as specified.
-  static SymbolicValueMemoryObject *create(Type type,
-                                           llvm::BumpPtrAllocator &allocator);
   static SymbolicValueMemoryObject *create(Type type, SymbolicValue value,
+                                           llvm::BumpPtrAllocator &allocator);
+  static SymbolicValueMemoryObject *create(Type type,
                                            llvm::BumpPtrAllocator &allocator) {
-    auto result = create(type, allocator);
-    result->value = value;
-    return result;
+    return create(type, SymbolicValue::getUninitMemory(), allocator);
   }
 
 private:
   const Type type;
   SymbolicValue value;
 
-  SymbolicValueMemoryObject(Type type)
-    : type(type), value(SymbolicValue::getUninitMemory()) {}
+  SymbolicValueMemoryObject(Type type, SymbolicValue value)
+    : type(type), value(value) {}
   SymbolicValueMemoryObject(const SymbolicValueMemoryObject&) = delete;
   void operator=(const SymbolicValueMemoryObject&) = delete;
 };

--- a/lib/SIL/SILConstants.cpp
+++ b/lib/SIL/SILConstants.cpp
@@ -196,10 +196,10 @@ SymbolicValue SymbolicValue::cloneInto(llvm::BumpPtrAllocator &allocator) const{
 //===----------------------------------------------------------------------===//
 
 SymbolicValueMemoryObject *
-SymbolicValueMemoryObject::create(Type type,
+SymbolicValueMemoryObject::create(Type type, SymbolicValue value,
                                   llvm::BumpPtrAllocator &allocator) {
   auto result = allocator.Allocate<SymbolicValueMemoryObject>();
-  new (result) SymbolicValueMemoryObject(type);
+  new (result) SymbolicValueMemoryObject(type, value);
   return result;
 }
 

--- a/test/SILOptimizer/pound_assert.swift
+++ b/test/SILOptimizer/pound_assert.swift
@@ -7,21 +7,19 @@ func trapsAndOverflows() {
 
   // expected-error @+1 {{#assert condition not constant}}
   #assert(Int8(123231) > 42)
-  // FIXME: xpected-note @-1 {{trap detected}}
+  // expected-note @-1 {{trap detected}}
 
   // expected-error @+1 {{#assert condition not constant}}
   #assert(Int8(124) + 8 > 42)
-  // FIXME: xpected-note @-1 {{integer overflow detected}}
+  // expected-note @-1 {{integer overflow detected}}
 
   // expected-error @+1 {{#assert condition not constant}}
   #assert({ () -> Int in fatalError(String()) }() > 42)
-  // expected-note @-1 {{could not fold operation}}
-  // FIXME: xpected-note @-1 {{trap detected}}
+  // expected-note @-1 {{trap detected}}
 
   // expected-error @+1 {{#assert condition not constant}}
   #assert({ () -> Int in fatalError("") }() > 42)
-  // expected-note @-1 {{could not fold operation}}
-  // TODO: xpected-note @-1 {{trap detected}}
+  // expected-note @-1 {{trap detected}}
 }
 
 func isOne(_ x: Int) -> Bool {
@@ -66,7 +64,7 @@ func loops1(a: Int) -> Int {
 // @constexpr
 func loops2(a: Int) -> Int {
   var x = 42
-  for i in 0 ... a {  // expected-note {{could not fold operation}}
+  for i in 0 ... a {
     x += i
   }
   return x


### PR DESCRIPTION
[constexpr] Reenable ptrtoint/inttoptr now that we have the address 
representation straightened out.  This fixes the testcases I failed a few patches ago.

This also incorporates the improvements hongm suggested in the last patch.