### PR TITLE
[Foundation] Adjust enumerate bytes to use bindMemory instead of assumingMemoryBound

### DIFF
--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -1620,7 +1620,9 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
                     memcpy(buffer.pointee.memory, $0.baseAddress!, hashRange.count)
                 }
             }
-            hashValue = Int(bitPattern: CFHashBytes(buffer.pointee.memory.bindMemory(to: UInt8.self, capacity: hashRange.count), hashRange.count))
+            // we are sending this directly to C – CFHashBytes takes a `uint8_t *` (and perhaps should have taken a `void *` but we probably cant change that at this point
+            // so it is "safe" to use `assumingMemoryBound(to:)` and perhaps safer than binding the memory directly
+            hashValue = Int(bitPattern: CFHashBytes(buffer.pointee.memory.assumingMemoryBound(to: UInt8.self), hashRange.count))
         }
         return hashValue
     }

--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -1298,7 +1298,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - warning: The byte pointer argument should not be stored and used outside of the lifetime of the call to the closure.
     public func withUnsafeBytes<ResultType, ContentType>(_ body: (UnsafePointer<ContentType>) throws -> ResultType) rethrows -> ResultType {
         return try _backing.withUnsafeBytes(in: _sliceRange) {
-            return try body($0.baseAddress?.assumingMemoryBound(to: ContentType.self) ?? UnsafePointer<ContentType>(bitPattern: 0xBAD0)!)
+            return try body($0.baseAddress?.bindMemory(to: ContentType.self, capacity: $0.count / MemoryLayout<ContentType>.size) ?? UnsafePointer<ContentType>(bitPattern: 0xBAD0)!)
         }
     }
     
@@ -1312,7 +1312,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
             _backing = _backing.mutableCopy(_sliceRange)
         }
         return try _backing.withUnsafeMutableBytes(in: _sliceRange) {
-            return try body($0.baseAddress?.assumingMemoryBound(to: ContentType.self) ?? UnsafeMutablePointer<ContentType>(bitPattern: 0xBAD0)!)
+            return try body($0.baseAddress?.bindMemory(to: ContentType.self, capacity: $0.count / MemoryLayout<ContentType>.size) ?? UnsafeMutablePointer<ContentType>(bitPattern: 0xBAD0)!)
         }
     }
     

--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -313,7 +313,8 @@ internal final class _DataStorage {
         case .swift: fallthrough
         case .immutable: fallthrough
         case .mutable:
-            block(UnsafeBufferPointer<UInt8>(start: _bytes?.advanced(by: range.lowerBound - _offset).assumingMemoryBound(to: UInt8.self), count: Swift.min(range.count, _length)), 0, &stopv)
+            let len = Swift.min(range.count, _length)
+            block(UnsafeBufferPointer<UInt8>(start: _bytes?.advanced(by: range.lowerBound - _offset).bindMemory(to: UInt8.self, capacity: len), count: len), 0, &stopv)
             return
         case .customReference(let d):
             data = d
@@ -329,8 +330,8 @@ internal final class _DataStorage {
             if region.lowerBound < range.lowerBound {
                 regionAdjustment = range.lowerBound - (region.lowerBound - _offset)
             }
-            let bytePtr  = ptr.advanced(by: regionAdjustment).assumingMemoryBound(to: UInt8.self)
             let effectiveLength = Swift.min((region.location - _offset) + region.length, range.upperBound) - (region.location - _offset)
+            let bytePtr  = ptr.advanced(by: regionAdjustment).bindMemory(to: UInt8.self, capacity: effectiveLength)
             block(UnsafeBufferPointer(start: bytePtr, count: effectiveLength - regionAdjustment), region.location + regionAdjustment - _offset, &stopv)
             if stopv {
                 stop.pointee = true


### PR DESCRIPTION
in the context of enumerateBytes using assumingMemoryBound under the hood could lead to undefined behavior. The current prevailing wisdom is to use bindMemory (again?) instead.