### PR TITLE
[stdlib] Factor a couple more universal inits into _Pointer

### DIFF
--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -422,42 +422,13 @@ public struct AutoreleasingUnsafeMutablePointer<Pointee /* TODO : class */>
   /// `self`.
   ///
   /// - Precondition: `self != nil`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // unsafe-performance
   public subscript(i: Int) -> Pointee {
     @_transparent
     get {
       // We can do a strong load normally.
       return (UnsafePointer<Pointee>(self) + i).pointee
     }
-  }
-
-  /// Explicit construction from an UnsafeMutablePointer.
-  ///
-  /// This is inherently unsafe; UnsafeMutablePointer assumes the
-  /// referenced memory has +1 strong ownership semantics, whereas
-  /// AutoreleasingUnsafeMutablePointer implies +0 semantics.
-  ///
-  /// - Warning: Accessing `pointee` as a type that is unrelated to
-  ///   the underlying memory's bound type is undefined.
-  @_transparent
-  public init<U>(_ from: UnsafeMutablePointer<U>) {
-    self._rawValue = from._rawValue
-  }
-
-  /// Explicit construction from an UnsafeMutablePointer.
-  ///
-  /// Returns nil if `from` is nil.
-  ///
-  /// This is inherently unsafe; UnsafeMutablePointer assumes the
-  /// referenced memory has +1 strong ownership semantics, whereas
-  /// AutoreleasingUnsafeMutablePointer implies +0 semantics.
-  ///
-  /// - Warning: Accessing `pointee` as a type that is unrelated to
-  ///   the underlying memory's bound type is undefined.
-  @_transparent
-  public init?<U>(_ from: UnsafeMutablePointer<U>?) {
-    guard let unwrapped = from else { return nil }
-    self.init(unwrapped)
   }
 
   /// Explicit construction from a UnsafePointer.
@@ -467,7 +438,6 @@ public struct AutoreleasingUnsafeMutablePointer<Pointee /* TODO : class */>
   ///
   /// - Warning: Accessing `pointee` as a type that is unrelated to
   ///   the underlying memory's bound type is undefined.
-  @inlinable // FIXME(sil-serialize-all)
   @_transparent
   internal init<U>(_ from: UnsafePointer<U>) {
     self._rawValue = from._rawValue
@@ -482,7 +452,6 @@ public struct AutoreleasingUnsafeMutablePointer<Pointee /* TODO : class */>
   ///
   /// - Warning: Accessing `pointee` as a type that is unrelated to
   ///   the underlying memory's bound type is undefined.
-  @inlinable // FIXME(sil-serialize-all)
   @_transparent
   internal init?<U>(_ from: UnsafePointer<U>?) {
     guard let unwrapped = from else { return nil }

--- a/stdlib/public/core/Pointer.swift
+++ b/stdlib/public/core/Pointer.swift
@@ -93,6 +93,34 @@ extension _Pointer {
     guard let unwrapped = other else { return nil }
     self.init(unwrapped._rawValue)
   }
+
+  // all pointers are creatable from mutable pointers
+  
+  /// Creates a new pointer from the given mutable pointer.
+  ///
+  /// Use this initializer to explicitly convert `other` to an `UnsafeRawPointer`
+  /// instance. This initializer creates a new pointer to the same address as
+  /// `other` and performs no allocation or copying.
+  ///
+  /// - Parameter other: The typed pointer to convert.
+  @_transparent
+  public init<T>(_ other: UnsafeMutablePointer<T>) {
+    self.init(other._rawValue)
+  }
+
+  /// Creates a new raw pointer from the given typed pointer.
+  ///
+  /// Use this initializer to explicitly convert `other` to an `UnsafeRawPointer`
+  /// instance. This initializer creates a new pointer to the same address as
+  /// `other` and performs no allocation or copying.
+  ///
+  /// - Parameter other: The typed pointer to convert. If `other` is `nil`, the
+  ///   result is `nil`.
+  @_transparent
+  public init?<T>(_ other: UnsafeMutablePointer<T>?) {
+    guard let unwrapped = other else { return nil }
+    self.init(unwrapped)
+  }
 }
 
 // well, this is pretty annoying

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -219,27 +219,6 @@ public struct UnsafePointer<Pointee>: _Pointer {
     self._rawValue = _rawValue
   }
 
-  /// Creates an immutable typed pointer referencing the same memory as the
-  /// given mutable pointer.
-  ///
-  /// - Parameter other: The pointer to convert.
-  @_transparent
-  public init(_ other: UnsafeMutablePointer<Pointee>) {
-    self._rawValue = other._rawValue
-  }
-
-  /// Creates an immutable typed pointer referencing the same memory as the
-  /// given mutable pointer.
-  ///
-  /// - Parameter other: The pointer to convert. If `other` is `nil`, the
-  ///   result is `nil`.
-  @_transparent
-  public init?(_ other: UnsafeMutablePointer<Pointee>?) {
-    guard let unwrapped = other else { return nil }
-    self.init(unwrapped)
-  }
-
-
   /// Deallocates the memory block previously allocated at this pointer.
   ///
   /// This pointer must be a pointer to the start of a previously allocated memory 
@@ -259,7 +238,6 @@ public struct UnsafePointer<Pointee>: _Pointer {
       return self
     }
   }
