### PR TITLE
[test] Stop a test relying on inconsistent formatting of an error message.

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/0166-sr8240-2.swift
+++ b/validation-test/compiler_crashers_2_fixed/0166-sr8240-2.swift
@@ -9,7 +9,7 @@ extension Repr {
 }
 extension Box where Representation == Repr, T == Representation.RawEnum {
     init(rawEnumValue: Representation.RawEnum) {
-        let _: Int.Type = T.self // expected-error {{cannot convert value of type '().Type' to specified type 'Int.Type'}}
+        let _: ().Type = T.self
         fatalError()
     }
 }


### PR DESCRIPTION
Fixes rdar://problem/42351773.
