### PR TITLE
Sema: Fix availability of inherited designated initializers, part 2

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -2404,8 +2404,20 @@ static void configureDesignatedInitAttributes(TypeChecker &tc,
   // If the superclass has its own availability, make sure the synthesized
   // constructor is only as available as its superclass's constructor.
   if (superclassCtor->getAttrs().hasAttribute<AvailableAttr>()) {
+    SmallVector<Decl *, 2> asAvailableAs;
+
+    // We don't have to look at enclosing contexts of the superclass constructor,
+    // because designated initializers must always be defined in the superclass
+    // body, and we already enforce that a superclass is at least as available as
+    // a subclass.
+    asAvailableAs.push_back(superclassCtor);
+    Decl *parentDecl = classDecl;
+    while (parentDecl != nullptr) {
+      asAvailableAs.push_back(parentDecl);
+      parentDecl = parentDecl->getDeclContext()->getAsDeclOrDeclExtensionContext();
+    }
     AvailabilityInference::applyInferredAvailableAttrs(
-        ctor, {classDecl, superclassCtor}, ctx);
+        ctor, asAvailableAs, ctx);
   }
 
   // Wire up the overrides.

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -998,6 +998,11 @@ class WidelyAvailableBase {
 @available(OSX, introduced: 10.53)
 class EsotericSmallBatchHipsterThing : WidelyAvailableBase {}
 
+@available(OSX, introduced: 10.53)
+class NestedClassTest {
+  class InnerClass : WidelyAvailableBase {}
+}
+
 // Useless #available(...) checks
 
 func functionWithDefaultAvailabilityAndUselessCheck(_ p: Bool) {

--- a/test/Sema/availability_versions_multi.swift
+++ b/test/Sema/availability_versions_multi.swift
@@ -35,14 +35,16 @@ func useFromOtherOn10_51() {
   _ = o10_51.returns10_52Introduced10_52() // expected-error {{'returns10_52Introduced10_52()' is only available on OS X 10.52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  _ = OtherIntroduced10_52() // expected-error {{'OtherIntroduced10_52' is only available on OS X 10.52 or newer}}
-      // expected-note@-1 {{add 'if #available' version check}}
+  _ = OtherIntroduced10_52()
+      // expected-error@-1 {{'OtherIntroduced10_52' is only available on OS X 10.52 or newer}}
+      // expected-note@-2 {{add 'if #available' version check}}
 
   o10_51.extensionMethodOnOtherIntroduced10_51AvailableOn10_52() // expected-error {{'extensionMethodOnOtherIntroduced10_51AvailableOn10_52()' is only available on OS X 10.52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  _ = OtherIntroduced10_51.NestedIntroduced10_52() // expected-error {{'NestedIntroduced10_52' is only available on OS X 10.52 or newer}}
-      // expected-note@-1 {{add 'if #available' version check}}
+  _ = OtherIntroduced10_51.NestedIntroduced10_52()
+      // expected-error@-1 {{'NestedIntroduced10_52' is only available on OS X 10.52 or newer}}
+      // expected-note@-2 {{add 'if #available' version check}}
 }
 
 @available(OSX, introduced: 10.52)


### PR DESCRIPTION
We need to explicitly handle nested types here.

Fixes the (re-opened) <rdar://problem/40853731>,
<https://bugs.swift.org/browse/SR-7881>.