### PR TITLE
Transform loops so that they have a single exit out of the loop header

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
+++ b/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
@@ -35,6 +35,10 @@
 using namespace swift;
 using namespace tf;
 
+static llvm::cl::opt<bool> TFEnsureSingleLoopExit(
+    "tf-ensure-single-loop-exit", llvm::cl::init(false),
+    llvm::cl::desc("Transform loops to have a single exit from header."));
+
 //===----------------------------------------------------------------------===//
 // SESERegionTree Implementation
 //===----------------------------------------------------------------------===//
@@ -133,7 +137,9 @@ namespace {
       canonicalizeAllLoops(&DI, &LI);
       // We need to ensure more invariants as SIL loop canonicalization
       // transformations don't do everything that we need.
-      ensureSingleExitFromLoops();
+      if (TFEnsureSingleLoopExit) {
+        ensureSingleExitFromLoops();
+      }
 
       for (auto *loop : LI)
         processLoop(loop);

--- a/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
+++ b/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
@@ -500,7 +500,7 @@ SingleExitLoopTransformer::patchEdges(SILBasicBlock *newHeader,
 
   unsigned oldHeaderNumArgs =
       newHeader->getNumArguments() -
-      (escapingValues.size() + /* exitIndex, stayLoop*/ 2);
+      (escapingValues.size() + /* exitIndex, stayInLoop*/ 2);
 
   // Identify the exit from the header (if any) and assign '0' as its index.
   SILBasicBlock *headerExit = nullptr;

--- a/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
+++ b/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
@@ -19,11 +19,19 @@
 //===----------------------------------------------------------------------===//
 
 #include "TFCanonicalizeCFG.h"
+#include "TFUtilities.h"
+#include "llvm/ADT/iterator_range.h"
+#include "swift/AST/TensorFlow.h"
+#include "swift/Basic/TransformArrayRef.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/LoopUtils.h"
+#include "swift/SILOptimizer/Utils/CFG.h"
 #include "swift/SIL/Dominance.h"
 #include "swift/SIL/LoopInfo.h"
+#include "swift/SIL/SILBuilder.h"
+#include "swift/SIL/SILUndef.h"
+
 using namespace swift;
 using namespace tf;
 
@@ -101,12 +109,13 @@ namespace {
     DominanceInfo DI;
     PostDominanceInfo PDI;
     SILLoopInfo LI;
+    SILFunction* F;
 
     /// processLoops fills in this mapping: it is keyed by the preheader block
     /// of each loop, and points to the region produced for it.
     llvm::DenseMap<SILBasicBlock*, WhileLoopSESERegion*> loopPreheaders;
   public:
-    SESERegionBuilder(SILFunction *F) : DI(F), PDI(F), LI(F, &DI) {}
+    SESERegionBuilder(SILFunction *F) : DI(F), PDI(F), LI(F, &DI), F(F) {}
 
     std::unique_ptr<SESERegionTree>
     processAcyclicRegion(SILBasicBlock *startBB, SILBasicBlock *endBB);
@@ -122,12 +131,20 @@ namespace {
       // automatically gives us the following invariants: loops are guaranteed
       // to have a single preheader, a single backedge block, and exit??
       canonicalizeAllLoops(&DI, &LI);
+      // We need to ensure more invariants as SIL loop canonicalization
+      // transformations don't do everything that we need.
+      ensureSingleExitFromLoops();
 
       for (auto *loop : LI)
         processLoop(loop);
     }
 
     void processLoop(SILLoop *loop);
+
+  private:
+    bool ensureSingleExitFromLoops();
+    bool ensureSingleExitFromLoop(SILLoop* loop);
+    SILValue getUndef(SILType type);
   };
 } // end anonymous namespace
 
@@ -218,6 +235,7 @@ SESERegionBuilder::processAcyclicRegionExcludingEnd(SILBasicBlock *startBB,
       processAcyclicRegionExcludingEnd(condBr->getFalseBB(), postidom);
 
     // Finally, form our conditional region.
+
     auto condRegion = new ConditionalSESERegion(startBB, std::move(trueRegion),
                                                 std::move(falseRegion));
     results.push_back(std::unique_ptr<SESERegionTree>(condRegion));
@@ -233,9 +251,330 @@ SESERegionBuilder::processAcyclicRegionExcludingEnd(SILBasicBlock *startBB,
   }
 }
 
+/// For loops in the SIL Function with multiple exit block successors,
+/// transforms the loop by introducing a common exit switch block that demuxes
+/// to the appropriate exit block. Updates the Dominanceinfo, PostDominanceinfo,
+/// and LoopInfo as well.
+bool SESERegionBuilder::ensureSingleExitFromLoops() {
+  // TODO: update changed appropriately.
+  // Visit the loop nest hierarchy bottom up.
+  bool changed = false;
+  llvm::SmallVector<std::pair<SILLoop *, bool>, 16> workList;
+  for (auto *L : LI.getTopLevelLoops())
+    workList.push_back({L, L->empty()});
+  while (workList.size() != 0) {
+    SILLoop *loop;
+    bool visited;
+    std::tie(loop, visited) = workList.pop_back_val();
+
+    if (!visited) {
+      workList.push_back({loop, true});
+      for (auto *Subloop : loop->getSubLoopRange()) {
+        workList.push_back({Subloop, Subloop->empty()});
+      }
+      continue;
+    }
+    changed |= ensureSingleExitFromLoop(loop);
+  }
+  if (changed) {
+    splitAllCondBrCriticalEdgesWithNonTrivialArgs(*F, nullptr, &LI);
+
+    DI.recalculate(*F);
+    PDI.recalculate(*F);
+  }
+  return changed;
+}
+
+namespace {
+
+/// Appends the given arguments to the given edge. Deletes the old TermInst
+/// and returns a new TermInst with the appropriate number of args.
+TermInst* appendArguments(TermInst *termInst, SILBasicBlock *target,
+                     ArrayRef<SILValue> newArgs) {
+
+  SILBuilder builder(termInst);
+  TermInst *newTermInst = nullptr;
+
+  auto createArgsArray = [target,
+                          &newArgs](const OperandValueArrayRef &currentArgs,
+                                    bool appendNewArgs) {
+    SmallVector<SILValue, 8> args(currentArgs.begin(), currentArgs.end());
+    if (appendNewArgs) {
+      args.append(newArgs.begin(), newArgs.end());
+      assert(args.size() == target->getNumArguments() &&
+             "Number of final arguments does not match target's arguments.");
+    }
+    return args;
+  };
+  if (auto *branch = dyn_cast<BranchInst>(termInst)) {
+    assert(branch->getDestBB() == target &&
+           "Incoming edge block and target do not match");
+    SmallVector<SILValue, 8> args =
+        createArgsArray(branch->getArgs(), /*appendNewArgs=*/true);
+    newTermInst =
+        builder.createBranch(branch->getLoc(), branch->getDestBB(), args);
+  } else if (auto *condBranch = dyn_cast<CondBranchInst>(termInst)) {
+    bool isTrueEdge = condBranch->getTrueBB() == target;
+    assert(((isTrueEdge && condBranch->getTrueBB() == target) ||
+            (!isTrueEdge && condBranch->getFalseBB() == target)) &&
+           "Incoming edge block and target do not match");
+    SmallVector<SILValue, 8> trueArgs = createArgsArray(
+        condBranch->getTrueArgs(), /*appendNewArgs=*/isTrueEdge);
+    SmallVector<SILValue, 8> falseArgs = createArgsArray(
+        condBranch->getFalseArgs(), /*appendNewArgs=*/!isTrueEdge);
+    newTermInst = builder.createCondBranch(
+        condBranch->getLoc(), condBranch->getCondition(),
+        condBranch->getTrueBB(), trueArgs, condBranch->getFalseBB(), falseArgs,
+        condBranch->getTrueBBCount(), condBranch->getFalseBBCount());
+  } else {
+    // At the moment we can only add arguments to br and cond_br.
+    llvm_unreachable("Can't add argument to terminator");
+  }
+  // Remove the old terminator instruction.
+  termInst->dropAllReferences();
+  termInst->eraseFromParent();
+  return newTermInst;
+}
+
+/// Creates a TF handle of appropriate type that is initialized to the given
+/// element value.
+SILValue createTFHandleFromElement(SILBuilder &builder, SILLocation location,
+                                   SILValue element) {
+  assert(builder.hasValidInsertionPoint());
+  ASTContext& context = builder.getASTContext();
+  SILType elementType = element->getType();
+  // Literals take attributes specifying the dtype, value, and device.
+  std::string opName("__tfop_Const,dtype$dtype,value$tensor,__device");
+  SmallVector<SILValue, 8> operands;
+  operands.push_back(builder.createIntegerLiteral(
+      location, SILType::getBuiltinIntegerType(32, context),
+      convertSwiftTypeToTF(elementType.getASTType())));
+  operands.push_back(element);
+  operands.push_back(builder.createStringLiteral(
+      location, StringRef(ALL_DEVICES), StringLiteralInst::Encoding::UTF8));
+  return builder.createBuiltin(location, context.getIdentifier(opName),
+                               convertElementTypeToTensorValueType(elementType),
+                               /*substitutionlist*/ {}, operands);
+}
+
+
+/// Creates a TF handle of the appropriate integer type for the given bitwith
+/// that is initialized to the given value.
+SILValue createTFIntegerConst(SILBuilder &builder, SILLocation location,
+                              unsigned bitwidth, intmax_t value) {
+  SILType intType =
+      SILType::getBuiltinIntegerType(bitwidth, builder.getASTContext());
+  SILValue ourCst = builder.createIntegerLiteral(location, intType, value);
+  return createTFHandleFromElement(builder, location, ourCst);
+}
+
+
+}  // namespace
+
+
+SILValue SESERegionBuilder::getUndef(SILType type) {
+  return SILUndef::get(type, F->getModule());
+}
+
+
+bool SESERegionBuilder::ensureSingleExitFromLoop(SILLoop* loop) {
+  // Return if the loop is already in the required form.
+  if (loop->getExitBlock() && loop->getExitingBlock() &&
+      loop->getExitingBlock() == loop->getHeader()) {
+    return false;
+  }
+
+  SmallVector<SILBasicBlock*, 8> exitBlocks;
+  loop->getExitBlocks(exitBlocks);
+
+  SILBasicBlock *header = loop->getHeader();
+  SILBasicBlock *preheader = loop->getLoopPreheader();
+  SILBasicBlock *latch = loop->getLoopLatch();
+  assert(preheader && "Canonicalization should have given us one preheader");
+  assert(latch && "Canonicalization should have given us one latch block");
+  SILFunction *currentFn = header->getParent();
+
+  // Identify the set of values that escape the loop.
+  llvm::SmallPtrSet<SILValue, 8> escapingValues;
+  for (const SILBasicBlock* bb : loop->getBlocks()) {
+    // Save the values that are escaping this loop in escapingValues set.
+    auto save_escaping = [this, &loop, &escapingValues](const SILValue &value) {
+      for (const auto *use : value->getUses()) {
+        const SILInstruction *use_inst = use->getUser();
+        if (LI.getLoopFor(use_inst->getParent()) != loop) {
+          escapingValues.insert(value);
+          break;
+        }
+      }
+    };
+    if (bb != header) {
+      llvm::for_each(bb->getArguments(), save_escaping);
+    }
+    for (const SILInstruction &inst : *bb) {
+      llvm::for_each(inst.getResults(), save_escaping);
+    }
+  }
+  llvm::outs() << "The following are live outside the loop:\n";
+  for (const auto &escapingValue : escapingValues) {
+    escapingValue->dump();
+  }
+
+  SmallVector<std::pair<const SILBasicBlock *, const SILBasicBlock *>, 8>
+      edgesToFix;
+  // Exiting edges
+  loop->getExitEdges(edgesToFix);
+  // Edges to header
+  for (SILBasicBlock *headerPred : header->getPredecessorBlocks()) {
+    edgesToFix.emplace_back(headerPred, header);
+  }
+
+  SILBuilder builder(header);
+  ASTContext& context = builder.getASTContext();
+
+  // Create a new header for the loop.
+  //
+  SILBasicBlock* newHeader = currentFn->createBasicBlock();
+  loop->addBasicBlockToLoop(newHeader, LI.getBase()); // Should be done first.
+  // Clone arguments and change all uses to the new header's arguments.
+  newHeader->cloneArgumentList(header);
+  SmallVector<SILValue, 8> headerArgs;
+  for (auto i : indices(header->getArguments())) {
+    header->getArgument(i)->replaceAllUsesWith(newHeader->getArgument(i));
+    headerArgs.push_back(newHeader->getArgument(i));
+  }
+  size_t oldHeaderNumArgs = header->getNumArguments();
+  header->dropAllArguments();
+  // Add phi arguments in the new header corresponding to the escaping values.
+  for (const auto &escapingValue : escapingValues) {
+    SILValue newValue = newHeader->createPHIArgument(
+        escapingValue->getType(), escapingValue.getOwnershipKind());
+    escapingValue->replaceAllUsesWith(newValue);
+  }
+  // An integer to identify the exit edge.
+  SILValue exitIndexArg = newHeader->createPHIArgument(
+      convertElementTypeToTensorValueType(
+          SILType::getBuiltinIntegerType(32, context)),
+      ValueOwnershipKind::Owned);
+  // A boolean corresponding to the stayInLoop flag.
+  newHeader->createPHIArgument(convertElementTypeToTensorValueType(
+                                   SILType::getBuiltinIntegerType(1, context)),
+                               ValueOwnershipKind::Trivial);
+
+  // Create a new latch block.
+  SILBasicBlock* latchBlock = currentFn->createBasicBlock();
+  latchBlock->cloneArgumentList(newHeader);
+  {
+    builder.setInsertionPoint(latchBlock);
+    SmallVector<SILValue, 8> latchArgs;
+    for (const SILArgument *latchArg : latchBlock->getArguments()) {
+      latchArgs.push_back(latchArg);
+    }
+    builder.createBranch(
+        getUserSourceLocation(header->getTerminator()->getDebugLocation()),
+        newHeader, latchArgs);
+  }
+
+  llvm::DenseMap<SILBasicBlock*, intmax_t> exitIndices;
+  // As a simplification, simply 0 as exit index for edges to the header
+  // even though header is not an exit block.
+  exitIndices.insert({header, 0});
+  for (const auto &edge : edgesToFix) {
+    SILBasicBlock *src = const_cast<SILBasicBlock *>(edge.first);
+    SILBasicBlock *tgt = const_cast<SILBasicBlock *>(edge.second);
+    SILBasicBlock *newTgt = loop->contains(src) ? latchBlock : newHeader;
+    bool stayInLoop = loop->contains(tgt);
+    replaceBranchTarget(src->getTerminator(), tgt, newTgt,
+                        /*preserveArgs=*/stayInLoop);
+    // Set up additional arguments.
+    // If we are exiting the loop, then we should simply use newHeader args.
+    SmallVector<SILValue, 8> newArgs;
+    if (!stayInLoop) {
+      for (unsigned i = 0; i < oldHeaderNumArgs; ++i) {
+        newArgs.push_back(newHeader->getArgument(i));
+      }
+    }
+    SILBuilder builder(src->getTerminator());
+    SILLocation location(
+      getUserSourceLocation(src->getTerminator()->getDebugLocation()));
+    // Find an appropriate value to use for each escaping value.
+    unsigned argIndex = oldHeaderNumArgs;
+    for (const SILValue &escapingValue : escapingValues) {
+      if (DI.properlyDominates(escapingValue, src->getTerminator())) {
+        newArgs.push_back(escapingValue);
+      } else if (src != preheader) {
+        // if src is not the preheader than new header arguments are available.
+        newArgs.push_back(newHeader->getArgument(argIndex));
+      } else {
+        newArgs.push_back(getUndef(escapingValue->getType() ));
+      }
+      ++argIndex;
+    }
+    // `exitIndex` to identify the block to which we exit from the loop.
+    // (insert a new value or get the old key value pair.)
+    auto kvPair = *exitIndices.try_emplace(tgt, exitIndices.size()).first;
+    newArgs.push_back(createTFIntegerConst(builder, location,
+                                           /*bitwidth*/ 32,
+                                           /*exitIndex*/ kvPair.second));
+    // `stayInLoop` flag
+    newArgs.push_back(createTFIntegerConst(builder, location,
+                                           /*bitwidth*/ 1, stayInLoop));
+    appendArguments(src->getTerminator(), newTgt, newArgs);
+  }
+
+  // Create a new exit block.
+  SILBasicBlock* newExitBlock = currentFn->createBasicBlock();
+
+  // Build a demuxing if..then..else block that can be used as a single exit
+  // block. This will not have any effect if there is a single exit block
+  // already.
+  auto curBlockIter = exitBlocks.rbegin();
+  SILBasicBlock *demuxBlock = *curBlockIter++;
+  SILLocation headerLocation =
+      getUserSourceLocation(header->getTerminator()->getDebugLocation());
+
+  while (curBlockIter != exitBlocks.rend()) {
+    SILBasicBlock *newBlock = currentFn->createBasicBlock();
+    SILBasicBlock *trueBlock = *curBlockIter++;
+    builder.setInsertionPoint(newBlock);
+    SILValue condTensor = builder.createBuiltin(
+        headerLocation, context.getIdentifier("__tfop_Equal,$in,$in,__device"),
+        convertElementTypeToTensorValueType(
+            SILType::getBuiltinIntegerType(1, context)),
+        /* SubstitutionMap*/ {},
+        {exitIndexArg,
+         createTFIntegerConst(builder, headerLocation, /*bitwidth*/ 32,
+                              exitIndices.lookup(trueBlock)),
+         builder.createStringLiteral(headerLocation, StringRef(ALL_DEVICES),
+                                     StringLiteralInst::Encoding::UTF8)});
+    SILValue condValue = builder.createBuiltin(
+        headerLocation, context.getIdentifier("tf_tensor_to_i1"),
+        SILType::getBuiltinIntegerType(1, context), /*SubstitutionMap*/ {},
+        {condTensor});
+    builder.createCondBranch(headerLocation, condValue, trueBlock, demuxBlock);
+    demuxBlock = newBlock;
+  }
+  builder.setInsertionPoint(newExitBlock);
+  builder.createBranch(headerLocation, demuxBlock);
+
+  // Now connect the newheader to the header and exit block.
+  builder.setInsertionPoint(newHeader);
+  {
+    SILValue loopExitCond = builder.createBuiltin(
+        headerLocation, context.getIdentifier("tf_tensor_to_i1"),
+        SILType::getBuiltinIntegerType(1, context), /*SubstitutionMap*/ {},
+        {newHeader->getArguments().back()});
+    builder.createCondBranch(headerLocation, loopExitCond, header, newExitBlock);
+  }
+  loop->moveToHeader(newHeader);
+  loop->addBasicBlockToLoop(latchBlock, LI.getBase());
+
+  return true;
+}
+
 /// Process the specified loop, collapsing it into a SESE region node.  This
 /// forms a WhileLoopSESERegion node and puts it into the loopPreheaders data
-/// structure, allowing the outer level's acyclic region handling to pick it up.
+/// structure, allowing the outer level's acyclic region handling to pick it
+/// up.
 void SESERegionBuilder::processLoop(SILLoop *loop) {
   // If there are any nested loops within this one, transform them inside out.
   for (auto *nested : *loop) {
@@ -261,8 +600,8 @@ void SESERegionBuilder::processLoop(SILLoop *loop) {
     llvm_unreachable("SESE FIXME: Loops with multiple exits not handled yet!");
   }
 
-  // Loop canonicalization also gives us the property that exits out of the loop
-  // have critical edges split, and that any exit block jumps to a block
+  // Loop canonicalization also gives us the property that exits out of the
+  // loop have critical edges split, and that any exit block jumps to a block
   // (outside the loop) that is *only* targeted by blocks inside the loop.
 
   // In many cases, we'll end up with the loop body in proper while form ready
@@ -285,8 +624,8 @@ void SESERegionBuilder::processLoop(SILLoop *loop) {
     // the acyclic region represented by the loop body into a SESE region.
     auto bodyRegion = processAcyclicRegion(body, latch);
 
-    auto result = new WhileLoopSESERegion(preheader, header, exit,
-                                          std::move(bodyRegion));
+    auto result =
+        new WhileLoopSESERegion(preheader, header, exit, std::move(bodyRegion));
     loopPreheaders.insert({preheader, result});
     return;
   }
@@ -294,10 +633,9 @@ void SESERegionBuilder::processLoop(SILLoop *loop) {
   llvm_unreachable("SESE FIXME: Imperfect loop exits not handled yet!");
   // splitCriticalEdge
 
-  // FIXME: Need to handle "break" edges that exit the loop, preventing the body
-  // from being an SESE region.
+  // FIXME: Need to handle "break" edges that exit the loop, preventing the
+  // body from being an SESE region.
 }
-
 
 /// Transform the function into a properly nested series of
 /// single-entry-single-exit regions.

--- a/test/TensorFlow/sese_loop_canonicalization.sil
+++ b/test/TensorFlow/sese_loop_canonicalization.sil
@@ -37,11 +37,8 @@ public func loopTest(breakCount:Int32) -> Int32 {
 
 //-- Preheader sets up the undefs, exit index, and stayInLoop flag.
 // CHECK: bb0(%0 : $Builtin.Int32):
-// CHECK: {{.*}} = integer_literal $Builtin.Int32, 0
-// CHECK: [[A:%.*]] = integer_literal $Builtin.Int32, 0
-// CHECK: [[PHDR_EXIT:%.*]] = graph_op "__tfop_Const,dtype$dtype,value$tensor,__device"({{.*}}, [[A]] : $Builtin.Int32, {{.*}})
-// CHECK: [[B:%.*]] = integer_literal $Builtin.Int1, -1
-// CHECK: [[PHDR_FLAG:%.*]] = graph_op "__tfop_Const,dtype$dtype,value$tensor,__device"({{.*}}, [[B]] : $Builtin.Int1, {{.*}})
+// CHECK: [[PHDR_EXIT:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.Int32, value$tensor: i32 0, __device: "ALL_DEVICES"}
+// CHECK: [[PHDR_FLAG:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.Int1, value$tensor: i1 -1, __device: "ALL_DEVICES"} 
 // CHECK: br bb9({{.*}} : $Builtin.Int32, {{.*}} : $Builtin.Int32, undef : $Builtin.Int32, [[PHDR_EXIT]] : $TensorHandle<Builtin.Int32>, [[PHDR_FLAG]] : $TensorHandle<Builtin.Int1>)
 
 //-- Original exiting blocks use appropriate arguments from new header.
@@ -57,9 +54,8 @@ public func loopTest(breakCount:Int32) -> Int32 {
 
 //-- Demuxing Block wires the exit blocks correctly.
 // CHECK: bb12:
-// CHECK:  [[A:%.*]] = integer_literal $Builtin.Int32, 0
-// CHECK:  [[ZERO_INDEX:%.*]] = graph_op "__tfop_Const,dtype$dtype,value$tensor,__device"({{.*}} : $Builtin.Int32, [[A]] : $Builtin.Int32, {{.*}} : $Builtin.RawPointer) : $TensorHandle<Builtin.Int32>
-// CHECK:  [[A:%.*]] = graph_op "__tfop_Equal,$in,$in,__device"([[HDR_EXIT_ARG]] : $TensorHandle<Builtin.Int32>, [[ZERO_INDEX]] : $TensorHandle<Builtin.Int32>, {{.*}} : $Builtin.RawPointer) : $TensorHandle<Builtin.Int1>
+// CHECK:  [[ZERO_INDEX:%.*]] = graph_op  "Const"() {dtype$dtype: $Builtin.Int32, value$tensor: i32 0, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int32> 
+// CHECK:  [[A:%.*]] = graph_op "Equal,i,i"([[HDR_EXIT_ARG]] : $TensorHandle<Builtin.Int32>, [[ZERO_INDEX]] : $TensorHandle<Builtin.Int32>) {{.*}} : $TensorHandle<Builtin.Int1>
 // CHECK:  [[B:%.*]] = graph_op "tf_tensor_to_i1"([[A]] : $TensorHandle<Builtin.Int1>) : $Builtin.Int1
 // CHECK:  cond_br [[B]], bb3, bb7
 

--- a/test/TensorFlow/sese_loop_canonicalization.sil
+++ b/test/TensorFlow/sese_loop_canonicalization.sil
@@ -38,12 +38,39 @@ public func loopTest(breakCount:Int32) -> Int32 {
 //-- Preheader sets up the undefs, exit index, and stayInLoop flag.
 // CHECK: bb0(%0 : $Builtin.Int32):
 // CHECK: [[PHDR_EXIT:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.Int32, value$tensor: i32 0, __device: "ALL_DEVICES"}
-// CHECK: [[PHDR_FLAG:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.Int1, value$tensor: i1 -1, __device: "ALL_DEVICES"} 
+// CHECK: [[PHDR_FLAG:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.Int1, value$tensor: i1 -1, __device: "ALL_DEVICES"}
 // CHECK: br bb9({{.*}} : $Builtin.Int32, {{.*}} : $Builtin.Int32, undef : $Builtin.Int32, [[PHDR_EXIT]] : $TensorHandle<Builtin.Int32>, [[PHDR_FLAG]] : $TensorHandle<Builtin.Int1>)
 
-//-- Original exiting blocks use appropriate arguments from new header.
+//- Sets up index to 0 and flag to false on the exit branch of the original header to latch.
+// CHECK: bb1:
+// CHECK:   [[LOCAL_EXIT_INDEX:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.Int32, value$tensor: i32 0, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int32>
+// CHECK:   [[LOCAL_STAY_FLAG:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.Int1, value$tensor: i1 0, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int1>
+//   cond_br {{.*}}, bb4, bb2
+
+// CHECK: bb2:
+// CHECK:  br bb10({{.*}}, [[LOCAL_EXIT_INDEX]] : $TensorHandle<Builtin.Int32>, [[LOCAL_STAY_FLAG]] : $TensorHandle<Builtin.Int1>)
+
+//-- Exit block from header uses original argument.
 // CHECK: bb3:
 // CHECK-NEXT:  br bb8([[HDR_ORIG_ARG:%.*]] : $Builtin.Int32)
+
+//- Sets up index to 1 and flag to false on the true branch of the if with break to latch.
+// CHECK: bb4:
+// CHECK:  [[LOCAL_EXIT_INDEX:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.Int32, value$tensor: i32 1, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int32>
+// CHECK:  [[LOCAL_STAY_FLAG:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.Int1, value$tensor: i1 0, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int1>
+// CHECK: cond_br {{.*}}, bb5, bb6
+
+// CHECK: bb5:                                              // Preds: bb4
+// CHECK:  br bb10({{.*}}, [[LOCAL_EXIT_INDEX]] : $TensorHandle<Builtin.Int32>, [[LOCAL_STAY_FLAG]] : $TensorHandle<Builtin.Int1>)
+
+
+//- Sets up index to 0 and flag to true on the false branch of the if with break to latch.
+// CHECK: bb6:
+// CHECK: [[LOCAL_EXIT_INDEX:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.Int32, value$tensor: i32 0, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int32>
+// CHECK: [[LOCAL_STAY_FLAG:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.Int1, value$tensor: i1 -1, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int1>
+// CHECK:  br bb10({{.*}}, [[LOCAL_EXIT_INDEX]] : $TensorHandle<Builtin.Int32>, [[LOCAL_STAY_FLAG]] : $TensorHandle<Builtin.Int1>)
+
+//- Exit block from a non-header uses escaping arg.
 // CHECK: bb7:
 // CHECK-NEXT:  br bb8([[HDR_ESCAPING_ARG:%.*]] : $Builtin.Int32)
 
@@ -52,13 +79,13 @@ public func loopTest(breakCount:Int32) -> Int32 {
 // CHECK:  [[B:%.*]] = graph_op "tf_tensor_to_i1"([[HDR_FLAG_ARG]] : $TensorHandle<Builtin.Int1>) : $Builtin.Int1
 // CHECK:  cond_br [[B]], bb1, bb11
 
+
 //-- Demuxing Block wires the exit blocks correctly.
 // CHECK: bb12:
-// CHECK:  [[ZERO_INDEX:%.*]] = graph_op  "Const"() {dtype$dtype: $Builtin.Int32, value$tensor: i32 0, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int32> 
+// CHECK:  [[ZERO_INDEX:%.*]] = graph_op  "Const"() {dtype$dtype: $Builtin.Int32, value$tensor: i32 0, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int32>
 // CHECK:  [[A:%.*]] = graph_op "Equal,i,i"([[HDR_EXIT_ARG]] : $TensorHandle<Builtin.Int32>, [[ZERO_INDEX]] : $TensorHandle<Builtin.Int32>) {{.*}} : $TensorHandle<Builtin.Int1>
 // CHECK:  [[B:%.*]] = graph_op "tf_tensor_to_i1"([[A]] : $TensorHandle<Builtin.Int1>) : $Builtin.Int1
 // CHECK:  cond_br [[B]], bb3, bb7
-
 
 sil @$loopWithBreak : $@convention(thin) (Builtin.Int32) -> Builtin.Int32 {
 // %0                                             // user: %12

--- a/test/TensorFlow/sese_loop_canonicalization.sil
+++ b/test/TensorFlow/sese_loop_canonicalization.sil
@@ -1,0 +1,219 @@
+// RUN: %target-sil-opt -tf-xla-cfg-canonicalize -tf-ensure-single-loop-exit -assume-parsing-unqualified-ownership-sil %s -o /dev/null | %FileCheck %s
+
+import Builtin
+import Swift
+import TensorFlow
+
+/*
+public func loopTest(breakCount:Int32) -> Int32 {
+  var count:Int32 = 0
+  var sum:Int32 = 0
+  while (count < 100) {
+    sum += count
+    count += 1
+    if (count == breakCount) {
+      break;
+    }
+  }
+  return sum
+}
+*/
+// CHECK-LABEL:--- XLA CFG Canonicalize: $loopWithBreak
+// CHECK: [sequence
+// CHECK:   <while Preheader: bb0, Header: bb9, exit: bb11
+// CHECK:     [sequence
+// CHECK:       {condition Header: bb1
+// CHECK:         {condition Header: bb4
+// CHECK:           block bb5
+// CHECK:           block bb6}
+// CHECK:         block bb2}
+// CHECK:       block bb10]>
+// CHECK:   block bb11
+// CHECK:   {condition Header: bb12
+// CHECK:     block bb3
+// CHECK:     block bb7}
+// CHECK:   block bb8]
+// CHECK: --- XLA CFG Canonicalize end
+
+//-- Preheader sets up the undefs, exit index, and stayInLoop flag.
+// CHECK: bb0(%0 : $Builtin.Int32):
+// CHECK: {{.*}} = integer_literal $Builtin.Int32, 0
+// CHECK: [[A:%.*]] = integer_literal $Builtin.Int32, 0
+// CHECK: [[PHDR_EXIT:%.*]] = builtin "__tfop_Const,dtype$dtype,value$tensor,__device"({{.*}}, [[A]] : $Builtin.Int32, {{.*}})
+// CHECK: [[B:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK: [[PHDR_FLAG:%.*]] = builtin "__tfop_Const,dtype$dtype,value$tensor,__device"({{.*}}, [[B]] : $Builtin.Int1, {{.*}})
+// CHECK: br bb9({{.*}} : $Builtin.Int32, {{.*}} : $Builtin.Int32, undef : $Builtin.Int32, [[PHDR_EXIT]] : $TensorHandle<Builtin.Int32>, [[PHDR_FLAG]] : $TensorHandle<Builtin.Int1>)
+
+//-- Original exiting blocks use appropriate arguments from new header.
+// CHECK: bb3:
+// CHECK-NEXT:  br bb8([[HDR_ORIG_ARG:%.*]] : $Builtin.Int32)
+// CHECK: bb7:
+// CHECK-NEXT:  br bb8([[HDR_ESCAPING_ARG:%.*]] : $Builtin.Int32)
+
+//-- New Header simply checks flag
+// CHECK: bb9([[HDR_ORIG_ARG]] : $Builtin.Int32, {{.*}} : $Builtin.Int32, [[HDR_ESCAPING_ARG]] : $Builtin.Int32, [[HDR_EXIT_ARG:%.*]] : $TensorHandle<Builtin.Int32>, [[HDR_FLAG_ARG:%.*]] : $TensorHandle<Builtin.Int1>):
+// CHECK:  [[B:%.*]] = builtin "tf_tensor_to_i1"([[HDR_FLAG_ARG]] : $TensorHandle<Builtin.Int1>) : $Builtin.Int1
+// CHECK:  cond_br [[B]], bb1, bb11
+
+//-- Demuxing Block wires the exit blocks correctly.
+// CHECK: bb12:
+// CHECK:  [[A:%.*]] = integer_literal $Builtin.Int32, 0
+// CHECK:  [[ZERO_INDEX:%.*]] = builtin "__tfop_Const,dtype$dtype,value$tensor,__device"({{.*}} : $Builtin.Int32, [[A]] : $Builtin.Int32, {{.*}} : $Builtin.RawPointer) : $TensorHandle<Builtin.Int32>
+// CHECK:  [[A:%.*]] = builtin "__tfop_Equal,$in,$in,__device"([[HDR_EXIT_ARG]] : $TensorHandle<Builtin.Int32>, [[ZERO_INDEX]] : $TensorHandle<Builtin.Int32>, {{.*}} : $Builtin.RawPointer) : $TensorHandle<Builtin.Int1>
+// CHECK:  [[B:%.*]] = builtin "tf_tensor_to_i1"([[A]] : $TensorHandle<Builtin.Int1>) : $Builtin.Int1
+// CHECK:  cond_br [[B]], bb3, bb7
+
+
+sil @$loopWithBreak : $@convention(thin) (Builtin.Int32) -> Builtin.Int32 {
+// %0                                             // user: %12
+bb0(%0 : $Builtin.Int32):
+  %1 = integer_literal $Builtin.Int32, 0          // user: %4
+  %2 = integer_literal $Builtin.Int32, 1          // users: %11, %4
+  %3 = integer_literal $Builtin.Int32, 100        // user: %7
+  br bb1(%1 : $Builtin.Int32, %1 : $Builtin.Int32) // id: %4
+
+// %5                                             // users: %10, %9
+// %6                                             // users: %11, %10, %7
+bb1(%5 : $Builtin.Int32, %6 : $Builtin.Int32):    // Preds: bb4 bb0
+  %7 = builtin "cmp_slt_Int32"(%6 : $Builtin.Int32, %3 : $Builtin.Int32) : $Builtin.Int1 // user: %8
+  cond_br %7, bb3, bb2                            // id: %8
+
+bb2:                                              // Preds: bb1
+  br bb6(%5 : $Builtin.Int32)                     // id: %9
+
+bb3:                                              // Preds: bb1
+  %10 = builtin "sadd_with_overflow_Int32"(%5 : $Builtin.Int32, %6 : $Builtin.Int32) : $Builtin.Int32 // users: %15, %14
+  %11 = builtin "sadd_with_overflow_Int32"(%6 : $Builtin.Int32, %2 : $Builtin.Int32) : $Builtin.Int32 // users: %14, %12
+  %12 = builtin "cmp_eq_Int32"(%11 : $Builtin.Int32, %0 : $Builtin.Int32) : $Builtin.Int1 // user: %13
+  cond_br %12, bb5, bb4                           // id: %13
+
+bb4:                                              // Preds: bb3
+  br bb1(%10 : $Builtin.Int32, %11 : $Builtin.Int32) // id: %14
+
+bb5:                                              // Preds: bb3
+  br bb6(%10 : $Builtin.Int32)                    // id: %15
+
+// %16                                            // user: %17
+bb6(%16 : $Builtin.Int32):                        // Preds: bb5 bb2
+  return %16 : $Builtin.Int32                     // id: %17
+}
+
+
+/*
+public func nestedLoopWithBreak(breakCount:Int32) -> Int32 {
+  var sum:Int32 = 0
+  var j:Int32 = 0
+  var count:Int32 = 0
+  while j < 100 {
+    while (count < 100) {
+      sum += count
+      count += 1
+      if (count == breakCount) {
+        break;
+      }
+    }
+    j += 1
+    count -= breakCount
+    if (sum > breakCount) {
+      break;
+    }
+  }
+  return sum
+}
+*/
+// CHECK-LABEL: --- XLA CFG Canonicalize: $nestedLoopWithBreak
+// CHECK:[sequence
+// CHECK:  <while Preheader: bb0, Header: bb21, exit: bb23
+// CHECK:    [sequence
+// CHECK:      {condition Header: bb1
+// CHECK:        [sequence
+// CHECK:          <while Preheader: bb4, Header: bb17, exit: bb19
+// CHECK:            [sequence
+// CHECK:              {condition Header: bb5
+// CHECK:                {condition Header: bb8
+// CHECK:                  block bb9
+// CHECK:                  block bb10}
+// CHECK:                block bb6}
+// CHECK:              block bb18]>
+// CHECK:          block bb19
+// CHECK:          {condition Header: bb20
+// CHECK:            block bb7
+// CHECK:            block bb11}
+// CHECK:          {condition Header: bb12
+// CHECK:            block bb13
+// CHECK:            block bb15}]
+// CHECK:        block bb2}
+// CHECK:      block bb22]>
+// CHECK:  block bb23
+// CHECK:  {condition Header: bb24
+// CHECK:    block bb3
+// CHECK:    block bb14}
+// CHECK:  block bb16]
+//-- Loop preheaders have appropriate number of additional arguments
+//-- Outer loop
+// CHECK: bb0(%0 : $Builtin.Int32):
+// CHECK: br bb21([[A:%.*]] : $Builtin.Int32, [[A]] : $Builtin.Int32, [[A]] : $Builtin.Int32, undef : $Builtin.Int32, {{.*}} : $TensorHandle<Builtin.Int32>, {{.*}} : $TensorHandle<Builtin.Int1>)
+//-- Inner loop
+// CHECK: bb4:                                              // Preds: bb1
+// CHECK:  br bb17({{.*}} : $Builtin.Int32, {{.*}} : $Builtin.Int32, undef : $Builtin.Int32, undef : $Builtin.Int32, {{.*}} : $TensorHandle<Builtin.Int32>, {{.*}} : $TensorHandle<Builtin.Int1>)
+
+sil @$nestedLoopWithBreak : $@convention(thin) (Builtin.Int32) -> Builtin.Int32 {
+// %0                                             // users: %27, %26, %19
+bb0(%0 : $Builtin.Int32):
+  %1 = integer_literal $Builtin.Int32, 0          // users: %4, %4, %4
+  %2 = integer_literal $Builtin.Int32, 100        // users: %14, %8
+  %3 = integer_literal $Builtin.Int32, 1          // users: %25, %18
+  br bb1(%1 : $Builtin.Int32, %1 : $Builtin.Int32, %1 : $Builtin.Int32) // id: %4
+
+// %5                                             // users: %11, %10
+// %6                                             // users: %25, %8
+// %7                                             // user: %11
+bb1(%5 : $Builtin.Int32, %6 : $Builtin.Int32, %7 : $Builtin.Int32): // Preds: bb11 bb0
+  %8 = builtin "cmp_slt_Int32"(%6 : $Builtin.Int32, %2 : $Builtin.Int32) : $Builtin.Int1 // user: %9
+  cond_br %8, bb3, bb2                            // id: %9
+
+bb2:                                              // Preds: bb1
+  br bb12(%5 : $Builtin.Int32)                    // id: %10
+
+bb3:                                              // Preds: bb1
+  br bb4(%5 : $Builtin.Int32, %7 : $Builtin.Int32) // id: %11
+
+// %12                                            // users: %17, %16
+// %13                                            // users: %18, %17, %16, %14
+bb4(%12 : $Builtin.Int32, %13 : $Builtin.Int32):  // Preds: bb7 bb3
+  %14 = builtin "cmp_slt_Int32"(%13 : $Builtin.Int32, %2 : $Builtin.Int32) : $Builtin.Int1 // user: %15
+  cond_br %14, bb6, bb5                           // id: %15
+
+bb5:                                              // Preds: bb4
+  br bb9(%12 : $Builtin.Int32, %13 : $Builtin.Int32) // id: %16
+
+bb6:                                              // Preds: bb4
+  %17 = builtin "sadd_with_overflow_Int32"(%12 : $Builtin.Int32, %13 : $Builtin.Int32) : $Builtin.Int32 // users: %22, %21
+  %18 = builtin "sadd_with_overflow_Int32"(%13 : $Builtin.Int32, %3 : $Builtin.Int32) : $Builtin.Int32 // users: %22, %21, %19
+  %19 = builtin "cmp_eq_Int32"(%18 : $Builtin.Int32, %0 : $Builtin.Int32) : $Builtin.Int1 // user: %20
+  cond_br %19, bb8, bb7                           // id: %20
+
+bb7:                                              // Preds: bb6
+  br bb4(%17 : $Builtin.Int32, %18 : $Builtin.Int32) // id: %21
+
+bb8:                                              // Preds: bb6
+  br bb9(%17 : $Builtin.Int32, %18 : $Builtin.Int32) // id: %22
+
+// %23                                            // users: %30, %29, %27
+// %24                                            // user: %26
+bb9(%23 : $Builtin.Int32, %24 : $Builtin.Int32):  // Preds: bb8 bb5
+  %25 = builtin "sadd_with_overflow_Int32"(%6 : $Builtin.Int32, %3 : $Builtin.Int32) : $Builtin.Int32 // user: %30
+  %26 = builtin "ssub_with_overflow_Int32"(%24 : $Builtin.Int32, %0 : $Builtin.Int32) : $Builtin.Int32 // user: %30
+  %27 = builtin "cmp_slt_Int32"(%0 : $Builtin.Int32, %23 : $Builtin.Int32) : $Builtin.Int1 // user: %28
+  cond_br %27, bb10, bb11                         // id: %28
+
+bb10:                                             // Preds: bb9
+  br bb12(%23 : $Builtin.Int32)                   // id: %29
+
+bb11:                                             // Preds: bb9
+  br bb1(%23 : $Builtin.Int32, %25 : $Builtin.Int32, %26 : $Builtin.Int32) // id: %30
+
+// %31                                            // user: %32
+bb12(%31 : $Builtin.Int32):                       // Preds: bb10 bb2
+  return %31 : $Builtin.Int32                     // id: %32
+} // end sil function '$S20canonicalize_cfg_xla10nestedLoop10breakCounts5Int32VAE_tF'

--- a/test/TensorFlow/sese_loop_canonicalization.sil
+++ b/test/TensorFlow/sese_loop_canonicalization.sil
@@ -39,9 +39,9 @@ public func loopTest(breakCount:Int32) -> Int32 {
 // CHECK: bb0(%0 : $Builtin.Int32):
 // CHECK: {{.*}} = integer_literal $Builtin.Int32, 0
 // CHECK: [[A:%.*]] = integer_literal $Builtin.Int32, 0
-// CHECK: [[PHDR_EXIT:%.*]] = builtin "__tfop_Const,dtype$dtype,value$tensor,__device"({{.*}}, [[A]] : $Builtin.Int32, {{.*}})
+// CHECK: [[PHDR_EXIT:%.*]] = graph_op "__tfop_Const,dtype$dtype,value$tensor,__device"({{.*}}, [[A]] : $Builtin.Int32, {{.*}})
 // CHECK: [[B:%.*]] = integer_literal $Builtin.Int1, -1
-// CHECK: [[PHDR_FLAG:%.*]] = builtin "__tfop_Const,dtype$dtype,value$tensor,__device"({{.*}}, [[B]] : $Builtin.Int1, {{.*}})
+// CHECK: [[PHDR_FLAG:%.*]] = graph_op "__tfop_Const,dtype$dtype,value$tensor,__device"({{.*}}, [[B]] : $Builtin.Int1, {{.*}})
 // CHECK: br bb9({{.*}} : $Builtin.Int32, {{.*}} : $Builtin.Int32, undef : $Builtin.Int32, [[PHDR_EXIT]] : $TensorHandle<Builtin.Int32>, [[PHDR_FLAG]] : $TensorHandle<Builtin.Int1>)
 
 //-- Original exiting blocks use appropriate arguments from new header.
@@ -52,15 +52,15 @@ public func loopTest(breakCount:Int32) -> Int32 {
 
 //-- New Header simply checks flag
 // CHECK: bb9([[HDR_ORIG_ARG]] : $Builtin.Int32, {{.*}} : $Builtin.Int32, [[HDR_ESCAPING_ARG]] : $Builtin.Int32, [[HDR_EXIT_ARG:%.*]] : $TensorHandle<Builtin.Int32>, [[HDR_FLAG_ARG:%.*]] : $TensorHandle<Builtin.Int1>):
-// CHECK:  [[B:%.*]] = builtin "tf_tensor_to_i1"([[HDR_FLAG_ARG]] : $TensorHandle<Builtin.Int1>) : $Builtin.Int1
+// CHECK:  [[B:%.*]] = graph_op "tf_tensor_to_i1"([[HDR_FLAG_ARG]] : $TensorHandle<Builtin.Int1>) : $Builtin.Int1
 // CHECK:  cond_br [[B]], bb1, bb11
 
 //-- Demuxing Block wires the exit blocks correctly.
 // CHECK: bb12:
 // CHECK:  [[A:%.*]] = integer_literal $Builtin.Int32, 0
-// CHECK:  [[ZERO_INDEX:%.*]] = builtin "__tfop_Const,dtype$dtype,value$tensor,__device"({{.*}} : $Builtin.Int32, [[A]] : $Builtin.Int32, {{.*}} : $Builtin.RawPointer) : $TensorHandle<Builtin.Int32>
-// CHECK:  [[A:%.*]] = builtin "__tfop_Equal,$in,$in,__device"([[HDR_EXIT_ARG]] : $TensorHandle<Builtin.Int32>, [[ZERO_INDEX]] : $TensorHandle<Builtin.Int32>, {{.*}} : $Builtin.RawPointer) : $TensorHandle<Builtin.Int1>
-// CHECK:  [[B:%.*]] = builtin "tf_tensor_to_i1"([[A]] : $TensorHandle<Builtin.Int1>) : $Builtin.Int1
+// CHECK:  [[ZERO_INDEX:%.*]] = graph_op "__tfop_Const,dtype$dtype,value$tensor,__device"({{.*}} : $Builtin.Int32, [[A]] : $Builtin.Int32, {{.*}} : $Builtin.RawPointer) : $TensorHandle<Builtin.Int32>
+// CHECK:  [[A:%.*]] = graph_op "__tfop_Equal,$in,$in,__device"([[HDR_EXIT_ARG]] : $TensorHandle<Builtin.Int32>, [[ZERO_INDEX]] : $TensorHandle<Builtin.Int32>, {{.*}} : $Builtin.RawPointer) : $TensorHandle<Builtin.Int1>
+// CHECK:  [[B:%.*]] = graph_op "tf_tensor_to_i1"([[A]] : $TensorHandle<Builtin.Int1>) : $Builtin.Int1
 // CHECK:  cond_br [[B]], bb3, bb7
 
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fix for [SR-7765](https://bugs.swift.org/browse/SR-7765). This is a first cut of the necessary transformations to convert loops into a form that can be translated directly to XF-TLA while loops. 

This does not work with labeled breaks yet. I will fix them in a subsequent PR. 
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-7765](https://bugs.swift.org/browse/SR-7765).
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
