### PR TITLE
[stdlib] Set/Dictionary: Make some implementation details non-inlinable

### DIFF
--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -502,49 +502,30 @@ extension UnsafeRawPointer {
   }
 }
 
-@_fixed_layout
-@usableFromInline
 internal struct _CocoaFastEnumerationStackBuf {
   // Clang uses 16 pointers.  So do we.
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var _item0: UnsafeRawPointer?
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var _item1: UnsafeRawPointer?
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var _item2: UnsafeRawPointer?
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var _item3: UnsafeRawPointer?
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var _item4: UnsafeRawPointer?
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var _item5: UnsafeRawPointer?
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var _item6: UnsafeRawPointer?
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var _item7: UnsafeRawPointer?
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var _item8: UnsafeRawPointer?
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var _item9: UnsafeRawPointer?
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var _item10: UnsafeRawPointer?
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var _item11: UnsafeRawPointer?
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var _item12: UnsafeRawPointer?
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var _item13: UnsafeRawPointer?
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var _item14: UnsafeRawPointer?
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var _item15: UnsafeRawPointer?
 
-  @usableFromInline @_transparent
+  @_transparent
   internal var count: Int {
     return 16
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   internal init() {
     _item0 = nil
     _item1 = _item0

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -3110,9 +3110,7 @@ internal struct _CocoaDictionaryBuffer: _HashBuffer {
   @inlinable // FIXME(sil-serialize-all)
   @inline(__always)
   internal func maybeGet(_ key: Key) -> Value? {
-
-  return cocoaDictionary.objectFor(key)
-
+    return cocoaDictionary.objectFor(key)
   }
 
   @inlinable // FIXME(sil-serialize-all)
@@ -3154,7 +3152,6 @@ internal struct _CocoaDictionaryBuffer: _HashBuffer {
   @inlinable // FIXME(sil-serialize-all)
   internal static func fromArray(_ elements: [SequenceElementWithoutLabels])
     -> _CocoaDictionaryBuffer {
-
     _sanityCheckFailure("this function should never be called")
   }
 

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -4100,7 +4100,7 @@ internal enum _VariantDictionaryBuffer<Key: Hashable, Value>: _HashBuffer {
         start: asNative.startIndex, end: asNative.endIndex, buffer: buffer)
 #if _runtime(_ObjC)
     case .cocoa(let cocoaBuffer):
-      return ._cocoa(_CocoaDictionaryIterator(cocoaBuffer.cocoaDictionary))
+      return ._cocoa(cocoaBuffer)
 #endif
     }
   }
@@ -4431,10 +4431,8 @@ extension Dictionary.Index {
 }
 
 #if _runtime(_ObjC)
-@_fixed_layout // FIXME(sil-serialize-all)
 @usableFromInline
 final internal class _CocoaDictionaryIterator: IteratorProtocol {
-  @usableFromInline
   internal typealias Element = (AnyObject, AnyObject)
 
   // Cocoa Dictionary iterator has to be a class, otherwise we cannot
@@ -4443,26 +4441,21 @@ final internal class _CocoaDictionaryIterator: IteratorProtocol {
 
   // This stored property should be stored at offset zero.  There's code below
   // relying on this.
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var _fastEnumerationState: _SwiftNSFastEnumerationState =
     _makeSwiftNSFastEnumerationState()
 
   // This stored property should be stored right after `_fastEnumerationState`.
   // There's code below relying on this.
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var _fastEnumerationStackBuf = _CocoaFastEnumerationStackBuf()
 
-  @usableFromInline // FIXME(sil-serialize-all)
   internal let cocoaDictionary: _NSDictionary
 
-  @inlinable // FIXME(sil-serialize-all)
   internal var _fastEnumerationStatePtr:
     UnsafeMutablePointer<_SwiftNSFastEnumerationState> {
     return _getUnsafePointerToStoredProperties(self).assumingMemoryBound(
       to: _SwiftNSFastEnumerationState.self)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   internal var _fastEnumerationStackBufPtr:
     UnsafeMutablePointer<_CocoaFastEnumerationStackBuf> {
     return UnsafeMutableRawPointer(_fastEnumerationStatePtr + 1)
@@ -4473,17 +4466,14 @@ final internal class _CocoaDictionaryIterator: IteratorProtocol {
   // Int8 just because our storage holds 16 elements: fast enumeration is
   // allowed to return inner pointers to the container, which can be much
   // larger.
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var itemIndex: Int = 0
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var itemCount: Int = 0
 
-  @inlinable // FIXME(sil-serialize-all)
   internal init(_ cocoaDictionary: _NSDictionary) {
     self.cocoaDictionary = cocoaDictionary
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @usableFromInline
   internal func next() -> Element? {
     if itemIndex < 0 {
       return nil
@@ -4575,10 +4565,11 @@ public struct DictionaryIterator<Key: Hashable, Value>: IteratorProtocol {
       _state: ._native(start: start, end: end, buffer: buffer))
   }
 #if _runtime(_ObjC)
-  @inlinable // FIXME(sil-serialize-all)
+  @usableFromInline
   internal static func _cocoa(
-    _ iterator: _CocoaDictionaryIterator
+    _ buffer: _CocoaDictionaryBuffer
   ) -> DictionaryIterator{
+    let iterator = _CocoaDictionaryIterator(cocoaBuffer.cocoaDictionary)
     return DictionaryIterator(_state: ._cocoa(iterator))
   }
 #endif

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -2488,7 +2488,7 @@ extension _NativeDictionaryBuffer where Key: Hashable
   }
 
 #if _runtime(_ObjC)
-  @inlinable // FIXME(sil-serialize-all)
+  @usableFromInline
   internal func bridged() -> _NSDictionary {
     // We can zero-cost bridge if our keys are verbatim
     // or if we're the empty singleton.
@@ -2770,28 +2770,18 @@ final internal class _NativeDictionaryNSEnumerator<Key, Value>
 /// This is the fallback implementation for situations where toll-free bridging
 /// isn't possible. On first access, a NativeDictionaryBuffer of AnyObject will be
 /// constructed containing all the bridged elements.
-@_fixed_layout // FIXME(sil-serialize-all)
-@usableFromInline // FIXME(sil-serialize-all)
 final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
   : _SwiftNativeNSDictionary, _NSDictionaryCore {
 
-  @usableFromInline
   internal typealias NativeBuffer = _NativeDictionaryBuffer<Key, Value>
-  @usableFromInline
   internal typealias BridgedBuffer = _NativeDictionaryBuffer<AnyObject, AnyObject>
-  @usableFromInline
-  internal typealias NativeIndex = _NativeDictionaryIndex<Key, Value>
-  @usableFromInline
-  internal typealias BridgedIndex = _NativeDictionaryIndex<AnyObject, AnyObject>
 
-  @inlinable // FIXME(sil-serialize-all)
   @nonobjc
   internal init(bucketCount: Int = 2) {
     nativeBuffer = NativeBuffer(bucketCount: bucketCount)
     super.init()
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   internal init(nativeBuffer: NativeBuffer) {
     self.nativeBuffer = nativeBuffer
     super.init()
@@ -2801,15 +2791,12 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
   // operations on it.
   //
   // Do not access this property directly.
-  @usableFromInline // FIXME(sil-serialize-all)
   @nonobjc
   internal var _heapStorageBridged_DoNotUse: AnyObject?
 
   /// The unbridged elements.
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var nativeBuffer: NativeBuffer
 
-  @inlinable // FIXME(sil-serialize-all)
   @objc(copyWithZone:)
   internal func copy(with zone: _SwiftNSZone?) -> AnyObject {
     // Instances of this class should be visible outside of standard library as
@@ -2824,7 +2811,6 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
   // `nativeBuffer`.
   //
 
-  @inlinable // FIXME(sil-serialize-all)
   @objc
   internal required init(
     objects: UnsafePointer<AnyObject?>,
@@ -2834,7 +2820,6 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
     _sanityCheckFailure("don't call this designated initializer")
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   @objc(objectForKey:)
   internal func objectFor(_ aKey: AnyObject) -> AnyObject? {
     return bridgingObjectForKey(aKey)
@@ -2845,7 +2830,6 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
     return enumerator()
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   @objc(getObjects:andKeys:count:)
   internal func getObjects(
     _ objects: UnsafeMutablePointer<AnyObject>?,
@@ -2855,7 +2839,6 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
     bridgedAllKeysAndValues(objects, keys, count)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   @objc(enumerateKeysAndObjectsWithOptions:usingBlock:)
   internal func enumerateKeysAndObjects(options: Int,
     using block: @convention(block) (Unmanaged<AnyObject>, Unmanaged<AnyObject>,
@@ -2875,7 +2858,6 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
 
   /// Returns the pointer to the stored property, which contains bridged
   /// Dictionary elements.
-  @inlinable // FIXME(sil-serialize-all)
   @nonobjc
   internal var _heapStorageBridgedPtr: UnsafeMutablePointer<AnyObject?> {
     return _getUnsafePointerToStoredProperties(self).assumingMemoryBound(
@@ -2883,7 +2865,6 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
   }
 
   /// The buffer for bridged Dictionary elements, if present.
-  @inlinable // FIXME(sil-serialize-all)
   @nonobjc
   internal var _bridgedStorage: BridgedBuffer.RawStorage? {
     get {
@@ -2895,7 +2876,6 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
   }
 
   /// Attach a buffer for bridged Dictionary elements.
-  @inlinable // FIXME(sil-serialize-all)
   @nonobjc
   internal func _initializeHeapStorageBridged(_ newStorage: AnyObject) {
     _stdlib_atomicInitializeARCRef(
@@ -2903,12 +2883,10 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
   }
 
   /// Returns the bridged Dictionary values.
-  @inlinable // FIXME(sil-serialize-all)
   internal var bridgedBuffer: BridgedBuffer {
     return BridgedBuffer(_storage: _bridgedStorage!)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   @nonobjc
   internal func bridgeEverything() {
     if _fastPath(_bridgedStorage != nil) {
@@ -2938,7 +2916,6 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
     _initializeHeapStorageBridged(bridged._storage)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   @nonobjc
   internal func bridgedAllKeysAndValues(
     _ objects: UnsafeMutablePointer<AnyObject>?,
@@ -2988,13 +2965,11 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
     }
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   @objc
   internal var count: Int {
     return nativeBuffer.count
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   @nonobjc
   internal func bridgingObjectForKey(_ aKey: AnyObject)
     -> AnyObject? {
@@ -3016,7 +2991,6 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
     return _NativeDictionaryNSEnumerator<AnyObject, AnyObject>(bridgedBuffer)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   @objc(countByEnumeratingWithState:objects:count:)
   internal func countByEnumerating(
     with state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
@@ -3065,8 +3039,6 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
   }
 }
 #else
-@_fixed_layout // FIXME(sil-serialize-all)
-@usableFromInline // FIXME(sil-serialize-all)
 final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value> { }
 #endif
 
@@ -4802,7 +4774,6 @@ extension Dictionary {
 
   /// Returns the native Dictionary hidden inside this NSDictionary;
   /// returns nil otherwise.
-  @inlinable // FIXME(sil-serialize-all)
   public static func _bridgeFromObjectiveCAdoptingNativeStorageOf(
     _ s: AnyObject
   ) -> Dictionary<Key, Value>? {

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1922,7 +1922,6 @@ internal class _RawNativeDictionaryStorage
   /// Get the NSEnumerator implementation for self.
   /// _HashableTypedNativeDictionaryStorage overloads this to give
   /// _NativeSelfNSEnumerator proper type parameters.
-  @inlinable // FIXME(sil-serialize-all)
   @objc
   internal func enumerator() -> _NSEnumerator {
     return _NativeDictionaryNSEnumerator<AnyObject, AnyObject>(
@@ -1971,7 +1970,6 @@ internal class _RawNativeDictionaryStorage
     return nil
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   internal func keyEnumerator() -> _NSEnumerator {
     return enumerator()
   }
@@ -2071,7 +2069,7 @@ final internal class _HashableTypedNativeDictionaryStorage<Key: Hashable, Value>
     return FullContainer(_nativeBuffer: buffer)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @objc
   internal override func enumerator() -> _NSEnumerator {
     return _NativeDictionaryNSEnumerator<Key, Value>(
         Buffer(_storage: self))
@@ -2699,33 +2697,24 @@ extension _NativeDictionaryBuffer where Key: Hashable
 #if _runtime(_ObjC)
 /// An NSEnumerator that works with any NativeDictionaryBuffer of
 /// verbatim bridgeable elements. Used by the various NSDictionary impls.
-@_fixed_layout // FIXME(sil-serialize-all)
-@usableFromInline // FIXME(sil-serialize-all)
 final internal class _NativeDictionaryNSEnumerator<Key, Value>
   : _SwiftNativeNSEnumerator, _NSEnumerator {
 
-  @usableFromInline
   internal typealias Buffer = _NativeDictionaryBuffer<Key, Value>
-  @usableFromInline
   internal typealias Index = _NativeDictionaryIndex<Key, Value>
 
-  @inlinable // FIXME(sil-serialize-all)
   internal override required init() {
     _sanityCheckFailure("don't call this designated initializer")
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   internal init(_ buffer: Buffer) {
     self.buffer = buffer
     nextIndex = buffer.startIndex
     endIndex = buffer.endIndex
   }
 
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var buffer: Buffer
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var nextIndex: Index
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var endIndex: Index
 
   //
@@ -2734,7 +2723,6 @@ final internal class _NativeDictionaryNSEnumerator<Key, Value>
   // Do not call any of these methods from the standard library!
   //
 
-  @inlinable // FIXME(sil-serialize-all)
   @objc
   internal func nextObject() -> AnyObject? {
     if nextIndex == endIndex {
@@ -2745,7 +2733,6 @@ final internal class _NativeDictionaryNSEnumerator<Key, Value>
     return key
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   @objc(countByEnumeratingWithState:objects:count:)
   internal func countByEnumerating(
     with state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
@@ -2853,7 +2840,6 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
     return bridgingObjectForKey(aKey)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   @objc
   internal func keyEnumerator() -> _NSEnumerator {
     return enumerator()
@@ -3024,7 +3010,6 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
     return nil
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   @objc
   internal func enumerator() -> _NSEnumerator {
     bridgeEverything()

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1869,24 +1869,6 @@ internal protocol _DictionaryBuffer {
   func maybeGet(_ key: Key) -> Value?
 }
 
-internal protocol _MutableDictionaryBuffer: _DictionaryBuffer {
-  @discardableResult
-  mutating func updateValue(_ value: Value, forKey key: Key) -> Value?
-
-  @discardableResult
-  mutating func insert(
-    _ value: Value, forKey key: Key
-  ) -> (inserted: Bool, memberAfterInsert: Value)
-
-  @discardableResult
-  mutating func remove(at index: Index) -> SequenceElement
-
-  @discardableResult
-  mutating func removeValue(forKey key: Key) -> Value?
-
-  mutating func removeAll(keepingCapacity keepCapacity: Bool)
-}
-
 /// An instance of this class has all `Dictionary` data tail-allocated.
 /// Enough bytes are allocated to hold the bitmap for marking valid entries,
 /// keys, and values. The data layout starts with the bitmap, followed by the
@@ -3132,7 +3114,7 @@ internal struct _CocoaDictionaryBuffer: _DictionaryBuffer {
 @usableFromInline
 @_frozen
 internal enum _VariantDictionaryBuffer<Key: Hashable, Value>
-  : _MutableDictionaryBuffer {
+  : _DictionaryBuffer {
 
   @usableFromInline
   internal typealias NativeBuffer = _NativeDictionaryBuffer<Key, Value>

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1865,9 +1865,6 @@ public func _dictionaryBridgeFromObjectiveCConditional<
 internal class _RawNativeDictionaryStorage
   : _SwiftNativeNSDictionary, _NSDictionaryCore
 {
-  @usableFromInline
-  internal typealias RawStorage = _RawNativeDictionaryStorage
-
   @usableFromInline // FIXME(sil-serialize-all)
   @nonobjc
   internal final var bucketCount: Int
@@ -1901,7 +1898,7 @@ internal class _RawNativeDictionaryStorage
   /// be mutated.
   @inlinable // FIXME(sil-serialize-all)
   @nonobjc
-  internal static var empty: RawStorage {
+  internal static var empty: _RawNativeDictionaryStorage {
     return Builtin.bridgeFromRawPointer(
       Builtin.addressof(&_swiftEmptyDictionaryStorage))
   }
@@ -2200,9 +2197,6 @@ final internal class _HashableTypedNativeDictionaryStorage<Key: Hashable, Value>
 @usableFromInline
 @_fixed_layout
 internal struct _NativeDictionaryBuffer<Key, Value> {
-
-  @usableFromInline // FIXME(sil-serialize-all)
-  internal typealias RawStorage = _RawNativeDictionaryStorage
   @usableFromInline // FIXME(sil-serialize-all)
   internal typealias TypedStorage = _TypedNativeDictionaryStorage<Key, Value>
   @usableFromInline // FIXME(sil-serialize-all)
@@ -2216,7 +2210,7 @@ internal struct _NativeDictionaryBuffer<Key, Value> {
   /// See this comments on _RawNativeDictionaryStorage and its subclasses to
   /// understand why we store an untyped storage here.
   @usableFromInline // FIXME(sil-serialize-all)
-  internal var _storage: RawStorage
+  internal var _storage: _RawNativeDictionaryStorage
 
   /// Creates a Buffer with a storage that is typed, but doesn't understand
   /// Hashing. Mostly for bridging; prefer `init(minimumCapacity:)`.
@@ -2230,10 +2224,13 @@ internal struct _NativeDictionaryBuffer<Key, Value> {
     self.init(_exactBucketCount: bucketCount, storage: storage)
   }
 
-  /// Given a bucket count and uninitialized RawStorage, completes the
-  /// initialization and returns a Buffer.
+  /// Given a bucket count and uninitialized _RawNativeDictionaryStorage,
+  /// completes the initialization and returns a Buffer.
   @inlinable // FIXME(sil-serialize-all)
-  internal init(_exactBucketCount bucketCount: Int, storage: RawStorage) {
+  internal init(
+    _exactBucketCount bucketCount: Int,
+    storage: _RawNativeDictionaryStorage
+  ) {
     storage.bucketCount = bucketCount
     storage.count = 0
 
@@ -2308,14 +2305,14 @@ internal struct _NativeDictionaryBuffer<Key, Value> {
 
   /// Constructs a buffer adopting the given storage.
   @inlinable // FIXME(sil-serialize-all)
-  internal init(_storage: RawStorage) {
+  internal init(_storage: _RawNativeDictionaryStorage) {
     self._storage = _storage
   }
 
   /// Constructs an instance from the empty singleton.
   @inlinable // FIXME(sil-serialize-all)
   internal init() {
-    self._storage = RawStorage.empty
+    self._storage = _RawNativeDictionaryStorage.empty
   }
 
   // Most of the implementation of the _HashBuffer protocol,
@@ -2498,7 +2495,7 @@ extension _NativeDictionaryBuffer where Key: Hashable
 
     if (_isBridgedVerbatimToObjectiveC(Key.self) &&
         _isBridgedVerbatimToObjectiveC(Value.self)) ||
-        self._storage === RawStorage.empty {
+        self._storage === _RawNativeDictionaryStorage.empty {
       nsSet = self._storage
     } else {
       nsSet = _SwiftDeferredNSDictionary(nativeBuffer: self)

--- a/stdlib/public/core/Hashing.swift
+++ b/stdlib/public/core/Hashing.swift
@@ -14,50 +14,6 @@
 // This file implements helpers for hashing collections.
 //
 
-/// This protocol is only used for compile-time checks that
-/// every buffer type implements all required operations.
-internal protocol _HashBuffer {
-  associatedtype Key
-  associatedtype Value
-  associatedtype Index
-  associatedtype SequenceElement
-  associatedtype SequenceElementWithoutLabels
-  var startIndex: Index { get }
-  var endIndex: Index { get }
-
-  func index(after i: Index) -> Index
-
-  func formIndex(after i: inout Index)
-
-  func index(forKey key: Key) -> Index?
-
-  func assertingGet(_ i: Index) -> SequenceElement
-
-  func assertingGet(_ key: Key) -> Value
-
-  func maybeGet(_ key: Key) -> Value?
-
-  @discardableResult
-  mutating func updateValue(_ value: Value, forKey key: Key) -> Value?
-
-  @discardableResult
-  mutating func insert(
-    _ value: Value, forKey key: Key
-  ) -> (inserted: Bool, memberAfterInsert: Value)
-
-  @discardableResult
-  mutating func remove(at index: Index) -> SequenceElement
-
-  @discardableResult
-  mutating func removeValue(forKey key: Key) -> Value?
-
-  mutating func removeAll(keepingCapacity keepCapacity: Bool)
-
-  var count: Int { get }
-
-  static func fromArray(_ elements: [SequenceElementWithoutLabels]) -> Self
-}
-
 /// The inverse of the default hash table load factor.  Factored out so that it
 /// can be used in multiple places in the implementation and stay consistent.
 /// Should not be used outside `Dictionary` implementation.

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1511,12 +1511,7 @@ extension Set {
 @_fixed_layout // FIXME(sil-serialize-all)
 @usableFromInline // FIXME(sil-serialize-all)
 @_objc_non_lazy_realization
-internal class _RawNativeSetStorage:
-  _SwiftNativeNSSet, _NSSetCore
-{
-  @usableFromInline
-  internal typealias RawStorage = _RawNativeSetStorage
-
+internal class _RawNativeSetStorage: _SwiftNativeNSSet, _NSSetCore {
   @usableFromInline // FIXME(sil-serialize-all)
   @nonobjc
   internal final var bucketCount: Int
@@ -1547,7 +1542,7 @@ internal class _RawNativeSetStorage:
   /// be mutated.
   @inlinable // FIXME(sil-serialize-all)
   @nonobjc
-  internal static var empty: RawStorage {
+  internal static var empty: _RawNativeSetStorage {
     return Builtin.bridgeFromRawPointer(
       Builtin.addressof(&_swiftEmptySetStorage))
   }
@@ -1783,8 +1778,6 @@ final internal class _HashableTypedNativeSetStorage<Element: Hashable>
 internal struct _NativeSetBuffer<Element> {
 
   @usableFromInline
-  internal typealias RawStorage = _RawNativeSetStorage
-  @usableFromInline
   internal typealias TypedStorage = _TypedNativeSetStorage<Element>
   @usableFromInline
   internal typealias Buffer = _NativeSetBuffer<Element>
@@ -1801,7 +1794,7 @@ internal struct _NativeSetBuffer<Element> {
   /// See this comments on _RawNativeSetStorage and its subclasses to
   /// understand why we store an untyped storage here.
   @usableFromInline // FIXME(sil-serialize-all)
-  internal var _storage: RawStorage
+  internal var _storage: _RawNativeSetStorage
 
   /// Creates a Buffer with a storage that is typed, but doesn't understand
   /// Hashing. Mostly for bridging; prefer `init(minimumCapacity:)`.
@@ -1814,10 +1807,13 @@ internal struct _NativeSetBuffer<Element> {
     self.init(_exactBucketCount: bucketCount, storage: storage)
   }
 
-  /// Given a bucket count and uninitialized RawStorage, completes the
+  /// Given a bucket count and uninitialized _RawNativeSetStorage, completes the
   /// initialization and returns a Buffer.
   @inlinable // FIXME(sil-serialize-all)
-  internal init(_exactBucketCount bucketCount: Int, storage: RawStorage) {
+  internal init(
+    _exactBucketCount bucketCount: Int,
+    storage: _RawNativeSetStorage
+  ) {
     storage.bucketCount = bucketCount
     storage.count = 0
 
@@ -1883,14 +1879,14 @@ internal struct _NativeSetBuffer<Element> {
 
   /// Constructs a buffer adopting the given storage.
   @inlinable // FIXME(sil-serialize-all)
-  internal init(_storage: RawStorage) {
+  internal init(_storage: _RawNativeSetStorage) {
     self._storage = _storage
   }
 
   /// Constructs an instance from the empty singleton.
   @inlinable // FIXME(sil-serialize-all)
   internal init() {
-    self._storage = RawStorage.empty
+    self._storage = _RawNativeSetStorage.empty
   }
 
   // Most of the implementation of the _HashBuffer protocol,
@@ -2068,7 +2064,7 @@ extension _NativeSetBuffer where Element: Hashable
 
     if (_isBridgedVerbatimToObjectiveC(Key.self) &&
         _isBridgedVerbatimToObjectiveC(Value.self)) ||
-        self._storage === RawStorage.empty {
+        self._storage === _RawNativeSetStorage.empty {
       nsSet = self._storage
     } else {
       nsSet = _SwiftDeferredNSSet(nativeBuffer: self)

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -2058,7 +2058,7 @@ extension _NativeSetBuffer where Element: Hashable
   }
 
 #if _runtime(_ObjC)
-  @inlinable // FIXME(sil-serialize-all)
+  @usableFromInline
   internal func bridged() -> _NSSet {
     // We can zero-cost bridge if our keys are verbatim
     // or if we're the empty singleton.
@@ -2345,33 +2345,21 @@ final internal class _NativeSetNSEnumerator<Element>
 /// This is the fallback implementation for situations where toll-free bridging
 /// isn't possible. On first access, a NativeSetBuffer of AnyObject will be
 /// constructed containing all the bridged elements.
-@_fixed_layout // FIXME(sil-serialize-all)
-@usableFromInline // FIXME(sil-serialize-all)
 final internal class _SwiftDeferredNSSet<Element: Hashable>
   : _SwiftNativeNSSet, _NSSetCore {
 
-  @usableFromInline
   internal typealias NativeBuffer = _NativeSetBuffer<Element>
-  @usableFromInline
   internal typealias BridgedBuffer = _NativeSetBuffer<AnyObject>
-  @usableFromInline
-  internal typealias NativeIndex = _NativeSetIndex<Element>
-  @usableFromInline
-  internal typealias BridgedIndex = _NativeSetIndex<AnyObject>
 
-  @usableFromInline
   internal typealias Key = Element
-  @usableFromInline
   internal typealias Value = Element
 
-  @inlinable // FIXME(sil-serialize-all)
   @nonobjc
   internal init(bucketCount: Int = 2) {
     nativeBuffer = NativeBuffer(bucketCount: bucketCount)
     super.init()
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   internal init(nativeBuffer: NativeBuffer) {
     self.nativeBuffer = nativeBuffer
     super.init()
@@ -2381,15 +2369,12 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
   // operations on it.
   //
   // Do not access this property directly.
-  @usableFromInline // FIXME(sil-serialize-all)
   @nonobjc
   internal var _heapStorageBridged_DoNotUse: AnyObject?
 
   /// The unbridged elements.
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var nativeBuffer: NativeBuffer
 
-  @inlinable // FIXME(sil-serialize-all)
   @objc(copyWithZone:)
   internal func copy(with zone: _SwiftNSZone?) -> AnyObject {
     // Instances of this class should be visible outside of standard library as
@@ -2404,13 +2389,11 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
   // `nativeBuffer`.
   //
 
-  @inlinable // FIXME(sil-serialize-all)
   @objc
   internal required init(objects: UnsafePointer<AnyObject?>, count: Int) {
     _sanityCheckFailure("don't call this designated initializer")
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   @objc
   internal func member(_ object: AnyObject) -> AnyObject? {
     return bridgingObjectForKey(object)
@@ -2423,7 +2406,6 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
 
   /// Returns the pointer to the stored property, which contains bridged
   /// Set elements.
-  @inlinable // FIXME(sil-serialize-all)
   @nonobjc
   internal var _heapStorageBridgedPtr: UnsafeMutablePointer<AnyObject?> {
     return _getUnsafePointerToStoredProperties(self).assumingMemoryBound(
@@ -2431,7 +2413,6 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
   }
 
   /// The buffer for bridged Set elements, if present.
-  @inlinable // FIXME(sil-serialize-all)
   @nonobjc
   internal var _bridgedStorage:
     BridgedBuffer.RawStorage? {
@@ -2444,7 +2425,6 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
   }
 
   /// Attach a buffer for bridged Set elements.
-  @inlinable // FIXME(sil-serialize-all)
   @nonobjc
   internal func _initializeHeapStorageBridged(_ newStorage: AnyObject) {
     _stdlib_atomicInitializeARCRef(
@@ -2452,12 +2432,10 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
   }
 
   /// Returns the bridged Set values.
-  @inlinable // FIXME(sil-serialize-all)
   internal var bridgedBuffer: BridgedBuffer {
     return BridgedBuffer(_storage: _bridgedStorage!)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   @nonobjc
   internal func bridgeEverything() {
     if _fastPath(_bridgedStorage != nil) {
@@ -2486,13 +2464,11 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
     _initializeHeapStorageBridged(bridged._storage)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   @objc
   internal var count: Int {
     return nativeBuffer.count
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   @nonobjc
   internal func bridgingObjectForKey(_ aKey: AnyObject)
     -> AnyObject? {
@@ -2514,7 +2490,6 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
     return _NativeSetNSEnumerator<AnyObject>(bridgedBuffer)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   @objc(countByEnumeratingWithState:objects:count:)
   internal func countByEnumerating(
     with state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
@@ -2563,8 +2538,6 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
   }
 }
 #else
-@_fixed_layout // FIXME(sil-serialize-all)
-@usableFromInline // FIXME(sil-serialize-all)
 final internal class _SwiftDeferredNSSet<Element: Hashable> { }
 #endif
 
@@ -4076,7 +4049,6 @@ extension Set {
 
   /// Returns the native Dictionary hidden inside this NSDictionary;
   /// returns nil otherwise.
-  @inlinable // FIXME(sil-serialize-all)
   public static func _bridgeFromObjectiveCAdoptingNativeStorageOf(
     _ s: AnyObject
   ) -> Set<Element>? {

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1515,25 +1515,6 @@ internal protocol _SetBuffer { // FIXME: Remove or refactor for Set.
   func maybeGet(_ key: Element) -> Element?
 }
 
-internal protocol _MutableSetBuffer: _SetBuffer {
-  @discardableResult
-  mutating func updateValue(_ value: Element, forKey key: Element) -> Element?
-
-  @discardableResult
-  mutating func insert(
-    _ value: Element, forKey key: Element
-  ) -> (inserted: Bool, memberAfterInsert: Element)
-
-  @discardableResult
-  mutating func remove(at index: Index) -> Element
-
-  @discardableResult
-  mutating func removeValue(forKey key: Element) -> Element?
-
-  mutating func removeAll(keepingCapacity keepCapacity: Bool)
-}
-
-
 /// An instance of this class has all `Set` data tail-allocated.
 /// Enough bytes are allocated to hold the bitmap for marking valid entries,
 /// keys, and values. The data layout starts with the bitmap, followed by the
@@ -2593,7 +2574,7 @@ internal struct _CocoaSetBuffer: _SetBuffer {
 
 @usableFromInline
 @_frozen
-internal enum _VariantSetBuffer<Element: Hashable>: _MutableSetBuffer {
+internal enum _VariantSetBuffer<Element: Hashable>: _SetBuffer {
 
   @usableFromInline
   internal typealias NativeBuffer = _NativeSetBuffer<Element>

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1568,7 +1568,6 @@ internal class _RawNativeSetStorage:
   /// Get the NSEnumerator implementation for self.
   /// _HashableTypedNativeSetStorage overloads this to give
   /// _NativeSelfNSEnumerator proper type parameters.
-  @inlinable // FIXME(sil-serialize-all)
   @objc
   internal func enumerator() -> _NSEnumerator {
     return _NativeSetNSEnumerator<AnyObject>(
@@ -1613,7 +1612,6 @@ internal class _RawNativeSetStorage:
     return nil
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   @objc
   internal func objectEnumerator() -> _NSEnumerator {
     return enumerator()
@@ -1697,7 +1695,7 @@ final internal class _HashableTypedNativeSetStorage<Element: Hashable>
     return FullContainer(_nativeBuffer: buffer)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @objc
   internal override func enumerator() -> _NSEnumerator {
     return _NativeSetNSEnumerator<Element>(
         Buffer(_storage: self))
@@ -2274,33 +2272,24 @@ extension _NativeSetBuffer where Element: Hashable
 #if _runtime(_ObjC)
 /// An NSEnumerator that works with any NativeSetBuffer of
 /// verbatim bridgeable elements. Used by the various NSSet impls.
-@_fixed_layout // FIXME(sil-serialize-all)
-@usableFromInline // FIXME(sil-serialize-all)
 final internal class _NativeSetNSEnumerator<Element>
   : _SwiftNativeNSEnumerator, _NSEnumerator {
 
-  @usableFromInline
   internal typealias Buffer = _NativeSetBuffer<Element>
-  @usableFromInline
   internal typealias Index = _NativeSetIndex<Element>
 
-  @inlinable // FIXME(sil-serialize-all)
   internal override required init() {
     _sanityCheckFailure("don't call this designated initializer")
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   internal init(_ buffer: Buffer) {
     self.buffer = buffer
     nextIndex = buffer.startIndex
     endIndex = buffer.endIndex
   }
 
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var buffer: Buffer
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var nextIndex: Index
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var endIndex: Index
 
   //
@@ -2309,7 +2298,6 @@ final internal class _NativeSetNSEnumerator<Element>
   // Do not call any of these methods from the standard library!
   //
 
-  @inlinable // FIXME(sil-serialize-all)
   @objc
   internal func nextObject() -> AnyObject? {
     if nextIndex == endIndex {
@@ -2320,7 +2308,6 @@ final internal class _NativeSetNSEnumerator<Element>
     return key
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   @objc(countByEnumeratingWithState:objects:count:)
   internal func countByEnumerating(
     with state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
@@ -2429,7 +2416,6 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
     return bridgingObjectForKey(object)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   @objc
   internal func objectEnumerator() -> _NSEnumerator {
     return enumerator()
@@ -2522,7 +2508,6 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
     return nil
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   @objc
   internal func enumerator() -> _NSEnumerator {
     bridgeEverything()

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -3382,7 +3382,7 @@ internal enum _VariantSetBuffer<Element: Hashable>: _HashBuffer {
         start: asNative.startIndex, end: asNative.endIndex, buffer: buffer)
 #if _runtime(_ObjC)
     case .cocoa(let cocoaBuffer):
-      return ._cocoa(_CocoaSetIterator(cocoaBuffer.cocoaSet))
+      return ._cocoa(cocoaBuffer)
 #endif
     }
   }
@@ -3711,10 +3711,8 @@ extension Set.Index {
 }
 
 #if _runtime(_ObjC)
-@_fixed_layout // FIXME(sil-serialize-all)
 @usableFromInline
 final internal class _CocoaSetIterator: IteratorProtocol {
-  @usableFromInline
   internal typealias Element = AnyObject
 
   // Cocoa Set iterator has to be a class, otherwise we cannot
@@ -3723,26 +3721,21 @@ final internal class _CocoaSetIterator: IteratorProtocol {
 
   // This stored property should be stored at offset zero.  There's code below
   // relying on this.
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var _fastEnumerationState: _SwiftNSFastEnumerationState =
     _makeSwiftNSFastEnumerationState()
 
   // This stored property should be stored right after `_fastEnumerationState`.
   // There's code below relying on this.
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var _fastEnumerationStackBuf = _CocoaFastEnumerationStackBuf()
 
-  @usableFromInline // FIXME(sil-serialize-all)
   internal let cocoaSet: _NSSet
 
-  @inlinable // FIXME(sil-serialize-all)
   internal var _fastEnumerationStatePtr:
     UnsafeMutablePointer<_SwiftNSFastEnumerationState> {
     return _getUnsafePointerToStoredProperties(self).assumingMemoryBound(
       to: _SwiftNSFastEnumerationState.self)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   internal var _fastEnumerationStackBufPtr:
     UnsafeMutablePointer<_CocoaFastEnumerationStackBuf> {
     return UnsafeMutableRawPointer(_fastEnumerationStatePtr + 1)
@@ -3753,17 +3746,14 @@ final internal class _CocoaSetIterator: IteratorProtocol {
   // Int8 just because our storage holds 16 elements: fast enumeration is
   // allowed to return inner pointers to the container, which can be much
   // larger.
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var itemIndex: Int = 0
-  @usableFromInline // FIXME(sil-serialize-all)
   internal var itemCount: Int = 0
 
-  @inlinable // FIXME(sil-serialize-all)
   internal init(_ cocoaSet: _NSSet) {
     self.cocoaSet = cocoaSet
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @usableFromInline
   internal func next() -> Element? {
     if itemIndex < 0 {
       return nil
@@ -3854,10 +3844,9 @@ public struct SetIterator<Element: Hashable>: IteratorProtocol {
       _state: ._native(start: start, end: end, buffer: buffer))
   }
 #if _runtime(_ObjC)
-  @inlinable // FIXME(sil-serialize-all)
-  internal static func _cocoa(
-    _ iterator: _CocoaSetIterator
-  ) -> SetIterator{
+  @usableFromInline
+  internal static func _cocoa(_ buffer: _CocoaSetBuffer) -> SetIterator {
+    let iterator = _CocoaSetIterator(buffer.cocoaSet)
     return SetIterator(_state: ._cocoa(iterator))
   }
 #endif

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -2609,9 +2609,7 @@ internal struct _CocoaSetBuffer: _HashBuffer {
   @inlinable // FIXME(sil-serialize-all)
   @inline(__always)
   internal func maybeGet(_ key: Key) -> Value? {
-
-  return cocoaSet.member(key)
-
+    return cocoaSet.member(key)
   }
 
   @inlinable // FIXME(sil-serialize-all)
@@ -2653,7 +2651,6 @@ internal struct _CocoaSetBuffer: _HashBuffer {
   @inlinable // FIXME(sil-serialize-all)
   internal static func fromArray(_ elements: [SequenceElementWithoutLabels])
     -> _CocoaSetBuffer {
-
     _sanityCheckFailure("this function should never be called")
   }
 


### PR DESCRIPTION
Do a quick inlinability audit pass for Set/Dictionary internals. Clean up obsolete gybisms.

* Classes and methods implementing Cocoa API (NSSet, NSDictionary, NSEnumerator) do not need to be included in the Swift ABI; make them internal.
* Make Set/Dictionary iteration state for the lazily bridged Cocoa case non-inlinable.
* Make the conversion from lazily bridged to native sets/dictionaries non-inlinable.
* Simplify code by refactoring some obsolete gybisms. (References to Key & Value in Set, pointless methods, `_HashBuffer`.)

rdar://problem/42282850