### PR TITLE
[AST] Member lookup in the GSB needs to understand equivalence classes with concrete types.

### DIFF
--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -220,9 +220,11 @@ Type CompleteGenericTypeResolver::resolveDependentMemberType(
       return concrete->getDeclaredInterfaceType().subst(subMap);
     }
 
-    if (auto superclass = baseEquivClass->superclass) {
-      return superclass->getTypeOfMember(
-                                       DC->getParentModule(), concrete,
+    Type baseType = baseEquivClass->concreteType ? baseEquivClass->concreteType
+                                                 : baseEquivClass->superclass;
+
+    if (baseType) {
+      return baseType->getTypeOfMember(DC->getParentModule(), concrete,
                                        concrete->getDeclaredInterfaceType());
     }
 

--- a/validation-test/compiler_crashers_2_fixed/0165-sr8240.swift
+++ b/validation-test/compiler_crashers_2_fixed/0165-sr8240.swift
@@ -1,0 +1,14 @@
+// RUN: %target-typecheck-verify-swift
+
+struct Box<Representation> {
+    let value: Representation
+}
+enum Repr {}
+extension Repr {
+    typealias RawEnum = ()
+}
+extension Box where Representation == Repr {
+    init(rawEnumValue: Representation.RawEnum) {
+        fatalError()
+    }
+}

--- a/validation-test/compiler_crashers_2_fixed/0166-sr8240-2.swift
+++ b/validation-test/compiler_crashers_2_fixed/0166-sr8240-2.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift
+
+struct Box<Representation, T> {
+    let value: Representation
+}
+enum Repr {}
+extension Repr {
+    typealias RawEnum = ()
+}
+extension Box where Representation == Repr, T == Representation.RawEnum {
+    init(rawEnumValue: Representation.RawEnum) {
+        let _: Int.Type = T.self // expected-error {{cannot convert value of type '().Type' to specified type 'Int.Type'}}
+        fatalError()
+    }
+}

--- a/validation-test/compiler_crashers_fixed/28850-unreachable-executed-at-swift-lib-sema-typecheckgeneric-cpp-220.swift
+++ b/validation-test/compiler_crashers_fixed/28850-unreachable-executed-at-swift-lib-sema-typecheckgeneric-cpp-220.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol P{class a{protocol a:P{func a:a.a{}typealias a


### PR DESCRIPTION
A constraint like `Parameter == SomethingConcrete` means references to
`Parameter` in that context behave like `SomethingConcrete`, including for name
resolution. Handling the parameter as just a parameter type means that it won't
find any non-protocol nested types (i.e. things other than associated types and
protocol typealiases are invisible).

Fixes rdar://problem/42136457 and fixes #50772.
