### PR TITLE
[IRGen] Fix ObjC method signatures for .cxx_construct and .cxx_destruct

### DIFF
--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -1159,7 +1159,9 @@ void irgen::emitObjCMethodDescriptorParts(IRGenModule &IGM,
   /// The first element is the selector.
   selectorRef = IGM.getAddrOfObjCMethodName(selector.str());
   
-  /// The second element is the type @encoding.
+  /// The second element is the method signature. A method signature is made of
+  /// the return type @encoding and every parameter type @encoding, glued with
+  /// numbers that used to represent stack offsets for each of these elements.
   CanSILFunctionType methodType = getObjCMethodType(IGM, method);
   atEncoding = getObjCEncodingForMethodType(IGM, methodType, extendedEncoding);
   
@@ -1349,9 +1351,13 @@ void irgen::emitObjCIVarInitDestroyDescriptor(IRGenModule &IGM,
   Selector selector(declRef);
   auto selectorRef = IGM.getAddrOfObjCMethodName(selector.str());
   
-  /// The second element is the type @encoding, which is always "@?"
-  /// for a function type.
-  auto atEncoding = IGM.getAddrOfGlobalString("@?");
+  /// The second element is the method signature. A method signature is made of
+  /// the return type @encoding and every parameter type @encoding, glued with
+  /// numbers that used to represent stack offsets for each of these elements.
+  auto ptrSize = IGM.getPointerSize().getValue();
+  llvm::SmallString<8> signature;
+  signature = "v" + llvm::itostr(ptrSize * 2) + "@0:" + llvm::itostr(ptrSize);
+  auto atEncoding = IGM.getAddrOfGlobalString(signature);
 
   /// The third element is the method implementation pointer.
   auto impl = llvm::ConstantExpr::getBitCast(objcImpl, IGM.Int8PtrTy);

--- a/test/IRGen/objc_methods.swift
+++ b/test/IRGen/objc_methods.swift
@@ -25,12 +25,12 @@ class Foo: Fooable {
   @IBAction func garply(_: AnyObject?) {}
   @objc func block(_: (Int) -> Int) {}
   @objc func block2(_: (Int,Int) -> Int) {}
-  
+
   @objc func takesString(_ x: String) -> String { return x }
   @objc func takesArray(_ x: [AnyObject]) -> [AnyObject] { return x }
   @objc func takesDict(_ x: [NSObject: AnyObject]) -> [NSObject: AnyObject] { return x }
   @objc func takesSet(_ x: Set<NSObject>) -> Set<NSObject> { return x }
-  
+
   @objc func fail() throws {}
 }
 
@@ -42,7 +42,7 @@ class ObjcDestructible: NSObject {
   }
 }
 
-// CHECK: [[IMPLICIT_PARAMS_SIGNATURE:@.*]] = private unnamed_addr constant [8 x i8] c"v16@0:8\00"
+// CHECK: [[NO_ARGS_SIGNATURE:@.*]] = private unnamed_addr constant [8 x i8] c"v16@0:8\00"
 // CHECK: [[GARPLY_SIGNATURE:@.*]] = private unnamed_addr constant [11 x i8] c"v24@0:8@16\00"
 // CHECK: [[BLOCK_SIGNATURE_TRAD:@.*]] = private unnamed_addr constant [12 x i8] c"v24@0:8@?16\00"
 // CHECK-macosx: [[FAIL_SIGNATURE:@.*]] = private unnamed_addr constant [12 x i8] c"c24@0:8^@16\00"
@@ -53,7 +53,7 @@ class ObjcDestructible: NSObject {
 // CHECK:   i32 9,
 // CHECK:   [9 x { i8*, i8*, i8* }] [{
 // CHECK:     i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"\01L_selector_data(baz)", i64 0, i64 0),
-// CHECK:     i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[IMPLICIT_PARAMS_SIGNATURE]], i64 0, i64 0),
+// CHECK:     i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[NO_ARGS_SIGNATURE]], i64 0, i64 0),
 // CHECK:     i8* bitcast (void (i8*, i8*)* @"$S12objc_methods3FooC3bazyyFTo" to i8*)
 // CHECK:   }, {
 // CHECK:     i8* getelementptr inbounds ([8 x i8], [8 x i8]* @"\01L_selector_data(garply:)", i64 0, i64 0),
@@ -79,7 +79,7 @@ class ObjcDestructible: NSObject {
 // CHECK:   i32 2,
 // CHECK:   [2 x { i8*, i8*, i8* }] [{
 // CHECK:     i8* getelementptr inbounds ([14 x i8], [14 x i8]* @"\01L_selector_data(.cxx_destruct)", i64 0, i64 0),
-// CHECK:     i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[IMPLICIT_PARAMS_SIGNATURE]], i64 0, i64 0),
+// CHECK:     i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[NO_ARGS_SIGNATURE]], i64 0, i64 0),
 // CHECK:     i8* bitcast (void (%6*, i8*)* @"$S12objc_methods16ObjcDestructibleCfETo" to i8*) }]
 // CHECK:   }]
 // CHECK: }, section "__DATA, __objc_const", align 8

--- a/test/IRGen/objc_methods.swift
+++ b/test/IRGen/objc_methods.swift
@@ -25,16 +25,24 @@ class Foo: Fooable {
   @IBAction func garply(_: AnyObject?) {}
   @objc func block(_: (Int) -> Int) {}
   @objc func block2(_: (Int,Int) -> Int) {}
-
+  
   @objc func takesString(_ x: String) -> String { return x }
   @objc func takesArray(_ x: [AnyObject]) -> [AnyObject] { return x }
   @objc func takesDict(_ x: [NSObject: AnyObject]) -> [NSObject: AnyObject] { return x }
   @objc func takesSet(_ x: Set<NSObject>) -> Set<NSObject> { return x }
-
+  
   @objc func fail() throws {}
 }
 
-// CHECK: [[BAZ_SIGNATURE:@.*]] = private unnamed_addr constant [8 x i8] c"v16@0:8\00"
+class ObjcDestructible: NSObject {
+  var object: NSObject
+  
+  init(object: NSObject) {
+    self.object = object
+  }
+}
+
+// CHECK: [[IMPLICIT_PARAMS_SIGNATURE:@.*]] = private unnamed_addr constant [8 x i8] c"v16@0:8\00"
 // CHECK: [[GARPLY_SIGNATURE:@.*]] = private unnamed_addr constant [11 x i8] c"v24@0:8@16\00"
 // CHECK: [[BLOCK_SIGNATURE_TRAD:@.*]] = private unnamed_addr constant [12 x i8] c"v24@0:8@?16\00"
 // CHECK-macosx: [[FAIL_SIGNATURE:@.*]] = private unnamed_addr constant [12 x i8] c"c24@0:8^@16\00"
@@ -45,7 +53,7 @@ class Foo: Fooable {
 // CHECK:   i32 9,
 // CHECK:   [9 x { i8*, i8*, i8* }] [{
 // CHECK:     i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"\01L_selector_data(baz)", i64 0, i64 0),
-// CHECK:     i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[BAZ_SIGNATURE]], i64 0, i64 0),
+// CHECK:     i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[IMPLICIT_PARAMS_SIGNATURE]], i64 0, i64 0),
 // CHECK:     i8* bitcast (void (i8*, i8*)* @"$S12objc_methods3FooC3bazyyFTo" to i8*)
 // CHECK:   }, {
 // CHECK:     i8* getelementptr inbounds ([8 x i8], [8 x i8]* @"\01L_selector_data(garply:)", i64 0, i64 0),
@@ -64,6 +72,15 @@ class Foo: Fooable {
 // CHECK:     i8* getelementptr inbounds ([12 x i8], [12 x i8]* [[FAIL_SIGNATURE]], i64 0, i64 0),
 // CHECK-macosx:     i8* bitcast (i8 (i8*, i8*, %4**)* @"$S12objc_methods3FooC4failyyKFTo" to i8*)
 // CHECK-ios:     i8* bitcast (i1 (i8*, i8*, %4**)* @"$S12objc_methods3FooC4failyyKFTo" to i8*)
+// CHECK:   }]
+// CHECK: }, section "__DATA, __objc_const", align 8
+// CHECK: @_INSTANCE_METHODS__TtC12objc_methods16ObjcDestructible = private constant { {{.*}}] } {
+// CHECK:   i32 24,
+// CHECK:   i32 2,
+// CHECK:   [2 x { i8*, i8*, i8* }] [{
+// CHECK:     i8* getelementptr inbounds ([14 x i8], [14 x i8]* @"\01L_selector_data(.cxx_destruct)", i64 0, i64 0),
+// CHECK:     i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[IMPLICIT_PARAMS_SIGNATURE]], i64 0, i64 0),
+// CHECK:     i8* bitcast (void (%6*, i8*)* @"$S12objc_methods16ObjcDestructibleCfETo" to i8*) }]
 // CHECK:   }]
 // CHECK: }, section "__DATA, __objc_const", align 8
 // CHECK: [[BLOCK_SIGNATURE_EXT_1:@.*]] = private unnamed_addr constant [18 x i8] c"v24@0:8@?<q@?q>16\00"


### PR DESCRIPTION
I'm starting the PR against 4.2, but I actually have no idea what I'm doing. I suspect that you have to get someone's blessing to do this, but it didn't seem to be explicitly mentioned in the [contribution guidelines](https://swift.org/contributing/#contributing-code). Let me know if this should be rebased on another branch.

## Explanation

For aeons past, the Swift compiler has emitted incorrect method signatures for `.cxx_construct` and `.cxx_destruct` methods. The signature was hard-coded to `"@?"`, which is the Objective-C type signature for a block. Type signatures and method signatures are different, and this is not a valid method signature.

## Scope

Only Swift classes that inherit from `NSObject` get `.cxx_{construct,destruct}` methods. It wouldn't be possible to call a Swift `.cxx_construct` or `.cxx_destruct` with `NSInvocation`, although I'm not entirely sure at which point that would fail. This bug is essentially annoying only to people who look at binaries.

## Issue

https://bugs.swift.org/browse/SR-8203

## Risk

Negligible. We know from experience that you can put garbage in the method signature of `.cxx_destruct` and it'll go unnoticed for years. In the unlikely, worst-case scenario in which I got it wrong, the garbage will have changed and someone else will step up in 2023 to fix it without anyone else ever noticing that there was a problem.

## Testing

Added a test in test/IRGen/objc_methods.swift.

## Reviewed By

You?