### PR TITLE
[IDE] Range info for accessor decl

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -376,12 +376,32 @@ case DeclKind::ID: return cast<ID##Decl>(this)->getSourceRange();
 SourceRange Decl::getSourceRangeIncludingAttrs() const {
   auto Range = getSourceRange();
 
-  // Attributes on AccessorDecl are syntactically belong to PatternBindingDecl.
-  if (isa<AccessorDecl>(this) || isa<VarDecl>(this))
+  // Attributes on AccessorDecl may syntactically belong to PatternBindingDecl.
+  // e.g. 'override'.
+  if (auto *AD = dyn_cast<AccessorDecl>(this)) {
+    // If this is implicit getter, accessor range should not include attributes.
+    if (!AD->getAccessorKeywordLoc().isValid())
+      return Range;
+
+    // Otherwise, include attributes directly attached to the accessor.
+    SourceLoc VarLoc = AD->getStorage()->getStartLoc();
+    for (auto Attr : getAttrs()) {
+      if (!Attr->getRange().isValid())
+        continue;
+
+      SourceLoc AttrStartLoc = Attr->getRangeWithAt().Start;
+      if (getASTContext().SourceMgr.isBeforeInBuffer(VarLoc, AttrStartLoc))
+        Range.widen(AttrStartLoc);
+    }
+    return Range;
+  }
+
+  // Attributes on VarDecl syntactically belong to PatternBindingDecl.
+  if (isa<VarDecl>(this))
     return Range;
 
   // Attributes on PatternBindingDecls are attached to VarDecls in AST.
-  if (const PatternBindingDecl *PBD = dyn_cast<PatternBindingDecl>(this)) {
+  if (auto *PBD = dyn_cast<PatternBindingDecl>(this)) {
     for (auto Entry : PBD->getPatternList())
       Entry.getPattern()->forEachVariable([&](VarDecl *VD) {
         for (auto Attr : VD->getAttrs())

--- a/test/IDE/range_info_declattr.swift
+++ b/test/IDE/range_info_declattr.swift
@@ -7,11 +7,32 @@ class ObjCBase {
   }
   @objc var bar = 12, baz = 13
 }
+class Derived : ObjCBase {
+  @available(*, unavailable)
+  override var quux: Int {
+    @inlinable get { return 0 }
+  }
+
+  subscript(idx: Int) -> Int {
+    @available(*, unavailable)
+    get { return 0 }
+
+    @available(*, unavailable)
+    @inlineable
+    set { }
+  }
+}
 
 // RUN: %target-swift-ide-test -range -pos=4:1 -end-pos=9:2 -source-filename %s | %FileCheck %s -check-prefix=CHECK1
 // RUN: %target-swift-ide-test -range -pos=5:3 -end-pos=7:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK2
 // RUN: %target-swift-ide-test -range -pos=5:25 -end-pos=7:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK3
 // RUN: %target-swift-ide-test -range -pos=8:3 -end-pos=8:31 -source-filename %s | %FileCheck %s -check-prefix=CHECK4
+// RUN: %target-swift-ide-test -range -pos=13:5 -end-pos=13:32 -source-filename %s | %FileCheck %s -check-prefix=CHECK5
+// RUN: %target-swift-ide-test -range -pos=13:16 -end-pos=13:32 -source-filename %s | %FileCheck %s -check-prefix=CHECK6
+// RUN: %target-swift-ide-test -range -pos=12:26 -end-pos=14:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK7
+// RUN: %target-swift-ide-test -range -pos=17:5 -end-pos=18:21 -source-filename %s | %FileCheck %s -check-prefix=CHECK8
+// RUN: %target-swift-ide-test -range -pos=20:5 -end-pos=22:12 -source-filename %s | %FileCheck %s -check-prefix=CHECK9
+// RUN: %target-swift-ide-test -range -pos=21:5 -end-pos=22:12 -source-filename %s | %FileCheck %s -check-prefix=CHECK10
 
 // CHECK1: <Kind>SingleDecl</Kind>
 // CHECK1-NEXT: <Content>@objc class ObjCClass : ObjCBase {
@@ -47,7 +68,6 @@ class ObjCBase {
 // CHECK3-NEXT: <ASTNodes>1</ASTNodes>
 // CHECK3-NEXT: <end>
 
-
 // CHECK4: <Kind>SingleDecl</Kind>
 // CHECK4-NEXT: <Content>@objc var bar = 12, baz = 13</Content>
 // CHECK4-NEXT: <Context>swift_ide_test.(file).ObjCClass</Context>
@@ -55,3 +75,45 @@ class ObjCBase {
 // CHECK4-NEXT: <Declared>baz</Declared><OutscopeReference>false</OutscopeReference>
 // CHECK4-NEXT: <ASTNodes>1</ASTNodes>
 // CHECK4-NEXT: <end>
+
+// CHECK5: <Kind>SingleDecl</Kind>
+// CHECK5-NEXT: <Content>@inlinable get { return 0 }</Content>
+// CHECK5-NEXT: <Context>swift_ide_test.(file).Derived</Context>
+// CHECK5-NEXT: <Declared>_</Declared><OutscopeReference>false</OutscopeReference>
+// CHECK5-NEXT: <ASTNodes>1</ASTNodes>
+// CHECK5-NEXT: <end>
+
+// CHECK6: <Kind>Invalid</Kind>
+// CHECK6-NEXT: <Content>get { return 0 }</Content>
+// CHECK6-NEXT: <ASTNodes>0</ASTNodes>
+// CHECK6-NEXT: <end>
+
+// CHECK7: <Kind>Invalid</Kind>
+// CHECK7-NEXT: <Content>{
+// CHECK7-NEXT:     @inlinable get { return 0 }
+// CHECK7-NEXT:   }</Content>
+// CHECK7-NEXT: <ASTNodes>0</ASTNodes>
+// CHECK7-NEXT: <end>
+
+// CHECK8: <Kind>SingleDecl</Kind>
+// CHECK8-NEXT: <Content>@available(*, unavailable)
+// CHECK8-NEXT:     get { return 0 }</Content>
+// CHECK8-NEXT: <Context>swift_ide_test.(file).Derived</Context>
+// CHECK8-NEXT: <Declared>_</Declared><OutscopeReference>false</OutscopeReference>
+// CHECK8-NEXT: <ASTNodes>1</ASTNodes>
+// CHECK8-NEXT: <end>
+
+// CHECK9: <Kind>SingleDecl</Kind>
+// CHECK9-NEXT: <Content>@available(*, unavailable)
+// CHECK9-NEXT:     @inlineable
+// CHECK9-NEXT:     set { }</Content>
+// CHECK9-NEXT: <Context>swift_ide_test.(file).Derived</Context>
+// CHECK9-NEXT: <Declared>_</Declared><OutscopeReference>false</OutscopeReference>
+// CHECK9-NEXT: <ASTNodes>1</ASTNodes>
+// CHECK9-NEXT: <end>
+
+// CHECK10: <Kind>Invalid</Kind>
+// CHECK10-NEXT: <Content>@inlineable
+// CHECK10-NEXT:     set { }</Content>
+// CHECK10-NEXT: <ASTNodes>0</ASTNodes>
+// CHECK10-NEXT: <end>


### PR DESCRIPTION
Revised version of #17239.

Attributes on explicit accessor decl may have attributes. Only when the range contains those attributes (but not attributes on `PatternBindingDecl`), the range-info should report `SingleDecl`.

CC: @jrose-apple , @nkcsgexi 