### PR TITLE
Unify several l-value access emission paths in SILGen

### DIFF
--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -105,6 +105,7 @@ public:
 
     // Logical LValue kinds
     GetterSetterKind,           // property or subscript getter/setter
+    MaterializeToTemporaryKind,
     OwnershipKind,              // weak pointer remapping
     AutoreleasingWritebackKind, // autorelease pointer on set
     WritebackPseudoKind,        // a fake component to customize writeback
@@ -261,13 +262,15 @@ public:
   virtual RValue get(SILGenFunction &SGF, SILLocation loc,
                      ManagedValue base, SGFContext c) && = 0;
 
-  /// Compare 'this' lvalue and the 'rhs' lvalue (which is guaranteed to have
-  /// the same dynamic PathComponent type as the receiver) to see if they are
-  /// identical.  If so, there is a conflicting writeback happening, so emit a
-  /// diagnostic.
-  virtual void diagnoseWritebackConflict(LogicalPathComponent *rhs,
-                                         SILLocation loc1, SILLocation loc2,
-                                         SILGenFunction &SGF) = 0;
+  struct AccessedStorage {
+    AbstractStorageDecl *Storage;
+    bool IsSuper;
+    const RValue *Indices;
+    Expr *IndexExprForDiagnostics;
+  };
+
+  /// Get the storage accessed by this component.
+  virtual Optional<AccessedStorage> getAccessedStorage() const = 0;
 
 
   /// Materialize the storage into memory.  If the access is for
@@ -313,10 +316,8 @@ public:
     return kind;
   }
 
-  void diagnoseWritebackConflict(LogicalPathComponent *RHS,
-                                 SILLocation loc1, SILLocation loc2,
-                                 SILGenFunction &SGF) override {
-    // no useful writeback diagnostics at this point
+  Optional<AccessedStorage> getAccessedStorage() const override {
+    return None;
   }
 
   RValue get(SILGenFunction &SGF, SILLocation loc,
@@ -428,25 +429,28 @@ public:
     Path.emplace_back(new T(std::forward<As>(args)...));
   }
 
+  void addNonMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
+                                VarDecl *var, Optional<SubstitutionMap> subs,
+                                LValueOptions options,
+                                AccessStrategy strategy,
+                                CanType formalRValueType);
+
   /// Add a member component to the access path of this lvalue.
   void addMemberComponent(SILGenFunction &SGF, SILLocation loc,
                           AbstractStorageDecl *storage,
                           SubstitutionMap subs,
                           LValueOptions options,
                           bool isSuper,
-                          AccessKind accessKind,
-                          AccessSemantics accessSemantics,
                           AccessStrategy accessStrategy,
                           CanType formalRValueType,
-                          RValue &&indices);
+                          RValue &&indices,
+                          Expr *indexExprForDiagnostics);
 
   void addMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
                              VarDecl *var,
                              SubstitutionMap subs,
                              LValueOptions options,
                              bool isSuper,
-                             AccessKind accessKind,
-                             AccessSemantics accessSemantics,
                              AccessStrategy accessStrategy,
                              CanType formalRValueType);
 
@@ -455,8 +459,6 @@ public:
                                    SubstitutionMap subs,
                                    LValueOptions options,
                                    bool isSuper,
-                                   AccessKind accessKind,
-                                   AccessSemantics accessSemantics,
                                    AccessStrategy accessStrategy,
                                    CanType formalRValueType,
                                    RValue &&indices,

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -334,8 +334,8 @@ public:
   
   SILDeclRef getGetterDeclRef(AbstractStorageDecl *decl);
   SILDeclRef getSetterDeclRef(AbstractStorageDecl *decl);
-  SILDeclRef getAddressorDeclRef(AbstractStorageDecl *decl,
-                                 AccessKind accessKind);
+  SILDeclRef getAddressorDeclRef(AbstractStorageDecl *decl);
+  SILDeclRef getMutableAddressorDeclRef(AbstractStorageDecl *decl);
   SILDeclRef getMaterializeForSetDeclRef(AbstractStorageDecl *decl);
 
   KeyPathPatternComponent

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5364,9 +5364,14 @@ emitMaterializeForSetAccessor(SILLocation loc, SILDeclRef materializeForSet,
                             optionalCallback, callbackStorage);
 }
 
-SILDeclRef SILGenModule::getAddressorDeclRef(AbstractStorageDecl *storage,
-                                             AccessKind accessKind) {
-  FuncDecl *addressorFunc = storage->getAddressorForAccess(accessKind);
+SILDeclRef SILGenModule::getAddressorDeclRef(AbstractStorageDecl *storage) {
+  FuncDecl *addressorFunc = storage->getAddressor();
+  return SILDeclRef(addressorFunc, SILDeclRef::Kind::Func);
+}
+
+SILDeclRef SILGenModule::getMutableAddressorDeclRef(
+                                                 AbstractStorageDecl *storage) {
+  FuncDecl *addressorFunc = storage->getMutableAddressor();
   return SILDeclRef(addressorFunc, SILDeclRef::Kind::Func);
 }
 

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1065,11 +1065,7 @@ public:
                                          AccessKind accessKind);
 
   // FIXME: demote this to private state.
-  ManagedValue maybeEmitAddressOfNonMemberVarDecl(SILLocation loc,
-                                                  VarDecl *var,
-                                                  CanType formalRValueType,
-                                                  AccessKind accessKind,
-                                                  AccessSemantics semantics);
+  ManagedValue maybeEmitValueOfLocalVarDecl(VarDecl *var);
 
   /// Produce an RValue for a reference to the specified declaration,
   /// with the given type and in response to the specified expression.  Try to

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -83,6 +83,8 @@ static void pushWriteback(SILGenFunction &SGF,
   cleanup.Depth = context.stable_begin();
 }
 
+static bool areCertainlyEqualIndices(const Expr *e1, const Expr *e2);
+
 void ExclusiveBorrowFormalAccess::diagnoseConflict(
                                     const ExclusiveBorrowFormalAccess &rhs,
                                     SILGenFunction &SGF) const {
@@ -102,7 +104,84 @@ void ExclusiveBorrowFormalAccess::diagnoseConflict(
     return;
   }
 
-  component->diagnoseWritebackConflict(rhs.component.get(), loc, rhs.loc, SGF);
+  auto lhsStorage = component->getAccessedStorage();
+  if (!lhsStorage) return;
+
+  auto rhsStorage = rhs.component->getAccessedStorage();
+  if (!rhsStorage) return;
+
+  // If the decls match, then this could conflict.
+  if (lhsStorage->Storage != rhsStorage->Storage ||
+      lhsStorage->IsSuper != rhsStorage->IsSuper)
+    return;
+
+  assert((lhsStorage->Indices != nullptr) == (rhsStorage->Indices != nullptr));
+
+  auto storage = lhsStorage->Storage;
+
+  // If the decl is monomorphically a stored property, allow aliases.
+  // It could be overridden by a computed property in a subclass, but
+  // that's not likely enough to be worth the strictness here.
+  auto impl = storage->getImplInfo();
+  // TODO: Stored properties with didSet accessors that don't look at the
+  // oldValue could also be addressed.
+  if ((impl.getReadImpl() == ReadImplKind::Stored ||
+       impl.getReadImpl() == ReadImplKind::Address) &&
+      (impl.getWriteImpl() == WriteImplKind::Immutable ||
+       impl.getWriteImpl() == WriteImplKind::Stored ||
+       impl.getWriteImpl() == WriteImplKind::MutableAddress)) {
+    return;
+  }
+
+  // If the property is a generic requirement, allow aliases, because
+  // it may be conformed to using a stored property.
+  if (isa<ProtocolDecl>(storage->getDeclContext()))
+    return;
+
+  // If this is a simple property access, then we must have a conflict.
+  if (!lhsStorage->Indices) {
+    assert(isa<VarDecl>(storage));
+    SGF.SGM.diagnose(loc, diag::writeback_overlap_property,
+                     storage->getBaseName().getIdentifier())
+       .highlight(loc.getSourceRange());
+    SGF.SGM.diagnose(rhs.loc, diag::writebackoverlap_note)
+       .highlight(rhs.loc.getSourceRange());
+    return;
+  }
+
+  // Otherwise, it is a subscript, check the index values.
+
+  // If the indices are literally identical SILValue's, then there is
+  // clearly a conflict.
+  if (!lhsStorage->Indices->isObviouslyEqual(*rhsStorage->Indices)) {
+    // If the index value doesn't lower to literally the same SILValue's,
+    // do some fuzzy matching to catch the common case.
+    if (!lhsStorage->IndexExprForDiagnostics ||
+        !rhsStorage->IndexExprForDiagnostics ||
+        !areCertainlyEqualIndices(lhsStorage->IndexExprForDiagnostics,
+                                  rhsStorage->IndexExprForDiagnostics))
+      return;
+  }
+
+  // The locations for the subscripts are almost certainly SubscriptExprs.
+  // If so, dig into them to produce better location info in the
+  // diagnostics and be able to do more precise analysis.
+  auto expr1 = loc.getAsASTNode<SubscriptExpr>();
+  auto expr2 = rhs.loc.getAsASTNode<SubscriptExpr>();
+
+  if (expr1 && expr2) {
+    SGF.SGM.diagnose(loc, diag::writeback_overlap_subscript)
+       .highlight(expr1->getBase()->getSourceRange());
+
+    SGF.SGM.diagnose(rhs.loc, diag::writebackoverlap_note)
+       .highlight(expr2->getBase()->getSourceRange());
+
+  } else {
+    SGF.SGM.diagnose(loc, diag::writeback_overlap_subscript)
+       .highlight(loc.getSourceRange());
+    SGF.SGM.diagnose(rhs.loc, diag::writebackoverlap_note)
+       .highlight(rhs.loc.getSourceRange());
+  }
 }
 
 //===----------------------------------------------------------------------===//
