### PR TITLE
[stdlib] Switch .first to use an index not an iterator

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1186,24 +1186,10 @@ extension Collection {
   ///     // Prints "10"
   @inlinable
   public var first: Element? {
-    @inline(__always)
-    get {
-      // NB: Accessing `startIndex` may not be O(1) for some lazy collections,
-      // so instead of testing `isEmpty` and then returning the first element,
-      // we'll just rely on the fact that the iterator always yields the
-      // first element first.
-      var i = makeIterator()
-      return i.next()
-    }
+    let start = startIndex
+    if start != endIndex { return self[start] }
+    else { return nil }
   }
-  
-  // TODO: swift-3-indexing-model - uncomment and replace above ready (or should we still use the iterator one?)
-  /// Returns the first element of `self`, or `nil` if `self` is empty.
-  ///
-  /// - Complexity: O(1)
-  //  public var first: Element? {
-  //    return isEmpty ? nil : self[startIndex]
-  //  }
 
   /// A value less than or equal to the number of elements in the collection.
   ///


### PR DESCRIPTION
Benchmark from #18054 suggests this improves performance, at least for strings.