### PR TITLE
[test] Don't actually emit a .so for autolink-extract tests

### DIFF
--- a/test/AutolinkExtract/error_no_inputs.swift
+++ b/test/AutolinkExtract/error_no_inputs.swift
@@ -1,4 +1,3 @@
-// RUN: %target-swiftc_driver -c %s -o %t
 // RUN: not %target-swift-autolink-extract 2>&1 | %FileCheck %s
 
 // REQUIRES: autolink-extract

--- a/test/AutolinkExtract/import.swift
+++ b/test/AutolinkExtract/import.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swiftc_driver -emit-library -emit-module -emit-module-path %t/empty.swiftmodule -module-name empty -module-link-name empty %S/empty.swift
+// RUN: %target-swiftc_driver -emit-module -emit-module-path %t/empty.swiftmodule -module-name empty -module-link-name empty %S/empty.swift
 // RUN: %target-swiftc_driver -c %s -I %t -o %t/import_experimental.o
 // RUN: %target-swift-autolink-extract %t/import_experimental.o -o - | %FileCheck --check-prefix CHECK-%target-object-format %s
 

--- a/test/AutolinkExtract/import_archive.swift
+++ b/test/AutolinkExtract/import_archive.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swiftc_driver -emit-library -emit-module -emit-module-path %t/empty.swiftmodule -module-name empty -module-link-name empty %S/empty.swift
+// RUN: %target-swiftc_driver -emit-module -emit-module-path %t/empty.swiftmodule -module-name empty -module-link-name empty %S/empty.swift
 // RUN: %target-swiftc_driver -c %s -I %t -o %t/import_experimental.o
 // RUN: llvm-ar cr %t/import_experimental.a %t/import_experimental.o
 // RUN: %target-swift-autolink-extract %t/import_experimental.a -o - | %FileCheck --check-prefix CHECK-%target-object-format %s


### PR DESCRIPTION
Two tests used -emit-library with the same module name and without an explicit -o path, meaning that the output would go into whatever lit.py was using as its working directory. If the tests ran at exactly the same time, they could contend for the output file. We don't actually use the built library at all in the test, so just drop the -emit-library entirely.

Also, remove an unused compilation step from another test, which just checks what happens when swift-autolink-extract doesn't use any arguments.

rdar://problem/39510413