### PR TITLE
Start refactoring bits of deabstraction

### DIFF
--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -365,7 +365,7 @@ public:
   }
   
   /// Returns the ASTContext for the referenced Swift type.
-  const ASTContext &getASTContext() const {
+  ASTContext &getASTContext() const {
     return getASTType()->getASTContext();
   }
 

--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -1556,7 +1556,7 @@ tryToPromoteTensorFromScalars(ApplyInst *inst,
   B.setCurrentDebugScope(inst->getDebugScope());
   auto result = createConstTensor(elementType, scalars, shape,
                                   inst->getType(), inst->getLoc(),
-                                  deviceConfig, B);
+                                  deviceConfig.primaryDeviceType, B);
 
   // Replace the old instruction with the new one.
   inst->replaceAllUsesPairwiseWith(result);
@@ -1619,7 +1619,7 @@ tryToPromoteTensorFromScalars1D(ApplyInst *inst,
   B.setCurrentDebugScope(inst->getDebugScope());
   auto result = createConstTensor(elementType, scalars, shape,
                                   inst->getType(), inst->getLoc(),
-                                  deviceConfig, B);
+                                  deviceConfig.primaryDeviceType, B);
 
   // Replace the old instruction with the new one.
   inst->replaceAllUsesPairwiseWith(result);

--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -1681,6 +1681,9 @@ GraphOperationInfo::decodeAttributeName(Identifier name) {
   return { nameStr.substr(0, dollarLoc), opClass };
 }
 
+// TODO: This shouldn't be on GraphOperationInfo, it should move into
+// deabstraction.
+
 /// Given a SILValue that may be an array literal, attempt to decode it into the
 /// values that make up its elements.  If this fails or if the value is not an
 /// array, this returns a null Type.  Otherwise it decodes the array, returns
@@ -1705,20 +1708,39 @@ decodeArrayElements(SILValue value, SmallVectorImpl<SILValue> &elements,
   // Figure out the number of elements, which must be a constant integer.
   auto *apply = cast<ApplyInst>(teiValue->getOperand());
 
+  if (decodeArrayElements(apply, elements, arrayInsts))
+    return elementType;
+  return Type();
+
+    return Type();
+  return elementType;
+}
+
+/// Given an apply that may be an array literal, attempt to decode it into
+/// the values that make up its elements.  If this fails or if the value is
+/// not an array, this returns false.  Otherwise it decodes the array,
+/// returns the values of each element, and returns true.
+///
+/// If arrayInsts is non-null and if decoding succeeds, this function adds
+/// all of the instructions relevant to the definition of this array into
+/// the set.  If decoding fails, then the contents of this set is undefined.
+bool GraphOperationInfo::
+decodeArrayElements(ApplyInst *apply,
+                    SmallVectorImpl<SILValue> &elements,
+                    SmallPtrSet<SILInstruction*, 8> *arrayInsts) {
+
   // Verify we have a call to _allocateUninitializedArray.
   SILValue numElementsVal;
   if (!isArrayAllocUninit(apply, numElementsVal) ||
       !isa<IntegerLiteralInst>(numElementsVal))
-    return Type();
+    return false;
   uint64_t numElements =
     cast<IntegerLiteralInst>(numElementsVal)->getValue().getLimitedValue();
 
-  if (tf::ConstExprEvaluator::decodeAllocUninitializedArray(apply,
-                                                            numElements,
-                                                            elements,
-                                                            arrayInsts))
-    return Type();
-  return elementType;
+  return !tf::ConstExprEvaluator::decodeAllocUninitializedArray(apply,
+                                                                numElements,
+                                                                elements,
+                                                                arrayInsts);
 }
 
 
@@ -1897,6 +1919,57 @@ SILLocation tf::getUserSourceLocation(SILInstruction *inst) {
   }
 
   return getUserSourceLocation(inst->getDebugLocation());
+}
+
+/// Create a "Const" tensor operation containing the specified scalars, with the
+/// specified shape and elementType (setting dtype).  The resultType is the
+/// TensorHandle type to produce.
+GraphOperationInst *
+tf::createConstTensor(Type elementType, SymbolicValue scalars,
+                      SymbolicValue shape, SILType resultType, SILLocation loc,
+                      GraphGlobalConfiguration &deviceConfig, SILBuilder &B) {
+  auto &context = B.getASTContext();
+  auto &allocator = context.getAllocator();
+
+  // Ensure that the array of initializer values is in the module's allocator.
+  scalars = scalars.cloneInto(allocator);
+  shape = shape.cloneInto(allocator);
+  assert(scalars.getKind() == SymbolicValue::Array &&
+         shape.getKind() == SymbolicValue::Array &&
+         "expected array constants for scalars and shape");
+
+  SmallVector<GraphOperationAttribute, 8> attributes;
+
+  // Add a dtype attribute for the array element.
+  attributes.push_back({
+    context.getIdentifier("dtype"),
+    SymbolicValue::getMetatype(elementType->getCanonicalType())
+  });
+
+  // Add an attribute for the value$tensor attribute.
+  auto tensorSuffix =
+  SILTensorOpInfo::getOperandClassSuffix(SILTensorOpInfo::OperandClass::Tensor);
+  attributes.push_back({
+    context.getIdentifier(std::string("value") + tensorSuffix), scalars
+  });
+
+  // Add the value$shape attribute.
+  auto shapeSuffix =
+  SILTensorOpInfo::getOperandClassSuffix(SILTensorOpInfo::OperandClass::Shape);
+  attributes.push_back({
+    context.getIdentifier(std::string("value") + shapeSuffix), shape
+  });
+
+  // All graph_op's get a device.
+  attributes.push_back({
+    context.getIdentifier(DEVICE_ATTR),
+    SymbolicValue::getString(getDeviceString(deviceConfig.primaryDeviceType),
+                             allocator)
+  });
+
+  // Finally build a new graphop instruction with the simplified operands.
+  return B.createGraphOperation(loc, context.getIdentifier("Const"),
+                                /*operands*/{}, attributes, resultType);
 }
 
 

