### PR TITLE
[RemoteMirrors] Rewrite the MachO reader path.

### DIFF
--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -202,10 +202,6 @@ public:
     if (!Buf)
       return false;
     auto HeaderMagic = reinterpret_cast<const uint32_t *>(Buf.get());
-    if (*HeaderMagic != llvm::MachO::MH_MAGIC &&
-        *HeaderMagic != llvm::MachO::MH_MAGIC_64)
-      return false;
-
     if (*HeaderMagic == llvm::MachO::MH_MAGIC)
       return readMachOSections<MachOTraits<4>>(ImageStart);
     if (*HeaderMagic == llvm::MachO::MH_MAGIC_64)

--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -215,7 +215,7 @@ public:
       return readMachOSections<MachOTraits<4>>(ImageStart);
     if (*HeaderMagic == llvm::MachO::MH_MAGIC_64)
       return readMachOSections<MachOTraits<8>>(ImageStart);
-    llvm_unreachable("invalid pointer size");
+    return false;
   }
 #endif // defined(__APPLE__) && defined(__MACH__)
   

--- a/tools/swift-reflection-dump/swift-reflection-dump.cpp
+++ b/tools/swift-reflection-dump/swift-reflection-dump.cpp
@@ -263,7 +263,12 @@ static int doDumpReflectionSections(ArrayRef<std::string> binaryFilenames,
     objectOwners.push_back(std::move(objectOwner));
     objectFiles.push_back(objectFile);
 
+#if defined(__APPLE__)
+    auto startAddress = (uintptr_t)objectFile->getData().begin();
+    context.addImage(RemoteAddress(startAddress));
+#else
     context.addReflectionInfo(findReflectionInfo(objectFile));
+#endif
   }
 
   switch (action) {


### PR DESCRIPTION
There are several problems fixed by this commit.
-> It removes the dependency on a system header.
-> It works when the pointer size for host and target don't match (i.e. 32-bits/64-bits and viceversa)
-> It reads the file lazily, mapping only the sections that are needed. The old approach mapped the whole __TEXT segment, causing significant slowdowns when trying to integrate this API in the debugger. Now it's almost instant (10 seconds vs milliseconds).
    
<rdar://problem/42306551>

