### PR TITLE
Turn on formation of Const graph_op's in deabstraction even for the non-strict-deabstraction case

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -207,8 +207,7 @@ void TFDeabstraction::inlineCalls() {
 
     // Never inline _allocateUninitializedArray (even of Tensors).  It is the
     // entrypoint used by SILGen to represent array allocations.
-    if (TFStrictDeabstraction &&
-        callee.getName().contains("_allocateUninitializedArray"))
+    if (callee.getName().contains("_allocateUninitializedArray"))
       return false;
 
     // FIXME: This is a specific hack to inline literal conversion operations
@@ -221,8 +220,7 @@ void TFDeabstraction::inlineCalls() {
         callee.getName().contains("S10TensorFlow0A0VAAs13FloatingPointRzrlE12"
                                   "randomNormal4mean6stddev5s") ||
         callee.getName().contains("S10TensorFlow0A5ShapeV12arrayLiteral"
-                                  "ACs5Int32Vd_tcfC") ||
-        callee.getName().contains("_allocateUninitializedArray"))
+                                  "ACs5Int32Vd_tcfC"))
       if (!TFStrictDeabstraction)
         return true;
 
@@ -1581,9 +1579,6 @@ tryToPromoteTensorFromScalars(ApplyInst *inst,
 /// On success, this removes the applyexpr and returns a pointer to the new
 /// instruction that it created.  On failure, it returns a nullptr.
 ///
-/// FIXME: This is a near duplication of the logic used by TFPartitioning in
-/// SILTensorOpInfo::decodeTensorFromScalars1D.  When constexpr propagation is
-/// done, we should remove the logic in SILTensorOpInfo.
 static GraphOperationInst *
 tryToPromoteTensorFromScalars1D(ApplyInst *inst,
                           const DenseMap<SILValue, SymbolicValue> &constants,

--- a/lib/SILOptimizer/Mandatory/TFUtilities.h
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.h
@@ -580,7 +580,6 @@ private:
     bool containsTensorFlowValue(SILType ty) {
       return containsTensorFlowValue(ty.getASTType());
     }
-
   };
 
   /// Partitions an accelerator SIL function into a set of per-device SIL

--- a/test/TensorFlow/diagnostics-da.swift
+++ b/test/TensorFlow/diagnostics-da.swift
@@ -10,3 +10,8 @@ public func testDeviceInvalid() {
   TensorFlow.enableTPU() // expected-error {{device configuration specified multiple times}}
 }
 
+public func shapeError() {
+  // expected-error @+1 {{tensor literal should have 9 scalars for this shape, but has 8}}
+  let _ = Tensor<Float>(shape: [1, 3, 3, 1],
+                        scalars: [0, 1, 0, 1, 1, 1, 0, 1])
+}

--- a/test/TensorFlow/diagnostics.swift
+++ b/test/TensorFlow/diagnostics.swift
@@ -25,13 +25,6 @@ public func nonConstantAttribute(x: Tensor<Float>, padding: Padding) {
                       padding: padding))
 }
 
