### PR TITLE
[4.2] [Driver] Always link compiler_rt on Darwin (when available)

### DIFF
--- a/include/swift/Basic/Platform.h
+++ b/include/swift/Basic/Platform.h
@@ -58,6 +58,11 @@ namespace swift {
   /// Returns the platform Kind for Darwin triples.
   DarwinPlatformKind getDarwinPlatformKind(const llvm::Triple &triple);
 
+  /// Maps an arbitrary platform to its non-simulator equivalent.
+  ///
+  /// If \p platform is not a simulator platform, it will be returned as is.
+  DarwinPlatformKind getNonSimulatorPlatform(DarwinPlatformKind platform);
+
   /// Returns the architecture component of the path for a given target triple.
   ///
   /// Typically this is used for mapping the architecture component of the

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -76,6 +76,22 @@ DarwinPlatformKind swift::getDarwinPlatformKind(const llvm::Triple &triple) {
   llvm_unreachable("Unsupported Darwin platform");
 }
 
+DarwinPlatformKind swift::getNonSimulatorPlatform(DarwinPlatformKind platform) {
+  switch (platform) {
+  case DarwinPlatformKind::MacOS:
+    return DarwinPlatformKind::MacOS;
+  case DarwinPlatformKind::IPhoneOS:
+  case DarwinPlatformKind::IPhoneOSSimulator:
+    return DarwinPlatformKind::IPhoneOS;
+  case DarwinPlatformKind::TvOS:
+  case DarwinPlatformKind::TvOSSimulator:
+    return DarwinPlatformKind::TvOS;
+  case DarwinPlatformKind::WatchOS:
+  case DarwinPlatformKind::WatchOSSimulator:
+    return DarwinPlatformKind::WatchOS;
+  }
+}
+
 static StringRef getPlatformNameForDarwin(const DarwinPlatformKind platform) {
   switch (platform) {
   case DarwinPlatformKind::MacOS:

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1113,8 +1113,12 @@ toolchains::Darwin::constructInvocation(const InterpretJobAction &job,
 }
 
 static StringRef
-getDarwinLibraryNameSuffixForTriple(const llvm::Triple &triple) {
-  switch (getDarwinPlatformKind(triple)) {
+getDarwinLibraryNameSuffixForTriple(const llvm::Triple &triple,
+                                    bool distinguishSimulator = true) {
+  const DarwinPlatformKind kind = getDarwinPlatformKind(triple);
+  const DarwinPlatformKind effectiveKind =
+      distinguishSimulator ? kind : getNonSimulatorPlatform(kind);
+  switch (effectiveKind) {
   case DarwinPlatformKind::MacOS:
     return "osx";
   case DarwinPlatformKind::IPhoneOS:
@@ -1357,7 +1361,22 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
   assert(Triple.isOSDarwin());
 
   // FIXME: If we used Clang as a linker instead of going straight to ld,
-  // we wouldn't have to replicate Clang's logic here.
+  // we wouldn't have to replicate a bunch of Clang's logic here.
+
+  // Always link the regular compiler_rt if it's present.
+  //
+  // Note: Normally we'd just add this unconditionally, but it's valid to build
+  // Swift and use it as a linker without building compiler_rt.
+  SmallString<128> CompilerRTPath;
+  getClangLibraryPath(*this, context.Args, CompilerRTPath);
+  llvm::sys::path::append(
+      CompilerRTPath,
+      Twine("libclang_rt.") +
+        getDarwinLibraryNameSuffixForTriple(Triple, /*simulator*/false) +
+        ".a");
+  if (llvm::sys::fs::exists(CompilerRTPath))
+    Arguments.push_back(context.Args.MakeArgString(CompilerRTPath));
+
   bool wantsObjCRuntime = false;
   if (Triple.isiOS())
     wantsObjCRuntime = Triple.isOSVersionLT(9);
@@ -1471,9 +1490,8 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
   }
 
   if (context.Args.hasArg(options::OPT_profile_generate)) {
-    SmallString<128> LibProfile(RuntimeLibPath);
-    llvm::sys::path::remove_filename(LibProfile); // remove platform name
-    llvm::sys::path::append(LibProfile, "clang", "lib", "darwin");
+    SmallString<128> LibProfile;
+    getClangLibraryPath(*this, context.Args, LibProfile);
 
     StringRef RT;
     if (Triple.isiOS()) {

--- a/test/Driver/linker-clang_rt.swift
+++ b/test/Driver/linker-clang_rt.swift
@@ -1,0 +1,38 @@
+// Make sure that the platform-appropriate clang_rt library (found relative to
+// the compiler) is included when using Swift as a linker (with Apple targets).
+
+// We use hard links to make sure the Swift driver really thinks it's been
+// moved.
+
+// RUN: rm -rf %t
+// RUN: %empty-directory(%t/bin)
+// RUN: %hardlink-or-copy(from: %swift_driver_plain, to: %t/bin/swiftc)
+// RUN: %empty-directory(%t/lib/clang/darwin/)
+
+// RUN: %t/bin/swiftc -driver-print-jobs -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-NO-RUNTIME %s
+
+// RUN: touch %t/lib/clang/darwin/libclang_rt.osx.a %t/lib/clang/darwin/libclang_rt.ios.a %t/lib/clang/darwin/libclang_rt.tvos.a %t/lib/clang/darwin/libclang_rt.watchos.a
+
+// RUN: %t/bin/swiftc -driver-print-jobs -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix MACOS %s
+
+// RUN: %t/bin/swiftc -driver-print-jobs -target i386-apple-ios7 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix IOS %s
+// RUN: %t/bin/swiftc -driver-print-jobs -target x86_64-apple-ios7 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix IOS %s
+// RUN: %t/bin/swiftc -driver-print-jobs -target armv7s-apple-ios7 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix IOS %s
+// RUN: %t/bin/swiftc -driver-print-jobs -target arm64-apple-ios7 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix IOS %s
+
+// RUN: %t/bin/swiftc -driver-print-jobs -target x86_64-apple-ios9 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix TVOS %s
+// RUN: %t/bin/swiftc -driver-print-jobs -target arm64-apple-tvos9 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix TVOS %s
+
+// RUN: %t/bin/swiftc -driver-print-jobs -target i386-apple-watchos2 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix WATCHOS %s
+// RUN: %t/bin/swiftc -driver-print-jobs -target armv7k-apple-watchos2 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix WATCHOS %s
+
+// Clean up the test executable because hard links are expensive.
+// RUN: rm -f %t/bin/swiftc
+
+// CHECK: bin/ld{{"? }}
+// CHECK-NO-RUNTIME-NOT: libclang_rt
+// CHECK-MACOS-SAME: {{[^ ]+/lib/clang/darwin/libclang_rt.osx.a}}
+// CHECK-IOS-SAME: {{[^ ]+/lib/clang/darwin/libclang_rt.ios.a}}
+// CHECK-TVOS-SAME: {{[^ ]+/lib/clang/darwin/libclang_rt.tvos.a}}
+// CHECK-WATCHOS-SAME: {{[^ ]+/lib/clang/darwin/libclang_rt.watchos.a}}
+// CHECK-SAME: -o {{[^ ]+}}

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -87,7 +87,7 @@
 
 // SIMPLE: bin/ld{{"? }}
 // SIMPLE-NOT: -syslibroot
-// SIMPLE-DAG: -macosx_version_min 10.{{[0-9]+}}.{{[0-9]+}}
+// SIMPLE: -macosx_version_min 10.{{[0-9]+}}.{{[0-9]+}}
 // SIMPLE-NOT: -syslibroot
 // SIMPLE: -o linker
 
@@ -312,11 +312,11 @@
 
 
 // FILELIST: bin/ld{{"? }}
-// FILELIST-NOT: .o
+// FILELIST-NOT: .o{{"? }}
 // FILELIST: -filelist {{"?[^-]}}
-// FILELIST-NOT: .o
-// FILELIST: /a.o
-// FILELIST-NOT: .o
+// FILELIST-NOT: .o{{"? }}
+// FILELIST: /a.o{{"? }}
+// FILELIST-NOT: .o{{"? }}
 // FILELIST: -o linker
 
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -957,8 +957,9 @@ def source_compiler_rt_libs(path):
                                         if lib.startswith('libclang_rt.')
                                         and config.compiler_rt_platform in lib])
 
-source_compiler_rt_libs(os.path.join(test_resource_dir, 'clang', 'lib',
-                        platform.system().lower()))
+compiler_rt_dir = os.path.join(test_resource_dir, 'clang', 'lib',
+                               platform.system().lower())
+source_compiler_rt_libs(compiler_rt_dir)
 
 def check_runtime_libs(features_to_check):
     for lib in config.compiler_rt_libs:
@@ -978,6 +979,17 @@ if run_ptrsize != "32":
     runtime_libs['tsan'] = 'tsan_runtime'
 
 check_runtime_libs(runtime_libs)
+
+# From https://stackoverflow.com/a/2393022
+def strip_right(text, suffix):
+    if not text.endswith(suffix):
+        return text
+    return text[:len(text)-len(suffix)]
+
+base_runtime_lib_name = (
+    'libclang_rt.' + strip_right(config.compiler_rt_platform, 'sim') + '.a')
+if os.path.exists(os.path.join(compiler_rt_dir, base_runtime_lib_name)):
+    config.available_features.add('c_runtime')
 
 if not getattr(config, 'target_run_simple_swift', None):
     config.target_run_simple_swift = (

--- a/validation-test/Driver/Inputs/clang_rt-helper.h
+++ b/validation-test/Driver/Inputs/clang_rt-helper.h
@@ -1,0 +1,9 @@
+#include <stdbool.h>
+
+static inline bool isRunningOnFairlyRecentOS() {
+  if (__builtin_available(macOS 10.12, iOS 10, tvOS 10, watchOS 3, *)) {
+    return true;
+  } else {
+    return false;
+  }
+}

--- a/validation-test/Driver/clang_rt.swift
+++ b/validation-test/Driver/clang_rt.swift
@@ -1,0 +1,11 @@
+// RUN: %target-build-swift -emit-executable %s -import-objc-header %S/Inputs/clang_rt-helper.h -o %t
+
+// REQUIRES: c_runtime
+
+// Just make sure we can build and link successfully.
+
+if isRunningOnFairlyRecentOS() {
+  print("new!")
+} else {
+  print("old...")
+}


### PR DESCRIPTION
- **Explanation**: Various C and Objective-C features are implemented using functions in the compiler_rt project, and Swift can end up using some of those features simply by importing inlinable C code. This includes Objective-C's `@available` feature (the equivalent of Swift's `#available`). Clang always links the usual `clang_rt` library to supply these features, so Swift should too.

- **Scope**: Affects the package manager and users manually invoking swiftc to build executables and libraries. (Xcode uses Clang to link.)

- **Issue**: rdar://problem/41911599

- **Risk**: Low. The change is straightforward and the effects should be safe, given that this is what Clang and Xcode already do.

- **Testing**: Added compiler regression tests.

- **Reviewed by**: @davidungar