### PR TITLE
[WIP] Change a few functions related to runtime library paths to use the correct architecture specific path

### DIFF
--- a/include/swift/Driver/ToolChain.h
+++ b/include/swift/Driver/ToolChain.h
@@ -195,6 +195,9 @@ protected:
   /// relative to the compiler.
   void getRuntimeLibraryPath(SmallVectorImpl<char> &runtimeLibPath,
                              const llvm::opt::ArgList &args, bool shared) const;
+  void getRuntimeLibraryPathWithArch(SmallVectorImpl<char> &runtimeLibPath,
+                                     const llvm::opt::ArgList &args,
+                                     bool shared) const;
 
   void addPathEnvironmentVariableIfNeeded(Job::EnvironmentVector &env,
                                           const char *name,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1038,6 +1038,14 @@ void ToolChain::getRuntimeLibraryPath(SmallVectorImpl<char> &runtimeLibPath,
                           getPlatformNameForTriple(getTriple()));
 }
 
+void ToolChain::getRuntimeLibraryPathWithArch(
+    SmallVectorImpl<char> &runtimeLibPath, const llvm::opt::ArgList &args,
+    bool shared) const {
+  getRuntimeLibraryPath(runtimeLibPath, args, shared);
+  llvm::sys::path::append(runtimeLibPath,
+                          swift::getMajorArchitectureName(getTriple()));
+}
+
 bool ToolChain::sanitizerRuntimeLibExists(const ArgList &args,
                                           StringRef sanitizerName,
                                           bool shared) const {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -47,10 +47,15 @@ static void updateRuntimeLibraryPath(SearchPathOptions &SearchPathOpts,
   llvm::SmallString<128> LibPath(SearchPathOpts.RuntimeResourcePath);
 
   llvm::sys::path::append(LibPath, getPlatformNameForTriple(Triple));
-  SearchPathOpts.RuntimeLibraryPath = LibPath.str();
+  if (Triple.isOSDarwin()) {
+    SearchPathOpts.RuntimeLibraryPath = LibPath.str();
+  }
 
   llvm::sys::path::append(LibPath, swift::getMajorArchitectureName(Triple));
   SearchPathOpts.RuntimeLibraryImportPath = LibPath.str();
+  if (!Triple.isOSDarwin()) {
+    SearchPathOpts.RuntimeLibraryPath = LibPath.str();
+  }
 }
 
 void CompilerInvocation::setRuntimeResourcePath(StringRef Path) {

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -157,7 +157,6 @@ if(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "LINUX")
   foreach(arch IN LISTS SWIFT_SDK_LINUX_ARCHITECTURES)
     add_dependencies(static_binary_magic ${swift_image_inspection_${arch}_static})
   endforeach()
-  add_dependencies(static_binary_magic ${swift_image_inspection_static_primary_arch})
 
   add_swift_library(swiftImageInspectionSharedObject OBJECT_LIBRARY TARGET_LIBRARY
     ImageInspectionELF.cpp

--- a/test/Driver/environment.swift
+++ b/test/Driver/environment.swift
@@ -3,5 +3,5 @@
 
 // RUN: %swift_driver -target x86_64-unknown-gnu-linux -L/foo/ -driver-use-frontend-path %S/Inputs/print-var.sh %s LD_LIBRARY_PATH | %FileCheck -check-prefix=CHECK${LD_LIBRARY_PATH+_LAX} %s
 
-// CHECK: {{^/foo/:[^:]+/lib/swift/linux$}}
-// CHECK_LAX: {{^/foo/:[^:]+/lib/swift/linux}}
+// CHECK: {{^/foo/:[^:]+/lib/swift/linux/x86_64$}}
+// CHECK_LAX: {{^/foo/:[^:]+/lib/swift/linux/x86_64}}

--- a/test/Driver/options-interpreter.swift
+++ b/test/Driver/options-interpreter.swift
@@ -18,8 +18,8 @@
 // CHECK-RESOURCE-DIR-ONLY: # DYLD_LIBRARY_PATH=/RSRC/macosx{{$}}
 
 // RUN: %swift_driver -### -target x86_64-unknown-linux-gnu -resource-dir /RSRC/ %s | %FileCheck -check-prefix=CHECK-RESOURCE-DIR-ONLY-LINUX${LD_LIBRARY_PATH+_LAX} %s
-// CHECK-RESOURCE-DIR-ONLY-LINUX: # LD_LIBRARY_PATH=/RSRC/linux{{$}}
-// CHECK-RESOURCE-DIR-ONLY-LINUX_LAX: # LD_LIBRARY_PATH=/RSRC/linux{{$|:}}
+// CHECK-RESOURCE-DIR-ONLY-LINUX: # LD_LIBRARY_PATH=/RSRC/linux/x86_64{{$}}
+// CHECK-RESOURCE-DIR-ONLY-LINUX_LAX: # LD_LIBRARY_PATH=/RSRC/linux/x86_64{{$|:}}
 
 // RUN: %swift_driver -### -target x86_64-apple-macosx10.9 -L/foo/ %s | %FileCheck -check-prefix=CHECK-L %s
 // CHECK-L: # DYLD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/macosx$}}
@@ -59,9 +59,9 @@
 // CHECK-COMPLEX-DAG: DYLD_LIBRARY_PATH={{/foo2/:/bar2/:[^:]+/lib/swift/macosx($| )}}
 
 // RUN: %swift_driver -### -target x86_64-unknown-linux-gnu -L/foo/ %s | %FileCheck -check-prefix=CHECK-L-LINUX${LD_LIBRARY_PATH+_LAX} %s
-// CHECK-L-LINUX: # LD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/linux$}}
-// CHECK-L-LINUX_LAX: # LD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/linux($|:)}}
+// CHECK-L-LINUX: # LD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/linux/x86_64$}}
+// CHECK-L-LINUX_LAX: # LD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/linux/x86_64($|:)}}
 
 // RUN: env LD_LIBRARY_PATH=/abc/ %swift_driver_plain -### -target x86_64-unknown-linux-gnu -L/foo/ -L/bar/ %s | %FileCheck -check-prefix=CHECK-LINUX-COMPLEX${LD_LIBRARY_PATH+_LAX} %s
-// CHECK-LINUX-COMPLEX: # LD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/linux:/abc/$}}
-// CHECK-LINUX-COMPLEX_LAX: # LD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/linux:/abc/($|:)}}
+// CHECK-LINUX-COMPLEX: # LD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/linux/x86_64:/abc/$}}
+// CHECK-LINUX-COMPLEX_LAX: # LD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/linux/x86_64:/abc/($|:)}}

--- a/validation-test/execution/interpret-with-dependencies-linux.swift
+++ b/validation-test/execution/interpret-with-dependencies-linux.swift
@@ -8,9 +8,9 @@
 // CHECK: {{okay}}
 
 // Now test a dependency on a library in the compiler's resource directory.
-// RUN: %empty-directory(%t/rsrc/%target-sdk-name)
-// RUN: ln -s %t/libabc.so %t/rsrc/%target-sdk-name/
-// RUN: ln -s %platform-module-dir/../* %t/rsrc/%target-sdk-name/
+// RUN: %empty-directory(%t/rsrc/%target-sdk-name/%target-cpu)
+// RUN: ln -s %t/libabc.so %t/rsrc/%target-sdk-name/%target-cpu/
+// RUN: ln -s %platform-module-dir/../%target-cpu/* %t/rsrc/%target-sdk-name/%target-cpu
 // RUN: ln -s %platform-module-dir/../../shims %t/rsrc/
 // RUN: %empty-directory(%t/other)
 // RUN: ln -s %t/libfoo.so %t/other


### PR DESCRIPTION
Adjust the runtimeLibPath for the GenerixUnix toolchain to use the
architecture specific path.

Modify the `runtimeLibraryPath` in CompilerInvocation.cpp to use the
architecture specific version for non-Darwin platforms.

Modify a few tests to agree with these changes.