-public func shapeError() {
-  // expected-error @+1 {{tensor literal should have 9 scalars for this shape, but has 8}}
-  let _ = Tensor<Float>(shape: [1, 3, 3, 1],
-                        scalars: [0, 1, 0, 1, 1, 1, 0, 1])
-}
-
-
 class ClassTest {
   var w = Tensor<Float>(zeros: [1, 2])  // expected-warning {{value implicitly copied to the host}}
   let b = Tensor<Float>(zeros: [1, 2])

--- a/test/TensorFlow/integration.swift
+++ b/test/TensorFlow/integration.swift
@@ -435,7 +435,7 @@ public func testResourceAndVariants() {
 
 /*
 CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testResourceAndVariantsyyF
-CHECK:  [[values:%.*]] = builtin "__tfop_Const,value$tensor,$elt,$elt,$elt,$elt,$elt,$elt,shape$shape,$elt,dtype,__device"(
+CHECK:  [[values:%.*]] = graph_op "Const"() {dtype: $Float, value$tensor: {{.}}[f32 0x3F800000 /* 1 */], [f32 0x40000000 /* 2 */],
 CHECK:  [[dataset:%.*]] = builtin "__tfop_TensorDataSet,$in,Toutput_types$array,$elt,output_shapes$shapearray,$shape,$elt,__device"([[values]] : $TensorHandle<Float>
 CHECK:  [[iterator:%.*]] = builtin "__tfop_Iterator,shared_name,container,output_types$array,$elt,output_shapes$shapearray,$shape,$elt,__device"({{.*}} : $Builtin.RawPointer, {{.*}} : $Builtin.RawPointer
 CHECK:  builtin "__tfop_MakeIterator,$in,$in,__device"([[dataset]] : $VariantHandle, [[iterator]] : $ResourceHandle, {{.*}}) : $()
@@ -464,7 +464,7 @@ public func testNotInlined() {
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testNotInlined
-// CHECK: = builtin "__tfop_Const,
+// CHECK: = graph_op "Const"()
 // CHECK: [[RESULT:%.*]] = builtin "__tfop_Add,
 // CHECK: return [[RESULT]]
 // CHECK-LABEL: ---

--- a/test/TensorFlow/no_copy.swift
+++ b/test/TensorFlow/no_copy.swift
@@ -1,3 +1,4 @@
+// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s
 // RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s | %FileCheck %s
 
 import TensorFlow
@@ -47,10 +48,7 @@ public func testEmptyScalarsArray() {
  CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testEmptyScalarsArray
  CHECK: sil private @{{.*}}testEmptyScalarsArray{{.*}} : $@callee_owned () -> () {
  CHECK: bb0:
- CHECK: integer_literal $Builtin.Int32, 0
- CHECK: integer_literal $Builtin.Int32, 20
- CHECK: integer_literal $Builtin.Int32, 30
- CHECK: builtin "__tfop_Const,value$tensor,value$shape,$elt,$elt,$elt,dtype,__device"({{.*}} : $@thin Int32.Type, {{.*}} : $@thin Int32.Type, {{.*}} : $Builtin.Int32, {{.*}} : $Builtin.Int32, {{.*}} : $Builtin.Int32, {{.*}} : $@thin Int32.Type
+ CHECK: graph_op "Const"() {dtype: $Int32, value$tensor: [], value$shape: [[i32 0], [i32 20], [i32 30]]
  CHECK: builtin "__tfop_Add,$in,$in,T,__device"({{.*}} : $TensorHandle<Int32>, {{.*}} : $TensorHandle<Int32>
  */
 

--- a/test/TensorFlow/no_copy.swift
+++ b/test/TensorFlow/no_copy.swift
@@ -1,4 +1,3 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s
 // RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s | %FileCheck %s
 
 import TensorFlow
@@ -48,7 +47,7 @@ public func testEmptyScalarsArray() {
  CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testEmptyScalarsArray
  CHECK: sil private @{{.*}}testEmptyScalarsArray{{.*}} : $@callee_owned () -> () {
  CHECK: bb0:
- CHECK: graph_op "Const"() {dtype: $Int32, value$tensor: [], value$shape: [[i32 0], [i32 20], [i32 30]]
+ CHECK: graph_op "Const"() {dtype: $Int32, value$tensor: [], value$shape: {{.}}[i32 0], [i32 20], [i32 30]]
  CHECK: builtin "__tfop_Add,$in,$in,T,__device"({{.*}} : $TensorHandle<Int32>, {{.*}} : $TensorHandle<Int32>
  */
 

--- a/test/TensorFlow/playground_1.swift
+++ b/test/TensorFlow/playground_1.swift
@@ -39,7 +39,7 @@ func someLocalFunctionThatShouldBeForceInlined() {
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: main
 // CHECK: sil private @main.tf : $@callee_owned ()
-// CHECK:   builtin "__tfop_Const,
+// CHECK:   graph_op "Const"
 // CHECK:   builtin "__tfop_Add,
 // CHECK:   builtin "__tfop_Sub,
 // CHECK:   return


### PR DESCRIPTION
This will start producing graph_op in more cases, and inches towards strict deabstraction being on by default.

This will mostly be about updating testcases, which I'll iterate in the PR.