### PR TITLE
⚠️[ObjectiveC] NSObject: Fix hashing implementation

### DIFF
--- a/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
+++ b/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
@@ -205,14 +205,30 @@ extension NSObject : Equatable, Hashable {
 
   /// The hash value.
   ///
+  /// NSObject implements this by returning `self.hash`. Subclasses can
+  /// customize hashing by overriding the `hash` property.
+  ///
   /// **Axiom:** `x == y` implies `x.hashValue == y.hashValue`
   ///
   /// - Note: the hash value is not guaranteed to be stable across
   ///   different invocations of the same program.  Do not persist the
   ///   hash value across program runs.
-  @objc
-  open var hashValue: Int {
+  @nonobjc
+  public var hashValue: Int {
     return hash
+  }
+
+  /// Hashes the essential components of this value by feeding them into the
+  /// given hasher.
+  ///
+  /// NSObject implements this by feeding `self.hash` to the hasher. Subclasses
+  /// can customize hashing by overriding the `hash` property.
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(hash)
+  }
+
+  public func _rawHashValue(seed: (UInt64, UInt64)) -> Int {
+    return self.hash._rawHashValue(seed: seed)
   }
 }
 


### PR DESCRIPTION
`NSObject` defines its own interface for hashing and equality. Subclasses must implement custom hashing by overriding the hash property, or `NSSet` and `NSDictionary` will not work correctly.

To prevent a common source of errors, make the `hashValue` property Swift-only, and non-overridable. (It was declared as `@objc open` by historical accident.)

Also add explicit, non-overridable definitions for `hash(into:)` and `_rawHashValue(seed:)` to prevent them from contributing to this issue in the future.

This is a potentially source-breaking change. Code that currently overrides `NSObject.hashValue` is almost certainly broken (because it violates the NSObject contract). However, this change trades a subtle runtime issue (that the code may or may not actually trigger) with an obvious compilation error.

rdar://problem/42623458