### PR TITLE
[4.2][IDE] Don't widen source range for AccessorDecl

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -370,12 +370,32 @@ case DeclKind::ID: return cast<ID##Decl>(this)->getSourceRange();
 SourceRange Decl::getSourceRangeIncludingAttrs() const {
   auto Range = getSourceRange();
 
-  // Attributes on AccessorDecl are syntactically belong to PatternBindingDecl.
-  if (isa<AccessorDecl>(this) || isa<VarDecl>(this))
+  // Attributes on AccessorDecl may syntactically belong to PatternBindingDecl.
+  // e.g. 'override'.
+  if (auto *AD = dyn_cast<AccessorDecl>(this)) {
+    // If this is implicit getter, accessor range should not include attributes.
+    if (!AD->getAccessorKeywordLoc().isValid())
+      return Range;
+
+    // Otherwise, include attributes directly attached to the accessor.
+    SourceLoc VarLoc = AD->getStorage()->getStartLoc();
+    for (auto Attr : getAttrs()) {
+      if (!Attr->getRange().isValid())
+        continue;
+
+      SourceLoc AttrStartLoc = Attr->getRangeWithAt().Start;
+      if (getASTContext().SourceMgr.isBeforeInBuffer(VarLoc, AttrStartLoc))
+        Range.widen(AttrStartLoc);
+    }
+    return Range;
+  }
+
+  // Attributes on VarDecl syntactically belong to PatternBindingDecl.
+  if (isa<VarDecl>(this))
     return Range;
 
   // Attributes on PatternBindingDecls are attached to VarDecls in AST.
-  if (const PatternBindingDecl *PBD = dyn_cast<PatternBindingDecl>(this)) {
+  if (auto *PBD = dyn_cast<PatternBindingDecl>(this)) {
     for (auto Entry : PBD->getPatternList())
       Entry.getPattern()->forEachVariable([&](VarDecl *VD) {
         for (auto Attr : VD->getAttrs())

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -369,9 +369,24 @@ case DeclKind::ID: return cast<ID##Decl>(this)->getSourceRange();
 
 SourceRange Decl::getSourceRangeIncludingAttrs() const {
   auto Range = getSourceRange();
+
+  // Attributes on AccessorDecl are syntactically belong to PatternBindingDecl.
+  if (isa<AccessorDecl>(this) || isa<VarDecl>(this))
+    return Range;
+
+  // Attributes on PatternBindingDecls are attached to VarDecls in AST.
+  if (const PatternBindingDecl *PBD = dyn_cast<PatternBindingDecl>(this)) {
+    for (auto Entry : PBD->getPatternList())
+      Entry.getPattern()->forEachVariable([&](VarDecl *VD) {
+        for (auto Attr : VD->getAttrs())
+          if (Attr->getRange().isValid())
+            Range.widen(Attr->getRangeWithAt());
+      });
+  }
+
   for (auto Attr : getAttrs()) {
     if (Attr->getRange().isValid())
-      Range.widen(Attr->getRange());
+      Range.widen(Attr->getRangeWithAt());
   }
   return Range;
 }

--- a/test/IDE/range_info_declattr.swift
+++ b/test/IDE/range_info_declattr.swift
@@ -1,0 +1,57 @@
+class ObjCBase {
+  var foo: Int { return 1 }
+}
+@objc class ObjCClass : ObjCBase {
+  override var foo: Int {
+    return 42
+  }
+  @objc var bar = 12, baz = 13
+}
+
+// RUN: %target-swift-ide-test -range -pos=4:1 -end-pos=9:2 -source-filename %s | %FileCheck %s -check-prefix=CHECK1
+// RUN: %target-swift-ide-test -range -pos=5:3 -end-pos=7:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK2
+// RUN: %target-swift-ide-test -range -pos=5:25 -end-pos=7:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK3
+// RUN: %target-swift-ide-test -range -pos=8:3 -end-pos=8:31 -source-filename %s | %FileCheck %s -check-prefix=CHECK4
+
+// CHECK1: <Kind>SingleDecl</Kind>
+// CHECK1-NEXT: <Content>@objc class ObjCClass : ObjCBase {
+// CHECK1-NEXT:   override var foo: Int {
+// CHECK1-NEXT:     return 42
+// CHECK1-NEXT:   }
+// CHECK1-NEXT:   @objc var bar = 12, baz = 13
+// CHECK1-NEXT: }</Content>
+// CHECK1-NEXT: <Context>swift_ide_test.(file)</Context>
+// CHECK1-NEXT: <Declared>ObjCClass</Declared><OutscopeReference>false</OutscopeReference>
+// CHECK1-NEXT: <Declared>foo</Declared><OutscopeReference>false</OutscopeReference>
+// CHECK1-NEXT: <Declared>_</Declared><OutscopeReference>false</OutscopeReference>
+// CHECK1-NEXT: <Declared>bar</Declared><OutscopeReference>false</OutscopeReference>
+// CHECK1-NEXT: <Declared>baz</Declared><OutscopeReference>false</OutscopeReference>
+// CHECK1-NEXT: <ASTNodes>1</ASTNodes>
+// CHECK1-NEXT: <end>
+
+// CHECK2: <Kind>SingleDecl</Kind>
+// CHECK2-NEXT: <Content>override var foo: Int {
+// CHECK2-NEXT:     return 42
+// CHECK2-NEXT:   }</Content>
+// CHECK2-NEXT: <Context>swift_ide_test.(file).ObjCClass</Context>
+// CHECK2-NEXT: <Declared>foo</Declared><OutscopeReference>false</OutscopeReference>
+// CHECK2-NEXT: <ASTNodes>1</ASTNodes>
+// CHECK2-NEXT: <end>
+
+// CHECK3: <Kind>SingleDecl</Kind>
+// CHECK3-NEXT: <Content>{
+// CHECK3-NEXT:     return 42
+// CHECK3-NEXT:   }</Content>
+// CHECK3-NEXT: <Context>swift_ide_test.(file).ObjCClass</Context>
+// CHECK3-NEXT: <Declared>_</Declared><OutscopeReference>false</OutscopeReference>
+// CHECK3-NEXT: <ASTNodes>1</ASTNodes>
+// CHECK3-NEXT: <end>
+
+
+// CHECK4: <Kind>SingleDecl</Kind>
+// CHECK4-NEXT: <Content>@objc var bar = 12, baz = 13</Content>
+// CHECK4-NEXT: <Context>swift_ide_test.(file).ObjCClass</Context>
+// CHECK4-NEXT: <Declared>bar</Declared><OutscopeReference>false</OutscopeReference>
+// CHECK4-NEXT: <Declared>baz</Declared><OutscopeReference>false</OutscopeReference>
+// CHECK4-NEXT: <ASTNodes>1</ASTNodes>
+// CHECK4-NEXT: <end>

--- a/test/IDE/range_info_declattr.swift
+++ b/test/IDE/range_info_declattr.swift
@@ -7,11 +7,32 @@ class ObjCBase {
   }
   @objc var bar = 12, baz = 13
 }
+class Derived : ObjCBase {
+  @available(*, unavailable)
+  override var quux: Int {
+    @inlinable get { return 0 }
+  }
+
+  subscript(idx: Int) -> Int {
+    @available(*, unavailable)
+    get { return 0 }
+
+    @available(*, unavailable)
+    @inlineable
+    set { }
+  }
+}
 
 // RUN: %target-swift-ide-test -range -pos=4:1 -end-pos=9:2 -source-filename %s | %FileCheck %s -check-prefix=CHECK1
 // RUN: %target-swift-ide-test -range -pos=5:3 -end-pos=7:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK2
 // RUN: %target-swift-ide-test -range -pos=5:25 -end-pos=7:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK3
 // RUN: %target-swift-ide-test -range -pos=8:3 -end-pos=8:31 -source-filename %s | %FileCheck %s -check-prefix=CHECK4
+// RUN: %target-swift-ide-test -range -pos=13:5 -end-pos=13:32 -source-filename %s | %FileCheck %s -check-prefix=CHECK5
+// RUN: %target-swift-ide-test -range -pos=13:16 -end-pos=13:32 -source-filename %s | %FileCheck %s -check-prefix=CHECK6
+// RUN: %target-swift-ide-test -range -pos=12:26 -end-pos=14:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK7
+// RUN: %target-swift-ide-test -range -pos=17:5 -end-pos=18:21 -source-filename %s | %FileCheck %s -check-prefix=CHECK8
+// RUN: %target-swift-ide-test -range -pos=20:5 -end-pos=22:12 -source-filename %s | %FileCheck %s -check-prefix=CHECK9
+// RUN: %target-swift-ide-test -range -pos=21:5 -end-pos=22:12 -source-filename %s | %FileCheck %s -check-prefix=CHECK10
 
 // CHECK1: <Kind>SingleDecl</Kind>
 // CHECK1-NEXT: <Content>@objc class ObjCClass : ObjCBase {
@@ -47,7 +68,6 @@ class ObjCBase {
 // CHECK3-NEXT: <ASTNodes>1</ASTNodes>
 // CHECK3-NEXT: <end>
 
-
 // CHECK4: <Kind>SingleDecl</Kind>
 // CHECK4-NEXT: <Content>@objc var bar = 12, baz = 13</Content>
 // CHECK4-NEXT: <Context>swift_ide_test.(file).ObjCClass</Context>
@@ -55,3 +75,45 @@ class ObjCBase {
 // CHECK4-NEXT: <Declared>baz</Declared><OutscopeReference>false</OutscopeReference>
 // CHECK4-NEXT: <ASTNodes>1</ASTNodes>
 // CHECK4-NEXT: <end>
+
+// CHECK5: <Kind>SingleDecl</Kind>
+// CHECK5-NEXT: <Content>@inlinable get { return 0 }</Content>
+// CHECK5-NEXT: <Context>swift_ide_test.(file).Derived</Context>
+// CHECK5-NEXT: <Declared>_</Declared><OutscopeReference>false</OutscopeReference>
+// CHECK5-NEXT: <ASTNodes>1</ASTNodes>
+// CHECK5-NEXT: <end>
+
+// CHECK6: <Kind>Invalid</Kind>
+// CHECK6-NEXT: <Content>get { return 0 }</Content>
+// CHECK6-NEXT: <ASTNodes>0</ASTNodes>
+// CHECK6-NEXT: <end>
+
+// CHECK7: <Kind>Invalid</Kind>
+// CHECK7-NEXT: <Content>{
+// CHECK7-NEXT:     @inlinable get { return 0 }
+// CHECK7-NEXT:   }</Content>
+// CHECK7-NEXT: <ASTNodes>0</ASTNodes>
+// CHECK7-NEXT: <end>
+
+// CHECK8: <Kind>SingleDecl</Kind>
+// CHECK8-NEXT: <Content>@available(*, unavailable)
+// CHECK8-NEXT:     get { return 0 }</Content>
+// CHECK8-NEXT: <Context>swift_ide_test.(file).Derived</Context>
+// CHECK8-NEXT: <Declared>_</Declared><OutscopeReference>false</OutscopeReference>
+// CHECK8-NEXT: <ASTNodes>1</ASTNodes>
+// CHECK8-NEXT: <end>
+
+// CHECK9: <Kind>SingleDecl</Kind>
+// CHECK9-NEXT: <Content>@available(*, unavailable)
+// CHECK9-NEXT:     @inlineable
+// CHECK9-NEXT:     set { }</Content>
+// CHECK9-NEXT: <Context>swift_ide_test.(file).Derived</Context>
+// CHECK9-NEXT: <Declared>_</Declared><OutscopeReference>false</OutscopeReference>
+// CHECK9-NEXT: <ASTNodes>1</ASTNodes>
+// CHECK9-NEXT: <end>
+
+// CHECK10: <Kind>Invalid</Kind>
+// CHECK10-NEXT: <Content>@inlineable
+// CHECK10-NEXT:     set { }</Content>
+// CHECK10-NEXT: <ASTNodes>0</ASTNodes>
+// CHECK10-NEXT: <end>


### PR DESCRIPTION
- **Explaination**: Range-info in SourceKit matches selection range and the range of the declaration. Previously, range-info for braces of implicit getter with attributes used to hit assertion because of mis-handing of attribute ranges. This change improves handling of attribute ranges for accessor, and pattern binding declarations so it doesn't hits assertion anymore.
- **Scope**: Affects range-info for `PatternBindingDecl`, `AccessorDecl`, `VarDecl`.
- **Issue**: rdar://problem/41073182
- **Risk**: Low. Although changes are in `lib/AST`, it's called only from range-info analyzer.
- **Testing**: Added regression test cases.
- **Reviewed By**: Jordan Rose (https://github.com/apple/swift/pull/17926), Xi Ge (https://github.com/apple/swift/pull/17239)
