### PR TITLE
SILGen: Cope with overloads when emitting artificial main for @UIApplicationMain.

### DIFF
--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -449,9 +449,24 @@ void SILGenFunction::emitArtificialTopLevel(ClassDecl *mainClass) {
                            /*resolver*/nullptr,
                            results);
     assert(!results.empty() && "couldn't find UIApplicationMain in UIKit");
-    assert(results.size() == 1 && "more than one UIApplicationMain?");
 
-    auto mainRef = SILDeclRef(results.front()).asForeign();
+    // We want the original UIApplicationMain() declaration from Objective-C,
+    // not any overlay overloads.
+    ValueDecl *UIApplicationMainDecl = nullptr;
+    for (auto *result : results) {
+      if (result->hasClangNode()) {
+        assert(!UIApplicationMainDecl
+               && "more than one UIApplicationMain defined in ObjC?!");
+        UIApplicationMainDecl = result;
+#ifndef NDEBUG
+        break;
+#endif
+      }
+    }
+    
+    assert(UIApplicationMainDecl && "no UIApplicationMain defined in ObjC?!");
+
+    auto mainRef = SILDeclRef(UIApplicationMainDecl).asForeign();
     auto UIApplicationMainFn = SGM.M.getOrCreateFunction(mainClass, mainRef,
                                                          NotForDefinition);
     auto fnTy = UIApplicationMainFn->getLoweredFunctionType();

--- a/test/SILGen/Inputs/UIKit.swift
+++ b/test/SILGen/Inputs/UIKit.swift
@@ -1,3 +1,4 @@
 import Foundation
 @_exported import UIKit
 
+public func UIApplicationMain() {}

--- a/test/SILGen/Inputs/usr/include/UIKit.h
+++ b/test/SILGen/Inputs/usr/include/UIKit.h
@@ -3,6 +3,12 @@
 @protocol UIApplicationDelegate
 @end
 
+#ifdef SILGEN_TEST_UIAPPLICATIONMAIN_NULLABILITY
+int UIApplicationMain(int argc, char *_Nullable *_Nonnull argv,
+                      NSString *_Nullable principalClassName, 
+                      NSString *_Nullable delegateClassName);
+#else
 int UIApplicationMain(int argc, char **argv,
                       NSString *principalClassName, 
                       NSString *delegateClassName);
+#endif

--- a/test/SILGen/UIApplicationMain.swift
+++ b/test/SILGen/UIApplicationMain.swift
@@ -1,8 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-silgen-test-overlays
+// RUN: %build-silgen-test-overlays-ios
 
 // RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) -parse-as-library %s | %FileCheck %s
 // RUN: %target-swift-emit-ir(mock-sdk: -sdk %S/Inputs -I %t) -parse-as-library %s | %FileCheck %s -check-prefix=IR
+
+// RUN: %target-swift-emit-silgen(mock-sdk: -Xcc -DSILGEN_TEST_UIAPPLICATIONMAIN_NULLABILITY -sdk %S/Inputs -I %t) -parse-as-library %s | %FileCheck %s
+// RUN: %target-swift-emit-ir(mock-sdk: -Xcc -DSILGEN_TEST_UIAPPLICATIONMAIN_NULLABILITY -sdk %S/Inputs -I %t) -parse-as-library %s | %FileCheck %s -check-prefix=IR
 
 // RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) -parse-as-library %s -D REFERENCE | %FileCheck %s
 // RUN: %target-swift-emit-ir(mock-sdk: -sdk %S/Inputs -I %t) -parse-as-library %s -D REFERENCE | %FileCheck %s -check-prefix=IR

--- a/test/SILGen/lit.local.cfg
+++ b/test/SILGen/lit.local.cfg
@@ -5,3 +5,6 @@ config.substitutions.insert(0, ('%build-silgen-test-overlays',
                                 '%target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -enable-objc-interop -o %t %S/Inputs/ObjectiveC.swift && '
                                 '%target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -enable-objc-interop -o %t %S/Inputs/Dispatch.swift && '
                                 '%target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -enable-objc-interop -o %t %S/Inputs/Foundation.swift'))
+
+config.substitutions.insert(0, ('%build-silgen-test-overlays-ios',
+                                '%target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -enable-objc-interop -o %t %S/Inputs/UIKit.swift'))


### PR DESCRIPTION
The overlay may add overloads for UIApplicationMain for various reasons. When we generate the special `main` implementation for a `@UIApplicationMain` class, we want to call the original function from Objective-C, so pick that one where there are multiple overloads to choose from. Fixes rdar://problem/42352695.