### PR TITLE
Extend the SymbolicValue array representation to track the element type of arrays

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1698,8 +1698,10 @@ ERROR(sil_const_expected_fp_datatype,PointsToFirstBadToken,
       "expected floating point datatype ('f32' or 'f64')", ())
 ERROR(sil_const_expected_fp_value,PointsToFirstBadToken,
       "expected floating point value in SIL constant value", ())
-ERROR(sil_const_aggregate_expected_rsquare,PointsToFirstBadToken,
-      "expected ']' at end of aggregate 'SymbolicValue'", ())
+ERROR(sil_const_array_expected_rsquare,PointsToFirstBadToken,
+      "expected ']' at end of array 'SymbolicValue'", ())
+ERROR(sil_const_aggregate_expected_rparen,PointsToFirstBadToken,
+      "expected ')' at end of aggregate 'SymbolicValue'", ())
 
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)

--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -29,6 +29,7 @@ class SerializedSILLoader;
 struct APIntSymbolicValue;
 struct APFloatSymbolicValue;
 struct EnumWithPayloadSymbolicValue;
+struct ArraySymbolicValue;
 struct DerivedAddressValue;
 struct SymbolicValueMemoryObject;
 
@@ -192,7 +193,7 @@ class SymbolicValue {
     DerivedAddressValue *derivedAddress;
 
     /// For RK_Array, this is the elements of the array.
-    const SymbolicValue *array;
+    ArraySymbolicValue *array;
 
     /// For RK_ArrayAddress, this is the memory object referenced.
     SymbolicValueMemoryObject *arrayAddress;
@@ -213,9 +214,6 @@ class SymbolicValue {
 
     /// This is the number of elements for an RK_Aggregate representation.
     unsigned aggregate_numElements;
-
-    /// This is the number of elements for an RK_Array representation.
-    unsigned array_numElements;
   } aux;
 
 public:
@@ -407,7 +405,9 @@ public:
   SymbolicValueMemoryObject *getAddressValueMemoryObject() const;
 
   /// Produce an array of elements.
+  
   static SymbolicValue getArray(ArrayRef<SymbolicValue> elements,
+                                CanType elementType,
                                 llvm::BumpPtrAllocator &allocator);
   static SymbolicValue getArrayAddress(SymbolicValueMemoryObject *memoryObject){
     SymbolicValue result;
@@ -416,7 +416,7 @@ public:
     return result;
   }
 
-  ArrayRef<SymbolicValue> getArrayValue() const;
+  ArrayRef<SymbolicValue> getArrayValue(CanType &elementType) const;
 
   //===--------------------------------------------------------------------===//
   // Helpers

--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -1495,15 +1495,6 @@ void TFDeabstraction::propagateTensorValues() {
   }
 }
 
-/// If the specified type is a Swift.Array or some element type, then return the
-/// element type.  Otherwise, return a null Type.
-static Type getArrayElementType(SILType ty) {
-  if (auto bgst = ty.getASTType()->getAs<BoundGenericStructType>())
-    if (bgst->getDecl() == bgst->getASTContext().getArrayDecl())
-      return bgst->getGenericArgs()[0];
-  return Type();
-}
-
 /// If all the operands to a call to __tf_tensor_from_scalars are constants, we
 /// can promote this to a 'Const' node with an attached TF_Tensor attribute.
 /// It takes a 1D array of scalars and a shape as a 1D array of integers.
