### PR TITLE
Fixed a markBlock() bug, when a switch_enum term inst is wrapped in a loop

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -1330,7 +1330,7 @@ bool TFFunctionPartition::markInstruction(SILInstruction &inst, Marking mark) {
 
   // If we're moving a computation to the accelerator and we see a tuple_extract
   // from a moved value, then we move the tuple_extract as well, to make sure
-  // that any copy-to-host or results are scalar values, not the multiple
+  // that all copy-to-host or results are scalar values, not the multiple
   // results of tensor ops.
   for (auto result : inst.getResults())
     for (auto *use : result->getUses()) {

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -1171,6 +1171,14 @@ bool TFFunctionPartition::markBlock(SILBasicBlock *BB) {
         // We intend for `predTerm` to still run on host (and thus did not
         // mark its parent block), but send its result to accelerator.
         markedInstructions.insert({predTerm, Marking::Send});
+        // Even though we don't need to mark `pred` for Accelerator if it has no
+        // block which it is control-dependent on, when there is a block that
+        // `pred` is control-dependent on, we need to mark that block. This is
+        // done by marking `pred` first. Otherwise we can miss marking an
+        // encompassing loop where `pred` and `thisBB` are part of the loop
+        // body.
+        if (markBlock(pred))
+          return true;
         continue;
       }
 
@@ -1261,36 +1269,15 @@ static ScalarPromoteClass shouldPromoteToTensorOp(SILInstruction *inst,
   return ScalarPromoteClass::CanPromote;
 }
 
+/// In addition to marking this inst itself for accelerator (Copy or Move), also
+/// mark the block, and the operands of this inst. In addition, for
+/// Marking::Copy, handle a few special types of scalar promotion.
 bool TFFunctionPartition::markInstruction(SILInstruction &inst, Marking mark) {
+  assert(mark == Marking::Copy || mark == Marking::Move);
+
   // Insert the specified instruction into the marked set.  If it is already
   // there then we have nothing more to do.
   if (!markedInstructions.insert({&inst, mark}).second)
-    return false;
-
-  // If we're moving a computation to the accelerator and we see a tuple_extract
-  // from a moved value, then we move the tuple_extract as well, to make sure
-  // that any copy-to-host or results are scalar values, not the multiple
-  // results of tensor ops.
-  if (mark == Marking::Move) {
-    for (auto result : inst.getResults())
-      for (auto *use : result->getUses()) {
-        auto user = use->getUser();
-
-        // FIXME: We should probably consider these as tensorops to make sure
-        // they get moved to the accelerator and we don't end up with any
-        // multi-result tensor operations being copied over.
-        if (isa<TupleExtractInst>(user)) {
-          // It is possible the tuple extract already got marked as a copy.  If
-          // so, remove its entry so we can upgrade it to a move.
-          markedInstructions.erase(user);
-          if (markInstruction(*user, Marking::Move))
-            return true;
-        }
-      }
-  }
-
-  // If we are simply deleting this instruction, then we're done.
-  if (mark == Marking::Delete)
     return false;
 
   // Make sure the instruction's block is marked as being copied over to the
@@ -1304,12 +1291,11 @@ bool TFFunctionPartition::markInstruction(SILInstruction &inst, Marking mark) {
   if (isa<BranchInst>(&inst))
     return false;
 
-  // If we are moving the instruction over, then we know it is a tensor op, and
-  // it get special attention.  Otherwise, we just recursively mark the
-  // operands in question.
+  // If we are copying the instruction over (for scalar promotion), we just
+  // recursively mark the operands in question.
   // TODO: This special case will go away when Tensor ops are not representing
   // attributes as operands.
-  if (mark != Marking::Move) {
+  if (mark == Marking::Copy) {
     auto operandRange = inst.getAllOperands();
 
     // Some instructions require special handling during marking.
@@ -1338,6 +1324,29 @@ bool TFFunctionPartition::markInstruction(SILInstruction &inst, Marking mark) {
     return false;
   }
 
+  assert(mark == Marking::Move);
+  // If we are moving the instruction over, then we know it is a tensor op, and
+  // it get special attention.
+
+  // If we're moving a computation to the accelerator and we see a tuple_extract
+  // from a moved value, then we move the tuple_extract as well, to make sure
+  // that any copy-to-host or results are scalar values, not the multiple
+  // results of tensor ops.
+  for (auto result : inst.getResults())
+    for (auto *use : result->getUses()) {
+      auto user = use->getUser();
+
+      // FIXME: We should probably consider these as tensorops to make sure
+      // they get moved to the accelerator and we don't end up with any
+      // multi-result tensor operations being copied over.
+      if (isa<TupleExtractInst>(user)) {
+        // It is possible the tuple extract already got marked as a copy.  If
+        // so, remove its entry so we can upgrade it to a move.
+        markedInstructions.erase(user);
+        if (markInstruction(*user, Marking::Move))
+          return true;
+      }
+    }
   // If this is a tuple_extract of a tensor op, then we already marked its
   // operand.
   if (isa<TupleExtractInst>(inst))

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -1171,7 +1171,7 @@ bool TFFunctionPartition::markBlock(SILBasicBlock *BB) {
         // We intend for `predTerm` to still run on host (and thus did not
         // mark its parent block), but send its result to accelerator.
         markedInstructions.insert({predTerm, Marking::Send});
-        // Even though we don't need to mark `pred` for Accelerator if it has no
+        // Even though we don't need to mark `pred` for accelerator if it has no
         // block which it is control-dependent on, when there is a block that
         // `pred` is control-dependent on, we need to mark that block. This is
         // done by marking `pred` first. Otherwise we can miss marking an
@@ -1326,7 +1326,7 @@ bool TFFunctionPartition::markInstruction(SILInstruction &inst, Marking mark) {
 
   assert(mark == Marking::Move);
   // If we are moving the instruction over, then we know it is a tensor op, and
-  // it get special attention.
+  // it gets special attention.
 
   // If we're moving a computation to the accelerator and we see a tuple_extract
   // from a moved value, then we move the tuple_extract as well, to make sure

--- a/test/TensorFlow/control_flow.swift
+++ b/test/TensorFlow/control_flow.swift
@@ -315,3 +315,17 @@ public func infLoop2(maxCount: Int32) {
   a -= a
   _hostOp(a)
 }
+
+// TODO: Enable this test when we fix
+// SESE FIXME: Imperfect loop exits not handled yet!
+// public func SR8256(_ cond: Int?) {
+//   let a = Tensor<Float>(1.0)
+//   var i: Int32 = 0
+//   let maxCount: Int32 = 10
+//   while i < maxCount {
+//     if cond != nil {
+//       _hostOp(a+a)
+//     }
+//     i += 1
+//   }
+// }


### PR DESCRIPTION
In that case we need to mark the loop for accelerator.

Also refactored markInstruction() to make the code more readable.

One test case is:
```swift
public func SR8256(_ cond: Int?) {
  let a = Tensor<Float>(1.0)
  var i: Int32 = 0
  let maxCount: Int32 = 10
  while i < maxCount {
    if cond != nil {
      _hostOp(a+a)
    }
    i += 1
  }
}
```

The INPUT function is:
```
---- INPUT FUNCTION $S15sends_recvs_tmp4testyySiSgF ----------
// test(_:)
sil hidden @$S15sends_recvs_tmp4testyySiSgF : $@convention(thin) (Optional<Int>) -> () {
// %0                                             // users: %12, %1
bb0(%0 : $Optional<Int>):
  debug_value %0 : $Optional<Int>, let, name "cond", argno 1 // id: %1
  %2 = float_literal $Builtin.FPIEEE32, 0x3F800000 // 1 // user: %3
  %3 = builtin "__tfop_tfc.scalarToTensor,$in"(%2 : $Builtin.FPIEEE32) : $TensorHandle<Float> // users: %40, %27, %26, %20, %19, %18, %18, %16, %15, %14, %13, %5, %4
  strong_retain %3 : $TensorHandle<Float>         // id: %4
  strong_release %3 : $TensorHandle<Float>        // id: %5
  %6 = integer_literal $Builtin.Int32, 0          // user: %10
  %7 = integer_literal $Builtin.Int32, 10         // user: %37
  %8 = integer_literal $Builtin.Int32, 1          // user: %33
  %9 = integer_literal $Builtin.Int1, -1          // user: %33
  br bb1(%6 : $Builtin.Int32)                     // id: %10

// %11                                            // user: %33
bb1(%11 : $Builtin.Int32):                        // Preds: bb5 bb0
  switch_enum %0 : $Optional<Int>, case #Optional.some!enumelt.1: bb2, case #Optional.none!enumelt: bb3 // id: %12

bb2:                                              // Preds: bb1
  strong_retain %3 : $TensorHandle<Float>         // id: %13
  strong_retain %3 : $TensorHandle<Float>         // id: %14
  strong_retain %3 : $TensorHandle<Float>         // id: %15
  strong_retain %3 : $TensorHandle<Float>         // id: %16
  %17 = metatype $@thick Float.Type               // user: %18
  %18 = builtin "__tfop_Add,$in,$in,T"(%3 : $TensorHandle<Float>, %3 : $TensorHandle<Float>, %17 : $@thick Float.Type) : $TensorHandle<Float> // users: %24, %30, %25, %23, %21, %22
  strong_release %3 : $TensorHandle<Float>        // id: %19
  strong_release %3 : $TensorHandle<Float>        // id: %20
  strong_retain %18 : $TensorHandle<Float>        // id: %21
  %22 = struct $Tensor<Float> (%18 : $TensorHandle<Float>) // user: %29
  strong_retain %18 : $TensorHandle<Float>        // id: %23
  strong_release %18 : $TensorHandle<Float>       // id: %24
  strong_release %18 : $TensorHandle<Float>       // id: %25
  strong_release %3 : $TensorHandle<Float>        // id: %26
  strong_release %3 : $TensorHandle<Float>        // id: %27
  // function_ref _hostOp<A>(_:)
  %28 = function_ref @$S10TensorFlow7_hostOpyyAA0A0VyxGAA013AccelerableByaB0RzlF : $@convention(thin) <τ_0_0 where τ_0_0 : AccelerableByTensorFlow> (@guaranteed Tensor<τ_0_0>) -> () // user: %29
  %29 = apply %28<Float>(%22) : $@convention(thin) <τ_0_0 where τ_0_0 : AccelerableByTensorFlow> (@guaranteed Tensor<τ_0_0>) -> ()
  strong_release %18 : $TensorHandle<Float>       // id: %30
  br bb4                                          // id: %31

bb3:                                              // Preds: bb1
  br bb4                                          // id: %32

bb4:                                              // Preds: bb3 bb2
  %33 = builtin "sadd_with_overflow_Int32"(%11 : $Builtin.Int32, %8 : $Builtin.Int32, %9 : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1) // users: %35, %34
  %34 = tuple_extract %33 : $(Builtin.Int32, Builtin.Int1), 0 // users: %39, %37
  %35 = tuple_extract %33 : $(Builtin.Int32, Builtin.Int1), 1 // user: %36
  cond_fail %35 : $Builtin.Int1                   // id: %36
  %37 = builtin "cmp_slt_Int32"(%34 : $Builtin.Int32, %7 : $Builtin.Int32) : $Builtin.Int1 // user: %38
  cond_br %37, bb5, bb6                           // id: %38

bb5:                                              // Preds: bb4
  br bb1(%34 : $Builtin.Int32)                    // id: %39

bb6:                                              // Preds: bb4
  strong_release %3 : $TensorHandle<Float>        // id: %40
  %41 = tuple ()                                  // user: %42
  return %41 : $()                                // id: %42
} // end sil function '$S15sends_recvs_tmp4testyySiSgF'
```
Before the fix, the accelerator code is the following (note bb2 above gets
marked, but the loop structure around it does not).
```
--- TFPartition Accelerator Result: $S15sends_recvs_tmp4testyySiSgF.tf
// test(_:)
sil private @$S15sends_recvs_tmp4testyySiSgF.tf : $@callee_owned () -> () {
bb0:
  %0 = graph_op "Const"() {dtype$dtype: $Builtin.FPIEEE32, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.FPIEEE32> // user: %1
  %1 = unchecked_ref_cast %0 : $TensorHandle<Builtin.FPIEEE32> to $TensorHandle<Float> // users: %5, %5
  br bb2                                          // id: %2

bb1:
  %3 = metatype $@thick Float.Type                // user: %5
  %4 = string_literal utf8 "/device:CPU:0"        // user: %5
  %5 = builtin "__tfop_Add,$in,$in,T,__device"(%1 : $TensorHandle<Float>, %1 : $TensorHandle<Float>, %3 : $@thick Float.Type, %4 : $Builtin.RawPointer) : $TensorHandle<Float> // user: %6
  %6 = graph_op "tfc.SendToHost,i"(%5 : $TensorHandle<Float>) {tensorId: i32 0, __device: "/device:CPU:0"} : $()
  br bb2                                          // id: %7

bb2:                                              // Preds: bb1 bb0
  %8 = tuple ()                                   // user: %9
  return %8 : $()                                 // id: %9
} // end sil function '$S15sends_recvs_tmp4testyySiSgF.tf'
```
After the fix, the accelerator code is:
```
--- TFPartition Accelerator Result: $S15sends_recvs_tmp4testyySbF.tf
// test(_:)
sil private @$S15sends_recvs_tmp4testyySbF.tf : $@callee_owned (TensorHandle<Builtin.Int1>) -> () {
// %0                                             // user: %8
bb0(%0 : $TensorHandle<Builtin.Int1>):
  %1 = graph_op "Const"() {dtype$dtype: $Builtin.FPIEEE32, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.FPIEEE32> // user: %2
  %2 = unchecked_ref_cast %1 : $TensorHandle<Builtin.FPIEEE32> to $TensorHandle<Float> // users: %12, %12
  %3 = graph_op "Const"() {dtype$dtype: $Builtin.Int32, value$tensor: i32 0, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int32> // user: %6
  %4 = graph_op "Const"() {dtype$dtype: $Builtin.Int32, value$tensor: i32 10, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int32> // user: %16
  %5 = graph_op "Const"() {dtype$dtype: $Builtin.Int32, value$tensor: i32 1, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int32> // user: %15
  br bb1(%3 : $TensorHandle<Builtin.Int32>)       // id: %6

// %7                                             // user: %15
bb1(%7 : $TensorHandle<Builtin.Int32>):           // Preds: bb4 bb0
  %8 = builtin "tf_tensor_to_i1"(%0 : $TensorHandle<Builtin.Int1>) : $Builtin.Int1 // user: %9
  cond_br %8, bb2, bb3                            // id: %9

bb2:                                              // Preds: bb1
  %10 = metatype $@thick Float.Type               // user: %12
  %11 = string_literal utf8 "/device:CPU:0"       // user: %12
  %12 = builtin "__tfop_Add,$in,$in,T,__device"(%2 : $TensorHandle<Float>, %2 : $TensorHandle<Float>, %10 : $@thick Float.Type, %11 : $Builtin.RawPointer) : $TensorHandle<Float> // user: %13
  %13 = graph_op "tfc.SendToHost,i"(%12 : $TensorHandle<Float>) {tensorId: i32 0, __device: "/device:CPU:0"} : $()
  br bb3                                          // id: %14

bb3:                                              // Preds: bb2 bb1
  %15 = graph_op "Add,i,i"(%7 : $TensorHandle<Builtin.Int32>, %5 : $TensorHandle<Builtin.Int32>) {__device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int32> // users: %19, %16
  %16 = graph_op "Less,i,i"(%15 : $TensorHandle<Builtin.Int32>, %4 : $TensorHandle<Builtin.Int32>) {__device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int1> // user: %17
  %17 = builtin "tf_tensor_to_i1"(%16 : $TensorHandle<Builtin.Int1>) : $Builtin.Int1 // user: %18
  cond_br %17, bb4, bb5                           // id: %18

bb4:                                              // Preds: bb3
  br bb1(%15 : $TensorHandle<Builtin.Int32>)      // id: %19

bb5:                                              // Preds: bb3
  %20 = tuple ()                                  // user: %21
  return %20 : $()                                // id: %21
} // end sil function '$S15sends_recvs_tmp4testyySbF.tf'
```
Resolves [SR-8256](https://bugs.swift.org/browse/SR-8256).

The test is now crashing elsewhere, so it's commented out.