### PR TITLE
[Parser] Support "<" unary operator in #if swift() and #if compiler() expressions

### DIFF
--- a/include/swift/Basic/Version.h
+++ b/include/swift/Basic/Version.h
@@ -161,6 +161,7 @@ public:
 };
 
 bool operator>=(const Version &lhs, const Version &rhs);
+bool operator<(const Version &lhs, const Version &rhs);
 bool operator==(const Version &lhs, const Version &rhs);
 inline bool operator!=(const Version &lhs, const Version &rhs) {
   return !(lhs == rhs);

--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -384,6 +384,11 @@ bool operator>=(const class Version &lhs,
   return true;
 }
 
+bool operator<(const class Version &lhs, const class Version &rhs) {
+
+  return !(lhs >= rhs);
+}
+
 bool operator==(const class Version &lhs,
                 const class Version &rhs) {
   auto n = std::max(lhs.size(), rhs.size());
@@ -446,4 +451,3 @@ std::string getSwiftRevision() {
 
 } // end namespace version
 } // end namespace swift
-

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -36,7 +36,7 @@ namespace {
 /// Get PlatformConditionKind from platform condition name.
 static
 Optional<PlatformConditionKind> getPlatformConditionKind(StringRef Name) {
-  return llvm::StringSwitch<llvm::Optional<PlatformConditionKind>>(Name)
+  return llvm::StringSwitch<Optional<PlatformConditionKind>>(Name)
     .Case("os", PlatformConditionKind::OS)
     .Case("arch", PlatformConditionKind::Arch)
     .Case("_endian", PlatformConditionKind::Endianness)
@@ -53,6 +53,20 @@ static StringRef extractExprSource(SourceManager &SM, Expr *E) {
   return SM.extractText(Range);
 }
 
+static bool isValidPrefixUnaryOperator(Optional<StringRef> UnaryOperator) {
+  return UnaryOperator != None &&
+         (UnaryOperator.getValue() == ">=" || UnaryOperator.getValue() == "<");
+}
+
+static bool isValidVersion(const version::Version &Version,
+                           const version::Version &ExpectedVersion,
+                           StringRef UnaryOperator) {
+  if (UnaryOperator == ">=")
+    return Version >= ExpectedVersion;
+  if (UnaryOperator == "<")
+    return Version < ExpectedVersion;
+  llvm_unreachable("unsupported unary operator");
+}
 
 /// The condition validator.
 class ValidateIfConfigCondition :
@@ -63,7 +77,7 @@ class ValidateIfConfigCondition :
   bool HasError;
 
   /// Get the identifier string of the UnresolvedDeclRefExpr.
-  llvm::Optional<StringRef> getDeclRefStr(Expr *E, DeclRefKind Kind) {
+  Optional<StringRef> getDeclRefStr(Expr *E, DeclRefKind Kind) {
     auto UDRE = dyn_cast<UnresolvedDeclRefExpr>(E);
     if (!UDRE ||
         !UDRE->hasName() ||
@@ -93,7 +107,7 @@ class ValidateIfConfigCondition :
   Expr *foldSequence(Expr *LHS, ArrayRef<Expr*> &S, bool isRecurse = false) {
     assert(!S.empty() && ((S.size() & 1) == 0));
 
-    auto getNextOperator = [&]() -> llvm::Optional<StringRef> {
+    auto getNextOperator = [&]() -> Optional<StringRef> {
       assert((S.size() & 1) == 0);
       while (!S.empty()) {
         auto Name = getDeclRefStr(S[0], DeclRefKind::BinaryOperator);
@@ -117,7 +131,7 @@ class ValidateIfConfigCondition :
       // If failed, it's not a sequence anymore.
       return LHS;
     Expr *Op = S[0];
-  
+
     // We will definitely be consuming at least one operator.
     // Pull out the prospective RHS and slice off the first two elements.
     Expr *RHS = validate(S[1]);
@@ -277,16 +291,16 @@ public:
       return E;
     }
 
-    // 'swift' '(' '>=' float-literal ( '.' integer-literal )* ')'
-    // 'compiler' '(' '>=' float-literal ( '.' integer-literal )* ')'
+    // 'swift' '(' ('>=' | '<') float-literal ( '.' integer-literal )* ')'
+    // 'compiler' '(' ('>=' | '<') float-literal ( '.' integer-literal )* ')'
     if (*KindName == "swift" || *KindName == "compiler") {
       auto PUE = dyn_cast<PrefixUnaryExpr>(Arg);
-      llvm::Optional<StringRef> PrefixName = PUE ?
-        getDeclRefStr(PUE->getFn(), DeclRefKind::PrefixOperator) : None;
-      if (!PrefixName || *PrefixName != ">=") {
-        D.diagnose(Arg->getLoc(),
-                   diag::unsupported_platform_condition_argument,
-                   "a unary comparison, such as '>=2.2'");
+      Optional<StringRef> PrefixName =
+          PUE ? getDeclRefStr(PUE->getFn(), DeclRefKind::PrefixOperator) : None;
+      if (!isValidPrefixUnaryOperator(PrefixName)) {
+        D.diagnose(
+            Arg->getLoc(), diag::unsupported_platform_condition_argument,
+            "a unary comparison '>=' or '<'; for example, '>=2.2' or '<2.2'");
         return nullptr;
       }
       auto versionString = extractExprSource(Ctx.SourceMgr, PUE->getArg());
@@ -448,13 +462,17 @@ public:
       return thisVersion >= Val;
     } else if ((KindName == "swift") || (KindName == "compiler")) {
       auto PUE = cast<PrefixUnaryExpr>(Arg);
+      auto PrefixName = getDeclRefStr(PUE->getFn());
       auto Str = extractExprSource(Ctx.SourceMgr, PUE->getArg());
       auto Val = version::Version::parseVersionString(
           Str, SourceLoc(), nullptr).getValue();
       if (KindName == "swift") {
-        return Ctx.LangOpts.EffectiveLanguageVersion >= Val;  
+        return isValidVersion(Ctx.LangOpts.EffectiveLanguageVersion, Val,
+                              PrefixName);
       } else if (KindName == "compiler") {
-        return version::Version::getCurrentLanguageVersion() >= Val;
+        auto currentLanguageVersion =
+            version::Version::getCurrentLanguageVersion();
+        return isValidVersion(currentLanguageVersion, Val, PrefixName);
       } else {
         llvm_unreachable("unsupported version conditional");
       }

--- a/test/Parse/ConditionalCompilation/compiler.swift
+++ b/test/Parse/ConditionalCompilation/compiler.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -swift-version 4
 
 #if !compiler(>=4.1)
  // There should be no error here.

--- a/test/Parse/ConditionalCompilation/compiler.swift
+++ b/test/Parse/ConditionalCompilation/compiler.swift
@@ -1,0 +1,29 @@
+// RUN: %target-typecheck-verify-swift
+
+#if !compiler(>=4.1)
+ // There should be no error here.
+ foo bar
+#else
+ let _: Int = 1
+#endif
+
+#if compiler(<4.1)
+ // There should be no error here.
+ foo bar
+#else
+ let _: Int = 1
+#endif
+
+#if (compiler(>=4.1))
+ let _: Int = 1
+#else
+ // There should be no error here.
+ foo bar
+#endif
+
+#if !compiler(<4.1)
+ let _: Int = 1
+#else
+ // There should be no error here.
+ foo bar
+#endif

--- a/test/Parse/ConditionalCompilation/language_version.swift
+++ b/test/Parse/ConditionalCompilation/language_version.swift
@@ -7,6 +7,20 @@
   asdf asdf asdf asdf
 #endif
 
+#if swift(<1.2)
+#endif
+
+#if swift(<4.2)
+  let a = 1
+#else
+  let a = 2
+#endif
+
+#if swift(<1.0)
+   // This shouldn't emit any diagnostics.
+   asdf asdf asdf asdf
+#endif
+
 #if swift(>=1.2)
 
 #if os(iOS)
@@ -34,13 +48,21 @@
   %#^*&
 #endif
 
-#if swift(">=7.1") // expected-error {{unexpected platform condition argument: expected a unary comparison, such as '>=2.2'}}
+#if !swift(<1000.0)
+  // This shouldn't emit any diagnostics.
+  %#^*&
 #endif
 
-#if swift(">=2n.2") // expected-error {{unexpected platform condition argument: expected a unary comparison, such as '>=2.2'}}
+#if swift(">=7.1") // expected-error {{unexpected platform condition argument: expected a unary comparison '>=' or '<'; for example, '>=2.2' or '<2.2'}}
 #endif
 
-#if swift("") // expected-error {{unexpected platform condition argument: expected a unary comparison, such as '>=2.2'}}
+#if swift("<7.1") // expected-error {{unexpected platform condition argument: expected a unary comparison '>=' or '<'; for example, '>=2.2' or '<2.2'}}
+#endif
+
+#if swift(">=2n.2") // expected-error {{unexpected platform condition argument: expected a unary comparison '>=' or '<'; for example, '>=2.2' or '<2.2'}}
+#endif
+
+#if swift("") // expected-error {{unexpected platform condition argument: expected a unary comparison '>=' or '<'; for example, '>=2.2' or '<2.2'}}
 #endif
 
 #if swift(>=2.2.1)


### PR DESCRIPTION
**Swift-evolution proposal:** https://github.com/apple/swift-evolution/pull/877
Resolves #49401.

Until now, only ">=" was supported in #if swift() expressions, for example:

```
#if swift(>=2.1)
#endif
```

This means that if we want to evaluate code only when the language version is
less than a particular version we need to do the following:

```
#if !swift(>=2.1)
#endif
```

An alternative to make this more readable (the "!" can be easily missed in a code
review) is to introduce another supported unary operator, "<". The previous
example could be rewritten like this:

```
#if swift(<2.1)
#endif
```

This commit adds support for that unary operator, along with some tests.