### PR TITLE
[stdlib] De-gyb Stride.swift

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -121,7 +121,7 @@ set(SWIFTLIB_ESSENTIAL
   SmallString.swift
   Sort.swift.gyb
   StaticString.swift
-  Stride.swift.gyb
+  Stride.swift
   StringHashable.swift  # ORDER DEPENDENCY: Must precede String.swift
   String.swift
   StringBridge.swift

--- a/stdlib/public/core/MigrationSupport.swift
+++ b/stdlib/public/core/MigrationSupport.swift
@@ -869,6 +869,52 @@ extension UnsafeMutablePointer {
   }
 }
 
+extension Strideable {
+  @available(swift, deprecated: 3, obsoleted: 4, message: "Please use explicit type conversions or Strideable methods for mixed-type arithmetics.")
+  public static func + (lhs: Self, rhs: Self.Stride) -> Self {
+    return lhs.advanced(by: rhs)
+  }
+
+  @available(swift, deprecated: 3, obsoleted: 4, message: "Please use explicit type conversions or Strideable methods for mixed-type arithmetics.")
+  public static func + (lhs: Self.Stride, rhs: Self) -> Self {
+    return rhs.advanced(by: lhs)
+  }
+
+  @available(swift, deprecated: 3, obsoleted: 4, message: "Please use explicit type conversions or Strideable methods for mixed-type arithmetics.")
+  public static func - (lhs: Self, rhs: Self.Stride) -> Self {
+    return lhs.advanced(by: -rhs)
+  }
+
+  @available(swift, deprecated: 3, obsoleted: 4, message: "Please use explicit type conversions or Strideable methods for mixed-type arithmetics.")
+  public static func - (lhs: Self, rhs: Self) -> Self.Stride {
+    return rhs.distance(to: lhs)
+  }
+
+  @available(swift, deprecated: 3, obsoleted: 4, message: "Please use explicit type conversions or Strideable methods for mixed-type arithmetics.")
+  public static func += (lhs: inout Self, rhs: Self.Stride) {
+    lhs = lhs.advanced(by: rhs)
+  }
+
+  @available(swift, deprecated: 3, obsoleted: 4, message: "Please use explicit type conversions or Strideable methods for mixed-type arithmetics.")
+  public static func -= (lhs: inout Self, rhs: Self.Stride) {
+    lhs = lhs.advanced(by: -rhs)
+  }
+}
+
+extension UnsafeMutableRawPointer {
+  @available(*, unavailable, renamed: "init(mutating:)")
+  public init(_ from : UnsafeRawPointer) { Builtin.unreachable() }
+
+  @available(*, unavailable, renamed: "init(mutating:)")
+  public init?(_ from : UnsafeRawPointer?) { Builtin.unreachable() }
+
+  @available(*, unavailable, renamed: "init(mutating:)")
+  public init<T>(_ from : UnsafePointer<T>) { Builtin.unreachable() }
+
+  @available(*, unavailable, renamed: "init(mutating:)")
+  public init?<T>(_ from : UnsafePointer<T>?) { Builtin.unreachable() }
+}
+
 extension UnsafeRawPointer : _CustomPlaygroundQuickLookable {
   internal var summary: String {
     let ptrValue = UInt64(

--- a/stdlib/public/core/Pointer.swift
+++ b/stdlib/public/core/Pointer.swift
@@ -292,6 +292,39 @@ extension UInt {
   }
 }
 
+// Pointer arithmetic operators (formerly via Strideable)
+extension Strideable where Self : _Pointer {
+  @_transparent
+  public static func + (lhs: Self, rhs: Self.Stride) -> Self {
+    return lhs.advanced(by: rhs)
+  }
+
+  @_transparent
+  public static func + (lhs: Self.Stride, rhs: Self) -> Self {
+    return rhs.advanced(by: lhs)
+  }
+
+  @_transparent
+  public static func - (lhs: Self, rhs: Self.Stride) -> Self {
+    return lhs.advanced(by: -rhs)
+  }
+
+  @_transparent
+  public static func - (lhs: Self, rhs: Self) -> Self.Stride {
+    return rhs.distance(to: lhs)
+  }
+
+  @_transparent
+  public static func += (lhs: inout Self, rhs: Self.Stride) {
+    lhs = lhs.advanced(by: rhs)
+  }
+
+  @_transparent
+  public static func -= (lhs: inout Self, rhs: Self.Stride) {
+    lhs = lhs.advanced(by: -rhs)
+  }
+}
+
 /// Derive a pointer argument from a convertible pointer type.
 @_transparent
 public // COMPILER_INTRINSIC

--- a/stdlib/public/core/Stride.swift
+++ b/stdlib/public/core/Stride.swift
@@ -1,4 +1,4 @@
-//===--- Stride.swift.gyb - Components for stride(...) iteration ----------===//
+//===--- Stride.swift - Components for stride(...) iteration --------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -162,68 +162,6 @@ extension Strideable {
     return x.distance(to: y) == 0
   }
 }
