### PR TITLE
[stdlib]Better error message for Arrays with mismatched types

### DIFF
--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -196,15 +196,24 @@ extension _ArrayBuffer {
   internal func _typeCheckSlowPath(_ index: Int) {
     if _fastPath(_isNative) {
       let element: AnyObject = cast(toBufferOf: AnyObject.self)._native[index]
-      _precondition(
+      precondition(
         element is Element,
-        "Down-casted Array element failed to match the target type")
+        """
+        Down-casted Array element failed to match the target type
+        Expected \(Element.self) but found \(type(of: element))
+        """
+      )
     }
     else {
       let ns = _nonNative
-      _precondition(
-        ns.objectAt(index) is Element,
-        "NSArray element failed to match the Swift Array Element type")
+      let element = ns.objectAt(index)
+      precondition(
+        element is Element,
+        """
+        NSArray element failed to match the Swift Array Element type
+        Expected \(Element.self) but found \(type(of: element))
+        """
+      )
     }
   }
 
@@ -404,15 +413,23 @@ extension _ArrayBuffer {
       _native._checkValidSubscript(i)
       
       element = cast(toBufferOf: AnyObject.self)._native[i]
-      _precondition(
+      precondition(
         element is Element,
-        "Down-casted Array element failed to match the target type")
+        """
+        Down-casted Array element failed to match the target type
+        Expected \(Element.self) but found \(type(of: element))
+        """
+      )
     } else {
       // ObjC arrays do their own subscript checking.
       element = _nonNative.objectAt(i)
-      _precondition(
+      precondition(
         element is Element,
-        "NSArray element failed to match the Swift Array Element type")
+        """
+        NSArray element failed to match the Swift Array Element type
+        Expected \(Element.self) but found \(type(of: element))
+        """
+      )
     }
     return element
   }

--- a/stdlib/public/core/Assert.swift
+++ b/stdlib/public/core/Assert.swift
@@ -85,7 +85,7 @@ public func precondition(
   _ message: @autoclosure () -> String = String(),
   file: StaticString = #file, line: UInt = #line
 ) {
-  // Only check in debug and release mode.  In release mode just trap.
+  // Only check in debug and release mode. In release mode just trap.
   if _isDebugAssertConfiguration() {
     if !_branchHint(condition(), expected: true) {
       _assertionFailure("Precondition failed", message(), file: file, line: line,


### PR DESCRIPTION
We should print the types involved when the types an array holds don't match expectations.

rdar://problem/21409565