### PR TITLE
Add missing default dependencies when linking statically in Linux

### DIFF
--- a/utils/gen-static-stdlib-link-args
+++ b/utils/gen-static-stdlib-link-args
@@ -63,7 +63,9 @@ function write_linkfile {
 -lpthread
 -latomic
 -lswiftCore
--latomic
+-lcurl
+-lxml2
+-lbsd
 -lswiftImageInspectionShared
 $ICU_LIBS
 -Xlinker


### PR DESCRIPTION
<!-- What's in this pull request? -->
Related bug: https://bugs.swift.org/browse/SR-2205

These new linker flags are required when statically linking a Swift binary in Linux. The changes required to add the missing libdispatch.a should be made on swift-corelibs-libdispatch, so these changes are related, but orthogonal to that.

I manually tested that a toolchain with static libdispatch.a can successfully link with this change and no extra linker flags.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
