### PR TITLE
[4.2] Handle unexpected raw values for @objc enums in derived conformances

### DIFF
--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -831,6 +831,35 @@ deriveBodyHashable_compat_hashInto(AbstractFunctionDecl *hashIntoDecl) {
   hashIntoDecl->setBody(body);
 }
 
+/// Derive the body for the 'hash(into:)' method for an enum by using its raw
+/// value.
+static void
+deriveBodyHashable_enum_rawValue_hashInto(
+  AbstractFunctionDecl *hashIntoDecl
+) {
+  // enum SomeEnum: Int {
+  //   case A, B, C
+  //   @derived func hash(into hasher: inout Hasher) {
+  //     hasher.combine(self.rawValue)
+  //   }
+  // }
+  ASTContext &C = hashIntoDecl->getASTContext();
+
+  // generate: self.rawValue
+  auto *selfRef = DerivedConformance::createSelfDeclRef(hashIntoDecl);
+  auto *rawValueRef = new (C) UnresolvedDotExpr(selfRef, SourceLoc(),
+                                                C.Id_rawValue, DeclNameLoc(),
+                                                /*Implicit=*/true);
+
+  // generate: hasher.combine(discriminator)
+  auto hasherParam = hashIntoDecl->getParameterList(1)->get(0);
+  ASTNode combineStmt = createHasherCombineCall(C, hasherParam, rawValueRef);
+
+  auto body = BraceStmt::create(C, SourceLoc(), combineStmt, SourceLoc(),
+                                /*implicit*/ true);
+  hashIntoDecl->setBody(body);
+}
+
 /// Derive the body for the 'hash(into:)' method for an enum without associated
 /// values.
 static void
