### PR TITLE
Require .upperBound - .lowerBound be finite for FloatingPoint random

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -2448,7 +2448,10 @@ where Self.RawSignificand : FixedWidthInteger {
       let significandCount = Self.significandBitCount + 1
       let maxSignificand: Self.RawSignificand = 1 << significandCount
 %     if 'Closed' not in Range:
-      rand = generator.next(upperBound: maxSignificand)
+      // Rather than use .next(upperBound:), which has to work with arbitrary
+      // upper bounds, and therefore does extra work to avoid bias, we can take
+      // a shortcut because we know that maxSignificand is a power of two.
+      rand = generator.next() & (maxSignificand - 1)
 %     else:
       rand = generator.next(upperBound: maxSignificand + 1)
       if rand == maxSignificand {
@@ -2456,7 +2459,7 @@ where Self.RawSignificand : FixedWidthInteger {
       }
 %     end
     }
-    let unitRandom = Self.init(rand) * Self.ulpOfOne / 2
+    let unitRandom = Self.init(rand) * (Self.ulpOfOne / 2)
     let randFloat = delta * unitRandom + range.lowerBound
 %   if 'Closed' not in Range:
     if randFloat == range.upperBound {

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -2411,7 +2411,7 @@ where Self.RawSignificand : FixedWidthInteger {
   /// - Parameters:
   ///   - range: The range in which to create a random value.
 %   if Range == 'Range':
-  ///     `range` must not be empty.
+  ///     `range` must not be empty and finite.
 %   end
   ///   - generator: The random number generator to use when creating the
   ///     new random value.
@@ -2426,6 +2426,15 @@ where Self.RawSignificand : FixedWidthInteger {
       "Can't get random value with an empty range"
     )
     let delta = range.upperBound - range.lowerBound
+    //  TODO: this still isn't quite right, because the computation of delta
+    //  can overflow (e.g. if .upperBound = .maximumFiniteMagnitude and
+    //  .lowerBound = -.upperBound); this should be re-written with an
+    //  algorithm that handles that case correctly, but this precondition
+    //  is an acceptable short-term fix.
+    _precondition(
+      delta.isFinite,
+      "There is no uniform distribution on an infinite range"
+    )
     let rand: Self.RawSignificand
     if Self.RawSignificand.bitWidth == Self.significandBitCount + 1 {
       rand = generator.next()
@@ -2482,7 +2491,7 @@ where Self.RawSignificand : FixedWidthInteger {
   ///
   /// - Parameter range: The range in which to create a random value.
 %   if Range == 'Range':
-  ///   `range` must not be empty.
+  ///   `range` must not be empty and finite.
 %   end
   /// - Returns: A random value within the bounds of `range`.
   @inlinable


### PR DESCRIPTION
This is a slightly conservative precondition; when we re-work the FloatingPoint random computation in a more principled fashion, we can relax this to only requiring that .upperBound and .lowerBound are both finite. However, the current computation will break down unless this conservative condition is used, and this is future proof--we will relax it in the future, but any code that works now will continue to work when we do that.