### PR TITLE
[pass-manager] notifyAddFunction => notifyAddedOrModifiedFunction.

### DIFF
--- a/include/swift/SILOptimizer/Analysis/AccessSummaryAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/AccessSummaryAnalysis.h
@@ -198,7 +198,7 @@ public:
   virtual void initialize(SILPassManager *PM) override {}
   virtual void invalidate() override;
   virtual void invalidate(SILFunction *F, InvalidationKind K) override;
-  virtual void notifyAddFunction(SILFunction *F) override {}
+  virtual void notifyAddedOrModifiedFunction(SILFunction *F) override {}
   virtual void notifyDeleteFunction(SILFunction *F) override {
     invalidate(F, InvalidationKind::Nothing);
   }

--- a/include/swift/SILOptimizer/Analysis/AliasAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/AliasAnalysis.h
@@ -281,7 +281,7 @@ public:
   }
 
   /// Notify the analysis about a newly created function.
-  virtual void notifyAddFunction(SILFunction *F) override { }
+  virtual void notifyAddedOrModifiedFunction(SILFunction *F) override {}
 
   /// Notify the analysis about a function which will be deleted from the
   /// module.

--- a/include/swift/SILOptimizer/Analysis/Analysis.h
+++ b/include/swift/SILOptimizer/Analysis/Analysis.h
@@ -116,8 +116,8 @@ public:
   /// Invalidate all of the information for a specific function.
   virtual void invalidate(SILFunction *f, InvalidationKind k) = 0;
 
-  /// Notify the analysis about a newly created function.
-  virtual void notifyAddFunction(SILFunction *f) = 0;
+  /// Notify the analysis about a newly added or modified function.
+  virtual void notifyAddedOrModifiedFunction(SILFunction *f) = 0;
 
   /// Notify the analysis about a function which will be deleted from the
   /// module.
@@ -244,7 +244,7 @@ public:
   }
 
   /// Notify the analysis about a newly created function.
-  virtual void notifyAddFunction(SILFunction *f) override {}
+  virtual void notifyAddedOrModifiedFunction(SILFunction *f) override {}
 
   /// Notify the analysis about a function which will be deleted from the
   /// module.

--- a/include/swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h
@@ -144,7 +144,7 @@ public:
   }
 
   /// Notify the analysis about a newly created function.
-  virtual void notifyAddFunction(SILFunction *F) override {
+  virtual void notifyAddedOrModifiedFunction(SILFunction *F) override {
     // Nothing to be done because the analysis does not cache anything
     // per call-site in functions.
   }

--- a/include/swift/SILOptimizer/Analysis/CallerAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/CallerAnalysis.h
@@ -104,8 +104,8 @@ public:
     RecomputeFunctionList.insert(F);
   }
 
-  /// Notify the analysis about a newly created function.
-  virtual void notifyAddFunction(SILFunction *F) override {
+  /// Notify the analysis about a newly created or modified function.
+  virtual void notifyAddedOrModifiedFunction(SILFunction *F) override {
     RecomputeFunctionList.insert(F);
   }
 

--- a/include/swift/SILOptimizer/Analysis/ClassHierarchyAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/ClassHierarchyAnalysis.h
@@ -54,7 +54,7 @@ public:
   virtual void invalidate(SILFunction *F, InvalidationKind K) override { }
 
   /// Notify the analysis about a newly created function.
-  virtual void notifyAddFunction(SILFunction *F) override { }
+  virtual void notifyAddedOrModifiedFunction(SILFunction *F) override {}
 
   /// Notify the analysis about a function which will be deleted from the
   /// module.

--- a/include/swift/SILOptimizer/Analysis/ClosureScope.h
+++ b/include/swift/SILOptimizer/Analysis/ClosureScope.h
@@ -144,7 +144,7 @@ public:
   }
 
   /// Notify the analysis about a newly created function.
-  virtual void notifyAddFunction(SILFunction *F) override {
+  virtual void notifyAddedOrModifiedFunction(SILFunction *F) override {
     // Nothing to be done because the analysis does not cache anything
     // per call-site in functions.
   }

--- a/include/swift/SILOptimizer/Analysis/DestructorAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/DestructorAnalysis.h
@@ -46,7 +46,7 @@ public:
   }
 
   /// Notify the analysis about a newly created function.
