### PR TITLE
[AutoDiff] Part 2: Add differentiable activity analysis and entry point of control flow canonicalization

### DIFF
--- a/include/swift/SILOptimizer/Analysis/Analysis.def
+++ b/include/swift/SILOptimizer/Analysis/Analysis.def
@@ -44,5 +44,7 @@ ANALYSIS(ProtocolConformance)
 ANALYSIS(RCIdentity)
 ANALYSIS(SideEffect)
 ANALYSIS(TypeExpansion)
+// SWIFT_ENABLE_TENSORFLOW
+ANALYSIS(DifferentiableActivity)
 
 #undef ANALYSIS

--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -479,12 +479,13 @@ bool ControlFlowCanonicalization::run() {
 namespace {
 
 class DifferentiableActivityInfo;
+
 class DifferentiableActivityAnalysis
   : public FunctionAnalysisBase<DifferentiableActivityInfo> {
-  private:
+private:
   DominanceAnalysis *dominanceAnalysis = nullptr;
 
-  public:
+public:
   explicit DifferentiableActivityAnalysis()
     : FunctionAnalysisBase(AnalysisKind::DifferentiableActivity) {}
 
@@ -678,10 +679,10 @@ isActive(SILValue value, const SILReverseAutoDiffIndices &indices) const {
   return isVaried(value, indices.parameters) && isUseful(value, indices.source);
 }
 
-static void dumpActivityInfo(SILValue value,
-                             const SILReverseAutoDiffIndices &indices,
-                             DifferentiableActivityInfo &activityInfo,
-                             llvm::raw_ostream &s = llvm::dbgs()) {
+static inline void dumpActivityInfo(SILValue value,
+                                    const SILReverseAutoDiffIndices &indices,
+                                    DifferentiableActivityInfo &activityInfo,
+                                    llvm::raw_ostream &s = llvm::dbgs()) {
   s << '[';
   if (activityInfo.isActive(value, indices))
     s << "ACTIVE";
@@ -692,10 +693,10 @@ static void dumpActivityInfo(SILValue value,
   s << "] " << value;
 }
 
-static void dumpActivityInfo(SILFunction &fn,
-                             const SILReverseAutoDiffIndices &indices,
-                             DifferentiableActivityInfo &activityInfo,
-                             llvm::raw_ostream &s = llvm::dbgs()) {
+static inline void dumpActivityInfo(SILFunction &fn,
+                                    const SILReverseAutoDiffIndices &indices,
+                                    DifferentiableActivityInfo &activityInfo,
+                                    llvm::raw_ostream &s = llvm::dbgs()) {
   s << "Activity info for " << fn.getName() << " at " << indices << '\n';
   for (auto &bb : fn) {
     for (auto *arg : bb.getArguments())

--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -45,7 +45,7 @@
 #include "swift/Serialization/SerializedSILLoader.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Hashing.h"
-#include "llvm/ADT/SmallDenseSet.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"


### PR DESCRIPTION
Activity analysis helps AD figure out the result indices and parameter indices for a nested differentiation task. For example:

```swift
func bar(x: Float) {
  let (a, b, c) = foo(x, 0, 1)
  return b
}

#gradient(bar)
```

During automatic differentiation, we only need the partial derivative of dependent variable `b` with respect to independent variable `x`, that is, to reverse-differentiate `foo` from the second result with respect to the first parameter. Activity analysis is a simple data flow analysis that tells what variables (in the SIL case, SSA values) are "varied" with respect to independent variables, and what are "useful" for the output of a function.

The [relevant literature](https://www-sop.inria.fr/tropics/papers/supportCoursDA.pdf) is not using SSA form, so we twisted the definition a little bit.

**Note**: This is going to produce a bunch of unused warnings, but I'm merging other bits of #17901  asap.