### PR TITLE
[4.2] Handle stray LoadExprs in RawRepresentable fix-its

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4535,8 +4535,14 @@ static bool diagnoseRawRepresentableMismatch(CalleeCandidateInfo &CCI,
     return false;
 
   const Expr *expr = argExpr;
-  if (auto *tupleArgs = dyn_cast<TupleExpr>(argExpr))
+  if (auto *tupleArgs = dyn_cast<TupleExpr>(argExpr)) {
     expr = tupleArgs->getElement(bestMatchIndex);
+  } else if (auto *misplacedLoad = dyn_cast<LoadExpr>(argExpr)) {
+    // If there are multiple possible overloads for a single-argument call
+    // expression, the partially-typed-checked AST may have a load around the
+    // call parentheses instead of inside them.
+    expr = misplacedLoad->getSubExpr();
+  }
   expr = expr->getValueProvidingExpr();
 
   auto parameters = bestMatchCandidate->getUncurriedFunctionType()->getParams();

--- a/test/Sema/enum_raw_representable.swift
+++ b/test/Sema/enum_raw_representable.swift
@@ -168,6 +168,19 @@ func sr8150(bar: Bar) {
   // expected-error@-1 {{cannot convert value of type 'Double' to expected argument type 'Bar'}} {{18-18=Bar(rawValue: }} {{21-21=)}}
 }
 
+class SR8150Box {
+  var bar: Bar
+  init(bar: Bar) { self.bar = bar }
+}
+// Bonus problem with mutable values being passed.
+func sr8150_mutable(obj: SR8150Box) {
+  sr8150_helper1(obj.bar)
+  // expected-error@-1 {{cannot convert value of type 'Bar' to expected argument type 'Double'}} {{18-18=}} {{25-25=.rawValue}}
+
+  var bar = obj.bar
+  sr8150_helper1(bar)
+  // expected-error@-1 {{cannot convert value of type 'Bar' to expected argument type 'Double'}} {{18-18=}} {{21-21=.rawValue}}
+}
 
 struct NotEquatable { }
 


### PR DESCRIPTION
- **Explanation**: The fix-it for automatically inserting `.rawValue` is *still* syntactically invalid when the expression is a single, unlabeled call argument that references a mutable property or variable. Recognize the unusual recovery AST that gets built in this situation and make sure the fix-it goes in the right place.

- **Scope**: Affects error diagnostics only, and even then only cases where we would have already decided that this was the right message to emit. This does come up in migration due to new `NS_TYPED_ENUM`s.

- **Issue**: [SR-8150](https://bugs.swift.org/browse/SR-8150) / rdar://problem/41725207 (again)

- **Risk**: Very low. There's one additional special case that then immediately goes back to the existing code path.

- **Testing**: Added compiler regression tests.

- **Reviewed by**: @rudkx  