### PR TITLE
[AutoDiff] Part 1: Add support for delayed gradients in AD configuration. 

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -19,6 +19,7 @@
 #define SWIFT_AST_AUTODIFF_H
 
 #include "ASTContext.h"
+#include "llvm/ADT/SmallBitVector.h"
 
 namespace swift {
 
@@ -50,7 +51,7 @@ public:
     : Loc(loc), Kind(kind), V(value) {}
 
   static AutoDiffParameter getIndexParameter(SourceLoc loc, unsigned index) {
-    return { loc, Kind::Index, { index } };
+    return { loc, Kind::Index, index };
   }
 
   static AutoDiffParameter getSelfParameter(SourceLoc loc) {
@@ -70,38 +71,135 @@ public:
     return Loc;
   }
 
-  bool isEqual(AutoDiffParameter other) const {
+  bool isEqual(const AutoDiffParameter &other) const {
     if (getKind() == other.getKind() && getKind() == Kind::Index)
       return getIndex() == other.getIndex();
     return getKind() == other.getKind() && getKind() == Kind::Self;
   }
 };
 
+/// SIL-level automatic differentiation indices. Consists of a source index,
+/// i.e. index of the dependent result to differentiate from, and parameter
+/// indices, i.e. index of independent parameters to differentiate with
+/// respect to.
+struct SILReverseAutoDiffIndices {
+  /// The index of the dependent result to differentiate from.
+  unsigned source;
+  /// Indices of independent parameters to differentiate with respect to.
+  llvm::SmallBitVector parameters;
+  
+  /// Creates a set of AD indices from the given source index and a bit vector
+  /// representing parameter indices.
+  /*implicit*/ SILReverseAutoDiffIndices(unsigned source,
+                                         llvm::SmallBitVector parameters)
+    : source(source), parameters(parameters) {}
+  
+  /// Creates a set of AD indices from the given source index and an array of
+  /// parameter indices. Elements in `parameters` must be acending integers.
+  /*implicit*/ SILReverseAutoDiffIndices(unsigned source,
+                                         ArrayRef<unsigned> parameters);
+
+  bool operator==(const SILReverseAutoDiffIndices &other) const {
+    return source == other.source && !parameters.test(other.parameters);
+  }
+
+  void print(llvm::raw_ostream &s = llvm::outs()) const {
+    s << "(source=" << source << " parameters=(";
+    interleave(parameters.set_bits(),
+               [&s](unsigned p) { s << p; }, [&s]{ s << ' '; });
+    s << "))";
+  }
+};
+
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &s,
+                                     const SILReverseAutoDiffIndices &indices) {
+  indices.print(s);
+  return s;
+}
+
+/// Flags to define the semantics and the type signature of a gradient function.
+enum class SILGradientFlags : unsigned {
+  /// The gradient function is seedable, i.e. able to take a back-propagated
+  /// adjoint value as the last parameter.
+  Seedable = 1 << 0,
+  
+  /// The gradient function is preserving the result of the original function.
+  PreservingResult = 1 << 1,
+  
+  /// The adjoint computation is "delayed". We say that the adjoint computation
+  /// is delayed when when it's returned as a thunk.
+  Delayed = 1 << 2
+};
+using SILGradientOptions = OptionSet<SILGradientFlags>;
+static inline SILGradientOptions operator|(SILGradientFlags lhs,
+                                           SILGradientFlags rhs) {
+  return SILGradientOptions(unsigned(lhs) | unsigned(rhs));
+}
+
 /// SIL-level automatic differentiation configuration.
 struct SILReverseAutoDiffConfiguration {
-  unsigned sourceIndex;
-  ArrayRef<unsigned> parameterIndices;
-  bool seedable;
-  bool preservingResult;
+  SILReverseAutoDiffIndices indices;
+  SILGradientOptions options;
+
+  /*implicit*/
+  SILReverseAutoDiffConfiguration(SILReverseAutoDiffIndices indices,
+                                  SILGradientOptions options)
+    : indices(indices), options(options) {}
+
+  /*implicit*/
+  SILReverseAutoDiffConfiguration(SILReverseAutoDiffIndices indices,
+                                  bool seedable, bool preservingResult)
+    : SILReverseAutoDiffConfiguration(indices, getCanonicalGradientOptions()) {}
+
+  unsigned getSourceIndex() const {
+    return indices.source;
+  }
+
+  llvm::SmallBitVector getParameterIndices() const {
+    return indices.parameters;
+  }
+
+  bool isSeedable() const {
+    return options.contains(SILGradientFlags::Seedable);
+  }
+
+  bool isPreservingResult() const {
+    return options.contains(SILGradientFlags::PreservingResult);
+  }
+
+  bool isDelayed() const {
+    return options.contains(SILGradientFlags::Delayed);
+  }
+
+  // FIXME: The master configuration should have all three gradient options
+  // enabled, that is, the canonical gradient should return a delayed gradient
+  // function. We need to handle this here as well as within the
+  // differentiation pass.
+  static SILGradientOptions getCanonicalGradientOptions() {
+    return SILGradientFlags::Seedable | SILGradientFlags::PreservingResult;
+  }
 
   /// Returns the "master" configuration, which all variants with the same
   /// parameter indices can derive from.
   static
-  SILReverseAutoDiffConfiguration getMaster(unsigned sourceIndex,
-                                            ArrayRef<unsigned> paramIndices) {
-    return { sourceIndex, paramIndices,
-             /*seedable*/ true, /*preservingResult*/ true };
+  SILReverseAutoDiffConfiguration getMaster(SILReverseAutoDiffIndices indices) {
+    return {
+      indices,
+      getCanonicalGradientOptions()
+    };
   }
 
-  bool isEqual(const SILReverseAutoDiffConfiguration &other) const {
-    return sourceIndex == other.sourceIndex &&
-           parameterIndices.equals(other.parameterIndices) &&
-           seedable == other.seedable &&
-           preservingResult == other.preservingResult;
+  SILReverseAutoDiffConfiguration getWithCanonicalOptions() const {
+    return getMaster(indices);
   }
 
   bool isMaster() const {
-    return seedable && preservingResult;
+    return options.toRaw() == getCanonicalGradientOptions().toRaw();
+  }
+
+  bool operator==(const SILReverseAutoDiffConfiguration &other) const {
+    return indices == other.indices &&
+           options.toRaw() == other.options.toRaw();
   }
 };
 
@@ -109,47 +207,61 @@ struct SILReverseAutoDiffConfiguration {
 
 namespace llvm {
 
+using swift::SILReverseAutoDiffIndices;
 using swift::SILReverseAutoDiffConfiguration;
+using swift::SILGradientFlags;
+using swift::OptionSet;
 
 template<typename T> struct DenseMapInfo;
 
+template<> struct DenseMapInfo<SILReverseAutoDiffIndices> {
+  static SILReverseAutoDiffIndices getEmptyKey() {
+    return { DenseMapInfo<unsigned>::getEmptyKey(), SmallBitVector() };
+  }
+
+  static SILReverseAutoDiffIndices getTombstoneKey() {
+    return { DenseMapInfo<unsigned>::getTombstoneKey(),
+             SmallBitVector(sizeof(intptr_t), true) };
+  }
+
+  static unsigned getHashValue(const SILReverseAutoDiffIndices &Val) {
+    auto params = Val.parameters.set_bits();
+    unsigned combinedHash =
+      hash_combine(~1U, DenseMapInfo<unsigned>::getHashValue(Val.source),
+                   hash_combine_range(params.begin(), params.end()));
+    return combinedHash;
+  }
+
+  static bool isEqual(const SILReverseAutoDiffIndices &LHS,
+                      const SILReverseAutoDiffIndices &RHS) {
+    return LHS == RHS;
+  }
+};
+
 template<> struct DenseMapInfo<SILReverseAutoDiffConfiguration> {
   static SILReverseAutoDiffConfiguration getEmptyKey() {
-    return { DenseMapInfo<unsigned>::getEmptyKey(),
-             DenseMapInfo<ArrayRef<unsigned>>::getEmptyKey(),
-             static_cast<bool>(DenseMapInfo<unsigned>::getEmptyKey()),
-             static_cast<bool>(DenseMapInfo<unsigned>::getEmptyKey()) };
+    return { DenseMapInfo<SILReverseAutoDiffIndices>::getEmptyKey(), None };
   }
 
   static SILReverseAutoDiffConfiguration getTombstoneKey() {
-    return { DenseMapInfo<unsigned>::getTombstoneKey(),
-             DenseMapInfo<ArrayRef<unsigned>>::getTombstoneKey(),
-             static_cast<bool>(DenseMapInfo<unsigned>::getTombstoneKey()),
-             static_cast<bool>(DenseMapInfo<unsigned>::getTombstoneKey()) };
+    return {
+      DenseMapInfo<SILReverseAutoDiffIndices>::getTombstoneKey(),
+      SILGradientFlags::Delayed
+    };
   }
 
   static unsigned getHashValue(const SILReverseAutoDiffConfiguration &Val) {
-    unsigned paramHash = ~1U;
-    for (auto i : Val.parameterIndices)
-      paramHash = hash_combine(paramHash,
-                               DenseMapInfo<unsigned>::getHashValue(i));
     return hash_combine(
-      paramHash,
-      DenseMapInfo<unsigned>::getHashValue(Val.seedable),
-      DenseMapInfo<unsigned>::getHashValue(Val.preservingResult)
+      DenseMapInfo<SILReverseAutoDiffIndices>::getHashValue(Val.indices),
+      DenseMapInfo<unsigned>::getHashValue(Val.options.toRaw())
     );
   }
 
   static bool isEqual(const SILReverseAutoDiffConfiguration &LHS,
                       const SILReverseAutoDiffConfiguration &RHS) {
-    auto numParams = LHS.parameterIndices.size();
-    if (numParams != RHS.parameterIndices.size())
-      return false;
-    for (unsigned i = 0; i < numParams; i++)
-      if (LHS.parameterIndices[i] != RHS.parameterIndices[i])
-        return false;
-    return LHS.seedable == RHS.seedable &&
-           LHS.preservingResult == LHS.preservingResult;
+    return DenseMapInfo<SILReverseAutoDiffIndices>
+             ::isEqual(LHS.indices, RHS.indices) &&
+           LHS.options.toRaw() == RHS.options.toRaw();
   }
 };
 

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1501,6 +1501,12 @@ ERROR(sil_reverse_autodiff_expected_source_index,PointsToFirstBadToken,
 ERROR(sil_reverse_autodiff_expected_parameter_index,PointsToFirstBadToken,
       "expected the index of a parameter to differentiate with respect to", ())
 
+ERROR(sil_reverse_autodiff_expected_option,PointsToFirstBadToken,
+      "expected a gradient option: 'seedable', 'preserving_result' or 'delayed'", ())
+
+ERROR(sil_reverse_autodiff_duplicate_option,PointsToFirstBadToken,
+      "duplicate gradient option", ())
+
 ERROR(sil_gradient_invalid_seed_type,PointsToFirstBadToken,
       "expected seed '%0' to have type %1", (StringRef, Type))
 

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -476,12 +476,10 @@ public:
 
   /// SWIFT_ENABLE_TENSORFLOW
   GradientInst *createGradient(SILLocation loc, SILValue original,
-                               unsigned sourceIndex,
-                               ArrayRef<unsigned> paramIndices, bool seedable,
-                               bool preservingResult) {
+                               SILReverseAutoDiffIndices indices,
+                               SILGradientOptions options) {
     return insert(GradientInst::create(getModule(), getSILDebugLocation(loc),
-                                       original, sourceIndex, paramIndices,
-                                       seedable, preservingResult));
+                                       original, indices, options));
   }
 
   BuiltinInst *createBuiltin(SILLocation Loc, Identifier Name, SILType ResultTy,

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -659,10 +659,8 @@ SILCloner<ImplClass>::visitGradientInst(GradientInst *Inst) {
   doPostProcess(Inst,
     getBuilder().createGradient(getOpLocation(Inst->getLoc()),
                                 getOpValue(Inst->getOriginal()),
-                                Inst->getSourceIndex(),
-                                Inst->getParameterIndices(),
-                                Inst->isSeedable(),
-                                Inst->isPreservingResult()));
+                                Inst->getIndices(),
+                                Inst->getOptions()));
 }
 
 template<typename ImplClass>

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -114,38 +114,29 @@ class SILReverseDifferentiableAttr final {
   friend SILFunction;
 
 private:
-  /// The index of the original result to differentiate from.
-  unsigned SourceIndex;
-  /// The number of parameters of the original function to differentiate with
-  /// respect to.
-  unsigned NumParamIndices;
+  /// The AD indices.
+  SILReverseAutoDiffIndices indices;
   /// The primal and adjoint function names.
   StringRef PrimalName, AdjointName;
   /// Constructor, copying parameter indices to the trailing buffer.
-  SILReverseDifferentiableAttr(unsigned sourceIndex,
-                               ArrayRef<unsigned> paramIndices,
+  SILReverseDifferentiableAttr(SILReverseAutoDiffIndices indices,
                                StringRef primalName,
                                StringRef adjointName);
 
 public:
   static SILReverseDifferentiableAttr *create(
-    SILModule &M, unsigned sourceIndex, ArrayRef<unsigned> paramIndices,
-    StringRef primalName = StringRef(),
-    StringRef adjointName = StringRef());
-
-  StringRef getPrimalName() const { return PrimalName; }
+      SILModule &M, SILReverseAutoDiffIndices indices,
+      StringRef primalName = StringRef(), StringRef adjointName = StringRef());
+  
+  bool hasPrimal() const { return !PrimalName.empty(); }
+  StringRef getPrimalName() const { assert(hasPrimal()); return PrimalName; }
   void setPrimalName(StringRef name) { PrimalName = name; }
-  StringRef getAdjointName() const { return AdjointName; }
+
+  bool hasAdjoint() const { return !AdjointName.empty(); }
+  StringRef getAdjointName() const { assert(hasAdjoint()); return AdjointName; }
   void setAdjointName(StringRef name) { AdjointName = name; }
 
-  unsigned getSourceIndex() const {
-    return SourceIndex;
-  }
-  
-  ArrayRef<unsigned> getParamIndices() const;
-  unsigned *getParamIndicesData() {
-    return reinterpret_cast<unsigned *>(this+1);
-  }
+  SILReverseAutoDiffIndices getIndices() const { return indices; }
 
   void print(llvm::raw_ostream &OS) const;
 };

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -1,0 +1,28 @@
+//===-------- AutoDiff.cpp - Routines for USR generation ------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/AutoDiff.h"
+#include "swift/Basic/LLVM.h"
+
+using namespace swift;
+
+SILReverseAutoDiffIndices::SILReverseAutoDiffIndices(
+    unsigned source, ArrayRef<unsigned> parameters) : source(source) {
+  auto max = *std::max_element(parameters.begin(), parameters.end());
+  this->parameters.resize(max + 1);
+  int last = -1;
+  for (auto paramIdx : parameters) {
+    assert((int)paramIdx > last && "Parameter indices must be ascending");
+    last = paramIdx;
+    this->parameters.set(paramIdx);
+  }
+}

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -15,6 +15,8 @@ add_swift_library(swiftAST STATIC
   ASTVerifier.cpp
   ASTWalker.cpp
   Attr.cpp
+  # SWIFT_ENABLE_TENSORFLOW
+  AutoDiff.cpp
   Availability.cpp
   AvailabilitySpec.cpp
   Builtins.cpp

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -1109,6 +1109,7 @@ static bool parseReverseDifferentiableAttr(
   // Function that parses an index into `ParamIndices`. Returns true on error.
   auto parseParam = [&]() -> bool {
     unsigned Index;
+    // TODO: Reject non-ascending parameter index lists.
     if (P.parseUnsignedInteger(Index, LastLoc,
           diag::sil_reverse_autodiff_expected_parameter_index))
       return true;
@@ -1146,9 +1147,8 @@ static bool parseReverseDifferentiableAttr(
                    diag::sil_attr_differentiable_expected_rsquare))
     return true;
   // Create an AdjointAttr and we are done.
-  auto *Attr =
-    SILReverseDifferentiableAttr::create(SP.SILMod, SourceIndex, ParamIndices,
-                                         PrimName.str(), AdjName.str());
+  auto *Attr = SILReverseDifferentiableAttr::create(
+      SP.SILMod, {SourceIndex, ParamIndices}, PrimName.str(), AdjName.str());
   DAs.push_back(Attr);
   return false;
 }
@@ -2812,9 +2812,10 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     if (P.parseToken(tok::l_square, diag::expected_tok_in_sil_instr, "[") ||
         parseVerbatim("wrt"))
       return true;
-    auto parseIndex = [&] {
+    auto parseIndex = [&]() -> bool {
       unsigned index;
       SourceLoc indexLoc;
+      // TODO: Reject non-ascending parameter index lists.
       if (P.parseUnsignedInteger(index, indexLoc,
                            diag::sil_reverse_autodiff_expected_parameter_index))
         return true;
@@ -2828,24 +2829,30 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
         return true;
     if (P.parseToken(tok::r_square, diag::expected_tok_in_sil_instr, "]"))
       return true;
-    // Parse optional [seedable] and optional [preserving_result].
-    bool seedable = false;
-    bool preservingResult = false;
-    if (P.peekToken().getText() != "preserving_result" &&
-        P.consumeIf(tok::l_square)) {
-      if (P.Tok.getText() != "preserving_result") {
-        if (parseVerbatim("seedable") ||
-            P.parseToken(tok::r_square, diag::expected_tok_in_sil_instr, "]"))
-          return true;
-        seedable = true;
-      }
-    }
-    if (P.consumeIf(tok::l_square)) {
-      if (parseVerbatim("preserving_result") ||
-          P.parseToken(tok::r_square, diag::expected_tok_in_sil_instr, "]"))
+    // Parse optional [seedable], [preserving_result] and [delayed].
+    SILGradientOptions existingOptions;
+    auto parseOption = [&]() -> bool {
+      SILGradientOptions option =
+        llvm::StringSwitch<SILGradientOptions>(P.Tok.getText())
+          .Case("seedable", SILGradientFlags::Seedable)
+          .Case("preserving_result", SILGradientFlags::PreservingResult)
+          .Case("delayed", SILGradientFlags::Delayed)
+          .Default(None);
+      P.consumeToken(tok::identifier);
+      if (!option) {
+        P.diagnose(P.Tok, diag::sil_reverse_autodiff_expected_option);
         return true;
-      preservingResult = true;
-    }
+      }
+      if (existingOptions.contains(option)) {
+        P.diagnose(P.Tok, diag::sil_reverse_autodiff_duplicate_option);
+        return true;
+      }
+      existingOptions |= option;
+      return P.parseToken(tok::r_square, diag::expected_tok_in_sil_instr, "]");
+    };
+    while (P.consumeIf(tok::l_square))
+      if (parseOption())
+        return true;
     // Parse original function value.
     UnresolvedValueName originalName;
     SILType originalTy;
@@ -2860,11 +2867,10 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
       return true;
     }
     SILValue original = getLocalValue(originalName, originalTy, InstLoc, B);
-
     if (parseSILDebugLocation(InstLoc, B))
       return true;
-    ResultVal = B.createGradient(
-      InstLoc, original, sourceIndex, paramIndices, seedable, preservingResult);
+    SILReverseAutoDiffIndices indices(sourceIndex, paramIndices);
+    ResultVal = B.createGradient(InstLoc, original, indices, existingOptions);
     break;
   }
 

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -58,33 +58,20 @@ void SILFunction::addSpecializeAttr(SILSpecializeAttr *Attr) {
 
 /// SWIFT_ENABLE_TENSORFLOW
 SILReverseDifferentiableAttr::
-SILReverseDifferentiableAttr(unsigned sourceIndex,
-                             ArrayRef<unsigned> paramIndices,
+SILReverseDifferentiableAttr(SILReverseAutoDiffIndices indices,
                              StringRef primalName,
                              StringRef adjointName)
-  : SourceIndex(sourceIndex), NumParamIndices(paramIndices.size()),
-    PrimalName(primalName), AdjointName(adjointName) {
-  std::copy(paramIndices.begin(), paramIndices.end(), getParamIndicesData());
-}
+  : indices(indices), PrimalName(primalName), AdjointName(adjointName) {}
 
 SILReverseDifferentiableAttr *
 SILReverseDifferentiableAttr::create(SILModule &M,
-                                     unsigned sourceIndex,
-                                     ArrayRef<unsigned> paramIndices,
+                                     SILReverseAutoDiffIndices indices,
                                      StringRef primalName,
                                      StringRef adjointName) {
-  size_t size = sizeof(SILReverseDifferentiableAttr)
-    + paramIndices.size() * sizeof(unsigned);
-  void *mem = M.allocate(size, alignof(SILReverseDifferentiableAttr));
-  return ::new (mem) SILReverseDifferentiableAttr(sourceIndex, paramIndices,
-                                                  primalName, adjointName);
-}
-
-ArrayRef<unsigned> SILReverseDifferentiableAttr::getParamIndices() const {
-  return {
-    const_cast<SILReverseDifferentiableAttr *>(this)->getParamIndicesData(),
-    NumParamIndices
-  };
+  void *mem = M.allocate(sizeof(SILReverseDifferentiableAttr),
+                         alignof(SILReverseDifferentiableAttr));
+  return ::new (mem)
+      SILReverseDifferentiableAttr(indices, primalName, adjointName);
 }
 
 SILFunction *SILFunction::create(

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -581,52 +581,34 @@ TryApplyInst *TryApplyInst::create(
 
 /// SWIFT_ENABLE_TENSORFLOW
 GradientInst::GradientInst(SILModule &module, SILDebugLocation debugLoc,
-                           SILValue original, unsigned sourceIndex,
-                           ArrayRef<unsigned> paramIndices,
-                           bool seedable, bool preservingResult)
-  : InstructionBase(debugLoc, getGradientSILType(module, original, sourceIndex,
-                                                 paramIndices, seedable,
-                                                 preservingResult)),
-    SourceIndex(sourceIndex),
-    NumParamIndices(paramIndices.size()), Seedable(seedable),
-    PreservingResult(preservingResult), Operands(this, original) {
-  std::copy(paramIndices.begin(), paramIndices.end(),
-            getParameterIndicesData());
-}
+                           SILValue original, SILReverseAutoDiffIndices indices,
+                           SILGradientOptions options)
+  : InstructionBase(debugLoc,
+                    getGradientSILType(module, original, indices, options)),
+    Indices(indices), Options(options),
+    Operands(this, original) {}
 
 SILType GradientInst::getGradientSILType(SILModule &module, SILValue original,
-                                         unsigned sourceIndex,
-                                         ArrayRef<unsigned> paramIndices,
-                                         bool seedable,
-                                         bool preservingResult) {
+                                         SILReverseAutoDiffIndices indices,
+                                         SILGradientOptions options) {
   // If parameter indices are empty, return an invalid type (empty tuple type).
   // An "empty parameter indices" will be produced during verification.
-  if (paramIndices.empty()) {
+  if (indices.parameters.none()) {
     auto invalidTy = TupleType::get({}, module.getASTContext());
     return SILType::getPrimitiveObjectType(CanType(invalidTy));
   }
-  SILReverseAutoDiffConfiguration config =
-    { sourceIndex, paramIndices, seedable, preservingResult };
-  auto origFnTy = original->getType().getAs<SILFunctionType>();
+  SILReverseAutoDiffConfiguration config(indices, options);
+  auto origFnTy = original->getType().castTo<SILFunctionType>();
   auto gradFnTy = origFnTy->getGradientType(config, module);
   return SILType::getPrimitiveObjectType(gradFnTy->getCanonicalType());
 }
 
 GradientInst *
 GradientInst::create(SILModule &M, SILDebugLocation debugLoc,
-                     SILValue original, unsigned sourceIndex,
-                     ArrayRef<unsigned> paramIndices,
-                     bool seedable, bool preservingResult) {
-  unsigned size = sizeof(GradientInst) + paramIndices.size() * sizeof(unsigned);
-  void *buffer = M.allocateInst(size, alignof(GradientInst));
-  return ::new (buffer) GradientInst(M, debugLoc, original, sourceIndex,
-                                     paramIndices, seedable, preservingResult);
-}
-
-ArrayRef<unsigned> GradientInst::getParameterIndices() const {
-  return {
-    const_cast<GradientInst *>(this)->getParameterIndicesData(), NumParamIndices
-  };
+                     SILValue original, SILReverseAutoDiffIndices indices,
+                     SILGradientOptions options) {
+  void *buffer = M.allocateInst(sizeof(GradientInst), alignof(GradientInst));
+  return ::new (buffer) GradientInst(M, debugLoc, original, indices, options);
 }
 
 FunctionRefInst::FunctionRefInst(SILDebugLocation Loc, SILFunction *F)

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1151,10 +1151,11 @@ public:
 
   /// SWIFT_ENABLE_TENSORFLOW
   void visitGradientInst(GradientInst *GI) {
-    *this << "[source " << GI->getSourceIndex() << "] ";
-    if (!GI->getParameterIndices().empty()) {
+    auto indices = GI->getIndices();
+    *this << "[source " << indices.source << "] ";
+    if (!indices.parameters.empty()) {
       *this << "[wrt ";
-      interleave(GI->getParameterIndices(), [&](unsigned idx) {
+      interleave(indices.parameters.set_bits(), [&](unsigned idx) {
         *this << idx;
       }, [&]{
         *this << ", ";
@@ -3176,8 +3177,9 @@ void SILSpecializeAttr::print(llvm::raw_ostream &OS) const {
 
 /// SWIFT_ENABLE_TENSORFLOW
 void SILReverseDifferentiableAttr::print(llvm::raw_ostream &OS) const {
-  OS << "source " << getSourceIndex() << " wrt ";
-  interleave(getParamIndices(),
+  auto indices = getIndices();
+  OS << "source " << indices.source << " wrt ";
+  interleave(indices.parameters.set_bits(),
              [&](unsigned index) { OS << index; },
              [&] { OS << ", "; });
   if (!PrimalName.empty()) OS << " primal @" << PrimalName;

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2789,7 +2789,8 @@ visitInterpolatedStringLiteralExpr(InterpolatedStringLiteralExpr *E,
 
 /// SWIFT_ENABLE_TENSORFLOW
 static RValue emitGradientInst(RValueEmitter &RVE, const SGFContext &C,
-                               ReverseAutoDiffExpr *E, bool isValueAndGrad) {
+                               ReverseAutoDiffExpr *E,
+                               SILGradientOptions options = None) {
   SILLocation loc(E);
   auto *origExpr = E->getOriginalExpr();
   auto origTy = origExpr->getType()->getAs<AnyFunctionType>();
@@ -2800,7 +2801,7 @@ static RValue emitGradientInst(RValueEmitter &RVE, const SGFContext &C,
   // If no differentiation parameters are specified, differentiation is done
   // with respect to all of original's parameters.
   if (E->getParameters().empty()) {
-    for (unsigned i : range(0, origTy->getNumParams()))
+    for (unsigned i : range(origTy->getNumParams()))
       allParamIndices.push_back({ E->getStartLoc(), i });
     diffParams = allParamIndices;
   }
@@ -2808,26 +2809,23 @@ static RValue emitGradientInst(RValueEmitter &RVE, const SGFContext &C,
   for (auto param : diffParams) {
     auto silParamIndices =
       RVE.SGF.SGM.getLoweredFunctionParameterIndex(param.index, origTy);
-    for (auto idx : silParamIndices)
-      loweredParamIndices.push_back(idx);
+    loweredParamIndices.append(silParamIndices.begin(), silParamIndices.end());
   }
+  SILReverseAutoDiffIndices indices(/*sourceIndex*/ 0, loweredParamIndices);
   auto gradInst = RVE.SGF.B.createGradient(loc, origVal.forward(RVE.SGF),
-                                           /*sourceIndex*/ 0,
-                                           loweredParamIndices,
-                                           /*seedable*/ false,
-                                           /*preservingResult*/ isValueAndGrad);
+                                           indices, options);
   ManagedValue v = RVE.SGF.emitManagedRValueWithCleanup(gradInst);
   return RValue(RVE.SGF, E, v);
 }
 
 RValue RValueEmitter::
 visitGradientExpr(GradientExpr *E, SGFContext C) {
-  return emitGradientInst(*this, C, E, /*isValueAndGrad*/ false);
+  return emitGradientInst(*this, C, E);
 }
 
 RValue RValueEmitter::
 visitValueAndGradientExpr(ValueAndGradientExpr *E, SGFContext C) {
-  return emitGradientInst(*this, C, E, /*isValueAndGrad*/ true);
+  return emitGradientInst(*this, C, E, SILGradientFlags::PreservingResult);
 }
 
 // SWIFT_ENABLE_TENSORFLOW


### PR DESCRIPTION
(Split from megapatch #17901)

This patch adds support for delayed gradients in AD configuration and merges `[seedable]`, `[preserving_result]` and `[delayed]` to an option set `SILGradientOptions`. This change is reflected on the differential operator in SIL, aka. the `gradient` instruction.

```
%0 = function_ref @foo : $(Float, Float) -> Float
%1 = gradient [source 0] [wrt 0, 1] [seedable] [preserving_result] [delayed] %0 : $(Float, Float) -> Float
// %1 has type $(Float, Float) -> (Float, @convention(thin) (Float) -> (Float, Float))
```

A seedable, result-preserving, delayed gradient takes the original parameters of function `@foo`, and returns a tuple of the original results and a thin closure that takes a seed and returns the partial derivatives.

**TODO:** The support for delayed gradient isn't complete. We need to change the canonical gradient options to include `SILGradientOptions::Delayed`, and change Differentiation pass to synthesize calls to the new canonical gradient.

Also included:
* NFC: Use a `llvm::SmallBitVector` to store AD parameter indices. This is being passed around inside `SILReverseAutoDiffIndices` by value, since the bit vector almost always fits in one word.
* Other NFC cleanup.