-
 
   /// Executes the given closure while temporarily binding the specified number
   /// of instances to the given type.

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -235,33 +235,6 @@ public struct UnsafeRawPointer: _Pointer {
     _rawValue = unwrapped._rawValue
   }
 
-  /// Creates a new raw pointer from the given typed pointer.
-  ///
-  /// Use this initializer to explicitly convert `other` to an `UnsafeRawPointer`
-  /// instance. This initializer creates a new pointer to the same address as
-  /// `other` and performs no allocation or copying.
-  ///
-  /// - Parameter other: The typed pointer to convert.
-  @_transparent
-  public init<T>(_ other: UnsafeMutablePointer<T>) {
-    _rawValue = other._rawValue
-  }
-
-  /// Creates a new raw pointer from the given typed pointer.
-  ///
-  /// Use this initializer to explicitly convert `other` to an `UnsafeRawPointer`
-  /// instance. This initializer creates a new pointer to the same address as
-  /// `other` and performs no allocation or copying.
-  ///
-  /// - Parameter other: The typed pointer to convert. If `other` is `nil`, the
-  ///   result is `nil`.
-  @_transparent
-  public init?<T>(_ other: UnsafeMutablePointer<T>?) {
-    guard let unwrapped = other else { return nil }
-    _rawValue = unwrapped._rawValue
-  }
-
-
   /// Deallocates the previously allocated memory block referenced by this pointer.
   ///
   /// The memory to be deallocated must be uninitialized or initialized to a
