### PR TITLE
[test] Disable getObjects:andKeys:count: tests.

### DIFF
--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -3416,7 +3416,9 @@ func checkGetObjectsAndKeys(
   withExtendedLifetime(canary) {}
 }
 
-DictionaryTestSuite.test("BridgedToObjC.Verbatim.getObjects:andKeys:count:") {
+DictionaryTestSuite.test("BridgedToObjC.Verbatim.getObjects:andKeys:count:")
+  .skip(.always("rdar://problem/41871587"))
+  .code {
   let d = getBridgedNSDictionaryOfRefTypesBridgedVerbatim()
   for count in 0 ..< d.count + 2 {
     checkGetObjectsAndKeys(d, count: count)
@@ -3521,7 +3523,9 @@ DictionaryTestSuite.test("BridgedToObjC.Custom.FastEnumeration_Empty") {
     { ($0 as! TestObjCValueTy).value })
 }
 
-DictionaryTestSuite.test("BridgedToObjC.Custom.getObjects:andKeys:count:") {
+DictionaryTestSuite.test("BridgedToObjC.Custom.getObjects:andKeys:count:")
+  .skip(.always("rdar://problem/41871587"))
+  .code {
   let d = getBridgedNSDictionaryOfKeyValue_ValueTypesCustomBridged()
   for count in 0 ..< d.count + 2 {
     checkGetObjectsAndKeys(d, count: count)


### PR DESCRIPTION
This is a followup to #17862. Plot twist: removing crash tests fixed optimized test runs, but exposed an issue in unoptimized i386 simulator tests.

Disable the two affected tests until we plug all their holes.

rdar://problem/41871587