### PR TITLE
[CMake] Use NO_CMAKE_FIND_ROOT_PATH for LLVM and clang

### DIFF
--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -24,7 +24,7 @@ macro(swift_common_standalone_build_config_llvm product is_cross_compiling)
   # Then we import LLVMConfig. This is going to override whatever cached value
   # we have for LLVM_ENABLE_ASSERTIONS.
   find_package(LLVM REQUIRED CONFIG
-    HINTS "${PATH_TO_LLVM_BUILD}" NO_DEFAULT_PATH)
+    HINTS "${PATH_TO_LLVM_BUILD}" NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
 
   # If we did not have a cached value for LLVM_ENABLE_ASSERTIONS, set
   # LLVM_ENABLE_ASSERTIONS_saved to be the ENABLE_ASSERTIONS value from LLVM so
@@ -69,7 +69,7 @@ macro(swift_common_standalone_build_config_llvm product is_cross_compiling)
   endif()
 
   find_program(LLVM_TABLEGEN_EXE "llvm-tblgen" "${${product}_NATIVE_LLVM_TOOLS_PATH}"
-    NO_DEFAULT_PATH)
+    NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
   if ("${LLVM_TABLEGEN_EXE}" STREQUAL "LLVM_TABLEGEN_EXE-NOTFOUND")
     message(FATAL_ERROR "Failed to find tablegen in ${${product}_NATIVE_LLVM_TOOLS_PATH}")
   endif()
@@ -149,7 +149,7 @@ macro(swift_common_standalone_build_config_clang product is_cross_compiling)
 
   # Then include Clang.
   find_package(Clang REQUIRED CONFIG
-    HINTS "${PATH_TO_CLANG_BUILD}" NO_DEFAULT_PATH)
+    HINTS "${PATH_TO_CLANG_BUILD}" NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
 
   if(NOT EXISTS "${PATH_TO_CLANG_SOURCE}/include/clang/AST/Decl.h")
     message(FATAL_ERROR "Please set ${product}_PATH_TO_CLANG_SOURCE to the root directory of Clang's source code.")


### PR DESCRIPTION
When cross-compiling or specifying a custom sysroot and desiring a
hermetic build, many CMake toolchain files will have a custom
CMAKE_FIND_ROOT_PATH and set the CMAKE_FIND_ROOT_PATH_MODE_* variables
to ONLY, meaning packages will only be searched for in the rerooted
directories. We don't want this rerooting to happen when searching for
the LLVM and clang packages though, since we're specifying our search
paths explicitly and excluding search paths from the system, and we
don't want those explicit search paths to be rerooted.

It's standard to set CMAKE_FIND_ROOT_PATH_MODE_PROGRAM to NEVER instead
of ONLY, since you usually want programs to be found for the build
system and not the host system, so the change for the llvm-config search
is not technically required. It doesn't hurt for consistency though, and
I can envision some scenarios in which it might come in handy.