### PR TITLE
Sema: Fix crash with UnresolvedType in coerceExistential() [4.2]

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5543,9 +5543,11 @@ Expr *ExprRewriter::coerceExistential(Expr *expr, Type toType,
   Type toInstanceType = toType;
 
   // Look through metatypes
-  while (fromInstanceType->is<AnyMetatypeType>() &&
+  while ((fromInstanceType->is<UnresolvedType>() ||
+          fromInstanceType->is<AnyMetatypeType>()) &&
          toInstanceType->is<ExistentialMetatypeType>()) {
-    fromInstanceType = fromInstanceType->castTo<AnyMetatypeType>()->getInstanceType();
+    if (!fromInstanceType->is<UnresolvedType>())
+      fromInstanceType = fromInstanceType->castTo<AnyMetatypeType>()->getInstanceType();
     toInstanceType = toInstanceType->castTo<ExistentialMetatypeType>()->getInstanceType();
   }
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1187,3 +1187,9 @@ func badTypes() {
   // expected-error@-1 {{type of expression is ambiguous without more context}}
   // FIXME: terrible diagnostic
 }
+
+// rdar://34357545
+func unresolvedTypeExistential() -> Bool {
+  return (Int.self==_{})
+  // expected-error@-1 {{ambiguous reference to member '=='}}
+}

--- a/validation-test/compiler_crashers_fixed/28739-unreachable-executed-at-swift-lib-ast-type-cpp-229.swift
+++ b/validation-test/compiler_crashers_fixed/28739-unreachable-executed-at-swift-lib-ast-type-cpp-229.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 (Int==_{


### PR DESCRIPTION
* Description: Long-standing crash-on-invalid in diagnostics.

* Origination: Probably there for a long time.

* Scope of the issue: Reported several times.

* Risk: Very low, this just adds some additional logic to a diagnostic path that only runs when we would have already crashed.

* Tested: New test case added.

* Reviewed by: @xedin 

* Radar: Fixes <rdar://problem/34357545>.