### PR TITLE
Introduce a ConstExpr representation for arrays, simplify the array/string representation

### DIFF
--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -1039,7 +1039,7 @@ static bool parseSymbolicValue(SymbolicValue &value, SILParser &SP,
     });
     if (status.isError())
       return true;
-    value = SymbolicValue::getAggregate(elements, allocator);
+    value = SymbolicValue::getArray(elements, allocator);
     return false;
   }
   P.diagnose(P.Tok, diag::sil_graph_op_expected_attr_value);

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1240,6 +1240,17 @@ public:
       visitSymbolicValue(v.getEnumPayloadValue());
       *this << ")";
       return;
+    case SymbolicValue::Array:
+      // Note, this prints arrays and aggregates as the same value.  We may want
+      // to produce distinguishing syntax at some point.
+      *this << "[";
+      interleave(v.getArrayValue(), [&](SymbolicValue element) {
+        visitSymbolicValue(element);
+      }, [&] {
+        *this << ", ";
+      });
+      *this << "]";
+      return;
     case SymbolicValue::UninitMemory:
     case SymbolicValue::Unknown:
     case SymbolicValue::Address:

--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -1501,6 +1501,7 @@ emitConstantInst(SymbolicValue symVal, SILType type, SILLocation loc,
   case SymbolicValue::Address:
     assert(0 && "Shouldn't happen");
   case SymbolicValue::Aggregate:
+  case SymbolicValue::Array:
   case SymbolicValue::Function:
   case SymbolicValue::Enum:
   case SymbolicValue::EnumWithPayload:

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -1813,7 +1813,8 @@ GLStatus TFGraphLowering::visitGraphOperationInst(GraphOperationInst *inst) {
         break;
       }
       case SymbolicValue::Aggregate:
-        llvm_unreachable("FIXME: Handle normal aggregate arguments");
+      case SymbolicValue::Array:
+        llvm_unreachable("FIXME: Handle normal aggregate/array arguments");
       }
       // Done with normal attributes.
       break;


### PR DESCRIPTION
This array representation overlaps with aggregate, and I'd like to eliminate
that, but I'd like to get this in as a precursor to the more interesting
patch.  I'll look to refactor if possible in a follow-on.

