### PR TITLE
GenericSpecializer: Allow simple function specialization cycles.

### DIFF
--- a/test/SILOptimizer/generic_specialization_loops_detection_with_loops.swift
+++ b/test/SILOptimizer/generic_specialization_loops_detection_with_loops.swift
@@ -21,16 +21,16 @@
 
 // Check that the compiler has produced a specialization information for a call-site that
 // was inlined from a specialized generic function.
-// CHECK-LABEL: // Generic specialization information for call-site $S044generic_specialization_loops_detection_with_C04foo4yyx_q_tr0_lF <Array<Int>, Array<Double>>
+// CHECK-LABEL: // Generic specialization information for call-site $S044generic_specialization_loops_detection_with_C04foo4yyx_q_tr0_lFSaySays5UInt8VGG_SaySaySiGGTg5:
 // CHECK-NEXT:  // Caller: $S044generic_specialization_loops_detection_with_C04foo4yyx_q_tr0_lFSi_SdTg5
 // CHECK-NEXT:  // Parent: $S044generic_specialization_loops_detection_with_C04bar4yyx_q_tr0_lF
-// CHECK-NEXT:  // Substitutions: <Int, Double>
+// CHECK-NEXT:  // Substitutions: <Array<UInt8>, Array<Int>>
 // CHECK-NEXT:  //
 // CHECK-NEXT:  // Caller: $S044generic_specialization_loops_detection_with_C011testFooBar4yyF
 // CHECK-NEXT:  // Parent: $S044generic_specialization_loops_detection_with_C04foo4yyx_q_tr0_lF
 // CHECK-NEXT:  // Substitutions: <Int, Double>
 // CHECK-NEXT:  //
-// CHECK-NEXT: apply %{{[0-9]+}}<Array<Int>, Array<Double>>
+// CHECK-NEXT: apply %{{.*}}Array<Array<UInt8>>
 
 // Check specializations of mutually recursive functions which
 // may result in an infinite specialization loop.

--- a/test/SILOptimizer/generic_specialization_loops_detection_without_loops.swift
+++ b/test/SILOptimizer/generic_specialization_loops_detection_without_loops.swift
@@ -137,13 +137,13 @@ func flood2<T>(_ x: T) {
 @inline(never)
 public func run_TypeFlood(_ N: Int) {
   for _ in 1...N {
-    flood3(Some1<Some1<Some1<Int>>>())
-    flood3(Some1<Some1<Some0<Int>>>())
-    flood3(Some1<Some0<Some1<Int>>>())
-    flood3(Some1<Some0<Some0<Int>>>())
-    flood3(Some0<Some1<Some1<Int>>>())
-    flood3(Some0<Some1<Some0<Int>>>())
-    flood3(Some0<Some0<Some1<Int>>>())
-    flood3(Some0<Some0<Some0<Int>>>())
+    flood2(Some1<Some1<Some1<Int>>>())
+    flood2(Some1<Some1<Some0<Int>>>())
+    flood2(Some1<Some0<Some1<Int>>>())
+    flood2(Some1<Some0<Some0<Int>>>())
+    flood2(Some0<Some1<Some1<Int>>>())
+    flood2(Some0<Some1<Some0<Int>>>())
+    flood2(Some0<Some0<Some1<Int>>>())
+    flood2(Some0<Some0<Some0<Int>>>())
   }
 }


### PR DESCRIPTION
So far we immediately bailed once we detect a cycle in specializations. But it turned out that this prevented efficient code generation for some stdlib functions like compactMap.
With this change we allow specialization of cycles up to a depth of 1 (= still very limited to prevent code size explosion in some corner cases).

The effect of this optimization is tested with the existing benchmark FatCompactMap.

SR-7952, rdar://problem/41005326

This PR also fixes a related test.