### PR TITLE
Never inline _stdlib_isOSVersionAtLeast

### DIFF
--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -21,6 +21,7 @@ import SwiftShims
 /// that relies on being able to tell whether this function is called. It does
 /// this using the semantics attribute.
 @_semantics("availability.osversion")
+@inline(never)
 public func _stdlib_isOSVersionAtLeast(
   _ major: Builtin.Word,
   _ minor: Builtin.Word,


### PR DESCRIPTION
Follow-up to "AllocStackHoisting: Don't hoist alloc_stacks in the presence of
an availability guard". The standard libary could use availability macros in the
future.
