### PR TITLE
[ConstExpr] implement flow-sensitive array initialization support

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -1830,6 +1830,7 @@ GLStatus TFGraphLowering::visitGraphOperationInst(GraphOperationInst *inst) {
       case SymbolicValue::Enum:
       case SymbolicValue::EnumWithPayload:
       case SymbolicValue::Address:
+      case SymbolicValue::Aggregate:  // Tuples and structs
         assert(0 && "These attribute kinds cannot happen here");
       case SymbolicValue::Integer: {
         auto value = attrValue.getIntegerValue();
@@ -1878,9 +1879,12 @@ GLStatus TFGraphLowering::visitGraphOperationInst(GraphOperationInst *inst) {
           return GLStatus::Error;
         break;
       }
-      case SymbolicValue::Aggregate:
-      case SymbolicValue::Array:
-        llvm_unreachable("FIXME: Handle normal aggregate/array arguments");
+      case SymbolicValue::Array: {
+        // FIXME: Handle array attributes.
+        internalError(getUserSourceLocation(inst->getDebugLocation()),
+                      "FIXME: Handle array attributes");
+        return GLStatus::Error;
+      }
       }
       // Done with normal attributes.
       break;
@@ -1948,7 +1952,10 @@ GLStatus TFGraphLowering::visitGraphOperationInst(GraphOperationInst *inst) {
     case SILTensorOpInfo::OperandClass::Array:
       // TODO: TF_SetAttrTypeList, TF_SetAttrStringList, TF_SetAttrIntList,
       // TF_SetAttrFloatList, TF_SetAttrBoolList
-      llvm_unreachable("FIXME: These operand classes are not yet handled");
+      internalError(getUserSourceLocation(inst->getDebugLocation()),
+                    "FIXME: Handle array and shapearray attributes");
+      return GLStatus::Error;
+
     case SILTensorOpInfo::OperandClass::ArrayElement:
       llvm_unreachable("This is a legacy class that shouldn't happen");
     }

--- a/test/TensorFlow/deabstraction_finished.swift
+++ b/test/TensorFlow/deabstraction_finished.swift
@@ -126,3 +126,11 @@ public func test75407624() {
  * CHECK: graph_op "Const"() {dtype: $Float, value$tensor: [ [f32 0x3F800000 /* 1 */], [f32 0x40000000 /* 2 */], [f32 0x40400000 /* 3 */], [f32 0x40800000 /* 4 */]], value$shape: [ [i32 2], [i32 2]],
  * CHECK-LABEL: ---- END OF 
 */
+
+
+public func testConvolution(x: Tensor<Float>, filter: Tensor<Float>) -> Tensor<Float> {
+  // expected-error @+1 {{FIXME: Handle array attributes}}
+  return x.toAccelerator().convolved2D(withFilter: filter.toAccelerator(),
+                                       strides: (1, 2, 3, 4), padding: .same)
+}
+


### PR DESCRIPTION
This requires several piece, including support for allocating uninit
arrays,support for pointer_to_address, index_addr, and updating
the middle of array values.

This is enough to get constexpr to handle "default argument #6" of the
Tensor.conv2d method, which does array stuff.

LowerGraph still doesn't support array attributes - upgrade the
llvm_unreachable that crashes to a generated error, so we get nicer
behavior in the testsuite when these are hit.  I'll tackle array arguments
next.

This fixes SR-8300
