### PR TITLE
Sema: Fix availability of inherited designated initializers, part 2 [4.2]

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -2152,9 +2152,16 @@ static void configureDesignatedInitAttributes(TypeChecker &tc,
 
   // If the superclass has its own availability, make sure the synthesized
   // constructor is only as available as its superclass's constructor.
-  if (superclassCtor->getAttrs().hasAttribute<AvailableAttr>()) {
+  {
+    SmallVector<Decl *, 2> asAvailableAs;
+    asAvailableAs.push_back(superclassCtor);
+    Decl *parentDecl = classDecl;
+    while (parentDecl != nullptr) {
+      asAvailableAs.push_back(parentDecl);
+      parentDecl = parentDecl->getDeclContext()->getAsDeclOrDeclExtensionContext();
+    }
     AvailabilityInference::applyInferredAvailableAttrs(
-        ctor, {classDecl, superclassCtor}, ctx);
+        ctor, asAvailableAs, ctx);
   }
 
   if (superclassCtor->isObjC()) {

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -998,6 +998,11 @@ class WidelyAvailableBase {
 @available(OSX, introduced: 10.53)
 class EsotericSmallBatchHipsterThing : WidelyAvailableBase {}
 
+@available(OSX, introduced: 10.53)
+class NestedClassTest {
+  class InnerClass : WidelyAvailableBase {}
+}
+
 // Useless #available(...) checks
 
 func functionWithDefaultAvailabilityAndUselessCheck(_ p: Bool) {

--- a/test/Sema/availability_versions_multi.swift
+++ b/test/Sema/availability_versions_multi.swift
@@ -35,14 +35,20 @@ func useFromOtherOn10_51() {
   _ = o10_51.returns10_52Introduced10_52() // expected-error {{'returns10_52Introduced10_52()' is only available on OS X 10.52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  _ = OtherIntroduced10_52() // expected-error {{'OtherIntroduced10_52' is only available on OS X 10.52 or newer}}
-      // expected-note@-1 {{add 'if #available' version check}}
+  _ = OtherIntroduced10_52()
+      // expected-error@-1 {{'OtherIntroduced10_52' is only available on OS X 10.52 or newer}}
+      // expected-error@-2 {{'init()' is only available on OS X 10.52 or newer}}
+      // expected-note@-3 {{add 'if #available' version check}}
+      // expected-note@-4 {{add 'if #available' version check}}
 
   o10_51.extensionMethodOnOtherIntroduced10_51AvailableOn10_52() // expected-error {{'extensionMethodOnOtherIntroduced10_51AvailableOn10_52()' is only available on OS X 10.52 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 
-  _ = OtherIntroduced10_51.NestedIntroduced10_52() // expected-error {{'NestedIntroduced10_52' is only available on OS X 10.52 or newer}}
-      // expected-note@-1 {{add 'if #available' version check}}
+  _ = OtherIntroduced10_51.NestedIntroduced10_52()
+      // expected-error@-1 {{'NestedIntroduced10_52' is only available on OS X 10.52 or newer}}
+      // expected-error@-2 {{'init()' is only available on OS X 10.52 or newer}}
+      // expected-note@-3 {{add 'if #available' version check}}
+      // expected-note@-4 {{add 'if #available' version check}}
 }
 
 @available(OSX, introduced: 10.52)


### PR DESCRIPTION
* Description: When a class inherits designated initializers from the superclass, we synthesize them. The superclass initializer might be less available than the superclass itself, so we have to inherit availability. We need to intersect this availability with all parent scopes of the subclass, to avoid a "declaration cannot be more available than its surrounding scope" error attached to an unknown source location.

* Risk: Low, this adds the outer scope walk to the existing fix.

* Tested: New test added.

* Radar: <rdar://problem/40853731>

* Reviewed by: @jrose-apple 