### PR TITLE
Refactor SILCombiner code for better reuse and extensibility

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -286,10 +286,17 @@ private:
                                               const ConcreteExistentialInfo &CEI,
                                               SILBuilderContext &BuilderCtx);
 
-  SILInstruction *
+  bool
   propagateConcreteTypeOfInitExistential(FullApplySite Apply,
                                          WitnessMethodInst *WMI);
   SILInstruction *propagateConcreteTypeOfInitExistential(FullApplySite Apply);
+
+  // Common utility function to replace the WitnessMethodInst using a
+  // BuilderCtx.
+  void replaceWitnessMethodInst(FullApplySite Apply, WitnessMethodInst *WMI,
+                                SILBuilderContext &BuilderCtx,
+                                const CanType &ConcreteType,
+                                ProtocolConformanceRef &ConformanceRef);
 
   /// Perform one SILCombine iteration.
   bool doOneIteration(SILFunction &F, unsigned Iteration);


### PR DESCRIPTION
This PR refactors SILCombiner code by 
(1) Changing the return type of "propagateConcreteTypeOfInitExistential(FullApplySite Apply, WitnessMethodInst *WMI)" to a boolean instead of "SILInstruction *". Today, the return type is not used anywhere. See https://github.com/apple/swift/pull/17373.
(2) Adding a new method replaceWitnessMethodInst that abstracts out WMI creationfunctionality to a new function. No new new functionality added here.
(3) In function "createApplyWithConcreteType", the condition
"if (CEI.isCopied && !canReplaceCopiedSelf(Apply, CEI.InitExistential, DA))" was changed to
"if (CEI.isCopied && (!CEI.InitExistential ||
                       !canReplaceCopiedSelf(Apply, CEI.InitExistential, DA)))"
in order to handle scenarios where CEI.InitExistential is null. This happens for https://github.com/apple/swift/pull/17373.