### PR TITLE
[test] Update String tests for older iOS versions

### DIFF
--- a/test/stdlib/StringBridge.swift
+++ b/test/stdlib/StringBridge.swift
@@ -34,6 +34,7 @@ func expectCocoa(_ str: String,
 }
 
 StringBridgeTests.test("Tagged NSString") {
+  guard #available(iOS 11.0, *) else { return }
 #if arch(i386) || arch(arm)
 #else
   // Bridge tagged strings as small

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -912,6 +912,7 @@ StringTests.test("stringGutsReserve")
   .skip(.nativeRuntime("Foundation dependency"))
   .code {
 #if _runtime(_ObjC)
+  guard #available(iOS 11.0, *) else { return }
   for k in 0...7 {
     var base: String
     var startedNative: Bool


### PR DESCRIPTION
4.2 cherry-pick of https://github.com/apple/swift/pull/17945

---

Explanation: Adds availability guard for iOS-tests which require a newer OS version.

Scope: Only affects testing on older OSes

Issue: <rdar://problem/41763351>

Risk: Low, only affects testing

Testing: Regular testing

Reviewer: @clackary 