### PR TITLE
Guard for null result from ClangModuleUnit::getClangModule().

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -3610,7 +3610,7 @@ bool ClangImporter::isInOverlayModuleForImportedModule(
   importedDC = importedDC->getModuleScopeContext();
 
   auto importedClangModuleUnit = dyn_cast<ClangModuleUnit>(importedDC);
-  if (!importedClangModuleUnit)
+  if (!importedClangModuleUnit || !importedClangModuleUnit->getClangModule())
     return false;
 
   auto overlayModule = overlayDC->getParentModule();


### PR DESCRIPTION
The documentation for this method states that this can return null if
the module unit represents [the] imported headers.

We have a crash report on dereferencing the result of this function
farther down, and I suspect it's hitting exactly that
case. Unfortunately we only have a back trace and no test case.

Fixes: rdar://problem/41888568
