### PR TITLE
Attempt to fix non-deterministic failure in CursorInfo test

### DIFF
--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -352,8 +352,8 @@ TEST_F(CursorInfoTest, CursorInfoMustWaitDueToken) {
   replaceText(DocName, findOffset(TextToReplace, Contents), TextToReplace.size(),
               ExpensiveInit);
   // Change 'foo' to 'fog' by replacing the last character.
-  replaceText(DocName, FooRefOffs+2, 1, "g");
   replaceText(DocName, FooOffs+2, 1, "g");
+  replaceText(DocName, FooRefOffs+2, 1, "g");
 
   // Should wait for the new AST, because the cursor location points to a
   // different token.
@@ -381,8 +381,8 @@ TEST_F(CursorInfoTest, CursorInfoMustWaitDueTokenRace) {
   setNeedsSema(true);
   open(DocName, Contents, llvm::makeArrayRef(Args));
   // Change 'foo' to 'fog' by replacing the last character.
-  replaceText(DocName, FooRefOffs + 2, 1, "g");
   replaceText(DocName, FooOffs + 2, 1, "g");
+  replaceText(DocName, FooRefOffs + 2, 1, "g");
 
   // Should wait for the new AST, because the cursor location points to a
   // different token.


### PR DESCRIPTION
The problem appears to be that cursor info is using an unsound mechanism
(canUseASTWithSnapshots) to run without rebuilding the AST and this test
was triggering it unintentionally. By changing the order of the edits we
force cursor info to notice the tokens have changed only after the code
is semantically correct again. In real code this issue is rare and
solves itself the next time you invoke the cursor info.

rdar://42247603