### PR TITLE
[docs] LibraryEvolution: Non-controversial updates for Swift 4.2

### DIFF
--- a/docs/LibraryEvolution.rst
+++ b/docs/LibraryEvolution.rst
@@ -89,10 +89,10 @@ This model is largely not of interest to libraries that are bundled with their
 clients (distribution via source, static library, or embedded/sandboxed dynamic
 library, as used by the `Swift Package Manager`_). Because a client always uses
 a particular version of such a library, there is no need to worry about
-backwards- or forwards-compatibility. Just as developers with a single app
-target are not forced to think about access control, anyone writing a bundled
-library should not be required to use any of the annotations described below in
-order to achieve full performance.
+backwards- or forwards-compatibility at the binary level. Just as developers
+with a single app target are not forced to think about access control, anyone
+writing a bundled library should not be required to use any of the annotations
+described below in order to achieve full performance.
 
 .. _Swift Package Manager: https://swift.org/package-manager/
 
@@ -172,7 +172,7 @@ Publishing Versioned API
 A library's API is already marked with the ``public`` modifier, but if a
 client wants to work with multiple releases of the library, the API needs
 versioning information as well. A *versioned entity* represents anything with a
-runtime presence that a client may rely on; its version records when the entity
+run-time presence that a client may rely on; its version records when the entity
 was first exposed publicly in its library. Put another way, it is the oldest
 version of the library where the entity may be used.
 
@@ -182,6 +182,8 @@ version of the library where the entity may be used.
 - Protocol conformances may be versioned entities, despite not explicitly having
   a declaration in Swift, because a client may depend on them.
   See `New Conformances`_, below.
+- Typealiases are treated as versioned entities for the purpose of verifying
+  availability, even though they have no run-time presence.
 
 In a versioned library, any top-level public entity from the list above may not
 be made ``public`` (or ``open``) without an appropriate version. A public
@@ -220,7 +222,7 @@ Syntax #1: Attributes
     @available(1.2)
     public func summonDemons()
 
-    @available(1.0) @inlineable(1.2)
+    @available(1.0) @inlinable(1.2)
     public func summonElves()
 
 Using the same attribute for both publishing and using versioned APIs helps tie
@@ -239,7 +241,7 @@ Syntax #2: Version Blocks
     public func summonDemons()
 
     #version(1.0) {}
-    #version(1.2) { @inlineable }
+    #version(1.2) { @inlinable }
     public func summonElves()
 
 Since there are potentially many annotations on a declaration that need
@@ -254,7 +256,7 @@ Syntax #3: The ``public`` modifier
 
     public(1.2) func summonDemons()
 
-    /* @inlineable ?? */
+    /* @inlinable ?? */
     public(1.0) func summonElves()
 
 Putting the version on the public modifier is the most concise option. However,
@@ -307,8 +309,8 @@ No other changes are permitted; the following are particularly of note:
   is safe when a client deploys against older versions of the library.
 
 
-Inlineable Functions
---------------------
+Inlinable Functions
+-------------------
 
 Functions are a very common example of resilience: the function's declaration
 is published as API, but its body may change between library versions as long
@@ -326,62 +328,44 @@ are a few common reasons for this:
   allows the library author to preserve invariants while still allowing
   efficient access to the struct.
 
-- The function is used to determine which version of the library a client was
-  compiled against.
+- The function is generic and its performance may be greatly increased by
+  specialization in the client.
 
-- The library author does not want to make the function part of their binary
-  interface, allowing for source-compatible changes 
-
-A versioned function marked with the ``@inlineable`` attribute makes its body
-available to clients as part of the module's public interface. ``@inlineable``
+A versioned function marked with the ``@inlinable`` attribute makes its body
+available to clients as part of the module's public interface. ``@inlinable``
 is a `versioned attribute`; clients may not assume that the body of the
-function is suitable when deploying against older versions of the library. If a
-function has been inlineable since it was introduced, it is not considered part
-of the library's binary interface.
+function is suitable when deploying against older versions of the library.
 
-Clients are not required to inline a function marked ``@inlineable``. However,
-if a function has been inlineable since the minimum required version of the
-library, any use of that function must copy its implementation into the client
-module.
+Clients are not required to inline a function marked ``@inlinable``.
 
 .. note::
 
