### PR TITLE
Reimplement lowering of __tf_tensor_from_scalars/__tf_tensor_from_scalars_1d in deabstraction

### DIFF
--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -337,6 +337,7 @@ public:
     return representationKind == RK_Inst ? value.inst : nullptr;
   }
 
+  static SymbolicValue getInteger(int64_t value, unsigned bitWidth);
   static SymbolicValue getInteger(const APInt &value,
                                   llvm::BumpPtrAllocator &allocator);
 

--- a/lib/SIL/SILConstants.cpp
+++ b/lib/SIL/SILConstants.cpp
@@ -264,17 +264,21 @@ SymbolicValueMemoryObject::create(Type type, SymbolicValue value,
 // Integers
 //===----------------------------------------------------------------------===//
 
+SymbolicValue SymbolicValue::getInteger(int64_t value, unsigned bitWidth) {
+  SymbolicValue result;
+  result.representationKind = RK_IntegerInline;
+  result.value.integerInline = value;
+  result.aux.integer_bitwidth = bitWidth;
+  return result;
+}
+
+
 SymbolicValue SymbolicValue::getInteger(const APInt &value,
                                         llvm::BumpPtrAllocator &allocator) {
   // In the common case, we can form an inline representation.
   unsigned numWords = value.getNumWords();
-  if (numWords == 1) {
-    SymbolicValue result;
-    result.representationKind = RK_IntegerInline;
-    result.value.integerInline = value.getRawData()[0];
-    result.aux.integer_bitwidth = value.getBitWidth();
-    return result;
-  }
+  if (numWords == 1)
+    return getInteger(value.getRawData()[0], value.getBitWidth());
 
   // Copy the integers from the APInt into the bump pointer.
   auto *words = allocator.Allocate<uint64_t>(numWords);

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
@@ -1440,6 +1440,7 @@ static bool analyzeArrayInitUses(SILValue v,
 
     // We can always remove retain/release instructions and debug_value.
     if (isa<StrongRetainInst>(user) || isa<StrongReleaseInst>(user) ||
+        isa<RetainValueInst>(user) || isa<ReleaseValueInst>(user) ||
         isa<DebugValueInst>(user)) {
       if (arrayInsts) arrayInsts->insert(user);
       continue;

--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -1713,7 +1713,6 @@ decodeArrayElements(SILValue value, SmallVectorImpl<SILValue> &elements,
   uint64_t numElements =
     cast<IntegerLiteralInst>(numElementsVal)->getValue().getLimitedValue();
 
-
   if (tf::ConstExprEvaluator::decodeAllocUninitializedArray(apply,
                                                             numElements,
                                                             elements,

--- a/lib/SILOptimizer/Mandatory/TFUtilities.h
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.h
@@ -112,7 +112,7 @@ static std::string getDeviceString(DeviceType deviceType) {
 }
 
 /// The returned string can be used to construct SIL function names.
-static std::string getDeviceShortName(DeviceType deviceType) {
+static inline std::string getDeviceShortName(DeviceType deviceType) {
   switch (deviceType) {
     case DeviceType::CPU:
       return "CPU";


### PR DESCRIPTION
This can be factored better, and I'd like to move array deletion to a
new pass, but this is a big step forward to making deabstraction more
complete.
