### PR TITLE
[analysis] Standardize AnalysisKind by moving it out of SILAnalysis i…

### DIFF
--- a/include/swift/SILOptimizer/Analysis/AccessSummaryAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/AccessSummaryAnalysis.h
@@ -176,7 +176,7 @@ private:
   IndexTrieNode *SubPathTrie;
 
 public:
-  AccessSummaryAnalysis() : BottomUpIPAnalysis(AnalysisKind::AccessSummary) {
+  AccessSummaryAnalysis() : BottomUpIPAnalysis(SILAnalysisKind::AccessSummary) {
     SubPathTrie = new IndexTrieNode();
   }
 
@@ -205,7 +205,7 @@ public:
   virtual void invalidateFunctionTables() override {}
 
   static bool classof(const SILAnalysis *S) {
-    return S->getKind() == AnalysisKind::AccessSummary;
+    return S->getKind() == SILAnalysisKind::AccessSummary;
   }
 
   /// Returns a description of the subpath suitable for use in diagnostics.

--- a/include/swift/SILOptimizer/Analysis/AccessedStorageAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/AccessedStorageAnalysis.h
@@ -251,10 +251,10 @@ class AccessedStorageAnalysis
 public:
   AccessedStorageAnalysis()
       : GenericFunctionEffectAnalysis<FunctionAccessedStorage>(
-            AnalysisKind::AccessedStorage) {}
+            SILAnalysisKind::AccessedStorage) {}
 
   static bool classof(const SILAnalysis *S) {
-    return S->getKind() == AnalysisKind::AccessedStorage;
+    return S->getKind() == SILAnalysisKind::AccessedStorage;
   }
 };
 

--- a/include/swift/SILOptimizer/Analysis/AliasAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/AliasAnalysis.h
@@ -155,11 +155,12 @@ private:
 
 
 public:
-  AliasAnalysis(SILModule *M) :
-    SILAnalysis(AnalysisKind::Alias), Mod(M), SEA(nullptr), EA(nullptr) {}
+  AliasAnalysis(SILModule *M)
+      : SILAnalysis(SILAnalysisKind::Alias), Mod(M), SEA(nullptr), EA(nullptr) {
+  }
 
   static bool classof(const SILAnalysis *S) {
-    return S->getKind() == AnalysisKind::Alias;
+    return S->getKind() == SILAnalysisKind::Alias;
   }
   
   virtual void initialize(SILPassManager *PM) override;

--- a/include/swift/SILOptimizer/Analysis/Analysis.h
+++ b/include/swift/SILOptimizer/Analysis/Analysis.h
@@ -28,6 +28,17 @@ class SILModule;
 class SILFunction;
 class SILPassManager;
 
+/// A list of the known analysis.
+struct SILAnalysisKind {
+  enum InnerTy {
+#define ANALYSIS(NAME) NAME,
+#include "Analysis.def"
+  } value;
+
+  SILAnalysisKind(InnerTy newValue) : value(newValue) {}
+  operator InnerTy() const { return value; }
+};
+
 /// The base class for all SIL-level analysis.
 class SILAnalysis : public DeleteNotificationHandler {
 public:
@@ -67,15 +78,9 @@ public:
     Everything = Calls | Branches | Instructions,
   };
 
-  /// A list of the known analysis.
-  enum class AnalysisKind {
-#define ANALYSIS(NAME) NAME,
-#include "Analysis.def"
-  };
-
 private:
   /// Stores the kind of derived class.
-  const AnalysisKind kind;
+  const SILAnalysisKind kind;
 
   /// A lock that prevents the invalidation of this analysis. When this
   /// variable is set to True then the PassManager should not invalidate
@@ -84,10 +89,10 @@ private:
 
 public:
   /// Returns the kind of derived class.
-  AnalysisKind getKind() const { return kind; }
+  SILAnalysisKind getKind() const { return kind; }
 
   /// Constructor.
-  SILAnalysis(AnalysisKind k) : kind(k), invalidationLock(false) {}
+  SILAnalysis(SILAnalysisKind k) : kind(k), invalidationLock(false) {}
 
   /// Destructor.
   virtual ~SILAnalysis() {}
@@ -239,7 +244,7 @@ public:
   virtual ~FunctionAnalysisBase() {
     deleteAllAnalysisProviders();
   }
