### PR TITLE
[stdlib] Try to make `magnitude` transparent again by using `&+`

### DIFF
--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -3592,12 +3592,10 @@ ${assignmentOperatorComment(x.operator, True)}
   /// to find an absolute value. In addition, because `abs(_:)` always returns
   /// a value of the same type, even in a generic context, using the function
   /// instead of the `magnitude` property is encouraged.
+  @_transparent
   public var magnitude: U${Self} {
-    @inline(__always)
-    get {
-      let base = U${Self}(_value)
-      return self < (0 as ${Self}) ? ~base + 1 : base
-    }
+    let base = U${Self}(_value)
+    return self < (0 as ${Self}) ? ~base &+ 1 : base
   }
 % end
 


### PR DESCRIPTION
Improvements from SE-0213 made constant propagation more
precise but, as a side-effect, resulted in more false positives,
to mitigate that `magnitude` has marked as `@inline(__always)`
but it could be made transparent again by using `&+` operator.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
