### PR TITLE
[WIP][CSRanking] Prefer declarations from constrained protocol extensions …

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -280,6 +280,10 @@ public:
   LLVM_READONLY
   bool isExtensionContext() const; // see swift/AST/Decl.h
 
+  /// \brief Determine whether this is a constrained protocol extension context.
+  LLVM_READONLY
+  bool isConstrainedProtocolExtensionContext() const;
+
   /// If this DeclContext is a NominalType declaration or an
   /// extension thereof, return the NominalTypeDecl.
   LLVM_READONLY

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -101,6 +101,15 @@ ProtocolDecl *DeclContext::getAsProtocolOrProtocolExtensionContext() const {
   return dyn_cast_or_null<ProtocolDecl>(getAsTypeOrTypeExtensionContext());
 }
 
+bool DeclContext::isConstrainedProtocolExtensionContext() const {
+  if (auto *decl = const_cast<Decl *>(getAsDeclOrDeclExtensionContext()))
+    if (auto *ED = dyn_cast<ExtensionDecl>(decl))
+      if (auto type = ED->getExtendedType())
+        return ED->isConstrainedExtension() &&
+               isa<ProtocolDecl>(type->getAnyNominal());
+  return false;
+}
+
 ProtocolDecl *DeclContext::getAsProtocolExtensionContext() const {
   if (auto decl = const_cast<Decl*>(getAsDeclOrDeclExtensionContext()))
     if (auto ED = dyn_cast<ExtensionDecl>(decl))

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -15,6 +15,7 @@
 //
 //===----------------------------------------------------------------------===//
 #include "ConstraintSystem.h"
+#include "swift/AST/DeclContext.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/ParameterList.h"
@@ -441,8 +442,22 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
           return better1;
         }
       } else if (inProtocolExtension1 || inProtocolExtension2) {
-        // One member is in a protocol extension, the other is in a concrete type.
-        // Prefer the member in the concrete type.
+        // If we are comparing declaration on protocol to
+        // declaration in constrained protocol extension,
+        // let's always prefer the one from extension as more
+        // "specialized" because static dispatch is preferable in that case.
+        if (inProtocolExtension1 &&
+            outerDC2->getAsProtocolOrProtocolExtensionContext()) {
+          return outerDC1->isConstrainedProtocolExtensionContext();
+        }
+
+        if (inProtocolExtension2 &&
+            outerDC1->getAsProtocolOrProtocolExtensionContext()) {
+          return !outerDC2->isConstrainedProtocolExtensionContext();
+        }
+
+        // One member is in a protocol extension, the other
+        // is in a concrete type. Prefer the member in the concrete type.
         return inProtocolExtension2;
       }
 

--- a/test/Constraints/rdar33142387.swift
+++ b/test/Constraints/rdar33142387.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s
+
+infix operator +++ : AdditionPrecedence
+protocol P {
+  associatedtype T
+  static func +++(lhs: Self, rhs: Self) -> Self
+}
+
+extension P {
+  static func +++(lhs: Self, rhs: Self) -> Self {
+    print("<default>")
+    return lhs
+  }
+}
+
+extension P where T == Int {
+  static func +++(lhs: Self, rhs: Self) -> Self {
+    print("<int>")
+    return rhs
+  }
+}
+
+struct A<U> : P {
+  typealias T = U
+}
+
+struct B : P {
+  typealias T = Int
+}
+
+var a = A<Int>()
+// CHECK: apply %21<A<Int>>(%8, %14, %19, %10) : $@convention(method) <τ_0_0 where τ_0_0 : P, τ_0_0.T == Int> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> @out τ_0_0
+let _ = a +++ a
+
+var b = B()
+// CHECK: apply %46<B>(%33, %39, %44, %35) : $@convention(method) <τ_0_0 where τ_0_0 : P, τ_0_0.T == Int> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> @out τ_0_0
+let _ = b +++ b


### PR DESCRIPTION
…over protocols

Currently if one declaration comes from protocol extension
and another doesn't, ranking simply assumes that the latter
must be declared on concrete type, but it's not always true.

As a consequence we always prefer declarations from
protocols over ones from constrained protocol extensions
which is incorrect, because constrained protocol extension
context is always more "specialized" than one of protocol.

Resolves: rdar://problem/33142387
Resolves: [SR-5181](https://bugs.swift.org/browse/SR-5181)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
