### PR TITLE
[test] Fix test failures in optimized test runs

### DIFF
--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -3429,9 +3429,7 @@ DictionaryTestSuite.test("BridgedToObjC.Verbatim.getObjects:andKeys:count:") {
 // Key type and value type are bridged non-verbatim.
 //===---
 
-DictionaryTestSuite.test("BridgedToObjC.KeyValue_ValueTypesCustomBridged")
-  .skip(.always("rdar://problem/41871587"))
-  .code {
+DictionaryTestSuite.test("BridgedToObjC.KeyValue_ValueTypesCustomBridged") {
   let d = getBridgedNSDictionaryOfKeyValue_ValueTypesCustomBridged()
   let enumerator = d.keyEnumerator()
 
@@ -3545,9 +3543,7 @@ func getBridgedNSDictionaryOfKey_ValueTypeCustomBridged() -> NSDictionary {
   return bridged
 }
 
-DictionaryTestSuite.test("BridgedToObjC.Key_ValueTypeCustomBridged")
-  .skip(.always("rdar://problem/41871587"))
-  .code {
+DictionaryTestSuite.test("BridgedToObjC.Key_ValueTypeCustomBridged") {
   let d = getBridgedNSDictionaryOfKey_ValueTypeCustomBridged()
   let enumerator = d.keyEnumerator()
 

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -3421,8 +3421,6 @@ DictionaryTestSuite.test("BridgedToObjC.Verbatim.getObjects:andKeys:count:") {
   for count in 0 ..< d.count + 2 {
     checkGetObjectsAndKeys(d, count: count)
   }
-  expectCrashLater()
-  checkGetObjectsAndKeys(d, count: -1)
 }
 
 //===---
@@ -3530,8 +3528,6 @@ DictionaryTestSuite.test("BridgedToObjC.Custom.getObjects:andKeys:count:") {
   for count in 0 ..< d.count + 2 {
     checkGetObjectsAndKeys(d, count: count)
   }
-  expectCrashLater()
-  checkGetObjectsAndKeys(d, count: -1)
 }
 
 func getBridgedNSDictionaryOfKey_ValueTypeCustomBridged() -> NSDictionary {


### PR DESCRIPTION
Crashes somehow interfere with object counters in optimized tests, breaking the tests immediately following a crash test.

Remove crash tests for `getObjects:andKeys:count:` until we know why, and reenable tests disabled in #17853.

rdar://problem/41871587