### PR TITLE
[stdlib] Remove first and last as customization points

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift
+++ b/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift
@@ -107,14 +107,12 @@ public class SequenceLog {
   public static var isEmpty = TypeIndexed(0)
   public static var count = TypeIndexed(0)
   public static var _customIndexOfEquatableElement = TypeIndexed(0)
-  public static var first = TypeIndexed(0)
   public static var advance = TypeIndexed(0)
   public static var advanceLimit = TypeIndexed(0)
   public static var distance = TypeIndexed(0)
   // BidirectionalCollection
   public static var predecessor = TypeIndexed(0)
   public static var formPredecessor = TypeIndexed(0)
-  public static var last = TypeIndexed(0)
   // MutableCollection
   public static var subscriptIndexSet = TypeIndexed(0)
   public static var subscriptRangeSet = TypeIndexed(0)
@@ -406,11 +404,6 @@ extension LoggingCollection: Collection {
     return base._customIndexOfEquatableElement(element)
   }
 
-  public var first: Element? {
-    CollectionLog.first[selfType] += 1
-    return base.first
-  }
-
   public func index(_ i: Index, offsetBy n: Int) -> Index {
     CollectionLog.advance[selfType] += 1
     return base.index(i, offsetBy: n)
@@ -442,11 +435,6 @@ extension LoggingBidirectionalCollection: BidirectionalCollection {
   public func formIndex(before i: inout Index) {
     BidirectionalCollectionLog.formPredecessor[selfType] += 1
     base.formIndex(before: &i)
-  }
-
-  public var last: Element? {
-    BidirectionalCollectionLog.last[selfType] += 1
-    return base.last
   }
 }
 

--- a/stdlib/public/SDK/Foundation/IndexSet.swift
+++ b/stdlib/public/SDK/Foundation/IndexSet.swift
@@ -238,16 +238,6 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
         if x == NSNotFound { return nil } else { return x }
     }
 
-    /// Returns the first integer in `self`, or nil if `self` is empty.
-    public var first: Element? {
-        return _handle.map { _toOptional($0.firstIndex) }
-    }
-    
-    /// Returns the last integer in `self`, or nil if `self` is empty.
-    public var last: Element? {
-        return _handle.map { _toOptional($0.lastIndex) }
-    }
-    
     /// Returns an integer contained in `self` which is greater than `integer`, or `nil` if a result could not be found.
     public func integerGreaterThan(_ integer: Element) -> Element? {
         return _handle.map { _toOptional($0.indexGreaterThanIndex(integer)) }

--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -191,20 +191,6 @@ where SubSequence: BidirectionalCollection, Indices: BidirectionalCollection {
   ///     // c == MyFancyCollection([2, 4, 6, 8, 10])
   var indices: Indices { get }
   
-  // TODO: swift-3-indexing-model: tests.
-  /// The last element of the collection.
-  ///
-  /// If the collection is empty, the value of this property is `nil`.
-  ///
-  ///     let numbers = [10, 20, 30, 40, 50]
-  ///     if let lastNumber = numbers.last {
-  ///         print(lastNumber)
-  ///     }
-  ///     // Prints "50"
-  ///     
-  /// - Complexity: O(1)
-  var last: Element? { get }
-
   /// Accesses a contiguous subrange of the collection's elements.
   ///
   /// The accessed slice uses the same indices for the same elements as the

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1194,36 +1194,6 @@ extension Collection {
     return startIndex == endIndex
   }
 
-  /// The first element of the collection.
-  ///
-  /// If the collection is empty, the value of this property is `nil`.
-  ///
-  ///     let numbers = [10, 20, 30, 40, 50]
-  ///     if let firstNumber = numbers.first {
-  ///         print(firstNumber)
-  ///     }
-  ///     // Prints "10"
-  @inlinable
-  public var first: Element? {
-    @inline(__always)
-    get {
-      // NB: Accessing `startIndex` may not be O(1) for some lazy collections,
-      // so instead of testing `isEmpty` and then returning the first element,
-      // we'll just rely on the fact that the iterator always yields the
-      // first element first.
-      var i = makeIterator()
-      return i.next()
-    }
-  }
-  
-  // TODO: swift-3-indexing-model - uncomment and replace above ready (or should we still use the iterator one?)
-  /// Returns the first element of `self`, or `nil` if `self` is empty.
-  ///
-  /// - Complexity: O(1)
-  //  public var first: Element? {
-  //    return isEmpty ? nil : self[startIndex]
-  //  }
-
   /// A value less than or equal to the number of elements in the collection.
   ///
   /// - Complexity: O(1) if the collection conforms to

--- a/stdlib/public/core/CollectionAlgorithms.swift
+++ b/stdlib/public/core/CollectionAlgorithms.swift
@@ -11,6 +11,28 @@
 //===----------------------------------------------------------------------===//
 
 //===----------------------------------------------------------------------===//
+// first
+//===----------------------------------------------------------------------===//
+
+extension Collection {
+  /// The first element of the collection.
+  ///
+  /// If the collection is empty, the value of this property is `nil`.
+  ///
+  ///     let numbers = [10, 20, 30, 40, 50]
+  ///     if let firstNumber = numbers.first {
+  ///         print(firstNumber)
+  ///     }
+  ///     // Prints "10"
+  @inlinable
+  public var first: Element? {
+    let start = startIndex
+    if start != endIndex { return self[start] }
+    else { return nil }
+  }  
+}
+
+//===----------------------------------------------------------------------===//
 // last
 //===----------------------------------------------------------------------===//
 

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -352,9 +352,6 @@ internal class _AnyRandomAccessCollectionBox<Element>
   func _customLastIndexOfEquatableElement(element: Element) -> Index??
   */
 
-  @inlinable // FIXME(sil-serialize-all)
-  internal var _first: Element? { _abstract() }
-
   @inlinable
   internal init(
     _startIndex: _AnyIndexBox,
@@ -385,8 +382,6 @@ internal class _AnyRandomAccessCollectionBox<Element>
   internal func _index(before i: _AnyIndexBox) -> _AnyIndexBox { _abstract() }
   @inlinable
   internal func _formIndex(before i: _AnyIndexBox) { _abstract() }
-  @inlinable
-  internal var _last: Element? { _abstract() }
 %   end
 }
 
@@ -617,11 +612,6 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Element>
     return numericCast(_base.count)
   }
 
-  @inlinable
-  internal override var _first: Element? {
-    return _base.first
-  }
-
 %     if Kind in ['BidirectionalCollection', 'RandomAccessCollection']:
   @inlinable
   internal override func _index(before position: _AnyIndexBox) -> _AnyIndexBox {
@@ -634,11 +624,6 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Element>
       return _base.formIndex(before: &p._base)
     }
     fatalError("Index type mismatch!")
-  }
-
-  @inlinable
-  internal override var _last: Element? {
-    return _base.last
   }
 %     end
 
@@ -1121,11 +1106,6 @@ extension ${Self}: ${SelfProtocol} {
     return _box._count
   }
 
-  @inlinable
-  public var first: Element? {
-    return _box._first
-  }
-
 %   if Traversal == 'Bidirectional' or Traversal == 'RandomAccess':
   @inlinable
   public func index(before i: Index) -> Index {
@@ -1140,11 +1120,6 @@ extension ${Self}: ${SelfProtocol} {
     else {
       i = index(before: i)
     }
-  }
-
-  @inlinable
-  public var last: Element? {
-    return _box._last
   }
 %   end
 }

--- a/stdlib/public/core/LazyCollection.swift
+++ b/stdlib/public/core/LazyCollection.swift
@@ -201,12 +201,6 @@ extension LazyCollection : Collection {
     return _base._customLastIndexOfEquatableElement(element)
   }
 
-  /// Returns the first element of `self`, or `nil` if `self` is empty.
-  @inlinable
-  public var first: Element? {
-    return _base.first
-  }
-
   // TODO: swift-3-indexing-model - add docs
   @inlinable
   public func index(_ i: Index, offsetBy n: Int) -> Index {
@@ -234,11 +228,6 @@ extension LazyCollection : BidirectionalCollection
   @inlinable
   public func index(before i: Index) -> Index {
     return _base.index(before: i)
-  }
-
-  @inlinable
-  public var last: Element? {
-    return _base.last
   }
 }
 

--- a/stdlib/public/core/Map.swift
+++ b/stdlib/public/core/Map.swift
@@ -188,9 +188,6 @@ extension LazyMapCollection: LazyCollectionProtocol {
   }
 
   @inlinable
-  public var first: Element? { return _base.first.map(_transform) }
-
-  @inlinable
   public func index(_ i: Index, offsetBy n: Int) -> Index {
     return _base.index(i, offsetBy: n)
   }
@@ -223,9 +220,6 @@ extension LazyMapCollection : BidirectionalCollection
   public func formIndex(before i: inout Index) {
     _base.formIndex(before: &i)
   }
-
-  @inlinable
-  public var last: Element? { return _base.last.map(_transform) }
 }
 
 extension LazyMapCollection : RandomAccessCollection

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -375,20 +375,6 @@ extension Set: Collection {
   public var isEmpty: Bool {
     return count == 0
   }
-
-  /// The first element of the set.
-  ///
-  /// The first element of the set is not necessarily the first element added
-  /// to the set. Don't expect any particular ordering of set elements.
-  ///
-  /// If the set is empty, the value of this property is `nil`.
-  @inlinable
-  public var first: Element? {
-    // FIXME: It'd better to use an iterator than to subscript with startIndex,
-    // because startIndex is currently O(n) in bridged sets. However,
-    // enumerators aren't guaranteed to have the same element order as allKeys.
-    return count > 0 ? self[startIndex] : nil
-  }
 }
 
 // FIXME: rdar://problem/23549059 (Optimize == for Set)

