### PR TITLE
[DO NOT MERGE] Drop the size heuristic once and for all

### DIFF
--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -1182,9 +1182,6 @@ namespace {
       // can assume the user did the right thing and that they don't need
       // a 'default' to be inserted.
       // FIXME: Do something sensible for non-frozen enums.
-      if (!sawRedundantPattern &&
-          coveredSpace.getSize(TC, DC) >= totalSpace.getSize(TC, DC))
-        return;
       diagnoseMissingCases(RequiresDefault::SpaceTooLarge, Space(),
                            unknownCase);
     }


### PR DESCRIPTION
⚠️  DO NOT MERGE ⚠️ 

This thing is [unsound](https://bugs.swift.org/browse/SR-7859) and subsumed by work on better heuristics.

Let's see what breaks if it's gone.