### PR TITLE
[4.2] Two small fixes for FloatingPoint .random( )

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -2423,7 +2423,7 @@ where Self.RawSignificand : FixedWidthInteger {
   /// - Parameters:
   ///   - range: The range in which to create a random value.
 %   if Range == 'Range':
-  ///     `range` must not be empty.
+  ///     `range` must not be empty and finite.
 %   end
   ///   - generator: The random number generator to use when creating the
   ///     new random value.
@@ -2438,6 +2438,15 @@ where Self.RawSignificand : FixedWidthInteger {
       "Can't get random value with an empty range"
     )
     let delta = range.upperBound - range.lowerBound
+    //  TODO: this still isn't quite right, because the computation of delta
+    //  can overflow (e.g. if .upperBound = .maximumFiniteMagnitude and
+    //  .lowerBound = -.upperBound); this should be re-written with an
+    //  algorithm that handles that case correctly, but this precondition
+    //  is an acceptable short-term fix.
+    _precondition(
+      delta.isFinite,
+      "There is no uniform distribution on an infinite range"
+    )
     let rand: Self.RawSignificand
     if Self.RawSignificand.bitWidth == Self.significandBitCount + 1 {
       rand = generator.next()
@@ -2451,7 +2460,10 @@ where Self.RawSignificand : FixedWidthInteger {
       let significandCount = Self.significandBitCount + 1
       let maxSignificand: Self.RawSignificand = 1 << significandCount
 %     if 'Closed' not in Range:
-      rand = generator.next(upperBound: maxSignificand)
+      // Rather than use .next(upperBound:), which has to work with arbitrary
+      // upper bounds, and therefore does extra work to avoid bias, we can take
+      // a shortcut because we know that maxSignificand is a power of two.
+      rand = generator.next() & (maxSignificand - 1)
 %     else:
       rand = generator.next(upperBound: maxSignificand + 1)
       if rand == maxSignificand {
@@ -2459,7 +2471,7 @@ where Self.RawSignificand : FixedWidthInteger {
       }
 %     end
     }
-    let unitRandom = Self.init(rand) * Self.ulpOfOne / 2
+    let unitRandom = Self.init(rand) * (Self.ulpOfOne / 2)
     let randFloat = delta * unitRandom + range.lowerBound
 %   if 'Closed' not in Range:
     if randFloat == range.upperBound {
@@ -2494,7 +2506,7 @@ where Self.RawSignificand : FixedWidthInteger {
   ///
   /// - Parameter range: The range in which to create a random value.
 %   if Range == 'Range':
-  ///   `range` must not be empty.
+  ///   `range` must not be empty and finite.
 %   end
   /// - Returns: A random value within the bounds of `range`.
   @inlinable

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -2460,7 +2460,13 @@ where Self.RawSignificand : FixedWidthInteger {
 %     end
     }
     let unitRandom = Self.init(rand) * Self.ulpOfOne / 2
-    return delta * unitRandom + range.lowerBound
+    let randFloat = delta * unitRandom + range.lowerBound
+%   if 'Closed' not in Range:
+    if randFloat == range.upperBound {
+      return Self.random(in: range, using: &generator)
+    }
+%   end
+    return randFloat
   }
 
   /// Returns a random value within the specified range.

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -2423,7 +2423,9 @@ where Self.RawSignificand : FixedWidthInteger {
   /// - Parameters:
   ///   - range: The range in which to create a random value.
 %   if Range == 'Range':
-  ///     `range` must not be empty and finite.
+  ///     `range` must be non-empty and finite.
+%   else:
+  ///     `range` must be finite.
 %   end
   ///   - generator: The random number generator to use when creating the
   ///     new random value.
@@ -2506,7 +2508,9 @@ where Self.RawSignificand : FixedWidthInteger {
   ///
   /// - Parameter range: The range in which to create a random value.
 %   if Range == 'Range':
-  ///   `range` must not be empty and finite.
+  ///   `range` must be non-empty and finite.
+%   else:
+  ///   `range` must be finite.
 %   end
   /// - Returns: A random value within the bounds of `range`.
   @inlinable


### PR DESCRIPTION
cherry-pick from master containing the following two fixes:

- [SR-8178] Fix BinaryFloatingPoint.random(in:) open range returning upperBound
- Require .upperBound - .lowerBound be finite for FloatingPoint random

These are low-risk changes that we want to have to ensure that the desired invariants for the random API actually hold for FloatingPoint.

Resolves <rdar://problem/41851227>.

----
- **Explanation**: There are two problems with FloatingPoint `.random(in:)` that this change addresses. First, the current `.random(in:)` implementation can sometimes return `.upperBound` of an open range due to rounding. This change fixes that behavior without introducing a bias via rejection sampling. Second, certain ranges do not admit a uniform distribution on the real number line (if either endpoint is infinite), and the current implementation breaks down even for finite ranges if `.upperBound - .lowerBound` overflows. This change makes this a precondition failure instead of producing garbage results.

- **Scope**: Change is limited to two minor edge cases.

- **Issue**: rdar://problem/41851227

- **Risk**: Very low. These cases have *never* worked correctly, so they can't get more broken, and the fix is simple enough to be confident that it doesn't affect other things.

- **Testing**: Some new test cases added, plus existing regression tests.

Reviewed by: @lorentey 