### PR TITLE
Remove willBeRelativelyAddressed hack for string constants

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3894,22 +3894,14 @@ Address IRGenFunction::createFixedSizeBufferAlloca(const llvm::Twine &name) {
 /// \returns an i8* with a null terminator; note that embedded nulls
 ///   are okay
 ///
-/// FIXME: willBeRelativelyAddressed is only needed to work around an ld64 bug
-/// resolving relative references to coalesceable symbols.
-/// It should be removed when fixed. rdar://problem/22674524
-llvm::Constant *IRGenModule::getAddrOfGlobalString(StringRef data,
-                                               bool willBeRelativelyAddressed) {
+llvm::Constant *IRGenModule::getAddrOfGlobalString(StringRef data) {
   // Check whether this string already exists.
   auto &entry = GlobalStrings[data];
   if (entry.second) {
-    // FIXME: Clear unnamed_addr if the global will be relative referenced
-    // to work around an ld64 bug. rdar://problem/22674524
-    if (willBeRelativelyAddressed)
-      entry.first->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::None);
     return entry.second;
   }
 
-  entry = createStringConstant(data, willBeRelativelyAddressed);
+  entry = createStringConstant(data);
   return entry.second;
 }
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -314,8 +314,7 @@ namespace {
     }
     
     void addName() {
-      B.addRelativeAddress(IGM.getAddrOfGlobalString(M->getName().str(),
-                                           /*willBeRelativelyAddressed*/ true));
+      B.addRelativeAddress(IGM.getAddrOfGlobalString(M->getName().str()));
     }
     
     bool isUniqueDescriptor() {
@@ -501,8 +500,7 @@ namespace {
         name = Type->getName().str();
       }
       
-      auto nameStr = IGM.getAddrOfGlobalString(name,
-                                           /*willBeRelativelyAddressed*/ true);
+      auto nameStr = IGM.getAddrOfGlobalString(name);
       B.addRelativeAddress(nameStr);
     }
       
@@ -3114,8 +3112,7 @@ namespace {
       IRGenMangler mangler;
       std::string Name =
         mangler.mangleTypeForForeignMetadataUniquing(targetType);
-      llvm::Constant *nameStr = IGM.getAddrOfGlobalString(Name,
-                                                 /*relatively addressed*/ true);
+      llvm::Constant *nameStr = IGM.getAddrOfGlobalString(Name);
       B.addRelativeAddress(nameStr);
     }
 
@@ -3703,8 +3700,7 @@ namespace {
     void addAssociatedTypeNames() {
       llvm::Constant *global = nullptr;
       if (!AssociatedTypeNames.empty()) {
-        global = IGM.getAddrOfGlobalString(AssociatedTypeNames,
-                                           /*willBeRelativelyAddressed=*/true);
+        global = IGM.getAddrOfGlobalString(AssociatedTypeNames);
       }
       B.addRelativeAddressOrNull(global);
     }

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -821,8 +821,7 @@ llvm::Constant *IRGenModule::getAddrOfFieldName(StringRef Name) {
   if (entry.second)
     return entry.second;
 
-  entry = createStringConstant(Name, /*willBeRelativelyAddressed*/ true,
-                               getReflectionStringsSectionName());
+  entry = createStringConstant(Name, getReflectionStringsSectionName());
   disableAddressSanitizer(*this, entry.first);
   return entry.second;
 }

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -576,20 +576,13 @@ llvm::Constant *swift::getRuntimeFn(llvm::Module &Module,
 #include "swift/Runtime/RuntimeFunctions.def"
 
 std::pair<llvm::GlobalVariable *, llvm::Constant *>
-IRGenModule::createStringConstant(StringRef Str,
-  bool willBeRelativelyAddressed, StringRef sectionName) {
+IRGenModule::createStringConstant(StringRef Str, StringRef sectionName) {
   // If not, create it.  This implicitly adds a trailing null.
   auto init = llvm::ConstantDataArray::getString(LLVMContext, Str);
   auto global = new llvm::GlobalVariable(Module, init->getType(), true,
                                          llvm::GlobalValue::PrivateLinkage,
                                          init);
-  // FIXME: ld64 crashes resolving relative references to coalesceable symbols.
-  // rdar://problem/22674524
-  // If we intend to relatively address this string, don't mark it with
-  // unnamed_addr to prevent it from going into the cstrings section and getting
-  // coalesced.
-  if (!willBeRelativelyAddressed)
-    global->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
+  global->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
 
   if (!sectionName.empty())
     global->setSection(sectionName);

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -777,10 +777,8 @@ private:
 //--- Globals ---------------------------------------------------------------
 public:
   std::pair<llvm::GlobalVariable *, llvm::Constant *>
-  createStringConstant(StringRef Str, bool willBeRelativelyAddressed = false,
-                       StringRef sectionName = "");
-  llvm::Constant *getAddrOfGlobalString(StringRef utf8,
-                                        bool willBeRelativelyAddressed = false);
+  createStringConstant(StringRef Str, StringRef sectionName = "");
+  llvm::Constant *getAddrOfGlobalString(StringRef utf8);
   llvm::Constant *getAddrOfGlobalUTF16String(StringRef utf8);
   llvm::Constant *getAddrOfGlobalConstantString(StringRef utf8);
   llvm::Constant *getAddrOfGlobalUTF16ConstantString(StringRef utf8);


### PR DESCRIPTION
It was added to work around a linker bug. The linker has since been
fixed and the workaround should no longer be necessary.

rdar://37552922