### PR TITLE
[DNM] [stdlib] Implement string case-folding and normalization APIs

### DIFF
--- a/stdlib/public/SwiftShims/UnicodeShims.h
+++ b/stdlib/public/SwiftShims/UnicodeShims.h
@@ -425,6 +425,13 @@ typedef enum __swift_stdlib_UCharNameChoice {
 #endif
 } __swift_stdlib_UCharNameChoice;
 
+typedef enum __swift_stdlib_UNormalization2Mode {
+  __swift_stdlib_UNORM2_COMPOSE,
+  __swift_stdlib_UNORM2_DECOMPOSE,
+  __swift_stdlib_UNORM2_FCD,
+  __swift_stdlib_UNORM2_COMPOSE_CONTIGUOUS
+} __swift_stdlib_UNormalization2Mode;
+
 typedef enum __swift_stdlib_UNumericType {
   __swift_stdlib_U_NT_NONE,
   __swift_stdlib_U_NT_DECIMAL,
@@ -501,7 +508,31 @@ __swift_stdlib_unorm2_hasBoundaryBefore(const __swift_stdlib_UNormalizer2 *,
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
 const __swift_stdlib_UNormalizer2 *
+__swift_stdlib_unorm2_getNFDInstance(__swift_stdlib_UErrorCode *);
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+const __swift_stdlib_UNormalizer2 *
 __swift_stdlib_unorm2_getNFCInstance(__swift_stdlib_UErrorCode *);
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+const __swift_stdlib_UNormalizer2 *
+__swift_stdlib_unorm2_getNFKDInstance(__swift_stdlib_UErrorCode *);
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+const __swift_stdlib_UNormalizer2 *
+__swift_stdlib_unorm2_getNFKCInstance(__swift_stdlib_UErrorCode *);
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+const __swift_stdlib_UNormalizer2 *
+__swift_stdlib_unorm2_getNFKCCasefoldInstance(__swift_stdlib_UErrorCode *);
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+const __swift_stdlib_UNormalizer2 *
+__swift_stdlib_unorm2_getFCDInstance(__swift_stdlib_UErrorCode *);
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+const __swift_stdlib_UNormalizer2 *
+__swift_stdlib_unorm2_getFCCInstance(__swift_stdlib_UErrorCode *);
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
 __swift_int32_t

--- a/stdlib/public/SwiftShims/UnicodeShims.h
+++ b/stdlib/public/SwiftShims/UnicodeShims.h
@@ -72,6 +72,11 @@ __swift_int32_t _swift_stdlib_unicode_strToLower(
   __swift_uint16_t *Destination, __swift_int32_t DestinationCapacity,
   const __swift_uint16_t *Source, __swift_int32_t SourceLength);
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
+__swift_int32_t _swift_stdlib_unicode_strFoldCase(
+  __swift_uint16_t *Destination, __swift_int32_t DestinationCapacity,
+  const __swift_uint16_t *Source, __swift_int32_t SourceLength);
+
 typedef enum __swift_stdlib_UProperty {
   __swift_stdlib_UCHAR_ALPHABETIC = 0,
   __swift_stdlib_UCHAR_BINARY_START = __swift_stdlib_UCHAR_ALPHABETIC,

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -1199,6 +1199,37 @@ internal func _nativeUnicodeUppercaseString(_ str: String) -> String {
 }
 #endif
 
+@usableFromInline // FIXME(sil-serialize-all)
+internal func _nativeUnicodeCaseFoldString(_ str: String) -> String {
+
+  // TODO (TODO: JIRA): check for small
+
+  let guts = str._guts._extractContiguousUTF16()
+  defer { _fixLifetime(guts) }
+  let utf16 = guts._unmanagedUTF16View
+  var storage = _SwiftStringStorage<UTF16.CodeUnit>.create(
+    capacity: utf16.count,
+    count: utf16.count)
+
+  // Try to write it out to the same length.
+  let z = _swift_stdlib_unicode_strFoldCase(
+    storage.start, Int32(storage.capacity), // FIXME: handle overflow case
+    utf16.start, Int32(utf16.count))
+  let correctSize = Int(z)
+
+  // If more space is needed, do it again with the correct buffer size.
+  if correctSize > storage.capacity {
+    storage = _SwiftStringStorage<UTF16.CodeUnit>.create(
+      capacity: correctSize,
+      count: correctSize)
+    _swift_stdlib_unicode_strFoldCase(
+      storage.start, Int32(storage.capacity), // FIXME: handle overflow case
+      utf16.start, Int32(utf16.count))
+  }
+  storage.count = correctSize
+  return String(_largeStorage: storage)
+}
+
 // Unicode algorithms
 extension String {
   // FIXME: implement case folding without relying on Foundation.
@@ -1306,6 +1337,44 @@ extension String {
 #else
     return _nativeUnicodeUppercaseString(self)
 #endif
+  }
+
+  /// Returns a case-folded version of the string using locale-independent
+  /// default case folding.
+  ///
+  /// The main purpose of case folding is to support caseless string matching.
+  /// Although it's related to and based on case conversion operations, case
+  /// folding is language-neutral and omits context-sensitive mappings.
+  /// Therefore, it's not suitable for transforming natural language text for
+  /// human consumption.
+  ///
+  /// Most characters are mapped to their lowercase counterparts. However, a
+  /// case-folded string is not necessarily lowercase. For example, Cherokee
+  /// letters are case-folded to their uppercase counterparts.
+  ///
+  /// - Note: Case folding does not preserve Unicode normalization forms.
+  ///
+  /// - Returns: A case-folded copy of the string.
+  ///
+  /// - Complexity: O(*n*)
+  public func caseFolded() -> String {
+    if _guts.isASCII {
+      var guts = _guts
+      guts.withMutableASCIIStorage(unusedCapacity: 0) { storage in
+        for i in 0..<storage._value.count {
+          // See the comment above in lowercased.
+          let value = storage._value.start[i]
+          let isUpper =
+            _asciiUpperCaseTable &>>
+            UInt64(((value &- 1) & 0b0111_1111) &>> 1)
+          let add = (isUpper & 0x1) &<< 5
+          storage._value.start[i] = value &+ UInt8(truncatingIfNeeded: add)
+        }
+      }
+      return String(guts)
+    }
+
+    return _nativeUnicodeCaseFoldString(self)
   }
 
   /// Creates an instance from the description of a given

--- a/stdlib/public/core/StringNormalization.swift
+++ b/stdlib/public/core/StringNormalization.swift
@@ -12,62 +12,163 @@
 
 import SwiftShims
 
-// A namespace for various heuristics
-//
+extension Unicode {
+  /// A normalization form for strings.
+  /* non-frozen */ public enum NormalizationForm {
+    /// Unicode normalization form D (canonical decomposition).
+    case nfd
+
+    /// Unicode normalization form C (canonical decomposition followed by
+    /// canonical composition).
+    case nfc
+
+    /// Unicode normalization form KD (compatibility decomposition).
+    case nfkd
+
+    /// Unicode normalization form KC (compatibility decomposition followed by
+    /// canonical composition).
+    case nfkc
+
+    /// Unicode normalization form KC (compatibility decomposition followed by
+    /// canonical composition) with case-folding.
+    ///
+    /// This algorithm is formalized by the Unicode standard. The expression
+    /// `str.normalized(.nfkc).caseFolded().normalized(.nfkc)` approximates, but
+    /// is not always identical to, `str.normalized(.nfkcCaseFold)`.
+    case nfkcCaseFold
+
+    /// "Fast C or D" (FCD) form, as described in Unicode Technical Note #5.
+    ///
+    /// FCD does not describe a unique form: two canonically equivalent strings
+    /// normalized using this algorithm can be non-identical. All NFD strings
+    /// and most NFC strings fulfill the conditions of FCD form.
+    case fcd
+
+    /// "Fast C Contiguous" (FCC) form, as described in Unicode Technical Note
+    /// #5.
+    ///
+    /// This algorithm is a modification of the NFC algorithm that eliminates
+    /// discontiguous composition. For most strings, the FCC and NFC forms are
+    /// identical.
+    case fcc
+  }
+}
+
+// An internal namespace for various normalization heuristics.
 internal enum _Normalization {
-  // ICU's NFC unorm2 instance
-  internal static var _nfcNormalizer: OpaquePointer = {
+  // ICU's NFD unorm2 instance.
+  internal static var _nfdNormalizer: OpaquePointer = {
     var err = __swift_stdlib_U_ZERO_ERROR
-    let normalizer = __swift_stdlib_unorm2_getNFCInstance(&err)
+    let normalizer = __swift_stdlib_unorm2_getNFDInstance(&err)
     guard err.isSuccess else {
       // This shouldn't be possible unless some deep (unrecoverable) system
-      // invariants are violated
+      // invariants are violated.
       fatalError("Unable to talk to ICU")
     }
     return normalizer
   }()
 
+  // ICU's NFC unorm2 instance.
+  internal static var _nfcNormalizer: OpaquePointer = {
+    var err = __swift_stdlib_U_ZERO_ERROR
+    let normalizer = __swift_stdlib_unorm2_getNFCInstance(&err)
+    guard err.isSuccess else { fatalError("Unable to talk to ICU") }
+    return normalizer
+  }()
+
+  // ICU's NFKD unorm2 instance.
+  internal static var _nfkdNormalizer: OpaquePointer = {
+    var err = __swift_stdlib_U_ZERO_ERROR
+    let normalizer = __swift_stdlib_unorm2_getNFKDInstance(&err)
+    guard err.isSuccess else { fatalError("Unable to talk to ICU") }
+    return normalizer
+  }()
+
+  // ICU's NFKC unorm2 instance.
+  internal static var _nfkcNormalizer: OpaquePointer = {
+    var err = __swift_stdlib_U_ZERO_ERROR
+    let normalizer = __swift_stdlib_unorm2_getNFKCInstance(&err)
+    guard err.isSuccess else { fatalError("Unable to talk to ICU") }
+    return normalizer
+  }()
+
+  // ICU's NFKCCasefold unorm2 instance.
+  internal static var _nfkcCasefoldNormalizer: OpaquePointer = {
+    var err = __swift_stdlib_U_ZERO_ERROR
+    let normalizer = __swift_stdlib_unorm2_getNFKCCasefoldInstance(&err)
+    guard err.isSuccess else { fatalError("Unable to talk to ICU") }
+    return normalizer
+  }()
+
+    // ICU's FCD unorm2 instance.
+  internal static var _fcdNormalizer: OpaquePointer = {
+    var err = __swift_stdlib_U_ZERO_ERROR
+    let normalizer = __swift_stdlib_unorm2_getFCDInstance(&err)
+    guard err.isSuccess else { fatalError("Unable to talk to ICU") }
+    return normalizer
+  }()
+
+  // ICU's FCC unorm2 instance.
+  internal static var _fccNormalizer: OpaquePointer = {
+    var err = __swift_stdlib_U_ZERO_ERROR
+    let normalizer = __swift_stdlib_unorm2_getFCCInstance(&err)
+    guard err.isSuccess else { fatalError("Unable to talk to ICU") }
+    return normalizer
+  }()
+
   // Whether this buffer of code units satisfies the quickCheck=YES property for
-  // normality checking under NFC.
+  // normality checking.
   //
   // ICU provides a quickCheck, which may yield "YES", "NO", or "MAYBE". YES
-  // means that the string was determined to definitely be normal under NFC. In
-  // practice, the majority of Strings have this property. Checking for YES is
+  // means that the string was determined to be definitely normal. In practice,
+  // the majority of strings have this property. Checking for YES is
   // considerably faster than trying to distinguish between NO and MAYBE.
   internal static func _prenormalQuickCheckYes(
+    normalizer: OpaquePointer = _Normalization._nfcNormalizer,
     _ buffer: UnsafeBufferPointer<UInt16>
   ) -> Bool {
     var err = __swift_stdlib_U_ZERO_ERROR
     let length = __swift_stdlib_unorm2_spanQuickCheckYes(
-      _Normalization._nfcNormalizer,
-      buffer.baseAddress._unsafelyUnwrappedUnchecked,
-      Int32(buffer.count),
-      &err)
+      normalizer, buffer.baseAddress._unsafelyUnwrappedUnchecked,
+      Int32(buffer.count), &err)
 
     guard err.isSuccess else {
       // This shouldn't be possible unless some deep (unrecoverable) system
-      // invariants are violated
+      // invariants are violated.
       fatalError("Unable to talk to ICU")
     }
     return length == buffer.count
   }
+
   internal static func _prenormalQuickCheckYes(
+    normalizer: OpaquePointer = _Normalization._nfcNormalizer,
     _ string: _UnmanagedString<UInt16>
   ) -> Bool {
     var err = __swift_stdlib_U_ZERO_ERROR
     let length = __swift_stdlib_unorm2_spanQuickCheckYes(
-      _Normalization._nfcNormalizer,
-      string.start,
-      Int32(string.count),
-      &err)
+      normalizer, string.start, Int32(string.count), &err)
 
     guard err.isSuccess else {
       // This shouldn't be possible unless some deep (unrecoverable) system
-      // invariants are violated
+      // invariants are violated.
       fatalError("Unable to talk to ICU")
     }
     return length == string.count
   }
+}
+
+extension _Normalization {
+  // When normalized in NFC, some segments may expand in size (e.g. some non-BMP
+  // musical notes). This expansion is capped by the maximum expansion factor of
+  // the normal form. For NFC, that is 3x.
+  //
+  // See <https://unicode.org/faq/normalization.html#12>.
+  internal static let _maxNFCExpansionFactor = 3
+
+  // A small output buffer to use for normalizing a single normalization
+  // segment. Fits all but pathological arbitrary-length segments (i.e. zalgo-
+  // segments).
+  internal typealias _SegmentOutputBuffer = _FixedArray16<UInt16>
 }
 
 extension UnicodeScalar {
@@ -88,16 +189,4 @@ extension UnicodeScalar {
     return 0 != __swift_stdlib_unorm2_hasBoundaryBefore(
       _Normalization._nfcNormalizer, value)
   }
-}
-
-extension _Normalization {
-  // When normalized in NFC, some segments may expand in size (e.g. some non-BMP
-  // musical notes). This expansion is capped by the maximum expansion factor of
-  // the normal form. For NFC, that is 3x.
-  internal static let _maxNFCExpansionFactor = 3
-
-  // A small output buffer to use for normalizing a single normalization
-  // segment. Fits all but pathological arbitrary-length segments (i.e. zalgo-
-  // segments)
-  internal typealias _SegmentOutputBuffer = _FixedArray16<UInt16>
 }

--- a/stdlib/public/core/StringProtocol.swift
+++ b/stdlib/public/core/StringProtocol.swift
@@ -39,6 +39,7 @@ public protocol StringProtocol
 
   func lowercased() -> String
   func uppercased() -> String
+  func caseFolded() -> String
 
   /// Creates a string from the given Unicode code units in the specified
   /// encoding.

--- a/stdlib/public/core/StringProtocol.swift
+++ b/stdlib/public/core/StringProtocol.swift
@@ -40,6 +40,7 @@ public protocol StringProtocol
   func lowercased() -> String
   func uppercased() -> String
   func caseFolded() -> String
+  func normalized(_ form: Unicode.NormalizationForm) -> String
 
   /// Creates a string from the given Unicode code units in the specified
   /// encoding.

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -557,6 +557,11 @@ extension Substring {
   }
 
   @inlinable // FIXME(sil-serialize-all)
+  public func caseFolded() -> String {
+    return String(self).caseFolded()
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
   public func filter(
     _ isIncluded: (Element) throws -> Bool
   ) rethrows -> String {

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -562,6 +562,11 @@ extension Substring {
   }
 
   @inlinable // FIXME(sil-serialize-all)
+  public func normalized(_ form: Unicode.NormalizationForm) -> String {
+    return String(self).normalized(form)
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
   public func filter(
     _ isIncluded: (Element) throws -> Bool
   ) rethrows -> String {

--- a/stdlib/public/stubs/UnicodeNormalization.cpp
+++ b/stdlib/public/stubs/UnicodeNormalization.cpp
@@ -41,7 +41,6 @@ typedef int32_t UChar32;
 typedef int8_t UBool;
 typedef swift::__swift_stdlib_UProperty UProperty;
 typedef swift::__swift_stdlib_UErrorCode UErrorCode;
-#define U_FAILURE(x) ((x)>__swift_stdlib_U_ZERO_ERROR)
 
 #define U_MAX_VERSION_LENGTH 4
 typedef uint8_t UVersionInfo[U_MAX_VERSION_LENGTH];
@@ -82,7 +81,6 @@ int32_t u_strToTitle(UChar *, int32_t, const UChar *, int32_t,
                      UBreakIterator *, const char *, UErrorCode *);
 int32_t u_strToUpper(UChar *, int32_t, const UChar *, int32_t, const char *,
                      UErrorCode *);
-#define U_FOLD_CASE_DEFAULT 0
 int32_t u_strFoldCase(UChar *, int32_t, const UChar *, int32_t, uint32_t,
                       UErrorCode *);
 double u_getNumericValue(UChar32);
@@ -125,7 +123,7 @@ swift::_swift_stdlib_unicode_strToUpper(uint16_t *Destination,
                                        SourceLength,
                                        "", &ErrorCode);
   if (U_FAILURE(ErrorCode) && ErrorCode != U_BUFFER_OVERFLOW_ERROR) {
-    swift::crash("u_strToUpper: Unexpected error uppercasing unicode string.");
+    swift::crash("u_strToUpper: Unexpected error uppercasing Unicode string.");
   }
   return OutputLength;
 }
@@ -146,7 +144,7 @@ swift::_swift_stdlib_unicode_strToLower(uint16_t *Destination,
                                        SourceLength,
                                        "", &ErrorCode);
   if (U_FAILURE(ErrorCode) && ErrorCode != U_BUFFER_OVERFLOW_ERROR) {
-    swift::crash("u_strToLower: Unexpected error lowercasing unicode string.");
+    swift::crash("u_strToLower: Unexpected error lowercasing Unicode string.");
   }
   return OutputLength;
 }
@@ -166,10 +164,11 @@ swift::_swift_stdlib_unicode_strFoldCase(uint16_t *Destination,
                                         DestinationCapacity,
                                         reinterpret_cast<const UChar *>(Source),
                                         SourceLength,
-                                        U_FOLD_CASE_DEFAULT, &ErrorCode);
-  if (U_FAILURE(ErrorCode) && ErrorCode !=
-      static_cast<UErrorCode>(__swift_stdlib_U_BUFFER_OVERFLOW_ERROR)) {
-    swift::crash("u_strFoldCase: Unexpected error case-folding unicode string.");
+                                        0, &ErrorCode);
+  if (ErrorCode > static_cast<UErrorCode>(__swift_stdlib_U_ZERO_ERROR) &&
+      ErrorCode !=
+          static_cast<UErrorCode>(__swift_stdlib_U_BUFFER_OVERFLOW_ERROR)) {
+    swift::crash("u_strFoldCase: Unexpected error case-folding Unicode string.");
   }
   return OutputLength;
 }

--- a/stdlib/public/stubs/UnicodeNormalization.cpp
+++ b/stdlib/public/stubs/UnicodeNormalization.cpp
@@ -34,13 +34,14 @@ typedef struct UBreakIterator UBreakIterator;
 typedef struct UText UText;
 typedef struct UBreakIterator UNormalizer2;
 typedef enum UBreakIteratorType {} UBreakIteratorType;
-typedef swift::__swift_stdlib_UErrorCode UErrorCode;
-#define U_FAILURE(x) ((x)>__swift_stdlib_U_ZERO_ERROR)
 typedef enum UCharNameChoice {} UCharNameChoice;
+typedef enum UNormalization2Mode {} UNormalization2Mode;
 typedef uint16_t UChar;
 typedef int32_t UChar32;
 typedef int8_t UBool;
 typedef swift::__swift_stdlib_UProperty UProperty;
+typedef swift::__swift_stdlib_UErrorCode UErrorCode;
+#define U_FAILURE(x) ((x)>__swift_stdlib_U_ZERO_ERROR)
 
 #define U_MAX_VERSION_LENGTH 4
 typedef uint8_t UVersionInfo[U_MAX_VERSION_LENGTH];
@@ -62,7 +63,14 @@ int32_t unorm2_spanQuickCheckYes(const UNormalizer2 *, const UChar *, int32_t,
                                  UErrorCode *);
 int32_t unorm2_normalize(const UNormalizer2 *, const UChar *, int32_t, UChar *,
                          int32_t, UErrorCode *);
+const UNormalizer2 *unorm2_getNFDInstance(UErrorCode *);
 const UNormalizer2 *unorm2_getNFCInstance(UErrorCode *);
+const UNormalizer2 *unorm2_getNFKDInstance(UErrorCode *);
+const UNormalizer2 *unorm2_getNFKCInstance(UErrorCode *);
+const UNormalizer2 *unorm2_getNFKCCasefoldInstance(UErrorCode *);
+const UNormalizer2 *unorm2_getInstance(const char *, const char *,
+                                       UNormalization2Mode, UErrorCode *);
+
 UBool unorm2_hasBoundaryBefore(const UNormalizer2 *norm2, UChar32 c);
 UBool u_hasBinaryProperty(UChar32, UProperty);
 void u_charAge(UChar32, UVersionInfo);
@@ -91,6 +99,7 @@ double u_getNumericValue(UChar32);
 #include <unicode/uiter.h>
 #include <unicode/ubrk.h>
 #include <unicode/uchar.h>
+#include <unicode/unorm2.h>
 #include <unicode/ustring.h>
 #include <unicode/uvernum.h>
 #include <unicode/uversion.h>
@@ -238,10 +247,53 @@ swift::__swift_stdlib_UBool swift::__swift_stdlib_unorm2_hasBoundaryBefore(
     const __swift_stdlib_UNormalizer2 *ptr, __swift_stdlib_UChar32 char32) {
   return unorm2_hasBoundaryBefore(ptr_cast<UNormalizer2>(ptr), char32);
 }
+
+const swift::__swift_stdlib_UNormalizer2 *
+swift::__swift_stdlib_unorm2_getNFDInstance(__swift_stdlib_UErrorCode *err) {
+  return ptr_cast<__swift_stdlib_UNormalizer2>(
+      unorm2_getNFDInstance(ptr_cast<UErrorCode>(err)));
+}
+
 const swift::__swift_stdlib_UNormalizer2 *
 swift::__swift_stdlib_unorm2_getNFCInstance(__swift_stdlib_UErrorCode *err) {
   return ptr_cast<__swift_stdlib_UNormalizer2>(
       unorm2_getNFCInstance(ptr_cast<UErrorCode>(err)));
+}
+
+const swift::__swift_stdlib_UNormalizer2 *
+swift::__swift_stdlib_unorm2_getNFKDInstance(__swift_stdlib_UErrorCode *err) {
+  return ptr_cast<__swift_stdlib_UNormalizer2>(
+      unorm2_getNFKDInstance(ptr_cast<UErrorCode>(err)));
+}
+
+const swift::__swift_stdlib_UNormalizer2 *
+swift::__swift_stdlib_unorm2_getNFKCInstance(__swift_stdlib_UErrorCode *err) {
+  return ptr_cast<__swift_stdlib_UNormalizer2>(
+      unorm2_getNFKCInstance(ptr_cast<UErrorCode>(err)));
+}
+
+const swift::__swift_stdlib_UNormalizer2 *
+swift::__swift_stdlib_unorm2_getNFKCCasefoldInstance(
+                                               __swift_stdlib_UErrorCode *err) {
+  return ptr_cast<__swift_stdlib_UNormalizer2>(
+      unorm2_getNFKCCasefoldInstance(ptr_cast<UErrorCode>(err)));
+}
+
+const swift::__swift_stdlib_UNormalizer2 *
+swift::__swift_stdlib_unorm2_getFCDInstance(__swift_stdlib_UErrorCode *err) {
+  return ptr_cast<__swift_stdlib_UNormalizer2>(
+      unorm2_getInstance(nullptr, "nfc",
+          static_cast<UNormalization2Mode>(__swift_stdlib_UNORM2_FCD),
+          ptr_cast<UErrorCode>(err)));
+}
+
+const swift::__swift_stdlib_UNormalizer2 *
+swift::__swift_stdlib_unorm2_getFCCInstance(__swift_stdlib_UErrorCode *err) {
+  return ptr_cast<__swift_stdlib_UNormalizer2>(
+      unorm2_getInstance(nullptr, "nfc",
+          static_cast<UNormalization2Mode>(
+              __swift_stdlib_UNORM2_COMPOSE_CONTIGUOUS),
+          ptr_cast<UErrorCode>(err)));
 }
 
 int32_t swift::__swift_stdlib_unorm2_normalize(

--- a/test/stdlib/StringCompatibility.swift
+++ b/test/stdlib/StringCompatibility.swift
@@ -142,6 +142,9 @@ extension MyString : StringProtocol {
   func caseFolded() -> String {
     return base.caseFolded()
   }
+  func normalized(_ form: Unicode.NormalizationForm) -> String {
+    return base.normalized(form)
+  }
 
   init<C: Collection, Encoding: Unicode.Encoding>(
     decoding codeUnits: C, as sourceEncoding: Encoding.Type

--- a/test/stdlib/StringCompatibility.swift
+++ b/test/stdlib/StringCompatibility.swift
@@ -139,6 +139,9 @@ extension MyString : StringProtocol {
   func uppercased() -> String {
     return base.uppercased()
   }
+  func caseFolded() -> String {
+    return base.caseFolded()
+  }
 
   init<C: Collection, Encoding: Unicode.Encoding>(
     decoding codeUnits: C, as sourceEncoding: Encoding.Type

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -1263,6 +1263,29 @@ StringTests.test("caseFolded()") {
   expectEqual("ᎠᎡᎢ", "ᎠᎡᎢ".caseFolded())
 }
 
+StringTests.test("normalized(_:)") {
+  // Use setlocale so tolower() is correct on ASCII.
+  setlocale(LC_ALL, "C")
+
+  // Check the ASCII domain.
+  let asciiDomain: [Int32] = Array(0..<128)
+  expectEqualFunctionsForDomain(
+    asciiDomain,
+    { String(UnicodeScalar(Int($0))!) },
+    { String(UnicodeScalar(Int($0))!).normalized(.nfc) })
+  expectEqualFunctionsForDomain(
+    asciiDomain,
+    { String(UnicodeScalar(Int(tolower($0)))!) },
+    { String(UnicodeScalar(Int($0))!).normalized(.nfkcCaseFold) })
+
+  expectEqual("∭", "∭".normalized(.nfd))
+  expectEqual("∭", "∭".normalized(.nfc))
+  expectEqual("∫∫∫", "∭".normalized(.nfkd))
+  expectEqual("∫∫∫", "∭".normalized(.nfkc))
+  expectEqual("∭", "∭".normalized(.fcd))
+  expectEqual("∭", "∭".normalized(.fcc))
+}
+
 StringTests.test("unicodeViews") {
   // Check the UTF views work with slicing
 

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -1243,6 +1243,26 @@ StringTests.test("uppercased()") {
   expectEqual("\u{0046}\u{0049}", "\u{fb01}".uppercased())
 }
 
+StringTests.test("caseFolded()") {
+  // Use setlocale so tolower() is correct on ASCII.
+  setlocale(LC_ALL, "C")
+
+  // Check the ASCII domain.
+  let asciiDomain: [Int32] = Array(0..<128)
+  expectEqualFunctionsForDomain(
+    asciiDomain,
+    { String(UnicodeScalar(Int(tolower($0)))!) },
+    { String(UnicodeScalar(Int($0))!).caseFolded() })
+
+  expectEqual("", "".caseFolded())
+  expectEqual("abcd", "abCD".caseFolded())
+  expectEqual("абвг", "абВГ".caseFolded())
+  expectEqual("たちつてと", "たちつてと".caseFolded())
+
+  // Check Cherokee letters, which are mapped to their uppercase counterparts.
+  expectEqual("ᎠᎡᎢ", "ᎠᎡᎢ".caseFolded())
+}
+
 StringTests.test("unicodeViews") {
   // Check the UTF views work with slicing
 

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -1273,10 +1273,6 @@ StringTests.test("normalized(_:)") {
     asciiDomain,
     { String(UnicodeScalar(Int($0))!) },
     { String(UnicodeScalar(Int($0))!).normalized(.nfc) })
-  expectEqualFunctionsForDomain(
-    asciiDomain,
-    { String(UnicodeScalar(Int(tolower($0)))!) },
-    { String(UnicodeScalar(Int($0))!).normalized(.nfkcCaseFold) })
 
   expectEqual("∭", "∭".normalized(.nfd))
   expectEqual("∭", "∭".normalized(.nfc))


### PR DESCRIPTION
<!-- What's in this pull request? -->
Another contributor made some changes to parse domains properly in cookies. In thinking about that PR, I went down the rabbit hole:

International domains should be punycode-encoded, which is implementable in Swift. But wait! They should first be case-folded, normalized by NFKC, and sanitized in other ways, and we __can't__ do that in Swift without exposing some ICU interfaces.

Exposing such facilities for strings is well precedented in other languages. For example, C#, JavaScript, Perl, and Python all offer Unicode normalization functions.

### Some notes on the design of the proposed API
See the [draft proposal text](https://gist.github.com/xwu/e687ed737d0e22817bc944b7099f8cfb).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
