### PR TITLE
[gardening] Eliminate \ from macro that is < 80 lines.

### DIFF
--- a/include/swift/SILOptimizer/Analysis/Analysis.h
+++ b/include/swift/SILOptimizer/Analysis/Analysis.h
@@ -292,8 +292,7 @@ public:
   FunctionInfoTy *operator->() { return *this; }
 };
 
-#define ANALYSIS(NAME)                                                         \
-SILAnalysis *create##NAME##Analysis(SILModule *);
+#define ANALYSIS(NAME) SILAnalysis *create##NAME##Analysis(SILModule *);
 #include "Analysis.def"
 
 } // end namespace swift


### PR DESCRIPTION
NFC.