### PR TITLE
[libSyntax] Fix a crash that happened when parsing an invalid type

### DIFF
--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -1180,11 +1180,17 @@ Parser::parseTypeOptional(TypeRepr *base) {
   auto TyR = new (Context) OptionalTypeRepr(base, questionLoc);
   llvm::Optional<TypeSyntax> SyntaxNode;
   if (SyntaxContext->isEnabled()) {
-    OptionalTypeSyntaxBuilder Builder(Context.getSyntaxArena());
-    Builder
-      .useQuestionMark(SyntaxContext->popToken())
-      .useWrappedType(SyntaxContext->popIf<TypeSyntax>().getValue());
-    SyntaxNode.emplace(Builder.build());
+    auto QuestionMark = SyntaxContext->popToken();
+    if (auto WrappedType = SyntaxContext->popIf<TypeSyntax>()) {
+      OptionalTypeSyntaxBuilder Builder(Context.getSyntaxArena());
+      Builder
+        .useQuestionMark(QuestionMark)
+        .useWrappedType(WrappedType.getValue());
+      SyntaxNode.emplace(Builder.build());
+    } else {
+      // Undo the popping of the question mark
+      SyntaxContext->addSyntax(QuestionMark);
+    }
   }
   return makeSyntaxResult(SyntaxNode, TyR);
 }

--- a/test/Syntax/Outputs/round_trip_invalid.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_invalid.swift.withkinds
@@ -1,4 +1,4 @@
-<FunctionDecl>// RUN: rm -rf %t
+<VariableDecl>// RUN: rm -rf %t
 // RUN: %swift-syntax-test -input-source-filename %s -parse-gen > %t
 // RUN: diff -u %s %t
 // RUN: %swift-syntax-test -input-source-filename %s -parse-gen -print-node-kind > %t.withkinds
@@ -8,6 +8,8 @@
 // RUN: %swift-syntax-test -serialize-raw-tree -input-source-filename %s > %t.dump
 // RUN: %swift-syntax-test -deserialize-raw-tree -input-source-filename %t.dump -output-filename %t
 // RUN: diff -u %s %t
+
+let <PatternBinding><IdentifierPattern>strings</IdentifierPattern><TypeAnnotation>: [<SimpleTypeIdentifier>Strin</SimpleTypeIdentifier>[<UnresolvedPatternExpr><IdentifierPattern>g</IdentifierPattern></UnresolvedPatternExpr>]?</TypeAnnotation></PatternBinding></VariableDecl><FunctionDecl>
 
 // Function body without closing brace token.
 func foo<FunctionSignature><ParameterClause>() </ParameterClause></FunctionSignature><CodeBlock>{<VariableDecl>

--- a/test/Syntax/round_trip_invalid.swift
+++ b/test/Syntax/round_trip_invalid.swift
@@ -9,6 +9,8 @@
 // RUN: %swift-syntax-test -deserialize-raw-tree -input-source-filename %t.dump -output-filename %t
 // RUN: diff -u %s %t
 
+let strings: [Strin[g]?
+
 // Function body without closing brace token.
 func foo() {
   var a = 2

--- a/test/Syntax/round_trip_misc.swift
+++ b/test/Syntax/round_trip_misc.swift
@@ -28,3 +28,5 @@ typealias c = @foobar(a) () -> Void
 let d = \.foo
 let e = \.[1]
 let f = \.?.bar
+
+let optionalArray: [Int]?


### PR DESCRIPTION
When parsing an invalid type like `[Stri?ng]`, the syntax parser would crash because it was trying to build an `OptionalType` but the second entry on the stack was no `TypeSyntax` but a `TokenSyntax`.  

Fix this by checking if the second next node on the parsing stack is a `TypeSyntax` and if not, just push the nodes back onto the stack so that they can later be gathered into an unknown node.