### PR TITLE
Remove third pass when validating generic function parameter lists

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5402,8 +5402,8 @@ bool EnumElementDecl::computeType() {
 
   // The type of the enum element is either (T) -> T or (T) -> ArgType -> T.
   if (auto *PL = getParameterList()) {
-    auto paramTy = PL->getType(getASTContext());
-    resultTy = FunctionType::get(paramTy->mapTypeOutOfContext(), resultTy);
+    auto paramTy = PL->getInterfaceType(getASTContext());
+    resultTy = FunctionType::get(paramTy, resultTy);
   }
 
   if (auto *genericSig = ED->getGenericSignatureOfContext())

--- a/lib/Sema/GenericTypeResolver.h
+++ b/lib/Sema/GenericTypeResolver.h
@@ -57,9 +57,6 @@ public:
   /// Determine whether the given types are equivalent within the generic
   /// context.
   virtual bool areSameType(Type type1, Type type2) = 0;
-
-  /// Set the contextual type or the interface type of the parameter.
-  virtual void recordParamType(ParamDecl *decl, Type ty) = 0;
 };
 
 /// Generic type resolver that leaves all generic types dependent.
@@ -78,8 +75,6 @@ public:
                                           ComponentIdentTypeRepr *ref);
 
   virtual bool areSameType(Type type1, Type type2);
-
-  virtual void recordParamType(ParamDecl *decl, Type ty);
 };
 
 /// Generic type resolver that maps a generic type parameter type to its
@@ -106,8 +101,6 @@ public:
                                           ComponentIdentTypeRepr *ref);
 
   virtual bool areSameType(Type type1, Type type2);
-
-  virtual void recordParamType(ParamDecl *decl, Type ty);
 };
 
 /// Generic type resolver that only handles what can appear in a protocol
@@ -126,8 +119,6 @@ public:
                                           ComponentIdentTypeRepr *ref);
 
   virtual bool areSameType(Type type1, Type type2);
-
-  virtual void recordParamType(ParamDecl *decl, Type ty);
 };
 
 /// Generic type resolver that performs complete resolution of dependent
@@ -155,8 +146,6 @@ public:
                                           ComponentIdentTypeRepr *ref);
 
   virtual bool areSameType(Type type1, Type type2);
-
-  virtual void recordParamType(ParamDecl *decl, Type ty);
 };
 
 } // end namespace swift

