### PR TITLE
Handle builtin FP types in SILBuilder::appendOperandTypeName

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -2099,6 +2099,18 @@ private:
         unsigned NumBits = BuiltinIntTy->getWidth().getFixedWidth();
         Name += "_Int" + llvm::utostr(NumBits);
       }
+    }
+    else if (auto BuiltinFloatTy =
+                 dyn_cast<BuiltinFloatType>(OpdTy.getASTType())) {
+      Name += "_FP";
+      switch (BuiltinFloatTy->getFPKind()) {
+      case BuiltinFloatType::IEEE16: Name += "IEEE16"; break;
+      case BuiltinFloatType::IEEE32: Name += "IEEE32"; break;
+      case BuiltinFloatType::IEEE64: Name += "IEEE64"; break;
+      case BuiltinFloatType::IEEE80: Name += "IEEE80"; break;
+      case BuiltinFloatType::IEEE128: Name += "IEEE128"; break;
+      case BuiltinFloatType::PPC128: Name += "PPC128"; break;
+      }
     } else {
       assert(OpdTy.getASTType() == getASTContext().TheRawPointerType);
       Name += "_RawPointer";

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -2099,9 +2099,8 @@ private:
         unsigned NumBits = BuiltinIntTy->getWidth().getFixedWidth();
         Name += "_Int" + llvm::utostr(NumBits);
       }
-    }
-    else if (auto BuiltinFloatTy =
-                 dyn_cast<BuiltinFloatType>(OpdTy.getASTType())) {
+    } else if (auto BuiltinFloatTy =
+                   dyn_cast<BuiltinFloatType>(OpdTy.getASTType())) {
       Name += "_FP";
       switch (BuiltinFloatTy->getFPKind()) {
       case BuiltinFloatType::IEEE16: Name += "IEEE16"; break;


### PR DESCRIPTION
The following builder method doesn't handle floating point operands yet.

```cpp
BuiltinInst *createBuiltinBinaryFunction(SILLocation Loc, StringRef Name,
                                         SILType OpdTy, SILType ResultTy,
                                         ArrayRef<SILValue> Args)
```

This patch adds support for calling this method with floating point operands.

```cpp
SILValue x = ...; // $Builtin.FPIEEE32
B.createBuiltinBinaryFunction(loc, "fmul", x->getType(), x->getType(), { x, x })
```

Corresponding SIL:
```
%0 = builtin "fmul_FPIEEE32"(%x : $Builtin.FPIEEE32, %x : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
```