### PR TITLE
[stdlib] Work-around incorrect name resolution with conditional BidirectionalCollections.

### DIFF
--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -255,7 +255,9 @@ extension BidirectionalCollection where SubSequence == Self {
     _precondition(n >= 0, "Number of elements to remove should be non-negative")
     _precondition(count >= n,
       "Can't remove more items from a collection than it contains")
-    self = self[startIndex..<index(endIndex, offsetBy: -n)]
+    // FIXME: using non-_'d `index` incorrectly calls the Collection one for
+    // conditional conformances to BidirectionalCollections.
+    self = self[startIndex..<_index(endIndex, offsetBy: -n)]
   }
 }
 
@@ -281,7 +283,9 @@ extension BidirectionalCollection {
   public func dropLast(_ n: Int) -> SubSequence {
     _precondition(
       n >= 0, "Can't drop a negative number of elements from a collection")
-    let end = index(
+    // FIXME: using non-_'d `index` incorrectly calls the Collection one for
+    // conditional conformances to BidirectionalCollections.
+    let end = _index(
       endIndex,
       offsetBy: -n,
       limitedBy: startIndex) ?? startIndex
@@ -311,7 +315,9 @@ extension BidirectionalCollection {
     _precondition(
       maxLength >= 0,
       "Can't take a suffix of negative length from a collection")
-    let start = index(
+    // FIXME: using non-_'d `index` incorrectly calls the Collection one for
+    // conditional conformances to BidirectionalCollections.
+    let start = _index(
       endIndex,
       offsetBy: -maxLength,
       limitedBy: startIndex) ?? startIndex

--- a/test/stdlib/conditional_collections.swift
+++ b/test/stdlib/conditional_collections.swift
@@ -1,0 +1,38 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+
+struct X: BidirectionalCollection {
+  var startIndex: Int { return 0 }
+  var endIndex: Int { return 10 }
+  subscript(position: Int) -> String { return "element" }
+  subscript(range: Range<Int>) -> X { return X() }
+  func index(after i: Int) -> Int { return i + 1 }
+  func index(before i: Int) -> Int { return i - 1 }
+}
+struct A<C: Collection>: Collection {
+  let c: C
+  var startIndex: C.Index { return c.startIndex }
+  var endIndex: C.Index { return c.endIndex }
+  subscript(position: C.Index) -> C.Element { return c[position] }
+  subscript(range: Range<C.Index>) -> A<C.SubSequence> {
+    return A<C.SubSequence>(c: c[range])
+  }
+  func index(after i: C.Index) -> C.Index { return c.index(after: i) }
+}
+
+extension A: BidirectionalCollection where C: BidirectionalCollection {
+  func index(before i: C.Index) -> C.Index { return c.index(before: i) }
+}
+
+// SR-8022
+func sr8022() {
+  var c = A(c: X())
+  _ = c.popLast()
+  _ = c.removeLast()
+  c.removeLast(2)
+  _ = c.dropLast(2)
+  _ = c.suffix(2)
+}
+
+sr8022()


### PR DESCRIPTION
If a type conditionally conforms to BidirectionalCollection, suffix's (and the
others) use of `index` ends up dispatching through `Collection.index` seemingly
because it is a protocol requirement. The intended function is
BidirectionalCollection's overloaded `index` (which _isn't_ connected to a
protocol requirement), which is called for non-conditional conformances. As
such, this is a work-around to stop code crashing.

Noticed in SR-8022, rdar://problem/41216424.
