### PR TITLE
[4.2][test] Fix test failures in optimized test runs

### DIFF
--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -3422,7 +3422,9 @@ func checkGetObjectsAndKeys(
   withExtendedLifetime(canary) {}
 }
 
-DictionaryTestSuite.test("BridgedToObjC.Verbatim.getObjects:andKeys:count:") {
+DictionaryTestSuite.test("BridgedToObjC.Verbatim.getObjects:andKeys:count:")
+  .skip(.always("rdar://problem/41871587"))
+  .code {
   let d = getBridgedNSDictionaryOfRefTypesBridgedVerbatim()
   for count in 0 ..< d.count + 2 {
     checkGetObjectsAndKeys(d, count: count)
@@ -3527,7 +3529,9 @@ DictionaryTestSuite.test("BridgedToObjC.Custom.FastEnumeration_Empty") {
     { ($0 as! TestObjCValueTy).value })
 }
 
-DictionaryTestSuite.test("BridgedToObjC.Custom.getObjects:andKeys:count:") {
+DictionaryTestSuite.test("BridgedToObjC.Custom.getObjects:andKeys:count:")
+  .skip(.always("rdar://problem/41871587"))
+  .code {
   let d = getBridgedNSDictionaryOfKeyValue_ValueTypesCustomBridged()
   for count in 0 ..< d.count + 2 {
     checkGetObjectsAndKeys(d, count: count)

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -3427,8 +3427,6 @@ DictionaryTestSuite.test("BridgedToObjC.Verbatim.getObjects:andKeys:count:") {
   for count in 0 ..< d.count + 2 {
     checkGetObjectsAndKeys(d, count: count)
   }
-  expectCrashLater()
-  checkGetObjectsAndKeys(d, count: -1)
 }
 
 //===---
@@ -3534,8 +3532,6 @@ DictionaryTestSuite.test("BridgedToObjC.Custom.getObjects:andKeys:count:") {
   for count in 0 ..< d.count + 2 {
     checkGetObjectsAndKeys(d, count: count)
   }
-  expectCrashLater()
-  checkGetObjectsAndKeys(d, count: -1)
 }
 
 func getBridgedNSDictionaryOfKey_ValueTypeCustomBridged() -> NSDictionary {


### PR DESCRIPTION
(Cherry picked from #17862)

**Explanation:** Crashes somehow interfere with object counters in optimized tests, breaking the tests immediately following a crash test. Remove recently added crash tests for now.
**Scope:** Limited to a particular test in the validation test suite.
**Issue:** rdar://problem/41871587
**Risk:** Very low.
**Testing:** Locally ran the validation tests in various build configurations.
**Reviewers:** @moiseev 