### PR TITLE
[Driver] Always link compiler_rt on Darwin

### DIFF
--- a/include/swift/Basic/Platform.h
+++ b/include/swift/Basic/Platform.h
@@ -58,6 +58,11 @@ namespace swift {
   /// Returns the platform Kind for Darwin triples.
   DarwinPlatformKind getDarwinPlatformKind(const llvm::Triple &triple);
 
+  /// Maps an arbitrary platform to its non-simulator equivalent.
+  ///
+  /// If \p platform is not a simulator platform, it will be returned as is.
+  DarwinPlatformKind getNonSimulatorPlatform(DarwinPlatformKind platform);
+
   /// Returns the architecture component of the path for a given target triple.
   ///
   /// Typically this is used for mapping the architecture component of the

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -76,6 +76,22 @@ DarwinPlatformKind swift::getDarwinPlatformKind(const llvm::Triple &triple) {
   llvm_unreachable("Unsupported Darwin platform");
 }
 
+DarwinPlatformKind swift::getNonSimulatorPlatform(DarwinPlatformKind platform) {
+  switch (platform) {
+  case DarwinPlatformKind::MacOS:
+    return DarwinPlatformKind::MacOS;
+  case DarwinPlatformKind::IPhoneOS:
+  case DarwinPlatformKind::IPhoneOSSimulator:
+    return DarwinPlatformKind::IPhoneOS;
+  case DarwinPlatformKind::TvOS:
+  case DarwinPlatformKind::TvOSSimulator:
+    return DarwinPlatformKind::TvOS;
+  case DarwinPlatformKind::WatchOS:
+  case DarwinPlatformKind::WatchOSSimulator:
+    return DarwinPlatformKind::WatchOS;
+  }
+}
+
 static StringRef getPlatformNameForDarwin(const DarwinPlatformKind platform) {
   switch (platform) {
   case DarwinPlatformKind::MacOS:

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -86,27 +86,24 @@ toolchains::Darwin::constructInvocation(const InterpretJobAction &job,
 static StringRef
 getDarwinLibraryNameSuffixForTriple(const llvm::Triple &triple,
                                     bool distinguishSimulator = true) {
-  switch (getDarwinPlatformKind(triple)) {
+  const DarwinPlatformKind kind = getDarwinPlatformKind(triple);
+  const DarwinPlatformKind effectiveKind =
+      distinguishSimulator ? kind : getNonSimulatorPlatform(kind);
+  switch (effectiveKind) {
   case DarwinPlatformKind::MacOS:
     return "osx";
-  case DarwinPlatformKind::IPhoneOSSimulator:
-    if (distinguishSimulator)
-      return "iossim";
-    LLVM_FALLTHROUGH;
   case DarwinPlatformKind::IPhoneOS:
     return "ios";
-  case DarwinPlatformKind::TvOSSimulator:
-    if (distinguishSimulator)
-      return "tvossim";
-    LLVM_FALLTHROUGH;
+  case DarwinPlatformKind::IPhoneOSSimulator:
+    return "iossim";
   case DarwinPlatformKind::TvOS:
     return "tvos";
-  case DarwinPlatformKind::WatchOSSimulator:
-    if (distinguishSimulator)
-      return "watchossim";
-    LLVM_FALLTHROUGH;
+  case DarwinPlatformKind::TvOSSimulator:
+    return "tvossim";
   case DarwinPlatformKind::WatchOS:
     return "watchos";
+  case DarwinPlatformKind::WatchOSSimulator:
+    return "watchossim";
   }
   llvm_unreachable("Unsupported Darwin platform");
 }

--- a/test/Driver/linker-clang_rt.swift
+++ b/test/Driver/linker-clang_rt.swift
@@ -1,0 +1,36 @@
+// REQUIRES: OS=macosx
+// Note: This is really about the /host/ environment, but since there are RUN
+// lines for multiple targets anyway it doesn't make a huge difference.
+
+// We use hard links to make sure the Swift driver really thinks it's been
+// moved.
+
+// RUN: rm -rf %t
+// RUN: %empty-directory(%t/bin)
+// RUN: %hardlink-or-copy(from: %swift_driver_plain, to: %t/bin/swiftc)
+// RUN: %empty-directory(%t/lib/clang/darwin/)
+
+// RUN: %t/bin/swiftc -driver-print-jobs -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-NO-RUNTIME %s
+
+// RUN: touch %t/lib/clang/darwin/libclang_rt.osx.a %t/lib/clang/darwin/libclang_rt.ios.a %t/lib/clang/darwin/libclang_rt.tvos.a %t/lib/clang/darwin/libclang_rt.watchos.a
+
+// RUN: %t/bin/swiftc -driver-print-jobs -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix MACOS %s
+
+// RUN: %t/bin/swiftc -driver-print-jobs -target i386-apple-ios7 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix IOS %s
+// RUN: %t/bin/swiftc -driver-print-jobs -target x86_64-apple-ios7 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix IOS %s
+// RUN: %t/bin/swiftc -driver-print-jobs -target armv7s-apple-ios7 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix IOS %s
+// RUN: %t/bin/swiftc -driver-print-jobs -target arm64-apple-ios7 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix IOS %s
+
+// RUN: %t/bin/swiftc -driver-print-jobs -target x86_64-apple-ios9 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix TVOS %s
+// RUN: %t/bin/swiftc -driver-print-jobs -target arm64-apple-tvos9 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix TVOS %s
+
+// RUN: %t/bin/swiftc -driver-print-jobs -target i386-apple-watchos2 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix WATCHOS %s
+// RUN: %t/bin/swiftc -driver-print-jobs -target armv7k-apple-watchos2 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix WATCHOS %s
+
+// CHECK: bin/ld{{"? }}
+// CHECK-NO-RUNTIME-NOT: libclang_rt
+// CHECK-MACOS-SAME: {{[^ ]+/lib/clang/darwin/libclang_rt.osx.a}}
+// CHECK-IOS-SAME: {{[^ ]+/lib/clang/darwin/libclang_rt.ios.a}}
+// CHECK-TVOS-SAME: {{[^ ]+/lib/clang/darwin/libclang_rt.tvos.a}}
+// CHECK-WATCHOS-SAME: {{[^ ]+/lib/clang/darwin/libclang_rt.watchos.a}}
+// CHECK-SAME: -o {{[^ ]+}}

--- a/test/Driver/linker-clang_rt.swift
+++ b/test/Driver/linker-clang_rt.swift
@@ -1,6 +1,5 @@
-// REQUIRES: OS=macosx
-// Note: This is really about the /host/ environment, but since there are RUN
-// lines for multiple targets anyway it doesn't make a huge difference.
+// Make sure that the platform-appropriate clang_rt library (found relative to
+// the compiler) is included when using Swift as a linker (with Apple targets).
 
 // We use hard links to make sure the Swift driver really thinks it's been
 // moved.
@@ -26,6 +25,9 @@
 
 // RUN: %t/bin/swiftc -driver-print-jobs -target i386-apple-watchos2 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix WATCHOS %s
 // RUN: %t/bin/swiftc -driver-print-jobs -target armv7k-apple-watchos2 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix WATCHOS %s
+
+// Clean up the test executable because hard links are expensive.
+// RUN: rm -f %t/bin/swiftc
 
 // CHECK: bin/ld{{"? }}
 // CHECK-NO-RUNTIME-NOT: libclang_rt

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -77,6 +77,7 @@
 // CHECK: -o [[OBJECTFILE:.*]]
 
 // CHECK-NEXT: bin/ld{{"? }}
+// CHECK-DAG: lib/darwin/libclang_rt.osx.a
 // CHECK-DAG: [[OBJECTFILE]]
 // CHECK-DAG: -L [[STDLIB_PATH:[^ ]+/lib/swift/macosx]]
 // CHECK-DAG: -rpath [[STDLIB_PATH]]
@@ -87,7 +88,7 @@
 
 // SIMPLE: bin/ld{{"? }}
 // SIMPLE-NOT: -syslibroot
-// SIMPLE-DAG: -macosx_version_min 10.{{[0-9]+}}.{{[0-9]+}}
+// SIMPLE: -macosx_version_min 10.{{[0-9]+}}.{{[0-9]+}}
 // SIMPLE-NOT: -syslibroot
 // SIMPLE: -o linker
 
@@ -97,6 +98,7 @@
 
 // SIMPLE_STATIC-NEXT: bin/ld{{"? }}
 // SIMPLE_STATIC: [[OBJECTFILE]]
+// SIMPLE_STATIC: lib/darwin/libclang_rt.osx.a
 // SIMPLE_STATIC: -lobjc
 // SIMPLE_STATIC: -lSystem
 // SIMPLE_STATIC: -arch x86_64
@@ -118,6 +120,7 @@
 // IOS_SIMPLE-DAG: -lSystem
 // IOS_SIMPLE-DAG: -arch x86_64
 // IOS_SIMPLE-DAG: -ios_simulator_version_min 7.1.{{[0-9]+}}
+// IOS_SIMPLE-DAG: lib/darwin/libclang_rt.ios.a
 // IOS_SIMPLE: -o linker
 
 
@@ -130,6 +133,7 @@
 // tvOS_SIMPLE-DAG: -lSystem
 // tvOS_SIMPLE-DAG: -arch x86_64
 // tvOS_SIMPLE-DAG: -tvos_simulator_version_min 9.0.{{[0-9]+}}
+// tvOS_SIMPLE-DAG: lib/darwin/libclang_rt.tvos.a
 // tvOS_SIMPLE: -o linker
 
 
@@ -142,6 +146,7 @@
 // watchOS_SIMPLE-DAG: -lSystem
 // watchOS_SIMPLE-DAG: -arch i386
 // watchOS_SIMPLE-DAG: -watchos_simulator_version_min 2.0.{{[0-9]+}}
+// watchOS_SIMPLE-DAG: lib/darwin/libclang_rt.watchos.a
 // watchOS_SIMPLE: -o linker
 
 
@@ -312,11 +317,11 @@
 
 
 // FILELIST: bin/ld{{"? }}
-// FILELIST-NOT: .o
+// FILELIST-NOT: .o{{"? }}
 // FILELIST: -filelist {{"?[^-]}}
-// FILELIST-NOT: .o
-// FILELIST: /a.o
-// FILELIST-NOT: .o
+// FILELIST-NOT: .o{{"? }}
+// FILELIST: /a.o{{"? }}
+// FILELIST-NOT: .o{{"? }}
 // FILELIST: -o linker
 
 

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -77,7 +77,6 @@
 // CHECK: -o [[OBJECTFILE:.*]]
 
 // CHECK-NEXT: bin/ld{{"? }}
-// CHECK-DAG: lib/darwin/libclang_rt.osx.a
 // CHECK-DAG: [[OBJECTFILE]]
 // CHECK-DAG: -L [[STDLIB_PATH:[^ ]+/lib/swift/macosx]]
 // CHECK-DAG: -rpath [[STDLIB_PATH]]
@@ -98,7 +97,6 @@
 
 // SIMPLE_STATIC-NEXT: bin/ld{{"? }}
 // SIMPLE_STATIC: [[OBJECTFILE]]
-// SIMPLE_STATIC: lib/darwin/libclang_rt.osx.a
 // SIMPLE_STATIC: -lobjc
 // SIMPLE_STATIC: -lSystem
 // SIMPLE_STATIC: -arch x86_64
@@ -120,7 +118,6 @@
 // IOS_SIMPLE-DAG: -lSystem
 // IOS_SIMPLE-DAG: -arch x86_64
 // IOS_SIMPLE-DAG: -ios_simulator_version_min 7.1.{{[0-9]+}}
-// IOS_SIMPLE-DAG: lib/darwin/libclang_rt.ios.a
 // IOS_SIMPLE: -o linker
 
 
@@ -133,7 +130,6 @@
 // tvOS_SIMPLE-DAG: -lSystem
 // tvOS_SIMPLE-DAG: -arch x86_64
 // tvOS_SIMPLE-DAG: -tvos_simulator_version_min 9.0.{{[0-9]+}}
-// tvOS_SIMPLE-DAG: lib/darwin/libclang_rt.tvos.a
 // tvOS_SIMPLE: -o linker
 
 
@@ -146,7 +142,6 @@
 // watchOS_SIMPLE-DAG: -lSystem
 // watchOS_SIMPLE-DAG: -arch i386
 // watchOS_SIMPLE-DAG: -watchos_simulator_version_min 2.0.{{[0-9]+}}
-// watchOS_SIMPLE-DAG: lib/darwin/libclang_rt.watchos.a
 // watchOS_SIMPLE: -o linker
 
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -945,8 +945,9 @@ def source_compiler_rt_libs(path):
                                         if lib.startswith('libclang_rt.')
                                         and config.compiler_rt_platform in lib])
 
-source_compiler_rt_libs(make_path(test_resource_dir, 'clang', 'lib',
-                        platform.system().lower()))
+compiler_rt_dir = make_path(test_resource_dir, 'clang', 'lib',
+                            platform.system().lower())
+source_compiler_rt_libs(compiler_rt_dir)
 
 def check_runtime_libs(features_to_check):
     for lib in config.compiler_rt_libs:
@@ -966,6 +967,17 @@ if run_ptrsize != "32":
     runtime_libs['tsan'] = 'tsan_runtime'
 
 check_runtime_libs(runtime_libs)
+
+# From https://stackoverflow.com/a/2393022
+def strip_right(text, suffix):
+    if not text.endswith(suffix):
+        return text
+    return text[:len(text)-len(suffix)]
+
+base_runtime_lib_name = (
+    'libclang_rt.' + strip_right(config.compiler_rt_platform, 'sim') + '.a')
+if os.path.exists(make_path(compiler_rt_dir, base_runtime_lib_name)):
+    config.available_features.add('c_runtime')
 
 if not getattr(config, 'target_run_simple_swift', None):
     config.target_run_simple_swift = (

--- a/validation-test/Driver/Inputs/clang_rt-helper.h
+++ b/validation-test/Driver/Inputs/clang_rt-helper.h
@@ -1,7 +1,7 @@
 #include <stdbool.h>
 
-static inline bool testNewOS() {
-  if (__builtin_available(macOS 10.12, *)) {
+static inline bool isRunningOnFairlyRecentOS() {
+  if (__builtin_available(macOS 10.12, iOS 10, tvOS 10, watchOS 3, *)) {
     return true;
   } else {
     return false;

--- a/validation-test/Driver/Inputs/clang_rt-helper.h
+++ b/validation-test/Driver/Inputs/clang_rt-helper.h
@@ -1,0 +1,9 @@
+#include <stdbool.h>
+
+static inline bool testNewOS() {
+  if (__builtin_available(macOS 10.12, *)) {
+    return true;
+  } else {
+    return false;
+  }
+}

--- a/validation-test/Driver/clang_rt.swift
+++ b/validation-test/Driver/clang_rt.swift
@@ -4,7 +4,7 @@
 
 // Just make sure we can build and link successfully.
 
-if testNewOS() {
+if isRunningOnFairlyRecentOS() {
   print("new!")
 } else {
   print("old...")

--- a/validation-test/Driver/clang_rt.swift
+++ b/validation-test/Driver/clang_rt.swift
@@ -1,0 +1,8 @@
+// RUN: %target-build-swift -emit-executable %s -import-objc-header %S/Inputs/clang_rt-helper.h -o %t
+
+// Just make sure we can build and link successfully.
+if testNewOS() {
+  print("new!")
+} else {
+  print("old...")
+}

--- a/validation-test/Driver/clang_rt.swift
+++ b/validation-test/Driver/clang_rt.swift
@@ -1,6 +1,9 @@
 // RUN: %target-build-swift -emit-executable %s -import-objc-header %S/Inputs/clang_rt-helper.h -o %t
 
+// REQUIRES: c_runtime
+
 // Just make sure we can build and link successfully.
+
 if testNewOS() {
   print("new!")
 } else {


### PR DESCRIPTION
Turns out it's needed for normal builtins that can appear in inlinable functions, including Objective-C's `@available`. Clang always links it unconditionally, so so should Swift.

~Note that this does mean you have to build compiler_rt to get a successful test run on Apple platforms. That was always true if you wanted the sanitizer tests to work, though.~

rdar://problem/41911599