### PR TITLE
[4.2][CodeComplete] Fix crasher when completing inout IUO variable

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1961,17 +1961,13 @@ public:
     // lookups is IUO, not Optional as it is for the @optional attribute.
     if (dynamicOrOptional) {
       T = T->getOptionalObjectType();
-      suffix = "!?";
-    } else {
-      suffix = "!";
+      suffix = "?";
     }
 
-    Type ObjectType = T->getReferenceStorageReferent()->getOptionalObjectType();
-
-    if (ObjectType->isVoid())
-      Builder.addTypeAnnotation("Void" + suffix);
-    else
-      Builder.addTypeAnnotation(ObjectType.getStringAsComponent() + suffix);
+    T = T->getReferenceStorageReferent();
+    PrintOptions PO;
+    PO.PrintOptionalAsImplicitlyUnwrapped = true;
+    Builder.addTypeAnnotation(T.getString(PO) + suffix);
   }
 
   /// For printing in code completion results, replace archetypes with

--- a/test/IDE/complete_crashes.swift
+++ b/test/IDE/complete_crashes.swift
@@ -295,3 +295,20 @@ func test_28188259(x: ((Int) -> Void) -> Void) {
 // RDAR_28188259: Begin completions
 // RDAR_28188259-DAG: Pattern/CurrModule:                 ({#_#})[#Void#]; name=(_)
 // RDAR_28188259: End completions
+
+// rdar://problem/40956846
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=RDAR_40956846 -source-filename=%s | %FileCheck %s -check-prefix=RDAR_40956846
+func test_40956846(
+  arg_40956846_1: inout Int!,
+  arg_40956846_2: Void!,
+  arg_40956846_3: (() -> Int)!,
+  arg_40956846_4: inout ((Int) -> Int)!
+) {
+  let y = #^RDAR_40956846^#
+}
+// RDAR_40956846: Begin completions
+// RDAR_40956846-DAG: Decl[LocalVar]/Local:               arg_40956846_1[#inout Int!#]; name=arg_40956846_1
+// RDAR_40956846-DAG: Decl[LocalVar]/Local:               arg_40956846_2[#Void!#]; name=arg_40956846_2
+// RDAR_40956846-DAG: Decl[LocalVar]/Local:               arg_40956846_3[#(() -> Int)!#]; name=arg_40956846_3
+// RDAR_40956846-DAG: Decl[LocalVar]/Local:               arg_40956846_4[#inout ((Int) -> Int)!#]; name=arg_40956846_4
+// RDAR_40956846: End completions


### PR DESCRIPTION
Cherry-pick of #17926 reviewed by @rudkx 

- **Explaination**: When code-completion tries to complete values, it annotates them with their types. Previously when completing `inout` arguments with IUO type, it used to crash. That was because there's wrong assumption that IUO types are always `OptionalType`. However, for `inout` case, it's actually a `InOutType` with underlying `OptionalType`. In this change, use `ASTPrinter` facility which correctly handles such case.
- **Scope**: Affects completing `inout` values with IUO. e.g. `func fn(arg: inout Int!) { ... }`
- **Issue**: rdar://problem/40956846
- **Risk**: Low. `ASTPrinter`'s type printing is well tested.
- **Testing**: Added regression test cases.
- **Reviewed By**: Mark Lacey (https://github.com/apple/swift/pull/17926)


