### PR TITLE
ASTContext: Recompute the insert position in getSpecializedConformanc…

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1836,6 +1836,7 @@ ASTContext::getSpecializedConformance(Type type,
     = new (*this, arena) SpecializedProtocolConformance(type, generic,
                                                         substitutions);
   auto node = specializedConformances.FindNodeOrInsertPos(id, insertPos);
+  (void)node;
   assert(!node);
   specializedConformances.InsertNode(result, insertPos);
   return result;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1835,6 +1835,8 @@ ASTContext::getSpecializedConformance(Type type,
   auto result
     = new (*this, arena) SpecializedProtocolConformance(type, generic,
                                                         substitutions);
+  auto node = specializedConformances.FindNodeOrInsertPos(id, insertPos);
+  assert(!node);
   specializedConformances.InsertNode(result, insertPos);
   return result;
 }


### PR DESCRIPTION
…e after the SpecializedProtocolConformance constructor

The constructor can modify the SpecializedConformances FoldingSet so that the
insertPos is no longer valid. It calls computeConditionalRequirements which
calls Type::subst which recursively can call getSpecializedConformance again.

This bug manifest itself either as memory error with libgmalloc or as
spurious errors later on.

rdar://42082352
