### PR TITLE
[4.2] ASTContext: Recompute the insert position in getSpecializedConformance after the SpecializedProtocolConformance constructor

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1871,6 +1871,9 @@ ASTContext::getSpecializedConformance(Type type,
   auto result
     = new (*this, arena) SpecializedProtocolConformance(type, generic,
                                                         substitutions);
+  auto node = specializedConformances.FindNodeOrInsertPos(id, insertPos);
+  (void)node;
+  assert(!node);
   specializedConformances.InsertNode(result, insertPos);
   return result;
 }


### PR DESCRIPTION
The constructor can modify the SpecializedConformances FoldingSet so that the
insertPos is no longer valid. It calls computeConditionalRequirements which
calls Type::subst which recursively can call getSpecializedConformance again.

Therefore, we need to recompute the insertPos after calling the
constructor.

This bug manifest itself either as memory error with libgmalloc or as
spurious errors later on.

* Explanation: Memory errors causing spurious failure later in the
compiler on our CI tests

* Scope: Memory errors are bad. This bug dates back to when conditional
conformance were added sometime during 2017.

* Risk: Low. A call to recompute the insertion point (a map lookup) is
added.

*Testing: Existing Swift CI test caught this

rdar://42082352