### PR TITLE
[libSyntax] Rename getAbsolutePosition-related methods for more clarity

### DIFF
--- a/include/swift/Syntax/Syntax.h
+++ b/include/swift/Syntax/Syntax.h
@@ -200,16 +200,15 @@ public:
     return Data->getAbsolutePosition();
   }
 
-  /// Get the absolute end position (exclusively) of this raw syntax: its offset,
-  /// line, and column.
-  AbsolutePosition getAbsoluteEndPosition() const {
-    return Data->getAbsoluteEndPosition();
+  /// Get the absolute end position (exclusively) where the trailing trivia of
+  /// this node ends.
+  AbsolutePosition getAbsoluteEndPositionAfterTrailingTrivia() const {
+    return Data->getAbsoluteEndPositionAfterTrailingTrivia();
   }
 
-  /// Get the absolute position without skipping the leading trivia of this
-  /// node.
-  AbsolutePosition getAbsolutePositionWithLeadingTrivia() const {
-    return Data->getAbsolutePositionWithLeadingTrivia();
+  /// Get the absolute position at which the leading trivia of this node starts.
+  AbsolutePosition getAbsolutePositionBeforeLeadingTrivia() const {
+    return Data->getAbsolutePositionBeforeLeadingTrivia();
   }
 
   // TODO: hasSameStructureAs ?

--- a/include/swift/Syntax/SyntaxData.h
+++ b/include/swift/Syntax/SyntaxData.h
@@ -255,11 +255,11 @@ public:
 
   /// Calculate the absolute end position of this node, use cache of the immediate
   /// next node if populated.
-  AbsolutePosition getAbsoluteEndPosition() const;
+  AbsolutePosition getAbsoluteEndPositionAfterTrailingTrivia() const;
 
   /// Get the absolute position without skipping the leading trivia of this
   /// node.
-  AbsolutePosition getAbsolutePositionWithLeadingTrivia() const;
+  AbsolutePosition getAbsolutePositionBeforeLeadingTrivia() const;
 
   /// Returns true if the data node represents type syntax.
   bool isType() const;

--- a/lib/Parse/SyntaxParsingCache.cpp
+++ b/lib/Parse/SyntaxParsingCache.cpp
@@ -17,7 +17,7 @@ using namespace swift::syntax;
 
 bool SyntaxParsingCache::nodeCanBeReused(const Syntax &Node, size_t Position,
                                          SyntaxKind Kind) const {
-  auto NodeStart = Node.getAbsolutePositionWithLeadingTrivia().getOffset();
+  auto NodeStart = Node.getAbsolutePositionBeforeLeadingTrivia().getOffset();
   if (NodeStart != Position)
     return false;
   if (Node.getKind() != Kind)
@@ -60,7 +60,8 @@ llvm::Optional<Syntax> SyntaxParsingCache::lookUpFrom(const Syntax &Node,
     if (!Child.hasValue()) {
       continue;
     }
-    auto ChildStart = Child->getAbsolutePositionWithLeadingTrivia().getOffset();
+    auto ChildStart =
+        Child->getAbsolutePositionBeforeLeadingTrivia().getOffset();
     auto ChildEnd = ChildStart + Child->getTextLength();
     if (ChildStart <= Position && Position < ChildEnd) {
       return lookUpFrom(Child.getValue(), Position, Kind);

--- a/lib/Syntax/RawSyntax.cpp
+++ b/lib/Syntax/RawSyntax.cpp
@@ -225,7 +225,7 @@ bool RawSyntax::accumulateLeadingTrivia(AbsolutePosition &Pos) const {
     }
   } else {
     for (auto &Child: getLayout()) {
-      if (!Child)
+      if (!Child || Child->isMissing())
         continue;
       if (Child->accumulateLeadingTrivia(Pos))
         return true;

--- a/lib/Syntax/SyntaxData.cpp
+++ b/lib/Syntax/SyntaxData.cpp
@@ -96,11 +96,11 @@ RC<SyntaxData> SyntaxData::getFirstToken() const {
   return getParent()->getChild(getIndexInParent());
 }
 
-AbsolutePosition SyntaxData::getAbsolutePositionWithLeadingTrivia() const {
+AbsolutePosition SyntaxData::getAbsolutePositionBeforeLeadingTrivia() const {
   if (PositionCache.hasValue())
     return *PositionCache;
   if (auto P = getPreviousNode()) {
-    auto Result = P->getAbsolutePositionWithLeadingTrivia();
+    auto Result = P->getAbsolutePositionBeforeLeadingTrivia();
     P->getRaw()->accumulateAbsolutePosition(Result);
     // FIXME: avoid using const_cast.
     const_cast<SyntaxData*>(this)->PositionCache = Result;
@@ -111,16 +111,16 @@ AbsolutePosition SyntaxData::getAbsolutePositionWithLeadingTrivia() const {
 }
 
 AbsolutePosition SyntaxData::getAbsolutePosition() const {
-  auto Result = getAbsolutePositionWithLeadingTrivia();
+  auto Result = getAbsolutePositionBeforeLeadingTrivia();
   getRaw()->accumulateLeadingTrivia(Result);
   return Result;
 }
 
-AbsolutePosition SyntaxData::getAbsoluteEndPosition() const {
+AbsolutePosition SyntaxData::getAbsoluteEndPositionAfterTrailingTrivia() const {
   if (auto N = getNextNode()) {
-    return N->getAbsolutePositionWithLeadingTrivia();
+    return N->getAbsolutePositionBeforeLeadingTrivia();
   } else {
-    auto Result = getAbsolutePositionWithLeadingTrivia();
+    auto Result = getAbsolutePositionBeforeLeadingTrivia();
     getRaw()->accumulateAbsolutePosition(Result);
     return Result;
   }

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -655,7 +655,7 @@ private:
       return;
 
     auto LeadingTriviaOffset =
-        Token.getAbsolutePositionWithLeadingTrivia().getOffset();
+        Token.getAbsolutePositionBeforeLeadingTrivia().getOffset();
     visitTrivia(Token.getLeadingTrivia(), LeadingTriviaOffset);
 
     SyntaxClassification Classification = TokenClassifications[Token.getId()];

--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -476,7 +476,7 @@ bool verifyReusedRegions(ByteBasedSourceRangeSet ExpectedReparseRegions,
                          SourceFile *SF) {
   // We always expect the EOF token to be reparsed. Don't complain about it.
   auto Eof = SF->getSyntaxRoot().getChild(SourceFileSyntax::Cursor::EOFToken);
-  auto EofNodeStart = Eof->getAbsolutePositionWithLeadingTrivia().getOffset();
+  auto EofNodeStart = Eof->getAbsolutePositionBeforeLeadingTrivia().getOffset();
   if (ExpectedReparseRegions.Ranges.back().End >= EofNodeStart) {
     // If the last expected reparse region already covers part of the eof
     // leading trivia, extended it

--- a/unittests/Syntax/AbsolutePositionTests.cpp
+++ b/unittests/Syntax/AbsolutePositionTests.cpp
@@ -16,7 +16,7 @@ TEST(PositionTests, AbsolutePosition1) {
   ASSERT_EQ(7u, Pos.getLine());
   ASSERT_EQ(1u, Pos.getColumn());
   ASSERT_EQ(8u, Pos.getOffset());
-  AbsolutePosition EndPos = Token.getAbsoluteEndPosition();
+  AbsolutePosition EndPos = Token.getAbsoluteEndPositionAfterTrailingTrivia();
   ASSERT_EQ(7u, EndPos.getLine());
   ASSERT_EQ(4u, EndPos.getColumn());
   ASSERT_EQ(11u, EndPos.getOffset());
@@ -30,7 +30,7 @@ TEST(PositionTests, AbsolutePosition2) {
   ASSERT_EQ(4u, Pos.getLine());
   ASSERT_EQ(4u, Pos.getColumn());
   ASSERT_EQ(10u, Pos.getOffset());
-  AbsolutePosition EndPos = Token.getAbsoluteEndPosition();
+  AbsolutePosition EndPos = Token.getAbsoluteEndPositionAfterTrailingTrivia();
   ASSERT_EQ(4u, EndPos.getLine());
   ASSERT_EQ(7u, EndPos.getColumn());
   ASSERT_EQ(13u, EndPos.getOffset());


### PR DESCRIPTION
Rename in `Syntax.h`:
- `getAbsoluteEndPosition` -> `getAbsoluteEndPositionAfterTrailingTrivia`
- `getAbsolutePositionWithLeadingTrivia` -> `getAbsolutePositionBeforeLeadingTrivia`

I believe this gives more clarity on what these methods are actually computing