@@ -1529,25 +1520,26 @@ tryToPromoteTensorFromScalars(ApplyInst *inst,
   if (scalarIt == constants.end() || !scalarIt->second.isConstant())
     return nullptr;
   auto scalars = scalarIt->second;
+  CanType scalarsElementType;
+  auto scalarsElements = scalars.getArrayValue(scalarsElementType);
 
   auto shapeIt = constants.find(shapeValue);
   if (shapeIt == constants.end() || !shapeIt->second.isConstant())
     return nullptr;
   auto shape = shapeIt->second;
 
-  // Get the element type of the array.
-  auto elementType = getArrayElementType(scalarsValue->getType());
-  if (!elementType) return nullptr;
+  CanType shapeElementType;
+  auto shapeElements = shape.getArrayValue(shapeElementType);
 
   // Verify we have the right number of scalars.  If not, emit an error and
   // leave the broken code without promoting it to an op.
   uint64_t scalarCount = 1;
-  for (auto elt : shape.getArrayValue()) {
+  for (auto elt : shapeElements) {
     if (!elt.isConstant()) return nullptr;
     elt = elt.lookThroughSingleElementAggregates();
     scalarCount *= elt.getIntegerValue().getLimitedValue();
   }
-  uint64_t numElements = scalars.getArrayValue().size();
+  uint64_t numElements = scalarsElements.size();
   if (scalarCount != numElements) {
     std::string errorInfo =
       "tensor literal should have " + llvm::utostr(scalarCount) +
@@ -1564,7 +1556,7 @@ tryToPromoteTensorFromScalars(ApplyInst *inst,
   // into the correct Const operation.
   SILBuilder B(inst);
   B.setCurrentDebugScope(inst->getDebugScope());
-  auto result = createConstTensor(elementType, scalars, shape,
+  auto result = createConstTensor(scalarsElementType, scalars, shape,
                                   inst->getType(), inst->getLoc(),
                                   deviceConfig.primaryDeviceType, B);
 
@@ -1608,10 +1600,8 @@ tryToPromoteTensorFromScalars1D(ApplyInst *inst,
   auto scalars = scalarIt->second;
   assert(scalars.getKind() == SymbolicValue::Array &&
          "Unexpected value for array constant");
-
-  // Add a dtype attribute for the array element.
-  auto elementType = getArrayElementType(arrayValue->getType());
-  if (!elementType) return nullptr;
+  CanType scalarElementType;
+  auto scalarElements = scalars.getArrayValue(scalarElementType);
 
   auto &allocator = inst->getType().getASTContext().getAllocator();
 
@@ -1619,12 +1609,12 @@ tryToPromoteTensorFromScalars1D(ApplyInst *inst,
   // our shape is just a single entry array with the length of scalars, like
   // [i32 42] if the scalars list is 42 entries in size.
   auto shape = SymbolicValue::getArray({
-    SymbolicValue::getInteger(scalars.getArrayValue().size(), /*bitwidth*/ 32)
-  }, allocator);
+    SymbolicValue::getInteger(scalarElements.size(), /*bitwidth*/ 32)
+  }, scalarElementType, allocator);
 
   SILBuilder B(inst);
   B.setCurrentDebugScope(inst->getDebugScope());
-  auto result = createConstTensor(elementType, scalars, shape,
+  auto result = createConstTensor(scalarElementType, scalars, shape,
                                   inst->getType(), inst->getLoc(),
                                   deviceConfig.primaryDeviceType, B);
 
@@ -2052,7 +2042,8 @@ formGraphOp(SILTensorOpInfo &opInfo,
         return diagnoseInvalidAttr("requires a constant that is an integer,"
                                    " floating point, or array thereof");
 
-      auto elements = constValue.getArrayValue();
+      CanType eltType;
+      auto elements = constValue.getArrayValue(eltType);
 
       /// Tensor array arguments must always be followed by a shape.
       if (i+1 >= opInfo.operandClasses.size() ||

--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -1603,14 +1603,15 @@ tryToPromoteTensorFromScalars1D(ApplyInst *inst,
   CanType scalarElementType;
   auto scalarElements = scalars.getArrayValue(scalarElementType);
 
-  auto &allocator = inst->getType().getASTContext().getAllocator();
+  auto &context = inst->getType().getASTContext();
+  auto &allocator = context.getAllocator();
 
   // This takes a Tensor operand, but needs a shape added.  Since this is 1d,
   // our shape is just a single entry array with the length of scalars, like
   // [i32 42] if the scalars list is 42 entries in size.
   auto shape = SymbolicValue::getArray({
     SymbolicValue::getInteger(scalarElements.size(), /*bitwidth*/ 32)
-  }, scalarElementType, allocator);
+  }, context.getInt32Decl()->getDeclaredType()->getCanonicalType(), allocator);
 
   SILBuilder B(inst);
   B.setCurrentDebugScope(inst->getDebugScope());

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -1792,7 +1792,8 @@ GLStatus TFGraphLowering::visitGraphOperationInst(GraphOperationInst *inst) {
   auto decodeShapeAttr =
     [&](SymbolicValue attr, SmallVectorImpl<int64_t> &result) {
     attr = attr.lookThroughSingleElementAggregates();
-    for (auto elt : attr.getArrayValue()) {
+    CanType eltType;
+    for (auto elt : attr.getArrayValue(eltType)) {
       elt = elt.lookThroughSingleElementAggregates();
       result.push_back(elt.getIntegerValue().getLimitedValue());
     }
@@ -1924,7 +1925,8 @@ GLStatus TFGraphLowering::visitGraphOperationInst(GraphOperationInst *inst) {
         addScalar(attrValue);
       } else {
         // Add all the elements to the elements list.
-        for (auto elt : attrValue.getArrayValue())
+        CanType eltType;
+        for (auto elt : attrValue.getArrayValue(eltType))
           addScalar(elt);
 
         // Decode the shape attribute which must come next.

--- a/test/TensorFlow/deabstraction_finished.swift
+++ b/test/TensorFlow/deabstraction_finished.swift
@@ -134,3 +134,7 @@ public func testConvolution(x: Tensor<Float>, filter: Tensor<Float>) -> Tensor<F
                                        strides: (1, 2, 3, 4), padding: .same)
 }
 
+/* CHECK-LABEL: ---- INPUT FUNCTION {{.*}}testConvolution
+ * CHECK: graph_op "Conv2D,i,i"({{.*}} : $TensorHandle<Float>, {{.*}} : $TensorHandle<Float>) {T: $Float, strides: [$Int: (i32 1), [i32 2], [i32 3], [i32 4]], use_cudnn_on_gpu: i1 -1, padding: "SAME", data_format: "NHWC", dilations: [ [i32 1], [i32 1], [i32 1], [i32 1]],
+ * CHECK-LABEL: ---- END OF
+*/

--- a/test/TensorFlow/deabstraction_finished.swift
+++ b/test/TensorFlow/deabstraction_finished.swift
@@ -116,14 +116,14 @@ public func test75407624() {
   _ = a+b+c+d
 }
 /* CHECK-LABEL: ---- INPUT FUNCTION {{.*}}test75407624
- * CHECK: graph_op "Const"() {dtype: $Float, value$tensor: [ [f32 0x3F800000 /* 1 */]], value$shape: [i32 1],
- * CHECK: [[B1X:%.*]] = graph_op "Const"() {dtype: $Int32, value$tensor: [ [i32 1]], value$shape: [i32 1],
+ * CHECK: graph_op "Const"() {dtype: $Float, value$tensor: [$Float: (f32 0x3F800000 /* 1 */)], value$shape: [$Int32: i32 1]
+ * CHECK: [[B1X:%.*]] = graph_op "Const"() {dtype: $Int32, value$tensor: [$Int32: (i32 1)], value$shape: [$Int32: i32 1],
  * CHECK: [[BX2:%.*]] = graph_op "tfc.scalarToTensor,s"(
  * CHECK:  graph_op "Fill,i,i"([[B1X]] : $TensorHandle<Int32>, [[BX2]] : $TensorHandle<Float>)
- * CHECK: [[C1X:%.*]] = graph_op "Const"() {dtype: $Int32, value$tensor: [ [i32 1]], value$shape: [i32 1],
+ * CHECK: [[C1X:%.*]] = graph_op "Const"() {dtype: $Int32, value$tensor: [$Int32: (i32 1)], value$shape: [$Int32: i32 1],
  * CHECK: [[CX2:%.*]] = graph_op "tfc.scalarToTensor,s"(
  * CHECK:  graph_op "Fill,i,i"([[C1X]] : $TensorHandle<Int32>, [[CX2]] : $TensorHandle<Float>)
- * CHECK: graph_op "Const"() {dtype: $Float, value$tensor: [ [f32 0x3F800000 /* 1 */], [f32 0x40000000 /* 2 */], [f32 0x40400000 /* 3 */], [f32 0x40800000 /* 4 */]], value$shape: [ [i32 2], [i32 2]],
+ * CHECK: graph_op "Const"() {dtype: $Float, value$tensor: [$Float: (f32 0x3F800000 /* 1 */), (f32 0x40000000 /* 2 */), (f32 0x40400000 /* 3 */), (f32 0x40800000 /* 4 */)], value$shape: [$Int32: (i32 2), (i32 2)],
  * CHECK-LABEL: ---- END OF 
 */
 
@@ -135,6 +135,6 @@ public func testConvolution(x: Tensor<Float>, filter: Tensor<Float>) -> Tensor<F
 }
 
 /* CHECK-LABEL: ---- INPUT FUNCTION {{.*}}testConvolution
- * CHECK: graph_op "Conv2D,i,i"({{.*}} : $TensorHandle<Float>, {{.*}} : $TensorHandle<Float>) {T: $Float, strides: [$Int: (i32 1), [i32 2], [i32 3], [i32 4]], use_cudnn_on_gpu: i1 -1, padding: "SAME", data_format: "NHWC", dilations: [ [i32 1], [i32 1], [i32 1], [i32 1]],
+ * CHECK: graph_op "Conv2D,i,i"({{.*}} : $TensorHandle<Float>, {{.*}} : $TensorHandle<Float>) {T: $Float, strides: [$Int32: (i32 1), (i32 2), (i32 3), (i32 4)], use_cudnn_on_gpu: i1 -1, padding: "SAME", data_format: "NHWC", dilations: [$Int32: (i32 1), (i32 1), (i32 1), (i32 1)],
  * CHECK-LABEL: ---- END OF
 */

--- a/test/TensorFlow/graph_op_inst.sil
+++ b/test/TensorFlow/graph_op_inst.sil
@@ -16,7 +16,8 @@ bb0:
   %3 = graph_op "tf.Dummy"() {string1: "hello", string2: "world"} : $Tensor<Float>
   %4 = graph_op "tf.Dummy"() {metatype1: $Float, metatype2: $Tensor<Float>} : $Tensor<Float>
   %5 = graph_op "tf.Dummy"() {function1: @chained_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> Tensor<Float>} : $Tensor<Float>
-  %6 = graph_op "tf.Dummy"() {array: [[i8 1, i32 -2], [f32 -1.0, $Float]]} : $Tensor<Float>
+  %6 = graph_op "tf.Dummy"() {aggregate: ((i8 1, i32 -2), (f32 -1.0, $Float))} : $Tensor<Float>
+  %7 = graph_op "tf.Smarty"() {array: [$Int: i32 -2, i32 97]} : $Tensor<Float>
   return %0 : $Tensor<Float>
 }
 
@@ -28,7 +29,8 @@ bb0:
 // CHECK-NEXT:   %3 = graph_op "tf.Dummy"() {string1: "hello", string2: "world"} : $Tensor<Float>
 // CHECK-NEXT:   %4 = graph_op "tf.Dummy"() {metatype1: $Float, metatype2: $Tensor<Float>} : $Tensor<Float>
 // CHECK-NEXT:   %5 = graph_op "tf.Dummy"() {function1: @chained_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> Tensor<Float>} : $Tensor<Float>
-// CHECK-NEXT:   %6 = graph_op "tf.Dummy"() {array: [ [i8 1, i32 -2], [f32 0xBF800000 /* -1 */, $Float]]} : $Tensor<Float>
+// CHECK-NEXT:   %6 = graph_op "tf.Dummy"() {aggregate: ((i8 1, i32 -2), (f32 0xBF800000 /* -1 */, $Float))} : $Tensor<Float>
+// CHECK-NEXT:   %7 = graph_op "tf.Smarty"() {array: [$Int: i32 -2, i32 97]} : $Tensor<Float>
 // CHECK-NEXT:   return %0 : $Tensor<Float>
 // CHECK-NEXT: }
 

--- a/test/TensorFlow/integration.swift
+++ b/test/TensorFlow/integration.swift
@@ -435,7 +435,7 @@ public func testResourceAndVariants() {
 
 /*
 CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testResourceAndVariantsyyF
-CHECK:  [[values:%.*]] = graph_op "Const"() {dtype: $Float, value$tensor: [ [f32 0x3F800000 /* 1 */], [f32 0x40000000 /* 2 */],
+CHECK:  [[values:%.*]] = graph_op "Const"() {dtype: $Float, value$tensor: [$Float: (f32 0x3F800000 /* 1 */), (f32 0x40000000 /* 2 */),
 CHECK:  [[dataset:%.*]] = builtin "__tfop_TensorDataSet,$in,Toutput_types$array,$elt,output_shapes$shapearray,$shape,$elt,__device"([[values]] : $TensorHandle<Float>
 CHECK:  [[iterator:%.*]] = builtin "__tfop_Iterator,shared_name,container,output_types$array,$elt,output_shapes$shapearray,$shape,$elt,__device"({{.*}} : $Builtin.RawPointer, {{.*}} : $Builtin.RawPointer
 CHECK:  builtin "__tfop_MakeIterator,$in,$in,__device"([[dataset]] : $VariantHandle, [[iterator]] : $ResourceHandle, {{.*}}) : $()

--- a/test/TensorFlow/no_copy.swift
+++ b/test/TensorFlow/no_copy.swift
@@ -47,7 +47,7 @@ public func testEmptyScalarsArray() {
  CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testEmptyScalarsArray
  CHECK: sil private @{{.*}}testEmptyScalarsArray{{.*}} : $@callee_owned () -> () {
  CHECK: bb0:
- CHECK: graph_op "Const"() {dtype: $Int32, value$tensor: [], value$shape: [ [i32 0], [i32 20], [i32 30]]
+ CHECK: graph_op "Const"() {dtype: $Int32, value$tensor: [$Int32: ], value$shape: [$Int32: (i32 0), (i32 20), (i32 30)],
  CHECK: builtin "__tfop_Add,$in,$in,T,__device"({{.*}} : $TensorHandle<Int32>, {{.*}} : $TensorHandle<Int32>
  */
 


### PR DESCRIPTION
This simplifies a bunch of code and will be useful for graph lowering.

This also switches the SILPrinter syntax for aggregates (used by tuples and structs)
to use parens, resolving a TODO.
