### PR TITLE
[caller-analysis] Improve memory usage of FunctionInfo structs by usi…

### DIFF
--- a/include/swift/SILOptimizer/Analysis/CallerAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/CallerAnalysis.h
@@ -132,7 +132,8 @@ class CallerAnalysis::FunctionInfo {
   friend class CallerAnalysis;
 
   /// A list of all the functions this function calls or partially applies.
-  llvm::SetVector<SILFunction *> Callees;
+  llvm::SmallSetVector<SILFunction *, 4> Callees;
+
   /// A list of all the callers this function has.
   llvm::SmallSet<SILFunction *, 4> Callers;
 
@@ -143,7 +144,7 @@ class CallerAnalysis::FunctionInfo {
   /// function.
   /// This is a little bit off-topic because a partial_apply is not really
   /// a "call" of this function.
-  llvm::DenseMap<SILFunction *, int> PartialAppliers;
+  llvm::SmallMapVector<SILFunction *, int, 1> PartialAppliers;
 
 public:
   /// Returns true if this function has at least one caller.


### PR DESCRIPTION
…ng small data structures instead of large.

This converts a DenseMap to a SmallMapVector and a SetVector to a
SmallSetVector. Both of these create large malloced data structures by
default. This really makes no sense when there are many functions that don't use
a partial apply or many applies.

Additionally, by changing the DenseMap to a MapVector container, this commit is
eliminating a potential source of non-determinism in the compiler since often
times we are iterating over the DenseMap to produce the results. Today all of
the usages of the DenseMap in this way are safe, but to defensively future proof
this analysis, it makes sense to use a MapVector here.
