### PR TITLE
Lifted the restriction that when we partition and lowering a function foo(), and  foo() references bar() as a function-typed attribute, bar() must have been partitioned and lowered already.

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -1618,6 +1618,8 @@ GLStatus TFGraphLowering::visitTFDataset(BuiltinInst *inst) {
   return GLStatus::Success;
 }
 
+/// Check whether the specified TensorFlow status object is valid or not.  If
+/// valid return false.  If invalid, emit a diagnostic and return true.
 static bool checkStatus(SILFunction &fn, SILLocation loc, TF_Status *status,
                         Diag<StringRef> id = diag::tf_lowering_error) {
   if (TF_GetCode(status) == TF_OK)

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -598,11 +598,11 @@ public:
                        ArrayRef<int64_t> dims, ArrayRef<int> numDims,
                        ArrayRef<int64_t *> dimPtrs);
 
-  // For `op` with `opName` under construction, set a function typed attribute
+  // For `op` with `opName` under construction, set a function-typed attribute
   // with a graph function name derived from `silFuncName` under the following
-  // naming convention Let `silFuncName` be "$foo", then the corresponding graph
-  // function name is "foo.tf_only". If that graph function's definition is
-  // available in `graphFunctions`, copy it cover to `resultGraph`. Otherwise
+  // naming convention: Let `silFuncName` be "$foo", then the corresponding
+  // graph function name is "foo.tf_only". If that graph function's definition
+  // is available in `graphFunctions`, copy it over to `resultGraph`. Otherwise
   // add an entry to `pendingGraphFnNames`, so that the graph function
   // definition can be copied over later when it becomes available.
   bool handleFunctionAttribute(TF_OperationDescription *op,
@@ -1650,23 +1650,13 @@ static bool copyGraphFunctions(SILFunction &fn, SILLocation loc,
     }
   };
 
-  // TODO: enable `foundFunc` related logic when the TF_GetFunctionName() API is
-  // added to TF. bool foundFunc = false;
+  // TODO: Add sanity-check code that `funcs` include a function named
+  // `graphFuncName`.
   for (auto *func : funcs) {
-#if 0
-#ifndef NDEBUG
-    const char *funcName = TF_GetFunctionName(func);
-    DEBUG(llvm::dbgs() << " Copying graph function " << funcName << " over.\n");
-    if (std::string(funcName) == graphFuncName)
-      foundFunc = true;
-#endif // NDEBUG
-#endif // 0
     TF_GraphCopyFunction(resultGraph, func, /*gradient*/ nullptr, status);
     if (checkStatus(fn, loc, status))
       return true;
   }
