### PR TITLE
[4.2] migrator: ensure we collect post-migration fixits from the compiler.

### DIFF
--- a/lib/Migrator/FixitApplyDiagnosticConsumer.cpp
+++ b/lib/Migrator/FixitApplyDiagnosticConsumer.cpp
@@ -59,12 +59,12 @@ handleDiagnostic(SourceManager &SM, SourceLoc Loc,
 
     // Ignore meaningless Fix-its.
     if (Length == 0 && Text.size() == 0)
-      return;
+      continue;
 
     // Ignore pre-applied equivalents.
     Replacement R { Offset, Length, Text };
     if (Replacements.count(R)) {
-      return;
+      continue;
     } else {
       Replacements.insert(R);
     }

--- a/test/Migrator/post_fixit_pass.swift
+++ b/test/Migrator/post_fixit_pass.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/post_fixit_pass.swift.result -o /dev/null -F %S/mock-sdk -swift-version 3
+// RUN: diff -u %S/post_fixit_pass.swift.expected %t/post_fixit_pass.swift.result
+
+#if swift(>=4)
+  public struct SomeAttribute: RawRepresentable {
+    public init(rawValue: Int) { self.rawValue = rawValue }
+    public init(_ rawValue: Int) { self.rawValue = rawValue }
+    public var rawValue: Int
+    public typealias RawValue = Int
+  }
+#else
+  public typealias SomeAttribute = Int
+#endif
+
+func foo(_ d: SomeAttribute) {
+  let i: Int = d
+}
+

--- a/test/Migrator/post_fixit_pass.swift.expected
+++ b/test/Migrator/post_fixit_pass.swift.expected
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/post_fixit_pass.swift.result -o /dev/null -F %S/mock-sdk -swift-version 3
+// RUN: diff -u %S/post_fixit_pass.swift.expected %t/post_fixit_pass.swift.result
+
+#if swift(>=4)
+  public struct SomeAttribute: RawRepresentable {
+    public init(rawValue: Int) { self.rawValue = rawValue }
+    public init(_ rawValue: Int) { self.rawValue = rawValue }
+    public var rawValue: Int
+    public typealias RawValue = Int
+  }
+#else
+  public typealias SomeAttribute = Int
+#endif
+
+func foo(_ d: SomeAttribute) {
+  let i: Int = d.rawValue
+}
+


### PR DESCRIPTION
Explanation: Some incorrect logics in the post-migration fixit pass prevent us from picking-up the fixits that help eliminate build errors, leading to the observed failing migration case in the nominated radar. This patch fixed this logic issue.

Scope: Swift 4.2 migrator

Origination: Incorrect logics in post-migration fixit pass

Radar: rdar://problem/40925061

Risk: Very Low

Testing: Added regression tests; manual tests on code examples from the radar.

Reviewed By: Nathan Hawes
