### PR TITLE
[stdlib] NFC: Unicode.Scalar.Properties documentation fixes

### DIFF
--- a/stdlib/public/core/UnicodeScalarProperties.swift
+++ b/stdlib/public/core/UnicodeScalarProperties.swift
@@ -236,7 +236,7 @@ extension Unicode.Scalar.Properties {
   ///
   /// This property roughly defines the class of "Chinese characters" and does
   /// not include characters of other logographic scripts such as Cuneiform or
-  /// Egyptian Hieroglyphs
+  /// Egyptian Hieroglyphs.
   ///
   /// This property corresponds to the `Ideographic` property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
@@ -291,8 +291,8 @@ extension Unicode.Scalar.Properties {
   ///   directs the rendering engine to render them as a connected glyph when it
   ///   would otherwise render them independently. The zero width joiner is also
   ///   used to construct complex emoji from sequences of base emoji characters.
-  ///   For example, "family" emoji are created by joining sequences of man,
-  ///   woman, and child emoji with the zero width joiner.
+  ///   For example, the various "family" emoji are encoded as sequences of man,
+  ///   woman, or child emoji that are interleaved with zero width joiners.
   ///
   /// This property corresponds to the `Join_Control` property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
@@ -519,8 +519,8 @@ extension Unicode.Scalar.Properties {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_CASE_IGNORABLE)
   }
 
-  /// A Boolean property indicating whether the scalar is one whose normalized
-  /// form is not stable under a `toLowercase` mapping.
+  /// A Boolean property indicating whether the scalar's `lowercaseMapping`
+  /// differs from the NFD normalized form of the scalar itself.
   ///
   /// This property corresponds to the `Changes_When_Lowercased` property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
@@ -528,8 +528,8 @@ extension Unicode.Scalar.Properties {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_CHANGES_WHEN_LOWERCASED)
   }
 
-  /// A Boolean property indicating whether the scalar is one whose normalized
-  /// form is not stable under a `toUppercase` mapping.
+  /// A Boolean property indicating whether the scalar's `uppercaseMapping`
+  /// differs from the NFD normalized form of the scalar itself.
   ///
   /// This property corresponds to the `Changes_When_Uppercased` property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
@@ -537,8 +537,8 @@ extension Unicode.Scalar.Properties {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_CHANGES_WHEN_UPPERCASED)
   }
 
-  /// A Boolean property indicating whether the scalar is one whose normalized
-  /// form is not stable under a `toTitlecase` mapping.
+  /// A Boolean property indicating whether the scalar's `titlecaseMapping`
+  /// differs from the NFD normalized form of the scalar itself.
   ///
   /// This property corresponds to the `Changes_When_Titlecased` property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
@@ -546,8 +546,8 @@ extension Unicode.Scalar.Properties {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_CHANGES_WHEN_TITLECASED)
   }
 
-  /// A Boolean property indicating whether the scalar is one whose normalized
-  /// form is not stable under case folding.
+  /// A Boolean property indicating whether the scalar is one that is not
+  /// identical to its case-fold mapping.
   ///
   /// This property corresponds to the `Changes_When_Casefolded` property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
@@ -556,7 +556,7 @@ extension Unicode.Scalar.Properties {
   }
 
   /// A Boolean property indicating whether the scalar may change when it
-  /// undergoes a case mapping.
+  /// undergoes case mapping.
   ///
   /// For any scalar `s`, it holds by definition that
   ///