-    It is legal to change the implementation of an inlineable function in the
+    It is legal to change the implementation of an inlinable function in the
     next release of the library. However, any such change must be made with the
     understanding that it will not affect existing clients. This is the
     standard example of a `binary-compatible source-breaking change`.
 
-Any local functions or closures within an inlineable function are themselves
-treated as ``@inlineable``. This is important in case it is necessary to change
-the inlineable function later; existing clients should not be depending on
-internal details of the previous implementation.
+Any local functions or closures within an inlinable function are themselves
+treated as ``@inlinable``, and a client that inlines the containing function
+must emit its own copy of the local functions or closures. This is important in
+case it is necessary to change the inlinable function later; existing clients
+should not be depending on internal details of the previous implementation.
 
-It is a `binary-compatible source-breaking change` to completely remove a
-public entity marked ``@inlineable`` from a library if and only if it has been
-inlineable since it was introduced. If not, it is considered a part of the
-library's binary interface and may not be removed.
-
-(Non-public, non-versioned entities may always be removed from a library; they
-are not part of its API or ABI.)
-
-.. note::
-
-    Removing ``@inlineable`` from a public entity without updating its
-    availability information is not permitted. Instead, add a second,
-    non-inlineable function that provides the implementation of the
-    ``@inlineable`` entity, and call through to that function when a new enough
-    version of the library is available.
+Removing the ``@inlinable`` attribute completely---say, to reference private
+implementation details that should not be `versioned <versioned entity>`---is a
+safe change. However, existing clients will of course not be affected by this
+change, and any future use of the function must take this into account.
 
 Although they are not a supported feature for arbitrary libraries at this time,
-`transparent`_ functions are implicitly marked ``@inlineable``.
+`transparent`_ functions are implicitly marked ``@inlinable``.
 
 .. _transparent: https://github.com/apple/swift/blob/master/docs/TransparentAttr.rst
 
 
-Restrictions on Inlineable Functions
-------------------------------------
+Restrictions on Inlinable Functions
+-----------------------------------
 
