### PR TITLE
Preserve specialized conformance better [4.2]

### DIFF
--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -181,6 +181,9 @@ public:
   /// Profile the substitution map, for use with LLVM's FoldingSet.
   void profile(llvm::FoldingSetNodeID &id) const;
 
+  const llvm::DenseMap<CanType, SmallVector<ProtocolConformanceRef, 1>> &
+  getConformanceMap() const { return conformanceMap; }
+  
 private:
   friend class GenericSignature;
   friend class GenericEnvironment;

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2920,7 +2920,8 @@ Optional<ProtocolConformanceRef>
 MakeAbstractConformanceForGenericType::operator()(CanType dependentType,
                                        Type conformingReplacementType,
                                        ProtocolType *conformedProtocol) const {
-  assert((conformingReplacementType->is<SubstitutableType>()
+  assert((conformingReplacementType->is<ErrorType>()
+          || conformingReplacementType->is<SubstitutableType>()
           || conformingReplacementType->is<DependentMemberType>())
          && "replacement requires looking up a concrete conformance");
   return ProtocolConformanceRef(conformedProtocol->getDecl());

--- a/validation-test/compiler_crashers_2_fixed/0168-rdar40164371.swift
+++ b/validation-test/compiler_crashers_2_fixed/0168-rdar40164371.swift
@@ -1,0 +1,44 @@
+// RUN: %target-swift-frontend -emit-sil %s
+
+protocol X1 {
+  associatedtype X3 : X4
+}
+
+protocol X4 {
+  associatedtype X15
+}
+
+protocol X7 { }
+
+protocol X9 : X7 {
+  associatedtype X10 : X7
+}
+
+struct X12 : X9 {
+  typealias X10 = X12
+}
+
+struct X13<I1 : X7> : X9 {
+  typealias X10 = X13<I1>
+}
+
+struct X14<G : X4> : X4 where G.X15 : X9 {
+  typealias X15 = X13<G.X15.X10>
+}
+
+struct X17<A : X4> : X1 where A.X15 == X12 {
+  typealias X3 = X14<A>
+}
+
+struct X18 : X4 {
+  typealias X15 = X12
+}
+
+@_transparent
+func callee<T>(_: T) where T : X1 {
+  let _: T.X3.X15? = nil
+}
+
+func caller(b: X17<X18>) {
+  callee(b)
+}


### PR DESCRIPTION
* Description: It's possible to have a substitution map where each generic parameter maps to itself, but some of the conformance requirements become concrete, because a same-type constraint in the generic signature makes an associated type of a generic parameter concrete. In a couple of places in the code, we would erroneously drop the substitutions from a specialized conformance in this scenario. This caused problems later when trying to resolve a nested type of the associated type that was subject to the concrete same type constraint.

* Origination: I suspect this was introduced at some point when we switched more of the conformance checking infrastructure over to use interface types, but I'm not sure.

* Scope of the issue: This problem would lead to hard-to-reduce crashes in various stages of the compiler, long after the original malformed AST was introduced in the type checker. It's hard to tell howe many people have hit this in the past, because without asserts this just shows up as a null pointer dereference when we notice a CanType we're working with is unexpectedly null.

* Risk: Low. I believe the new logic is "more obviously correct".

* Tested: New test case added.

* Reviewed by: @DougGregor LGTM'd this on master

* Radar: rdar://problem/40164371