### PR TITLE
Fixed a bug in createHostSend(), where the scalar to send may not be produced by a struct_extract inst

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -2749,6 +2749,8 @@ static T* castWithDebugInfo(SILInstruction *inst) {
 /// corresponding stdlib numeric type, such as $Bool.
 /// See extractBuiltinTypeFromStdlibNumericType() on the reverse type
 /// conversion.
+/// This function only supports element data types that are accelerable by
+/// tensorflow (e.g. BuiltinFloatType::IEEE80 and Float80 are not).
 static NominalTypeDecl *
 getStdlibNumericTypeDeclFromBuiltinType(Type ty, ASTContext &ctx) {
   // BuiltinIntegerType doesn't carry sign information, which TensorFlow needs,

--- a/test/TensorFlow/control_flow.swift
+++ b/test/TensorFlow/control_flow.swift
@@ -269,3 +269,14 @@ public func foo<T>(_ a: T) {
   _hostOp(b)
 }
 */
+
+// TODO: enable this for-loop test once we resolve
+// https://bugs.swift.org/browse/SR-7765:
+/// SESE FIXME: Imperfect loop exits not handled yet!
+// public func foo(n: Int32) {
+//   var a = Tensor<Float>(1.0)
+//   for _ in 0..<n {
+//     a += a
+//   }
+//   _hostOp(a)
+// }


### PR DESCRIPTION
Instead of patterning matching on inst type, we now pattern match on the data type.

The test case is now failing with a different error related to loop
canonicalization (https://bugs.swift.org/browse/SR-7765), so it's commented out.

Resolves [SR-8227](https://bugs.swift.org/browse/SR-8227).
