### PR TITLE
Remove an unnecessary const qualifier, NFC

### DIFF
--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -365,7 +365,7 @@ public:
   }
   
   /// Returns the ASTContext for the referenced Swift type.
-  const ASTContext &getASTContext() const {
+  ASTContext &getASTContext() const {
     return getASTType()->getASTContext();
   }
 


### PR DESCRIPTION
This makes SILType less useful than Type for no apparent reason.
