### PR TITLE
[caller-analysis] Implement findLocalApplySites and reimplement caller analysis on top of it

### DIFF
--- a/include/swift/SILOptimizer/Analysis/CallerAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/CallerAnalysis.h
@@ -13,10 +13,11 @@
 #ifndef SWIFT_SILOPTIMIZER_ANALYSIS_CALLERANALYSIS_H
 #define SWIFT_SILOPTIMIZER_ANALYSIS_CALLERANALYSIS_H
 
-#include "swift/SILOptimizer/Analysis/Analysis.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILModule.h"
+#include "swift/SILOptimizer/Analysis/Analysis.h"
+#include "swift/SILOptimizer/Utils/Local.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallSet.h"
@@ -24,108 +25,91 @@
 
 namespace swift {
 
-/// CallerAnalysis relies on keeping the Caller/Callee relation up-to-date
-/// lazily. i.e. when a function is invalidated, instead of recomputing the
-/// function it calls right away, its kept in a recompute list and
-/// CallerAnalysis recomputes and empty the recompute list before any query.
+/// \brief A lazy caller analysis that works by only recomputing its state upon
+/// an ask for information.
 ///
-/// We also considered the possibility of keeping a computed list, instead of
-/// recompute Every time we need to complete the computed list (i.e. we want
-/// to the computed list to contain every function in the module). We need to
-/// walk through every function in the module. This leads to O(n) And we need
-/// to run every function through the a sequence of function passes which might
-/// invalidate the functions and make the computed list incomplete. So
-/// O(n) * O(n) = O(n^2).
+/// This laziness is implemented by the pass invalidating its internal state for
+/// a function F when receiving an invalidation message for F and then adding F
+/// to a recompute list. When the method getFunctionInfo is called, the
+/// recompute list is used to recompute all of the invalidated state.
 ///
-/// In addition of caller information this analysis also provides information
-/// about partial applies of a function.
-class CallerAnalysis : public SILAnalysis {
+/// Originally, swift had an eagerly recomputed caller analysis. This was found
+/// to cause large compile time problems since after every invalidation we
+/// needed to walk every function in the module to update any invalidated
+/// state. This in combination with a sequence of invalidating function passes
+/// can lead to many invalidations even if the information is not used.
+///
+/// NOTE: We use the term caller in a loose way here since in this analysis, we
+/// consider partial applies of the function to be "callers" of the function.
+class CallerAnalysis final : public SILAnalysis {
 public:
   class FunctionInfo;
 
 private:
+  struct CallerInfo;
+  struct ApplySiteFinderVisitor;
+
   /// Current module we are analyzing.
-  SILModule &Mod;
+  SILModule &mod;
 
   /// A map between all the functions and their callsites in the module.
-  llvm::DenseMap<SILFunction *, FunctionInfo> FuncInfos;
+  mutable llvm::DenseMap<SILFunction *, FunctionInfo> funcInfos;
 
-  /// A list of functions that needs to be recomputed.
-  llvm::SetVector<SILFunction *> RecomputeFunctionList;
-
-  /// Iterate over all the call sites in the function and update
-  /// CallInfo.
-  void processFunctionCallSites(SILFunction *F); 
-
-  /// This function is about to become "unknown" to us. Invalidate any 
-  /// callsite information related to it.
-  void invalidateExistingCalleeRelation(SILFunction *F); 
-
-  void processRecomputeFunctionList() {
-    for (auto &F : RecomputeFunctionList) {
-      processFunctionCallSites(F);
-    }
-    RecomputeFunctionList.clear(); 
-  }
+  /// A set of functions that needs to be recomputed before we can serve
+  /// queries.
+  llvm::SetVector<SILFunction *> recomputeFunctionList;
 
 public:
-  CallerAnalysis(SILModule *M) : SILAnalysis(SILAnalysisKind::Caller), Mod(*M) {
-    // Make sure we compute everything first time called.
-    for (auto &F : Mod) {
-      FuncInfos.FindAndConstruct(&F);
-      RecomputeFunctionList.insert(&F);
-    }
-  }
+  CallerAnalysis(SILModule *m);
 
-  static bool classof(const SILAnalysis *S) {
-    return S->getKind() == SILAnalysisKind::Caller;
+  static bool classof(const SILAnalysis *s) {
+    return s->getKind() == SILAnalysisKind::Caller;
   }
 
   /// Invalidate all information in this analysis.
-  virtual void invalidate() override {
-    FuncInfos.clear();
-    RecomputeFunctionList.clear();
-    for (auto &F : Mod) {
-      RecomputeFunctionList.insert(&F);
-    }
-  }
+  void invalidate() override;
 
-  /// Invalidate all of the information for a specific function.
-  virtual void invalidate(SILFunction *F, InvalidationKind K) override {
+  /// Invalidate all of the information for a specific caller function.
+  void invalidate(SILFunction *caller, InvalidationKind k) override {
     // Should we invalidate based on the invalidation kind.
-    bool shouldInvalidate = K & InvalidationKind::CallsAndInstructions;
+    bool shouldInvalidate = k & InvalidationKind::CallsAndInstructions;
     if (!shouldInvalidate)
       return;
 
     // This function has become "unknown" to us. Invalidate any callsite
     // information related to this function.
-    invalidateExistingCalleeRelation(F);
+    invalidateKnownCallees(caller);
+
     // Make sure this function is recomputed next time.
-    RecomputeFunctionList.insert(F);
+    recomputeFunctionList.insert(caller);
   }
 
   /// Notify the analysis about a newly created or modified function.
-  virtual void notifyAddedOrModifiedFunction(SILFunction *F) override {
-    RecomputeFunctionList.insert(F);
+  void notifyAddedOrModifiedFunction(SILFunction *f) override {
+    auto &fInfo = getOrInsertFunctionInfo(f);
+    (void)fInfo;
+    recomputeFunctionList.insert(f);
   }
 
   /// Notify the analysis about a function which will be deleted from the
   /// module.
-  virtual void notifyWillDeleteFunction(SILFunction *F) override {
-    invalidateExistingCalleeRelation(F);
-    RecomputeFunctionList.remove(F);
+  void notifyWillDeleteFunction(SILFunction *f) override {
+    invalidateAllInfo(f);
+    recomputeFunctionList.remove(f);
+    // Now that we have invalidated all references to the function, delete it.
+    funcInfos.erase(f);
   }
 
   /// Notify the analysis about changed witness or vtables.
-  virtual void invalidateFunctionTables() override { }
+  ///
+  /// Today this is unimplemented since the CallerAnalysis does not attempt...
+  /// yet... to understand class_method or witness_method. Once that is
+  /// is implemented,
+  void invalidateFunctionTables() override {}
 
-  const FunctionInfo &getCallerInfo(SILFunction *F) const {
-    // Recompute every function in the invalidated function list and empty the
-    // list.
-    auto *self = const_cast<CallerAnalysis *>(this);
-    self->processRecomputeFunctionList();
-    return self->FuncInfos[F];
-  }
+  /// Look up the function info that we have stored for f, recomputing all
+  /// invalidating parts of the call graph.
+  const FunctionInfo &getFunctionInfo(SILFunction *f) const;
 
   LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
                             "Only for use in the debugger");
@@ -139,45 +123,231 @@ public:
   LLVM_ATTRIBUTE_DEPRECATED(void print(const char *filePath)
                                 const LLVM_ATTRIBUTE_USED,
                             "Only for use in the debugger");
+
+  void verify() const override;
+  void verify(SILFunction *f) const override;
+
+private:
+  /// Iterate over all the call sites in the function and update
+  /// CallInfo.
+  void processFunctionCallSites(SILFunction *f);
+
+  /// This function is about to become "unknown" to us. Invalidate any
+  /// callsite information related to it.
+  ///
+  /// This is a function that just looks up the function info for f and then
+  /// calls:
+  ///
+  /// void invalidateKnownCallees(SILFunction *caller,
+  ///       FunctionInfo &callerInfo);
+  void invalidateKnownCallees(SILFunction *f);
+
+  /// Using the passed in caller info and caller function, eliminate the edge
+  /// inbetween the caller and its callees.
+  ///
+  /// NOTE: This does not remove the "book keeping" backedges from the caller
+  /// function to its own set of callers. This must be invalidated by using
+  /// invalidateAllInfo.
+  void invalidateKnownCallees(SILFunction *caller, FunctionInfo &callerInfo);
+
+  /// Invalidate both the known callees of f and the known callers of f.
+  void invalidateAllInfo(SILFunction *f);
+
+  /// Helper method that reprocesses all elements of recomputeFunctionList and
+  /// then clears the function list.
+  ///
+  /// NOTE: This is the part of the analysis that performs the lazy
+  /// recomputation upon access.
+  void processRecomputeFunctionList() {
+    for (auto &f : recomputeFunctionList) {
+      processFunctionCallSites(f);
+    }
+    recomputeFunctionList.clear();
+  }
+
+  /// Internal only way for getting a caller info. Will insert f if needed and
+  /// _WILL NOT_ preform any recomputation of the callgraph.
+  FunctionInfo &getOrInsertFunctionInfo(SILFunction *f);
+
+  /// Internal only method for unsafely getting the FunctionInfo for the
+  /// SILFunction \p f.
+  ///
+  /// This is valid since we assume that we have maintained our datastructures
+  /// via notifications for functions being added/destroyed.
+  ///
+  /// NOTE: In asserts builds this routine asserts if we do not have function
+  /// info for f.
+  /// NOTE: This routine _WILL NOT_ perform any recomputation of the callgraph.
+  FunctionInfo &unsafeGetFunctionInfo(SILFunction *f);
+
+  /// const_cast version of FunctionInfo &unsafeGetFunctionInfo(SILFunction *).
+  const FunctionInfo &unsafeGetFunctionInfo(SILFunction *f) const;
+
+  /// Helper function for verification that hoists out the callerInfo.
+  void verify(SILFunction *caller, const FunctionInfo &callerInfo) const;
 };
 
-/// NOTE: this can be extended to contain the callsites of the function.
+/// Auxillary information that we store about a specific caller.
+struct CallerAnalysis::CallerInfo {
+  /// Given a SILFunction F that contains at least one partial apply of the
+  /// given function, map F to the minimum number of partial applied
+  /// arguments of any partial application in F.
+  ///
+  /// By storing the minimum number of partial applied arguments, we are able
+  /// to decide quickly if we are able to eliminate dead captured arguments.
+  ///
+  /// NOTE: We know that we will never have more than 2^16 generic arguments due
+  /// to the runtime implementation.
+  uint8_t numPartiallyAppliedArguments[2];
+
+  /// A boolean flag to say if we actually have partially applied arguments.
+  ///
+  /// Otherwise it would be unable to distinguish not having partially applied
+  /// arguments from having zero partially applied argument.
+  bool hasPartiallyAppliedArguments : 1;
+
+  /// True if this caller performs at least one full application of the
+  /// callee.
+  bool hasFullApply : 1;
+
+  /// True if this caller can guarantee that all direct caller's of this
+  /// function inside of it can be found.
+  ///
+  /// NOTE: This does not imply that a function can not be called
+  /// indirectly. That is a separate query that is type system specific.
+  bool isDirectCallerSetComplete : 1;
+
+  Optional<unsigned> getNumPartiallyAppliedArguments() const {
+    if (!hasPartiallyAppliedArguments) {
+      return None;
+    }
+
+    auto *x = reinterpret_cast<const uint16_t *>(numPartiallyAppliedArguments);
+    return unsigned(*x);
+  }
+
+  void setNumPartiallyAppliedArguments(unsigned newValue) {
+    hasPartiallyAppliedArguments = true;
+    auto *x = reinterpret_cast<uint16_t *>(numPartiallyAppliedArguments);
+    x[0] = uint16_t(newValue);
+  }
+};
+
+/// This is a representation of the caller information that we have associated
+/// with a specific function.
+///
+/// NOTE: If needed, this can be extended to contain the callsites of the
+/// function. Today we do not provide any functionality that requires knowledge
+/// of exact callsites, so it would just be a waste of memory.
 class CallerAnalysis::FunctionInfo {
   friend class CallerAnalysis;
+  using CallerInfo = CallerAnalysis::CallerInfo;
+  struct YAMLRepresentation;
 
-  /// A list of all the functions this function calls or partially applies.
-  llvm::SmallSetVector<SILFunction *, 4> Callees;
+  // A static_assert to make sure that CallerInfo remains 3 bytes for
+  // performance reasons. We are going to store a bunch of these in callerStates
+  // so we want them to be as small as possible.
+  static_assert(sizeof(CallerAnalysis::CallerInfo) == 3,
+                "Expected caller info to be 3 bytes for performance reasons");
 
-  /// A list of all the callers this function has.
-  llvm::SmallSet<SILFunction *, 4> Callers;
+  /// A map from a function containing uses of a function_ref of the callee to
+  /// the state that we store about the caller's body.
+  llvm::SmallMapVector<SILFunction *, CallerInfo, 1> callerStates;
 
-  /// The number of partial applied arguments of this function.
+  /// Private helper type to reduce 80 column violations.
+  using CallerStatesValueType = decltype(callerStates)::value_type;
+
+  /// This set vector maintains edges from a function to its callees.
   ///
-  /// Specifically, it stores the minimum number of partial applied arguments
-  /// of each function which contain one or multiple partial_applys of this
-  /// function.
-  /// This is a little bit off-topic because a partial_apply is not really
-  /// a "call" of this function.
-  llvm::SmallMapVector<SILFunction *, int, 1> PartialAppliers;
+  /// This is used in caller analysis to quickly invalidate all of the callee
+  /// information associated with a function when the function's body is
+  /// invalidated.
+  ///
+  /// NOTE: If a function is deleted, we can not only use this callee set. We
+  /// also have to eliminate caller edges pointing at the function.
+  ///
+  /// \see CallerAnalysis::invalidateExistingCalleeRelation.
+  llvm::SmallSetVector<SILFunction *, 1> calleeStates;
+
+  /// True if this function is something that could be called via a vtable or
+  /// a witness table. This does not include escaping uses.
+  ///
+  /// TODO: For now this is very conservative and is only set to false if we
+  /// have a function whose representation never can escape. In future cases, we
+  /// should consider refining this to take into account the compilation
+  /// visibility of a protocol conformance or class.
+  bool mayHaveIndirectCallers : 1;
 
 public:
-  /// Returns true if this function has at least one caller.
-  bool hasCaller() const { return !Callers.empty(); }
+  FunctionInfo(SILFunction *f);
 
-  /// Returns non zero if this function is partially applied anywhere.
+  /// Returns true if and only if the analysis was able to find all direct
+  /// callers of this function /and/ if the function can not be called
+  /// indirectly given visibility and compilation mode.
   ///
-  /// The return value is the minimum number of partially applied arguments.
-  /// Usually all partial applies of a function partially apply the same
-  /// number of arguments anyway.
-  int getMinPartialAppliedArgs() const {
-    int minArgs = 0;
-    for (auto Iter : PartialAppliers) {
-      int numArgs = Iter.second;
-      if (minArgs == 0 || numArgs < minArgs)
-        minArgs = numArgs;
-    }
-    return minArgs;
+  /// This implies that the function can be replaced by an optimized form of the
+  /// function (e.g. a specialized function) without needing to introduce a
+  /// thunk since we can rewrite all of the callers to call the new function.
+  bool foundAllCallers() const {
+    return hasOnlyCompleteDirectCallerSets() && !mayHaveIndirectCallers;
   }
+
+  /// Returns true if this function has at least one direct caller.
+  bool hasDirectCaller() const {
+    return callerStates.size() &&
+           llvm::any_of(callerStates, [](const CallerStatesValueType &v) {
+             return v.second.hasFullApply;
+           });
+  }
+
+  /// Returns the minimum number of partially applied arguments over all partial
+  /// applications of this function.
+  ///
+  /// This is useful information to have since in many cases, all of the partial
+  /// applies of a function partially apply the same number of arguments. In
+  /// such a case, we may be able to eliminate some of the partially applied
+  /// arguments without increasing code-size.
+  ///
+  /// NOTE: This returning non-zero /does not/ mean that we found all such apply
+  /// sites.
+  unsigned getMinPartialAppliedArgs() const {
+    if (callerStates.empty())
+      return 0;
+
+    bool foundArg = false;
+    unsigned minArgs = UINT_MAX;
+    for (const auto &iter : callerStates) {
+      if (auto numArgs = iter.second.getNumPartiallyAppliedArguments()) {
+        foundArg = true;
+        minArgs = std::min(minArgs, numArgs.getValue());
+      }
+    }
+
+    return foundArg ? minArgs : 0;
+  }
+
+  /// Returns true if we were able to find all direct callers of this function.
+  ///
+  /// NOTE: The function may still be called indirectly. To ascertain if we
+  /// found all of the function's direct callers and that it does not have any
+  /// indirect callers, \see FunctionInfo::foundAllCallers().
+  bool hasOnlyCompleteDirectCallerSets() const {
+    return llvm::all_of(callerStates, [](const CallerStatesValueType &v) {
+      return v.second.isDirectCallerSetComplete;
+    });
+  }
+
+  /// Return a range containing the partial and full apply sites that we found
+  /// in the given caller for our callee.
+  auto getAllReferencingCallers() const
+      -> decltype(llvm::make_range(callerStates.begin(), callerStates.end())) {
+    return llvm::make_range(callerStates.begin(), callerStates.end());
+  }
+
+  LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
+                            "Only for use in the debugger");
+
+  void print(llvm::raw_ostream &os) const;
 };
 
 } // end namespace swift

--- a/include/swift/SILOptimizer/Utils/Local.h
+++ b/include/swift/SILOptimizer/Utils/Local.h
@@ -643,6 +643,52 @@ protected:
   }
 };
 
+/// Move only data structure that is the result of findLocalApplySite.
+///
+/// NOTE: Generally it is not suggested to have move only types that contain
+/// small vectors. Since our small vectors contain one element or a std::vector
+/// like data structure , this is ok since we will either just copy the single
+/// element when we do the move or perform a move of the vector type.
+struct LLVM_LIBRARY_VISIBILITY FindLocalApplySitesResult {
+  /// Contains the list of local non fully applied partial apply sites that we
+  /// found.
+  SmallVector<ApplySite, 1> partialApplySites;
+
+  /// Contains the list of full apply sites that we found.
+  SmallVector<FullApplySite, 1> fullApplySites;
+
+  /// Set to true if the function_ref escapes into a use that our analysis does
+  /// not understand. Set to false if we found a use that had an actual
+  /// escape. Set to None if we did not find any call sites, but also didn't
+  /// find any "escaping uses" as well.
+  ///
+  /// The none case is so that we can distinguish in between saying that a value
+  /// did escape and saying that we did not find any conservative information.
+  bool escapes;
+
+  FindLocalApplySitesResult() = default;
+  FindLocalApplySitesResult(const FindLocalApplySitesResult &) = delete;
+  FindLocalApplySitesResult &
+  operator=(const FindLocalApplySitesResult &) = delete;
+  FindLocalApplySitesResult(FindLocalApplySitesResult &&) = default;
+  FindLocalApplySitesResult &operator=(FindLocalApplySitesResult &&) = default;
+  ~FindLocalApplySitesResult() = default;
+
+  /// Treat this function ref as escaping only if we found an actual user we
+  /// didn't understand. Do not treat it as escaping if we did not find any
+  /// users at all.
+  bool isEscaping() const { return escapes; }
+};
+
+/// Returns .some(FindLocalApplySitesResult) if we found any interesting
+/// information for the given function_ref. Otherwise, returns None.
+///
+/// We consider "interesting information" to mean inclusively that:
+///
+/// 1. We discovered that the function_ref never escapes.
+/// 2. We were able to find either a partial apply or a full apply site.
+Optional<FindLocalApplySitesResult> findLocalApplySites(FunctionRefInst *FRI);
+
 } // end namespace swift
 
 #endif

--- a/lib/SILOptimizer/Analysis/CallerAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/CallerAnalysis.cpp
@@ -10,8 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#define DEBUG_TYPE "sil-caller-analysis"
 #include "swift/SILOptimizer/Analysis/CallerAnalysis.h"
-
+#include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SILOptimizer/Utils/Local.h"
 #include "llvm/Support/FileSystem.h"
@@ -19,56 +20,344 @@
 
 using namespace swift;
 
+namespace {
+using FunctionInfo = CallerAnalysis::FunctionInfo;
+} // end anonymous namespace
+
 //===----------------------------------------------------------------------===//
-//                              Actual Analysis
+//                        CallerAnalysis::FunctionInfo
 //===----------------------------------------------------------------------===//
 
-void CallerAnalysis::processFunctionCallSites(SILFunction *F) {
-  // Scan the whole module and search Apply sites.
-  for (auto &BB : *F) {
-    for (auto &II : BB) {
-      if (auto Apply = FullApplySite::isa(&II)) {
-        SILFunction *CalleeFn = Apply.getCalleeFunction();
-        if (!CalleeFn)
-          continue;
+CallerAnalysis::FunctionInfo::FunctionInfo(SILFunction *f)
+    : callerStates(),
+      // TODO: Make this more aggressive by considering
+      // final/visibility/etc.
+      mayHaveIndirectCallers(canBeCalledIndirectly(f->getRepresentation())) {}
 
-        // Update the callee information for this function.
-        FunctionInfo &CallerInfo = FuncInfos[F];
-        CallerInfo.Callees.insert(CalleeFn);
-        
-        // Update the callsite information for the callee.
-        FunctionInfo &CalleeInfo = FuncInfos[CalleeFn];
-        CalleeInfo.Callers.insert(F);
-        continue;
-      }
-      if (auto *PAI = dyn_cast<PartialApplyInst>(&II)) {
-        SILFunction *CalleeFn = PAI->getCalleeFunction();
-        if (!CalleeFn)
-          continue;
+//===----------------------------------------------------------------------===//
+//                   CallerAnalysis::ApplySiteFinderVisitor
+//===----------------------------------------------------------------------===//
 
-        // Update the callee information for this function.
-        FunctionInfo &CallerInfo = FuncInfos[F];
-        CallerInfo.Callees.insert(CalleeFn);
-        
-        // Update the partial-apply information for the callee.
-        FunctionInfo &CalleeInfo = FuncInfos[CalleeFn];
-        int &minAppliedArgs = CalleeInfo.PartialAppliers[F];
-        int numArgs = (int)PAI->getNumArguments();
-        if (minAppliedArgs == 0 || numArgs < minAppliedArgs) {
-          minAppliedArgs = numArgs;
-        }
+struct CallerAnalysis::ApplySiteFinderVisitor
+    : SILInstructionVisitor<ApplySiteFinderVisitor, bool> {
+  CallerAnalysis *analysis;
+  SILFunction *callerFn;
+  FunctionInfo &callerInfo;
+
+#ifndef NDEBUG
+  SmallPtrSet<SILInstruction *, 8> visitedCallSites;
+  SmallSetVector<SILInstruction *, 8> callSitesThatMustBeVisited;
+#endif
+
+  ApplySiteFinderVisitor(CallerAnalysis *analysis, SILFunction *callerFn)
+      : analysis(analysis), callerFn(callerFn),
+        callerInfo(analysis->unsafeGetFunctionInfo(callerFn)) {}
+  ~ApplySiteFinderVisitor();
+
+  bool visitSILInstruction(SILInstruction *) { return false; }
+  bool visitFunctionRefInst(FunctionRefInst *fri);
+
+  void process();
+  void processApplySites(ArrayRef<ApplySite> applySites);
+  void processApplySites(ArrayRef<FullApplySite> applySites);
+  void checkCallSiteInvariants(SILInstruction &i);
+};
+
+void CallerAnalysis::ApplySiteFinderVisitor::processApplySites(
+    ArrayRef<ApplySite> applySites) {
+  // For now we just verify our invariants. If we need to update other
+  // non-NDEBUG state related to apply sites, this should be updated.
+#ifndef NDEBUG
+  for (auto applySite : applySites) {
+    visitedCallSites.insert(applySite.getInstruction());
+    callSitesThatMustBeVisited.remove(applySite.getInstruction());
+  }
+#endif
+}
+
+void CallerAnalysis::ApplySiteFinderVisitor::processApplySites(
+    ArrayRef<FullApplySite> applySites) {
+  // For now we just verify our invariants. If we need to update other
+  // non-NDEBUG state related to apply sites, this should be updated.
+#ifndef NDEBUG
+  for (auto applySite : applySites) {
+    visitedCallSites.insert(applySite.getInstruction());
+    callSitesThatMustBeVisited.remove(applySite.getInstruction());
+  }
+#endif
+}
+
+CallerAnalysis::ApplySiteFinderVisitor::~ApplySiteFinderVisitor() {
+#ifndef NDEBUG
+  if (callSitesThatMustBeVisited.empty())
+    return;
+  llvm::errs() << "Found unhandled call sites!\n";
+  while (callSitesThatMustBeVisited.size()) {
+    auto *i = callSitesThatMustBeVisited.pop_back_val();
+    llvm::errs() << "Inst: " << *i;
+  }
+  assert(false && "Unhandled call site?!");
+#endif
+}
+
+bool CallerAnalysis::ApplySiteFinderVisitor::visitFunctionRefInst(
+    FunctionRefInst *fri) {
+  auto optResult = findLocalApplySites(fri);
+  auto *calleeFn = fri->getReferencedFunction();
+  FunctionInfo &calleeInfo = analysis->unsafeGetFunctionInfo(calleeFn);
+
+  // First make an edge from our callerInfo to our calleeState for invalidation
+  // purposes.
+  callerInfo.calleeStates.insert(calleeFn);
+
+  // Then grab our callee state and update it with state for this caller.
+  auto iter = calleeInfo.callerStates.insert({callerFn, {}});
+  // If we succeeded in inserting a new value, put in an optimistic
+  // value for escaping.
+  if (iter.second) {
+    iter.first->second.isDirectCallerSetComplete = true;
+  }
+
+  // Then check if we found any information at all from our result. If we
+  // didn't, then mark this as escaping and bail.
+  if (!optResult.hasValue()) {
+    iter.first->second.isDirectCallerSetComplete = false;
+    return true;
+  }
+
+  auto &result = optResult.getValue();
+
+  // Ok. We know that we have some sort of information. Merge that information
+  // into our information.
+  iter.first->second.isDirectCallerSetComplete &= !result.isEscaping();
+
+  if (result.fullApplySites.size()) {
+    iter.first->second.hasFullApply = true;
+    processApplySites(llvm::makeArrayRef(result.fullApplySites));
+  }
+
+  if (result.partialApplySites.size()) {
+    auto optMin = iter.first->second.getNumPartiallyAppliedArguments();
+    unsigned min = optMin.getValueOr(UINT_MAX);
+    for (ApplySite partialSite : result.partialApplySites) {
+      min = std::min(min, partialSite.getNumArguments());
+    }
+    iter.first->second.setNumPartiallyAppliedArguments(min);
+    processApplySites(result.partialApplySites);
+  }
+
+  return true;
+}
+
+void CallerAnalysis::ApplySiteFinderVisitor::checkCallSiteInvariants(
+    SILInstruction &i) {
+#ifndef NDEBUG
+  if (auto apply = FullApplySite::isa(&i)) {
+    if (apply.getCalleeFunction() && !visitedCallSites.count(&i)) {
+      callSitesThatMustBeVisited.insert(&i);
+    }
+    return;
+  }
+
+  // Make sure that we are in sync with looking for partial apply callees.
+  if (auto *pai = dyn_cast<PartialApplyInst>(&i)) {
+    if (pai->getCalleeFunction() && !visitedCallSites.count(&i)) {
+      callSitesThatMustBeVisited.insert(pai);
+    }
+    return;
+  }
+#endif
+}
+
+void CallerAnalysis::ApplySiteFinderVisitor::process() {
+  for (auto &block : *callerFn) {
+    for (auto &i : block) {
+#ifndef NDEBUG
+      // If this is a call site that we visited as part of seeing a different
+      // function_ref, skip it. We know that it has been processed correctly.
+      //
+      // NOTE: This is only used in NDEBUG builds since we only use this as part
+      // of the verification that we can find all callees going forward along
+      // def-use edges that FullApplySite is able to track backwards along
+      // def-use edges.
+      if (visitedCallSites.count(&i))
         continue;
-      }
+#endif
+
+      // Try to find the apply sites for this specific FRI.
+      if (visit(&i))
+        continue;
+
+#ifndef NDEBUG
+      checkCallSiteInvariants(i);
+#endif
     }
   }
 }
 
-void CallerAnalysis::invalidateExistingCalleeRelation(SILFunction *F) {
-  FunctionInfo &CallerInfo = FuncInfos[F];
-  for (auto Callee : CallerInfo.Callees) {
-    FunctionInfo &CalleeInfo = FuncInfos[Callee];
-    CalleeInfo.Callers.erase(F);
-    CalleeInfo.PartialAppliers.erase(F);
+//===----------------------------------------------------------------------===//
+//                               CallerAnalysis
+//===----------------------------------------------------------------------===//
+
+// NOTE: This is only meant to be used by external users of CallerAnalysis since
+// it recomputes our invalidated results. For internal uses, please instead use
+// getOrInsertFunctionInfo or unsafeGetFunctionInfo.
+const FunctionInfo &CallerAnalysis::getFunctionInfo(SILFunction *f) const {
+  // Recompute every function in the invalidated function list and empty the
+  // list.
+  auto &self = const_cast<CallerAnalysis &>(*this);
+  self.processRecomputeFunctionList();
+  return self.unsafeGetFunctionInfo(f);
+}
+
+// Private only version of this function for mutable callers that tries to
+// initialize a new f.
+FunctionInfo &CallerAnalysis::getOrInsertFunctionInfo(SILFunction *f) {
+  LLVM_DEBUG(llvm::dbgs() << "CallerAnalysis: Creating caller info for: "
+                          << f->getName() << "\n");
+  return funcInfos.try_emplace(f, f).first->second;
+}
+
+FunctionInfo &CallerAnalysis::unsafeGetFunctionInfo(SILFunction *f) {
+  auto r = funcInfos.find(f);
+  assert(r != funcInfos.end() && "Function does not have functionInfo!");
+  return r->second;
+}
+
+const FunctionInfo &
+CallerAnalysis::unsafeGetFunctionInfo(SILFunction *f) const {
+  auto r = funcInfos.find(f);
+  assert(r != funcInfos.end() && "Function does not have functionInfo!");
+  return r->second;
+}
+
+CallerAnalysis::CallerAnalysis(SILModule *m)
+    : SILAnalysis(SILAnalysisKind::Caller), mod(*m) {
+  // When we start we create a function info for each f and add all f to the
+  // recompute function list.
+  for (auto &f : mod) {
+    getOrInsertFunctionInfo(&f);
+    recomputeFunctionList.insert(&f);
+  }
+}
+
+void CallerAnalysis::processFunctionCallSites(SILFunction *callerFn) {
+  ApplySiteFinderVisitor visitor(this, callerFn);
+  visitor.process();
+}
+
+void CallerAnalysis::invalidateAllInfo(SILFunction *f) {
+  // Look up the callees that our caller refers to and invalidate any
+  // values that point back at the caller.
+  FunctionInfo &fInfo = unsafeGetFunctionInfo(f);
+
+  // Then we first eliminate any callees that we point at.
+  invalidateKnownCallees(f, fInfo);
+
+  // And then eliminate any caller edges that we need.
+  while (fInfo.callerStates.size()) {
+    auto back = fInfo.callerStates.back();
+    SILFunction *caller = back.first;
+    auto &callerInfo = unsafeGetFunctionInfo(caller);
+    LLVM_DEBUG(llvm::dbgs()
+               << "    caller-backedge: " << caller->getName() << "\n");
+    bool foundF = callerInfo.calleeStates.remove(f);
+    (void)foundF;
+    assert(foundF && "Bad caller edge pointing at f?");
+    fInfo.callerStates.pop_back();
+  }
+}
+
+void CallerAnalysis::invalidateKnownCallees(SILFunction *caller,
+                                            FunctionInfo &callerInfo) {
+  LLVM_DEBUG(llvm::dbgs() << "Invalidating caller: " << caller->getName()
+                          << "\n");
+  while (callerInfo.calleeStates.size()) {
+    auto *callee = callerInfo.calleeStates.pop_back_val();
+    FunctionInfo &calleeInfo = unsafeGetFunctionInfo(callee);
+    LLVM_DEBUG(llvm::dbgs() << "    callee: " << callee->getName() << "\n");
+    assert(calleeInfo.callerStates.count(caller) &&
+           "Referenced callee is not fully/partially applied in the caller?!");
+
+    // Then remove the caller from this specific callee's info struct
+    // and to be conservative mark the callee as potentially having an
+    // escaping use that we do not understand.
+    calleeInfo.callerStates.erase(caller);
+  }
+}
+
+void CallerAnalysis::invalidateKnownCallees(SILFunction *caller) {
+  // Look up the callees that our caller refers to and invalidate any
+  // values that point back at the caller.
+  invalidateKnownCallees(caller, unsafeGetFunctionInfo(caller));
+}
+
+void CallerAnalysis::verify(SILFunction *caller) const {
+#ifndef NDEBUG
+  const FunctionInfo &callerInfo = unsafeGetFunctionInfo(caller);
+  verify(caller, callerInfo);
+#endif
+}
+
+void CallerAnalysis::verify(SILFunction *function,
+                            const FunctionInfo &functionInfo) const {
+#ifndef NDEBUG
+  LLVM_DEBUG(llvm::dbgs() << "Validating function: " << function->getName()
+                          << "\n");
+  for (auto *callee : functionInfo.calleeStates) {
+    LLVM_DEBUG(llvm::dbgs() << "    callee: " << callee->getName() << "\n");
+    const FunctionInfo &calleeInfo = unsafeGetFunctionInfo(callee);
+    assert(calleeInfo.callerStates.count(function) &&
+           "Referenced callee is not fully/partially applied in the caller");
+  }
+
+  // Make sure all caller edges are valid.
+  for (auto callerPair : functionInfo.callerStates) {
+    auto *caller = callerPair.first;
+    LLVM_DEBUG(llvm::dbgs() << "    caller: " << caller->getName() << "\n");
+    const FunctionInfo &callerInfo = unsafeGetFunctionInfo(caller);
+    assert(callerInfo.calleeStates.count(function) &&
+           "Referencing caller does not have a callee edge for function");
+  }
+#endif
+}
+
+void CallerAnalysis::verify() const {
+#ifndef NDEBUG
+  std::vector<SILFunction *> seenFunctions;
+  for (auto &fn : mod) {
+    bool found = funcInfos.count(&fn);
+    if (!found) {
+      llvm::errs() << "Missing notification for added function: '"
+                   << fn.getName() << "'\n";
+      llvm_unreachable("standard error assertion");
+    }
+    seenFunctions.push_back(&fn);
+  }
+
+  sortUnique(seenFunctions);
+  for (auto &pair : funcInfos) {
+    bool found = std::binary_search(seenFunctions.begin(), seenFunctions.end(),
+                                    pair.first);
+    if (!found) {
+      llvm::errs() << "Notification not sent for deleted function: '"
+                   << pair.first->getName() << "'.";
+      llvm_unreachable("standard error assertion");
+    }
+    verify(pair.first, pair.second);
+  }
+#endif
+}
+
+void CallerAnalysis::invalidate() {
+  for (auto &f : mod) {
+    // Since we are going over all functions in the module
+    // invalidateKnownCallees should be sufficient.
+    invalidateKnownCallees(&f);
+    // We do not need to clear recompute function list since we know that it can
+    // at most contain a subset of the functions in the module so the SetVector
+    // will unique for us.
+    recomputeFunctionList.insert(&f);
   }
 }
 
@@ -84,20 +373,22 @@ using llvm::yaml::Output;
 using llvm::yaml::ScalarEnumerationTraits;
 using llvm::yaml::SequenceTraits;
 
-/// A special struct that marshals call graph state into a form that is easy for
-/// llvm's yaml i/o to dump. Its structure is meant to correspond to how the
-/// data should be shown by the printer, so naturally it is slightly redundant.
+/// A special struct that marshals call graph state into a form that
+/// is easy for llvm's yaml i/o to dump. Its structure is meant to
+/// correspond to how the data should be shown by the printer, so
+/// naturally it is slightly redundant.
 struct YAMLCallGraphNode {
   StringRef calleeName;
   bool hasCaller;
   unsigned minPartialAppliedArgs;
+  bool hasOnlyCompleteDirectCallerSets;
+  bool hasAllCallers;
   std::vector<StringRef> partialAppliers;
   std::vector<StringRef> fullAppliers;
 
   YAMLCallGraphNode() = delete;
   ~YAMLCallGraphNode() = default;
 
-  // This is a data structure that can not be copied or moved.
   YAMLCallGraphNode(const YAMLCallGraphNode &) = delete;
   YAMLCallGraphNode(YAMLCallGraphNode &&) = delete;
   YAMLCallGraphNode &operator=(const YAMLCallGraphNode &) = delete;
@@ -105,10 +396,13 @@ struct YAMLCallGraphNode {
 
   YAMLCallGraphNode(StringRef calleeName, bool hasCaller,
                     unsigned minPartialAppliedArgs,
+                    bool hasOnlyCompleteDirectCallerSets, bool hasAllCallers,
                     std::vector<StringRef> &&partialAppliers,
                     std::vector<StringRef> &&fullAppliers)
       : calleeName(calleeName), hasCaller(hasCaller),
         minPartialAppliedArgs(minPartialAppliedArgs),
+        hasOnlyCompleteDirectCallerSets(hasOnlyCompleteDirectCallerSets),
+        hasAllCallers(hasAllCallers),
         partialAppliers(std::move(partialAppliers)),
         fullAppliers(std::move(fullAppliers)) {}
 };
@@ -123,6 +417,9 @@ template <> struct MappingTraits<YAMLCallGraphNode> {
     io.mapRequired("calleeName", func.calleeName);
     io.mapRequired("hasCaller", func.hasCaller);
     io.mapRequired("minPartialAppliedArgs", func.minPartialAppliedArgs);
+    io.mapRequired("hasOnlyCompleteDirectCallerSets",
+                   func.hasOnlyCompleteDirectCallerSets);
+    io.mapRequired("hasAllCallers", func.hasAllCallers);
     io.mapRequired("partialAppliers", func.partialAppliers);
     io.mapRequired("fullAppliers", func.fullAppliers);
   }
@@ -150,21 +447,24 @@ void CallerAnalysis::print(llvm::raw_ostream &os) const {
   // NOTE: We purposely do not iterate over our internal state here to ensure
   // that we dump for all functions and that we dump the state we have stored
   // with the functions in module order.
-  for (auto &f : Mod) {
-    const auto &fi = getCallerInfo(&f);
+  for (auto &f : mod) {
+    const auto &fi = getFunctionInfo(&f);
 
-    std::vector<StringRef> fullAppliers;
-    for (auto *caller : fi.Callers) {
-      fullAppliers.push_back(caller->getName());
-    }
     std::vector<StringRef> partialAppliers;
-    for (auto iter : fi.PartialAppliers) {
-      partialAppliers.push_back(iter.first->getName());
+    std::vector<StringRef> fullAppliers;
+    for (auto &apply : fi.getAllReferencingCallers()) {
+      if (apply.second.hasFullApply) {
+        fullAppliers.push_back(apply.first->getName());
+      }
+      if (apply.second.getNumPartiallyAppliedArguments().hasValue()) {
+        partialAppliers.push_back(apply.first->getName());
+      }
     }
 
-    YAMLCallGraphNode node(f.getName(), fi.hasCaller(),
-                           fi.getMinPartialAppliedArgs(),
-                           std::move(partialAppliers), std::move(fullAppliers));
+    YAMLCallGraphNode node(
+        f.getName(), fi.hasDirectCaller(), fi.getMinPartialAppliedArgs(),
+        fi.hasOnlyCompleteDirectCallerSets(), fi.foundAllCallers(),
+        std::move(partialAppliers), std::move(fullAppliers));
     yout << node;
   }
 }
@@ -173,6 +473,6 @@ void CallerAnalysis::print(llvm::raw_ostream &os) const {
 //                              Main Entry Point
 //===----------------------------------------------------------------------===//
 
-SILAnalysis *swift::createCallerAnalysis(SILModule *M) {
-  return new CallerAnalysis(M);
+SILAnalysis *swift::createCallerAnalysis(SILModule *mod) {
+  return new CallerAnalysis(mod);
 }

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -756,8 +756,8 @@ public:
       return;
     }
 
-    CallerAnalysis *CA = PM->getAnalysis<CallerAnalysis>();
-    const CallerAnalysis::FunctionInfo &FuncInfo = CA->getCallerInfo(F);
+    const CallerAnalysis *CA = PM->getAnalysis<CallerAnalysis>();
+    const CallerAnalysis::FunctionInfo &FuncInfo = CA->getFunctionInfo(F);
 
     // Check the signature of F to make sure that it is a function that we
     // can specialize. These are conditions independent of the call graph.
@@ -807,7 +807,7 @@ public:
     if (OptForPartialApply) {
       Changed = FST.removeDeadArgs(FuncInfo.getMinPartialAppliedArgs());
     } else {
-      Changed = FST.run(FuncInfo.hasCaller());
+      Changed = FST.run(FuncInfo.hasDirectCaller());
     }
 
     if (!Changed) {

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1586,4 +1586,72 @@ StaticInitCloner::clone(SingleValueInstruction *InitVal) {
   return cast<SingleValueInstruction>(ValueMap[InitVal]);
 }
 
+Optional<FindLocalApplySitesResult>
+swift::findLocalApplySites(FunctionRefInst *FRI) {
+  SmallVector<Operand *, 32> worklist(FRI->use_begin(), FRI->use_end());
 
+  FindLocalApplySitesResult f;
+
+  // Optimistically state that we have no escapes before our def-use dataflow.
+  f.escapes = false;
+
+  while (!worklist.empty()) {
+    auto *op = worklist.pop_back_val();
+    auto *user = op->getUser();
+
+    // If we have a full apply site as our user.
+    if (auto apply = FullApplySite::isa(user)) {
+      if (apply.getCallee() == op->get()) {
+        f.fullApplySites.push_back(apply);
+        continue;
+      }
+    }
+
+    // If we have a partial apply as a user, start tracking it, but also look at
+    // its users.
+    if (auto *pai = dyn_cast<PartialApplyInst>(user)) {
+      if (pai->getCallee() == op->get()) {
+        // Track the partial apply that we saw so we can potentially eliminate
+        // dead closure arguments.
+        f.partialApplySites.push_back(pai);
+        // Look to see if we can find a full application of this partial apply
+        // as well.
+        copy(pai->getUses(), std::back_inserter(worklist));
+        continue;
+      }
+    }
+
+    // Otherwise, see if we have any function casts to look through...
+    switch (user->getKind()) {
+    case SILInstructionKind::ThinToThickFunctionInst:
+    case SILInstructionKind::ConvertFunctionInst:
+    case SILInstructionKind::ConvertEscapeToNoEscapeInst:
+      copy(cast<SingleValueInstruction>(user)->getUses(),
+           std::back_inserter(worklist));
+      continue;
+
+    // Look through any reference count instructions since these are not
+    // escapes:
+    case SILInstructionKind::CopyValueInst:
+      copy(cast<CopyValueInst>(user)->getUses(), std::back_inserter(worklist));
+      continue;
+    case SILInstructionKind::StrongRetainInst:
+    case SILInstructionKind::StrongReleaseInst:
+    case SILInstructionKind::RetainValueInst:
+    case SILInstructionKind::ReleaseValueInst:
+    case SILInstructionKind::DestroyValueInst:
+      continue;
+    default:
+      break;
+    }
+
+    // But everything else is considered an escape.
+    f.escapes = true;
+  }
+
+  // If we did escape and didn't find any apply sites, then we have no
+  // information for our users that is interesting.
+  if (f.escapes && f.partialApplySites.empty() && f.fullApplySites.empty())
+    return None;
+  return f;
+}

--- a/test/SILOptimizer/caller_analysis.sil
+++ b/test/SILOptimizer/caller_analysis.sil
@@ -7,6 +7,8 @@ import Builtin
 // CHECK-LABEL: calleeName:      dead_func
 // CHECK-NEXT:  hasCaller:       false
 // CHECK-NEXT:  minPartialAppliedArgs: 0
+// CHECK-NEXT:  hasOnlyCompleteDirectCallerSets: true
+// CHECK-NEXT:  hasAllCallers:   true
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:  ...
@@ -18,6 +20,8 @@ sil hidden @dead_func : $@convention(thin) () -> () {
 // CHECK-LABEL: calleeName:      call_top
 // CHECK-NEXT:  hasCaller:       false
 // CHECK-NEXT:  minPartialAppliedArgs: 0
+// CHECK-NEXT:  hasOnlyCompleteDirectCallerSets: true
+// CHECK-NEXT:  hasAllCallers:   true
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:  ...
@@ -32,6 +36,8 @@ bb0:
 // CHECK-LABEL: calleeName:      call_middle
 // CHECK-NEXT:  hasCaller:       true
 // CHECK-NEXT:  minPartialAppliedArgs: 0
+// CHECK-NEXT:  hasOnlyCompleteDirectCallerSets: true
+// CHECK-NEXT:  hasAllCallers:   true
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:    - call_top
@@ -47,6 +53,8 @@ bb0:
 // CHECK-LABEL: calleeName:      call_bottom
 // CHECK-NEXT:  hasCaller:       true
 // CHECK-NEXT:  minPartialAppliedArgs: 0
+// CHECK-NEXT:  hasOnlyCompleteDirectCallerSets: true
+// CHECK-NEXT:  hasAllCallers:   true
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:    - call_middle
@@ -60,6 +68,8 @@ bb0:
 // CHECK-LABEL: calleeName:      self_recursive_func
 // CHECK-NEXT:  hasCaller:       true
 // CHECK-NEXT:  minPartialAppliedArgs: 0
+// CHECK-NEXT:  hasOnlyCompleteDirectCallerSets: true
+// CHECK-NEXT:  hasAllCallers:   true
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:    - self_recursive_func
@@ -75,6 +85,8 @@ bb0:
 // CHECK-LABEL: calleeName:      mutual_recursive_func1
 // CHECK-NEXT:  hasCaller:       true
 // CHECK-NEXT:  minPartialAppliedArgs: 0
+// CHECK-NEXT:  hasOnlyCompleteDirectCallerSets: true
+// CHECK-NEXT:  hasAllCallers:   true
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:    - mutual_recursive_func2
@@ -90,6 +102,8 @@ bb0:
 // CHECK-LABEL: calleeName:      mutual_recursive_func2
 // CHECK-NEXT:  hasCaller:       true
 // CHECK-NEXT:  minPartialAppliedArgs: 0
+// CHECK-NEXT:  hasOnlyCompleteDirectCallerSets: true
+// CHECK-NEXT:  hasAllCallers:   true
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:    - mutual_recursive_func1
@@ -105,6 +119,8 @@ bb0:
 // CHECK-LABEL: calleeName:      multi_called
 // CHECK-NEXT:  hasCaller:       true
 // CHECK-NEXT:  minPartialAppliedArgs: 0
+// CHECK-NEXT:  hasOnlyCompleteDirectCallerSets: true
+// CHECK-NEXT:  hasAllCallers:   true
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:    - multi_calles
@@ -118,6 +134,8 @@ bb0:
 // CHECK-LABEL: calleeName:      multi_calles
 // CHECK-NEXT:  hasCaller:       false
 // CHECK-NEXT:  minPartialAppliedArgs: 0
+// CHECK-NEXT:  hasOnlyCompleteDirectCallerSets: true
+// CHECK-NEXT:  hasAllCallers:   true
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:  ...
@@ -140,6 +158,8 @@ bb3:
 // CHECK-LABEL: calleeName:      multi_callers
 // CHECK-NEXT:  hasCaller:       true
 // CHECK-NEXT:  minPartialAppliedArgs: 0
+// CHECK-NEXT:  hasOnlyCompleteDirectCallerSets: true
+// CHECK-NEXT:  hasAllCallers:   true
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:    - multi_caller1
@@ -154,6 +174,8 @@ bb0:
 // CHECK-LABEL: calleeName:      multi_caller1
 // CHECK-NEXT:  hasCaller:       false
 // CHECK-NEXT:  minPartialAppliedArgs: 0
+// CHECK-NEXT:  hasOnlyCompleteDirectCallerSets: true
+// CHECK-NEXT:  hasAllCallers:   true
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:  ...
@@ -168,6 +190,8 @@ bb0:
 // CHECK-LABEL: calleeName:      multi_caller2
 // CHECK-NEXT:  hasCaller:       false
 // CHECK-NEXT:  minPartialAppliedArgs: 0
+// CHECK-NEXT:  hasOnlyCompleteDirectCallerSets: true
+// CHECK-NEXT:  hasAllCallers:   true
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:  ...
@@ -185,6 +209,8 @@ bb0:
 // CHECK-LABEL: calleeName:      closure1
 // CHECK-NEXT:  hasCaller:       false
 // CHECK-NEXT:  minPartialAppliedArgs: 1
+// CHECK-NEXT:  hasOnlyCompleteDirectCallerSets: false
+// CHECK-NEXT:  hasAllCallers:   false
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:    - partial_apply_one_arg
 // CHECK-NEXT:    - partial_apply_two_args1
@@ -198,6 +224,8 @@ bb0(%0 : $Builtin.Int32, %1 : $Builtin.Int32):
 // CHECK-LABEL: calleeName:      closure2
 // CHECK-NEXT:  hasCaller:       false
 // CHECK-NEXT:  minPartialAppliedArgs: 2
+// CHECK-NEXT:  hasOnlyCompleteDirectCallerSets: false
+// CHECK-NEXT:  hasAllCallers:   false
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:    - partial_apply_two_args2
 // CHECK-NEXT:  fullAppliers:
@@ -210,6 +238,8 @@ bb0(%0 : $Builtin.Int32, %1 : $Builtin.Int32):
 // CHECK-LABEL: calleeName:      partial_apply_one_arg
 // CHECK-NEXT:  hasCaller:       false
 // CHECK-NEXT:  minPartialAppliedArgs: 0
+// CHECK-NEXT:  hasOnlyCompleteDirectCallerSets: true
+// CHECK-NEXT:  hasAllCallers:   true
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:  ...
@@ -223,6 +253,8 @@ bb0(%0 : $Builtin.Int32):
 // CHECK-LABEL: calleeName:      partial_apply_two_args1
 // CHECK-NEXT:  hasCaller:       false
 // CHECK-NEXT:  minPartialAppliedArgs: 0
+// CHECK-NEXT:  hasOnlyCompleteDirectCallerSets: true
+// CHECK-NEXT:  hasAllCallers:   true
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:  ...
@@ -236,6 +268,8 @@ bb0(%0 : $Builtin.Int32):
 // CHECK-LABEL: calleeName:      partial_apply_two_args2
 // CHECK-NEXT:  hasCaller:       false
 // CHECK-NEXT:  minPartialAppliedArgs: 0
+// CHECK-NEXT:  hasOnlyCompleteDirectCallerSets: true
+// CHECK-NEXT:  hasAllCallers:   true
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:  ...
@@ -249,6 +283,8 @@ bb0(%0 : $Builtin.Int32):
 // CHECK-LABEL: calleeName:      called_closure
 // CHECK-NEXT:  hasCaller:       true
 // CHECK-NEXT:  minPartialAppliedArgs: 2
+// CHECK-NEXT:  hasOnlyCompleteDirectCallerSets: true
+// CHECK-NEXT:  hasAllCallers:   true
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:    - partial_apply_that_is_applied
 // CHECK-NEXT:  fullAppliers:
@@ -274,6 +310,8 @@ bb0(%0 : $Builtin.Int32):
 // CHECK-LABEL: calleeName:      called_closure_then_destroy
 // CHECK-NEXT:  hasCaller:       true
 // CHECK-NEXT:  minPartialAppliedArgs: 2
+// CHECK-NEXT:  hasOnlyCompleteDirectCallerSets: true
+// CHECK-NEXT:  hasAllCallers:   true
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:    - partial_apply_that_is_applied
 // CHECK-NEXT:  fullAppliers:
@@ -297,6 +335,8 @@ bb0(%0 : $Builtin.Int32):
 // CHECK-LABEL: calleeName:      called_escaping_closure
 // CHECK-NEXT:  hasCaller:       true
 // CHECK-NEXT:  minPartialAppliedArgs: 2
+// CHECK-NEXT:  hasOnlyCompleteDirectCallerSets: false
+// CHECK-NEXT:  hasAllCallers:   false
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:    - partial_apply_that_is_applied
 // CHECK-NEXT:  fullAppliers:
@@ -320,6 +360,8 @@ bb0(%0 : $Builtin.Int32):
 // CHECK-LABEL: calleeName:      called_closure_then_copy_destroy
 // CHECK-NEXT:  hasCaller:       true
 // CHECK-NEXT:  minPartialAppliedArgs: 2
+// CHECK-NEXT:  hasOnlyCompleteDirectCallerSets: true
+// CHECK-NEXT:  hasAllCallers:   true
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:    - partial_apply_that_is_applied
 // CHECK-NEXT:  fullAppliers:
@@ -351,6 +393,8 @@ bb0(%0 : $Builtin.Int32):
 // CHECK-LABEL: calleeName:      noescape_callee
 // CHECK-NEXT:  hasCaller:       false
 // CHECK-NEXT:  minPartialAppliedArgs: 2
+// CHECK-NEXT:  hasOnlyCompleteDirectCallerSets: false
+// CHECK-NEXT:  hasAllCallers:   false
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:    - partial_apply_that_is_applied_and_passed_noescape
 // CHECK-NEXT:  fullAppliers:
@@ -363,6 +407,8 @@ bb0(%0 : $Builtin.Int32, %1 : $Builtin.Int32):
 // CHECK-LABEL: calleeName:      noescape_caller
 // CHECK-NEXT:  hasCaller:       true
 // CHECK-NEXT:  minPartialAppliedArgs: 0
+// CHECK-NEXT:  hasOnlyCompleteDirectCallerSets: true
+// CHECK-NEXT:  hasAllCallers:   true
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:    - partial_apply_that_is_applied_and_passed_noescape
@@ -389,6 +435,8 @@ bb0(%0 : $Builtin.Int32):
 // CHECK-LABEL: calleeName:      noescape_callee2
 // CHECK-NEXT:  hasCaller:       false
 // CHECK-NEXT:  minPartialAppliedArgs: 0
+// CHECK-NEXT:  hasOnlyCompleteDirectCallerSets: false
+// CHECK-NEXT:  hasAllCallers:   false
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:  ...
@@ -424,6 +472,8 @@ class Klass {
 // CHECK-LABEL: calleeName:      called_method
 // CHECK-NEXT:  hasCaller:       true
 // CHECK-NEXT:  minPartialAppliedArgs: 0
+// CHECK-NEXT:  hasOnlyCompleteDirectCallerSets: true
+// CHECK-NEXT:  hasAllCallers:   false
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:    - apply_called_method
@@ -448,6 +498,8 @@ bb0(%0 : $Klass):
 // CHECK-LABEL: calleeName:      final_called_method
 // CHECK-NEXT:  hasCaller:       true
 // CHECK-NEXT:  minPartialAppliedArgs: 0
+// CHECK-NEXT:  hasOnlyCompleteDirectCallerSets: true
+// CHECK-NEXT:  hasAllCallers:   false
 // CHECK-NEXT:  partialAppliers:
 // CHECK-NEXT:  fullAppliers:
 // CHECK-NEXT:    - final_apply_called_method


### PR DESCRIPTION
This is a reimplementation of caller analysis on top of a new utility called findLocalApplySites. This utility works in spirit as an inverse operation to ApplySite::getCalleeOrigin(). At a high level starting at a specific function_ref, the utility traverses through the transitive use edges from the function_ref, looking through specific conversion insts and uses that it understands. All of the apply sites found this way are returned to the user and more importantly if there is an unknown use, a bool is set. As a result, the caller analysis (although not used anywhere beyond tests in this commit), can not be used to determine if the analysis can guarantee that all callers for a specific callee have been found.

rdar://41146023