### PR TITLE
[test] Fix the install_name for class_getImageName.swift tests

### DIFF
--- a/test/Interpreter/SDK/class_getImageName-static.swift
+++ b/test/Interpreter/SDK/class_getImageName-static.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -emit-library -o %t/libSimpleNSObjectSubclass.dylib %S/Inputs/SimpleNSObjectSubclass.swift
+// RUN: %target-build-swift -emit-library -o %t/libSimpleNSObjectSubclass.dylib %S/Inputs/SimpleNSObjectSubclass.swift -Xlinker -install_name -Xlinker @executable_path/libSimpleNSObjectSubclass.dylib
 // RUN: %target-codesign %t/libSimpleNSObjectSubclass.dylib
 
 // RUN: %target-build-swift %s -o %t/main -lSimpleNSObjectSubclass -L%t -import-objc-header %S/Inputs/class_getImageName-static-helper.h

--- a/test/Interpreter/SDK/class_getImageName.swift
+++ b/test/Interpreter/SDK/class_getImageName.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -emit-library -o %t/libGetImageNameHelper.dylib -emit-module %S/Inputs/class_getImageName-helper.swift
+// RUN: %target-build-swift -emit-library -o %t/libGetImageNameHelper.dylib -emit-module %S/Inputs/class_getImageName-helper.swift -Xlinker -install_name -Xlinker @executable_path/libGetImageNameHelper.dylib
 // RUN: %target-codesign %t/libGetImageNameHelper.dylib
 
 // RUN: %target-build-swift -g %s -I %t -o %t/main -L %t -lGetImageNameHelper


### PR DESCRIPTION
Important when `%target-run` is not going to run the executable from its current location.

rdar://problem/42184572