@@ -752,10 +752,8 @@ extension Unicode.Scalar.Properties {
   /// WITH DOT ABOVE) becomes two scalars (U+0069 LATIN SMALL LETTER I, U+0307
   /// COMBINING DOT ABOVE) when converted to lowercase.
   ///
-  /// This function corresponds to the `Lowercase_Mapping` property in the
+  /// This property corresponds to the `Lowercase_Mapping` property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
-  ///
-  /// - Returns: The lowercase mapping of the scalar.
   public var lowercaseMapping: String {
     return _applyMapping(__swift_stdlib_u_strToLower)
   }
@@ -768,10 +766,8 @@ extension Unicode.Scalar.Properties {
   /// becomes "Fi" (U+0046 LATIN CAPITAL LETTER F, U+0069 LATIN SMALL LETTER I)
   /// when converted to titlecase.
   ///
-  /// This function corresponds to the `Titlecase_Mapping` property in the
+  /// This property corresponds to the `Titlecase_Mapping` property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
-  ///
-  /// - Returns: The titlecase mapping of the scalar.
   public var titlecaseMapping: String {
     return _applyMapping { ptr, cap, src, len, locale, err in
       return __swift_stdlib_u_strToTitle(ptr, cap, src, len, nil, locale, err)
@@ -786,10 +782,8 @@ extension Unicode.Scalar.Properties {
   /// SHARP S) becomes "SS" (U+0053 LATIN CAPITAL LETTER S, U+0053 LATIN CAPITAL
   /// LETTER S) when converted to uppercase.
   ///
-  /// This function corresponds to the `Uppercase_Mapping` property in the
+  /// This property corresponds to the `Uppercase_Mapping` property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
-  ///
-  /// - Returns: The uppercase mapping of the scalar.
   public var uppercaseMapping: String {
     return _applyMapping(__swift_stdlib_u_strToUpper)
   }
@@ -1354,14 +1348,14 @@ extension Unicode.Scalar.Properties {
   /// number.
   ///
   /// ```
-  /// print("X", ("X" as Unicode.Scalar).properties.numericType)
+  /// print("X", ("X" as Unicode.Scalar).properties.numericType ?? "nil")
   /// // Prints "X nil"
-  /// print("4", ("4" as Unicode.Scalar).properties.numericType)
-  /// // Prints "4 Optional(Swift.Unicode.NumericType.decimal)"
-  /// print("\u{2463}", ("\u{2463}" as Unicode.Scalar).properties.numericType)
-  /// // Prints "④ Optional(Swift.Unicode.NumericType.digit)"
-  /// print("\u{2155}", ("\u{2155}" as Unicode.Scalar).properties.numericType)
-  /// // Prints "⅕ Optional(Swift.Unicode.NumericType.numeric)"
+  /// print("4", ("4" as Unicode.Scalar).properties.numericType ?? "nil")
+  /// // Prints "4 decimal"
+  /// print("\u{2463}", ("\u{2463}" as Unicode.Scalar).properties.numericType ?? "nil")
+  /// // Prints "④ digit"
+  /// print("\u{2155}", ("\u{2155}" as Unicode.Scalar).properties.numericType ?? "nil")
+  /// // Prints "⅕ numeric"
   /// ```
   ///
   /// This property corresponds to the `Numeric_Type` property in the
@@ -1375,20 +1369,20 @@ extension Unicode.Scalar.Properties {
 
   /// The numeric value of the scalar.
   ///
-  /// The value of this property is `nil` for scalars that do not represent a
+  /// The value of this property is nil for scalars that do not represent a
   /// number.
   ///
   /// The numeric value of a scalar is represented as a `Double` because some
   /// scalars represent fractions:
   ///
   /// ```
-  /// print("X", ("X" as Unicode.Scalar).properties.numericValue)
-  /// // Prints "X nan"
-  /// print("4", ("4" as Unicode.Scalar).properties.numericValue)
+  /// print("X", ("X" as Unicode.Scalar).properties.numericValue ?? "nil")
+  /// // Prints "X nil"
+  /// print("4", ("4" as Unicode.Scalar).properties.numericValue ?? "nil")
   /// // Prints "4 4.0"
-  /// print("\u{2463}", ("\u{2463}" as Unicode.Scalar).properties.numericValue)
+  /// print("\u{2463}", ("\u{2463}" as Unicode.Scalar).properties.numericValue ?? "nil")
   /// // Prints "④ 4.0"
-  /// print("\u{2155}", ("\u{2155}" as Unicode.Scalar).properties.numericValue)
+  /// print("\u{2155}", ("\u{2155}" as Unicode.Scalar).properties.numericValue ?? "nil")
   /// // Prints "⅕ 0.2"
   /// ```
   ///

--- a/stdlib/public/core/UnicodeScalarProperties.swift
+++ b/stdlib/public/core/UnicodeScalarProperties.swift
@@ -519,8 +519,8 @@ extension Unicode.Scalar.Properties {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_CASE_IGNORABLE)
   }
 
-  /// A Boolean property indicating whether the scalar's `lowercaseMapping`
-  /// differs from the NFD normalized form of the scalar itself.
+  /// A Boolean property indicating whether the scalar's normalized form differs
+  /// from the `lowercaseMapping` of each constituent scalar.
   ///
   /// This property corresponds to the `Changes_When_Lowercased` property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
@@ -528,8 +528,8 @@ extension Unicode.Scalar.Properties {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_CHANGES_WHEN_LOWERCASED)
   }
 
-  /// A Boolean property indicating whether the scalar's `uppercaseMapping`
-  /// differs from the NFD normalized form of the scalar itself.
+  /// A Boolean property indicating whether the scalar's normalized form differs
+  /// from the `uppercaseMapping` of each constituent scalar.
   ///
   /// This property corresponds to the `Changes_When_Uppercased` property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
@@ -537,8 +537,8 @@ extension Unicode.Scalar.Properties {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_CHANGES_WHEN_UPPERCASED)
   }
 
-  /// A Boolean property indicating whether the scalar's `titlecaseMapping`
-  /// differs from the NFD normalized form of the scalar itself.
+  /// A Boolean property indicating whether the scalar's normalized form differs
+  /// from the `titlecaseMapping` of each constituent scalar.
   ///
   /// This property corresponds to the `Changes_When_Titlecased` property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
@@ -546,8 +546,8 @@ extension Unicode.Scalar.Properties {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_CHANGES_WHEN_TITLECASED)
   }
 
-  /// A Boolean property indicating whether the scalar is one that is not
-  /// identical to its case-fold mapping.
+  /// A Boolean property indicating whether the scalar's normalized form differs
+  /// from the case-fold mapping of each constituent scalar.
   ///
   /// This property corresponds to the `Changes_When_Casefolded` property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).


### PR DESCRIPTION
Non-functional cleanup/improvements missed after changes in the initial implementation PR:

* Updated the description of family emoji to be less "nuclear"
* Reference the Swift string properties `*caseMapping` instead of the Unicode transforms `to*case` in the descriptions of the Boolean `changesWhen*cased` properties (this change is still consistent with the definitions of those transforms)
* Remove `- Returns:` sections from the case mapping properties now that they're properties instead of functions
* Update description of `numericValue` to return nil instead of `nan`
* Update the code examples in `numeric{Type,Value}` with slightly cleaner output

ping: @milseman