-  FunctionAnalysisBase(AnalysisKind k) : SILAnalysis(k), storage() {}
+  FunctionAnalysisBase(SILAnalysisKind k) : SILAnalysis(k), storage() {}
   FunctionAnalysisBase(const FunctionAnalysisBase &) = delete;
   FunctionAnalysisBase &operator=(const FunctionAnalysisBase &) = delete;
 

--- a/include/swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h
@@ -126,10 +126,10 @@ class BasicCalleeAnalysis : public SILAnalysis {
 
 public:
   BasicCalleeAnalysis(SILModule *M)
-      : SILAnalysis(AnalysisKind::BasicCallee), M(*M), Cache(nullptr) {}
+      : SILAnalysis(SILAnalysisKind::BasicCallee), M(*M), Cache(nullptr) {}
 
   static bool classof(const SILAnalysis *S) {
-    return S->getKind() == AnalysisKind::BasicCallee;
+    return S->getKind() == SILAnalysisKind::BasicCallee;
   }
 
   /// Invalidate all information in this analysis.

--- a/include/swift/SILOptimizer/Analysis/BottomUpIPAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/BottomUpIPAnalysis.h
@@ -286,7 +286,7 @@ protected:
     }
   };
 
-  BottomUpIPAnalysis(AnalysisKind K) : SILAnalysis(K) { }
+  BottomUpIPAnalysis(SILAnalysisKind k) : SILAnalysis(k) {}
 
   /// Increments the CurrentUpdateID.
   /// Should be called at the beginning of a recomputation.

--- a/include/swift/SILOptimizer/Analysis/CallerAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/CallerAnalysis.h
@@ -69,7 +69,7 @@ private:
   }
 
 public:
-  CallerAnalysis(SILModule *M) : SILAnalysis(AnalysisKind::Caller), Mod(*M) {
+  CallerAnalysis(SILModule *M) : SILAnalysis(SILAnalysisKind::Caller), Mod(*M) {
     // Make sure we compute everything first time called.
     for (auto &F : Mod) {
       FuncInfos.FindAndConstruct(&F);
@@ -78,7 +78,7 @@ public:
   }
 
   static bool classof(const SILAnalysis *S) {
-    return S->getKind() == AnalysisKind::Caller;
+    return S->getKind() == SILAnalysisKind::Caller;
   }
 
   /// Invalidate all information in this analysis.

--- a/include/swift/SILOptimizer/Analysis/ClassHierarchyAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/ClassHierarchyAnalysis.h
@@ -34,14 +34,14 @@ public:
       ProtocolImplementations;
 
   ClassHierarchyAnalysis(SILModule *Mod)
-      : SILAnalysis(AnalysisKind::ClassHierarchy), M(Mod) {
-      init(); 
-    }
+      : SILAnalysis(SILAnalysisKind::ClassHierarchy), M(Mod) {
+    init();
+  }
 
   ~ClassHierarchyAnalysis();
 
   static bool classof(const SILAnalysis *S) {
-    return S->getKind() == AnalysisKind::ClassHierarchy;
+    return S->getKind() == SILAnalysisKind::ClassHierarchy;
   }
 
   /// Invalidate all information in this analysis.

--- a/include/swift/SILOptimizer/Analysis/ClosureScope.h
+++ b/include/swift/SILOptimizer/Analysis/ClosureScope.h
@@ -120,7 +120,7 @@ public:
   ~ClosureScopeAnalysis();
 
   static bool classof(const SILAnalysis *S) {
-    return S->getKind() == AnalysisKind::ClosureScope;
+    return S->getKind() == SILAnalysisKind::ClosureScope;
   }
 
   SILModule *getModule() const { return M; }

--- a/include/swift/SILOptimizer/Analysis/DestructorAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/DestructorAnalysis.h
@@ -23,12 +23,11 @@ class DestructorAnalysis : public SILAnalysis {
   SILModule *Mod;
   llvm::DenseMap<CanType, bool> Cached;
 public:
-
   DestructorAnalysis(SILModule *M)
-      : SILAnalysis(AnalysisKind::Destructor), Mod(M) {}
+      : SILAnalysis(SILAnalysisKind::Destructor), Mod(M) {}
 
   static bool classof(const SILAnalysis *S) {
-    return S->getKind() == AnalysisKind::Destructor;
+    return S->getKind() == SILAnalysisKind::Destructor;
   }
 
   /// Returns true if destruction of T may store to memory.

--- a/include/swift/SILOptimizer/Analysis/DominanceAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/DominanceAnalysis.h
@@ -32,13 +32,13 @@ protected:
 
 public:
   DominanceAnalysis()
-  : FunctionAnalysisBase<DominanceInfo>(AnalysisKind::Dominance) {}
+      : FunctionAnalysisBase<DominanceInfo>(SILAnalysisKind::Dominance) {}
 
   DominanceAnalysis(const DominanceAnalysis &) = delete;
   DominanceAnalysis &operator=(const DominanceAnalysis &) = delete;
 
   static bool classof(const SILAnalysis *S) {
-    return S->getKind() == AnalysisKind::Dominance;
+    return S->getKind() == SILAnalysisKind::Dominance;
   }
 
   DominanceInfo *newFunctionAnalysis(SILFunction *F) override {
@@ -60,13 +60,14 @@ protected:
 
 public:
   PostDominanceAnalysis()
-  : FunctionAnalysisBase<PostDominanceInfo>(AnalysisKind::PostDominance) {}
+      : FunctionAnalysisBase<PostDominanceInfo>(
+            SILAnalysisKind::PostDominance) {}
 
   PostDominanceAnalysis(const PostDominanceAnalysis &) = delete;
   PostDominanceAnalysis &operator=(const PostDominanceAnalysis &) = delete;
 
   static bool classof(const SILAnalysis *S) {
-    return S->getKind() == AnalysisKind::PostDominance;
+    return S->getKind() == SILAnalysisKind::PostDominance;
   }
 
   PostDominanceInfo *newFunctionAnalysis(SILFunction *F) override {

--- a/include/swift/SILOptimizer/Analysis/EpilogueARCAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EpilogueARCAnalysis.h
@@ -271,8 +271,9 @@ class EpilogueARCAnalysis : public FunctionAnalysisBase<EpilogueARCFunctionInfo>
 
 public:
   EpilogueARCAnalysis(SILModule *)
-    : FunctionAnalysisBase<EpilogueARCFunctionInfo>(AnalysisKind::EpilogueARC),
-      PO(nullptr), AA(nullptr), RC(nullptr) {}
+      : FunctionAnalysisBase<EpilogueARCFunctionInfo>(
+            SILAnalysisKind::EpilogueARC),
+        PO(nullptr), AA(nullptr), RC(nullptr) {}
 
   EpilogueARCAnalysis(const EpilogueARCAnalysis &) = delete;
   EpilogueARCAnalysis &operator=(const EpilogueARCAnalysis &) = delete;
@@ -294,7 +295,7 @@ public:
   virtual bool needsNotifications() override { return true; }
 
   static bool classof(const SILAnalysis *S) {
-    return S->getKind() == AnalysisKind::EpilogueARC;
+    return S->getKind() == SILAnalysisKind::EpilogueARC;
   }
 
   virtual void initialize(SILPassManager *PM) override;

--- a/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
@@ -750,7 +750,7 @@ public:
   EscapeAnalysis(SILModule *M);
 
   static bool classof(const SILAnalysis *S) {
-    return S->getKind() == AnalysisKind::Escape;
+    return S->getKind() == SILAnalysisKind::Escape;
   }
 
   virtual void initialize(SILPassManager *PM) override;

--- a/include/swift/SILOptimizer/Analysis/IVAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/IVAnalysis.h
@@ -82,12 +82,12 @@ private:
 class IVAnalysis final : public FunctionAnalysisBase<IVInfo> {
 public:
   IVAnalysis(SILModule *)
-      : FunctionAnalysisBase<IVInfo>(AnalysisKind::InductionVariable) {}
+      : FunctionAnalysisBase<IVInfo>(SILAnalysisKind::InductionVariable) {}
   IVAnalysis(const IVAnalysis &) = delete;
   IVAnalysis &operator=(const IVAnalysis &) = delete;
 
   static bool classof(const SILAnalysis *S) {
-    return S->getKind() == AnalysisKind::InductionVariable;
+    return S->getKind() == SILAnalysisKind::InductionVariable;
   }
 
   IVInfo *newFunctionAnalysis(SILFunction *F) override {

--- a/include/swift/SILOptimizer/Analysis/LoopAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/LoopAnalysis.h
@@ -32,10 +32,10 @@ class SILLoopAnalysis : public FunctionAnalysisBase<SILLoopInfo> {
   DominanceAnalysis *DA;
 public:
   SILLoopAnalysis(SILModule *)
-      : FunctionAnalysisBase(AnalysisKind::Loop), DA(nullptr) {}
+      : FunctionAnalysisBase(SILAnalysisKind::Loop), DA(nullptr) {}
 
   static bool classof(const SILAnalysis *S) {
-    return S->getKind() == AnalysisKind::Loop;
+    return S->getKind() == SILAnalysisKind::Loop;
   }
 
   virtual bool shouldInvalidate(SILAnalysis::InvalidationKind K) override {

--- a/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
@@ -1066,7 +1066,8 @@ class LoopRegionAnalysis : public FunctionAnalysisBase<LoopRegionFunctionInfo> {
 
 public:
   LoopRegionAnalysis(SILModule *M)
-    : FunctionAnalysisBase<LoopRegionFunctionInfo>(AnalysisKind::LoopRegion) {}
+      : FunctionAnalysisBase<LoopRegionFunctionInfo>(
+            SILAnalysisKind::LoopRegion) {}
 
   LoopRegionAnalysis(const LoopRegionAnalysis &) = delete;
   LoopRegionAnalysis &operator=(const LoopRegionAnalysis &) = delete;
@@ -1076,7 +1077,7 @@ public:
   virtual void initialize(SILPassManager *PM) override;
 
   static bool classof(const SILAnalysis *S) {
-    return S->getKind() == AnalysisKind::LoopRegion;
+    return S->getKind() == SILAnalysisKind::LoopRegion;
   }
 
   virtual LoopRegionFunctionInfo *newFunctionAnalysis(SILFunction *F) override {

--- a/include/swift/SILOptimizer/Analysis/PostOrderAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/PostOrderAnalysis.h
@@ -44,14 +44,15 @@ protected:
 
 public:
   PostOrderAnalysis()
-      : FunctionAnalysisBase<PostOrderFunctionInfo>(AnalysisKind::PostOrder) {}
+      : FunctionAnalysisBase<PostOrderFunctionInfo>(
+            SILAnalysisKind::PostOrder) {}
 
   // This is a cache and shouldn't be copied around.
   PostOrderAnalysis(const PostOrderAnalysis &) = delete;
   PostOrderAnalysis &operator=(const PostOrderAnalysis &) = delete;
 
   static bool classof(const SILAnalysis *S) {
-    return S->getKind() == AnalysisKind::PostOrder;
+    return S->getKind() == SILAnalysisKind::PostOrder;
   }
 };
 

--- a/include/swift/SILOptimizer/Analysis/ProtocolConformanceAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/ProtocolConformanceAnalysis.h
@@ -37,14 +37,14 @@ public:
       ProtocolConformanceMap;
 
   ProtocolConformanceAnalysis(SILModule *Mod)
-      : SILAnalysis(AnalysisKind::ProtocolConformance), M(Mod) {
+      : SILAnalysis(SILAnalysisKind::ProtocolConformance), M(Mod) {
     init();
   }
 
   ~ProtocolConformanceAnalysis();
 
   static bool classof(const SILAnalysis *S) {
-    return S->getKind() == AnalysisKind::ProtocolConformance;
+    return S->getKind() == SILAnalysisKind::ProtocolConformance;
   }
 
   /// Invalidate all information in this analysis.

--- a/include/swift/SILOptimizer/Analysis/RCIdentityAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RCIdentityAnalysis.h
@@ -93,8 +93,9 @@ class RCIdentityAnalysis : public FunctionAnalysisBase<RCIdentityFunctionInfo> {
 
 public:
   RCIdentityAnalysis(SILModule *)
-    : FunctionAnalysisBase<RCIdentityFunctionInfo>(AnalysisKind::RCIdentity),
-      DA(nullptr) {}
+      : FunctionAnalysisBase<RCIdentityFunctionInfo>(
+            SILAnalysisKind::RCIdentity),
+        DA(nullptr) {}
 
   RCIdentityAnalysis(const RCIdentityAnalysis &) = delete;
   RCIdentityAnalysis &operator=(const RCIdentityAnalysis &) = delete;
@@ -112,7 +113,7 @@ public:
   virtual bool needsNotifications() override { return true; }
 
   static bool classof(const SILAnalysis *S) {
-    return S->getKind() == AnalysisKind::RCIdentity;
+    return S->getKind() == SILAnalysisKind::RCIdentity;
   }
 
   virtual void initialize(SILPassManager *PM) override;

--- a/include/swift/SILOptimizer/Analysis/SideEffectAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/SideEffectAnalysis.h
@@ -89,7 +89,8 @@ class GenericFunctionEffectAnalysis : public BottomUpIPAnalysis {
   BasicCalleeAnalysis *BCA;
 
 public:
-  GenericFunctionEffectAnalysis(AnalysisKind kind) : BottomUpIPAnalysis(kind) {}
+  GenericFunctionEffectAnalysis(SILAnalysisKind kind)
+      : BottomUpIPAnalysis(kind) {}
 
   const FunctionEffects &getEffects(SILFunction *F) {
     FunctionInfo *functionInfo = getFunctionInfo(F);
@@ -441,10 +442,10 @@ class SideEffectAnalysis
 public:
   SideEffectAnalysis()
       : GenericFunctionEffectAnalysis<FunctionSideEffects>(
-            AnalysisKind::SideEffect) {}
+            SILAnalysisKind::SideEffect) {}
 
   static bool classof(const SILAnalysis *S) {
-    return S->getKind() == AnalysisKind::SideEffect;
+    return S->getKind() == SILAnalysisKind::SideEffect;
   }
 };
 

--- a/include/swift/SILOptimizer/Analysis/TypeExpansionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/TypeExpansionAnalysis.h
@@ -25,10 +25,10 @@ class TypeExpansionAnalysis : public SILAnalysis {
   llvm::DenseMap<SILType, ProjectionPathList> ExpansionCache;
 public:
   TypeExpansionAnalysis(SILModule *M)
-      : SILAnalysis(AnalysisKind::TypeExpansion) {}
+      : SILAnalysis(SILAnalysisKind::TypeExpansion) {}
 
   static bool classof(const SILAnalysis *S) {
-    return S->getKind() == AnalysisKind::TypeExpansion;
+    return S->getKind() == SILAnalysisKind::TypeExpansion;
   }
 
   /// Return ProjectionPath to every leaf or intermediate node of the given type.

--- a/lib/SILOptimizer/Analysis/ClosureScope.cpp
+++ b/lib/SILOptimizer/Analysis/ClosureScope.cpp
@@ -133,7 +133,7 @@ void ClosureScopeData::compute(SILModule *M) {
 }
 
 ClosureScopeAnalysis::ClosureScopeAnalysis(SILModule *M)
-    : SILAnalysis(AnalysisKind::ClosureScope), M(M), scopeData(nullptr) {}
+    : SILAnalysis(SILAnalysisKind::ClosureScope), M(M), scopeData(nullptr) {}
 
 ClosureScopeAnalysis::~ClosureScopeAnalysis() = default;
 

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -993,11 +993,9 @@ void EscapeAnalysis::ConnectionGraph::verifyStructure() const {
 //                          EscapeAnalysis
 //===----------------------------------------------------------------------===//
 
-EscapeAnalysis::EscapeAnalysis(SILModule *M) :
-  BottomUpIPAnalysis(AnalysisKind::Escape), M(M),
-  ArrayType(M->getASTContext().getArrayDecl()), BCA(nullptr) {
-}
-
+EscapeAnalysis::EscapeAnalysis(SILModule *M)
+    : BottomUpIPAnalysis(SILAnalysisKind::Escape), M(M),
+      ArrayType(M->getASTContext().getArrayDecl()), BCA(nullptr) {}
 
 void EscapeAnalysis::initialize(SILPassManager *PM) {
   BCA = PM->getAnalysis<BasicCalleeAnalysis>();

--- a/lib/SILOptimizer/Utils/OptimizerStatsUtils.cpp
+++ b/lib/SILOptimizer/Utils/OptimizerStatsUtils.cpp
@@ -474,10 +474,10 @@ class OptimizerStatsAnalysis : public SILAnalysis {
 
 public:
   OptimizerStatsAnalysis(SILModule *M)
-      : SILAnalysis(AnalysisKind::OptimizerStats), M(*M), Cache(nullptr) {}
+      : SILAnalysis(SILAnalysisKind::OptimizerStats), M(*M), Cache(nullptr) {}
 
   static bool classof(const SILAnalysis *S) {
-    return S->getKind() == AnalysisKind::OptimizerStats;
+    return S->getKind() == SILAnalysisKind::OptimizerStats;
   }
 
   /// Invalidate all information in this analysis.


### PR DESCRIPTION
…nto its own "struct enum" in a non-nested scope.

Generally in the SIL/SILOptimizer libraries we have been putting kinds in the
swift namespace, not a nested scope in a type in swift (see ValueKind as an
example of this).