--- a/lib/Sema/GenericTypeResolver.h
+++ b/lib/Sema/GenericTypeResolver.h
@@ -140,7 +140,7 @@ public:
 class CompleteGenericTypeResolver : public GenericTypeResolver {
   TypeChecker &tc;
   GenericSignature *genericSig;
-  GenericSignatureBuilder &builder;
+  GenericSignatureBuilder *builder;
 
 public:
   CompleteGenericTypeResolver(TypeChecker &tc, GenericSignature *genericSig);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4249,9 +4249,6 @@ void TypeChecker::validateDecl(ValueDecl *D) {
         // had an @objc or @iboutlet property.
 
         AbstractStorageDecl *storage = accessor->getStorage();
-        // Validate the subscript or property because it might not be type
-        // checked yet.
-        validateDecl(storage);
 
         if (storage->getAttrs().hasAttribute<NonObjCAttr>())
           isObjC = None;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4178,8 +4178,6 @@ void TypeChecker::validateDecl(ValueDecl *D) {
 
     // If we have generic parameters, check the generic signature now.
     if (auto gp = FD->getGenericParams()) {
-      gp->setOuterParameters(FD->getDeclContext()->getGenericParamsOfContext());
-
       validateGenericFuncSignature(FD);
     } else if (auto genericSig =
                  FD->getDeclContext()->getGenericSignatureOfContext()) {
@@ -4397,9 +4395,6 @@ void TypeChecker::validateDecl(ValueDecl *D) {
       configureImplicitSelf(*this, CD);
 
     if (auto gp = CD->getGenericParams()) {
-      // Write up generic parameters and check the generic parameter list.
-      gp->setOuterParameters(CD->getDeclContext()->getGenericParamsOfContext());
-
       validateGenericFuncSignature(CD);
     } else if (CD->getDeclContext()->getGenericSignatureOfContext()) {
       validateGenericFuncSignature(CD);
@@ -4515,9 +4510,6 @@ void TypeChecker::validateDecl(ValueDecl *D) {
     auto dc = SD->getDeclContext();
 
     if (auto gp = SD->getGenericParams()) {
-      // Write up generic parameters and check the generic parameter list.
-      gp->setOuterParameters(dc->getGenericParamsOfContext());
-
       validateGenericSubscriptSignature(SD);
     } else if (dc->getGenericSignatureOfContext()) {
       validateGenericSubscriptSignature(SD);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4158,16 +4158,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
     if (auto gp = FD->getGenericParams()) {
       gp->setOuterParameters(FD->getDeclContext()->getGenericParamsOfContext());
 
-      auto *sig = validateGenericFuncSignature(FD);
-
-      GenericEnvironment *env;
-      if (auto AD = dyn_cast<AccessorDecl>(FD)) {
-        env = cast<SubscriptDecl>(AD->getStorage())->getGenericEnvironment();
-        assert(env && "accessor has generics but subscript is not generic");
-      } else {
-        env = sig->createGenericEnvironment();
-      }
-      FD->setGenericEnvironment(env);
+      validateGenericFuncSignature(FD);
 
       // Revert the types within the signature so it can be type-checked with
       // archetypes below.
@@ -4175,17 +4166,17 @@ void TypeChecker::validateDecl(ValueDecl *D) {
     } else if (auto genericSig =
                  FD->getDeclContext()->getGenericSignatureOfContext()) {
       if (!isa<AccessorDecl>(FD)) {
-        (void)validateGenericFuncSignature(FD);
+        validateGenericFuncSignature(FD);
 
         // Revert all of the types within the signature of the function.
         revertGenericFuncSignature(FD);
       } else {
         // We've inherited all of the type information already.
         configureInterfaceType(FD, genericSig);
-      }
 
-      FD->setGenericEnvironment(
+        FD->setGenericEnvironment(
           FD->getDeclContext()->getGenericEnvironmentOfContext());
+      }
     }
 
     // Set the context type of 'self'.
@@ -4387,21 +4378,16 @@ void TypeChecker::validateDecl(ValueDecl *D) {
       // Write up generic parameters and check the generic parameter list.
       gp->setOuterParameters(CD->getDeclContext()->getGenericParamsOfContext());
 
-      auto *sig = validateGenericFuncSignature(CD);
-      auto *env = sig->createGenericEnvironment();
-      CD->setGenericEnvironment(env);
+      validateGenericFuncSignature(CD);
 
       // Revert the types within the signature so it can be type-checked with
       // archetypes below.
       revertGenericFuncSignature(CD);
     } else if (CD->getDeclContext()->getGenericSignatureOfContext()) {
-      (void)validateGenericFuncSignature(CD);
+      validateGenericFuncSignature(CD);
 
       // Revert all of the types within the signature of the constructor.
       revertGenericFuncSignature(CD);
-
-      CD->setGenericEnvironment(
-          CD->getDeclContext()->getGenericEnvironmentOfContext());
     }
 
     // Set the context type of 'self'.
@@ -4471,9 +4457,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
     configureImplicitSelf(*this, DD);
 
     if (DD->getDeclContext()->getGenericSignatureOfContext()) {
-      (void)validateGenericFuncSignature(DD);
-      DD->setGenericEnvironment(
-          DD->getDeclContext()->getGenericEnvironmentOfContext());
+      validateGenericFuncSignature(DD);
     }
 
     // Set the context type of 'self'.
@@ -4514,21 +4498,16 @@ void TypeChecker::validateDecl(ValueDecl *D) {
       // Write up generic parameters and check the generic parameter list.
       gp->setOuterParameters(dc->getGenericParamsOfContext());
 
-      auto *sig = validateGenericSubscriptSignature(SD);
-      auto *env = sig->createGenericEnvironment();
-      SD->setGenericEnvironment(env);
+      validateGenericSubscriptSignature(SD);
 
       // Revert the types within the signature so it can be type-checked with
       // archetypes below.
       revertGenericSubscriptSignature(SD);
     } else if (dc->getGenericSignatureOfContext()) {
-      (void)validateGenericSubscriptSignature(SD);
+      validateGenericSubscriptSignature(SD);
 
       // Revert all of the types within the signature of the subscript.
       revertGenericSubscriptSignature(SD);
-
-      SD->setGenericEnvironment(
-          SD->getDeclContext()->getGenericEnvironmentOfContext());
     }
 
     // Type check the subscript parameters.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4116,7 +4116,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
           auto accessorParam = valueParams->get(valueParams->size() - e + i);
           accessorParam->setType(paramTy);
           accessorParam->setInterfaceType(paramIfaceTy);
-          accessorParam->getTypeLoc().setType(paramTy);
+          accessorParam->getTypeLoc().setType(paramIfaceTy);
         }
       }
 

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -840,6 +840,9 @@ static void checkReferencedGenericParams(GenericContext *dc,
 void TypeChecker::validateGenericFuncSignature(AbstractFunctionDecl *func) {
   bool invalid = false;
 
+  if (auto *selfDecl = func->getImplicitSelfDecl())
+    invalid |= selfDecl->getInterfaceType()->hasError();
+
   auto *dc = func->getDeclContext();
 
   GenericSignature *sig;

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -837,8 +837,11 @@ static void checkReferencedGenericParams(GenericContext *dc,
 void TypeChecker::validateGenericFuncSignature(AbstractFunctionDecl *func) {
   bool invalid = false;
 
+  auto *dc = func->getDeclContext();
+
   GenericSignature *sig;
   if (auto gp = func->getGenericParams()) {
+    gp->setOuterParameters(dc->getGenericParamsOfContext());
     prepareGenericParamList(gp, func);
 
     // Create the generic signature builder.
@@ -882,9 +885,8 @@ void TypeChecker::validateGenericFuncSignature(AbstractFunctionDecl *func) {
     func->setGenericEnvironment(env);
   } else {
     // Inherit the signature of our environment.
-    sig = func->getDeclContext()->getGenericSignatureOfContext();
-    func->setGenericEnvironment(
-      func->getDeclContext()->getGenericEnvironmentOfContext());
+    sig = dc->getGenericSignatureOfContext();
+    func->setGenericEnvironment(dc->getGenericEnvironmentOfContext());
   }
 
   CompleteGenericTypeResolver completeResolver(*this, sig);
@@ -1081,8 +1083,11 @@ void
 TypeChecker::validateGenericSubscriptSignature(SubscriptDecl *subscript) {
   bool invalid = false;
 
+  auto *dc = subscript->getDeclContext();
+
   GenericSignature *sig;
   if (auto *gp = subscript->getGenericParams()) {
+    gp->setOuterParameters(dc->getGenericParamsOfContext());
     prepareGenericParamList(gp, subscript);
 
     // Create the generic signature builder.
@@ -1121,9 +1126,8 @@ TypeChecker::validateGenericSubscriptSignature(SubscriptDecl *subscript) {
     subscript->setGenericEnvironment(sig->createGenericEnvironment());
   } else {
     // Inherit the signature of our environment.
-    sig = subscript->getDeclContext()->getGenericSignatureOfContext();
-    subscript->setGenericEnvironment(
-      subscript->getDeclContext()->getGenericEnvironmentOfContext());
+    sig = dc->getGenericSignatureOfContext();
+    subscript->setGenericEnvironment(dc->getGenericEnvironmentOfContext());
   }
 
   CompleteGenericTypeResolver completeResolver(*this, sig);

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -576,7 +576,7 @@ static bool checkGenericFuncSignature(TypeChecker &tc,
   return badType;
 }
 
-void TypeChecker::revertGenericFuncSignature(AbstractFunctionDecl *func) {
+static void revertGenericFuncSignature(AbstractFunctionDecl *func) {
   // Revert the result type.
   if (auto fn = dyn_cast<FuncDecl>(func))
     if (!fn->getBodyResultTypeLoc().isNull())
@@ -1047,7 +1047,7 @@ static bool checkGenericSubscriptSignature(TypeChecker &tc,
   return badType;
 }
 
-void TypeChecker::revertGenericSubscriptSignature(SubscriptDecl *subscript) {
+static void revertGenericSubscriptSignature(SubscriptDecl *subscript) {
   // Revert the element type.
   if (!subscript->getElementTypeLoc().isNull())
     revertDependentTypeLoc(subscript->getElementTypeLoc());

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -50,10 +50,6 @@ bool DependentGenericTypeResolver::areSameType(Type type1, Type type2) {
   return true;
 }
 
-void DependentGenericTypeResolver::recordParamType(ParamDecl *decl, Type type) {
-  // Do nothing
-}
-
 Type GenericTypeToArchetypeResolver::mapTypeIntoContext(Type type) {
   return GenericEnvironment::mapTypeIntoContext(GenericEnv, type);
 }
@@ -68,19 +64,6 @@ Type GenericTypeToArchetypeResolver::resolveDependentMemberType(
 
 bool GenericTypeToArchetypeResolver::areSameType(Type type1, Type type2) {
   return type1->isEqual(type2);
-}
-
-void GenericTypeToArchetypeResolver::recordParamType(ParamDecl *decl, Type type) {
-  decl->setType(type);
-
-  // When type checking a closure or subscript index, this is the only
-  // resolver that runs, so make sure we also set the interface type,
-  // if one was not already set.
-  //
-  // When type checking functions, the CompleteGenericTypeResolver sets
-  // the interface type.
-  if (!decl->hasInterfaceType())
-    decl->setInterfaceType(type->mapTypeOutOfContext());
 }
 
 Type ProtocolRequirementTypeResolver::mapTypeIntoContext(Type type) {
@@ -108,12 +91,6 @@ bool ProtocolRequirementTypeResolver::areSameType(Type type1, Type type2) {
   if (depMem1->getName() != depMem2->getName()) return false;
 
   return areSameType(depMem1->getBase(), depMem2->getBase());
-}
-
-void ProtocolRequirementTypeResolver::recordParamType(ParamDecl *decl,
-                                                      Type type) {
-  llvm_unreachable(
-      "recording a param type of a protocol requirement doesn't make sense");
 }
 
 CompleteGenericTypeResolver::CompleteGenericTypeResolver(
@@ -240,11 +217,6 @@ Type CompleteGenericTypeResolver::resolveDependentMemberType(
 bool CompleteGenericTypeResolver::areSameType(Type type1, Type type2) {
   return genericSig->getCanonicalTypeInContext(type1)
            == genericSig->getCanonicalTypeInContext(type2);
-}
-
-void
-CompleteGenericTypeResolver::recordParamType(ParamDecl *decl, Type type) {
-  decl->setInterfaceType(type);
 }
 
 ///

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -1344,6 +1344,8 @@ RequirementCheckResult TypeChecker::checkGenericArguments(
   SmallVector<RequirementSet, 8> pendingReqs;
   pendingReqs.push_back({requirements, {}});
 
+  auto *env = dc->getGenericEnvironmentOfContext();
+
   while (!pendingReqs.empty()) {
     auto current = pendingReqs.pop_back_val();
 
@@ -1363,10 +1365,21 @@ RequirementCheckResult TypeChecker::checkGenericArguments(
       auto kind = req.getKind();
       Type rawFirstType = rawReq.getFirstType();
       Type firstType = req.getFirstType();
+      if (firstType->hasTypeParameter()) {
+        if (!env)
+          continue;
+        firstType = env->mapTypeIntoContext(firstType);
+      }
+
       Type rawSecondType, secondType;
       if (kind != RequirementKind::Layout) {
         rawSecondType = rawReq.getSecondType();
         secondType = req.getSecondType();
+        if (secondType->hasTypeParameter()) {
+          if (!env)
+            continue;
+          secondType = env->mapTypeIntoContext(secondType);
+        }
       }
 
       // Don't do further checking on error types.

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -856,10 +856,9 @@ bool TypeChecker::typeCheckParameterList(ParameterList *PL, DeclContext *DC,
       param->markInvalid();
       hadError = true;
     } else {
-      if (!type->isMaterializable()) {
+      if (type->is<InOutType>())
         param->setSpecifier(VarDecl::Specifier::InOut);
-      }
-      resolver.recordParamType(param, type->getInOutObjectType());
+      param->setInterfaceType(type->getInOutObjectType());
     }
     
     checkTypeModifyingDeclAttributes(param);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -509,7 +509,7 @@ Type TypeChecker::applyUnboundGenericArguments(
   // generic arguments.
   auto resultType = decl->getDeclaredInterfaceType();
 
-  bool hasTypeParameterOrVariable = false;
+  bool hasTypeVariable = false;
 
   // Get the substitutions for outer generic parameters from the parent
   // type.
@@ -526,9 +526,7 @@ Type TypeChecker::applyUnboundGenericArguments(
     }
 
     subs = parentType->getContextSubstitutions(decl->getDeclContext());
-
-    hasTypeParameterOrVariable |=
-      (parentType->hasTypeParameter() || parentType->hasTypeVariable());
+    hasTypeVariable |= parentType->hasTypeVariable();
   }
 
   SourceLoc noteLoc = decl->getLoc();
@@ -545,13 +543,12 @@ Type TypeChecker::applyUnboundGenericArguments(
     subs[origTy->getCanonicalType()->castTo<GenericTypeParamType>()] =
       substTy;
 
-    hasTypeParameterOrVariable |=
-      (substTy->hasTypeParameter() || substTy->hasTypeVariable());
+    hasTypeVariable |= substTy->hasTypeVariable();
   }
 
   // Check the generic arguments against the requirements of the declaration's
   // generic signature.
-  if (!hasTypeParameterOrVariable) {
+  if (!hasTypeVariable) {
     auto result =
       checkGenericArguments(dc, loc, noteLoc, unboundType,
                             genericSig->getGenericParams(),

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1046,7 +1046,6 @@ public:
   /// to be in a correct and valid form.
   ///
   /// \param type The generic type to which to apply arguments.
-  /// \param decl The declaration of the type.
   /// \param loc The source location for diagnostic reporting.
   /// \param dc The context where the arguments are applied.
   /// \param generic The arguments to apply with the angle bracket range for
@@ -1058,7 +1057,7 @@ public:
   /// error.
   ///
   /// \see applyUnboundGenericArguments
-  Type applyGenericArguments(Type type, TypeDecl *decl, SourceLoc loc,
+  Type applyGenericArguments(Type type, SourceLoc loc,
                              DeclContext *dc, GenericIdentTypeRepr *generic,
                              TypeResolutionOptions options,
                              GenericTypeResolver *resolver);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1275,10 +1275,9 @@ public:
   void configureInterfaceType(AbstractFunctionDecl *func,
                               GenericSignature *sig);
 
-  /// Validate the signature of a generic function.
-  ///
-  /// \param func The generic function.
-  GenericSignature *validateGenericFuncSignature(AbstractFunctionDecl *func);
+  /// Compute the generic signature, generic environment and interface type
+  /// of a generic function.
+  void validateGenericFuncSignature(AbstractFunctionDecl *func);
 
   /// Revert the signature of a generic function to its pre-type-checked state,
   /// so that it can be type checked again when we have resolved its generic
@@ -1292,10 +1291,9 @@ public:
                              GenericSignature *parentSig,
                              GenericTypeResolver *resolver);
 
-  /// Validate the signature of a generic subscript.
-  ///
-  /// \param subscript The generic subscript.
-  GenericSignature *validateGenericSubscriptSignature(SubscriptDecl *subscript);
+  /// Compute the generic signature, generic environment and interface type
+  /// of a generic subscript.
+  void validateGenericSubscriptSignature(SubscriptDecl *subscript);
 
   /// Revert the signature of a generic function to its pre-type-checked state,
   /// so that it can be type checked again when we have resolved its generic

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1278,11 +1278,6 @@ public:
   /// of a generic function.
   void validateGenericFuncSignature(AbstractFunctionDecl *func);
 
-  /// Revert the signature of a generic function to its pre-type-checked state,
-  /// so that it can be type checked again when we have resolved its generic
-  /// parameters.
-  void revertGenericFuncSignature(AbstractFunctionDecl *func);
-
   /// Check the generic parameters in the given generic parameter list (and its
   /// parent generic parameter lists) according to the given resolver.
   void checkGenericParamList(GenericSignatureBuilder *builder,
@@ -1293,11 +1288,6 @@ public:
   /// Compute the generic signature, generic environment and interface type
   /// of a generic subscript.
   void validateGenericSubscriptSignature(SubscriptDecl *subscript);
-
-  /// Revert the signature of a generic function to its pre-type-checked state,
-  /// so that it can be type checked again when we have resolved its generic
-  /// parameters.
-  void revertGenericSubscriptSignature(SubscriptDecl *subscript);
 
   /// Configure the interface type of a subscript declaration.
   void configureInterfaceType(SubscriptDecl *subscript,

--- a/test/Generics/function_decls.swift
+++ b/test/Generics/function_decls.swift
@@ -25,9 +25,29 @@ public class A<X> {
   public func f11<T, U>(x: X, y: T) {} //expected-error{{generic parameter 'U' is not used in function signature}}
 }
 
-protocol P { associatedtype A }
+struct G<T> {} // expected-note {{generic type 'G' declared here}}
 
-func f12<T : P>(x: T) -> T.A<Int> {} //expected-error{{cannot specialize non-generic type 'T.A'}}{{29-34=}}
+struct GG<T, U> {}
+
+protocol P {
+  associatedtype A
+  typealias B = Int
+  typealias C<T> = T
+  typealias D = G
+  typealias E<T> = GG<T, T>
+}
+
+func f12<T : P>(x: T) -> T.A<Int> {} // expected-error {{cannot specialize non-generic type 'T.A'}}{{29-34=}}
+
+func f13<T : P>(x: T) -> T.B<Int> {} // expected-error {{cannot specialize non-generic type 'Int'}}{{29-34=}}
+
+func f14<T : P>(x: T) -> T.C<Int> {}
+
+func f15<T : P>(x: T) -> T.D<Int> {}
+
+func f16<T : P>(x: T) -> T.D {} // expected-error {{reference to generic type 'G' requires arguments in <...>}}
+
+func f17<T : P>(x: T) -> T.E<Int> {}
 
 public protocol Q {
     associatedtype AT1

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -1358,7 +1358,7 @@ func testForFixitWithNestedMemberRefExpr() {
 // Protocol Conformances
 
 protocol ProtocolWithRequirementMentioningUnavailable {
-      // expected-note@-1 4{{add @available attribute to enclosing protocol}}
+      // expected-note@-1 2{{add @available attribute to enclosing protocol}}
   func hasUnavailableParameter(_ p: ClassAvailableOn10_51) // expected-error * {{'ClassAvailableOn10_51' is only available on OS X 10.51 or newer}}
       // expected-note@-1 * {{add @available attribute to enclosing instance method}}
       

--- a/test/Sema/diag_erroneous_iuo.swift
+++ b/test/Sema/diag_erroneous_iuo.swift
@@ -64,10 +64,8 @@ func genericFunctionSigilArray<T>(
   // FIXME: We validate these types multiple times resulting in multiple diagnostics
   iuo: [T!] // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{10-11=?}}
   // expected-error@-1 {{'!' is not allowed here; perhaps '?' was intended?}}{{10-11=?}}
-  // expected-error@-2 {{'!' is not allowed here; perhaps '?' was intended?}}{{10-11=?}}
 ) -> [T!] { // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{8-9=?}}
   // expected-error@-1 {{'!' is not allowed here; perhaps '?' was intended?}}{{8-9=?}}
-  // expected-error@-2 {{'!' is not allowed here; perhaps '?' was intended?}}{{8-9=?}}
   return iuo
 }
 


### PR DESCRIPTION
When checking a generic function we make up to three passes over the parameter list because of how member types (T.X) work:

- (If the function has a generic parameter list) First, we collect requirements and form unresolved dependent member types, so that we can build a generic signature.
- (If the function is in generic context) Then, we build fully resolved dependent member types using the new generic signature from step 1 (or the generic signature from context if we skipped step 1), and use these types to form the interface type
- Finally, we make one final pass, using the generic parameter to archetype resolver

The third pass is actually unnecessary, and instead we perform the second pass unconditionally even when there is no generic signature.

The only useful work done by the third pass that wasn't done in the second pass is validating generic requirements involving type parameters. For example, if I had a parameter containing `Set<U>`, and U was not hashable, the third pass produced a diagnostic because the archetype for `U` is known not to conform to Hashable. The second pass was previously unable to diagnose this because a generic parameter never conforms to anything.

A small refactoring to `checkGenericArguments()` allows us to map type parameters into context before checking requirements. With this checking now done in the second pass, the third pass is no longer necessary.

This is NFC, but hopefully in the future will make it easier to move `getInterfaceType()` and `getGenericSignature()` to the request evaluator.