### PR TITLE
[TF API] Add the missing `Tensor.product` op

### DIFF
--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -924,13 +924,22 @@ public extension Tensor where Scalar : Numeric {
     return _TFGetScalarOrDie(Raw.sum(self, reductionIndices: axes).handle)
   }
 
+  // NOTE: This overload is necessary, otherwise `sum()` would refer
+  // to the variadic method `sum(squeezingAxes:)` with zero indices.
+  @inlinable @inline(__always)
+  func product() -> Scalar {
+    let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
+    return _TFGetScalarOrDie(Raw.prod(self, reductionIndices: axes).handle)
+  }
+
   /// Returns the arithmetic mean along the specified axes. The reduced
   /// dimensions are removed.
   /// - Parameter axes: The dimensions to reduce.
   /// - Precondition: Each value in `axes` must be in the range `-rank...rank`.
   @inlinable @inline(__always)
   func mean(squeezingAxes axes: Int32...) -> Tensor {
-    return Raw.mean(self, reductionIndices: Tensor<Int32>(axes), keepDims: false)
+    return Raw.mean(self, reductionIndices: Tensor<Int32>(axes),
+                    keepDims: false)
   }
 
   /// Returns the sum along the specified axes. The reduced dimensions are
@@ -942,6 +951,16 @@ public extension Tensor where Scalar : Numeric {
     return Raw.sum(self, reductionIndices: Tensor<Int32>(axes), keepDims: false)
   }
 
+  /// Returns the product along the specified axes. The reduced dimensions are
+  /// removed.
+  /// - Parameter axes: The dimensions to reduce.
+  /// - Precondition: Each value in `axes` must be in the range `-rank...rank`.
+  @inlinable @inline(__always)
+  func product(squeezingAxes axes: Int32...) -> Tensor {
+    return Raw.prod(self, reductionIndices: Tensor<Int32>(axes),
+                    keepDims: false)
+  }
+
   /// Returns the arithmetic mean along the specified axes. The reduced
   /// dimensions are retained with value 1.
   /// - Parameter axes: The dimensions to reduce.
@@ -951,13 +970,22 @@ public extension Tensor where Scalar : Numeric {
     return Raw.mean(self, reductionIndices: Tensor<Int32>(axes), keepDims: true)
   }
 
-  /// Returns the arithmetic mean along the specified axes. The reduced
-  /// dimensions are retained with value 1.
+  /// Returns the sum along the specified axes. The reduced dimensions are
+  /// retained with value 1.
   /// - Parameter axes: The dimensions to reduce.
   /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
   @inlinable @inline(__always)
   func sum(alongAxes axes: Int32...) -> Tensor {
     return Raw.sum(self, reductionIndices: Tensor<Int32>(axes), keepDims: true)
+  }
+
+  /// Returns the product along the specified axes. The reduced dimensions are
+  /// retained with value 1.
+  /// - Parameter axes: The dimensions to reduce.
+  /// - Precondition: Each value in `axes` must be in the range `-rank..<rank`.
+  @inlinable @inline(__always)
+  func product(alongAxes axes: Int32...) -> Tensor {
+    return Raw.prod(self, reductionIndices: Tensor<Int32>(axes), keepDims: true)
   }
 }
 

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -197,8 +197,14 @@ TensorTests.test("WholeTensorSlicing") {
 TensorTests.testAllBackends("Reduction") {
   // 2 x 5
   let x = Tensor<Float>([[1, 2, 3, 4, 5], [1, 2, 3, 4, 5]])
-  let sum = x.sum(squeezingAxes: 0)
-  expectEqual(ShapedArray(shape: [5], scalars: [2, 4, 6, 8, 10]), sum.array)
+  expectEqual(ShapedArray(shape: [5], scalars: [2, 4, 6, 8, 10]),
+              x.sum(squeezingAxes: 0).array)
+  expectEqual(ShapedArray(shape: [1, 5], scalars: [2, 4, 6, 8, 10]),
+              x.sum(alongAxes: 0).array)
+  expectEqual(ShapedArray(shape: [5], scalars: [1, 4, 9, 16, 25]),
+              x.product(squeezingAxes: 0).array)
+  expectEqual(ShapedArray(shape: [1, 5], scalars: [1, 4, 9, 16, 25]),
+              x.product(alongAxes: 0).array)
 }
 
 TensorTests.testAllBackends("Concatenation") {


### PR DESCRIPTION
[`prod`](https://www.tensorflow.org/api_docs/python/tf/reduce_prod) is one of the five arithmetic "reduction ops" in TensorFlow: `mean`, `sum`, `prod`, `min`, `max`.