### PR TITLE
[stdlib] Replace Random.default with SystemRandomNumberGenerator

### DIFF
--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -122,15 +122,16 @@ public struct Bool {
   ///         print("Maybe another try?")
   ///     }
   ///
-  /// `Bool.random()` uses the default random generator, `Random.default`. The
-  /// call in the example above is equivalent to
-  /// `Bool.random(using: &Random.default)`.
+  /// `Bool.random()` uses the default random generator,
+  /// `SystemRandomNumberGenerator`. To supply a non-default generator, call the
+  /// equivalent method that takes one as an argument.
   ///
   /// - Returns: Either `true` or `false`, randomly chosen with equal
   ///   probability.
   @inlinable
   public static func random() -> Bool {
-    return Bool.random(using: &Random.default)
+    var g = SystemRandomNumberGenerator()
+    return Bool.random(using: &g)
   }
 }
 

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1052,7 +1052,8 @@ extension Collection {
   ///   empty, the method returns `nil`.
   @inlinable
   public func randomElement() -> Element? {
-    return randomElement(using: &Random.default)
+    var g = SystemRandomNumberGenerator()
+    return randomElement(using: &g)
   }
 
   /// Do not use this method directly; call advanced(by: n) instead.

--- a/stdlib/public/core/CollectionAlgorithms.swift
+++ b/stdlib/public/core/CollectionAlgorithms.swift
@@ -415,7 +415,8 @@ extension Sequence {
   /// - Complexity: O(*n*)
   @inlinable
   public func shuffled() -> [Element] {
-    return shuffled(using: &Random.default)
+    var g = SystemRandomNumberGenerator()
+    return shuffled(using: &g)
   }
 }
 
@@ -470,6 +471,7 @@ extension MutableCollection where Self : RandomAccessCollection {
   /// - Complexity: O(*n*)
   @inlinable
   public mutating func shuffle() {
-    shuffle(using: &Random.default)
+    var g = SystemRandomNumberGenerator()
+    shuffle(using: &g)
   }
 }

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -2499,7 +2499,8 @@ where Self.RawSignificand : FixedWidthInteger {
   /// - Returns: A random value within the bounds of `range`.
   @inlinable
   public static func random(in range: ${Range}<Self>) -> Self {
-    return Self.random(in: range, using: &Random.default)
+    var g = SystemRandomNumberGenerator()
+    return Self.random(in: range, using: &g)
   }
 }
 

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2602,7 +2602,8 @@ extension FixedWidthInteger {
   /// - Returns: A random value within the bounds of `range`.
   @inlinable
   public static func random(in range: ${Range}<Self>) -> Self {
-    return Self.random(in: range, using: &Random.default)
+    var g = SystemRandomNumberGenerator()
+    return Self.random(in: range, using: &g)
   }
 }
 

--- a/stdlib/public/core/Random.swift
+++ b/stdlib/public/core/Random.swift
@@ -113,38 +113,33 @@ extension RandomNumberGenerator {
 /// The default source of random data.
 ///
 /// When you generate random values, shuffle a collection, or perform another
-/// operation that depends on random data, this type's `default` property is
-/// the generator used by default. For example, the two method calls in this
-/// example are equivalent:
+/// operation that depends on random data, this type's `default` property is the
+/// generator used by default. For example, the two method calls in this example
+/// are equivalent:
 ///
 ///     let x = Int.random(in: 1...100)
-///     let y = Int.random(in: 1...100, using: &Random.default)
+///     var g = SystemRandomNumberGenerator()
+///     let y = Int.random(in: 1...100, using: &g)
 ///
-/// `Random.default` is automatically seeded, is safe to use in multiple
-/// threads, and uses a cryptographically secure algorithm whenever possible.
+/// `SystemRandomNumberGenerator` is automatically seeded, is safe to use in
+/// multiple threads, and uses a cryptographically secure algorithm whenever
+/// possible.
 ///
 /// Platform Implementation of `Random`
 /// ===================================
 ///
-/// While the `Random.default` generator is automatically seeded and
-/// thread-safe on every platform, the cryptographic quality of the stream of
-/// random data produced by the generator may vary. For more detail, see the
+/// While the `SystemRandomNumberGenerator` generator is automatically seeded
+/// and thread-safe on every platform, the cryptographic quality of the stream
+/// of random data produced by the generator may vary. For more detail, see the
 /// documentation for the APIs used by each platform.
 ///
 /// - Apple platforms use `arc4random_buf(3)`.
 /// - Linux platforms use `getrandom(2)` when available; otherwise, they read
 ///   from `/dev/urandom`.
 @_fixed_layout
-public struct Random : RandomNumberGenerator {
-  /// The default instance of the `Random` random number generator.
+public struct SystemRandomNumberGenerator : RandomNumberGenerator {
   @inlinable
-  public static var `default`: Random {
-    get { return Random() }
-    set { /* Discard */ }
-  }
-
-  @inlinable
-  internal init() {}
+  public init() { }
 
   /// Returns a value from a uniform, independent distribution of binary data.
   ///

--- a/validation-test/stdlib/Random.swift
+++ b/validation-test/stdlib/Random.swift
@@ -17,11 +17,12 @@ RandomTests.test("_fill(bytes:)") {
     expectEqual(bytes1, zeros)
     expectEqual(bytes2, zeros)
     
-    bytes1.withUnsafeMutableBytes { Random.default._fill(bytes: $0) }
+    var g = SystemRandomNumberGenerator()
+    bytes1.withUnsafeMutableBytes { g._fill(bytes: $0) }
     expectNotEqual(bytes1, bytes2)
     expectNotEqual(bytes1, zeros)
     
-    bytes2.withUnsafeMutableBytes { Random.default._fill(bytes: $0) }
+    bytes2.withUnsafeMutableBytes { g._fill(bytes: $0) }
     expectNotEqual(bytes1, bytes2)
     expectNotEqual(bytes2, zeros)
   }


### PR DESCRIPTION
As described in [this forum post](https://forums.swift.org/t/se-0202-amendment-proposal-rename-random-to-defaultrandomnumbergenerator/12942/98) as an amendment to SE-0202.