-  virtual void notifyAddFunction(SILFunction *F) override { }
+  virtual void notifyAddedOrModifiedFunction(SILFunction *F) override {}
 
   /// Notify the analysis about a function which will be deleted from the
   /// module.

--- a/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
@@ -802,7 +802,7 @@ public:
   virtual void invalidate(SILFunction *F, InvalidationKind K) override;
 
   /// Notify the analysis about a newly created function.
-  virtual void notifyAddFunction(SILFunction *F) override { }
+  virtual void notifyAddedOrModifiedFunction(SILFunction *F) override {}
 
   /// Notify the analysis about a function which will be deleted from the
   /// module.

--- a/include/swift/SILOptimizer/Analysis/ProtocolConformanceAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/ProtocolConformanceAnalysis.h
@@ -54,7 +54,7 @@ public:
   virtual void invalidate(SILFunction *F, InvalidationKind K) override {}
 
   /// Notify the analysis about a newly created function.
-  virtual void notifyAddFunction(SILFunction *F) override {}
+  virtual void notifyAddedOrModifiedFunction(SILFunction *F) override {}
 
   /// Notify the analysis about a function which will be deleted from the
   /// module.

--- a/include/swift/SILOptimizer/Analysis/SideEffectAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/SideEffectAnalysis.h
@@ -123,7 +123,7 @@ public:
   virtual void invalidate(SILFunction *F, InvalidationKind K) override;
 
   /// Notify the analysis about a newly created function.
-  virtual void notifyAddFunction(SILFunction *F) override {}
+  virtual void notifyAddedOrModifiedFunction(SILFunction *F) override {}
 
   /// Notify the analysis about a function which will be deleted from the
   /// module.

--- a/include/swift/SILOptimizer/Analysis/TypeExpansionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/TypeExpansionAnalysis.h
@@ -44,7 +44,7 @@ public:
   virtual void invalidate(SILFunction *F, InvalidationKind K)  override { }
 
   /// Notify the analysis about a newly created function.
-  virtual void notifyAddFunction(SILFunction *F) override { }
+  virtual void notifyAddedOrModifiedFunction(SILFunction *F) override {}
 
   /// Notify the analysis about a function which will be deleted from the
   /// module.

--- a/include/swift/SILOptimizer/PassManager/PassManager.h
+++ b/include/swift/SILOptimizer/PassManager/PassManager.h
@@ -163,14 +163,16 @@ public:
   /// is derived. This is used to avoid an infinite amount of functions pushed
   /// on the worklist (e.g. caused by a bug in a specializing optimization).
   void addFunctionToWorklist(SILFunction *F, SILFunction *DerivedFrom);
-  
+
   /// \brief Iterate over all analysis and notify them of the function.
+  ///
   /// This function does not necessarily have to be newly created function. It
   /// is the job of the analysis to make sure no extra work is done if the
   /// particular analysis has been done on the function.
   void notifyAnalysisOfFunction(SILFunction *F) {
-    for (auto AP : Analysis)
-      AP->notifyAddFunction(F);
+    for (auto AP : Analysis) {
+      AP->notifyAddedOrModifiedFunction(F);
+    }
   }
 
   /// \brief Broadcast the invalidation of the function to all analysis.

--- a/lib/SILOptimizer/Utils/OptimizerStatsUtils.cpp
+++ b/lib/SILOptimizer/Utils/OptimizerStatsUtils.cpp
@@ -492,7 +492,7 @@ public:
   }
 
   /// Notify the analysis about a newly created function.
-  virtual void notifyAddFunction(SILFunction *F) override {
+  virtual void notifyAddedOrModifiedFunction(SILFunction *F) override {
     AddedFuncs.push_back(F);
   }
 


### PR DESCRIPTION
The name notifyAddFunction is actively harmful since the pass manager uses this
entrypoint to notify analyses of added *OR* modified functions. It is up to the
caller analysis to distinguish in between these cases.

I am not vouching for the design, just trying to make names match the
current behavior.
