### PR TITLE
AllocStackHoisting: Don't hoist alloc_stacks in the presence of an av…

### DIFF
--- a/lib/IRGen/AllocStackHoisting.cpp
+++ b/lib/IRGen/AllocStackHoisting.cpp
@@ -348,7 +348,13 @@ void HoistAllocStack::collectHoistableInstructions() {
           FunctionExits.push_back(Term);
         continue;
       }
-
+      // Don't perform alloc_stack hoisting in functions with availability.
+      if (auto *Apply = dyn_cast<ApplyInst>(&Inst)) {
+        if (Apply->hasSemantics("availability.osversion")) {
+          AllocStackToHoist.clear();
+          return;
+        }
+      }
       auto *ASI = dyn_cast<AllocStackInst>(&Inst);
       if (!ASI) {
         continue;

--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -17,7 +17,9 @@ import SwiftShims
 ///
 /// This is a magic entry point known to the compiler. It is called in
 /// generated code for API availability checking.
-@inlinable // FIXME(sil-serialize-all)
+/// Note: It is important not to make this function inlinable. There is a pass
+/// that relies on being able to tell whether this function is called. It does
+/// this using the semantics attribute.
 @_semantics("availability.osversion")
 public func _stdlib_isOSVersionAtLeast(
   _ major: Builtin.Word,

--- a/test/IRGen/availability.swift
+++ b/test/IRGen/availability.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -O -emit-ir | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+// We mustn't hoist the alloc_stack for measurement out of the availability
+// guard.
+
+// CHECK-LABEL: define{{.*}} @{{.*}}dontHoist
+// CHECK-NOT: S10Foundation11MeasurementVySo17NSUnitTemperature
+// CHECK: call swiftcc i1 @"$Ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"(
+// CHECK: S10Foundation11MeasurementVySo17NSUnitTemperature
+
+public func dontHoist() {
+  if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+      let measurement = Measurement<UnitTemperature>(value: Double(42), unit: .celsius)
+      print("\(measurement)")
+  } else {
+      print("Not measurement")
+  }
+}


### PR DESCRIPTION
…ailability guard

This disables inlinability of _stdlib_isOSVersionAtLeast. I don't see
value in making it inlinable as long as _swift_stdlib_operatingSystemVersion is
opaque.

rdar://41849700