-Because the body of an inlineable function (or method, accessor, initializer,
+Because the body of an inlinable function (or method, accessor, initializer,
 or deinitializer) will be inlined into another module, it must not make any
 assumptions that rely on knowledge of the current module. Here is a trivial
 example using methods::
@@ -392,7 +376,7 @@ example using methods::
     }
 
     extension Point2D {
-      @inlineable public func distance(to other: Point2D) -> Double {
+      @inlinable public func distance(to other: Point2D) -> Double {
         let deltaX = self.x - other.x
         let deltaY = self.y - other.y
         return sqrt(deltaX*deltaX + deltaY*deltaY)
@@ -409,40 +393,39 @@ polar representation::
     }
 
 and the ``x`` and ``y`` properties have now disappeared. To avoid this, the
-bodies of inlineable functions have the following restrictions:
+bodies of inlinable functions have the following restrictions:
 
 - They may not define any local types (other than typealiases).
 
-- They must not reference any ``private`` or ``fileprivate`` entities, except
-  for other declarations marked ``@inlineable``.
+- They must not reference any ``private`` or ``fileprivate`` entities.
 
 - They must not reference any ``internal`` entities except for those that have
-  been `versioned`_ and those declared ``@inlineable``. See below for a
-  discussion of versioning internal API.
-
-- In addition, no non-public, non-versioned stored constants or variables may
-  be referenced even if they are declared ``@inlineable``. (This is because
-  their storage is still considered part of the defining library.)
+  been ``versioned <versioned entity>` and those declared ``@inlinable``. See
+  below for a discussion of versioning internal API.
 
 - They must not reference any entities from the current module introduced
-  after the function was made inlineable, except under appropriate availability
+  after the function was made inlinable, except under appropriate availability
   guards.
-
-.. _versioned: #versioning-internal-api
 
 
 Default Argument Expressions
 ----------------------------
 
-Default argument expressions are implemented as ``@inlineable`` functions and
-thus are subject to the same restrictions as inlineable functions. A default
-argument implicitly has the same availability as the function it is attached to.
+Default argument expressions for functions that are public, versioned, or
+inlinable are implemented very similar to inlinable functions and thus are
+subject to similar restrictions:
 
-.. note::
+- They may not define any local types (other than typealiases).
 
-    Swift 4.0's implementation of default arguments puts the evaluation of the
-    default argument expression in the library, rather than in the client like
-    C++ or C#. We plan to change this.
+- They must not reference any non-``public`` entities.
+
+- They must not reference any entities from the current module introduced
+  after the function was made inlinable, except under appropriate availability
+  guards.
+
+A default argument implicitly has the same availability as the function it is
+attached to. Because default argument expressions can be added and removed, a
+client that uses one must always emit its own copy of the implementation.
 
 
 Top-Level Variables and Constants
@@ -491,8 +474,9 @@ program once they have been initialized.
 Giving Up Flexibility
 ---------------------
 
-Both top-level constants and variables can be marked ``@inlineable`` to allow
-clients to access them more efficiently. This restricts changes a fair amount:
+Both top-level constants and variables can be marked ``@inlinableAccess`` to
+allow clients to access them more efficiently. This restricts changes a fair
+amount:
 
 - Adding a versioned setter to a computed variable is still permitted.
 - Adding or removing a non-public, non-versioned setter is still permitted.
@@ -513,22 +497,15 @@ clients to access them more efficiently. This restricts changes a fair amount:
 .. admonition:: TODO
 
     It Would Be Nice(tm) to allow marking the *getter* of a top-level variable
-    inlineable while still allowing the setter to change. This would need
+    inlinable while still allowing the setter to change. This would need
     syntax, though.
 
-Any inlineable accessors must follow the rules for `inlineable functions`_, as
+Any inlinable accessors must follow the rules for `inlinable functions`_, as
 described above.
-
-Unlike functions, inlineable stored constants and variables (including those
-with accessors) may not be removed even if they have been inlineable since they
-were first introduced, because the storage for these bindings is still part of
-the library in which they were defined. Removing computed variables that have
-been inlineable since their introduction is a `binary-compatible
-source-breaking change`.
 
 Note that if a constant's initial value expression has any observable side
 effects, including the allocation of class instances, it must not be treated
-as inlineable. A constant must always behave as if it is initialized exactly
+as inlinable. A constant must always behave as if it is initialized exactly
 once.
 
 .. admonition:: TODO
@@ -536,6 +513,13 @@ once.
     Is this a condition we can detect at compile-time? Do we have to be
     restricted to things that can be lowered to compile-time constants?
 
+.. admonition:: TODO
+
+    ``@inlinableAccess`` isn't implemented yet, but for computed properties we
+    already allow putting ``@inlinable`` on the accessors individually. That
+    doesn't support all the use cases, like promising that a stored property
+    will remain stored, but it also provides flexibility in only making *one*
+    accessor inlinable. Is that important?
 
 Structs
 ~~~~~~~
@@ -568,10 +552,11 @@ Methods and Initializers
 
 For the most part struct methods and initializers are treated exactly like
 top-level functions. They permit all of the same modifications and can also be
-marked ``@inlineable``, with the same restrictions. Inlineable initializers
-must always delegate to another initializer, since new properties may be added
-between new releases. For the same reason, initializers declared outside of the
-struct's module must always delegate to another initializer.
+marked ``@inlinable``, with the same restrictions. Inlinable initializers must
+always delegate to another initializer or assign an entire value to ``self``,
+since new properties may be added between new releases. For the same reason,
+initializers declared outside of the struct's module must always delegate to
+another initializer or assign to ``self``.
 
 
 Properties
@@ -581,8 +566,8 @@ Struct properties behave largely the same as top-level bindings. They permit
 all of the same modifications, and also allow adding or removing an initial
 value entirely.
 
-Struct properties can also be marked ``@inlineable``, with the same
-restrictions as for top-level bindings. An inlineable stored property may not
+Struct properties can also be marked ``@inlinableAccess``, with the same
+restrictions as for top-level bindings. An inlinable stored property may not
 become computed, but the offset of its storage within the struct is not
 necessarily fixed.
 
@@ -607,9 +592,9 @@ stored subscripts. This means that the following changes are permitted:
 - Changing or removing a default argument is a `binary-compatible
   source-breaking change`.
 
-Like properties, subscripts can be marked ``@inlineable``, which makes changing
-the body of an accessor a `binary-compatible source-breaking change`. Any
-inlineable accessors must follow the rules for `inlineable functions`_, as
+Like properties, subscripts can be marked ``@inlinableAccess``, which makes
+changing the body of an accessor a `binary-compatible source-breaking change`.
+Any inlinable accessors must follow the rules for `inlinable functions`_, as
 described above.
 
 
@@ -660,7 +645,7 @@ To opt out of this flexibility, a struct may be marked ``@fixedContents``.
 This promises that no stored properties will be added to or removed from the
 struct, even non-public ones. Additionally, all versioned instance stored
 properties in a ``@fixedContents`` struct are implicitly declared
-``@inlineable`` (as described above for top-level variables). In effect:
+``@inlinable`` (as described above for top-level variables). In effect:
 
 - Reordering stored instance properties (public or non-public) is not permitted.
   Reordering all other members is still permitted.
@@ -700,8 +685,8 @@ still be modified in limited ways:
 - A versioned ``internal`` property may be made ``public`` (without changing
   its version).
 
-An initializer of a fixed-contents struct may be declared ``@inlineable`` even
-if it does not delegate to another initializer, as long as the ``@inlineable``
+An initializer of a fixed-contents struct may be declared ``@inlinable`` even
+if it does not delegate to another initializer, as long as the ``@inlinable``
 attribute, or the initializer itself, is not introduced earlier than the
 ``@fixedContents`` attribute and the struct has no non-versioned stored
 properties.
@@ -714,7 +699,8 @@ defined in a C header and imported into Swift.
 
     We can add a *different* feature to control layout some day, or something
     equivalent, but this feature should not restrict Swift from doing useful
-    things like minimizing member padding.
+    things like minimizing member padding. At the very least, Swift structs
+    don't guarantee the same tail padding that C structs do.
 
 .. note::
 
@@ -781,9 +767,7 @@ Initializers
 
 For the most part enum initializers are treated exactly like top-level
 functions. They permit all of the same modifications and can also be marked
-``@inlineable``, with the same restrictions. Unlike struct initializers, enum
-initializers do not always need to delegate to another initializer, even if
-they are inlineable or declared in a separate module.
+``@inlinable``, with the same restrictions.
 
 
 Methods and Subscripts
@@ -793,11 +777,11 @@ The rules for enum methods and subscripts are identical to those for struct
 members.
 
 
-Closed Enums
+Frozen Enums
 ------------
 
 A library owner may opt out of this flexibility by marking a versioned enum as
-``@closed``. A "closed" enum may not have any cases with less access than the
+``@frozen``. A "frozen" enum may not have any cases with less access than the
 enum itself, and may not add new cases in the future. This guarantees to
 clients that the enum cases are exhaustive. In particular:
 
@@ -813,19 +797,19 @@ clients that the enum cases are exhaustive. In particular:
 
 .. note::
 
-    Were a public "closed" enum allowed to have non-public cases, clients of
+    Were a public "frozen" enum allowed to have non-public cases, clients of
     the library would still have to treat the enum as opaque and would still
     have to be able to handle unknown cases in their ``switch`` statements.
 
-``@closed`` is a `versioned attribute`. This is so that clients can deploy
+``@frozen`` is a `versioned attribute`. This is so that clients can deploy
 against older versions of the library, which may have non-public cases in the
-enum. (In this case the client must manipulate the enum as if the ``@closed``
+enum. (In this case the client must manipulate the enum as if the ``@frozen``
 attribute were absent.) All cases that are not versioned become implicitly
 versioned with this number.
 
-Even for default "open" enums, adding new cases should not be done lightly. Any
-clients attempting to do an exhaustive switch over all enum cases will likely
-not handle new cases well.
+Even for default "non-frozen" enums, adding new cases should not be done
+lightly. Any clients attempting to do an exhaustive switch over all enum cases
+will likely not handle new cases well.
 
 .. note::
 
@@ -843,10 +827,9 @@ There are very few safe changes to make to protocols and their members:
 
 - A new non-type requirement may be added to a protocol, as long as it has an
   unconstrained default implementation.
-- A new associated type may be added to a protocol, as long as it has a default.
-  As with any other declarations, newly-added associated types must be marked
-  with ``@available`` specifying when they were introduced.
 - A default may be added to an associated type.
+- Removing a default from an associated type is a `binary-compatible
+  source-breaking change`.
 - A new optional requirement may be added to an ``@objc`` protocol.
 - All members may be reordered, including associated types.
 - Changing *internal* parameter names of function and subscript requirements
@@ -859,10 +842,12 @@ There are very few safe changes to make to protocols and their members:
 
 All other changes to the protocol itself are forbidden, including:
 
+- Adding a new associated type.
+- Removing any existing requirements (type or non-type).
 - Making an existing requirement optional.
 - Making a non-``@objc`` protocol ``@objc`` or vice versa.
-- Adding or removing constraints from an associated type.
-- Removing a default from an associated type.
+- Adding or removing constraints from an associated type, including inherited
+  associated types.
 
 Protocol extensions may be more freely modified; `see below`__.
 
@@ -870,16 +855,14 @@ __ #protocol-extensions
 
 .. note::
 
-    Allowing the addition of associated types means implementing some form of
-    "generalized existentials", so that existing existential values (values
-    with protocol type) continue to work even if a protocol gets its first
-    associated type. Until we have that feature implemented, it would only be
-    safe to add an associated type to a protocol that already has associated
-    types, or uses ``Self`` in a non-return position (i.e. one that currently
-    cannot be used as the type of a value).
+    A protocol's associated types are used in computing the "generic signature"
+    that uniquely identifies a generic function. Adding an associated type
+    could perturb the generic signature and thus change the identity of a
+    function, breaking binary compatibility.
     
-    As a first pass, it is likely that we will not allow adding new associated
-    types to existing protocols at all.
+    It may be possible to allow adding associated types as long as they have
+    proper availability annotations, but this is not in scope for the initial
+    version of Swift ABI stability.
 
 
 Classes
@@ -926,7 +909,7 @@ Finally, classes allow the following changes that do not apply to structs:
   automatically use the superclass implementation.
 - Within an ``open`` class, any public method, subscript, or property may be
   marked ``open`` if it is not already marked ``final``.
-- Any public method, subscript, or property may be marked ``final`` if it is not
+- Any method, subscript, or property may be marked ``final`` if it is not
   already marked ``open``.
 - ``@IBOutlet``, ``@IBAction``, ``@IBInspectable``, and ``@GKInspectable`` may
   be added to a member without providing any extra version information.
@@ -976,9 +959,9 @@ are permitted. In particular:
 
 .. admonition:: TODO
 
-    The ``@NSManaged`` attribute as it is in Swift 4 exposes implementation
-    details to clients in a bad way. We need to fix this.
-    rdar://problem/20829214
+    ``@NSManaged`` as it is in Swift 4.2 exposes implementation details to
+    clients in a bad way. If we want to use ``@NSManaged`` in frameworks with
+    binary compatibility concerns, we need to fix this. rdar://problem/20829214
 
 
 Initializers
@@ -993,8 +976,14 @@ A new ``required`` initializer may be added to a class only if it is a
 convenience initializer; that initializer may only call existing ``required``
 initializers. An existing initializer may not be marked ``required``.
 
+.. admonition:: TODO
+
+    This implies a different rule for inheriting ``required`` convenience
+    initializers than non-required convenience initializers, which is not
+    currently implemented.
+
 All of the modifications permitted for top-level functions are also permitted
-for class initializers. Convenience initializers may be marked ``@inlineable``,
+for class initializers. Convenience initializers may be marked ``@inlinable``,
 with the same restrictions as top-level functions; designated initializers may
 not.
 
@@ -1016,19 +1005,16 @@ little. They allow the following changes:
 - The ``@discardableResult`` and ``@warn_unqualified_access`` attributes may
   be added to a method without any additional versioning information.
 
-Class and instance methods may be marked ``@inlineable``, with the same
+Class and instance methods may be marked ``@inlinable``, with the same
 restrictions as struct methods. Additionally, only non-overriding ``final``
-methods may be marked ``@inlineable``.
+methods may be marked ``@inlinable``.
 
 .. note::
 
     A previous draft of this document allowed non-``final`` methods to be
-    marked ``@inlineable``, permitting inlining based on speculative
-    devirtualization. This was removed both because of the added complexity for
-    users and because it would make methods on classes different from
-    struct/enum methods and top-level functions: a method on a class would be
-    part of the library's module interface even if it had been inlineable since
-    its introduction.
+    marked ``@inlinable``, permitting inlining based on speculative
+    devirtualization. This was removed because of the added complexity for
+    users.
 
 
 Properties
@@ -1059,7 +1045,7 @@ Constant properties (those declared with ``let``) still permit changing their
 value, as well as adding or removing an initial value entirely.
 
 Non-overriding ``final`` variable and constant properties (on both instances
-and classes) may be marked ``@inlineable``. This behaves as described for
+and classes) may be marked ``@inlinableAccess``. This behaves as described for
 struct properties.
 
 
@@ -1084,8 +1070,8 @@ Adding a public setter to an ``open`` subscript is a
 `binary-compatible source-breaking change`; any existing overrides will not
 know what to do with the setter and will likely not behave correctly.
 
-Non-overriding ``final`` class subscripts may be marked ``@inlineable``, which
-behaves as described for struct subscripts.
+Non-overriding ``final`` class subscripts may be marked ``@inlinableAccess``,
+which behaves as described for struct subscripts.
 
 
 Possible Restrictions on Classes
@@ -1144,19 +1130,19 @@ following changes are permitted:
     overridable, even when the conforming type is a class.
 
 
-Operators
-~~~~~~~~~
+Operators and Precedence Groups
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Operator declarations are entirely compile-time constructs, so changing them
-does not have any affect on binary compatibility. However, they do affect
-*source* compatibility, so it is recommended that existing operators are not
-changed at all except for the following:
+Operator and precedence group declarations are entirely compile-time
+constructs, so changing them does not have any affect on binary compatibility.
+However, they do affect *source* compatibility, so it is recommended that
+existing operators are not changed at all except for the following:
 
-- Making a non-associative operator left- or right-associative.
+- Making a non-associative precedence group left- or right-associative.
 
 Any other change counts as a `binary-compatible source-breaking change`.
 
-Operator declarations are not versioned.
+Operator and precedence group declarations are not versioned.
 
 
 Typealiases
@@ -1176,14 +1162,15 @@ may be an actual breaking change and would not be permitted.
 It is always permitted to change the *use* of a public typealias to its
 underlying type, and vice versa, at any location in the program.
 
-Neither top-level nor member typealiases are versioned.
+Typealiases are `versioned <versioned entity>` despite being compile-time
+constructs in order to verify the availability of their underlying types.
 
 
 A Unifying Theme
 ~~~~~~~~~~~~~~~~
 
 So far this document has talked about ways to give up flexibility for several
-different kinds of declarations: ``@inlineable`` for functions,
+different kinds of declarations: ``@inlinable`` for functions,
 ``@fixedContents`` for structs, etc. Each of these has a different set of
 constraints it enforces on the library author and promises it makes to clients.
 However, they all follow a common theme of giving up the flexibility of future
@@ -1202,13 +1189,13 @@ Versioning Internal Declarations
 
 The initial discussion on versioning focused on public APIs, making sure
 that a client knows what features they can use when a specific version of a
-library is present. Inlineable functions have much the same constraints, except
-the inlineable function is the client and the entities being used may not be
+library is present. Inlinable functions have much the same constraints, except
+the inlinable function is the client and the entities being used may not be
 public.
 
 Adding a versioning annotation to an ``internal`` entity promises that the
 entity will be available at link time in the containing module's binary. This
-makes it safe to refer to such an entity from an inlineable function. If the
+makes it safe to refer to such an entity from an inlinable function. If the
 entity is ever made ``public`` or ``open``, its availability should not be
 changed; not only is it safe for new clients to rely on it, but *existing*
 clients require its presence as well.
@@ -1218,6 +1205,10 @@ clients require its presence as well.
     Why isn't this a special form of ``public``? Because we don't want it to
     imply everything that ``public`` does, such as requiring overrides to be
     ``public``.
+
+In libraries without binary compatibility concerns, the equivalent annotation
+is ``@usableFromInline``, since inlinable functions are the only way that a
+non-public entity can be referenced from outside of a module.
 
 Because a versioned class member may eventually be made ``open``, it must be
 assumed that new overrides may eventually appear from outside the module if the
@@ -1240,9 +1231,9 @@ at run time if the source code is reorganized, which is unacceptable.
     as ``internal`` entities. However, this is a purely additive feature, so to
     keep things simple we'll stick with the basics.
 
-We could do away with the entire feature if we restricted inlineable functions
+We could do away with the entire feature if we restricted inlinable functions
 and fixed-contents structs to only refer to public entities. However, this
-removes one of the primary reasons to make something inlineable: to allow
+removes one of the primary reasons to make something inlinable: to allow
 efficient access to a type while still protecting its invariants.
 
 
@@ -1274,6 +1265,12 @@ or struct.
     originally presented for the limited set of clients, since as mentioned
     above this may affect how those existing clients use the entities declared
     in the library.
+
+The one exception is ``@inlinable``, which does not change how a function is
+called or otherwise used at the ABI level. If the implementation being provided
+is compatible with a previous version of a library, and the function was
+present and public (or `versioned <versioned entity>`) there, then the library
+author may choose to backdate the ``@inlinable`` annotation.
 
 
 Optimization
@@ -1315,31 +1312,31 @@ library, the compiler should be able to take advantage of any fragility
 information (and performance assertions) introduced prior to version 1.5.
 
 
-Inlineable Code
-~~~~~~~~~~~~~~~
+Inlinable Code
+~~~~~~~~~~~~~~
 
 By default, the availability context for a library always includes the latest
 version of the library itself, since that code is always distributed as a unit.
-However, this is not true for functions that have been marked inlineable (see
-`Inlineable Functions`_ above). Inlineable code must be treated as if it is
+However, this is not true for functions that have been marked inlinable (see
+`Inlinable Functions`_ above). Inlinable code must be treated as if it is
 outside the current module, since once it's inlined it will be.
 
-For inlineable code, the availability context is exactly the same as the
-equivalent non-inlineable code except that the assumed version of the
-containing library is the version attached to the ``@inlineable`` attribute, or
+For inlinable code, the availability context is exactly the same as the
+equivalent non-inlinable code except that the assumed version of the
+containing library is the version attached to the ``@inlinable`` attribute, or
 the version of the library in which the entity was introduced, and any `library
 version dependencies <#declaring-library-version-dependencies>`_ or minimum
 deployment target must be specified explicitly using ``@available``. Code
 within this context must be treated as if the containing library were just a
 normal dependency.
 
-A versioned inlineable function still has an exported symbol in the library
+A versioned inlinable function still has an exported symbol in the library
 binary, which may be used when the function is referenced from a client rather
 than called. This version of the function is not subject to the same
 restrictions as the version that may be inlined, and so it may be desirable to
 compile a function twice: once for inlining, once for maximum performance.
 
-If the body of an inlineable function is used in any way by a client module
+If the body of an inlinable function is used in any way by a client module
 (say, to determine that it does not read any global variables), that module
 must take care to emit and use its own copy of the function. This is because
 analysis of the function body may not apply to the version of the function
@@ -1391,7 +1388,8 @@ these qualities to static or dynamic queries for performance-sensitive code.
     ``maximumFootprint``, and the latter is more flexible.
 
 .. note:: None of these names / spellings are final. The name "trivial" comes
-    from C++, though Swift's trivial is closer to C++'s "`trivially copyable`__".
+    from C++, though Swift's trivial is closer to C++'s "`trivially
+    copyable`__".
 
 All of these features need to be versioned, just like the more semantic
 fragility attributes above. The exact spelling is not proposed by this document.
@@ -1406,7 +1404,7 @@ As described in the `Introduction`_, the features and considerations discussed
 in this document do not apply to libraries distributed in a bundle with their
 clients. In this case, a client can rely on all the current implementation
 details of its libraries when compiling, since the same version of the library
-is guaranteed to be present at runtime. This allows more optimization than
+is guaranteed to be present at run time. This allows more optimization than
 would otherwise be possible.
 
 In some cases, a collection of libraries may be built and delivered together,
@@ -1423,7 +1421,7 @@ Exactly how resilience domains are specified is not covered by this document,
 and indeed they are an additive feature. One possibility is that a library's
 resilience domain defaults to the name of the module, but can be overridden. If
 a client has the same resilience domain name as a library it is using, it may
-assume that version of the library will be present at runtime.
+assume that version of the library will be present at run time.
 
 
 Deployments
@@ -1630,20 +1628,17 @@ document that affect language semantics:
 
 - (draft) `Overridable methods in extensions`_
 - (planned) Restricting retroactive modeling (protocol conformances for types you don't own)
-- (planned) Default implementations in protocols
 - (planned) `Generalized existentials (values of protocol type) <Generics>`_
-- (planned) Open and closed enums
+- (planned) Frozen enums (building on `SE-0192 <SE0192>`_)
 - (planned) Removing the "constant" guarantee for 'let' across module boundaries
-- (planned) Syntax for declaring "versioned" entities and their features
-- (planned) Syntax for declaring inlineable code
 - (planned) Syntax for declaring fixed-contents structs
-- (?) Non-inherited protocol conformances
 - (future) Performance annotations for types
 - (future) Attributes for stored property accessors
 - (future) Stored properties in extensions
 
 .. _Overridable methods in extensions: https://github.com/jrose-apple/swift-evolution/blob/overridable-members-in-extensions/proposals/nnnn-overridable-members-in-extensions.md
 .. _Generics: https://github.com/apple/swift/blob/master/docs/GenericsManifesto.md#generalized-existentials
+.. _SE0192: https://github.com/apple/swift-evolution/blob/master/proposals/0192-non-exhaustive-enums.md
 
 This does not mean all of these proposals need to be accepted, only that their
 acceptance or rejection will affect this document.
@@ -1655,7 +1650,7 @@ Glossary
 .. glossary::
 
   ABI
-    The runtime contract for using a particular API (or for an entire library),
+    The run-time contract for using a particular API (or for an entire library),
     including things like symbol names, calling conventions, and type layout
     information. Stands for "Application Binary Interface".
 
@@ -1702,7 +1697,7 @@ Glossary
 
   entity
     A type, function, member, or global in a Swift program. Occasionally the
-    term "entities" also includes conformances, since these have a runtime
+    term "entities" also includes conformances, since these have a run-time
     presence and are depended on by clients.
 
   forwards-compatible


### PR DESCRIPTION
- Standardize on "inlinable" instead of "inlineable", per [SE-0193][].
- Standardize on "frozen enums" instead of "closed enums", even though [SE-0192][] wasn't quite conclusive on this.
- Typealiases are treated as versioned entities for the purpose of verifying availability.
- Per [SE-0193][], inlinable functions do not have always-emit-into-client behavior.
- Rename the fragility attribute for properties and subscripts to `@inlinableAccess` for now, since `@inlinable` has been implemented for functions now. (We may still end up choosing to use the same name for these declarations too.)
- Private and fileprivate entities cannot be `@inlinable` today.
- We implemented the always-emit-into-client change for default arguments.
- Disallow adding new associated types to protocols for now.
- ~Disallow adding setters to 'open' properties for now; we have no good way to backwards-deploy such a change.~
- Mention that precedence groups exist.
- Mention that `@usableFromInline` exists.
- `@inlinable` can be backdated, even though all the other fragility attributes cannot.
- Tweak TODO around `@NSManaged`.
- Tweak list of planned proposals.
- A struct initializer can also assign to `self` instead of delegating with `self.init`. (See [SE-0189][] for more details.)

This document still deserves some more drastic restructuring to separate the near-term features from the long-term features.

[SE-0189]: https://github.com/apple/swift-evolution/blob/master/proposals/0189-restrict-cross-module-struct-initializers.md
[SE-0192]: https://github.com/apple/swift-evolution/blob/master/proposals/0192-non-exhaustive-enums.md
[SE-0193]: https://github.com/apple/swift-evolution/blob/master/proposals/0193-cross-module-inlining-and-specialization.md