-  // assert(foundFunc);
-  // (void)foundFunc;
 
   // All done!
   return false;

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -682,7 +682,7 @@ public:
   SmallPtrSet<SILInstruction*, 8> explicitCopyMarkers;
 
   struct PartitionedTensorProgram {
-    // Needed to work with unique_ptr.
+    // Initialize all members to NULL.
     PartitionedTensorProgram() {}
 
     PartitionedTensorProgram(

--- a/test/TensorFlow/dataset.swift
+++ b/test/TensorFlow/dataset.swift
@@ -74,7 +74,7 @@ public func createMockDataSet() -> VariantHandle {
 // CHECK-NOT:   node {
 // CHECK:       function {
 // CHECK-NEXT:    signature {
-// CHECK-NEXT:      name: "{{.*}}createMockDataSet{{.*}}.tf_CPU.device_partition"
+// CHECK-NEXT:      name: "{{.*}}createMockDataSet{{.*}}.tf_only"
 // CHECK:           output_arg {
 // CHECK-NEXT:        name: "op_createmockdataset{{.*}}"
 // CHECK-NEXT:        type: DT_VARIANT

--- a/test/TensorFlowRuntime/dataset_1.swift
+++ b/test/TensorFlowRuntime/dataset_1.swift
@@ -1,0 +1,86 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize
+//
+// Retain/release tests.
+
+import TensorFlow
+
+#if TPU
+import TensorFlowUnittestTPU
+#else
+import TensorFlowUnittest
+#endif
+import StdlibUnittest
+
+var DatasetTests = TestSuite("Dataset")
+
+// Creates a dataset, which produces one float scalar value in each get next
+// call.
+@TensorFlowGraph
+public func createMockDataSet() -> VariantHandle {
+  let values = Tensor<Float>([1.0, 2.0, 3.0])
+  // REGISTER_OP("TensorSliceDataset")
+  //   .Input("components: Toutput_types")
+  //   .Output("handle: variant")
+  //   .Attr("Toutput_types: list(type) >= 1")
+  //   .Attr("output_shapes: list(shape) >= 1")
+  let dataset : VariantHandle = #tfop("TensorSliceDataset",
+                                      [values],
+                                      Toutput_types: [Float.self],
+                                      output_shapes: [TensorShape()])
+  return dataset
+}
+
+func getNextScalarFloatTensor(_ iterator: ResourceHandle) -> Tensor<Float> {
+  // REGISTER_OP("IteratorGetNext")
+  //   .Input("iterator: resource")
+  //   .Output("components: output_types")
+  //   .Attr("output_types: list(type) >= 1")
+  //   .Attr("output_shapes: list(shape) >= 1")
+  let ret: TensorHandle<Float> = #tfop("IteratorGetNext",
+                                       iterator,
+                                       output_types: [Float.self],
+                                       output_shapes: [TensorShape()])
+  return Tensor(handle: ret)
+}
+
+public func model() {
+  // REGISTER_OP("OneShotIterator")
+  //   .Output("handle: resource")
+  //   .Attr("dataset_factory: func")
+  //   .Attr("output_types: list(type) >= 1")
+  //   .Attr("output_shapes: list(shape) >= 1")
+  //   .Attr("container: string = ''")
+  //   .Attr("shared_name: string = ''")
+  let iterator: ResourceHandle = #tfop(
+    "OneShotIterator",
+    dataset_factory : createMockDataSet,
+    output_types: [Float.self],
+    output_shapes: [TensorShape()]
+  )
+
+  let one = getNextScalarFloatTensor(iterator)
+  _hostOp(one)
+  expectNearlyEqualWithScalarTensor(1.0, one)
+
+  let two = getNextScalarFloatTensor(iterator)
+  _hostOp(two)
+  expectNearlyEqualWithScalarTensor(2.0, two)
+
+  let three = getNextScalarFloatTensor(iterator)
+  _hostOp(three)
+  expectNearlyEqualWithScalarTensor(3.0, three)
+
+  // TODO: do not crash when TF emits "Fatal error: End of sequence"
+  // let error: TensorHandle<Float> = #tfop("IteratorGetNext",
+  //                                      iterator,
+  //                                      output_types: [Float.self],
+  //                                      output_shapes: [TensorShape()])
+}
+
+DatasetTests.testAllBackends("Basic") {
+  model()
+}
+
+runAllTests()


### PR DESCRIPTION
Added an e2e (runtime) test on dataset / iterator support.

To summarize the changes:

1. Changed TFPartition into be a module pass, to gain more flexibility in
iterating over the functions.

2. Implemented the following two-pass design for TFPartition, in order to lift
the ordering constraint on graph lowering.

The first pass partitions and lowers those partitionable functions into
graphs. When we process a function that references other functions that are not
yet lowered, such as foo() above, do not serialize the graph into bytes.

In the second pass, copy over the graph func bodies, such as copying the graph
function of bar() into the graph corresponding to foo() in the above example.

Note the following outstanding limitations in/after this PR:

1. Transitive referencies: If bar() references another graph function baz(),
baz() will need to be copied over to the graph of foo() as well, but currently
it might not, if baz() is processed after foo() in the first pass.

2. If bar() is defined in a different module from foo(), we will need to first
either load/link bar() when processing foo(), and lowering bar() (again) into a
graph function, or somehow load the graph function of bar() from its module, so
that we can copy it into the graph of foo().