@@ -332,7 +305,6 @@ public struct UnsafeRawPointer: _Pointer {
   public func assumingMemoryBound<T>(to: T.Type) -> UnsafePointer<T> {
     return UnsafePointer<T>(_rawValue)
   }
-
 
   /// Returns a new instance of the given type, constructed from the raw memory
   /// at the specified offset.

--- a/test/stdlib/UnsafePointerDiagnostics.swift
+++ b/test/stdlib/UnsafePointerDiagnostics.swift
@@ -55,6 +55,11 @@ func unsafePointerConversionAvailability(
   _ = UnsafeRawPointer(oupi)
   _ = UnsafeRawPointer(oumps)
   _ = UnsafeRawPointer(oups)
+  _ = UnsafePointer<Int>(upi)
+  _ = UnsafePointer<Int>(oumpi)
+  _ = UnsafePointer<Int>(oupi)
+  _ = UnsafeMutablePointer<Int>(umpi)
+  _ = UnsafeMutablePointer<Int>(oumpi)
 
   _ = UnsafeMutablePointer<Void>(rp) // expected-warning 4 {{UnsafeMutablePointer<Void> has been replaced by UnsafeMutableRawPointer}} expected-error {{cannot convert value of type 'UnsafeRawPointer' to expected argument type 'RawPointer'}}
   _ = UnsafeMutablePointer<Void>(mrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer' to expected argument type 'RawPointer'}} expected-warning 4 {{UnsafeMutablePointer<Void> has been replaced by UnsafeMutableRawPointer}}
@@ -62,8 +67,8 @@ func unsafePointerConversionAvailability(
   _ = UnsafeMutablePointer<Void>(umpi) // expected-warning {{UnsafeMutablePointer<Void> has been replaced by UnsafeMutableRawPointer}}
   _ = UnsafeMutablePointer<Void>(umps) // expected-warning {{UnsafeMutablePointer<Void> has been replaced by UnsafeMutableRawPointer}}
 
-  _ = UnsafePointer<Void>(rp)  // expected-error {{cannot invoke initializer for type 'UnsafePointer<Void>' with an argument list of type '(UnsafeRawPointer)'}} expected-note {{overloads for 'UnsafePointer<Void>' exist with these partially matching parameter lists: (RawPointer), (UnsafeMutablePointer<Pointee>), (UnsafeMutablePointer<Pointee>?)}} expected-note {{Pointer conversion restricted: use '.assumingMemoryBound(to:)' or '.bindMemory(to:capacity:)' to view memory as a type.}} expected-warning 4 {{UnsafePointer<Void> has been replaced by UnsafeRawPointer}}
-  _ = UnsafePointer<Void>(mrp) // expected-error {{cannot invoke initializer for type 'UnsafePointer<Void>' with an argument list of type '(UnsafeMutableRawPointer)'}} expected-note {{}} expected-warning 4 {{UnsafePointer<Void> has been replaced by UnsafeRawPointer}} expected-note{{overloads for 'UnsafePointer<Void>' exist with these partially matching parameter lists: (RawPointer), (UnsafeMutablePointer<Pointee>), (UnsafeMutablePointer<Pointee>?)}}
+  _ = UnsafePointer<Void>(rp)  // expected-error {{cannot convert value of type 'UnsafeRawPointer' to expected argument type 'RawPointer'}} expected-warning 4 {{UnsafePointer<Void> has been replaced by UnsafeRawPointer}}
+  _ = UnsafePointer<Void>(mrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer' to expected argument type 'RawPointer'}} expected-warning 4 {{UnsafePointer<Void> has been replaced by UnsafeRawPointer}}
   _ = UnsafePointer<Void>(umpv) // expected-warning {{UnsafePointer<Void> has been replaced by UnsafeRawPointer}}
   _ = UnsafePointer<Void>(upv) // expected-warning {{UnsafePointer<Void> has been replaced by UnsafeRawPointer}}
   _ = UnsafePointer<Void>(umpi) // expected-warning {{UnsafePointer<Void> has been replaced by UnsafeRawPointer}}
@@ -73,18 +78,13 @@ func unsafePointerConversionAvailability(
 
   _ = UnsafeMutablePointer<Int>(rp) // expected-error {{cannot convert value of type 'UnsafeRawPointer' to expected argument type 'RawPointer'}} 
   _ = UnsafeMutablePointer<Int>(mrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer' to expected argument type 'RawPointer'}} 
-  _ = UnsafeMutablePointer<Int>(umpi)
   _ = UnsafeMutablePointer<Int>(orp) // expected-error {{cannot convert value of type 'UnsafeRawPointer?' to expected argument type 'RawPointer'}}
   _ = UnsafeMutablePointer<Int>(omrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer?' to expected argument type 'RawPointer'}} 
-  _ = UnsafeMutablePointer<Int>(oumpi)
 
-  _ = UnsafePointer<Int>(rp)  // expected-error {{cannot invoke initializer for type 'UnsafePointer<Int>' with an argument list of type '(UnsafeRawPointer)'}} expected-note {{Pointer conversion restricted: use '.assumingMemoryBound(to:)' or '.bindMemory(to:capacity:)' to view memory as a type.}} expected-note {{}}
-  _ = UnsafePointer<Int>(mrp) // expected-error {{cannot invoke initializer for type 'UnsafePointer<Int>' with an argument list of type '(UnsafeMutableRawPointer)'}} expected-note {{Pointer conversion restricted: use '.assumingMemoryBound(to:)' or '.bindMemory(to:capacity:)' to view memory as a type.}} expected-note {{}}
-  _ = UnsafePointer<Int>(upi)
-  _ = UnsafePointer<Int>(orp)  // expected-error {{cannot invoke initializer for type 'UnsafePointer<Int>' with an argument list of type '(UnsafeRawPointer?)'}} expected-note {{Pointer conversion restricted: use '.assumingMemoryBound(to:)' or '.bindMemory(to:capacity:)' to view memory as a type.}} expected-note {{}}
-  _ = UnsafePointer<Int>(omrp) // expected-error {{cannot invoke initializer for type 'UnsafePointer<Int>' with an argument list of type '(UnsafeMutableRawPointer?)'}} expected-note {{Pointer conversion restricted: use '.assumingMemoryBound(to:)' or '.bindMemory(to:capacity:)' to view memory as a type.}} expected-note {{}}
-  _ = UnsafePointer<Int>(oumpi)
-  _ = UnsafePointer<Int>(oupi)
+  _ = UnsafePointer<Int>(rp)  // expected-error {{cannot convert value of type 'UnsafeRawPointer' to expected argument type 'RawPointer'}}
+  _ = UnsafePointer<Int>(mrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer' to expected argument type 'RawPointer'}}
+  _ = UnsafePointer<Int>(orp)  // expected-error {{cannot convert value of type 'UnsafeRawPointer?' to expected argument type 'RawPointer'}}
+  _ = UnsafePointer<Int>(omrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer?' to expected argument type 'RawPointer'}}
 }
 
 func unsafeRawBufferPointerConversions(


### PR DESCRIPTION
All pointers can be created from an `UnsafeMutablePointer`, so those can move to `_Pointer`