### PR TITLE
[AutoDiff] Part 1: Add support for delayed gradients in AD configuration.

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -19,6 +19,7 @@
 #define SWIFT_AST_AUTODIFF_H
 
 #include "ASTContext.h"
+#include "llvm/ADT/BitVector.h"
 
 namespace swift {
 
@@ -50,7 +51,7 @@ public:
     : Loc(loc), Kind(kind), V(value) {}
 
   static AutoDiffParameter getIndexParameter(SourceLoc loc, unsigned index) {
-    return { loc, Kind::Index, { index } };
+    return { loc, Kind::Index, index };
   }
 
   static AutoDiffParameter getSelfParameter(SourceLoc loc) {
@@ -77,31 +78,130 @@ public:
   }
 };
 
+/// SIL-level automatic differentiation indices. Consists of a source index,
+/// i.e. index of the dependent result to differentiate from, and parameter
+/// indices, i.e. index of an independent parameter to differentiate with
+/// respect to.
+struct SILReverseAutoDiffIndices {
+  unsigned source;
+  llvm::BitVector parameters;
+  
+  /*implicit*/ SILReverseAutoDiffIndices(unsigned source,
+                                         llvm::BitVector parameters)
+    : source(source), parameters(parameters) {}
+  
+  /*implicit*/ SILReverseAutoDiffIndices(unsigned source,
+                                         ArrayRef<unsigned> parameters)
+    : SILReverseAutoDiffIndices(source, llvm::BitVector(parameters.size())) {
+    int last = -1;
+    for (auto paramIdx : parameters) {
+      assert((int)paramIdx > last && "Parameter indices must be ascending");
+      last = paramIdx;
+      this->parameters.set(paramIdx);
+    }
+  }
+
+  bool operator==(const SILReverseAutoDiffIndices &other) const {
+    return source == other.source && parameters == other.parameters;
+  }
+
+  void print(llvm::raw_ostream &s = llvm::outs()) const {
+    s << "(source=" << source << " parameters=(";
+    interleave(parameters.set_bits(),
+               [&s](unsigned p) { s << p; }, [&s]{ s << ' '; });
+    s << "))";
+  }
+};
+
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
+                                     const SILReverseAutoDiffIndices &indices) {
+  indices.print(s);
+  return s;
+}
+
+/// Flags to define the semantics and the type signature of a gradient function.
+enum class SILGradientFlags : unsigned {
+  /// The gradient function is seedable, i.e. able to take a back-propagated
+  /// adjoint value as the last parameter.
+  Seedable = 1 << 0,
+  
+  /// The gradient function is preserving the result of the original function.
+  PreservingResult = 1 << 1,
+  
+  /// The adjoint computation is "delayed". We say that the adjoint computation
+  /// is delayed when when it's returned as a thunk.
+  Delayed = 1 << 2
+};
+using SILGradientOptions = OptionSet<SILGradientFlags>;
+static inline SILGradientOptions operator|(SILGradientFlags lhs,
+                                           SILGradientFlags rhs) {
+  return SILGradientOptions(unsigned(lhs) | unsigned(rhs));
+}
+
 /// SIL-level automatic differentiation configuration.
 struct SILReverseAutoDiffConfiguration {
-  unsigned sourceIndex;
-  ArrayRef<unsigned> parameterIndices;
-  bool seedable;
-  bool preservingResult;
+  SILReverseAutoDiffIndices indices;
+  SILGradientOptions options;
+
+  /*implicit*/
+  SILReverseAutoDiffConfiguration(SILReverseAutoDiffIndices indices,
+                                  bool seedable, bool preservingResult)
+    : indices(indices), options(getCanonicalGradientOptions()) {}
+
+  /*implicit*/
+  SILReverseAutoDiffConfiguration(SILReverseAutoDiffIndices indices,
+                                  SILGradientOptions options)
+    : indices(indices), options(options) {}
+
+  unsigned getSourceIndex() const {
+    return indices.source;
+  }
+
+  llvm::BitVector getParameterIndices() const {
+    return indices.parameters;
+  }
+
+  bool isSeedable() const {
+    return options.contains(SILGradientFlags::Seedable);
+  }
+
+  bool isPreservingResult() const {
+    return options.contains(SILGradientFlags::PreservingResult);
+  }
+
+  bool isDelayed() const {
+    return options.contains(SILGradientFlags::Delayed);
+  }
+
+  // FIXME: The master configuration should have all three gradient options
+  // enabled, that is, the canonical gradient should return a delayed gradient
+  // function. We need to handle this here as well as within the
+  // differentiation pass.
+  static SILGradientOptions getCanonicalGradientOptions() {
+    return SILGradientFlags::Seedable | SILGradientFlags::PreservingResult;
+  }
 
   /// Returns the "master" configuration, which all variants with the same
   /// parameter indices can derive from.
   static
-  SILReverseAutoDiffConfiguration getMaster(unsigned sourceIndex,
-                                            ArrayRef<unsigned> paramIndices) {
-    return { sourceIndex, paramIndices,
-             /*seedable*/ true, /*preservingResult*/ true };
+  SILReverseAutoDiffConfiguration getMaster(SILReverseAutoDiffIndices indices) {
+    return {
+      indices,
+      getCanonicalGradientOptions()
+    };
   }
 
-  bool isEqual(const SILReverseAutoDiffConfiguration &other) const {
-    return sourceIndex == other.sourceIndex &&
-           parameterIndices.equals(other.parameterIndices) &&
-           seedable == other.seedable &&
-           preservingResult == other.preservingResult;
+  SILReverseAutoDiffConfiguration getWithCanonicalOptions() const {
+    return getMaster(indices);
   }
 
   bool isMaster() const {
-    return seedable && preservingResult;
+    return options.toRaw() == getCanonicalGradientOptions().toRaw();
+  }
+
+  bool operator==(const SILReverseAutoDiffConfiguration &other) const {
+    return indices == other.indices &&
+           options.toRaw() == other.options.toRaw();
   }
 };
 
@@ -109,47 +209,62 @@ struct SILReverseAutoDiffConfiguration {
 
 namespace llvm {
 
+using swift::SILReverseAutoDiffIndices;
 using swift::SILReverseAutoDiffConfiguration;
+using swift::SILGradientFlags;
+using swift::OptionSet;
 
 template<typename T> struct DenseMapInfo;
 
+template<> struct DenseMapInfo<SILReverseAutoDiffIndices> {
+  static SILReverseAutoDiffIndices getEmptyKey() {
+    return { DenseMapInfo<unsigned>::getEmptyKey(), BitVector() };
+  }
+
+  static SILReverseAutoDiffIndices getTombstoneKey() {
+    return { DenseMapInfo<unsigned>::getTombstoneKey(),
+             BitVector(sizeof(intptr_t), true) };
+  }
+
+  static unsigned getHashValue(const SILReverseAutoDiffIndices &Val) {
+    unsigned combinedHash =
+      hash_combine(~1U, DenseMapInfo<unsigned>::getHashValue(Val.source));
+    for (auto i : Val.parameters.set_bits())
+      combinedHash = hash_combine(combinedHash,
+        DenseMapInfo<unsigned>::getHashValue(i));
+    return combinedHash;
+  }
+
+  static bool isEqual(const SILReverseAutoDiffIndices &LHS,
+                      const SILReverseAutoDiffIndices &RHS) {
+    return LHS == RHS;
+  }
+};
+
 template<> struct DenseMapInfo<SILReverseAutoDiffConfiguration> {
   static SILReverseAutoDiffConfiguration getEmptyKey() {
-    return { DenseMapInfo<unsigned>::getEmptyKey(),
-             DenseMapInfo<ArrayRef<unsigned>>::getEmptyKey(),
-             static_cast<bool>(DenseMapInfo<unsigned>::getEmptyKey()),
-             static_cast<bool>(DenseMapInfo<unsigned>::getEmptyKey()) };
+    return { DenseMapInfo<SILReverseAutoDiffIndices>::getEmptyKey(), None };
   }
 
   static SILReverseAutoDiffConfiguration getTombstoneKey() {
-    return { DenseMapInfo<unsigned>::getTombstoneKey(),
-             DenseMapInfo<ArrayRef<unsigned>>::getTombstoneKey(),
-             static_cast<bool>(DenseMapInfo<unsigned>::getTombstoneKey()),
-             static_cast<bool>(DenseMapInfo<unsigned>::getTombstoneKey()) };
+    return {
+      DenseMapInfo<SILReverseAutoDiffIndices>::getTombstoneKey(),
+      SILGradientFlags::Delayed
+    };
   }
 
   static unsigned getHashValue(const SILReverseAutoDiffConfiguration &Val) {
-    unsigned paramHash = ~1U;
-    for (auto i : Val.parameterIndices)
-      paramHash = hash_combine(paramHash,
-                               DenseMapInfo<unsigned>::getHashValue(i));
     return hash_combine(
-      paramHash,
-      DenseMapInfo<unsigned>::getHashValue(Val.seedable),
-      DenseMapInfo<unsigned>::getHashValue(Val.preservingResult)
+      DenseMapInfo<SILReverseAutoDiffIndices>::getHashValue(Val.indices),
+      DenseMapInfo<unsigned>::getHashValue(Val.options.toRaw())
     );
   }
 
   static bool isEqual(const SILReverseAutoDiffConfiguration &LHS,
                       const SILReverseAutoDiffConfiguration &RHS) {
-    auto numParams = LHS.parameterIndices.size();
-    if (numParams != RHS.parameterIndices.size())
-      return false;
-    for (unsigned i = 0; i < numParams; i++)
-      if (LHS.parameterIndices[i] != RHS.parameterIndices[i])
-        return false;
-    return LHS.seedable == RHS.seedable &&
-           LHS.preservingResult == LHS.preservingResult;
+    return DenseMapInfo<SILReverseAutoDiffIndices>
+             ::isEqual(LHS.indices, RHS.indices) &&
+           LHS.options.toRaw() == RHS.options.toRaw();
   }
 };
 

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1501,6 +1501,12 @@ ERROR(sil_reverse_autodiff_expected_source_index,PointsToFirstBadToken,
 ERROR(sil_reverse_autodiff_expected_parameter_index,PointsToFirstBadToken,
       "expected the index of a parameter to differentiate with respect to", ())
 
+ERROR(sil_reverse_autodiff_expected_option,PointsToFirstBadToken,
+      "expected a gradient option: 'seedable', 'preserving_result' or 'delayed'", ())
+
+ERROR(sil_reverse_autodiff_duplicate_option,PointsToFirstBadToken,
+      "duplicate gradient option", ())
+
 ERROR(sil_gradient_invalid_seed_type,PointsToFirstBadToken,
       "expected seed '%0' to have type %1", (StringRef, Type))
 

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -476,12 +476,10 @@ public:
 
   /// SWIFT_ENABLE_TENSORFLOW
   GradientInst *createGradient(SILLocation loc, SILValue original,
-                               unsigned sourceIndex,
-                               ArrayRef<unsigned> paramIndices, bool seedable,
-                               bool preservingResult) {
+                               SILReverseAutoDiffIndices indices,
+                               SILGradientOptions options) {
     return insert(GradientInst::create(getModule(), getSILDebugLocation(loc),
-                                       original, sourceIndex, paramIndices,
-                                       seedable, preservingResult));
+                                       original, indices, options));
   }
 
   BuiltinInst *createBuiltin(SILLocation Loc, Identifier Name, SILType ResultTy,

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -659,10 +659,8 @@ SILCloner<ImplClass>::visitGradientInst(GradientInst *Inst) {
   doPostProcess(Inst,
     getBuilder().createGradient(getOpLocation(Inst->getLoc()),
                                 getOpValue(Inst->getOriginal()),
-                                Inst->getSourceIndex(),
-                                Inst->getParameterIndices(),
-                                Inst->isSeedable(),
-                                Inst->isPreservingResult()));
+                                Inst->getIndices(),
+                                Inst->getOptions()));
 }
 
 template<typename ImplClass>

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -124,10 +124,9 @@ private:
                                StringRef adjointName);
 
 public:
-  static SILReverseDifferentiableAttr *create(SILModule &M,
-                                              SILReverseAutoDiffIndices indices,
-                                              StringRef primalName,
-                                              StringRef adjointName);
+  static SILReverseDifferentiableAttr *create(
+      SILModule &M, SILReverseAutoDiffIndices indices,
+      StringRef primalName = StringRef(), StringRef adjointName = StringRef());
   
   bool hasPrimal() const { return !PrimalName.empty(); }
   StringRef getPrimalName() const { assert(hasPrimal()); return PrimalName; }

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -114,38 +114,30 @@ class SILReverseDifferentiableAttr final {
   friend SILFunction;
 
 private:
-  /// The index of the original result to differentiate from.
-  unsigned SourceIndex;
-  /// The number of parameters of the original function to differentiate with
-  /// respect to.
-  unsigned NumParamIndices;
+  /// The AD indices.
+  SILReverseAutoDiffIndices indices;
   /// The primal and adjoint function names.
   StringRef PrimalName, AdjointName;
   /// Constructor, copying parameter indices to the trailing buffer.
-  SILReverseDifferentiableAttr(unsigned sourceIndex,
-                               ArrayRef<unsigned> paramIndices,
+  SILReverseDifferentiableAttr(SILReverseAutoDiffIndices indices,
                                StringRef primalName,
                                StringRef adjointName);
 
 public:
-  static SILReverseDifferentiableAttr *create(
-    SILModule &M, unsigned sourceIndex, ArrayRef<unsigned> paramIndices,
-    StringRef primalName = StringRef(),
-    StringRef adjointName = StringRef());
-
-  StringRef getPrimalName() const { return PrimalName; }
+  static SILReverseDifferentiableAttr *create(SILModule &M,
+                                              SILReverseAutoDiffIndices indices,
+                                              StringRef primalName,
+                                              StringRef adjointName);
+  
+  bool hasPrimal() const { return !PrimalName.empty(); }
+  StringRef getPrimalName() const { assert(hasPrimal()); return PrimalName; }
   void setPrimalName(StringRef name) { PrimalName = name; }
-  StringRef getAdjointName() const { return AdjointName; }
+
+  bool hasAdjoint() const { return !AdjointName.empty(); }
+  StringRef getAdjointName() const { assert(hasAdjoint()); return AdjointName; }
   void setAdjointName(StringRef name) { AdjointName = name; }
 
-  unsigned getSourceIndex() const {
-    return SourceIndex;
-  }
-  
-  ArrayRef<unsigned> getParamIndices() const;
-  unsigned *getParamIndicesData() {
-    return reinterpret_cast<unsigned *>(this+1);
-  }
+  SILReverseAutoDiffIndices getIndices() const { return indices; }
 
   void print(llvm::raw_ostream &OS) const;
 };

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -1077,6 +1077,7 @@ static bool parseReverseDifferentiableAttr(
   // Function that parses an index into `ParamIndices`. Returns true on error.
   auto parseParam = [&]() -> bool {
     unsigned Index;
+    // TODO: Reject non-ascending parameter index lists.
     if (P.parseUnsignedInteger(Index, LastLoc,
           diag::sil_reverse_autodiff_expected_parameter_index))
       return true;
@@ -1114,9 +1115,8 @@ static bool parseReverseDifferentiableAttr(
                    diag::sil_attr_differentiable_expected_rsquare))
     return true;
   // Create an AdjointAttr and we are done.
-  auto *Attr =
-    SILReverseDifferentiableAttr::create(SP.SILMod, SourceIndex, ParamIndices,
-                                         PrimName.str(), AdjName.str());
+  auto *Attr = SILReverseDifferentiableAttr::create(
+      SP.SILMod, {SourceIndex, ParamIndices}, PrimName.str(), AdjName.str());
   DAs.push_back(Attr);
   return false;
 }
@@ -2780,9 +2780,10 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     if (P.parseToken(tok::l_square, diag::expected_tok_in_sil_instr, "[") ||
         parseVerbatim("wrt"))
       return true;
-    auto parseIndex = [&] {
+    auto parseIndex = [&]() -> bool {
       unsigned index;
       SourceLoc indexLoc;
+      // TODO: Reject non-ascending parameter index lists.
       if (P.parseUnsignedInteger(index, indexLoc,
                            diag::sil_reverse_autodiff_expected_parameter_index))
         return true;
@@ -2796,24 +2797,30 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
         return true;
     if (P.parseToken(tok::r_square, diag::expected_tok_in_sil_instr, "]"))
       return true;
-    // Parse optional [seedable] and optional [preserving_result].
-    bool seedable = false;
-    bool preservingResult = false;
-    if (P.peekToken().getText() != "preserving_result" &&
-        P.consumeIf(tok::l_square)) {
-      if (P.Tok.getText() != "preserving_result") {
-        if (parseVerbatim("seedable") ||
-            P.parseToken(tok::r_square, diag::expected_tok_in_sil_instr, "]"))
-          return true;
-        seedable = true;
-      }
-    }
-    if (P.consumeIf(tok::l_square)) {
-      if (parseVerbatim("preserving_result") ||
-          P.parseToken(tok::r_square, diag::expected_tok_in_sil_instr, "]"))
+    // Parse optional [seedable], [preserving_result] and [delayed].
+    SILGradientOptions existingOptions;
+    auto parseOption = [&]() -> bool {
+      SILGradientOptions option =
+        llvm::StringSwitch<SILGradientOptions>(P.Tok.getText())
+          .Case("seedable", SILGradientFlags::Seedable)
+          .Case("preserving_result", SILGradientFlags::PreservingResult)
+          .Case("delayed", SILGradientFlags::Delayed)
+          .Default(None);
+      P.consumeToken(tok::identifier);
+      if (!option) {
+        P.diagnose(P.Tok, diag::sil_reverse_autodiff_expected_option);
         return true;
-      preservingResult = true;
-    }
+      }
+      if (existingOptions.contains(option)) {
+        P.diagnose(P.Tok, diag::sil_reverse_autodiff_duplicate_option);
+        return true;
+      }
+      existingOptions |= option;
+      return P.parseToken(tok::r_square, diag::expected_tok_in_sil_instr, "]");
+    };
+    while (P.consumeIf(tok::l_square))
+      if (parseOption())
+        return true;
     // Parse original function value.
     UnresolvedValueName originalName;
     SILType originalTy;
@@ -2828,11 +2835,10 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
       return true;
     }
     SILValue original = getLocalValue(originalName, originalTy, InstLoc, B);
-
     if (parseSILDebugLocation(InstLoc, B))
       return true;
-    ResultVal = B.createGradient(
-      InstLoc, original, sourceIndex, paramIndices, seedable, preservingResult);
+    SILReverseAutoDiffIndices indices(sourceIndex, paramIndices);
+    ResultVal = B.createGradient(InstLoc, original, indices, existingOptions);
     break;
   }
 

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -58,33 +58,20 @@ void SILFunction::addSpecializeAttr(SILSpecializeAttr *Attr) {
 
 /// SWIFT_ENABLE_TENSORFLOW
 SILReverseDifferentiableAttr::
-SILReverseDifferentiableAttr(unsigned sourceIndex,
-                             ArrayRef<unsigned> paramIndices,
+SILReverseDifferentiableAttr(SILReverseAutoDiffIndices indices,
                              StringRef primalName,
                              StringRef adjointName)
-  : SourceIndex(sourceIndex), NumParamIndices(paramIndices.size()),
-    PrimalName(primalName), AdjointName(adjointName) {
-  std::copy(paramIndices.begin(), paramIndices.end(), getParamIndicesData());
-}
+  : indices(indices), PrimalName(primalName), AdjointName(adjointName) {}
 
 SILReverseDifferentiableAttr *
 SILReverseDifferentiableAttr::create(SILModule &M,
-                                     unsigned sourceIndex,
-                                     ArrayRef<unsigned> paramIndices,
+                                     SILReverseAutoDiffIndices indices,
                                      StringRef primalName,
                                      StringRef adjointName) {
-  size_t size = sizeof(SILReverseDifferentiableAttr)
-    + paramIndices.size() * sizeof(unsigned);
-  void *mem = M.allocate(size, alignof(SILReverseDifferentiableAttr));
-  return ::new (mem) SILReverseDifferentiableAttr(sourceIndex, paramIndices,
-                                                  primalName, adjointName);
-}
-
-ArrayRef<unsigned> SILReverseDifferentiableAttr::getParamIndices() const {
-  return {
-    const_cast<SILReverseDifferentiableAttr *>(this)->getParamIndicesData(),
-    NumParamIndices
-  };
+  void *mem = M.allocate(sizeof(SILReverseDifferentiableAttr),
+                         alignof(SILReverseDifferentiableAttr));
+  return ::new (mem)
+      SILReverseDifferentiableAttr(indices, primalName, adjointName);
 }
 
 SILFunction *SILFunction::create(

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -102,11 +102,11 @@ CanType SILFunctionType::getSelfInstanceType() const {
 CanSILFunctionType
 SILFunctionType::getGradientType(SILReverseAutoDiffConfiguration config,
                                  SILModule &M) {
+  // FIXME: Handle `Delayed` gradient option.
   auto originalParams = getParameters();
-  auto originalResult = getResults()[config.sourceIndex];
+  auto originalResult = getResults()[config.getSourceIndex()];
   auto originalSourceResultTy = originalResult.getType();
-  SmallVector<unsigned, 4> allParamIndices;
-  ArrayRef<unsigned> paramIndices = config.parameterIndices;
+  llvm::BitVector paramIndices = config.getParameterIndices();
   SmallVector<SILParameterInfo, 4> gradParams;
   SmallVector<SILResultInfo, 4> gradResults;
   // Collect original parameters to gradient parameters. They have the same
@@ -114,7 +114,7 @@ SILFunctionType::getGradientType(SILReverseAutoDiffConfiguration config,
   for (auto &originalParam : originalParams)
     gradParams.push_back(originalParam);
   // If seedable, add original result to the parameter list.
-  if (config.seedable) {
+  if (config.isSeedable()) {
     ParameterConvention seedConv;
     switch (originalResult.getConvention()) {
     case ResultConvention::Indirect:
@@ -133,17 +133,13 @@ SILFunctionType::getGradientType(SILReverseAutoDiffConfiguration config,
   // If no differentiation parameters are specified, differentiation is done
   // with respect to all of original's parameters. For simplicity, we add all
   // parameter indices to a temporary.
-  if (config.parameterIndices.empty()) {
-    auto allParamRange = range(0, getNumParameters());
-    allParamIndices.append(allParamRange.begin(), allParamRange.end());
-    paramIndices = allParamIndices;
-  }
+  if (config.getParameterIndices().empty())
+    paramIndices = llvm::BitVector(getNumParameters());
   // If preserving result, the original result will be the first result.
-  if (config.preservingResult) {
+  if (config.isPreservingResult())
     gradResults.push_back(originalResult);
-  }
   // Collect differentiation parameters to gradient results.
-  for (auto index : paramIndices) {
+  for (auto index : paramIndices.set_bits()) {
     auto param = originalParams[index];
     ResultConvention conv;
     switch (param.getConvention()) {
@@ -162,7 +158,40 @@ SILFunctionType::getGradientType(SILReverseAutoDiffConfiguration config,
     }
     gradResults.push_back({ param.getType(), conv });
   }
-  // Create an expected function type.
+  // If the gradient is delayed, the result type is
+  //   (original_params...) -> (original_result?, (seed?) -> (derivatives...))
+  if (config.isDelayed()) {
+    // The delayed gradient function (inner) type.
+    ArrayRef<SILParameterInfo> delayedGradParams = config.isSeedable()
+      ? ArrayRef<SILParameterInfo>(&gradParams.back(), 1)
+      : ArrayRef<SILParameterInfo>();
+    ArrayRef<SILResultInfo> delayedGradResults = config.isPreservingResult()
+      ? ArrayRef<SILResultInfo>(gradResults).drop_front()
+      : ArrayRef<SILResultInfo>(gradResults);
+    auto delayedGradFuncTy = SILFunctionType::get(
+      getGenericSignature(),
+      getExtInfo().withRepresentation(Representation::Thin),
+      getCoroutineKind(), getCalleeConvention(),
+      delayedGradParams, {}, delayedGradResults, None,
+      getASTContext(), getWitnessMethodConformanceOrNone());
+    ArrayRef<SILParameterInfo> params = config.isSeedable()
+      ? ArrayRef<SILParameterInfo>(gradParams).drop_back()
+      : ArrayRef<SILParameterInfo>(gradParams);
+    SILResultInfo delayedGradFuncResult(
+      delayedGradFuncTy, ResultConvention::Unowned);
+    SmallVector<SILResultInfo, 2> results;
+    if (config.isPreservingResult())
+      results.append({gradResults.front(), delayedGradFuncResult});
+    else
+      results.append({delayedGradFuncResult});
+    // $convention(thin) (seed?) -> (derivatives...)
+    return SILFunctionType::get(getGenericSignature(), getExtInfo(),
+                                getCoroutineKind(), getCalleeConvention(),
+                                params, getYields(), results,
+                                getOptionalErrorResult(), getASTContext(),
+                                None);
+  }
+  // Create an expected function type for the non-delayed case.
   return SILFunctionType::get(getGenericSignature(), getExtInfo(),
                               getCoroutineKind(), getCalleeConvention(),
                               gradParams, getYields(), gradResults,

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1151,10 +1151,11 @@ public:
 
   /// SWIFT_ENABLE_TENSORFLOW
   void visitGradientInst(GradientInst *GI) {
-    *this << "[source " << GI->getSourceIndex() << "] ";
-    if (!GI->getParameterIndices().empty()) {
+    auto indices = GI->getIndices();
+    *this << "[source " << indices.source << "] ";
+    if (!indices.parameters.empty()) {
       *this << "[wrt ";
-      interleave(GI->getParameterIndices(), [&](unsigned idx) {
+      interleave(indices.parameters.set_bits(), [&](unsigned idx) {
         *this << idx;
       }, [&]{
         *this << ", ";
@@ -3173,8 +3174,9 @@ void SILSpecializeAttr::print(llvm::raw_ostream &OS) const {
 
 /// SWIFT_ENABLE_TENSORFLOW
 void SILReverseDifferentiableAttr::print(llvm::raw_ostream &OS) const {
-  OS << "source " << getSourceIndex() << " wrt ";
-  interleave(getParamIndices(),
+  auto indices = getIndices();
+  OS << "source " << indices.source << " wrt ";
+  interleave(indices.parameters.set_bits(),
              [&](unsigned index) { OS << index; },
              [&] { OS << ", "; });
   if (!PrimalName.empty()) OS << " primal @" << PrimalName;

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1211,17 +1211,15 @@ public:
     CanSILFunctionType origFnTy = GI->getOriginalType();
     require(origFnTy, "Original function value must have function type");
     auto config = GI->getConfiguration();
-    require(config.sourceIndex < origFnTy->getNumResults(),
+    require(config.getSourceIndex() < origFnTy->getNumResults(),
             "Differentiation source index out of bounds");
-    SmallVector<unsigned, 8> allParamIndices;
-    ArrayRef<unsigned> paramIndices = config.parameterIndices;
-    require(!config.parameterIndices.empty(),
+    llvm::BitVector paramIndices = config.getParameterIndices();
+    require(!config.getParameterIndices().empty(),
             "Parameter indices cannot be empty; they must be explicitly "
             "specified");
     // Verify differentiation parameters.
     int lastIndex = -1;
-    for (unsigned i = 0, n = paramIndices.size(); i != n; ++i) {
-      auto index = paramIndices[i];
+    for (auto index : paramIndices.set_bits()) {
       require((int)index > lastIndex, "Parameter indices must be ascending");
       auto paramTy = origFnTy->getParameters()[index].getType();
       require(!(paramTy.isAnyClassReferenceType() ||
@@ -4460,12 +4458,12 @@ public:
   void verifyReverseDifferentiableAttr(SILFunction *F,
                                        SILReverseDifferentiableAttr &Attr) {
     // Parameter indices must be specified.
-    require(!Attr.getParamIndices().empty(),
+    require(!Attr.getIndices().parameters.empty(),
             "Parameter indices cannot be empty");
     // Verify if specified parameter indices are valid.
     auto numParams = F->getLoweredFunctionType()->getNumParameters();
     int lastIndex = -1;
-    for (auto paramIdx : Attr.getParamIndices()) {
+    for (auto paramIdx : Attr.getIndices().parameters.set_bits()) {
       require(paramIdx < numParams, "Parameter index out of bounds.");
       auto currentIdx = (int)paramIdx;
       require(currentIdx > lastIndex, "Parameter indices not ascending.");

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -724,46 +724,47 @@ getLoweredFunctionParameterIndex(unsigned paramIndex, AnyFunctionType *ty) {
 /// Given a @differentiable attribute and the function declaration that holds
 /// this attribute, this function returns the lowered (SIL) parameter indices
 /// to differentiate with respect to.
-static
-void getLoweredDifferentiationIndices(SILGenModule &SGM,
-                                      const AbstractFunctionDecl *AFD,
-                                      const SILFunction *F,
-                                      const DifferentiableAttr *DA,
-                                      SmallVectorImpl<unsigned> &indices) {
-  auto fnTy =
+static llvm::BitVector getLoweredAutoDiffParameterIndices(
+    SILGenModule &SGM, const AbstractFunctionDecl *AFD, const SILFunction *F,
+    const DifferentiableAttr *DA) {
+  auto *fnTy =
     AFD->getInterfaceType()->getCanonicalType()->getAs<AnyFunctionType>();
+  auto silFnTy = SGM.getLoweredType(fnTy).castTo<SILFunctionType>();
+  llvm::BitVector indices(silFnTy->getNumParameters());
   // We don't diff wrt `self` unless it is explicitly specified, therefore
   // dropping the last SIL parameter if it's a method.
   if (AFD->getImplicitSelfDecl())
     fnTy = fnTy->getResult()->getAs<AnyFunctionType>();
   // If no parameters are specified, add all parameter indices.
   if (DA->getParameters().empty()) {
-    for (unsigned i = 0, n = fnTy->getNumParams(); i != n; ++i)
+    for (unsigned i : range(fnTy->getNumParams()))
       for (unsigned paramIdx : SGM.getLoweredFunctionParameterIndex(i, fnTy))
-        indices.push_back(paramIdx);
-    return;
+        indices.set(paramIdx);
   }
   // Otherwise, convert differentiation parameters.
-  bool hasSelf = false;
-  for (auto param : DA->getParameters()) {
-    switch (param.getKind()) {
-    // Normal index maps directly to a SIL parameter index.
-    case AutoDiffParameter::Kind::Index: {
-      auto idx = param.getIndex();
-      auto paramIdxRange = SGM.getLoweredFunctionParameterIndex(idx, fnTy);
-      indices.append(paramIdxRange.begin(), paramIdxRange.end());
-      break;
+  else {
+    bool hasSelf = false;
+    for (auto param : DA->getParameters()) {
+      switch (param.getKind()) {
+      // Normal index maps directly to a SIL parameter index.
+      case AutoDiffParameter::Kind::Index: {
+        auto idx = param.getIndex();
+        auto paramIdxRange = SGM.getLoweredFunctionParameterIndex(idx, fnTy);
+        indices.set(paramIdxRange.front(), paramIdxRange.back());
+        break;
+      }
+      // 'self' is always the last SIL parameter.
+      case AutoDiffParameter::Kind::Self:
+        // Sema guarantees this case to occur at most once.
+        hasSelf = true;
+        break;
+      }
     }
-    // 'self' is always the last SIL parameter.
-    case AutoDiffParameter::Kind::Self:
-      // Sema guarantees this case to occur at most once.
-      hasSelf = true;
-      break;
-    }
+    // The last SIL parameter is `self`, if needed.
+    if (hasSelf)
+      indices.set(fnTy->getNumParams());
   }
-  // The last SIL parameter is `self`, if needed.
-  if (hasSelf)
-    indices.push_back(fnTy->getNumParams());
+  return indices;
 }
 
 void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
@@ -823,12 +824,11 @@ void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
       StringRef adjName =
         getFunction(SILDeclRef(adjointFn), ForDefinition)->getName();
       // Get lowered argument indices.
-      SmallVector<unsigned, 8> indices;
-      getLoweredDifferentiationIndices(*this, AFD, silOriginalFn, diffAttr,
-                                       indices);
+      auto paramIndices =
+        getLoweredAutoDiffParameterIndices(*this, AFD, silOriginalFn, diffAttr);
+      SILReverseAutoDiffIndices indices(/*source*/ 0, paramIndices);
       silOriginalFn->addReverseDifferentiableAttr(
-        SILReverseDifferentiableAttr::create(M, /*sourceIndex*/ 0,
-                                             indices, primName, adjName));
+          SILReverseDifferentiableAttr::create(M, indices, primName, adjName));
       break;
     }
     }

--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -58,7 +58,7 @@ using llvm::DenseMap;
 //===----------------------------------------------------------------------===//
 
 static NominalTypeDecl *getStdlibTypeDecl(StringRef, ASTContext &);
-static std::string manglePositionalConfig(unsigned, ArrayRef<unsigned>);
+static std::string mangleADIndices(SILReverseAutoDiffIndices);
 static std::string mangleADConfig(const SILReverseAutoDiffConfiguration &);
 static SILFunction *lookupOrLinkFunction(StringRef name, SILModule &);
 static FuncDecl *lookupAssociativeOperatorDeclInProtocol(DeclName operatorName,
@@ -86,8 +86,7 @@ struct DifferentiationTask {
   }
 
   SILReverseAutoDiffConfiguration getMasterConfig() const {
-    return SILReverseAutoDiffConfiguration::getMaster(attr->getSourceIndex(),
-                                                      attr->getParamIndices());
+    return SILReverseAutoDiffConfiguration::getMaster(attr->getIndices());
   }
 };
 } // end anonymous namespace
@@ -284,32 +283,32 @@ public:
   /// Determines whether the given type conforms to FloatingPoint.
   bool supportsFloatingPointDifferentiation(Type type) const;
 
-  void insertPrimal(SILFunction *original, unsigned sourceIndex,
-                    ArrayRef<unsigned> paramIndices, SILFunction *primal) {
+  void insertPrimal(SILFunction *original, SILReverseAutoDiffIndices indices,
+                    SILFunction *primal) {
     auto *attr =
-      getOrCreateReverseDifferentiableAttr(original, sourceIndex, paramIndices);
+      getOrCreateReverseDifferentiableAttr(original, indices);
     attr->setPrimalName(primal->getName());
   }
 
-  void insertAdjoint(SILFunction *original, unsigned sourceIndex,
-                     ArrayRef<unsigned> paramIndices, SILFunction *adjoint) {
+  void insertAdjoint(SILFunction *original, SILReverseAutoDiffIndices indices,
+                     SILFunction *adjoint) {
     auto *attr =
-      getOrCreateReverseDifferentiableAttr(original, sourceIndex, paramIndices);
+      getOrCreateReverseDifferentiableAttr(original, indices);
     attr->setAdjointName(adjoint->getName());
   }
 
-  SILFunction *lookupPrimal(SILFunction *original, unsigned sourceIndex,
-                            ArrayRef<unsigned> paramIndices) {
+  SILFunction *lookupPrimal(SILFunction *original,
+                            SILReverseAutoDiffIndices indices) {
     if (auto *attr =
-        lookupReverseDifferentiableAttr(original, sourceIndex, paramIndices))
+        lookupReverseDifferentiableAttr(original, indices))
       return lookupPrimal(attr);
     return nullptr;
   }
 
-  SILFunction *lookupAdjoint(SILFunction *original, unsigned sourceIndex,
-                             ArrayRef<unsigned> paramIndices) {
+  SILFunction *lookupAdjoint(SILFunction *original,
+                             SILReverseAutoDiffIndices indices) {
     if (auto *attr =
-        lookupReverseDifferentiableAttr(original, sourceIndex, paramIndices))
+        lookupReverseDifferentiableAttr(original, indices))
       return lookupPrimal(attr);
     return nullptr;
   }
@@ -343,12 +342,10 @@ public:
   /// hashing on SILFunction's side or maintaining a dictionary in ADContext.
   /// In any case, this is not performance-critical.
   SILReverseDifferentiableAttr *
-  lookupReverseDifferentiableAttr(SILFunction *original, unsigned sourceIndex,
-                                  ArrayRef<unsigned> paramIndices) const {
+  lookupReverseDifferentiableAttr(SILFunction *original,
+                                  SILReverseAutoDiffIndices indices) const {
     for (auto *attr : original->getReverseDifferentiableAttrs())
-      if (attr->getSourceIndex() == sourceIndex &&
-          (attr->getParamIndices().data() == paramIndices.data() ||
-           attr->getParamIndices().equals(paramIndices)))
+      if (attr->getIndices() == indices)
         return attr;
     return nullptr;
   }
@@ -357,14 +354,11 @@ public:
   /// original function corresponding to the specified parameter indices.
   SILReverseDifferentiableAttr *
   getOrCreateReverseDifferentiableAttr(SILFunction *function,
-                                       unsigned sourceIndex,
-                                       ArrayRef<unsigned> paramIndices) {
+                                       SILReverseAutoDiffIndices indices) {
     if (auto *attr =
-        lookupReverseDifferentiableAttr(function, sourceIndex, paramIndices))
+        lookupReverseDifferentiableAttr(function, indices))
       return attr;
-    auto *attr = SILReverseDifferentiableAttr::create(getModule(),
-                                                      sourceIndex,
-                                                      paramIndices);
+    auto *attr = SILReverseDifferentiableAttr::create(getModule(), indices);
     function->addReverseDifferentiableAttr(attr);
     return attr;
   }
@@ -435,19 +429,18 @@ public:
                           PrimalFunctionInfo>;
   /// Perform primal generation, and indirectly returns a mapping from original
   /// functions to primal infos.
-  void generate(Result &primalInfos);
+  void generate();
 
 private:
   /// Creates an empty primal function.
-  SILFunction *createPrimalFunction(SILFunction *original, unsigned sourceIndex,
-                                    ArrayRef<unsigned> paramIndices);
+  SILFunction *createPrimalFunction(SILFunction *original,
+                                    SILReverseAutoDiffIndices indices);
   /// A task specifies the empty primal function to be filled in, and what its
   /// corresponding original and parameter indices are.
   struct Task {
     SILFunction *original;
     SILFunction *primal;
-    unsigned sourceIndex;
-    ArrayRef<unsigned> paramIndices;
+    SILReverseAutoDiffIndices indices;
   };
   /// Processes an original function and generate its adjoint.
   void processTask(Task task,
@@ -535,12 +528,12 @@ void PrimalGen::processTask(PrimalGen::Task task,
 }
 
 /// Creates a primal function.
-SILFunction *PrimalGen::createPrimalFunction(SILFunction *original,
-                                             unsigned sourceIndex,
-                                             ArrayRef<unsigned> paramIndices) {
+SILFunction *
+PrimalGen::createPrimalFunction(SILFunction *original,
+                                SILReverseAutoDiffIndices indices) {
   auto &module = context.getModule();
-  std::string primalName = original->getName().str() + "__primal_" +
-                           manglePositionalConfig(sourceIndex, paramIndices);
+  std::string primalName =
+    original->getName().str() + "__primal_" + mangleADIndices(indices);
   // Create a `<fn_name>__Checkpoints` struct.
   auto checkpointStructName = original->getName().str() + "__Checkpoints";
   StructDecl *checkpointStorageDecl =
@@ -575,7 +568,7 @@ SILFunction *PrimalGen::createPrimalFunction(SILFunction *original,
 /// Starting from functions to be differentiated using the `gradient`
 /// instruction, recursively generate a primal function for each original
 /// function along the differentiation path.
-void PrimalGen::generate(PrimalGen::Result &primalInfos) {
+void PrimalGen::generate() {
   SmallVector<Task, 16> worklist;
   // Push everything to the worklist.
   for (auto &task : diffTasks) {
@@ -584,10 +577,9 @@ void PrimalGen::generate(PrimalGen::Result &primalInfos) {
       continue;
     auto *original = task.original;
     auto *diffAttr = task.attr;
-    auto sourceIndex = diffAttr->getSourceIndex();
-    auto paramIndices = diffAttr->getParamIndices();
-    auto *primal = createPrimalFunction(original, sourceIndex, paramIndices);
-    worklist.push_back({original, primal, sourceIndex, paramIndices});
+    auto indices = diffAttr->getIndices();
+    auto *primal = createPrimalFunction(original, indices);
+    worklist.push_back({original, primal, indices});
   }
   // Iterate through the worklist, look up existing adjoint. If an adjoint
   // exists for the task, do nothing. Otherwise, create a function and process
@@ -597,7 +589,6 @@ void PrimalGen::generate(PrimalGen::Result &primalInfos) {
     worklist.pop_back();
     PrimalFunctionInfo pi;
     pi.primal = task.primal;
-    primalInfos.insert({{task.original, task.paramIndices}, pi});
     processTask(task, worklist, pi);
   }
 }
@@ -616,8 +607,6 @@ private:
   ArrayRef<DifferentiationTask> diffTasks;
   /// The global AD context.
   ADContext &context;
-  /// A mapping from original functions to their primal infos.
-  PrimalGen::Result &primalInfos;
 
   /// Emit instructions to accumulate adjoint.
   void accumulateAdjoint(SILValue oldAdjoint, SILValue newAdjoint,
@@ -626,22 +615,21 @@ private:
 
 public:
   explicit AdjointGen(ArrayRef<DifferentiationTask> diffTasks,
-                      ADContext &context, PrimalGen::Result &primalInfos)
-    : diffTasks(diffTasks), context(context), primalInfos(primalInfos) {}
+                      ADContext &context)
+    : diffTasks(diffTasks), context(context) {}
   void generate();
 
 private:
   /// Creates an empty adjoint function.
   SILFunction *createAdjointFunction(SILFunction *original,
                                      CanType checkpointsType,
-                                     unsigned sourceIndex,
-                                     ArrayRef<unsigned> paramIndices);
+                                     SILReverseAutoDiffIndices indices);
   /// A task specifies the empty adjoint function to be filled in, and what its
   /// corresponding original and parameter indices are.
   struct Task {
     SILFunction *original;
     SILFunction *adjoint;
-    ArrayRef<unsigned> paramIndices;
+    llvm::BitVector paramIndices;
   };
   /// Process an original function and generate its adjoint.
   void processTask(Task task, SmallVectorImpl<Task> &worklist);
@@ -696,8 +684,7 @@ void AdjointGen::accumulateAdjoint(SILValue oldAdjoint, SILValue newAdjoint,
 SILFunction *
 AdjointGen::createAdjointFunction(SILFunction *original,
                                   CanType checkpointsType,
-                                  unsigned sourceIndex,
-                                  ArrayRef<unsigned> paramIndices) {
+                                  SILReverseAutoDiffIndices indices) {
   auto &module = context.getModule();
 
   // Given a canonical type, returns parameter info.
@@ -739,8 +726,8 @@ AdjointGen::createAdjointFunction(SILFunction *original,
   adjParams.push_back(getFormalParamInfo(checkpointsType));
   adjParams.push_back(
     getFormalParamInfo(origTy->getSingleResult().getType()));
-  auto adjName = original->getName().str() + "__adj_" +
-                 manglePositionalConfig(sourceIndex, paramIndices);
+  auto adjName =
+    original->getName().str() + "__adj_" + mangleADIndices(indices);
   auto adjType = SILFunctionType::get(origTy->getGenericSignature(),
                                       origTy->getExtInfo(),
                                       origTy->getCoroutineKind(),
@@ -772,15 +759,14 @@ void AdjointGen::generate() {
       continue;
     auto *original = task.original;
     auto *diffAttr = task.attr;
-    auto sourceIndex = diffAttr->getSourceIndex();
-    auto paramIndices = diffAttr->getParamIndices();
+    auto indices = diffAttr->getIndices();
     auto *primal = context.lookupPrimal(task.attr);
     assert(primal && "PrimalGen didn't run on this function before?!");
     auto primalTy = primal->getLoweredFunctionType();
     auto checkpointsTy = primalTy->getSingleResult().getType();
     auto *adjoint =
-      createAdjointFunction(original, checkpointsTy, sourceIndex, paramIndices);
-    worklist.push_back({original, adjoint, paramIndices});
+      createAdjointFunction(original, checkpointsTy, indices);
+    worklist.push_back({original, adjoint, indices.parameters});
   }
   // Iterate over the worklist, look up existing adjoint. If an adjoint exists
   // for the task, do nothing. Otherwise, create a function and process it.
@@ -901,12 +887,10 @@ static SILFunction *lookupOrLinkFunction(StringRef name, SILModule &module) {
   return module.findFunction(name, SILLinkage::PublicExternal);
 }
 
-/// Mangles a positional AD config, i.e. a source index and a parameter index
-/// list.
-static std::string manglePositionalConfig(unsigned sourceIndex,
-                                          ArrayRef<unsigned> paramIndices) {
-  std::string result = "src_" + llvm::utostr(sourceIndex) + "_wrt_";
-  interleave(paramIndices,
+/// Mangles a set of AD indices.
+static std::string mangleADIndices(SILReverseAutoDiffIndices indices) {
+  std::string result = "src_" + llvm::utostr(indices.source) + "_wrt_";
+  interleave(indices.parameters.set_bits(),
              [&](unsigned idx) { result += llvm::utostr(idx); },
              [&]{ result += '_'; });
   return result;
@@ -915,12 +899,13 @@ static std::string manglePositionalConfig(unsigned sourceIndex,
 /// Mangles an AD configuration.
 static
 std::string mangleADConfig(const SILReverseAutoDiffConfiguration &config) {
-  std::string result = "grad_" +
-    manglePositionalConfig(config.sourceIndex, config.parameterIndices);
-  if (config.seedable)
+  std::string result = "grad_" + mangleADIndices(config.indices);
+  if (config.isSeedable())
     result += "_s";
-  if (config.preservingResult)
+  if (config.isPreservingResult())
     result += "_p";
+  if (config.isDelayed())
+    result += "_d";
   return result;
 }
 
@@ -1160,20 +1145,18 @@ static SILFunction *getOrCreateGradient(
   // Step 1: Make sure the `[differentiable]` attribute exists. Based on this
   // attribute, create a differentiation task.
   SILReverseDifferentiableAttr *attr =
-    context.getOrCreateReverseDifferentiableAttr(original, config.sourceIndex,
-                                                 config.parameterIndices);
+    context.getOrCreateReverseDifferentiableAttr(original, config.indices);
   DifferentiationTask newTask { original, attr };
   // Update config's parameter indices to not depend on GradientInst's storage
   // because it will be removed.
-  config.parameterIndices = attr->getParamIndices();
+  config.indices.parameters = attr->getIndices().parameters;
 
   // Step 2: Get or create a seedable, result-preserving gradient function. If
   // this function exists, return it.
   SILFunction *canonicalGrad = nullptr;
   // The master AD config corresponds to the canonical gradient.
   auto masterConfig =
-    SILReverseAutoDiffConfiguration::getMaster(config.sourceIndex,
-                                               config.parameterIndices);
+    SILReverseAutoDiffConfiguration::getMaster(config.indices);
   // If it already exists, we'll simply use the existing one.
   if (auto *existingGrad = context.lookupGradient({original, masterConfig}))
     canonicalGrad = existingGrad;
@@ -1213,7 +1196,7 @@ static SILFunction *getOrCreateGradient(
     for (auto arg : gradFn->getArguments())
       args.push_back(arg);
     // If it's not seedable, we need to create a default seed.
-    if (!config.seedable) {
+    if (!config.isSeedable()) {
       auto seedTy = origTy->getSingleResult().getType();
       auto seedSILTy = SILType::getPrimitiveObjectType(seedTy);
       // Call `<seed type>.init(1)` to create a default
@@ -1253,7 +1236,7 @@ static SILFunction *getOrCreateGradient(
     // If the config is result-preserving, or if the original result is
     // indirect, we can just return whatever direct results the canonical
     // gradient produces.
-    if (config.preservingResult ||
+    if (config.isPreservingResult() ||
         canGradConv.getResults()[0].isFormalIndirect()) {
       builder.createReturn(loc, resultAndGrad);
     }
@@ -1504,15 +1487,14 @@ void Differentiation::run() {
 
   // Run primal generation.
   PrimalGen primalGen(worklist, context);
-  PrimalGen::Result primalInfos;
-  primalGen.generate(primalInfos);
+  primalGen.generate();
 
   // If there were any error, back out.
   if (context.hasErrorOccurred())
     return;
 
   // Run adjoint generation.
-  AdjointGen adjointGen(worklist, context, primalInfos);
+  AdjointGen adjointGen(worklist, context);
   adjointGen.generate();
 
   // If there were any error, back out.


### PR DESCRIPTION
(Split from megapatch #17901)

This patch adds support for delayed gradients in AD configuration and merges `[seedable]`, `[preserving_result]` and `[delayed]` to an option set `SILGradientOptions`. This change is reflected on the differential operator in SIL, aka. the `gradient` instruction.

```
%0 = function_ref @foo : $(Float, Float) -> Float
%1 = gradient [source 0] [wrt 0, 1] [seedable] [preserving_result] [delayed] %0 : $(Float, Float) -> Float
// %1 has type $(Float, Float) -> (Float, @convention(thin) (Float) -> (Float, Float))
```

A seedable, result-preserving, delayed gradient takes the original parameters of function `@foo`, and returns a tuple of the original results and a thin closure that takes a seed and returns the partial derivatives.

**TODO:** The support for delayed gradient isn't complete. We need to change the canonical gradient options to include `SILGradientOptions::Delayed`, and change Differentiation pass to synthesize calls to the new canonical gradient.

Also included:
* NFC: Use a `llvm::BitVector` to store AD parameter indices.
* Other NFC cleanup.