### PR TITLE
[stdlib] Restore Sequence conformance to FlattenSequence.Iterator

### DIFF
--- a/stdlib/public/core/Flatten.swift
+++ b/stdlib/public/core/Flatten.swift
@@ -85,6 +85,8 @@ extension FlattenSequence.Iterator: IteratorProtocol {
   }
 }
 
+extension FlattenSequence.Iterator: Sequence { }
+
 extension FlattenSequence: Sequence {
   /// Returns an iterator over the elements of this sequence.
   ///

--- a/validation-test/stdlib/Collection/FlattenCollection.swift.gyb
+++ b/validation-test/stdlib/Collection/FlattenCollection.swift.gyb
@@ -66,9 +66,14 @@ tests.test("FlattenCollection instances (${traversal}${kind})") {
   do {
     let expected = ["apple", "orange", "banana", "grapefruit", "lychee"]
     let base = [["apple", "orange"], ["banana", "grapefruit"], ["lychee"]]
+    let flattened = Minimal${traversal}${kind}(elements: base).joined()
     check${traversal}${kind}(
       expected,
       Minimal${traversal}${kind}(elements: base).joined(),
+      sameValue: { $0 == $1 })
+    checkSequence(
+      expected,
+      flattened.makeIterator(),
       sameValue: { $0 == $1 })
   }
 }


### PR DESCRIPTION
This was dropped during the refactor that nested the iterator. Adds a test to check it.