### PR TITLE
Sprinkle LLVM_READONLY on some potentially complex accessors

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -692,6 +692,7 @@ public:
   /// not be serialized.
   bool canHaveComment() const;
 
+  LLVM_READONLY
   DeclContext *getDeclContext() const {
     if (auto dc = Context.dyn_cast<DeclContext *>())
       return dc;
@@ -706,9 +707,11 @@ public:
   DeclContext *getInnermostDeclContext() const;
 
   /// \brief Retrieve the module in which this declaration resides.
+  LLVM_READONLY
   ModuleDecl *getModuleContext() const;
 
   /// getASTContext - Return the ASTContext that this decl lives in.
+  LLVM_READONLY
   ASTContext &getASTContext() const {
     if (auto dc = Context.dyn_cast<DeclContext *>())
       return dc->getASTContext();
@@ -851,6 +854,7 @@ public:
 
   /// \brief Retrieve the Clang AST node from which this declaration was
   /// synthesized, if any.
+  LLVM_READONLY
   ClangNode getClangNode() const {
     if (!Bits.Decl.FromClang)
       return ClangNode();
@@ -860,6 +864,7 @@ public:
 
   /// \brief Retrieve the Clang declaration from which this declaration was
   /// synthesized, if any.
+  LLVM_READONLY
   const clang::Decl *getClangDecl() const {
     if (!Bits.Decl.FromClang)
       return nullptr;
@@ -869,6 +874,7 @@ public:
 
   /// \brief Retrieve the Clang macro from which this declaration was
   /// synthesized, if any.
+  LLVM_READONLY
   const clang::MacroInfo *getClangMacro() {
     if (!Bits.Decl.FromClang)
       return nullptr;
@@ -877,6 +883,7 @@ public:
   }
 
   /// \brief Return the GenericContext if the Decl has one.
+  LLVM_READONLY
   const GenericContext *getAsGenericContext() const;
 
   bool isPrivateStdlibDecl(bool treatNonBuiltinProtocolsAsPublic = true) const;
@@ -900,6 +907,7 @@ public:
   }
 
   /// Retrieve the diagnostic engine for diagnostics emission.
+  LLVM_READONLY
   DiagnosticEngine &getDiags() const;
 
   // Make vanilla new/delete illegal for Decls.

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -237,6 +237,7 @@ class alignas(1 << DeclContextAlignInBits) DeclContext {
   }
 
 public:
+  LLVM_READONLY
   Decl *getAsDeclOrDeclExtensionContext() {
     return ParentAndKind.getInt() == ASTHierarchy::Decl ?
       reinterpret_cast<Decl*>(this + 1) : nullptr;
@@ -262,40 +263,50 @@ public:
   }
   
   /// isModuleContext - Return true if this is a subclass of Module.
+  LLVM_READONLY
   bool isModuleContext() const; // see swift/AST/Module.h
 
   /// \returns true if this is a context with module-wide scope, e.g. a module
   /// or a source file.
+  LLVM_READONLY
   bool isModuleScopeContext() const; // see swift/AST/Module.h
 
   /// \returns true if this is a type context, e.g., a struct, a class, an
   /// enum, a protocol, or an extension.
+  LLVM_READONLY
   bool isTypeContext() const;
 
   /// \brief Determine whether this is an extension context.
+  LLVM_READONLY
   bool isExtensionContext() const; // see swift/AST/Decl.h
 
   /// If this DeclContext is a NominalType declaration or an
   /// extension thereof, return the NominalTypeDecl.
+  LLVM_READONLY
   NominalTypeDecl *getAsNominalTypeOrNominalTypeExtensionContext() const;
 
   /// If this DeclContext is a class, or an extension on a class, return the
   /// ClassDecl, otherwise return null.
+  LLVM_READONLY
   ClassDecl *getAsClassOrClassExtensionContext() const;
 
   /// If this DeclContext is an enum, or an extension on an enum, return the
   /// EnumDecl, otherwise return null.
+  LLVM_READONLY
   EnumDecl *getAsEnumOrEnumExtensionContext() const;
 
   /// If this DeclContext is a struct, or an extension on a struct, return the
   /// StructDecl, otherwise return null.
+  LLVM_READONLY
   StructDecl *getAsStructOrStructExtensionContext() const;
 
   /// If this DeclContext is a protocol, or an extension on a
   /// protocol, return the ProtocolDecl, otherwise return null.
+  LLVM_READONLY
   ProtocolDecl *getAsProtocolOrProtocolExtensionContext() const;
 
   /// If this DeclContext is a protocol extension, return the extended protocol.
+  LLVM_READONLY
   ProtocolDecl *getAsProtocolExtensionContext() const;
 
   /// \brief Retrieve the generic parameter 'Self' from a protocol or
@@ -351,6 +362,7 @@ public:
 
   /// Returns this or the first local parent context, or nullptr if it is not
   /// contained in one.
+  LLVM_READONLY
   DeclContext *getLocalContext();
   const DeclContext *getLocalContext() const {
     return const_cast<DeclContext*>(this)->getLocalContext();
@@ -363,6 +375,7 @@ public:
   /// destructors).
   ///
   /// \returns the innermost method, or null if there is no such method.
+  LLVM_READONLY
   AbstractFunctionDecl *getInnermostMethodContext();
   const AbstractFunctionDecl *getInnermostMethodContext() const {
     return const_cast<DeclContext*>(this)->getInnermostMethodContext();
@@ -373,6 +386,7 @@ public:
   /// This routine looks through closure, initializer, and local function
   /// contexts to find the innermost type context -- nominal type or
   /// extension.
+  LLVM_READONLY
   DeclContext *getInnermostTypeContext();
   const DeclContext *getInnermostTypeContext() const {
     return const_cast<DeclContext *>(this)->getInnermostTypeContext();
@@ -382,6 +396,7 @@ public:
   ///
   /// This routine looks through contexts to find the innermost
   /// declaration context that is itself a declaration.
+  LLVM_READONLY
   Decl *getInnermostDeclarationDeclContext();
   const Decl *getInnermostDeclarationDeclContext() const {
     return
@@ -409,15 +424,18 @@ public:
   }
 
   /// Returns the module context that contains this context.
+  LLVM_READONLY
   ModuleDecl *getParentModule() const;
 
   /// Returns the module scope context that contains this context.
   ///
   /// This is either a \c Module or a \c FileUnit.
+  LLVM_READONLY
   DeclContext *getModuleScopeContext() const;
 
   /// Returns the source file that contains this context, or null if this
   /// is not within a source file.
+  LLVM_READONLY
   SourceFile *getParentSourceFile() const;
 
   /// Determine whether this declaration context is generic, meaning that it or
@@ -476,6 +494,7 @@ public:
 
   /// Return the ASTContext for a specified DeclContext by
   /// walking up to the enclosing module and returning its ASTContext.
+  LLVM_READONLY
   ASTContext &getASTContext() const;
 
   /// Retrieve the set of protocols whose conformances will be


### PR DESCRIPTION
I picked accessors that not only return the same result every time, but also do no interesting validation work with possible side effects. We have a lot more accessors that return the same result but also force a bunch of things to be loaded or diagnostics to be emitted, and I didn't want to change the behavior of any of those.

No intended functionality change; this is just supposed to be a small optimization hint.