--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -1921,13 +1921,14 @@ SILLocation tf::getUserSourceLocation(SILInstruction *inst) {
   return getUserSourceLocation(inst->getDebugLocation());
 }
 
-/// Create a "Const" tensor operation containing the specified scalars, with the
-/// specified shape and elementType (setting dtype).  The resultType is the
-/// TensorHandle type to produce.
+/// Create a "Const" tensor operation containing the specified scalars, with
+/// the specified shape and elementType (setting dtype).  The resultType is
+/// the TensorHandle type to produce, and targetDevice is the device set for
+/// the operation.
 GraphOperationInst *
 tf::createConstTensor(Type elementType, SymbolicValue scalars,
                       SymbolicValue shape, SILType resultType, SILLocation loc,
-                      GraphGlobalConfiguration &deviceConfig, SILBuilder &B) {
+                      DeviceType targetDevice, SILBuilder &B) {
   auto &context = B.getASTContext();
   auto &allocator = context.getAllocator();
 
@@ -1963,8 +1964,7 @@ tf::createConstTensor(Type elementType, SymbolicValue scalars,
   // All graph_op's get a device.
   attributes.push_back({
     context.getIdentifier(DEVICE_ATTR),
-    SymbolicValue::getString(getDeviceString(deviceConfig.primaryDeviceType),
-                             allocator)
+    SymbolicValue::getString(getDeviceString(targetDevice), allocator)
   });
 
   // Finally build a new graphop instruction with the simplified operands.

--- a/lib/SILOptimizer/Mandatory/TFUtilities.h
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.h
@@ -541,11 +541,12 @@ private:
 
   /// Create a "Const" tensor operation containing the specified scalars, with
   /// the specified shape and elementType (setting dtype).  The resultType is
-  /// the TensorHandle type to produce.
+  /// the TensorHandle type to produce, and targetDevice is the device set for
+  /// the operation.
   GraphOperationInst *
   createConstTensor(Type elementType, SymbolicValue scalars,
                     SymbolicValue shape, SILType resultType, SILLocation loc,
-                    GraphGlobalConfiguration &deviceConfig, SILBuilder &B);
+                    DeviceType targetDevice, SILBuilder &B);
 
   /// This struct provides a an efficient implementation of a predicate that
   /// determines whether a type is or contains a TensorHandle that will be

--- a/lib/SILOptimizer/Mandatory/TFUtilities.h
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.h
@@ -496,6 +496,19 @@ private:
                                     SmallVectorImpl<SILValue> &elements,
                         SmallPtrSet<SILInstruction*, 8> *arrayInsts = nullptr);
 
+    /// Given an apply that may be an array literal, attempt to decode it into
+    /// the values that make up its elements.  If this fails or if the value is
+    /// not an array, this returns false.  Otherwise it decodes the array,
+    /// returns the values of each element, and returns true.
+    ///
+    /// If arrayInsts is non-null and if decoding succeeds, this function adds
+    /// all of the instructions relevant to the definition of this array into
+    /// the set.  If decoding fails, then the contents of this set is undefined.
+    static bool decodeArrayElements(ApplyInst *apply,
+                                    SmallVectorImpl<SILValue> &elements,
+                        SmallPtrSet<SILInstruction*, 8> *arrayInsts = nullptr);
+
+
   private:
     void assertWithDump(bool cond, const char *assertMsg) const;
   };
@@ -525,6 +538,14 @@ private:
   //===--------------------------------------------------------------------===//
   // Other stuff
   //===--------------------------------------------------------------------===//
+
+  /// Create a "Const" tensor operation containing the specified scalars, with
+  /// the specified shape and elementType (setting dtype).  The resultType is
+  /// the TensorHandle type to produce.
+  GraphOperationInst *
+  createConstTensor(Type elementType, SymbolicValue scalars,
+                    SymbolicValue shape, SILType resultType, SILLocation loc,
+                    GraphGlobalConfiguration &deviceConfig, SILBuilder &B);
 
   /// This struct provides a an efficient implementation of a predicate that
   /// determines whether a type is or contains a TensorHandle that will be


### PR DESCRIPTION
 - introduce a new pass to clean up instructions instead of having
   all the transformations do it.  This needs to be generalized, but is
   a start.  This should improve compile time when strict deabstraction
   is on.
 - Refactor a bunch of code into a "createConstTensor" helper in
   TFUtilities.  It would be nice for the rest of the compiler that
   produces "Const" nodes to start using this.

The patch to SILType.h has been sent upstream in PR18003 so it has no
SWIFT_ENABLE_TENSORFLOW marker.
