### PR TITLE
[GPE] Make TF infinite-loop error more user-friendly

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -1083,11 +1083,10 @@ bool TFFunctionPartition::markBlock(SILBasicBlock *BB) {
         // out here.
         // FIXME: Consider using a different error code than `tf_op_misuse`.
         diagnose(hostFn.getASTContext(),
-                 getUserSourceLocation(pred->front().getDebugLocation())
-                     .getSourceLoc(),
+                 hostFn.getLocation().getSourceLoc(),
                  diag::tf_op_misuse,
-                 "Cannot partition function '" + hostFn.getName().str() +
-                     "' -- is there an infinite loop?");
+                 "Functions containing infinite loops are not supported by "
+                 "TensorFlow yet");
         return true;
       }
 
@@ -1103,11 +1102,10 @@ bool TFFunctionPartition::markBlock(SILBasicBlock *BB) {
           // out here.
           // FIXME: Consider using a different error code than `tf_op_misuse`.
           diagnose(hostFn.getASTContext(),
-                   getUserSourceLocation(succ->front().getDebugLocation())
-                       .getSourceLoc(),
+                   hostFn.getLocation().getSourceLoc(),
                    diag::tf_op_misuse,
-                   "Cannot partition function '" + hostFn.getName().str() +
-                       "' -- is there an infinite loop?");
+                   "Functions containing infinite loops are not supported by "
+                   "TensorFlow yet");
           return true;
         }
         if (tensorCodeBlocks.contains(succ))

--- a/test/TensorFlow/control_flow.swift
+++ b/test/TensorFlow/control_flow.swift
@@ -281,12 +281,12 @@ public func foo<T>(_ a: T) {
 // }
 
 // An infinite loop that we reject in partitioning.
+// expected-error @+1 {{Functions containing infinite loops are not supported by TensorFlow yet}}
 public func infLoop1() {
   let maxCount: Int32 = 100
   var a = Tensor<Int32>(0)
   let count: Int32 = 0 
   while count < maxCount {
-    // expected-error @+1 {{Cannot partition function}}
     a += a
   }
   a -= a
@@ -295,6 +295,7 @@ public func infLoop1() {
 
 // Another infinite loop that we reject in partitioning.
 // simplified from https://bugs.swift.org/browse/SR-8236
+// expected-error @+1 {{Functions containing infinite loops are not supported by TensorFlow yet}}
 public func infLoop2(maxCount: Int32) {
   var a = Tensor<Int32>(0)
   var count: Int32 = 0
@@ -307,7 +308,7 @@ public func infLoop2(maxCount: Int32) {
       // this causes trouble: infinite loop
       while i < maxCount {
         count += i
-      }  // expected-error {{Cannot partition function}}
+      }
       a = Tensor<Int32>(count)
       break
     }


### PR DESCRIPTION
```swift
import TensorFlow
func foo() {
  var t: Tensor<Float> = [[1.0, 2.0]]
  var i = 0
  repeat {
    t += t + t
  } while i < 10
}
foo()
```

Previously this test would yield the following error:
```console
test.swift:6:9: error: Cannot partition function '$S4test3fooyyF' -- is there an infinite loop?
          t += t + t
               ^
```

This is confusing because the function name is a SIL name, the term "partitioning" is an implementation detail, and the source location is a rather random AST node within the loop. This patch moves the source loc to the function declaration and makes the error messages a bit more user-friendly.

After the patch:
```console
test.swift:2:6: error: Functions containing infinite loops are not supported by TensorFlow yet
func foo() {
     ^
```