@@ -113,6 +192,7 @@ static CanType getSubstFormalRValueType(Expr *expr) {
 
 static LValueTypeData getLogicalStorageTypeData(SILGenModule &SGM,
                                                 CanType substFormalType) {
+  assert(!isa<ReferenceStorageType>(substFormalType));
   AbstractionPattern origFormalType(
       substFormalType.getReferenceStorageReferent());
   return {
@@ -125,6 +205,7 @@ static LValueTypeData getLogicalStorageTypeData(SILGenModule &SGM,
 static LValueTypeData getPhysicalStorageTypeData(SILGenModule &SGM,
                                                  AbstractStorageDecl *storage,
                                                  CanType substFormalType) {
+  assert(!isa<ReferenceStorageType>(substFormalType));
   auto origFormalType = SGM.Types.getAbstractionPattern(storage)
                                  .getReferenceStorageReferentType();
   return {
@@ -418,10 +499,8 @@ namespace {
       llvm_unreachable("called getMaterialized on a pseudo-component");
     }
 
-    void diagnoseWritebackConflict(LogicalPathComponent *rhs,
-                                   SILLocation loc1, SILLocation loc2,
-                                   SILGenFunction &SGF) override {
-      // do nothing
+    Optional<AccessedStorage> getAccessedStorage() const override {
+      return None;
     }
   };
 
@@ -772,10 +851,8 @@ namespace {
       return kind;
     }
 
-    void diagnoseWritebackConflict(LogicalPathComponent *RHS,
-                                   SILLocation loc1, SILLocation loc2,
-                                   SILGenFunction &SGF) override {
-      // no useful writeback diagnostics at this point
+    Optional<AccessedStorage> getAccessedStorage() const override {
+      return None;
     }
 
     RValue get(SILGenFunction &SGF, SILLocation loc,
@@ -998,29 +1075,30 @@ static ArgumentSource emitBaseValueForAccessor(SILGenFunction &SGF,
                                                CanType baseFormalType,
                                                SILDeclRef accessor);
 
+static AccessKind getBaseAccessKind(AbstractStorageDecl *member,
+                                    AccessKind accessKind,
+                                    AccessStrategy strategy);
+
 namespace {
-  /// A helper class for implementing a component that involves
-  /// calling accessors.
+  /// A helper class for implementing components that involve accessing
+  /// storage.
   template <class Base>
-  class AccessorBasedComponent : public Base {
+  class AccessComponent : public Base {
   protected:
     // The VarDecl or SubscriptDecl being get/set.
-    AbstractStorageDecl *decl;
-    bool IsSuper;
-    bool IsDirectAccessorUse;
-    SubstitutionMap substitutions;
+    AbstractStorageDecl *Storage;
 
     /// The subscript index expression.  Useless
-    Expr *subscriptIndexExpr;
-    RValue subscripts;
+    Expr *IndexExprForDiagnostics;
+    RValue Indices;
 
     /// AST type of the base expression, in case the accessor call
     /// requires re-abstraction.
-    CanType baseFormalType;
+    CanType BaseFormalType;
 
     struct AccessorArgs {
       ArgumentSource base;
-      RValue subscripts;
+      RValue Indices;
     };
 
     /// Returns a tuple of RValues holding the accessor value, base (retained if
@@ -1031,47 +1109,37 @@ namespace {
     {
       AccessorArgs result;
       if (base)
-        result.base = SGF.prepareAccessorBaseArg(loc, base, baseFormalType,
+        result.base = SGF.prepareAccessorBaseArg(loc, base, BaseFormalType,
                                                  accessor);
 
-      if (!subscripts.isNull())
-        result.subscripts = std::move(subscripts);
+      if (!Indices.isNull())
+        result.Indices = std::move(Indices);
       
       return result;
     }
 
-    AccessorBasedComponent(PathComponent::KindTy kind,
-                           AbstractStorageDecl *decl,
-                           bool isSuper, bool isDirectAccessorUse,
-                           SubstitutionMap substitutions,
-                           CanType baseFormalType,
-                           LValueTypeData typeData,
-                           Expr *subscriptIndexExpr,
-                           RValue *optSubscripts)
-      : Base(typeData, kind), decl(decl),
-        IsSuper(isSuper), IsDirectAccessorUse(isDirectAccessorUse),
-        substitutions(substitutions),
-        subscriptIndexExpr(subscriptIndexExpr),
-        baseFormalType(baseFormalType)
+    AccessComponent(PathComponent::KindTy kind,
+                    AbstractStorageDecl *storage,
+                    CanType baseFormalType,
+                    LValueTypeData typeData,
+                    Expr *indexExprForDiagnostics,
+                    RValue *optSubscripts)
+      : Base(typeData, kind), Storage(storage),
+        IndexExprForDiagnostics(indexExprForDiagnostics),
+        BaseFormalType(baseFormalType)
     {
       if (optSubscripts)
-        subscripts = std::move(*optSubscripts);
+        Indices = std::move(*optSubscripts);
     }
 
-    AccessorBasedComponent(const AccessorBasedComponent &copied,
-                           SILGenFunction &SGF,
-                           SILLocation loc)
+    AccessComponent(const AccessComponent &copied,
+                    SILGenFunction &SGF,
+                    SILLocation loc)
       : Base(copied.getTypeData(), copied.getKind()),
-        decl(copied.decl),
-        IsSuper(copied.IsSuper),
-        IsDirectAccessorUse(copied.IsDirectAccessorUse),
-        substitutions(copied.substitutions),
-        subscriptIndexExpr(copied.subscriptIndexExpr),
-        subscripts(copied.subscripts.copy(SGF, loc)) ,
-        baseFormalType(copied.baseFormalType) {}
-
-    virtual bool doesAccessMutateSelf(SILGenFunction &SGF,
-                                      AccessKind kind) const = 0;
+        Storage(copied.Storage),
+        IndexExprForDiagnostics(copied.IndexExprForDiagnostics),
+        Indices(copied.Indices.copy(SGF, loc)) ,
+        BaseFormalType(copied.BaseFormalType) {}
 
     bool doesAccessorMutateSelf(SILGenFunction &SGF,
                                 SILDeclRef accessor) const {
@@ -1079,23 +1147,55 @@ namespace {
       return accessorSelf.getType() && accessorSelf.isIndirectMutating();
     }
     
-    AccessKind getBaseAccessKind(SILGenFunction &SGF,
-                                 AccessKind kind) const override {
-      if (doesAccessMutateSelf(SGF, kind))
-        return AccessKind::ReadWrite;
-      else
-        return AccessKind::Read;
-    }
-
     void printBase(raw_ostream &OS, unsigned indent, StringRef name) const {
-      OS.indent(indent) << name << "(" << decl->getBaseName() << ")";
-      if (IsSuper) OS << " isSuper";
-      if (IsDirectAccessorUse) OS << " isDirectAccessorUse";
-      if (subscriptIndexExpr) {
+      OS.indent(indent) << name << "(" << Storage->getBaseName() << ")";
+      if (IndexExprForDiagnostics) {
         OS << " subscript_index:\n";
-        subscriptIndexExpr->print(OS, 2);
+        IndexExprForDiagnostics->print(OS, 2);
       }
       OS << '\n';
+    }
+  };
+
+  /// A helper class for implementing a component that involves
+  /// calling accessors.
+  template <class Base>
+  class AccessorBasedComponent : public AccessComponent<Base> {
+    using super = AccessComponent<Base>;
+
+  protected:
+    SILDeclRef Accessor;
+    bool IsSuper;
+    bool IsDirectAccessorUse;
+    SubstitutionMap Substitutions;
+
+  public:
+    AccessorBasedComponent(PathComponent::KindTy kind,
+                           AbstractStorageDecl *decl,
+                           SILDeclRef accessor,
+                           bool isSuper, bool isDirectAccessorUse,
+                           SubstitutionMap substitutions,
+                           CanType baseFormalType,
+                           LValueTypeData typeData,
+                           Expr *indexExprForDiagnostics,
+                           RValue *optIndices)
+      : super(kind, decl, baseFormalType, typeData,
+              indexExprForDiagnostics, optIndices),
+        Accessor(accessor), IsSuper(isSuper),
+        IsDirectAccessorUse(isDirectAccessorUse),
+        Substitutions(substitutions) {}
+
+    AccessorBasedComponent(const AccessorBasedComponent &copied,
+                           SILGenFunction &SGF,
+                           SILLocation loc)
+      : super(copied, SGF, loc),
+        Accessor(copied.Accessor),
+        IsSuper(copied.IsSuper),
+        IsDirectAccessorUse(copied.IsDirectAccessorUse),
+        Substitutions(copied.Substitutions) {}
+
+    AccessorDecl *getAccessorDecl() const {
+      return cast<AccessorDecl>(Accessor.getFuncDecl());
     }
   };
 
@@ -1104,17 +1204,20 @@ namespace {
   public:
 
      GetterSetterComponent(AbstractStorageDecl *decl,
+                           SILDeclRef accessor,
                            bool isSuper, bool isDirectAccessorUse,
                            SubstitutionMap substitutions,
                            CanType baseFormalType,
                            LValueTypeData typeData,
                            Expr *subscriptIndexExpr = nullptr,
                            RValue *subscriptIndex = nullptr)
-      : AccessorBasedComponent(GetterSetterKind, decl, isSuper,
+      : AccessorBasedComponent(GetterSetterKind, decl, accessor, isSuper,
                                isDirectAccessorUse, substitutions,
                                baseFormalType, typeData, subscriptIndexExpr,
                                subscriptIndex)
     {
+      assert(getAccessorDecl()->isGetterOrSetter() ||
+             getAccessorDecl()->isMaterializeForSet());
     }
     
     GetterSetterComponent(const GetterSetterComponent &copied,
@@ -1124,38 +1227,26 @@ namespace {
     {
     }
 
-    bool doesAccessMutateSelf(SILGenFunction &SGF,
-                              AccessKind accessKind) const override {
-      switch (accessKind) {
-      case AccessKind::Read: {
-        auto getter = SGF.SGM.getGetterDeclRef(decl);
-        return doesAccessorMutateSelf(SGF, getter);
-      }
-      case AccessKind::Write: {
-        auto setter = SGF.SGM.getSetterDeclRef(decl);
-        return doesAccessorMutateSelf(SGF, setter);
-      }
-      case AccessKind::ReadWrite: {
-        auto getter = SGF.SGM.getGetterDeclRef(decl);
-        auto setter = SGF.SGM.getSetterDeclRef(decl);
-        return doesAccessorMutateSelf(SGF, getter)
-            || doesAccessorMutateSelf(SGF, setter);
-      }
-      }
-      llvm_unreachable("unknown access kind");
+    AccessKind getBaseAccessKind(SILGenFunction &SGF,
+                                 AccessKind kind) const override {
+      if (doesAccessorMutateSelf(SGF, Accessor))
+        return AccessKind::ReadWrite;
+      else
+        return AccessKind::Read;
     }
 
     void emitAssignWithSetter(SILGenFunction &SGF, SILLocation loc,
                               LValue &&dest, ArgumentSource &&value) {
-      SILDeclRef setter = SGF.SGM.getSetterDeclRef(decl);
+      assert(getAccessorDecl()->isSetter());
+      SILDeclRef setter = Accessor;
 
       // Pull everything out of this that we'll need, because we're
       // about to modify the LValue and delete this component.
-      auto subs = this->substitutions;
+      auto subs = this->Substitutions;
       bool isSuper = this->IsSuper;
       bool isDirectAccessorUse = this->IsDirectAccessorUse;
-      RValue indices = std::move(this->subscripts);
-      auto baseFormalType = this->baseFormalType;
+      RValue indices = std::move(this->Indices);
+      auto baseFormalType = this->BaseFormalType;
 
       // Drop this component from the l-value.
       dest.dropLastComponent(*this);
@@ -1190,75 +1281,35 @@ namespace {
 
     void set(SILGenFunction &SGF, SILLocation loc,
              ArgumentSource &&value, ManagedValue base) && override {
-      SILDeclRef setter = SGF.SGM.getSetterDeclRef(decl);
+      assert(getAccessorDecl()->isSetter());
+      SILDeclRef setter = Accessor;
 
       FormalEvaluationScope scope(SGF);
       // Pass in just the setter.
       auto args =
         std::move(*this).prepareAccessorArgs(SGF, loc, base, setter);
 
-      return SGF.emitSetAccessor(loc, setter, substitutions,
+      return SGF.emitSetAccessor(loc, setter, Substitutions,
                                  std::move(args.base), IsSuper,
                                  IsDirectAccessorUse,
-                                 std::move(args.subscripts),
+                                 std::move(args.Indices),
                                  std::move(value));
-    }
-
-    bool shouldUseMaterializeForSet(SILGenFunction &SGF,
-                                    AccessKind accessKind) {
-      // If this access is for a read, we can just call the getter.
-      if (accessKind == AccessKind::Read)
-        return false;
-
-      // If the declaration is dynamic, there's no materializeForSet.
-      if (decl->isDynamic())
-        return false;
-
-      // If the declaration was imported from C, we won't gain anything
-      // from using materializeForSet, and furthermore, it might not
-      // exist.
-      if (decl->hasClangNode())
-        return false;
-
-      // If the declaration is not in type context, there's no
-      // materializeForSet.
-      if (!decl->getDeclContext()->isTypeContext())
-        return false;
-
-      // If the declaration is in a different resilience domain, we have
-      // to use materializeForSet.
-      if (decl->isResilient(SGF.SGM.M.getSwiftModule(),
-                            SGF.F.getResilienceExpansion()))
-        return true;
-
-      // If the declaration is dynamically dispatched through a class,
-      // we have to use materializeForSet.
-      if (auto *classDecl = dyn_cast<ClassDecl>(decl->getDeclContext())) {
-        if (decl->isFinal() || classDecl->isFinal())
-          return false;
-
-        return true;
-      }
-
-      // If the declaration is dynamically dispatched through a
-      // non-ObjC protocol, we have to use materializeForSet.
-      if (auto *protoDecl = dyn_cast<ProtocolDecl>(decl->getDeclContext()))
-        if (!protoDecl->isObjC())
-          return true;
-
-      return false;
     }
 
     ManagedValue getMaterialized(SILGenFunction &SGF,
                                  SILLocation loc,
                                  ManagedValue base,
                                  AccessKind accessKind) && override {
-      if (!shouldUseMaterializeForSet(SGF, accessKind)) {
+      assert(accessKind == AccessKind::Read ||
+             accessKind == AccessKind::ReadWrite);
+      if (accessKind == AccessKind::Read) {
         return std::move(*this).LogicalPathComponent::getMaterialized(SGF,
                                                         loc, base, accessKind);
       }
 
-      assert(decl->getMaterializeForSetFunc() &&
+      assert(getAccessorDecl()->isMaterializeForSet());
+
+      assert(Storage->getMaterializeForSetFunc() &&
              "polymorphic storage without materializeForSet");
       assert(SGF.InFormalEvaluationScope &&
              "materializing l-value for modification without writeback scope");
@@ -1280,23 +1331,24 @@ namespace {
         // can peek at them in diagnoseWritebackConflict.
         //
         // This is *amazingly* unprincipled.
-        RValue borrowedSubscripts;
-        RValue *optSubscripts = nullptr;
-        if (!subscripts.isNull()) {
-          CanType type = subscripts.getType();
+        RValue borrowedIndices;
+        RValue *optIndices = nullptr;
+        if (!Indices.isNull()) {
+          CanType type = Indices.getType();
           SmallVector<ManagedValue, 4> values;
-          std::move(subscripts).getAll(values);
-          subscripts = RValue(SGF, values, type);
-          borrowedSubscripts = RValue(SGF, values, type);
-          optSubscripts = &borrowedSubscripts;
+          std::move(Indices).getAll(values);
+          Indices = RValue(SGF, values, type);
+          borrowedIndices = RValue(SGF, values, type);
+          optIndices = &borrowedIndices;
         }
-        return new GetterSetterComponent(decl, IsSuper, IsDirectAccessorUse,
-                                         substitutions, baseFormalType,
-                                         getTypeData(), subscriptIndexExpr,
-                                         optSubscripts);
+        return new GetterSetterComponent(Storage, Accessor, IsSuper,
+                                         IsDirectAccessorUse,
+                                         Substitutions, BaseFormalType,
+                                         getTypeData(), IndexExprForDiagnostics,
+                                         optIndices);
       }());
 
-      SILDeclRef materializeForSet = SGF.SGM.getMaterializeForSetDeclRef(decl);
+      SILDeclRef materializeForSet = Accessor;
 
       MaterializedLValue materialized;
       {
@@ -1310,9 +1362,9 @@ namespace {
         auto args = std::move(*this).prepareAccessorArgs(SGF, loc, borrowedBase,
                                                          materializeForSet);
         materialized = SGF.emitMaterializeForSetAccessor(
-            loc, materializeForSet, substitutions,
+            loc, materializeForSet, Substitutions,
             std::move(args.base),
-            IsSuper, IsDirectAccessorUse, std::move(args.subscripts), buffer,
+            IsSuper, IsDirectAccessorUse, std::move(args.Indices), buffer,
             callbackStorage);
 
         // Mark a value-dependence on the base.  We do this regardless
@@ -1381,7 +1433,7 @@ namespace {
         // Cast the callback to the correct polymorphic function type.
         SILFunctionTypeRepresentation rep;
         Optional<ProtocolConformanceRef> witnessMethodConformance;
-        if (auto proto = dyn_cast<ProtocolDecl>(decl->getDeclContext())) {
+        if (auto proto = dyn_cast<ProtocolDecl>(Storage->getDeclContext())) {
           rep = SILFunctionTypeRepresentation::WitnessMethod;
           witnessMethodConformance = ProtocolConformanceRef(proto);
         } else {
@@ -1390,13 +1442,13 @@ namespace {
 
         auto origCallbackFnType =
             SGF.SGM.Types.getMaterializeForSetCallbackType(
-                decl, materialized.genericSig, materialized.origSelfType, rep,
-                witnessMethodConformance);
+                Storage, materialized.genericSig, materialized.origSelfType,
+                rep, witnessMethodConformance);
         auto origCallbackType = SILType::getPrimitiveObjectType(origCallbackFnType);
         callback = SGF.B.createPointerToThinFunction(loc, callback, origCallbackType);
 
         auto substCallbackFnType = origCallbackFnType->substGenericArgs(
-            M, substitutions);
+            M, Substitutions);
         auto metatypeType =
             SGF.getSILType(substCallbackFnType->getParameters().back());
 
@@ -1414,7 +1466,7 @@ namespace {
             AbstractionPattern origSelfType(materialized.genericSig,
                                             materialized.origSelfType);
             base = SGF.emitSubstToOrigValue(loc, base, origSelfType,
-                                            baseFormalType);
+                                            BaseFormalType);
 
             baseAddress = SGF.emitTemporaryAllocation(loc, base.getType());
             // Create an unenforced formal access for the temporary base, which
@@ -1444,7 +1496,7 @@ namespace {
 
         // Apply the callback.
         SGF.B.createApply(loc, callback,
-                          substitutions, {
+                          Substitutions, {
                             temporaryPointer,
                             materialized.callbackStorage,
                             baseAddress,
@@ -1461,17 +1513,18 @@ namespace {
     
     RValue get(SILGenFunction &SGF, SILLocation loc,
                ManagedValue base, SGFContext c) && override {
-      SILDeclRef getter = SGF.SGM.getGetterDeclRef(decl);
+      assert(getAccessorDecl()->isGetter());
+      SILDeclRef getter = Accessor;
 
       FormalEvaluationScope scope(SGF);
 
       auto args =
         std::move(*this).prepareAccessorArgs(SGF, loc, base, getter);
       
-      return SGF.emitGetAccessor(loc, getter, substitutions,
+      return SGF.emitGetAccessor(loc, getter, Substitutions,
                                  std::move(args.base), IsSuper,
                                  IsDirectAccessorUse,
-                                 std::move(args.subscripts), c);
+                                 std::move(args.Indices), c);
     }
     
     std::unique_ptr<LogicalPathComponent>
@@ -1488,79 +1541,10 @@ namespace {
     /// the same dynamic PathComponent type as the receiver) to see if they are
     /// identical.  If so, there is a conflicting writeback happening, so emit a
     /// diagnostic.
-    void diagnoseWritebackConflict(LogicalPathComponent *RHS,
-                                   SILLocation loc1, SILLocation loc2,
-                                   SILGenFunction &SGF) override {
-      auto &rhs = (GetterSetterComponent&)*RHS;
-
-      // If the decls match, then this could conflict.
-      if (decl != rhs.decl || IsSuper != rhs.IsSuper) return;
-
-      // If the decl is monomorphically a stored property, allow aliases.
-      // It could be overridden by a computed property in a subclass, but
-      // that's not likely enough to be worth the strictness here.
-      if (auto storage = dyn_cast<AbstractStorageDecl>(decl)) {
-        auto impl = storage->getImplInfo();
-        // TODO: Stored properties with didSet accessors that don't look at the
-        // oldValue could also be addressed.
-        if ((impl.getReadImpl() == ReadImplKind::Stored ||
-             impl.getReadImpl() == ReadImplKind::Address) &&
-            (impl.getWriteImpl() == WriteImplKind::Immutable ||
-             impl.getWriteImpl() == WriteImplKind::Stored ||
-             impl.getWriteImpl() == WriteImplKind::MutableAddress)) {
-          return;
-        }
-      }
-      
-      // If the property is a generic requirement, allow aliases, because
-      // it may be conformed to using a stored property.
-      if (isa<ProtocolDecl>(decl->getDeclContext()))
-        return;
-
-      // If this is a simple property access, then we must have a conflict.
-      if (subscripts.isNull()) {
-        assert(isa<VarDecl>(decl));
-        SGF.SGM.diagnose(loc1, diag::writeback_overlap_property,
-                         decl->getBaseName().getIdentifier())
-           .highlight(loc1.getSourceRange());
-        SGF.SGM.diagnose(loc2, diag::writebackoverlap_note)
-           .highlight(loc2.getSourceRange());
-        return;
-      }
-
-      // Otherwise, it is a subscript, check the index values.
-      
-      // If the indices are literally identical SILValue's, then there is
-      // clearly a conflict.
-      if (!subscripts.isObviouslyEqual(rhs.subscripts)) {
-        // If the index value doesn't lower to literally the same SILValue's,
-        // do some fuzzy matching to catch the common case.
-        if (!subscriptIndexExpr ||
-            !rhs.subscriptIndexExpr ||
-            !areCertainlyEqualIndices(subscriptIndexExpr,
-                                      rhs.subscriptIndexExpr))
-          return;
-      }
-
-      // The locations for the subscripts are almost certainly SubscriptExprs.
-      // If so, dig into them to produce better location info in the
-      // diagnostics and be able to do more precise analysis.
-      auto expr1 = loc1.getAsASTNode<SubscriptExpr>();
-      auto expr2 = loc2.getAsASTNode<SubscriptExpr>();
-
-      if (expr1 && expr2) {
-        SGF.SGM.diagnose(loc1, diag::writeback_overlap_subscript)
-           .highlight(expr1->getBase()->getSourceRange());
-
-        SGF.SGM.diagnose(loc2, diag::writebackoverlap_note)
-           .highlight(expr2->getBase()->getSourceRange());
-
-      } else {
-        SGF.SGM.diagnose(loc1, diag::writeback_overlap_subscript)
-           .highlight(loc1.getSourceRange());
-        SGF.SGM.diagnose(loc2, diag::writebackoverlap_note)
-           .highlight(loc2.getSourceRange());
-      }
+    Optional<AccessedStorage> getAccessedStorage() const override {
+      return AccessedStorage{Storage, IsSuper,
+                             Indices.isNull() ? nullptr : &Indices,
+                             IndexExprForDiagnostics };
     }
   };
 
@@ -1591,30 +1575,132 @@ namespace {
     }
   };
 
+  class MaterializeToTemporaryComponent final
+      : public AccessComponent<LogicalPathComponent> {
+    SubstitutionMap Substitutions;
+    AccessStrategy ReadStrategy;
+    AccessStrategy WriteStrategy;
+    LValueOptions Options;
+    bool IsSuper;
+
+  public:
+    MaterializeToTemporaryComponent(AbstractStorageDecl *storage,
+                                    bool isSuper, SubstitutionMap subs,
+                                    LValueOptions options,
+                                    AccessStrategy readStrategy,
+                                    AccessStrategy writeStrategy,
+                                    CanType baseFormalType,
+                                    LValueTypeData typeData,
+                                    Expr *indexExprForDiagnostics,
+                                    RValue *optIndices)
+      : AccessComponent(MaterializeToTemporaryKind, storage, baseFormalType,
+                        typeData, indexExprForDiagnostics, optIndices),
+        Substitutions(subs),
+        ReadStrategy(readStrategy), WriteStrategy(writeStrategy),
+        Options(options), IsSuper(isSuper) {}
+
+
+    AccessKind getBaseAccessKind(SILGenFunction &SGF,
+                                 AccessKind kind) const override {
+      return combineAccessKinds(
+                ::getBaseAccessKind(Storage, AccessKind::Read, ReadStrategy),
+                ::getBaseAccessKind(Storage, AccessKind::Write, WriteStrategy));
+    }
+
+    std::unique_ptr<LogicalPathComponent>
+    clone(SILGenFunction &SGF, SILLocation loc) const override {
+      RValue clonedIndicesBuffer;
+      RValue *clonedIndices = nullptr;
+      if (!Indices.isNull()) {
+        clonedIndicesBuffer = Indices.copy(SGF, loc);
+        clonedIndices = &clonedIndicesBuffer;
+      }
+
+      LogicalPathComponent *clone =
+        new MaterializeToTemporaryComponent(Storage, IsSuper, Substitutions,
+                                            Options,
+                                            ReadStrategy, WriteStrategy,
+                                            BaseFormalType, getTypeData(),
+                                            IndexExprForDiagnostics,
+                                            clonedIndices);
+      return std::unique_ptr<LogicalPathComponent>(clone);
+    }
+
+    RValue get(SILGenFunction &SGF, SILLocation loc,
+               ManagedValue base, SGFContext C) && override {
+      LValue lv = std::move(*this).prepareLValue(SGF, loc, base, ReadStrategy);
+      return SGF.emitLoadOfLValue(loc, std::move(lv), C);
+    }
+
+    void set(SILGenFunction &SGF, SILLocation loc,
+             ArgumentSource &&value, ManagedValue base) && override {
+      LValue lv = std::move(*this).prepareLValue(SGF, loc, base, WriteStrategy);
+      return SGF.emitAssignToLValue(loc, std::move(value), std::move(lv));
+    }
+
+    Optional<AccessedStorage> getAccessedStorage() const override {
+      return AccessedStorage{Storage, IsSuper,
+                             Indices.isNull() ? nullptr : &Indices,
+                             IndexExprForDiagnostics};
+    }
+
+    void dump(raw_ostream &OS, unsigned indent) const override {
+      OS.indent(indent) << "MaterializeToTemporaryComponent";
+    }
+
+  private:
+    LValue prepareLValue(SILGenFunction &SGF, SILLocation loc,
+                         ManagedValue base, AccessStrategy strategy) && {
+      LValue lv = (base ? LValue::forValue(base, BaseFormalType) : LValue());
+
+      if (auto subscript = dyn_cast<SubscriptDecl>(Storage)) {
+        lv.addMemberSubscriptComponent(SGF, loc, subscript, Substitutions,
+                                       Options, IsSuper, strategy,
+                                       getSubstFormalType(),
+                                       std::move(Indices),
+                                       IndexExprForDiagnostics);
+      } else {
+        auto var = cast<VarDecl>(Storage);
+        if (base) {
+          lv.addMemberVarComponent(SGF, loc, var, Substitutions, Options,
+                                   IsSuper, strategy, getSubstFormalType());
+        } else {
+          lv.addNonMemberVarComponent(SGF, loc, var, Substitutions, Options,
+                                      strategy, getSubstFormalType());
+        }
+      }
+
+      return lv;
+    }
+  };
+
   /// A physical component which involves calling addressors.
   class AddressorComponent
       : public AccessorBasedComponent<PhysicalPathComponent> {
     SILType SubstFieldType;
   public:
-     AddressorComponent(AbstractStorageDecl *decl,
+     AddressorComponent(AbstractStorageDecl *decl, SILDeclRef accessor,
                         bool isSuper, bool isDirectAccessorUse,
                         SubstitutionMap substitutions,
                         CanType baseFormalType, LValueTypeData typeData,
                         SILType substFieldType,
                         Expr *subscriptIndexExpr = nullptr,
                         RValue *subscriptIndex = nullptr)
-      : AccessorBasedComponent(AddressorKind, decl, isSuper,
+      : AccessorBasedComponent(AddressorKind, decl, accessor, isSuper,
                                isDirectAccessorUse, substitutions,
                                baseFormalType, typeData, subscriptIndexExpr,
                                subscriptIndex),
         SubstFieldType(substFieldType)
     {
+      assert(getAccessorDecl()->isAnyAddressor());
     }
 
-    bool doesAccessMutateSelf(SILGenFunction &SGF,
-                              AccessKind kind) const override {
-      auto addressor = SGF.SGM.getAddressorDeclRef(decl, kind);
-      return doesAccessorMutateSelf(SGF, addressor);
+    AccessKind getBaseAccessKind(SILGenFunction &SGF,
+                                 AccessKind kind) const override {
+      if (doesAccessorMutateSelf(SGF, Accessor))
+        return AccessKind::ReadWrite;
+      else
+        return AccessKind::Read;
     }
 
     ManagedValue offset(SILGenFunction &SGF, SILLocation loc, ManagedValue base,
@@ -1622,20 +1708,19 @@ namespace {
       assert(SGF.InFormalEvaluationScope &&
              "offsetting l-value for modification without writeback scope");
 
-      SILDeclRef addressor = SGF.SGM.getAddressorDeclRef(decl, accessKind);
       std::pair<ManagedValue, ManagedValue> result;
       {
         FormalEvaluationScope scope(SGF);
 
         auto args =
-            std::move(*this).prepareAccessorArgs(SGF, loc, base, addressor);
+            std::move(*this).prepareAccessorArgs(SGF, loc, base, Accessor);
         result = SGF.emitAddressorAccessor(
-            loc, addressor, substitutions, std::move(args.base),
-            IsSuper,
-            IsDirectAccessorUse, std::move(args.subscripts), SubstFieldType);
+            loc, Accessor, Substitutions, std::move(args.base),
+            IsSuper, IsDirectAccessorUse,
+            std::move(args.Indices), SubstFieldType);
       }
 
-      switch (cast<AccessorDecl>(addressor.getDecl())->getAddressorKind()) {
+      switch (getAccessorDecl()->getAddressorKind()) {
       case AddressorKind::NotAddressor:
         llvm_unreachable("not an addressor!");
 
@@ -1971,10 +2056,8 @@ namespace {
       return kind;
     }
 
-    void diagnoseWritebackConflict(LogicalPathComponent *RHS,
-                                   SILLocation loc1, SILLocation loc2,
-                                   SILGenFunction &SGF) override {
-      // no useful writeback diagnostics at this point
+    Optional<AccessedStorage> getAccessedStorage() const override {
+      return None;
     }
 
     RValue get(SILGenFunction &SGF, SILLocation loc,
@@ -2047,21 +2130,19 @@ void LValue::addMemberComponent(SILGenFunction &SGF, SILLocation loc,
                                 SubstitutionMap subs,
                                 LValueOptions options,
                                 bool isSuper,
-                                AccessKind accessKind,
-                                AccessSemantics accessSemantics,
                                 AccessStrategy accessStrategy,
                                 CanType formalRValueType,
-                                RValue &&indices) {
+                                RValue &&indices,
+                                Expr *indexExprForDiagnostics) {
   if (auto var = dyn_cast<VarDecl>(storage)) {
     assert(indices.isNull());
     addMemberVarComponent(SGF, loc, var, subs, options, isSuper,
-                          accessKind, accessSemantics, accessStrategy,
-                          formalRValueType);
+                          accessStrategy, formalRValueType);
   } else {
     auto subscript = cast<SubscriptDecl>(storage);
     addMemberSubscriptComponent(SGF, loc, subscript, subs, options, isSuper,
-                                accessKind, accessSemantics, accessStrategy,
-                                formalRValueType, std::move(indices));
+                                accessStrategy, formalRValueType,
+                                std::move(indices), indexExprForDiagnostics);
   }
 }
 
@@ -2256,6 +2337,82 @@ LValue SILGenLValue::visitExpr(Expr *e, AccessKind accessKind,
   llvm_unreachable("unimplemented lvalue expr");
 }
 
+namespace {
+  /// A CRTP class for emitting accesses.
+  template <class Impl, class StorageType>
+  struct AccessEmitter {
+    SILGenFunction &SGF;
+    StorageType *Storage;
+    CanType FormalRValueType;
+
+    Impl &asImpl() { return static_cast<Impl&>(*this); }
+
+    AccessEmitter(SILGenFunction &SGF, StorageType *storage,
+                  CanType formalRValueType)
+      : SGF(SGF), Storage(storage), FormalRValueType(formalRValueType) {}
+
+    void emitUsingStrategy(AccessStrategy strategy) {
+      switch (strategy.getKind()) {
+      case AccessStrategy::Storage: {
+        auto typeData =
+          getPhysicalStorageTypeData(SGF.SGM, Storage, FormalRValueType);
+        return asImpl().emitUsingStorage(typeData);
+      }
+
+      case AccessStrategy::BehaviorStorage:
+        return asImpl().emitUsingBehaviorStorage();
+
+      case AccessStrategy::DirectToAccessor:
+        return asImpl().emitUsingAccessor(strategy.getAccessor(), true);
+
+      case AccessStrategy::DispatchToAccessor:
+        return asImpl().emitUsingAccessor(strategy.getAccessor(), false);
+
+      case AccessStrategy::MaterializeToTemporary: {
+        auto typeData = getLogicalStorageTypeData(SGF.SGM, FormalRValueType);
+        return asImpl().emitUsingMaterialization(strategy.getReadStrategy(),
+                                                 strategy.getWriteStrategy(),
+                                                 typeData);
+      }
+      }
+      llvm_unreachable("unknown kind");
+    }
+
+    void emitUsingAccessor(AccessorKind accessorKind, bool isDirect) {
+      switch (accessorKind) {
+      case AccessorKind::Get:
+      case AccessorKind::Set:
+      case AccessorKind::MaterializeForSet: {
+        auto accessor =
+          accessorKind == AccessorKind::Get ?
+            SGF.SGM.getGetterDeclRef(Storage) :
+          accessorKind == AccessorKind::Set ?
+            SGF.SGM.getSetterDeclRef(Storage) :
+            SGF.SGM.getMaterializeForSetDeclRef(Storage);
+        auto typeData = getLogicalStorageTypeData(SGF.SGM, FormalRValueType);
+        return asImpl().emitUsingGetterSetter(accessor, isDirect, typeData);
+      }
+
+      case AccessorKind::Address:
+      case AccessorKind::MutableAddress: {
+        auto accessor =
+          accessorKind == AccessorKind::Address
+            ? SGF.SGM.getAddressorDeclRef(Storage)
+            : SGF.SGM.getMutableAddressorDeclRef(Storage);
+        auto typeData =
+          getPhysicalStorageTypeData(SGF.SGM, Storage, FormalRValueType);
+        return asImpl().emitUsingAddressor(accessor, isDirect, typeData);
+      }
+
+      case AccessorKind::WillSet:
+      case AccessorKind::DidSet:
+        llvm_unreachable("cannot use accessor directly to perform an access");
+      }
+      llvm_unreachable("bad kind");
+    }
+  };
+}
+
 SubstitutionMap
 SILGenModule::getNonMemberVarDeclSubstitutions(VarDecl *var) {
   auto *dc = var->getDeclContext();
@@ -2263,21 +2420,6 @@ SILGenModule::getNonMemberVarDeclSubstitutions(VarDecl *var) {
     return genericEnv->getForwardingSubstitutionMap();
 
   return SubstitutionMap();
-}
-
-// For now, we don't need either an AccessKind or an
-// AccessSemantics, because addressors are always directly
-// dispatched.
-static void
-addNonMemberVarDeclAddressorComponent(SILGenModule &SGM, VarDecl *var,
-                                      CanType formalRValueType,
-                                      LValue &lvalue) {
-  assert(!lvalue.isValid());
-  auto typeData = getPhysicalStorageTypeData(SGM, var, formalRValueType);
-  SILType storageType = SGM.Types.getLoweredType(var->getType()).getAddressType();
-  lvalue.add<AddressorComponent>(var, /*isSuper=*/ false, /*direct*/ true,
-                             SGM.getNonMemberVarDeclSubstitutions(var),
-                                 CanType(), typeData, storageType);
 }
 
 static LValue emitLValueForNonMemberVarDecl(SILGenFunction &SGF,
@@ -2289,76 +2431,111 @@ static LValue emitLValueForNonMemberVarDecl(SILGenFunction &SGF,
   LValue lv;
 
   auto strategy = var->getAccessStrategy(semantics, accessKind, SGF.FunctionDC);
-  switch (strategy.getKind()) {
 
-  case AccessStrategy::DispatchToAccessor:
-    llvm_unreachable("can't polymorphically access non-member variable");
-
-  // If it's a computed variable, push a reference to the getter and setter.
-  case AccessStrategy::DirectToAccessor:
-    if (strategy.getAccessor() == AccessorKind::Address ||
-        strategy.getAccessor() == AccessorKind::MutableAddress) {
-      addNonMemberVarDeclAddressorComponent(SGF.SGM, var, formalRValueType, lv);
-      break;
-    }
-    LLVM_FALLTHROUGH;
-  case AccessStrategy::MaterializeToTemporary: {
-    // FIXME: this is not correct for all materialization-based strategies.
-    auto typeData = getLogicalStorageTypeData(SGF.SGM, formalRValueType);
-    lv.add<GetterSetterComponent>(var, /*isSuper=*/false, /*direct*/ true,
-                                  SGF.SGM.getNonMemberVarDeclSubstitutions(var),
-                                  CanType(), typeData);
-    break;
-  }
-
-  case AccessStrategy::Storage: {
-    // If it's a physical value (e.g. a local variable in memory), push its
-    // address.
-    auto address =
-      SGF.maybeEmitAddressOfNonMemberVarDecl(loc, var, formalRValueType,
-                                             accessKind, semantics);
-    assert(address.isLValue() &&
-           "physical lvalue decl ref must evaluate to an address");
-    auto typeData = getPhysicalStorageTypeData(SGF.SGM, var, formalRValueType);
-
-    Optional<SILAccessEnforcement> enforcement;
-    if (!var->isLet()) {
-      if (options.IsNonAccessing) {
-        enforcement = None;
-      } else if (var->getDeclContext()->isLocalContext()) {
-        enforcement = SGF.getUnknownEnforcement(var);
-      } else if (var->getDeclContext()->isModuleScopeContext()) {
-        enforcement = SGF.getDynamicEnforcement(var);
-      } else {
-        assert(var->getDeclContext()->isTypeContext() &&
-               !var->isInstanceMember());
-        enforcement = SGF.getDynamicEnforcement(var);
-      }
-    }
-
-    lv.add<ValueComponent>(address, enforcement, typeData);
-
-    if (address.getType().is<ReferenceStorageType>())
-      lv.add<OwnershipComponent>(typeData);
-    break;
-  }
-  
-  case AccessStrategy::BehaviorStorage:
-    // TODO: Behaviors aren't supported for non-instance properties yet.
-    llvm_unreachable("not implemented");
-  }
+  lv.addNonMemberVarComponent(SGF, loc, var, /*be lazy*/ None,
+                              options, strategy, formalRValueType);
 
   return lv;
 }
 
-/// Emit the specified declaration as an address if possible,
-/// otherwise return null.
+void LValue::addNonMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
+                                      VarDecl *var,
+                                      Optional<SubstitutionMap> subs,
+                                      LValueOptions options,
+                                      AccessStrategy strategy,
+                                      CanType formalRValueType) {
+  struct NonMemberVarAccessEmitter :
+      AccessEmitter<NonMemberVarAccessEmitter, VarDecl> {
+    LValue &LV;
+    SILLocation Loc;
+    Optional<SubstitutionMap> Subs;
+    LValueOptions Options;
+
+    SubstitutionMap getSubs() {
+      if (Subs) return *Subs;
+      Subs = SGF.SGM.getNonMemberVarDeclSubstitutions(Storage);
+      return *Subs;
+    }
+
+    NonMemberVarAccessEmitter(SILGenFunction &SGF, SILLocation loc,
+                              VarDecl *var, Optional<SubstitutionMap> subs,
+                              CanType formalRValueType,
+                              LValueOptions options, LValue &lv)
+      : AccessEmitter(SGF, var, formalRValueType),
+        LV(lv), Loc(loc), Subs(subs), Options(options) {}
+
+    void emitUsingAddressor(SILDeclRef addressor, bool isDirect,
+                            LValueTypeData typeData) {
+      SILType storageType =
+        SGF.SGM.Types.getLoweredType(Storage->getType()).getAddressType();
+      LV.add<AddressorComponent>(Storage, addressor,
+                                 /*isSuper=*/false, isDirect, getSubs(),
+                                 CanType(), typeData, storageType);
+    }
+
+    void emitUsingGetterSetter(SILDeclRef accessor, bool isDirect,
+                               LValueTypeData typeData) {
+      LV.add<GetterSetterComponent>(Storage, accessor,
+                                    /*isSuper=*/false, isDirect, getSubs(),
+                                    CanType(), typeData);
+    }
+
+    void emitUsingMaterialization(AccessStrategy readStrategy,
+                                  AccessStrategy writeStrategy,
+                                  LValueTypeData typeData) {
+      LV.add<MaterializeToTemporaryComponent>(Storage, /*super*/false,
+                                              getSubs(), Options,
+                                              readStrategy, writeStrategy,
+                                              /*base type*/CanType(), typeData,
+                                              nullptr, nullptr);
+    }
+
+    void emitUsingStorage(LValueTypeData typeData) {
+      // If it's a physical value (e.g. a local variable in memory), push its
+      // address.
+
+      // Check for a local (possibly captured) variable.
+      auto address = SGF.maybeEmitValueOfLocalVarDecl(Storage);
+
+      // The only other case that should get here is a global variable.
+      if (!address) {
+        address = SGF.emitGlobalVariableRef(Loc, Storage);
+      }
+      assert(address.isLValue() &&
+             "physical lvalue decl ref must evaluate to an address");
+
+      Optional<SILAccessEnforcement> enforcement;
+      if (!Storage->isLet()) {
+        if (Options.IsNonAccessing) {
+          enforcement = None;
+        } else if (Storage->getDeclContext()->isLocalContext()) {
+          enforcement = SGF.getUnknownEnforcement(Storage);
+        } else if (Storage->getDeclContext()->isModuleScopeContext()) {
+          enforcement = SGF.getDynamicEnforcement(Storage);
+        } else {
+          assert(Storage->getDeclContext()->isTypeContext() &&
+                 !Storage->isInstanceMember());
+          enforcement = SGF.getDynamicEnforcement(Storage);
+        }
+      }
+
+      LV.add<ValueComponent>(address, enforcement, typeData);
+
+      if (address.getType().is<ReferenceStorageType>())
+        LV.add<OwnershipComponent>(typeData);
+    }
+  
+    void emitUsingBehaviorStorage() {
+      // TODO: Behaviors aren't supported for non-instance properties yet.
+      llvm_unreachable("not implemented");
+    }
+  } emitter(SGF, loc, var, subs, formalRValueType, options, *this);
+
+  emitter.emitUsingStrategy(strategy);
+}
+
 ManagedValue
-SILGenFunction::maybeEmitAddressOfNonMemberVarDecl(SILLocation loc,
-                                                   VarDecl *var,
-                                                   CanType formalRValueType,
-                                                   AccessKind accessKind,
-                                                   AccessSemantics semantics) {
+SILGenFunction::maybeEmitValueOfLocalVarDecl(VarDecl *var) {
   // For local decls, use the address we allocated or the value if we have it.
   auto It = VarLocs.find(var);
   if (It != VarLocs.end()) {
@@ -2367,39 +2544,15 @@ SILGenFunction::maybeEmitAddressOfNonMemberVarDecl(SILLocation loc,
     if (ptr->getType().isAddress())
       return ManagedValue::forLValue(ptr);
 
-    // Otherwise, it is an RValue let.
-    return ManagedValue();
+    // Otherwise, it is an RValue let.  Uses of it are borrows, but we don't
+    // want to proactively emit a borrow here.
+    // TODO: integrate this with how callers want these values so we can do
+    // something more semantic than just forUnmanaged.
+    return ManagedValue::forUnmanaged(ptr);
   }
 
-  auto strategy = var->getAccessStrategy(semantics, accessKind, FunctionDC);
-
-  switch (strategy.getKind()) {
-  case AccessStrategy::Storage:
-    // The only kind of stored variable that should make it to here is
-    // a global variable.  Just invoke its accessor function to get its
-    // address.
-    return emitGlobalVariableRef(loc, var);
-
-  case AccessStrategy::DirectToAccessor:
-  case AccessStrategy::DispatchToAccessor: {
-    auto accessor = strategy.getAccessor();
-    if (accessor != AccessorKind::Address &&
-        accessor != AccessorKind::MutableAddress)
-      return ManagedValue();
-
-    LValue lv;
-    addNonMemberVarDeclAddressorComponent(SGM, var, formalRValueType, lv);
-    return emitAddressOfLValue(loc, std::move(lv), accessKind);
-  }
-
-  case AccessStrategy::MaterializeToTemporary:
-    return ManagedValue();
-
-  case AccessStrategy::BehaviorStorage:
-    // TODO: Behaviors aren't supported on non-instance properties yet.
-    llvm_unreachable("not implemented");
-  }
-  llvm_unreachable("bad access strategy");
+  // Otherwise, it's non-local or not stored.
+  return ManagedValue();
 }
 
 ManagedValue
@@ -2408,9 +2561,7 @@ SILGenFunction::emitAddressOfLocalVarDecl(SILLocation loc, VarDecl *var,
                                           AccessKind accessKind) {
   assert(var->getDeclContext()->isLocalContext());
   assert(var->getImplInfo().isSimpleStored());
-  auto address =
-    maybeEmitAddressOfNonMemberVarDecl(loc, var, formalRValueType, accessKind,
-                                       AccessSemantics::Ordinary);
+  auto address = maybeEmitValueOfLocalVarDecl(var);
   assert(address);
   assert(address.isLValue());
   return address;
@@ -2424,11 +2575,11 @@ RValue SILGenFunction::emitRValueForNonMemberVarDecl(SILLocation loc,
   // Any writebacks for this access are tightly scoped.
   FormalEvaluationScope scope(*this);
 
+  auto localValue = maybeEmitValueOfLocalVarDecl(var);
+
   // If this VarDecl is represented as an address, emit it as an lvalue, then
   // perform a load to get the rvalue.
-  if (ManagedValue result =
-        maybeEmitAddressOfNonMemberVarDecl(loc, var, formalRValueType,
-                                           AccessKind::Read, semantics)) {
+  if (localValue && localValue.isLValue()) {
     bool guaranteedValid = false;
     IsTake_t shouldTake = IsNotTake;
 
@@ -2442,7 +2593,7 @@ RValue SILGenFunction::emitRValueForNonMemberVarDecl(SILLocation loc,
     // Protect the lvalue read with access markers. The !is<LValueType> assert
     // above ensures that the "LValue" is actually immutable, so we use an
     // unenforced access marker.
-    SILValue destAddr = result.getLValueAddress();
+    SILValue destAddr = localValue.getLValueAddress();
     SILValue accessAddr = UnenforcedFormalAccess::enter(*this, loc, destAddr,
                                                         SILAccessKind::Read);
     auto propagateRValuePastAccess = [&](RValue &&rvalue) {
@@ -2494,13 +2645,12 @@ RValue SILGenFunction::emitRValueForNonMemberVarDecl(SILLocation loc,
   }
 
   // For local decls, use the address we allocated or the value if we have it.
-  auto It = VarLocs.find(var);
-  if (It != VarLocs.end()) {
+  if (localValue) {
     // Mutable lvalue and address-only 'let's are LValues.
-    assert(!It->second.value->getType().isAddress() &&
+    assert(!localValue.getType().isAddress() &&
            "LValue cases should be handled above");
 
-    SILValue Scalar = It->second.value;
+    SILValue Scalar = localValue.getUnmanagedValue();
 
     // For weak and unowned types, convert the reference to the right
     // pointer.
@@ -2522,40 +2672,10 @@ RValue SILGenFunction::emitRValueForNonMemberVarDecl(SILLocation loc,
                     ? Result : Result.copyUnmanaged(*this, loc));
   }
 
-  assert(var->getGetter() && "Unknown rvalue case");
-
-  SILDeclRef getter = SGM.getGetterDeclRef(var);
-
-  ArgumentSource selfSource;
-
-  // Global properties have no base or subscript. Static properties
-  // use the metatype as their base.
-  // FIXME: This has to be dynamically looked up for classes, and
-  // dynamically instantiated for generics.
-  if (var->isStatic()) {
-    auto baseTy = cast<NominalTypeDecl>(var->getDeclContext())
-      ->getDeclaredInterfaceType();
-    assert(!baseTy->is<BoundGenericType>() &&
-           "generic static stored properties not implemented");
-    assert((baseTy->getStructOrBoundGenericStruct() ||
-            baseTy->getEnumOrBoundGenericEnum()) &&
-           "static stored properties for classes/protocols not implemented");
-    auto baseMeta = MetatypeType::get(baseTy)->getCanonicalType();
-
-    auto metatype = B.createMetatype(loc,
-                                     getLoweredLoadableType(baseMeta));
-    auto metatypeMV = ManagedValue::forUnmanaged(metatype);
-    auto metatypeRV = RValue(*this, loc, baseMeta, metatypeMV);
-    selfSource = ArgumentSource(loc, std::move(metatypeRV));
-  }
-
-  bool isDirectAccessorUse =
-    (semantics == AccessSemantics::DirectToImplementation);
-  return emitGetAccessor(loc, getter,
-                         SGM.getNonMemberVarDeclSubstitutions(var),
-                         std::move(selfSource),
-                         /*isSuper=*/false, isDirectAccessorUse,
-                         RValue(), C);
+  LValue lv = emitLValueForNonMemberVarDecl(*this, loc, var, formalRValueType,
+                                            AccessKind::Read, LValueOptions(),
+                                            semantics);
+  return emitLoadOfLValue(loc, std::move(lv), C);
 }
 
 LValue SILGenLValue::visitDiscardAssignmentExpr(DiscardAssignmentExpr *e,
@@ -2686,128 +2806,129 @@ LValue SILGenLValue::visitMemberRefExpr(MemberRefExpr *e,
   CanType substFormalRValueType = getSubstFormalRValueType(e);
   lv.addMemberVarComponent(SGF, e, var,
                            e->getMember().getSubstitutions(),
-                           options, e->isSuper(), accessKind,
-                           e->getAccessSemantics(),
+                           options, e->isSuper(),
                            strategy, substFormalRValueType);
   return lv;
 }
 
-static bool isDirectAccessorUse(AccessStrategy strategy) {
-  switch (strategy.getKind()) {
-  case AccessStrategy::Storage:
-  case AccessStrategy::BehaviorStorage:
-    // This is only necessary to support because of the recursive use in
-    // MaterializeToTemporary.
-    //llvm_unreachable("not an accessor use");
-    return false;
+namespace {
 
-  case AccessStrategy::MaterializeToTemporary:
-    // FIXME: this case should never be handled this way.
-    return isDirectAccessorUse(strategy.getReadStrategy()) ||
-           isDirectAccessorUse(strategy.getWriteStrategy());
+/// A CRTP class for emitting member accesses.
+template <class Impl, class StorageType>
+struct MemberStorageAccessEmitter : AccessEmitter<Impl, StorageType> {
+  using super = AccessEmitter<Impl, StorageType>;
+  using super::SGF;
+  using super::Storage;
+  using super::FormalRValueType;
+  LValue &LV;
+  LValueOptions Options;
+  SILLocation Loc;
+  bool IsSuper;
+  CanType BaseFormalType;
+  SubstitutionMap Subs;
+  Expr *IndexExprForDiagnostics;
+  RValue *Indices;
 
-  case AccessStrategy::DirectToAccessor:
-    return true;
+  MemberStorageAccessEmitter(SILGenFunction &SGF, SILLocation loc,
+                             StorageType *storage,
+                             SubstitutionMap subs,
+                             bool isSuper,
+                             CanType formalRValueType,
+                             LValueOptions options,
+                             LValue &lv,
+                             Expr *indexExprForDiagnostics,
+                             RValue *indices)
+    : super(SGF, storage, formalRValueType),
+      LV(lv), Options(options), Loc(loc), IsSuper(isSuper),
+      BaseFormalType(lv.getSubstFormalType()), Subs(subs),
+      IndexExprForDiagnostics(indexExprForDiagnostics), Indices(indices) {}
 
-  case AccessStrategy::DispatchToAccessor:
-    return false;
+  void emitUsingAddressor(SILDeclRef addressor, bool isDirect,
+                          LValueTypeData typeData) {
+    SILType varStorageType =
+      SGF.SGM.Types.getSubstitutedStorageType(Storage, FormalRValueType);
+
+    LV.add<AddressorComponent>(Storage, addressor, IsSuper, isDirect, Subs,
+                               BaseFormalType, typeData, varStorageType,
+                               IndexExprForDiagnostics, Indices);
   }
-  llvm_unreachable("bad access strategy");
-}
 
-static AccessorKind getRepresentativeAccessor(AccessStrategy strategy) {
-  // HACK: this is only necessary because we don't do the generally-correct
-  // thing yet for MaterializeToTemporary.
-  if (strategy.getKind() == AccessStrategy::MaterializeToTemporary)
-    return AccessorKind::MaterializeForSet;
+  void emitUsingGetterSetter(SILDeclRef accessor, bool isDirect,
+                             LValueTypeData typeData) {
+    LV.add<GetterSetterComponent>(Storage, accessor, IsSuper, isDirect,
+                                  Subs, BaseFormalType, typeData,
+                                  IndexExprForDiagnostics, Indices);
+  }
 
-  return strategy.getAccessor();
-}
+  void emitUsingMaterialization(AccessStrategy readStrategy,
+                                AccessStrategy writeStrategy,
+                                LValueTypeData typeData) {
+    LV.add<MaterializeToTemporaryComponent>(Storage, IsSuper, Subs, Options,
+                                            readStrategy, writeStrategy,
+                                            BaseFormalType, typeData,
+                                            IndexExprForDiagnostics, Indices);
+  }
+};
+} // end anonymous namespace
 
 void LValue::addMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
                                    VarDecl *var,
                                    SubstitutionMap subs,
                                    LValueOptions options,
                                    bool isSuper,
-                                   AccessKind accessKind,
-                                   AccessSemantics accessSemantics,
                                    AccessStrategy strategy,
                                    CanType formalRValueType) {
-  CanType baseFormalType = getSubstFormalType();
+  struct MemberVarAccessEmitter
+      : MemberStorageAccessEmitter<MemberVarAccessEmitter, VarDecl> {
+    using MemberStorageAccessEmitter::MemberStorageAccessEmitter;
 
-  switch (strategy.getKind()) {
-  case AccessStrategy::Storage: {
-    // For static variables, emit a reference to the global variable backing
-    // them.
-    // FIXME: This has to be dynamically looked up for classes, and
-    // dynamically instantiated for generics.
-    if (var->isStatic()) {
-      // FIXME: this implicitly drops the earlier components, but maybe
-      // we ought to evaluate them for side-effects even during the
-      // formal access?
-      *this = emitLValueForNonMemberVarDecl(SGF, loc, var,
-                                            formalRValueType, accessKind,
-                                            options, accessSemantics);
-      return;
-    }
+    void emitUsingStorage(LValueTypeData typeData) {
+      // For static variables, emit a reference to the global variable backing
+      // them.
+      // FIXME: This has to be dynamically looked up for classes, and
+      // dynamically instantiated for generics.
+      if (Storage->isStatic()) {
+        // FIXME: this implicitly drops the earlier components, but maybe
+        // we ought to evaluate them for side-effects even during the
+        // formal access?
+        LV.Path.clear();
+        LV.addNonMemberVarComponent(SGF, Loc, Storage, Subs, Options,
+                                    AccessStrategy::getStorage(),
+                                    FormalRValueType);
+        return;
+      }
 
-    // Otherwise, it's a physical member.
-    SILType varStorageType =
-      SGF.SGM.Types.getSubstitutedStorageType(var, formalRValueType);
-    auto typeData = getPhysicalStorageTypeData(SGF.SGM, var, formalRValueType);
-
-    if (baseFormalType->mayHaveSuperclass()) {
-      add<RefElementComponent>(var, options, varStorageType, typeData);
-    } else {
-      assert(baseFormalType->getStructOrBoundGenericStruct());
-      add<StructElementComponent>(var, varStorageType, typeData);
-    }
-    
-    // If the member has weak or unowned storage, convert it away.
-    if (varStorageType.is<ReferenceStorageType>()) {
-      add<OwnershipComponent>(typeData);
-    }
-    return;
-  }
-
-  case AccessStrategy::MaterializeToTemporary: // FIXME
-  case AccessStrategy::DirectToAccessor:
-  case AccessStrategy::DispatchToAccessor: {
-    auto accessor = getRepresentativeAccessor(strategy);
-
-    if (accessor == AccessorKind::Address ||
-        accessor == AccessorKind::MutableAddress) {
+      // Otherwise, it's a physical member.
       SILType varStorageType =
-        SGF.SGM.Types.getSubstitutedStorageType(var, formalRValueType);
-      auto typeData = getPhysicalStorageTypeData(SGF.SGM, var, formalRValueType);
+        SGF.SGM.Types.getSubstitutedStorageType(Storage, FormalRValueType);
 
-      add<AddressorComponent>(var, isSuper, /*direct*/ true, subs,
-                              baseFormalType, typeData, varStorageType);
-      return;
+      if (BaseFormalType->mayHaveSuperclass()) {
+        LV.add<RefElementComponent>(Storage, Options, varStorageType, typeData);
+      } else {
+        assert(BaseFormalType->getStructOrBoundGenericStruct());
+        LV.add<StructElementComponent>(Storage, varStorageType, typeData);
+      }
+
+      // If the member has weak or unowned storage, convert it away.
+      if (varStorageType.is<ReferenceStorageType>()) {
+        LV.add<OwnershipComponent>(typeData);
+      }
     }
 
-    // Use the property accessors if the variable has accessors and this isn't a
-    // direct access to underlying storage.
-    bool isDirect = isDirectAccessorUse(strategy);
-    auto typeData = getLogicalStorageTypeData(SGF.SGM, formalRValueType);
-    add<GetterSetterComponent>(var, isSuper, isDirect,
-                               subs, baseFormalType, typeData);
-    return;
-  }
+    // For behavior initializations, we should have set up a marking proxy that
+    // replaces the access path.
+    void emitUsingBehaviorStorage() {
+      auto addr = SGF.maybeEmitValueOfLocalVarDecl(Storage);
+      assert(addr && addr.isLValue());
+      LV = LValue();
+      auto typeData =
+        getPhysicalStorageTypeData(SGF.SGM, Storage, FormalRValueType);
+      LV.add<ValueComponent>(addr, None, typeData);
+    }
+  } emitter(SGF, loc, var, subs, isSuper, formalRValueType, options, *this,
+            /*indices for diags*/ nullptr, /*indices*/ nullptr);
 
-  // For behavior initializations, we should have set up a marking proxy that
-  // replaces the access path.
-  case AccessStrategy::BehaviorStorage: {
-    auto addr = SGF.VarLocs.find(var);
-    assert(addr != SGF.VarLocs.end() && addr->second.value);
-    Path.clear();
-    auto typeData = getPhysicalStorageTypeData(SGF.SGM, var, formalRValueType);
-    add<ValueComponent>(ManagedValue::forUnmanaged(addr->second.value),
-                        None, typeData);
-    return;
-  }
-  }
-  llvm_unreachable("bad access strategy");
+  emitter.emitUsingStrategy(strategy);
 }
 
 LValue SILGenLValue::visitSubscriptExpr(SubscriptExpr *e,
@@ -2832,8 +2953,7 @@ LValue SILGenLValue::visitSubscriptExpr(SubscriptExpr *e,
   CanType formalRValueType = getSubstFormalRValueType(e);
   lv.addMemberSubscriptComponent(SGF, e, decl,
                                  e->getDecl().getSubstitutions(),
-                                 options, e->isSuper(), accessKind,
-                                 accessSemantics, strategy,
+                                 options, e->isSuper(), strategy,
                                  formalRValueType, std::move(index),
                                  indexExpr);
   return lv;
@@ -2887,44 +3007,26 @@ void LValue::addMemberSubscriptComponent(SILGenFunction &SGF, SILLocation loc,
                                          SubstitutionMap subs,
                                          LValueOptions options,
                                          bool isSuper,
-                                         AccessKind accessKind,
-                                         AccessSemantics accessSemantics,
                                          AccessStrategy strategy,
                                          CanType formalRValueType,
                                          RValue &&indices,
                                          Expr *indexExprForDiagnostics) {
-  CanType baseFormalType = getSubstFormalType();
+  struct MemberSubscriptAccessEmitter
+      : MemberStorageAccessEmitter<MemberSubscriptAccessEmitter,
+                                   SubscriptDecl> {
+    using MemberStorageAccessEmitter::MemberStorageAccessEmitter;
 
-  switch (strategy.getKind()) {
-  case AccessStrategy::Storage:
-    llvm_unreachable("subscripts never have storage");
-
-  case AccessStrategy::BehaviorStorage:
-    llvm_unreachable("subscripts never have behaviors");
-
-  case AccessStrategy::MaterializeToTemporary:
-  case AccessStrategy::DirectToAccessor:
-  case AccessStrategy::DispatchToAccessor: {
-    auto accessor = getRepresentativeAccessor(strategy);
-    if (accessor == AccessorKind::Address ||
-        accessor == AccessorKind::MutableAddress) {
-      auto typeData = getPhysicalStorageTypeData(SGF.SGM, decl, formalRValueType);
-      auto storageType = 
-        SGF.SGM.Types.getSubstitutedStorageType(decl, formalRValueType);
-      add<AddressorComponent>(decl, isSuper, /*direct*/ true,
-                              subs, baseFormalType, typeData, storageType,
-                              indexExprForDiagnostics, &indices);
-    } else {
-      bool isDirect = isDirectAccessorUse(strategy);
-      auto typeData = getLogicalStorageTypeData(SGF.SGM, formalRValueType);
-      add<GetterSetterComponent>(decl, isSuper, isDirect,
-                                 subs, baseFormalType, typeData,
-                                 indexExprForDiagnostics, &indices);
+    void emitUsingStorage(LValueTypeData typeData) {
+      llvm_unreachable("subscripts never have storage");
     }
-    return;
-  }
-  }
-  llvm_unreachable("bad access strategy");
+
+    void emitUsingBehaviorStorage() {
+      llvm_unreachable("subscripts never have behaviors");
+    }
+  } emitter(SGF, loc, decl, subs, isSuper, formalRValueType, options, *this,
+            indexExprForDiagnostics, &indices);
+
+  emitter.emitUsingStrategy(strategy);
 }
 
 bool LValue::isObviouslyNonConflicting(const LValue &other,
@@ -3001,7 +3103,10 @@ getOptionalObjectTypeData(SILGenFunction &SGF,
 LValue SILGenLValue::visitForceValueExpr(ForceValueExpr *e,
                                          AccessKind accessKind,
                                          LValueOptions options) {
-  LValue lv = visitRec(e->getSubExpr(), accessKind,
+  // Like BindOptional, this is a read even if we only write to the result.
+  // (But it's unnecessary to use a force this way!)
+  LValue lv = visitRec(e->getSubExpr(),
+                       combineAccessKinds(accessKind, AccessKind::Read),
                        options.forComputedBaseLValue());
   LValueTypeData typeData = getOptionalObjectTypeData(SGF, lv.getTypeData());
   lv.add<ForceOptionalObjectComponent>(typeData);
@@ -3011,6 +3116,9 @@ LValue SILGenLValue::visitForceValueExpr(ForceValueExpr *e,
 LValue SILGenLValue::visitBindOptionalExpr(BindOptionalExpr *e,
                                            AccessKind accessKind,
                                            LValueOptions options) {
+  // Binding reads the base even if we then only write to the result.
+  accessKind = combineAccessKinds(accessKind, AccessKind::Read);
+
   // Do formal evaluation of the base l-value.
   LValue optLV = visitRec(e->getSubExpr(), accessKind,
                           options.forComputedBaseLValue());
@@ -3065,65 +3173,14 @@ LValue SILGenFunction::emitPropertyLValue(SILLocation loc, ManagedValue base,
                          /*isRValue=*/!base.isLValue());
 
   auto substFormalType = ivar->getInterfaceType().subst(subMap)
-    ->getCanonicalType();
+    ->getCanonicalType().getReferenceStorageReferent();
 
   AccessStrategy strategy =
     ivar->getAccessStrategy(semantics, accessKind, FunctionDC);
 
-
-  // Use the property accessors if the variable has accessors and this
-  // isn't a direct access to underlying storage.
-  switch (strategy.getKind()) {
-  case AccessStrategy::Storage: {
-    // Find the substituted storage type.
-    SILType varStorageType =
-      SGM.Types.getSubstitutedStorageType(ivar, substFormalType);
-    auto typeData = getPhysicalStorageTypeData(SGM, ivar, substFormalType);
-
-    if (baseFormalType->hasReferenceSemantics()) {
-      lv.add<RefElementComponent>(ivar, options, varStorageType, typeData);
-    } else {
-      lv.add<StructElementComponent>(ivar, varStorageType, typeData);
-    }
-
-    if (varStorageType.is<ReferenceStorageType>()) {
-      auto formalRValueType =
-        ivar->getDeclContext()->mapTypeIntoContext(ivar->getInterfaceType())
-            ->getReferenceStorageReferent()
-            ->getCanonicalType();
-      auto typeData =
-        getPhysicalStorageTypeData(SGM, ivar, formalRValueType);
-      lv.add<OwnershipComponent>(typeData);
-    }
-    return lv;
-  }
-
-  case AccessStrategy::DirectToAccessor:
-  case AccessStrategy::DispatchToAccessor:
-  case AccessStrategy::MaterializeToTemporary: {
-    auto accessor = getRepresentativeAccessor(strategy);
-    bool isDirect = isDirectAccessorUse(strategy);
-    if (accessor == AccessorKind::Address ||
-        accessor == AccessorKind::MutableAddress) {
-      SILType varStorageType =
-        SGM.Types.getSubstitutedStorageType(ivar, substFormalType);
-      auto typeData = getPhysicalStorageTypeData(SGM, ivar, substFormalType);
-
-      lv.add<AddressorComponent>(ivar, /*super*/ false, isDirect,
-                                 subMap, baseFormalType, typeData,
-                                 varStorageType);
-    } else {
-      auto typeData = getLogicalStorageTypeData(SGM, substFormalType);
-      lv.add<GetterSetterComponent>(ivar, /*super*/ false, isDirect,
-                                    subMap, baseFormalType, typeData);
-    }
-    return lv;
-  }
-
-  case AccessStrategy::BehaviorStorage:
-    llvm_unreachable("behaviors not expected here?");
-  }
-  llvm_unreachable("bad kind");
+  lv.addMemberVarComponent(*this, loc, ivar, subMap, options, /*super*/ false,
+                           strategy, substFormalType);
+  return lv;
 }
 
 // This is emitLoad that will handle re-abstraction and bridging for the client.

--- a/lib/SILGen/SILGenMaterializeForSet.cpp
+++ b/lib/SILGen/SILGenMaterializeForSet.cpp
@@ -494,9 +494,8 @@ public:
 
     // Drill down to the member storage.
     lv.addMemberComponent(SGF, loc, WitnessStorage, WitnessSubs,
-                          LValueOptions(), IsSuper,
-                          accessKind, TheAccessSemantics, strategy,
-                          SubstStorageType, std::move(indices));
+                          LValueOptions(), IsSuper, strategy, SubstStorageType,
+                          std::move(indices), /*index expr for diags*/ nullptr);
 
     SILType expectedTy = SGM.Types.getLoweredType(
         lv.getOrigFormalType(),
@@ -824,8 +823,7 @@ SILValue MaterializeForSetEmitter::emitUsingAddressor(SILGenFunction &SGF,
   bool isDirect = (TheAccessSemantics != AccessSemantics::Ordinary);
 
   // Call the mutable addressor.
-  auto addressor = SGF.SGM.getAddressorDeclRef(WitnessStorage,
-                                               AccessKind::ReadWrite);
+  auto addressor = SGF.SGM.getMutableAddressorDeclRef(WitnessStorage);
   std::pair<ManagedValue, ManagedValue> result;
   {
     FormalEvaluationScope Scope(SGF);

--- a/test/SILGen/multi_file.swift
+++ b/test/SILGen/multi_file.swift
@@ -37,7 +37,9 @@ func finalVarsAreDevirtualized(_ obj: FinalPropertyClass) {
 // CHECK-LABEL: sil hidden @$S10multi_file34finalVarsDontNeedMaterializeForSetyyAA27ObservingPropertyFinalClassCF
 func finalVarsDontNeedMaterializeForSet(_ obj: ObservingPropertyFinalClass) {
   obj.foo += 1
-  // CHECK: function_ref @$S10multi_file27ObservingPropertyFinalClassC3fooSivg
+  // CHECK: [[T0:%.*]] = ref_element_addr %0 : $ObservingPropertyFinalClass, #ObservingPropertyFinalClass.foo
+  // CHECK-NEXT: [[T1:%.*]] = begin_access [read] [dynamic] [[T0]] : $*Int
+  // CHECK-NEXT: load [trivial] [[T1]] : $*Int
   // CHECK: function_ref @$S10multi_file27ObservingPropertyFinalClassC3fooSivs
 }
 

--- a/test/SILGen/optional_lvalue.swift
+++ b/test/SILGen/optional_lvalue.swift
@@ -73,3 +73,53 @@ func generate_int() -> Int { return 0 }
 func assign_bound_optional_lvalue(_ x: inout Int?) {
   x? = generate_int()
 }
+
+struct ComputedOptional {
+  var computedOptional : Int? {
+    get {}
+    set {}
+  }
+}
+
+// CHECK-LABEL: sil hidden @$S15optional_lvalue013assign_bound_a10_computed_B0yyAA16ComputedOptionalVzF
+// CHECK:  [[SELF:%.*]] = begin_access [modify] [unknown] %0 : $*ComputedOptional
+// CHECK:  [[TEMP:%.*]] = alloc_stack $Optional<Int>
+// CHECK:  [[T0:%.*]] = load [trivial] [[SELF]] : $*ComputedOptional
+// CHECK:  [[GETTER:%.*]] = function_ref @$S15optional_lvalue16ComputedOptionalV08computedD0SiSgvg
+// CHECK:  [[VALUE:%.*]] = apply [[GETTER]]([[T0]])
+// CHECK:  store [[VALUE]] to [trivial] [[TEMP]] : $*Optional<Int>
+// CHECK:  select_enum_addr [[TEMP]] : $*Optional<Int>
+// CHECK:  cond_br
+// CHECK:  [[VALUE_ADDR:%.*]] = unchecked_take_enum_data_addr [[TEMP]] : $*Optional<Int>
+// CHECK:  [[GENERATOR:%.*]] = function_ref @$S15optional_lvalue12generate_intSiyF
+// CHECK:  [[VALUE:%.*]] = apply [[GENERATOR]]()
+// CHECK:  assign [[VALUE]] to [[VALUE_ADDR]] : $*Int
+// CHECK:  [[OPTVALUE:%.*]] = load [trivial] [[TEMP]] : $*Optional<Int>
+// CHECK:  [[SETTER:%.*]] = function_ref @$S15optional_lvalue16ComputedOptionalV08computedD0SiSgvs
+// CHECK:  apply [[SETTER]]([[OPTVALUE]], [[SELF]])
+// CHECK:  end_access [[SELF]]
+// CHECK:  dealloc_stack [[TEMP]]
+func assign_bound_optional_computed_lvalue(_ co: inout ComputedOptional) {
+  co.computedOptional? = generate_int()
+}
+
+// CHECK-LABEL: sil hidden @$S15optional_lvalue014assign_forced_a10_computed_B0yyAA16ComputedOptionalVzF
+// CHECK:  [[GENERATOR:%.*]] = function_ref @$S15optional_lvalue12generate_intSiyF
+// CHECK:  [[VALUE:%.*]] = apply [[GENERATOR]]()
+// CHECK:  [[SELF:%.*]] = begin_access [modify] [unknown] %0 : $*ComputedOptional
+// CHECK:  [[TEMP:%.*]] = alloc_stack $Optional<Int>
+// CHECK:  [[T0:%.*]] = load [trivial] [[SELF]] : $*ComputedOptional
+// CHECK:  [[GETTER:%.*]] = function_ref @$S15optional_lvalue16ComputedOptionalV08computedD0SiSgvg
+// CHECK:  [[OPTVALUE:%.*]] = apply [[GETTER]]([[T0]])
+// CHECK:  store [[OPTVALUE]] to [trivial] [[TEMP]]
+// CHECK:  switch_enum_addr [[TEMP]]
+// CHECK:  [[VALUE_ADDR:%.*]] = unchecked_take_enum_data_addr [[TEMP]] : $*Optional<Int>
+// CHECK:  assign [[VALUE]] to [[VALUE_ADDR]] : $*Int
+// CHECK:  [[OPTVALUE:%.*]] = load [trivial] [[TEMP]] : $*Optional<Int>
+// CHECK:  [[SETTER:%.*]] = function_ref @$S15optional_lvalue16ComputedOptionalV08computedD0SiSgvs
+// CHECK:  apply [[SETTER]]([[OPTVALUE]], [[SELF]])
+// CHECK:  end_access [[SELF]]
+// CHECK:  dealloc_stack [[TEMP]]
+func assign_forced_optional_computed_lvalue(_ co: inout ComputedOptional) {
+  co.computedOptional! = generate_int()
+}

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -613,6 +613,47 @@ struct DidSetWillSetTests: ForceAccessors {
   // CHECK-NEXT: // function_ref {{.*}}.DidSetWillSetTests.a.didset : Swift.Int
   // CHECK-NEXT: [[DIDSETFN:%.*]] = function_ref @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vW : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
   // CHECK-NEXT: apply [[DIDSETFN]]([[OLDVAL]], [[WRITE]]) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
+
+  // CHECK-LABEL: sil hidden @$S10properties010DidSetWillC5TestsV8testReadSiyF
+  // CHECK:         [[SELF:%.*]] = begin_access [read] [unknown] %0 : $*DidSetWillSetTests
+  // CHECK-NEXT:    [[PROP:%.*]] = struct_element_addr [[SELF]] : $*DidSetWillSetTests
+  // CHECK-NEXT:    [[LOAD:%.*]] = load [trivial] [[PROP]] : $*Int
+  // CHECK-NEXT:    end_access [[SELF]] : $*DidSetWillSetTests
+  // CHECK-NEXT:    return [[LOAD]] : $Int
+  mutating func testRead() -> Int {
+    return a
+  }
+
+  // CHECK-LABEL: sil hidden @$S10properties010DidSetWillC5TestsV9testWrite5inputySi_tF
+  // CHECK:         [[SELF:%.*]] = begin_access [modify] [unknown] %1 : $*DidSetWillSetTests
+  // CHECK-NEXT:    // function_ref properties.DidSetWillSetTests.a.setter
+  // CHECK-NEXT:    [[SETTER:%.*]] = function_ref @$S10properties010DidSetWillC5TestsV1aSivs
+  // CHECK-NEXT:    apply [[SETTER]](%0, [[SELF]])
+  // CHECK-NEXT:    end_access [[SELF]] : $*DidSetWillSetTests
+  // CHECK-NEXT:    [[RET:%.*]] = tuple ()
+  // CHECK-NEXT:    return [[RET]] : $()
+  mutating func testWrite(input: Int) {
+    a = input
+  }
+
+  // CHECK-LABEL: sil hidden @$S10properties010DidSetWillC5TestsV13testReadWrite5inputySi_tF
+  // CHECK:         [[SELF:%.*]] = begin_access [modify] [unknown] %1 : $*DidSetWillSetTests
+  // CHECK-NEXT:    [[TEMP:%.*]] = alloc_stack $Int
+  // CHECK-NEXT:    [[PROP:%.*]] = struct_element_addr [[SELF]] : $*DidSetWillSetTests
+  // CHECK-NEXT:    [[LOAD:%.*]] = load [trivial] [[PROP]] : $*Int
+  // CHECK-NEXT:    store [[LOAD]] to [trivial] [[TEMP]] : $*Int
+  // (modification goes here)
+  // CHECK:         [[RELOAD:%.*]] = load [trivial] [[TEMP]] : $*Int
+  // CHECK-NEXT:    // function_ref properties.DidSetWillSetTests.a.setter
+  // CHECK-NEXT:    [[SETTER:%.*]] = function_ref @$S10properties010DidSetWillC5TestsV1aSivs
+  // CHECK-NEXT:    apply [[SETTER]]([[RELOAD]], [[SELF]])
+  // CHECK-NEXT:    end_access [[SELF]] : $*DidSetWillSetTests
+  // CHECK-NEXT:    dealloc_stack [[TEMP]] : $*Int
+  // CHECK-NEXT:    [[RET:%.*]] = tuple ()
+  // CHECK-NEXT:    return [[RET]] : $()
+  mutating func testReadWrite(input: Int) {
+    a += input
+  }
 }
 
 


### PR DESCRIPTION
There were several bits of code which were unnecessarily repeating the core logic of breaking down an access strategy and either setting up an `LValue` or directly emitting it.  These places have now been unified to just create and then load or othrwise use an `LValue`.

Introduce a visitor which handles the common parts of breaking down an access strategy and computing information like the `LValueTypeData`.  In addition to its direct benefits (which are somewhat lost in the boilerplate of capturing local state into the visitor subclass), this eliminates some of the *ad hoc*-ness of how the various emission paths use `AccessStrategy`.

Finally, implement the `MaterializeToTemporary` strategy in its full generality by using the actual read and write sub-strategies instead of always falling back on calling the getter and setter.  This part is not NFC because it causes us to perform the read part of a read/write to a stored-with-observers property by directly accessing the storage instead of calling the getter.  It will be even less NFC as we generalize ways in which accesses can be performed.