### PR TITLE
[Driver] Diagnose -emit-objc-header With Pre-Typechecking Actions

### DIFF
--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -251,6 +251,8 @@ bool FrontendOptions::canActionEmitReferenceDependencies(ActionType action) {
 bool FrontendOptions::canActionEmitObjCHeader(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
+  case ActionType::Parse:
+  case ActionType::ResolveImports:
   case ActionType::DumpParse:
   case ActionType::DumpInterfaceHash:
   case ActionType::DumpAST:
@@ -262,8 +264,6 @@ bool FrontendOptions::canActionEmitObjCHeader(ActionType action) {
   case ActionType::Immediate:
   case ActionType::REPL:
     return false;
-  case ActionType::Parse:
-  case ActionType::ResolveImports:
   case ActionType::Typecheck:
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:

--- a/test/Driver/options.swift
+++ b/test/Driver/options.swift
@@ -39,6 +39,13 @@
 // RUN: not %target-swift-frontend -resolve-imports -emit-reference-dependencies %s 2>&1 | %FileCheck -check-prefix=RESOLVE_IMPORTS_NO_REFERENCE_DEPS %s
 // RESOLVE_IMPORTS_NO_REFERENCE_DEPS: error: this mode does not support emitting reference dependency files{{$}}
 
+// RUN: not %target-swift-frontend -parse -emit-objc-header %s 2>&1 | %FileCheck -check-prefix=PARSE_NO_OBJC_HEADER %s
+// PARSE_NO_OBJC_HEADER: error: this mode does not support emitting Objective-C headers{{$}}
+// RUN: not %target-swift-frontend -dump-ast -emit-objc-header %s 2>&1 | %FileCheck -check-prefix=DUMP_NO_OBJC_HEADER %s
+// DUMP_NO_OBJC_HEADER: error: this mode does not support emitting Objective-C headers{{$}}
+// RUN: not %target-swift-frontend -resolve-imports -emit-objc-header %s 2>&1 | %FileCheck -check-prefix=RESOLVE_IMPORTS_NO_OBJC_HEADER %s
+// RESOLVE_IMPORTS_NO_OBJC_HEADER: error: this mode does not support emitting Objective-C headers{{$}}
+
 // Should not fail with non-zero exit code.
 // RUN: %target-swift-frontend -emit-silgen %S/Inputs/invalid-module-name.swift > /dev/null
 // RUN: %target-swift-frontend -emit-silgen -parse-as-library %S/Inputs/invalid-module-name.swift -module-name foo > /dev/null


### PR DESCRIPTION
Depends on #17645. See the last commit.