### PR TITLE
[4.2] SILGen: Cope with overloads when emitting artificial main for @UIApplicationMain.

### DIFF
--- a/test/SILGen/Inputs/UIKit.swift
+++ b/test/SILGen/Inputs/UIKit.swift
@@ -1,3 +1,4 @@
 import Foundation
 @_exported import UIKit
 
+public func UIApplicationMain() {}

--- a/test/SILGen/Inputs/usr/include/UIKit.h
+++ b/test/SILGen/Inputs/usr/include/UIKit.h
@@ -3,6 +3,12 @@
 @protocol UIApplicationDelegate
 @end
 
+#ifdef SILGEN_TEST_UIAPPLICATIONMAIN_NULLABILITY
+int UIApplicationMain(int argc, char *_Nullable *_Nonnull argv,
+                      NSString *_Nullable principalClassName, 
+                      NSString *_Nullable delegateClassName);
+#else
 int UIApplicationMain(int argc, char **argv,
                       NSString *principalClassName, 
                       NSString *delegateClassName);
+#endif

--- a/test/SILGen/UIApplicationMain.swift
+++ b/test/SILGen/UIApplicationMain.swift
@@ -1,8 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-silgen-test-overlays
+// RUN: %build-silgen-test-overlays-ios
 
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-silgen -parse-as-library %s | %FileCheck %s
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-ir -parse-as-library %s | %FileCheck %s -check-prefix=IR
+
+// RUN: %target-swift-frontend(mock-sdk: -DSILGEN_TEST_UIAPPLICATIONMAIN_NULLABILITY -sdk %S/Inputs -I %t) -emit-silgen -parse-as-library %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -DSILGEN_TEST_UIAPPLICATIONMAIN_NULLABILITY -sdk %S/Inputs -I %t) -emit-ir -parse-as-library %s | %FileCheck %s -check-prefix=IR
 
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-silgen -parse-as-library %s -D REFERENCE | %FileCheck %s
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-ir -parse-as-library %s -D REFERENCE | %FileCheck %s -check-prefix=IR

--- a/test/SILGen/lit.local.cfg
+++ b/test/SILGen/lit.local.cfg
@@ -5,3 +5,6 @@ config.substitutions.insert(0, ('%build-silgen-test-overlays',
   '%target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -o %t %S/Inputs/ObjectiveC.swift && '
   '%target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -o %t %S/Inputs/Dispatch.swift && '
   '%target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -o %t %S/Inputs/Foundation.swift'))
+
+config.substitutions.insert(0, ('%build-silgen-test-overlays-ios',
+  '%target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -o %t %S/Inputs/UIKit.swift'))


### PR DESCRIPTION
Explanation: Overloading `UIApplicationMain` in the UIKit overlay would cause an assertion failure.

Scope: Allows a compatibility break introduced by changes to the iOS SDK to be handled in the overlay.

Issue: rdar://problem/42352695

Risk: Low. Replaces an assertion failure on overloading with a check to filter out non-ObjC-defined declarations of UIApplicationMain.

Testing: Swift CI, compatibility suite

Reviewed by: @slavapestov 