### PR TITLE
[Basic] NFC: Silence a -Wcast-qual-unrelated warning

### DIFF
--- a/include/swift/Basic/ExternalUnion.h
+++ b/include/swift/Basic/ExternalUnion.h
@@ -194,7 +194,7 @@ public:
     static_assert(typeIndex != -1, "type not in union");
     assert(index == Index(typeIndex) && "current kind is wrong for access");
 
-    return reinterpret_cast<const T &>(Storage);
+    return *reinterpret_cast<const T *>(Storage);
   }
 
   /// Destruct the current union member.


### PR DESCRIPTION
For example: ISO C++ does not allow reinterpret_cast from 'char const[72]' to 'swift::Expr *const &' because it casts away qualifiers, even though the source and destination types are unrelated [-Wcast-qual-unrelated]