### PR TITLE
[4.2] migrator: handle changed parameter declarations by introducing bridging local variables.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4830,6 +4830,9 @@ public:
   /// Retrieve the argument (API) name for this function parameter.
   Identifier getArgumentName() const { return ArgumentName; }
 
+  /// Retrieve the parameter (local) name for this function parameter.
+  Identifier getParameterName() const { return getName(); }
+
   /// Retrieve the source location of the argument (API) name.
   ///
   /// The resulting source location will be valid if the argument name

--- a/test/Migrator/Inputs/Cities.swift
+++ b/test/Migrator/Inputs/Cities.swift
@@ -35,25 +35,26 @@ public func globalCityFunc4(_ c : Cities, _ p : Int, _ q: Int) -> Int { return 0
 public func globalCityFunc5() -> Int { return 0 }
 public func globalCityPointerTaker(_ c : UnsafePointer<Cities>, _ p : Int, _ q: Int) -> Int { return 0 }
 
-public class Container {
-  public var Value: String = ""
-  public var attrDict: [String: Any] = [:]
-  public var attrArr: [String] = []
-  public var optionalAttrDict: [String: Any]? = nil
-  public func addingAttributes(_ input: [String: Any]) {}
-  public func adding(attributes: [String: Any]) {}
-  public func adding(optionalAttributes: [String: Any]?) {}
+open class Container {
   public init(optionalAttributes: [String: Any]?) {}
-  public func adding(attrArray: [String]) {}
   public init(optionalAttrArray: [String]?) {}
-  public func add(single: String) {}
-  public func add(singleOptional: String?) {}
-  public func getAttrArray() -> [String] { return [] }
-  public func getOptionalAttrArray() -> [String]? { return [] }
-  public func getAttrDictionary() -> [String: Any] { return [:] }
-  public func getOptionalAttrDictionary() -> [String: Any]? { return nil }
-  public func getSingleAttr() -> String { return "" }
-  public func getOptionalSingleAttr() -> String? { return nil }
+
+  open func adding(attrArray: [String]) {}
+  open var Value: String = ""
+  open var attrDict: [String: Any] = [:]
+  open var attrArr: [String] = []
+  open var optionalAttrDict: [String: Any]? = nil
+  open func addingAttributes(_ input: [String: Any]) {}
+  open func adding(attributes: [String: Any]) {}
+  open func adding(optionalAttributes: [String: Any]?) {}
+  open func add(single: String) {}
+  open func add(singleOptional: String?) {}
+  open func getAttrArray() -> [String] { return [] }
+  open func getOptionalAttrArray() -> [String]? { return [] }
+  open func getAttrDictionary() -> [String: Any] { return [:] }
+  open func getOptionalAttrDictionary() -> [String: Any]? { return nil }
+  open func getSingleAttr() -> String { return "" }
+  open func getOptionalSingleAttr() -> String? { return nil }
 }
 
 open class ToplevelType {

--- a/test/Migrator/string-representable.swift
+++ b/test/Migrator/string-representable.swift
@@ -65,3 +65,11 @@ func bar(_ c: Container) {
   let attr: AliasAttribute = ""
   c.add(single: attr)
 }
+
+public class SubContainer: Container {
+  public override func adding(optionalAttributes subname: [String: Any]?) {}
+  public override func adding(attributes myname: [String: Any]) {}
+  public override func adding(attrArray: [String]) {}
+  public override func add(single: String) {}
+  public override func add(singleOptional: String?) {}
+}

--- a/test/Migrator/string-representable.swift.expected
+++ b/test/Migrator/string-representable.swift.expected
@@ -66,6 +66,56 @@ func bar(_ c: Container) {
   c.add(single: attr)
 }
 
+public class SubContainer: Container {
+  public override func adding(optionalAttributes subname: [String: Any]?) {
+// Local variable inserted by Swift 4.2 migrator.
+let subname = convertFromOptionalSimpleAttributeDictionary(subname)
+}
+  public override func adding(attributes myname: [String: Any]) {
+// Local variable inserted by Swift 4.2 migrator.
+let myname = convertFromSimpleAttributeDictionary(myname)
+}
+  public override func adding(attrArray: [String]) {
+// Local variable inserted by Swift 4.2 migrator.
+let attrArray = convertFromSimpleAttributeArray(attrArray)
+}
+  public override func add(single: String) {
+// Local variable inserted by Swift 4.2 migrator.
+let single = convertFromSimpleAttribute(single)
+}
+  public override func add(singleOptional: String?) {
+// Local variable inserted by Swift 4.2 migrator.
+let singleOptional = convertFromOptionalSimpleAttribute(singleOptional)
+}
+}
+
+// Helper function inserted by Swift 4.2 migrator.
+fileprivate func convertFromOptionalSimpleAttributeDictionary(_ input: [SimpleAttribute: Any]?) -> [String: Any]? {
+	guard let input = input else { return nil }
+	return Dictionary(uniqueKeysWithValues: input.map {key, value in (key.rawValue, value)})
+}
+
+// Helper function inserted by Swift 4.2 migrator.
+fileprivate func convertFromSimpleAttributeDictionary(_ input: [SimpleAttribute: Any]) -> [String: Any] {
+	return Dictionary(uniqueKeysWithValues: input.map {key, value in (key.rawValue, value)})
+}
+
+// Helper function inserted by Swift 4.2 migrator.
+fileprivate func convertFromSimpleAttributeArray(_ input: [SimpleAttribute]) -> [String] {
+	return input.map { key in key.rawValue }
+}
+
+// Helper function inserted by Swift 4.2 migrator.
+fileprivate func convertFromSimpleAttribute(_ input: SimpleAttribute) -> String {
+	return input.rawValue
+}
+
+// Helper function inserted by Swift 4.2 migrator.
+fileprivate func convertFromOptionalSimpleAttribute(_ input: SimpleAttribute?) -> String? {
+	guard let input = input else { return nil }
+	return input.rawValue
+}
+
 // Helper function inserted by Swift 4.2 migrator.
 fileprivate func convertToNewAttribute(_ input: String) -> NewAttribute {
 	return NewAttribute(rawValue: input)
@@ -107,33 +157,6 @@ fileprivate func convertToSimpleAttribute(_ input: String) -> SimpleAttribute {
 fileprivate func convertToOptionalSimpleAttribute(_ input: String?) -> SimpleAttribute? {
 	guard let input = input else { return nil }
 	return SimpleAttribute(rawValue: input)
-}
-
-// Helper function inserted by Swift 4.2 migrator.
-fileprivate func convertFromSimpleAttributeDictionary(_ input: [SimpleAttribute: Any]) -> [String: Any] {
-	return Dictionary(uniqueKeysWithValues: input.map {key, value in (key.rawValue, value)})
-}
-
-// Helper function inserted by Swift 4.2 migrator.
-fileprivate func convertFromOptionalSimpleAttributeDictionary(_ input: [SimpleAttribute: Any]?) -> [String: Any]? {
-	guard let input = input else { return nil }
-	return Dictionary(uniqueKeysWithValues: input.map {key, value in (key.rawValue, value)})
-}
-
-// Helper function inserted by Swift 4.2 migrator.
-fileprivate func convertFromSimpleAttribute(_ input: SimpleAttribute) -> String {
-	return input.rawValue
-}
-
-// Helper function inserted by Swift 4.2 migrator.
-fileprivate func convertFromOptionalSimpleAttribute(_ input: SimpleAttribute?) -> String? {
-	guard let input = input else { return nil }
-	return input.rawValue
-}
-
-// Helper function inserted by Swift 4.2 migrator.
-fileprivate func convertFromSimpleAttributeArray(_ input: [SimpleAttribute]) -> [String] {
-	return input.map { key in key.rawValue }
 }
 
 // Helper function inserted by Swift 4.2 migrator.


### PR DESCRIPTION
Explanation: When users override a SDK function whose parameter types have been changed,
we should introduce a local variable in the body of the function definition
to shadow the changed parameter. Also, a proper conversion function should
be applied to bridge the parameter to the local variable.

Scope: Swift 4.2 migrator

Issue: rdar://problem/41828411

Risk: Low

Testing: Added regression tests; manual tests using swift-migrate-test

Reviewed by: Nathan Hawes