### PR TITLE
[Diagnostics] Remove misplaced LoadExpr workaround for RawRepresentable

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4685,14 +4685,9 @@ static bool diagnoseRawRepresentableMismatch(CalleeCandidateInfo &CCI,
     return false;
 
   const Expr *expr = argExpr;
-  if (auto *tupleArgs = dyn_cast<TupleExpr>(argExpr)) {
+  if (auto *tupleArgs = dyn_cast<TupleExpr>(argExpr))
     expr = tupleArgs->getElement(bestMatchIndex);
-  } else if (auto *misplacedLoad = dyn_cast<LoadExpr>(argExpr)) {
-    // If there are multiple possible overloads for a single-argument call
-    // expression, the partially-typed-checked AST may have a load around the
-    // call parentheses instead of inside them.
-    expr = misplacedLoad->getSubExpr();
-  }
+
   expr = expr->getValueProvidingExpr();
 
   auto parameters = bestMatchCandidate->getParameters();


### PR DESCRIPTION
Since verifier is now in place to make sure that ParenExpr/ForceValueExpr
always preceed LoadExpr there is need to special case against incorrect
ordering in diagnostics.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
