### PR TITLE
add missing python substitution in test

### DIFF
--- a/test/Driver/response-file.swift
+++ b/test/Driver/response-file.swift
@@ -24,7 +24,7 @@
 // RUN: %target-build-swift -typecheck @%t.4B.resp 2>&1 | %FileCheck %s -check-prefix=RECURSIVE
 // RECURSIVE: warning: result of call to 'abs' is unused
 
-// RUN: python -c 'for i in range(500001): print "-DTEST5_" + str(i)' > %t.5.resp
+// RUN: %{python} -c 'for i in range(500001): print "-DTEST5_" + str(i)' > %t.5.resp
 // RUN: %target-build-swift -typecheck @%t.5.resp %s 2>&1 | %FileCheck %s -check-prefix=LONG
 // LONG: warning: result of call to 'abs' is unused
 // RUN: %empty-directory(%t/tmp)


### PR DESCRIPTION
This adds a missing `%{python}` substitution in a test file. Without this, the test will fail on systems where the default Python is Python 3, even when overriding the python version using CMake.

(ps: as this, plus some other upcoming PRs wrt building on python3 systems, only impact the build/test process, I think they would probably be fine to be included into 4.2. Should I make PRs against the swift-4.2-branch directly, or do the changes need to go into master first?)