### PR TITLE
Fix warning for uninitialized va_list variable.

### DIFF
--- a/stdlib/public/SDK/os/os.m
+++ b/stdlib/public/SDK/os/os.m
@@ -161,6 +161,6 @@ _swift_os_signpost(
     const char * _Nonnull spnm,
     os_signpost_id_t spid)
 {
-  va_list x;
+  static va_list x;
   _swift_os_signpost_with_format(dso, ra, h, spty, spnm, spid, NULL, x);
 }


### PR DESCRIPTION
rdar://problem/40626177

Initializes a va_list variable that is currently not initialized. This is purely to silence a compiler warning because the value will not be used.