### PR TITLE
[Type checker] Allow forward references to local types.

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -601,10 +601,14 @@ resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC) {
   auto isValid = [&](ValueDecl *D) {
     // FIXME: The source-location checks won't make sense once
     // EnableASTScopeLookup is the default.
+    //
+    // Note that we allow forward references to types, because they cannot
+    // capture.
     if (Loc.isValid() && D->getLoc().isValid() &&
         D->getDeclContext()->isLocalContext() &&
         D->getDeclContext() == DC &&
-        Context.SourceMgr.isBeforeInBuffer(Loc, D->getLoc())) {
+        Context.SourceMgr.isBeforeInBuffer(Loc, D->getLoc()) &&
+        !isa<TypeDecl>(D)) {
       localDeclAfterUse = D;
       return false;
     }

--- a/test/Compatibility/local_types.swift
+++ b/test/Compatibility/local_types.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift
+
+func foo() {
+  // Okay to reference a type declared later in the same function.
+  _ = Visitor()
+  struct Visitor { }
+}


### PR DESCRIPTION
Recent work to improve checking for forward references to local types
(https://github.com/apple/swift/pull/16967) started rejecting code
that referred to a local type before it is defined. Swift previously
accepted such code, because local types can’t capture anyway, so allow
it again… for now.

As a separate action item, I’d like to revisit the language design
here, because it’s somewhat surprising when we can vs. cannot
forward-reference local declarations, and the rules differ from
those of top-level code in scripts *and* top-level code for non-scripts.

Fixes rdar://problem/41659447