--- a/validation-test/stdlib/CollectionType.swift.gyb
+++ b/validation-test/stdlib/CollectionType.swift.gyb
@@ -560,8 +560,8 @@ CollectionTypeTests.test("Collection.makeIterator()/CustomImplementation") {
 CollectionTypeTests.test("subscript(_: Range<Index>)/Dispatch") {
   let tester = CollectionLog.dispatchTester([OpaqueValue(1)])
   _ = tester[tester.startIndex..<tester.endIndex]
-  let log = tester.log
-  let log2 = tester.log.subscriptRange
+  _ = tester.log
+  _ = tester.log.subscriptRange
   expectCustomizable(tester, tester.log.subscriptRange)
 }
 
@@ -573,8 +573,7 @@ CollectionTypeTests.test("subscript(_: Range<Index>)/writeback") {
   let i = collection.startIndex
   let j = collection.index(i, offsetBy: 5)
   collection[i..<j].sort()
-  expectEqualSequence(
-    [ 1, 2, 3, 4, 5, 0, -1, -2, -3, -4 ], collection)
+  expectEqualSequence([ 1, 2, 3, 4, 5, 0, -1, -2, -3, -4 ], collection)
 }
 
 CollectionTypeTests.test("subscript(_: Range<Index>)/defaultImplementation/sliceTooLarge")
@@ -601,16 +600,6 @@ CollectionTypeTests.test("isEmpty/dispatch") {
   let tester = CollectionLog.dispatchTester([OpaqueValue(1)])
   _ = tester.isEmpty
   expectCustomizable(tester, tester.log.isEmpty)
-}
-
-//===----------------------------------------------------------------------===//
-// first
-//===----------------------------------------------------------------------===//
-
-CollectionTypeTests.test("first/dispatch") {
-  let tester = CollectionLog.dispatchTester([OpaqueValue(1)])
-  _ = tester.first
-  expectCustomizable(tester, tester.log.first)
 }
 
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/ExistentialCollection.swift.gyb
+++ b/validation-test/stdlib/ExistentialCollection.swift.gyb
@@ -331,23 +331,6 @@ tests.test("${TestedType}: dispatch to wrapped, CollectionLog") {
     _blackHole(x)
   }
 %   end
-
-  Log.first.expectIncrement(Base.self) {
-    Log.startIndex.expectUnchanged(Base.self) {
-      Log.makeIterator.expectUnchanged(Base.self) {
-        _ = c.first
-      }
-    }
-  }
-
-%   if Traversal in ['Bidirectional', 'RandomAccess']:
-  BidirectionalCollectionLog.last.expectIncrement(Base.self) {
-    Log.endIndex.expectUnchanged(Base.self) {
-      _ = c.last
-    }
-  }
-%   end
-
 }
 %   end
 % end

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -747,7 +747,6 @@ tests.test("LazyCollection/Passthrough") {
   CollectionLog._customIndexOfEquatableElement.expectIncrement(baseType) {
     _ = s._customIndexOfEquatableElement(OpaqueValue(0))
   }
-  CollectionLog.first.expectIncrement(baseType) { _ = s.first }
 }
 
 //===--- Map --------------------------------------------------------------===//
@@ -844,9 +843,6 @@ tests.test("LazyMapCollection/Passthrough") {
   }
   CollectionLog.isEmpty.expectIncrement(type(of: base)) {
     _ = mapped.isEmpty
-  }
-  CollectionLog.first.expectIncrement(type(of: base)) {
-    _ = mapped.first
   }
   CollectionLog.underestimatedCount.expectIncrement(type(of: base)) {
     _ = mapped.underestimatedCount
@@ -1291,7 +1287,7 @@ do {
 }
 
 struct TryFlattenIndex<C: Collection> where C.Element: Collection {
-  typealias FlattenedIndex = FlattenCollectionIndex<C>
+  typealias FlattenedIndex = FlattenCollection<C>.Index
 }
 
 


### PR DESCRIPTION
`first` and `last` have long been customization points, but this presents a problem for move-only types, which would need to be able to somehow form a temporary `Optional<Element>` value from a non-optional Element without modifying the collection.

Since ABI stability would lock these customization points in place, the conservative move is to remove them for now, since the actual optimizability of `first` is questionably material anyway. In future, the extension that adds them could be constrained to only copyable types.

This would only be source-breaking change if someone has implemented `first` to somehow have different semantic behavior to, you know, getting the first element.