### PR TITLE
Remove inlinability etc from DoubleWidth prototype

### DIFF
--- a/test/Prototypes/DoubleWidth.swift.gyb
+++ b/test/Prototypes/DoubleWidth.swift.gyb
@@ -222,8 +222,8 @@ extension DoubleWidth: _ExpressibleByBuiltinIntegerLiteral {
 #endif
 
 
-extension DoubleWidth : FixedWidthInteger {
-    public struct Words : Collection {
+extension DoubleWidth {
+  public struct Words : Collection {
     public enum _IndexValue {
       case low(Low.Words.Index)
       case high(High.Words.Index)
@@ -308,7 +308,9 @@ extension DoubleWidth : FixedWidthInteger {
       }
     }
   }
+}
 
+extension DoubleWidth : FixedWidthInteger {
   public var words: Words {
     return Words(self)
   }

--- a/test/Prototypes/DoubleWidth.swift.gyb
+++ b/test/Prototypes/DoubleWidth.swift.gyb
@@ -224,7 +224,6 @@ extension DoubleWidth: _ExpressibleByBuiltinIntegerLiteral {
 
 extension DoubleWidth : FixedWidthInteger {
     public struct Words : Collection {
-    @_frozen // FIXME(sil-serialize-all)
     public enum _IndexValue {
       case low(Low.Words.Index)
       case high(High.Words.Index)

--- a/test/Prototypes/DoubleWidth.swift.gyb
+++ b/test/Prototypes/DoubleWidth.swift.gyb
@@ -106,20 +106,18 @@ extension DoubleWidth : CustomDebugStringConvertible {
   }
 }
 
-extension DoubleWidth : Comparable {
+extension DoubleWidth : Equatable {
   public static func ==(lhs: DoubleWidth, rhs: DoubleWidth) -> Bool {
-    return lhs._storage.low == rhs._storage.low &&
-      lhs._storage.high == rhs._storage.high
+    return lhs._storage.low == rhs._storage.low
+        && lhs._storage.high == rhs._storage.high
   }
+}
 
+extension DoubleWidth : Comparable {
   public static func <(lhs: DoubleWidth, rhs: DoubleWidth) -> Bool {
-    if lhs._storage.high < rhs._storage.high {
-      return true
-    }
-    if lhs._storage.high > rhs._storage.high {
-      return false
-    }
-    return lhs._storage.low < rhs._storage.low
+    if lhs._storage.high < rhs._storage.high { return true }
+    else if lhs._storage.high > rhs._storage.high { return false }
+    else { return lhs._storage.low < rhs._storage.low }
   }
 }
 

--- a/test/Prototypes/DoubleWidth.swift.gyb
+++ b/test/Prototypes/DoubleWidth.swift.gyb
@@ -237,16 +237,16 @@ extension DoubleWidth {
       self._low = value._storage.low.words
       _sanityCheck(!_low.isEmpty)
     }
-
-    internal enum _WordsIndexValue: Equatable {
-      case low(Low.Words.Index)
-      case high(High.Words.Index)
-    }
   }
 }
 
-extension DoubleWidth.Words {
+extension DoubleWidth.Words {  
   public struct Index {
+    internal enum _WordsIndexValue: Equatable {
+      case low(DoubleWidth.Low.Words.Index)
+      case high(DoubleWidth.High.Words.Index)
+    }
+
     internal var _value: _WordsIndexValue
 
     internal init(_ _value: _WordsIndexValue) { self._value = _value }
@@ -259,8 +259,8 @@ extension DoubleWidth.Words.Index: Comparable {
   public static func <(lhs: DoubleWidth.Words.Index, rhs: DoubleWidth.Words.Index) -> Bool {
     switch (lhs._value, rhs._value) {
     case let (.low(l), .low(r)): return l < r
-    case (.low(_), .high(_)): return true
-    case (.high(_), .low(_)): return false
+    case (.low, .high): return true
+    case (.high, .low): return false
     case let (.high(l), .high(r)): return l < r
     }
   }
@@ -282,15 +282,15 @@ extension DoubleWidth.Words: Collection {
 
   public func index(after i: Index) -> Index {
     switch i._value {
+    case let .low(li) where Base.bitWidth < UInt.bitWidth:
+      return Index(.high(_high.endIndex)) 
     case let .low(li):
-      if Base.bitWidth < UInt.bitWidth {
-        return Index(.high(_high.endIndex)) 
-      }
       let next = _low.index(after: li)
       if next == _low.endIndex { 
         return Index(.high(_high.startIndex)) 
+      } else {
+        return Index(.low(next))        
       }
-      return Index(.low(next))
     case let .high(hi):
       return Index(.high(_high.index(after: hi)))
     }

--- a/test/Prototypes/DoubleWidth.swift.gyb
+++ b/test/Prototypes/DoubleWidth.swift.gyb
@@ -38,7 +38,6 @@ import StdlibUnittest
 /// The `DoubleWidth` type is not intended as a replacement for a variable-width
 /// integer type. Nesting `DoubleWidth` instances, in particular, may result in
 /// undesirable performance.
-@_fixed_layout // FIXME(sil-serialize-all)
 public struct DoubleWidth<Base : FixedWidthInteger>
   where Base.Magnitude : UnsignedInteger,
   Base.Words : Collection, Base.Magnitude.Words : Collection {
@@ -47,21 +46,17 @@ public struct DoubleWidth<Base : FixedWidthInteger>
   public typealias Low = Base.Magnitude
 
 #if _endian(big)
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var _storage: (high: High, low: Low)
 #else
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var _storage: (low: Low, high: High)
 #endif
 
   /// The high part of the value.
-  @_transparent
   public var high: High {
     return _storage.high
   }
 
   /// The low part of the value.
-  @_transparent
   public var low: Low {
     return _storage.low
   }
@@ -70,7 +65,6 @@ public struct DoubleWidth<Base : FixedWidthInteger>
   ///
   /// - Parameter value: The tuple to use as the source of the new instance's
   ///   high and low parts.
-  @_transparent
   public init(_ value: (high: High, low: Low)) {
 #if _endian(big)
     self._storage = (high: value.0, low: value.1)
@@ -91,40 +85,33 @@ public struct DoubleWidth<Base : FixedWidthInteger>
   //
   // For that reason, we'll include an internal initializer that takes two
   // separate arguments.
-  @inlinable // FIXME(sil-serialize-all)
-  @usableFromInline  @_transparent
   internal init(_ _high: High, _ low: Low) {
     self.init((_high, low))
   }
 
-  @_transparent
   public init() {
     self.init(0, 0)
   }
 }
 
 extension DoubleWidth : CustomStringConvertible {
-  @inlinable // FIXME(sil-serialize-all)
   public var description: String {
     return String(self, radix: 10)
   }
 }
 
 extension DoubleWidth : CustomDebugStringConvertible {
-  @inlinable // FIXME(sil-serialize-all)
   public var debugDescription: String {
     return "(\(_storage.high), \(_storage.low))"
   }
 }
 
 extension DoubleWidth : Comparable {
-  @inlinable // FIXME(sil-serialize-all)
   public static func ==(lhs: DoubleWidth, rhs: DoubleWidth) -> Bool {
     return lhs._storage.low == rhs._storage.low &&
       lhs._storage.high == rhs._storage.high
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public static func <(lhs: DoubleWidth, rhs: DoubleWidth) -> Bool {
     if lhs._storage.high < rhs._storage.high {
       return true
@@ -137,12 +124,10 @@ extension DoubleWidth : Comparable {
 }
 
 extension DoubleWidth : Hashable {
-  @inlinable // FIXME(sil-serialize-all)
   public var hashValue: Int {
     return _hashValue(for: self)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public func hash(into hasher: inout Hasher) {
     hasher.combine(low)
     hasher.combine(high)
@@ -152,7 +137,6 @@ extension DoubleWidth : Hashable {
 extension DoubleWidth : Numeric {
   public typealias Magnitude = DoubleWidth<Low>
 
-  @inlinable // FIXME(sil-serialize-all)
   public var magnitude: Magnitude {
     let result = Magnitude(Low(truncatingIfNeeded: _storage.high), _storage.low)
     if Base.isSigned && _storage.high < (0 as High) {
@@ -162,13 +146,10 @@ extension DoubleWidth : Numeric {
     }
   }
 
-  @inlinable // FIXME(sil-serialize-all)
-  @usableFromInline // FIXME(sil-serialize-all)
   internal init(_ _magnitude: Magnitude) {
     self.init(High(_magnitude._storage.high), _magnitude._storage.low)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public init<T : BinaryInteger>(_ source: T) {
     guard let result = DoubleWidth<Base>(exactly: source) else {
       _preconditionFailure("Value is outside the representable range")
@@ -176,7 +157,6 @@ extension DoubleWidth : Numeric {
     self = result
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public init?<T : BinaryInteger>(exactly source: T) {
     // Can't represent a negative 'source' if Base is unsigned.
     guard DoubleWidth.isSigned || source >= 0 else { return nil }
@@ -202,7 +182,6 @@ extension DoubleWidth : Numeric {
 // This conformance is only possible once the type is in the stdlib, as it uses
 // Builtin
 extension DoubleWidth: _ExpressibleByBuiltinIntegerLiteral {
-  @inlinable // FIXME(sil-serialize-all)
   public init(_builtinIntegerLiteral _x: _MaxBuiltinIntegerType) {
     var _x = _x
     self = DoubleWidth()
@@ -246,22 +225,18 @@ extension DoubleWidth: _ExpressibleByBuiltinIntegerLiteral {
 
 
 extension DoubleWidth : FixedWidthInteger {
-  @_fixed_layout // FIXME(sil-serialize-all)
-  public struct Words : Collection {
+    public struct Words : Collection {
     @_frozen // FIXME(sil-serialize-all)
     public enum _IndexValue {
       case low(Low.Words.Index)
       case high(High.Words.Index)
     }
     
-    @_fixed_layout // FIXME(sil-serialize-all)
-    public struct Index : Comparable {
+        public struct Index : Comparable {
       public var _value: _IndexValue
 
-      @inlinable // FIXME(sil-serialize-all)
       public init(_ _value: _IndexValue) { self._value = _value }
 
-      @inlinable // FIXME(sil-serialize-all)
       public static func ==(lhs: Index, rhs: Index) -> Bool {
         switch (lhs._value, rhs._value) {
         case let (.low(l), .low(r)): return l == r
@@ -270,7 +245,6 @@ extension DoubleWidth : FixedWidthInteger {
         }
       }
 
-      @inlinable // FIXME(sil-serialize-all)
       public static func <(lhs: Index, rhs: Index) -> Bool {
         switch (lhs._value, rhs._value) {
         case let (.low(l), .low(r)): return l < r
@@ -284,7 +258,6 @@ extension DoubleWidth : FixedWidthInteger {
     public var _high: High.Words
     public var _low: Low.Words
 
-    @inlinable // FIXME(sil-serialize-all)
     public init(_ value: DoubleWidth<Base>) {
       // Multiples of word size only.
       guard Base.bitWidth == Base.Magnitude.bitWidth &&
@@ -297,23 +270,19 @@ extension DoubleWidth : FixedWidthInteger {
       _sanityCheck(!_low.isEmpty)
     }
 
-    @inlinable // FIXME(sil-serialize-all)
     public var startIndex: Index {
       return Index(.low(_low.startIndex))
     }
 
-    @inlinable // FIXME(sil-serialize-all)
     public var endIndex: Index {
       return Index(.high(_high.endIndex))
     }
     
-    @inlinable // FIXME(sil-serialize-all)
     public var count: Int {
       if Base.bitWidth < UInt.bitWidth { return 1 }
       return Int(_low.count) + Int(_high.count)
     }
   
-    @inlinable // FIXME(sil-serialize-all)
     public func index(after i: Index) -> Index {
       switch i._value {
       case let .low(li):
@@ -330,7 +299,6 @@ extension DoubleWidth : FixedWidthInteger {
       }
     }
   
-    @inlinable // FIXME(sil-serialize-all)
     public subscript(_ i: Index) -> UInt {
       if Base.bitWidth < UInt.bitWidth {
         _precondition(i == Index(.low(_low.startIndex)), "Invalid index")
@@ -344,34 +312,28 @@ extension DoubleWidth : FixedWidthInteger {
     }
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public var words: Words {
     return Words(self)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public static var isSigned: Bool {
     return Base.isSigned
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public static var max: DoubleWidth {
     return self.init(High.max, Low.max)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public static var min: DoubleWidth {
     return self.init(High.min, Low.min)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public static var bitWidth: Int {
     return High.bitWidth + Low.bitWidth
   }
 
 % for (operator, name) in [('+', 'adding'), ('-', 'subtracting')]:
 %   highAffectedByLowOverflow = 'Base.max' if operator == '+' else 'Base.min'
-  @inlinable // FIXME(sil-serialize-all)
   public func ${name}ReportingOverflow(_ rhs: DoubleWidth)
     -> (partialValue: DoubleWidth, overflow: Bool) {
     let (low, lowOverflow) =
@@ -385,7 +347,6 @@ extension DoubleWidth : FixedWidthInteger {
   }
 % end
 
-  @inlinable // FIXME(sil-serialize-all)
   public func multipliedReportingOverflow(
     by rhs: DoubleWidth
   ) -> (partialValue: DoubleWidth, overflow: Bool) {
@@ -403,7 +364,6 @@ extension DoubleWidth : FixedWidthInteger {
     return (result, didCarry || hadPositiveOverflow)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public func quotientAndRemainder(
     dividingBy other: DoubleWidth
   ) -> (quotient: DoubleWidth, remainder: DoubleWidth) {
@@ -424,7 +384,6 @@ extension DoubleWidth : FixedWidthInteger {
     return (quotient_, remainder_)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public func dividedReportingOverflow(
     by other: DoubleWidth
   ) -> (partialValue: DoubleWidth, overflow: Bool) {
@@ -435,7 +394,6 @@ extension DoubleWidth : FixedWidthInteger {
     return (quotientAndRemainder(dividingBy: other).quotient, false)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public func remainderReportingOverflow(
     dividingBy other: DoubleWidth
   ) -> (partialValue: DoubleWidth, overflow: Bool) {
@@ -444,7 +402,6 @@ extension DoubleWidth : FixedWidthInteger {
     return (quotientAndRemainder(dividingBy: other).remainder, false)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public func multipliedFullWidth(
     by other: DoubleWidth
   ) -> (high: DoubleWidth, low: DoubleWidth.Magnitude) {
@@ -487,7 +444,6 @@ extension DoubleWidth : FixedWidthInteger {
     }
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public func dividingFullWidth(
     _ dividend: (high: DoubleWidth, low: DoubleWidth.Magnitude)
   ) -> (quotient: DoubleWidth, remainder: DoubleWidth) {
@@ -511,7 +467,6 @@ extension DoubleWidth : FixedWidthInteger {
   }
 
 % for operator in ['&', '|', '^']:
-  @inlinable // FIXME(sil-serialize-all)
   public static func ${operator}=(
     lhs: inout DoubleWidth, rhs: DoubleWidth
   ) {
@@ -520,7 +475,6 @@ extension DoubleWidth : FixedWidthInteger {
   }
 % end
 
-  @inlinable // FIXME(sil-serialize-all)
   public static func <<=(lhs: inout DoubleWidth, rhs: DoubleWidth) {
     if DoubleWidth.isSigned && rhs < (0 as DoubleWidth) {
       lhs >>= 0 - rhs
@@ -538,7 +492,6 @@ extension DoubleWidth : FixedWidthInteger {
     lhs &<<= rhs
   }
   
-  @inlinable // FIXME(sil-serialize-all)
   public static func >>=(lhs: inout DoubleWidth, rhs: DoubleWidth) {
     if DoubleWidth.isSigned && rhs < (0 as DoubleWidth) {
       lhs <<= 0 - rhs
@@ -561,7 +514,6 @@ extension DoubleWidth : FixedWidthInteger {
   /// "Masking" notionally involves repeatedly incrementing or decrementing this
   /// value by `self.bitWidth` until the result is contained in the range
   /// `0..<self.bitWidth`.
-  @usableFromInline  @_transparent
   internal func _masked() -> DoubleWidth {
     // FIXME(integers): test types with bit widths that aren't powers of 2
     if DoubleWidth.bitWidth.nonzeroBitCount == 1 {
@@ -573,7 +525,6 @@ extension DoubleWidth : FixedWidthInteger {
     return self % DoubleWidth(DoubleWidth.bitWidth)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public static func &<<=(lhs: inout DoubleWidth, rhs: DoubleWidth) {
     let rhs = rhs._masked()
 
@@ -593,7 +544,6 @@ extension DoubleWidth : FixedWidthInteger {
     lhs._storage.low &<<= rhs._storage.low
   }
   
-  @inlinable // FIXME(sil-serialize-all)
   public static func &>>=(lhs: inout DoubleWidth, rhs: DoubleWidth) {
     let rhs = rhs._masked()
 
@@ -625,7 +575,6 @@ binaryOperators = [
 % for (operator, name, firstArg, kind) in binaryOperators:
 
   // FIXME(integers): remove this once the operators are back to Numeric
-  @inlinable // FIXME(sil-serialize-all)
   public static func ${operator} (
     lhs: DoubleWidth, rhs: DoubleWidth
   ) -> DoubleWidth {
@@ -635,7 +584,6 @@ binaryOperators = [
   }
 
 %   argumentLabel = (firstArg + ':') if firstArg != '_' else ''
-  @inlinable // FIXME(sil-serialize-all)
   public static func ${operator}=(
     lhs: inout DoubleWidth, rhs: DoubleWidth
   ) {
@@ -645,36 +593,30 @@ binaryOperators = [
   }
 % end
 
-  @inlinable // FIXME(sil-serialize-all)
   public init(_truncatingBits bits: UInt) {
     _storage.low = Low(_truncatingBits: bits)
     _storage.high = High(_truncatingBits: bits >> UInt(Low.bitWidth))
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public init(integerLiteral x: Int) {
     self.init(x)
   }
-  @inlinable // FIXME(sil-serialize-all)
   public var leadingZeroBitCount: Int {
     return high == (0 as High)
       ? High.bitWidth + low.leadingZeroBitCount
       : high.leadingZeroBitCount
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public var trailingZeroBitCount: Int {
     return low == (0 as Low)
       ? Low.bitWidth + high.trailingZeroBitCount
       : low.trailingZeroBitCount
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public var nonzeroBitCount: Int {
     return high.nonzeroBitCount + low.nonzeroBitCount
   }
 
-  @_transparent
   public var byteSwapped: DoubleWidth {
     return DoubleWidth(
       High(truncatingIfNeeded: low.byteSwapped),
@@ -688,8 +630,6 @@ extension DoubleWidth : UnsignedInteger where Base : UnsignedInteger {
   ///
   /// This operation is conceptually that described by Burnikel and Ziegler
   /// (1998).
-  @inlinable // FIXME(sil-serialize-all)
-  @usableFromInline
   internal static func _divide(
     _ lhs: (high: Low, mid: Low, low: Low), by rhs: Magnitude
   ) -> (quotient: Low, remainder: Magnitude) {
@@ -725,8 +665,6 @@ extension DoubleWidth : UnsignedInteger where Base : UnsignedInteger {
 
   /// Returns the quotient and remainder after dividing a quadruple-width
   /// magnitude `lhs` by a double-width magnitude `rhs`.
-  @inlinable // FIXME(sil-serialize-all)
-  @usableFromInline
   internal static func _divide(
     _ lhs: DoubleWidth<Magnitude>, by rhs: Magnitude
   ) -> (quotient: Magnitude, remainder: Magnitude) {
@@ -774,8 +712,6 @@ extension DoubleWidth : UnsignedInteger where Base : UnsignedInteger {
 
   /// Returns the quotient and remainder after dividing a double-width
   /// magnitude `lhs` by a double-width magnitude `rhs`.
-  @inlinable // FIXME(sil-serialize-all)
-  @usableFromInline
   internal static func _divide(
     _ lhs: Magnitude, by rhs: Magnitude
   ) -> (quotient: Magnitude, remainder: Magnitude) {

--- a/test/Prototypes/DoubleWidth.swift.gyb
+++ b/test/Prototypes/DoubleWidth.swift.gyb
@@ -238,7 +238,7 @@ extension DoubleWidth {
       _sanityCheck(!_low.isEmpty)
     }
 
-    internal enum _WordsIndexValue {
+    internal enum _WordsIndexValue: Equatable {
       case low(Low.Words.Index)
       case high(High.Words.Index)
     }
@@ -253,15 +253,7 @@ extension DoubleWidth.Words {
   }
 }
 
-extension DoubleWidth.Words.Index: Equatable {
-  public static func ==(lhs: DoubleWidth.Words.Index, rhs: DoubleWidth.Words.Index) -> Bool {
-    switch (lhs._value, rhs._value) {
-    case let (.low(l), .low(r)): return l == r
-    case let (.high(l), .high(r)): return l == r
-    default: return false
-    }
-  }
-}
+extension DoubleWidth.Words.Index: Equatable { }
 
 extension DoubleWidth.Words.Index: Comparable {
   public static func <(lhs: DoubleWidth.Words.Index, rhs: DoubleWidth.Words.Index) -> Bool {

--- a/test/Prototypes/DoubleWidth.swift.gyb
+++ b/test/Prototypes/DoubleWidth.swift.gyb
@@ -246,7 +246,7 @@ extension DoubleWidth {
   }
 }
 
-extension DoubleWidth.Words: Collection {  
+extension DoubleWidth.Words {
   public struct Index : Comparable {
     public var _value: _IndexValue
 
@@ -268,8 +268,10 @@ extension DoubleWidth.Words: Collection {
       case let (.high(l), .high(r)): return l < r
       }
     }
-  }
+  }  
+}
 
+extension DoubleWidth.Words: Collection {
   public var startIndex: Index {
     return Index(.low(_low.startIndex))
   }

--- a/test/Prototypes/DoubleWidth.swift.gyb
+++ b/test/Prototypes/DoubleWidth.swift.gyb
@@ -223,35 +223,7 @@ extension DoubleWidth: _ExpressibleByBuiltinIntegerLiteral {
 
 
 extension DoubleWidth {
-  public struct Words : Collection {
-    public enum _IndexValue {
-      case low(Low.Words.Index)
-      case high(High.Words.Index)
-    }
-    
-        public struct Index : Comparable {
-      public var _value: _IndexValue
-
-      public init(_ _value: _IndexValue) { self._value = _value }
-
-      public static func ==(lhs: Index, rhs: Index) -> Bool {
-        switch (lhs._value, rhs._value) {
-        case let (.low(l), .low(r)): return l == r
-        case let (.high(l), .high(r)): return l == r
-        default: return false
-        }
-      }
-
-      public static func <(lhs: Index, rhs: Index) -> Bool {
-        switch (lhs._value, rhs._value) {
-        case let (.low(l), .low(r)): return l < r
-        case (.low(_), .high(_)): return true
-        case (.high(_), .low(_)): return false
-        case let (.high(l), .high(r)): return l < r
-        }
-      }
-    }
-
+  public struct Words {
     public var _high: High.Words
     public var _low: Low.Words
 
@@ -267,45 +239,75 @@ extension DoubleWidth {
       _sanityCheck(!_low.isEmpty)
     }
 
-    public var startIndex: Index {
-      return Index(.low(_low.startIndex))
+    public enum _IndexValue {
+      case low(Low.Words.Index)
+      case high(High.Words.Index)
+    }
+  }
+}
+
+extension DoubleWidth.Words: Collection {  
+  public struct Index : Comparable {
+    public var _value: _IndexValue
+
+    public init(_ _value: _IndexValue) { self._value = _value }
+
+    public static func ==(lhs: Index, rhs: Index) -> Bool {
+      switch (lhs._value, rhs._value) {
+      case let (.low(l), .low(r)): return l == r
+      case let (.high(l), .high(r)): return l == r
+      default: return false
+      }
     }
 
-    public var endIndex: Index {
-      return Index(.high(_high.endIndex))
-    }
-    
-    public var count: Int {
-      if Base.bitWidth < UInt.bitWidth { return 1 }
-      return Int(_low.count) + Int(_high.count)
-    }
-  
-    public func index(after i: Index) -> Index {
-      switch i._value {
-      case let .low(li):
-        if Base.bitWidth < UInt.bitWidth {
-          return Index(.high(_high.endIndex)) 
-        }
-        let next = _low.index(after: li)
-        if next == _low.endIndex { 
-          return Index(.high(_high.startIndex)) 
-        }
-        return Index(.low(next))
-      case let .high(hi):
-        return Index(.high(_high.index(after: hi)))
+    public static func <(lhs: Index, rhs: Index) -> Bool {
+      switch (lhs._value, rhs._value) {
+      case let (.low(l), .low(r)): return l < r
+      case (.low(_), .high(_)): return true
+      case (.high(_), .low(_)): return false
+      case let (.high(l), .high(r)): return l < r
       }
     }
+  }
+
+  public var startIndex: Index {
+    return Index(.low(_low.startIndex))
+  }
+
+  public var endIndex: Index {
+    return Index(.high(_high.endIndex))
+  }
   
-    public subscript(_ i: Index) -> UInt {
+  public var count: Int {
+    if Base.bitWidth < UInt.bitWidth { return 1 }
+    return Int(_low.count) + Int(_high.count)
+  }
+
+  public func index(after i: Index) -> Index {
+    switch i._value {
+    case let .low(li):
       if Base.bitWidth < UInt.bitWidth {
-        _precondition(i == Index(.low(_low.startIndex)), "Invalid index")
-        _sanityCheck(2 * Base.bitWidth <= UInt.bitWidth)
-        return _low.first! | (_high.first! &<< Base.bitWidth._lowWord) 
+        return Index(.high(_high.endIndex)) 
       }
-      switch i._value {
-      case let .low(li): return _low[li]
-      case let .high(hi): return _high[hi]
+      let next = _low.index(after: li)
+      if next == _low.endIndex { 
+        return Index(.high(_high.startIndex)) 
       }
+      return Index(.low(next))
+    case let .high(hi):
+      return Index(.high(_high.index(after: hi)))
+    }
+  }
+
+  public subscript(_ i: Index) -> UInt {
+    if Base.bitWidth < UInt.bitWidth {
+      _precondition(i == Index(.low(_low.startIndex)), "Invalid index")
+      _sanityCheck(2 * Base.bitWidth <= UInt.bitWidth)
+      return _low.first! | (_high.first! &<< Base.bitWidth._lowWord) 
+    }
+    switch i._value {
+    case let .low(li): return _low[li]
+    case let .high(hi): return _high[hi]
     }
   }
 }

--- a/test/Prototypes/DoubleWidth.swift.gyb
+++ b/test/Prototypes/DoubleWidth.swift.gyb
@@ -221,7 +221,6 @@ extension DoubleWidth: _ExpressibleByBuiltinIntegerLiteral {
 
 #endif
 
-
 extension DoubleWidth {
   public struct Words {
     public var _high: High.Words
@@ -239,7 +238,7 @@ extension DoubleWidth {
       _sanityCheck(!_low.isEmpty)
     }
 
-    public enum _IndexValue {
+    internal enum _WordsIndexValue {
       case low(Low.Words.Index)
       case high(High.Words.Index)
     }
@@ -247,28 +246,32 @@ extension DoubleWidth {
 }
 
 extension DoubleWidth.Words {
-  public struct Index : Comparable {
-    public var _value: _IndexValue
+  public struct Index {
+    internal var _value: _WordsIndexValue
 
-    public init(_ _value: _IndexValue) { self._value = _value }
+    internal init(_ _value: _WordsIndexValue) { self._value = _value }
+  }
+}
 
-    public static func ==(lhs: Index, rhs: Index) -> Bool {
-      switch (lhs._value, rhs._value) {
-      case let (.low(l), .low(r)): return l == r
-      case let (.high(l), .high(r)): return l == r
-      default: return false
-      }
+extension DoubleWidth.Words.Index: Equatable {
+  public static func ==(lhs: DoubleWidth.Words.Index, rhs: DoubleWidth.Words.Index) -> Bool {
+    switch (lhs._value, rhs._value) {
+    case let (.low(l), .low(r)): return l == r
+    case let (.high(l), .high(r)): return l == r
+    default: return false
     }
+  }
+}
 
-    public static func <(lhs: Index, rhs: Index) -> Bool {
-      switch (lhs._value, rhs._value) {
-      case let (.low(l), .low(r)): return l < r
-      case (.low(_), .high(_)): return true
-      case (.high(_), .low(_)): return false
-      case let (.high(l), .high(r)): return l < r
-      }
+extension DoubleWidth.Words.Index: Comparable {
+  public static func <(lhs: DoubleWidth.Words.Index, rhs: DoubleWidth.Words.Index) -> Bool {
+    switch (lhs._value, rhs._value) {
+    case let (.low(l), .low(r)): return l < r
+    case (.low(_), .high(_)): return true
+    case (.high(_), .low(_)): return false
+    case let (.high(l), .high(r)): return l < r
     }
-  }  
+  }
 }
 
 extension DoubleWidth.Words: Collection {


### PR DESCRIPTION
Since this moved to the Prototypes directory, it probably makes sense to remove the inlinability and similar annotations, to be put back on with re-consideration if it ever moves back into the stdlib. Seems better than just removing the `// FIXME(sil-serialize-all)` annotations.