@@ -1203,10 +1232,13 @@ ValueDecl *DerivedConformance::deriveHashable(ValueDecl *requirement) {
         return nullptr;
 
       if (auto ED = dyn_cast<EnumDecl>(Nominal)) {
-        auto bodySynthesizer =
-            !ED->hasOnlyCasesWithoutAssociatedValues()
-                ? &deriveBodyHashable_enum_hasAssociatedValues_hashInto
-                : &deriveBodyHashable_enum_noAssociatedValues_hashInto;
+        void (*bodySynthesizer)(AbstractFunctionDecl *);
+        if (ED->isObjC())
+          bodySynthesizer = deriveBodyHashable_enum_rawValue_hashInto;
+        else if (ED->hasOnlyCasesWithoutAssociatedValues())
+          bodySynthesizer = deriveBodyHashable_enum_noAssociatedValues_hashInto;
+        else
+          bodySynthesizer=deriveBodyHashable_enum_hasAssociatedValues_hashInto;
         return deriveHashable_hashInto(*this, bodySynthesizer);
       } else if (isa<StructDecl>(Nominal))
         return deriveHashable_hashInto(*this,

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -90,6 +90,27 @@ static void deriveBodyRawRepresentable_raw(AbstractFunctionDecl *toRawDecl) {
   }
 #endif
 
+  if (enumDecl->isObjC()) {
+    // Special case: ObjC enums are represented by their raw value, so just use
+    // a bitcast.
+
+    // return unsafeBitCast(self, to: RawType.self)
+    DeclName name(C, C.getIdentifier("unsafeBitCast"), {Identifier(), C.Id_to});
+    auto functionRef = new (C) UnresolvedDeclRefExpr(name,
+                                                     DeclRefKind::Ordinary,
+                                                     DeclNameLoc());
+    auto selfRef = DerivedConformance::createSelfDeclRef(toRawDecl);
+    auto bareTypeExpr = TypeExpr::createImplicit(rawTy, C);
+    auto typeExpr = new (C) DotSelfExpr(bareTypeExpr, SourceLoc(), SourceLoc());
+    auto call = CallExpr::createImplicit(C, functionRef, {selfRef, typeExpr},
+                                         {Identifier(), C.Id_to});
+    auto returnStmt = new (C) ReturnStmt(SourceLoc(), call);
+    auto body = BraceStmt::create(C, SourceLoc(), ASTNode(returnStmt),
+                                  SourceLoc());
+    toRawDecl->setBody(body);
+    return;
+  }
+
   Type enumType = parentDC->getDeclaredTypeInContext();
 
   SmallVector<ASTNode, 4> cases;

--- a/test/Interpreter/enum-nonexhaustivity.swift
+++ b/test/Interpreter/enum-nonexhaustivity.swift
@@ -91,6 +91,18 @@ EnumTestSuite.test("UnexpectedOkayNested2/NonExhaustive") {
   expectTrue(gotCorrectValue)
 }
 
+EnumTestSuite.test("Equatable/NonExhaustive") {
+  expectEqual(getExpectedValue(), .B)
+  expectNotEqual(getUnexpectedValue(), .B)
+  expectNotEqual(getExpectedValue(), getUnexpectedValue())
+  expectEqual(getUnexpectedValue(), getUnexpectedValue())
+}
+
+EnumTestSuite.test("Hashable/NonExhaustive") {
+  expectEqual(getExpectedValue().hashValue, NonExhaustiveEnum.B.hashValue)
+  expectNotEqual(getUnexpectedValue().hashValue, NonExhaustiveEnum.B.hashValue)
+}
+
 
 EnumTestSuite.test("PlainOldSwitch/LyingExhaustive") {
   var gotCorrectValue = false
@@ -170,6 +182,18 @@ EnumTestSuite.test("UnexpectedOkayNested2/LyingExhaustive") {
     expectUnreachable()
   }
   expectTrue(gotCorrectValue)
+}
+
+EnumTestSuite.test("Equatable/LyingExhaustive") {
+  expectEqual(getExpectedLiarValue(), .B)
+  expectNotEqual(getUnexpectedLiarValue(), .B)
+  expectNotEqual(getExpectedLiarValue(), getUnexpectedLiarValue())
+  expectEqual(getUnexpectedLiarValue(), getUnexpectedLiarValue())
+}
+
+EnumTestSuite.test("Hashable/LyingExhaustive") {
+  expectEqual(getExpectedLiarValue().hashValue, LyingExhaustiveEnum.B.hashValue)
+  expectNotEqual(getUnexpectedLiarValue().hashValue, LyingExhaustiveEnum.B.hashValue)
 }
 
 
@@ -262,6 +286,18 @@ EnumTestSuite.test("UnexpectedOkayNested2/SwiftExhaustive") {
     expectUnreachable()
   }
   expectTrue(gotCorrectValue)
+}
+
+EnumTestSuite.test("Equatable/SwiftExhaustive") {
+  expectEqual(SwiftEnum.getExpectedValue(), .B)
+  expectNotEqual(SwiftEnum.getUnexpectedValue(), .B)
+  expectNotEqual(SwiftEnum.getExpectedValue(), SwiftEnum.getUnexpectedValue())
+  expectEqual(SwiftEnum.getUnexpectedValue(), SwiftEnum.getUnexpectedValue())
+}
+
+EnumTestSuite.test("Hashable/SwiftExhaustive") {
+  expectEqual(SwiftEnum.getExpectedValue().hashValue, SwiftEnum.B.hashValue)
+  expectNotEqual(SwiftEnum.getUnexpectedValue().hashValue, SwiftEnum.B.hashValue)
 }
 
 @inline(never)

--- a/test/SILGen/enum_raw_representable.swift
+++ b/test/SILGen/enum_raw_representable.swift
@@ -1,12 +1,16 @@
-// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %s | %FileCheck %s
-// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -enable-resilience %s | %FileCheck -check-prefix=CHECK-RESILIENT %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -emit-sorted-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -emit-sorted-sil -enable-resilience %s | %FileCheck -check-prefix=CHECK-RESILIENT %s
 
 public enum E: Int {
   case a, b, c
 }
 
-// CHECK-DAG: sil [serialized] @$S22enum_raw_representable1EO0B5ValueACSgSi_tcfC
-// CHECK-DAG: sil [serialized] @$S22enum_raw_representable1EO0B5ValueSivg
+// CHECK-LABEL: sil [serialized] @$S22enum_raw_representable1EO0B5ValueACSgSi_tcfC
+
+// CHECK-LABEL: sil [serialized] @$S22enum_raw_representable1EO0B5ValueSivg
+// CHECK: switch_enum %0 : $E
+// CHECK: end sil function '$S22enum_raw_representable1EO0B5ValueSivg'
+
 
 // CHECK-RESILIENT-DAG: sil @$S22enum_raw_representable1EO0B5ValueACSgSi_tcfC
 // CHECK-RESILIENT-DAG: sil @$S22enum_raw_representable1EO0B5ValueSivg

--- a/test/SILGen/enum_raw_representable_objc.swift
+++ b/test/SILGen/enum_raw_representable_objc.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -emit-sorted-sil -enable-objc-interop -disable-objc-attr-requires-foundation-module %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -emit-sorted-sil -enable-objc-interop -disable-objc-attr-requires-foundation-module -enable-resilience %s | %FileCheck -check-prefix=CHECK-RESILIENT %s
+
+@objc public enum CLike: Int {
+  case a, b, c
+}
+
+// CHECK-LABEL: sil [serialized] @$S27enum_raw_representable_objc5CLikeO0B5ValueACSgSi_tcfC
+
+// CHECK-LABEL: sil [serialized] @$S27enum_raw_representable_objc5CLikeO0B5ValueSivg
+// CHECK-DAG: [[RESULT_BOX:%.+]] = alloc_stack $Int
+// CHECK-DAG: [[INPUT_BOX:%.+]] = alloc_stack $CLike
+// CHECK: [[RAW_TYPE:%.+]] = metatype $@thick Int.Type
+// CHECK: [[CAST_FUNC:%.+]] = function_ref @$Ss13unsafeBitCast_2toq_x_q_mtr0_lF
+// CHECK: = apply [[CAST_FUNC]]<CLike, Int>([[RESULT_BOX]], [[INPUT_BOX]], [[RAW_TYPE]])
+// CHECK: [[RESULT:%.+]] = load [trivial] [[RESULT_BOX]]
+// CHECK: return [[RESULT]]
+// CHECK: end sil function '$S27enum_raw_representable_objc5CLikeO0B5ValueSivg'
+
+// CHECK-RESILIENT-DAG: sil @$S27enum_raw_representable_objc5CLikeO0B5ValueSivg
+// CHECK-RESILIENT-DAG: sil @$S27enum_raw_representable_objc5CLikeO0B5ValueACSgSi_tcfC


### PR DESCRIPTION
- **Explanation**: Because people put all sorts of nonsense into `@objc` enums (most reasonably, "private cases", which represent valid values that are not API), the Swift-synthesized implementation of `hash(into:)` needs to not expect a switch statement to be exhaustive. And since Swift-defined `@objc` enums are supposed to behave enough like C-defined enums, they should at least handle simple method calls with an invalid raw value, which means that `rawValue` likewise should not use a switch. Implement `hash(into:)` in terms of `rawValue` and `rawValue` in terms of `unsafeBitCast`.

- **Scope**: Affects `hash(into:)` and `rawValue` for both imported and user-defined `@objc` enums.

- **Issue**: rdar://problem/41913284

- **Risk**: Medium-low. The code change is very straightforward and we have pretty good test coverage, but it is a broad scope.

- **Testing**: Added compiler regression tests.

- **Reviewed by**: @jckarter, @itaiferber, @slavapestov 