### PR TITLE
[AST] [Sema] [IDE] Fix places where we set bare arguments

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3825,11 +3825,17 @@ class ApplyExpr : public Expr {
 
   /// The argument being passed to it, and whether it's a 'super' argument.
   llvm::PointerIntPair<Expr *, 1, bool> ArgAndIsSuper;
+  
+  /// Returns true if \c e could be used as the call's argument. For most \c ApplyExpr
+  /// subclasses, this means it is a \c ParenExpr, \c TupleExpr, or 
+  /// \c TupleShuffleExpr.
+  bool validateArg(Expr *e) const;
 
 protected:
   ApplyExpr(ExprKind Kind, Expr *Fn, Expr *Arg, bool Implicit, Type Ty = Type())
     : Expr(Kind, Implicit, Ty), Fn(Fn), ArgAndIsSuper(Arg, false) {
     assert(classof((Expr*)this) && "ApplyExpr::classof out of date");
+    assert(validateArg(Arg) && "Arg is not a permitted expr kind");
     Bits.ApplyExpr.ThrowsIsSet = false;
   }
 
@@ -3840,8 +3846,7 @@ public:
   
   Expr *getArg() const { return ArgAndIsSuper.getPointer(); }
   void setArg(Expr *e) {
-    assert((getKind() != ExprKind::Binary || isa<TupleExpr>(e)) &&
-           "BinaryExprs must have a TupleExpr as the argument");
+    assert(validateArg(e) && "Arg is not a permitted expr kind");
     ArgAndIsSuper = {e, ArgAndIsSuper.getInt()};
   }
   
@@ -5127,6 +5132,15 @@ public:
 inline bool Expr::isInfixOperator() const {
   return isa<BinaryExpr>(this) || isa<IfExpr>(this) ||
          isa<AssignExpr>(this) || isa<ExplicitCastExpr>(this);
+}
+  
+inline bool ApplyExpr::validateArg(Expr *e) const {
+  if (isa<SelfApplyExpr>(this))
+    return true;
+  else if (isa<BinaryExpr>(this))
+    return isa<TupleExpr>(e);
+  else
+    return isa<ParenExpr>(e) || isa<TupleExpr>(e) || isa<TupleShuffleExpr>(e);
 }
 
 inline Expr *const *CollectionExpr::getTrailingObjectsPointer() const {

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -3283,7 +3283,10 @@ public:
     // escape and there isn't a better way to allocate scratch Expr nodes.
     UnresolvedDeclRefExpr UDRE(op->getName(), DeclRefKind::PostfixOperator,
                                DeclNameLoc(expr->getSourceRange().End));
-    PostfixUnaryExpr opExpr(&UDRE, expr);
+    ParenExpr parenExpr(expr->getSourceRange().Start, expr,
+                        expr->getSourceRange().End,
+                        /*hasTrailingClosure=*/false);
+    PostfixUnaryExpr opExpr(&UDRE, &parenExpr);
     Expr *tempExpr = &opExpr;
     ConcreteDeclRef referencedDecl;
     if (auto T = getTypeOfCompletionContextExpr(

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7360,9 +7360,8 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
           return cs.getType(E);
         };
 
-        auto callSubExpr = CallExpr::create(tc.Context, body, escapable, {}, {},
-                                            /*trailing closure*/ false,
-                                            /*implicit*/ true, Type(), getType);
+        auto callSubExpr = CallExpr::createImplicit(tc.Context, body, {escapable}, {}, getType);
+        cs.cacheSubExprTypes(callSubExpr);
         cs.setType(callSubExpr, resultType);
         
         auto replacement = new (tc.Context)
@@ -7414,10 +7413,8 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
           return cs.getType(E);
         };
 
-        auto callSubExpr = CallExpr::create(tc.Context, body, opaqueValue, {},
-                                            {}, /*trailing closure*/ false,
-                                            /*implicit*/ true,
-                                            Type(), getType);
+        auto callSubExpr = CallExpr::createImplicit(tc.Context, body, {opaqueValue}, {}, getType);
+        cs.cacheSubExprTypes(callSubExpr);
         cs.setType(callSubExpr, resultTy);
         
         auto replacement = new (tc.Context)

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -986,8 +986,10 @@ namespace {
 
     std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
       // If this is a call, record the argument expression.
-      if (auto call = dyn_cast<CallExpr>(expr)) {
-        CallArgs.insert(call->getArg());
+      if (auto call = dyn_cast<ApplyExpr>(expr)) {
+        if (!isa<SelfApplyExpr>(expr)) {
+          CallArgs.insert(call->getArg());
+        }
       }
 
       // If this is an unresolved member with a call argument (e.g.,


### PR DESCRIPTION
This change adds an assertion that, except on `SelfApplyExpr`s, `Arg` must always be a `ParenExpr`, `TupleExpr`, `TupleShuffleExpr`, ~~`CodeCompletionExpr`, or `ErrorExpr`~~. It then fixes all failures caught by build-script -t or -T on macOS. I'm opening this PR now so I can let CI have a crack at it.

Along the way, I *may* have fixed rdar://41416911, but I'll need someone at Apple to confirm that for me.

I'm not sure if we should keep the assertions in the compiler or revert them and just merge the fixes, but I'm not at that stage yet anyway.

@CodaFi @slavapestov Probably relevant to your interests.