-
-//===----------------------------------------------------------------------===//
-
-%{
-  # Strideable used to provide + and - unconditionally. With the updated
-  # collection indexing model of Swift 3 this became unnecessary for integer
-  # types, and was deprecated, as it was a way to write mixed-type arithmetic
-  # expressions, that are otherwise are not allowed.
-}%
-% for Base, VersionInfo in [
-%   ('Strideable where Self : _Pointer', None),
-%   ('Strideable', 'deprecated: 3, obsoleted: 4'),
-%   ]:
-%   Availability = '@available(swift, %s, message: "Please use explicit type conversions or Strideable methods for mixed-type arithmetics.")' % (VersionInfo) if VersionInfo else ''
-
-extension ${Base} {
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
-  ${Availability}
-  public static func + (lhs: Self, rhs: Self.Stride) -> Self {
-    return lhs.advanced(by: rhs)
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
-  ${Availability}
-  public static func + (lhs: Self.Stride, rhs: Self) -> Self {
-    return rhs.advanced(by: lhs)
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
-  ${Availability}
-  public static func - (lhs: Self, rhs: Self.Stride) -> Self {
-    return lhs.advanced(by: -rhs)
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
-  ${Availability}
-  public static func - (lhs: Self, rhs: Self) -> Self.Stride {
-    return rhs.distance(to: lhs)
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
-  ${Availability}
-  public static func += (lhs: inout Self, rhs: Self.Stride) {
-    lhs = lhs.advanced(by: rhs)
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
-  ${Availability}
-  public static func -= (lhs: inout Self, rhs: Self.Stride) {
-    lhs = lhs.advanced(by: -rhs)
-  }
-}
-
-% end
-
-//===----------------------------------------------------------------------===//
 
 extension Strideable {
   @inlinable // protocol-only
@@ -718,7 +656,3 @@ public func stride<T>(
 ) -> StrideThrough<T> {
   return StrideThrough(_start: start, end: end, stride: stride)
 }
-
-// ${'Local Variables'}:
-// eval: (read-only-mode 1)
-// End:

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -969,18 +969,3 @@ extension OpaquePointer {
     self._rawValue = unwrapped._rawValue
   }
 }
-
-
-extension UnsafeMutableRawPointer {
-  @available(*, unavailable, renamed: "init(mutating:)")
-  public init(_ from : UnsafeRawPointer) { Builtin.unreachable() }
-
-  @available(*, unavailable, renamed: "init(mutating:)")
-  public init?(_ from : UnsafeRawPointer?) { Builtin.unreachable(); return nil }
-
-  @available(*, unavailable, renamed: "init(mutating:)")
-  public init<T>(_ from : UnsafePointer<T>) { Builtin.unreachable() }
-
-  @available(*, unavailable, renamed: "init(mutating:)")
-  public init?<T>(_ from : UnsafePointer<T>?) { Builtin.unreachable(); return nil }
-}


### PR DESCRIPTION
The only remaining uses of gyb here were for some deprecated compatibility shims, plus some operators for pointer arithmetic that would be better located next to the pointer types.