### PR TITLE
[4 2][stdlib] Restore Sequence conformance to FlattenSequence.Iterator

### DIFF
--- a/stdlib/public/core/Flatten.swift
+++ b/stdlib/public/core/Flatten.swift
@@ -85,6 +85,8 @@ extension FlattenSequence.Iterator: IteratorProtocol {
   }
 }
 
+extension FlattenSequence.Iterator: Sequence { }
+
 extension FlattenSequence: Sequence {
   /// Returns an iterator over the elements of this sequence.
   ///

--- a/validation-test/stdlib/Collection/FlattenCollection.swift.gyb
+++ b/validation-test/stdlib/Collection/FlattenCollection.swift.gyb
@@ -66,9 +66,14 @@ tests.test("FlattenCollection instances (${traversal}${kind})") {
   do {
     let expected = ["apple", "orange", "banana", "grapefruit", "lychee"]
     let base = [["apple", "orange"], ["banana", "grapefruit"], ["lychee"]]
+    let flattened = Minimal${traversal}${kind}(elements: base).joined()
     check${traversal}${kind}(
       expected,
       Minimal${traversal}${kind}(elements: base).joined(),
+      sameValue: { $0 == $1 })
+    checkSequence(
+      expected,
+      flattened.makeIterator(),
       sameValue: { $0 == $1 })
   }
 }


### PR DESCRIPTION
Cherry-pick of #18024

- **Explanation**: This conformance was dropped during the refactoring that nested the iterator in 4.2.
- **Scope**: Small, just adding a conformance to one type.
- **Issue**: rdar://problem/42312634
- **Risk**: Very low. Adds a defaulted conformance that was previously present on this type.
- **Testing**: Existing test cases, plus one to check for this conformance, that was missing.
- **Reviewed By**: @moiseev
