### PR TITLE
[4.2][SpaceEngine] Improve total search space size estimation

### DIFF
--- a/test/stmt/rdar40400251.swift
+++ b/test/stmt/rdar40400251.swift
@@ -1,0 +1,37 @@
+// RUN: %target-typecheck-verify-swift
+
+enum E1 {
+  case v1
+  case v2
+  case v3
+  case v4
+  case v5
+  case v6
+  indirect case v7(E1)
+}
+
+enum E2 {
+  case foo((E1, E1, E1)) // total size of this case is 7 ^ 3 + 1
+  case bar(E1)
+  case baz
+}
+
+func foo(_ e: E2) {
+  switch e {
+    // expected-error@-1 {{switch must be exhaustive}}
+    // expected-note@-2 {{add missing case: '.bar(_)'}}
+
+    case .foo(let tuple): break // expected-warning {{immutable value 'tuple' was never used; consider replacing with '_' or removing it}}
+    case .baz: break
+  }
+}
+
+func bar(_ e: E2) {
+  switch e {
+    // expected-error@-1 {{switch must be exhaustive}}
+    // expected-note@-2 {{add missing case: '.bar(_)'}}
+    // expected-note@-3 {{add missing case: '.baz'}}
+
+    case .foo((_, _, _)): break
+  }
+}


### PR DESCRIPTION
- **Explanation**:  In some situations it is possible to determine that a particular
associated value is completely covered by a given `switch` statement
before running main checker algorithm, so let's not include sizes
of such cases into "total" search space size estimate.

- **Issue**: rdar://problem/40400251

- **Scope**: Affects only preliminary total space size check done by space engine.

- **Risk**: Low. 

- **Testing**: Added compiler regression tests.

- **Reviewed by**: @jrose-apple and @CodaFi 

Resolves: rdar://problem/40400251
(cherry picked from commit 2b78e16224619c305c6be1432a2779eeb1435b45)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
