### PR TITLE
Remove the '++' and '--' operators.

### DIFF
--- a/stdlib/public/core/MigrationSupport.swift
+++ b/stdlib/public/core/MigrationSupport.swift
@@ -369,27 +369,6 @@ extension LazyMapCollection {
   }
 }
 
-@available(*, unavailable, message: "use += 1")
-@discardableResult
-public prefix func ++ <F: FloatingPoint>(rhs: inout F) -> F {
-  fatalError("++ is not available")
-}
-@available(*, unavailable, message: "use -= 1")
-@discardableResult
-public prefix func -- <F: FloatingPoint>(rhs: inout F) -> F {
-  fatalError("-- is not available")
-}
-@available(*, unavailable, message: "use += 1")
-@discardableResult
-public postfix func ++ <F: FloatingPoint>(lhs: inout F) -> F {
-  fatalError("++ is not available")
-}
-@available(*, unavailable, message: "use -= 1")
-@discardableResult
-public postfix func -- <F: FloatingPoint>(lhs: inout F) -> F {
-  fatalError("-- is not available")
-}
-
 extension FloatingPoint {
   @available(swift, deprecated: 3.1, obsoleted: 4.0, message: "Please use the `abs(_:)` free function")
   public static func abs(_ x: Self) -> Self {

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -377,8 +377,6 @@ precedencegroup BitwiseShiftPrecedence {
 //===----------------------------------------------------------------------===//
 
 // Standard postfix operators.
-postfix operator ++
-postfix operator --
 postfix operator ...
 
 // Optional<T> unwrapping operator is built into the compiler as a part of
@@ -387,8 +385,6 @@ postfix operator ...
 // postfix operator !
 
 // Standard prefix operators.
-prefix operator ++
-prefix operator --
 prefix operator !
 prefix operator ~
 prefix operator +

--- a/test/Index/kinds.swift
+++ b/test/Index/kinds.swift
@@ -185,6 +185,7 @@ prefix func -(a: AStruct) -> AStruct { return a }
 // CHECK: [[@LINE-1]]:13 | function/prefix-operator/Swift | -(_:) | s:14swift_ide_test1sopyAA7AStructVADF | Def | rel: 0
 
 // PostfixOperator
+postfix operator ++
 postfix func ++(a: AStruct) -> AStruct { return a }
 // CHECK: [[@LINE-1]]:14 | function/postfix-operator/Swift | ++(_:) | s:14swift_ide_test2ppoPyAA7AStructVADF | Def | rel: 0
 

--- a/test/Parse/optional_chain_lvalues.swift
+++ b/test/Parse/optional_chain_lvalues.swift
@@ -21,6 +21,12 @@ struct T {
 var mutT: T?
 let immT: T? = nil  // expected-note {{change 'let' to 'var' to make it mutable}} {{1-4=var}}
 
+postfix operator ++
+prefix operator ++
+
+public postfix func ++ <T>(rhs: inout T) -> T { fatalError() }
+public prefix func ++ <T>(rhs: inout T) -> T { fatalError() }
+
 mutT?.mutateT()
 immT?.mutateT() // expected-error{{cannot use mutating member on immutable value: 'immT' is a 'let' constant}}
 mutT?.mutS?.mutateS()

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -489,7 +489,7 @@ struct ErrorInFunctionSignatureResultArrayType5 {
 
 
 struct ErrorInFunctionSignatureResultArrayType11 { // expected-note{{in declaration of 'ErrorInFunctionSignatureResultArrayType11'}}
-  func foo() -> Int[(a){a++}] { // expected-error {{consecutive declarations on a line must be separated by ';'}} {{29-29=;}} expected-error {{expected ']' in array type}} expected-note {{to match this opening '['}} expected-error {{use of unresolved identifier 'a'}} expected-error {{expected declaration}}
+  func foo() -> Int[(a){a++}] { // expected-error {{consecutive declarations on a line must be separated by ';'}} {{29-29=;}} expected-error {{expected ']' in array type}} expected-note {{to match this opening '['}} expected-error {{use of unresolved operator '++'; did you mean '+= 1'?}} expected-error {{use of unresolved identifier 'a'}} expected-error {{expected declaration}}
   }
 }
 

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -2,6 +2,9 @@
 
 func markUsed<T>(_ t: T) {}
 
+prefix operator ++
+public prefix func ++ <T>(rhs: inout T) -> T { fatalError() }
+
 let bad_property_1: Int {    // expected-error {{'let' declarations cannot be computed properties}} {{1-4=var}}
   get {
     return 42

--- a/test/SourceKit/CodeComplete/complete_operators.swift
+++ b/test/SourceKit/CodeComplete/complete_operators.swift
@@ -11,6 +11,7 @@ struct MyInt {
   var bigPowers: Int { return 1 }
 }
 func +(x: MyInt, y: MyInt) -> MyInt { return x }
+postfix operator ++
 postfix func ++(x: inout MyInt) -> MyInt { return x }
 func !=(x: MyInt, y: MyInt) -> Bool { return true }
 

--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -142,6 +142,9 @@ func test_14705150() {
 
 }
 
+postfix operator ++
+prefix operator ++
+
 prefix postfix func ++(x: Int) {} // expected-error {{'postfix' contradicts previous modifier 'prefix'}} {{8-16=}}
 postfix prefix func ++(x: Float) {} // expected-error {{'prefix' contradicts previous modifier 'postfix'}} {{9-16=}}
 postfix prefix infix func ++(x: Double) {} // expected-error {{'prefix' contradicts previous modifier 'postfix'}} {{9-16=}} expected-error {{'infix' contradicts previous modifier 'postfix'}} {{16-22=}}
@@ -355,13 +358,3 @@ class C6 {
     if x == x && x = x { } // expected-error{{expression is not assignable: '&&' returns immutable value}}
   }
 }
-
-_ = 1..<1 // OK
-_ = 1…1 // expected-error {{use of unresolved operator '…'; did you mean '...'?}} {{6-9=...}}
-_ = 1….1 // expected-error {{use of unresolved operator '…'; did you mean '...'?}} {{6-9=...}}
-_ = 1.…1 // expected-error {{use of unresolved operator '.…'; did you mean '...'?}} {{6-10=...}}
-_ = 1…<1 // expected-error {{use of unresolved operator '…<'; did you mean '..<'?}} {{6-10=..<}}
-_ = 1..1 // expected-error {{use of unresolved operator '..'; did you mean '...'?}} {{6-8=...}}
-_ = 1....1 // expected-error {{use of unresolved operator '....'; did you mean '...'?}} {{6-10=...}}
-_ = 1...<1 // expected-error {{use of unresolved operator '...<'; did you mean '..<'?}} {{6-10=..<}}
-_ = 1....<1 // expected-error {{use of unresolved operator '....<'; did you mean '..<'?}} {{6-11=..<}}

--- a/test/decl/func/operator_suggestions.swift
+++ b/test/decl/func/operator_suggestions.swift
@@ -1,0 +1,23 @@
+// RUN: %target-typecheck-verify-swift
+
+_ = 1..<1 // OK
+_ = 1…1 // expected-error {{use of unresolved operator '…'; did you mean '...'?}} {{6-9=...}}
+_ = 1….1 // expected-error {{use of unresolved operator '…'; did you mean '...'?}} {{6-9=...}}
+_ = 1.…1 // expected-error {{use of unresolved operator '.…'; did you mean '...'?}} {{6-10=...}}
+_ = 1…<1 // expected-error {{use of unresolved operator '…<'; did you mean '..<'?}} {{6-10=..<}}
+_ = 1..1 // expected-error {{use of unresolved operator '..'; did you mean '...'?}} {{6-8=...}}
+_ = 1....1 // expected-error {{use of unresolved operator '....'; did you mean '...'?}} {{6-10=...}}
+_ = 1...<1 // expected-error {{use of unresolved operator '...<'; did you mean '..<'?}} {{6-10=..<}}
+_ = 1....<1 // expected-error {{use of unresolved operator '....<'; did you mean '..<'?}} {{6-11=..<}}
+
+var i = 1
+i++ // expected-error {{use of unresolved operator '++'; did you mean '+= 1'?}}
+++i // expected-error {{use of unresolved operator '++'; did you mean '+= 1'?}}
+i-- // expected-error {{use of unresolved operator '--'; did you mean '-= 1'?}}
+--i // expected-error {{use of unresolved operator '--'; did you mean '-= 1'?}}
+
+var d = 1.0
+d++ // expected-error {{use of unresolved operator '++'; did you mean '+= 1'?}}
+++d // expected-error {{use of unresolved operator '++'; did you mean '+= 1'?}}
+d-- // expected-error {{use of unresolved operator '--'; did you mean '-= 1'?}}
+--d // expected-error {{use of unresolved operator '--'; did you mean '-= 1'?}}


### PR DESCRIPTION
We still had unavailable versions of these for floating-point types
only. We shouldn't need to keep these around, and can instead just
emit a helpful diagnostic for anyone that attempts to use them.

Unfortunately I don't see any way for the diagnostic to produce an
actual fix-it, so it just suggests '+= 1' or '-= 1' without actually
producing a fix.
