### PR TITLE
[pass-manager] Add a new analysis PassManagerVerifierAnalysis that va…

### DIFF
--- a/include/swift/SILOptimizer/Analysis/Analysis.def
+++ b/include/swift/SILOptimizer/Analysis/Analysis.def
@@ -44,5 +44,6 @@ ANALYSIS(ProtocolConformance)
 ANALYSIS(RCIdentity)
 ANALYSIS(SideEffect)
 ANALYSIS(TypeExpansion)
+ANALYSIS(PassManagerVerifier)
 
 #undef ANALYSIS

--- a/include/swift/SILOptimizer/Analysis/PassManagerVerifierAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/PassManagerVerifierAnalysis.h
@@ -1,0 +1,65 @@
+//===--- PassManagerVerifierAnalysis.h ------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILOPTIMIZER_ANALYSIS_PASSMANAGERVERIFIERANALYSIS_H
+#define SWIFT_SILOPTIMIZER_ANALYSIS_PASSMANAGERVERIFIERANALYSIS_H
+
+#include "swift/SIL/SILFunction.h"
+#include "swift/SILOptimizer/Analysis/Analysis.h"
+#include "llvm/ADT/DenseSet.h"
+
+namespace swift {
+
+/// An analysis that validates that the pass manager properly sends add/delete
+/// messages as functions are added/deleted from the module.
+///
+/// All methods are no-ops when asserts are disabled.
+class PassManagerVerifierAnalysis : public SILAnalysis {
+  /// The module that we are processing.
+  SILModule &mod;
+
+  /// The set of "live" functions that we are tracking.
+  ///
+  /// All functions in mod must be in liveFunctions and vis-a-versa.
+  llvm::DenseSet<SILFunction *> liveFunctions;
+
+public:
+  PassManagerVerifierAnalysis(SILModule *mod);
+
+  static bool classof(const SILAnalysis *analysis) {
+    return analysis->getKind() == SILAnalysisKind::PassManagerVerifier;
+  }
+
+  /// Validate that the analysis is able to look up all functions and that those
+  /// functions are live.
+  void invalidate() override final;
+
+  /// Validate that the analysis is able to look up the given function.
+  void invalidate(SILFunction *f, InvalidationKind k) override final;
+
+  /// If a function has not yet been seen start tracking it.
+  void notifyAddedOrModifiedFunction(SILFunction *f) override final;
+
+  /// Stop tracking a function.
+  void notifyWillDeleteFunction(SILFunction *f) override final;
+
+  /// Make sure that when we invalidate a function table, make sure we can find
+  /// all functions for all witness tables.
+  void invalidateFunctionTables() override final;
+
+  /// Run the entire verification.
+  void verify() const override final;
+};
+
+} // namespace swift
+
+#endif

--- a/lib/SILOptimizer/Analysis/CMakeLists.txt
+++ b/lib/SILOptimizer/Analysis/CMakeLists.txt
@@ -19,6 +19,7 @@ silopt_register_sources(
   LoopAnalysis.cpp
   LoopRegionAnalysis.cpp
   MemoryBehavior.cpp
+  PassManagerVerifierAnalysis.cpp
   ProtocolConformanceAnalysis.cpp
   RCIdentityAnalysis.cpp
   SideEffectAnalysis.cpp

--- a/lib/SILOptimizer/Analysis/PassManagerVerifierAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/PassManagerVerifierAnalysis.cpp
@@ -1,0 +1,100 @@
+//===--- PassManagerVerifierAnalysis.cpp ----------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-passmanager-verifier-analysis"
+#include "swift/SILOptimizer/Analysis/PassManagerVerifierAnalysis.h"
+#include "swift/SIL/SILModule.h"
+#include "llvm/Support/CommandLine.h"
+
+static llvm::cl::opt<bool>
+    EnableVerifier("enable-sil-passmanager-verifier-analysis",
+                   llvm::cl::desc("Enable verification of the passmanagers "
+                                  "function notification infrastructure"),
+                   llvm::cl::init(false));
+
+using namespace swift;
+
+PassManagerVerifierAnalysis::PassManagerVerifierAnalysis(SILModule *mod)
+    : SILAnalysis(SILAnalysisKind::PassManagerVerifier), mod(*mod) {
+#ifndef NDEBUG
+  if (!EnableVerifier)
+    return;
+  for (auto &fn : *mod) {
+    DEBUG(llvm::dbgs() << "PMVerifierAnalysis. Add: " << fn.getName() << '\n');
+    liveFunctions.insert(&fn);
+  }
+#endif
+}
+
+/// Validate that the analysis is able to look up all functions and that those
+/// functions are live.
+void PassManagerVerifierAnalysis::invalidate() {}
+
+/// Validate that the analysis is able to look up the given function.
+void PassManagerVerifierAnalysis::invalidate(SILFunction *f,
+                                             InvalidationKind k) {}
+
+/// If a function has not yet been seen start tracking it.
+void PassManagerVerifierAnalysis::notifyAddedOrModifiedFunction(
+    SILFunction *f) {
+#ifndef NDEBUG
+  if (!EnableVerifier)
+    return;
+  DEBUG(llvm::dbgs() << "PMVerifierAnalysis. Add|Mod: " << f->getName()
+                     << '\n');
+  liveFunctions.insert(f);
+#endif
+}
+
+/// Stop tracking a function.
+void PassManagerVerifierAnalysis::notifyWillDeleteFunction(SILFunction *f) {
+#ifndef NDEBUG
+  if (!EnableVerifier)
+    return;
+  DEBUG(llvm::dbgs() << "PMVerifierAnalysis. Delete: " << f->getName() << '\n');
+  assert(liveFunctions.count(f) &&
+         "Tried to delete function that analysis was not aware of?!");
+  liveFunctions.erase(f);
+#endif
+}
+
+/// Make sure that when we invalidate a function table, make sure we can find
+/// all functions for all witness tables.
+void PassManagerVerifierAnalysis::invalidateFunctionTables() {}
+
+/// Run the entire verification.
+void PassManagerVerifierAnalysis::verify() const {
+#ifndef NDEBUG
+  if (!EnableVerifier)
+    return;
+
+  // We check that all functions in the module are in liveFunctions /and/ then
+  // make sure that liveFunctions has the same number of elements. If we have
+  // too many elements, this means we missed a delete event.
+  unsigned funcCount = 0;
+  for (auto &fn : mod) {
+    ++funcCount;
+    assert(liveFunctions.count(&fn) &&
+           "Found function in module that verifier is not aware of?!");
+  }
+  assert(liveFunctions.size() == funcCount &&
+         "Analysis has state for deleted functions?!");
+#endif
+}
+
+//===----------------------------------------------------------------------===//
+//                              Main Entry Point
+//===----------------------------------------------------------------------===//
+
+SILAnalysis *swift::createPassManagerVerifierAnalysis(SILModule *m) {
+  return new PassManagerVerifierAnalysis(m);
+}


### PR DESCRIPTION
…lidates that the pass manager is sending new/delete messages appropriately to analyses.

The invariant is that this analysis should be able to stay in sync with the list
of functions stored in SILModule's function list. If any functions are
added/deleted then analyses can get out of sync with the state of the underlying
SILModule.

Some notes:

1. This is currently disabled by default since there are a bunch of
violations of this in the compiler. I am in the process of fixing violations.
Some examples: the linker and global opt.
2. This is a no-op in non-assert builds.
3. The full verification will only happen when -sil-verify-all is enabled.
Otherwise, we only check that when we delete a function, we had state for the
function.

rdar://42301529