### PR TITLE
[4.2] SILGen: When transforming to AnyHashable materialize the value in a temporary

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -599,8 +599,10 @@ ManagedValue Transform::transform(ManagedValue v,
         KnownProtocolKind::Hashable);
     auto conformance = SGF.SGM.M.getSwiftModule()->lookupConformance(
         inputSubstType, protocol);
-    auto result = SGF.emitAnyHashableErasure(Loc, v, inputSubstType,
-                                             *conformance, ctxt);
+    auto addr = v.getType().isAddress() ? v : v.materialize(SGF, Loc);
+    auto result = SGF.emitAnyHashableErasure(Loc, addr,
+                                             inputSubstType, *conformance,
+                                             ctxt);
     if (result.isInContext())
       return ManagedValue::forInContext();
     return std::move(result).getAsSingleValue(SGF, Loc);

--- a/test/SILGen/function_conversion.swift
+++ b/test/SILGen/function_conversion.swift
@@ -665,3 +665,21 @@ struct FunctionConversionParameterSubstToOrigReabstractionTest {
     return Foo<Klass>.enum1Func(SelfTy.bar)
   }
 }
+
+// CHECK: sil {{.*}} @$SS4SIgggoo_S2Ss11AnyHashableVyps5Error_pIegggrrzo_TR
+// CHECK:  [[TUPLE:%.*]] = apply %4(%2, %3) : $@noescape @callee_guaranteed (@guaranteed String, @guaranteed String) -> (@owned String, @owned String)
+// CHECK:  [[BORROW:%.*]] = begin_borrow [[TUPLE]] : $(String, String)
+// CHECK:  [[FRST:%.*]] = tuple_extract [[BORROW]] : $(String, String), 0
+// CHECK:  [[COPY1:%.*]] = copy_value [[FRST]] : $String
+// CHECK:  [[SND:%.*]] = tuple_extract [[BORROW]] : $(String, String), 1
+// CHECK:  [[COPY2:%.*]] = copy_value [[SND]] : $String
+// CHECK:  end_borrow [[BORROW]] from [[TUPLE]] : $(String, String), $(String, String)
+// CHECK:  destroy_value [[TUPLE]] : $(String, String)
+// CHECK:  [[ADDR:%.*]] = alloc_stack $String
+// CHECK:  store [[COPY1]] to [init] [[ADDR]] : $*String
+// CHECK:  [[CVT:%.*]] = function_ref @$Ss21_convertToAnyHashableys0cD0VxSHRzlF : $@convention(thin) <τ_0_0 where τ_0_0 : Hashable> (@in_guaranteed τ_0_0) -> @out AnyHashable
+// CHECK:  apply [[CVT]]<String>(%0, [[ADDR]])
+func dontCrash() {
+  let userInfo = ["hello": "world"]
+  let d = [AnyHashable: Any](uniqueKeysWithValues: userInfo.map { ($0.key, $0.value) })
+}


### PR DESCRIPTION

emitAnyHashable expects an address value.

Cherry-pick from #17928.

Explanation: When transforming values to AnyHashable we sometimes (e.g
tuples of strings) omit converting the value to an address type by
storing it to the stack leading to a compiler crash.
The fix is to store the value to the stack if it is not already
available as an in memory value.

Scope: Affects only conversions to AnyHashable. The code seems to stem
from 2016.

Risk: Low. Code is added that checks that the value expected by
emitAnyHashable is already in memory if it is not we store it to memory.

Testing: A Swift CI test was added.

rdar://40583597