### PR TITLE
Use the custom @objc name in the available attribute when generates ObjC headers

### DIFF
--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -928,7 +928,11 @@ private:
     Optional<ValueDecl *>renamedFuncDecl = None;
     
     if (isa<ClassDecl>(D) || isa<ProtocolDecl>(D)) {
-      UnqualifiedLookup lookup(renamedDeclName.getBaseIdentifier(), declContext->getModuleScopeContext(), nullptr);
+      UnqualifiedLookup lookup(renamedDeclName.getBaseIdentifier(),
+                               declContext->getModuleScopeContext(),
+                               nullptr,
+                               SourceLoc(),
+                               UnqualifiedLookup::Flags::TypeLookup);
       renamedFuncDecl = lookup.getSingleTypeResult();
     } else {
       SmallVector<ValueDecl *, 4> lookupResults;

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -799,7 +799,7 @@ private:
             os << "SWIFT_UNAVAILABLE_MSG(\"'"
                << cast<ValueDecl>(D)->getBaseName()
                << "' has been renamed to '";
-            printRenameForDecl(AvAttr, D, false);
+            printRenameForDecl(AvAttr, cast<ValueDecl>(D), false);
             os << '\'';
             if (!AvAttr->Message.empty()) {
               os << ": ";
@@ -824,7 +824,7 @@ private:
             printEncodedString(AvAttr->Message);
             if (!AvAttr->Rename.empty()) {
               os << ", ";
-              printRenameForDecl(AvAttr, D, true);
+              printRenameForDecl(AvAttr, cast<ValueDecl>(D), true);
             }
             os << ")";
           } else {
@@ -900,7 +900,7 @@ private:
       if (!AvAttr->Rename.empty() && isa<ValueDecl>(D)) {
         os << ",message=\"'" << cast<ValueDecl>(D)->getBaseName()
            << "' has been renamed to '";
-        printRenameForDecl(AvAttr, D, false);
+        printRenameForDecl(AvAttr, cast<ValueDecl>(D), false);
         os << '\'';
         if (!AvAttr->Message.empty()) {
           os << ": ";
@@ -916,10 +916,10 @@ private:
     return hasPrintedAnything;
   }
     
-  void printRenameForDecl(const AvailableAttr *AvAttr, const Decl *D,
+  void printRenameForDecl(const AvailableAttr *AvAttr, const ValueDecl *D,
                           bool includeQuotes) {
-    if (AvAttr->Rename.empty() && isa<ValueDecl>(D))
-      return ;
+    if (AvAttr->Rename.empty())
+      return;
     
     auto renamedParsedDeclName = parseDeclName(AvAttr->Rename);
     auto renamedDeclName = renamedParsedDeclName.formDeclName(D->getASTContext());

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -918,8 +918,7 @@ private:
     
   void printRenameForDecl(const AvailableAttr *AvAttr, const ValueDecl *D,
                           bool includeQuotes) {
-    if (AvAttr->Rename.empty())
-      return;
+    assert(!AvAttr->Rename.empty());
     
     auto renamedParsedDeclName = parseDeclName(AvAttr->Rename);
     auto renamedDeclName = renamedParsedDeclName.formDeclName(D->getASTContext());

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -953,9 +953,11 @@ private:
              cast<FuncDecl>(D)->getParameters()->size()))
           continue;
         
-        if (renamedFuncDecl)
-        /* TODO: Diagnose to compiler to tell the user that we found multiple candidates */;
-        
+        if (renamedFuncDecl) {
+          // If we found a duplicated candidate then we would silently fail.
+          renamedFuncDecl = nullptr;
+          break;
+        }
         renamedFuncDecl = candidate;
       }
     }

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -925,7 +925,7 @@ private:
     auto renamedDeclName = renamedParsedDeclName.formDeclName(D->getASTContext());
     
     auto declContext = D->getDeclContext();
-    ValueDecl *renamedFuncDecl = nullptr;
+    const ValueDecl *renamedFuncDecl = nullptr;
     
     if (isa<ClassDecl>(D) || isa<ProtocolDecl>(D)) {
       UnqualifiedLookup lookup(renamedDeclName.getBaseIdentifier(),

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -925,7 +925,7 @@ private:
     auto renamedDeclName = renamedParsedDeclName.formDeclName(D->getASTContext());
     
     auto declContext = D->getDeclContext();
-    const ValueDecl *renamedFuncDecl = nullptr;
+    const ValueDecl *renamedDecl = nullptr;
     
     if (isa<ClassDecl>(D) || isa<ProtocolDecl>(D)) {
       UnqualifiedLookup lookup(renamedDeclName.getBaseIdentifier(),
@@ -933,7 +933,7 @@ private:
                                nullptr,
                                SourceLoc(),
                                UnqualifiedLookup::Flags::TypeLookup);
-      renamedFuncDecl = lookup.getSingleTypeResult();
+      renamedDecl = lookup.getSingleTypeResult();
     } else {
       SmallVector<ValueDecl *, 4> lookupResults;
       declContext->lookupQualified(declContext->getSelfTypeInContext(),
@@ -953,18 +953,18 @@ private:
              cast<FuncDecl>(D)->getParameters()->size()))
           continue;
         
-        if (renamedFuncDecl) {
+        if (renamedDecl) {
           // If we found a duplicated candidate then we would silently fail.
-          renamedFuncDecl = nullptr;
+          renamedDecl = nullptr;
           break;
         }
-        renamedFuncDecl = candidate;
+        renamedDecl = candidate;
       }
     }
     
-    if (renamedFuncDecl) {
+    if (renamedDecl) {
       SmallString<128> scratch;
-      auto renamedObjCRuntimeName = renamedFuncDecl->getObjCRuntimeName()
+      auto renamedObjCRuntimeName = renamedDecl->getObjCRuntimeName()
         ->getString(scratch);
       printEncodedString(renamedObjCRuntimeName, includeQuotes);
     } else {

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -767,18 +767,18 @@ private:
                !FD->getAttrs().hasAttribute<DiscardableResultAttr>()) {
       os << " SWIFT_WARN_UNUSED_RESULT";
     }
-    
+
     printAvailability(FD);
     
     os << ';';
   }
-  
+
   enum class PrintLeadingSpace : bool {
     No = false,
     Yes = true
   };
-    
-    /// Returns \c true if anything was printed.
+
+  /// Returns \c true if anything was printed.
   bool printAvailability(
       const Decl *D,
       PrintLeadingSpace printLeadingSpace = PrintLeadingSpace::Yes) {
@@ -1905,7 +1905,7 @@ private:
   Optional<ValueDecl *> findRenamedDecl(const swift::AvailableAttr *AvAttr, const swift::Decl *D) {
     if (!isa<ValueDecl>(D) || isa<ClassDecl>(D))
       return None;
-      
+    
     SmallVector<ValueDecl *, 4> lookupResults;
     auto renamedParsedDeclName = swift::parseDeclName(AvAttr->Rename);
     auto renamedDeclName = renamedParsedDeclName.formDeclName(D->getASTContext());
@@ -1936,7 +1936,7 @@ private:
     
     return renamedFuncDecl;
   }
-    
+
   /// RAII class for printing multi-part C types, such as functions and arrays.
   class PrintMultiPartType {
     ObjCPrinter &Printer;

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -925,7 +925,7 @@ private:
     auto renamedDeclName = renamedParsedDeclName.formDeclName(D->getASTContext());
     
     auto declContext = D->getDeclContext();
-    Optional<ValueDecl *>renamedFuncDecl = None;
+    ValueDecl *renamedFuncDecl = nullptr;
     
     if (isa<ClassDecl>(D) || isa<ProtocolDecl>(D)) {
       UnqualifiedLookup lookup(renamedDeclName.getBaseIdentifier(),
@@ -960,10 +960,10 @@ private:
       }
     }
     
-    if (renamedFuncDecl.hasValue()) {
+    if (renamedFuncDecl) {
       SmallString<128> scratch;
-      auto renamedObjCRuntimeName = renamedFuncDecl.getValue()->
-      getObjCRuntimeName()->getString(scratch);
+      auto renamedObjCRuntimeName = renamedFuncDecl->getObjCRuntimeName()
+        ->getString(scratch);
       printEncodedString(renamedObjCRuntimeName, includeQuotes);
     } else {
       printEncodedString(AvAttr->Rename, includeQuotes);

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -943,7 +943,7 @@ private:
         if (!shouldInclude(candidate))
           continue;
         
-        if (candidate->getKind() != D->getKind() &&
+        if (candidate->getKind() != D->getKind() ||
             (candidate->isInstanceMember() !=
              cast<ValueDecl>(D)->isInstanceMember()))
           continue;

--- a/test/PrintAsObjC/availability-real-sdk.swift
+++ b/test/PrintAsObjC/availability-real-sdk.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t %s
+// RUN: %target-swift-frontend -parse-as-library %t/availability-real-sdk.swiftmodule -typecheck -emit-objc-header-path %t/availability-real-sdk.h -import-objc-header %S/../Inputs/empty.h
+// RUN: %FileCheck %s < %t/availability-real-sdk.h
+// RUN: %check-in-clang %t/availability-real-sdk.h
+
+// REQUIRES: objc_interop
+
+
+// CHECK-LABEL: @interface NSArray<ObjectType> (SWIFT_EXTENSION(main))
+// CHECK-NEXT: - (id _Nonnull)methodDeprecatedInFavorOfReverseObjectEnumerator SWIFT_WARN_UNUSED_RESULT
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("", "reverseObjectEnumerator");
+// CHECK-NEXT: - (NSArray * _Nonnull)methodDeprecatedInFavorOfAddingObjectWithObject:(id _Nonnull)object SWIFT_WARN_UNUSED_RESULT
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("", "arrayByAddingObject:");
+
+// CHECK-NEXT: @end
+
+// CHECK-LABEL: @interface SubClassOfSet : NSSet
+// CHECK-NEXT: - (id _Nonnull)methodDeprecatedInFavorOfAnyObject SWIFT_WARN_UNUSED_RESULT
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("", "anyObject");
+// CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
+// CHECK-NEXT: - (nonnull instancetype)initWithObjects:(id _Nonnull const * _Nullable)objects count:(NSUInteger)cnt OBJC_DESIGNATED_INITIALIZER;
+// CHECK-NEXT: - (nullable instancetype)initWithCoder:(NSCoder * _Nonnull)aDecoder OBJC_DESIGNATED_INITIALIZER;
+// CHECK-NEXT: @end
+
+
+import Foundation
+
+
+public class SubClassOfSet: NSSet {
+  @available(*, deprecated, renamed: "anyObject()")
+  @objc func methodDeprecatedInFavorOfAnyObject() -> Any { return 0 }
+}
+
+
+extension NSArray {
+  @available(*, deprecated, renamed: "reverseObjectEnumerator()")
+  @objc func methodDeprecatedInFavorOfReverseObjectEnumerator() -> Any { return 0 }
+  
+  @available(*, deprecated, renamed: "adding(_:)")
+  @objc func methodDeprecatedInFavorOfAddingObject(object: Any) -> NSArray {
+    return self.adding(object) as NSArray
+  }
+}
+

--- a/test/PrintAsObjC/availability-real-sdk.swift
+++ b/test/PrintAsObjC/availability-real-sdk.swift
@@ -8,18 +8,42 @@
 
 
 // CHECK-LABEL: @interface NSArray<ObjectType> (SWIFT_EXTENSION(main))
-// CHECK-NEXT: - (id _Nonnull)methodDeprecatedInFavorOfReverseObjectEnumerator SWIFT_WARN_UNUSED_RESULT
+// CHECK-NEXT: - (id _Nonnull)deprecatedMethodInFavorOfReverseObjectEnumerator SWIFT_WARN_UNUSED_RESULT
 // CHECK-SAME: SWIFT_DEPRECATED_MSG("This method is deprecated in favor to the old reverseObjectEnumerator method", "reverseObjectEnumerator");
-// CHECK-NEXT: - (NSArray * _Nonnull)methodDeprecatedInFavorOfAddingObjectWithObject:(id _Nonnull)object SWIFT_WARN_UNUSED_RESULT
+// CHECK-NEXT: - (id _Nonnull)deprecatedMethodOnMacOSInFavorOfReverseObjectEnumerator SWIFT_WARN_UNUSED_RESULT
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedMethodOnMacOSInFavorOfReverseObjectEnumerator' has been renamed to 'reverseObjectEnumerator': This method is deprecated in favor to the old reverseObjectEnumerator method");
+// CHECK-NEXT: - (id _Nonnull)unavailableMethodInFavorOfReverseObjectEnumerator SWIFT_WARN_UNUSED_RESULT
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInFavorOfReverseObjectEnumerator' has been renamed to 'reverseObjectEnumerator': This method is unavailable in favor to the old reverseObjectEnumerator method");
+// CHECK-NEXT: - (id _Nonnull)unavailableMethodOnMacOSInFavorOfReverseObjectEnumerator SWIFT_WARN_UNUSED_RESULT
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableMethodOnMacOSInFavorOfReverseObjectEnumerator' has been renamed to 'reverseObjectEnumerator': This method is unavailable in favor to the old reverseObjectEnumerator method");
+// CHECK-NEXT: - (NSArray * _Nonnull)deprecatedMethodInFavorOfAddingObjectWithObject:(id _Nonnull)object SWIFT_WARN_UNUSED_RESULT
 // CHECK-SAME: SWIFT_DEPRECATED_MSG("This method is deprecated in favor to the old adding method", "arrayByAddingObject:");
-
+// CHECK-NEXT: - (NSArray * _Nonnull)deprecatedMethodOnMacOSInFavorOfAddingObjectWithObject:(id _Nonnull)object SWIFT_WARN_UNUSED_RESULT
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedMethodOnMacOSInFavorOfAddingObject' has been renamed to 'arrayByAddingObject:': This method is deprecated in favor to the old adding method");
+// CHECK-NEXT: - (NSArray * _Nonnull)unavailableMethodInFavorOfAddingObjectWithObject:(id _Nonnull)object SWIFT_WARN_UNUSED_RESULT
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInFavorOfAddingObject' has been renamed to 'arrayByAddingObject:': This method is unavailable in favor to the old adding method");
+// CHECK-NEXT: - (NSArray * _Nonnull)unavailableMethodOnMacOSInFavorOfAddingObjectWithObject:(id _Nonnull)object SWIFT_WARN_UNUSED_RESULT
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableMethodOnMacOSInFavorOfAddingObject' has been renamed to 'arrayByAddingObject:': This method is unavailable in favor to the old adding method");
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: @interface SubClassOfSet : NSSet
-// CHECK-NEXT: - (id _Nonnull)methodDeprecatedInFavorOfAnyObject SWIFT_WARN_UNUSED_RESULT
+// CHECK-NEXT: - (id _Nonnull)deprecatedMethodInFavorOfAnyObject SWIFT_WARN_UNUSED_RESULT
 // CHECK-SAME: SWIFT_DEPRECATED_MSG("This method is deprecated in favor to the old anyObject method", "anyObject");
+// CHECK-NEXT: - (id _Nonnull)deprecatedMethodOnMacOSInFavorOfAnyObject SWIFT_WARN_UNUSED_RESULT
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedMethodOnMacOSInFavorOfAnyObject' has been renamed to 'anyObject': This method is deprecated in favor to the old anyObject method");
+// CHECK-NEXT: - (id _Nonnull)unavailableMethodInFavorOfAnyObject SWIFT_WARN_UNUSED_RESULT
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInFavorOfAnyObject' has been renamed to 'anyObject': This method is unavailable in favor to the old anyObject method");
+// CHECK-NEXT: - (id _Nonnull)unavailableMethodOnMacOSInFavorOfAnyObject SWIFT_WARN_UNUSED_RESULT
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableMethodOnMacOSInFavorOfAnyObject' has been renamed to 'anyObject': This method is unavailable in favor to the old anyObject method");
 // CHECK-NEXT: @property (nonatomic, readonly) NSInteger deprecatedPropertyInFavorOfCount
 // CHECK-SAME: SWIFT_DEPRECATED_MSG("This property is deprecated in favor to the old count property", "count");
+// CHECK-NEXT: @property (nonatomic, readonly) NSInteger deprecatedOnMacOSPropertyInFavorOfCount
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSPropertyInFavorOfCount' has been renamed to 'count': This property is deprecated in favor to the old count property");
+// CHECK-NEXT: @property (nonatomic, readonly) NSInteger unavailablePropertyInFavorOfCount
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailablePropertyInFavorOfCount' has been renamed to 'count': This property is unavailable in favor to the old count property");
+// CHECK-NEXT: @property (nonatomic, readonly) NSInteger unavailableOnMacOSPropertyInFavorOfCount
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSPropertyInFavorOfCount' has been renamed to 'count': This property is unavailable in favor to the old count property");
+
 // CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 // CHECK-NEXT: - (nonnull instancetype)initWithObjects:(id _Nonnull const * _Nullable)objects count:(NSUInteger)cnt OBJC_DESIGNATED_INITIALIZER;
 // CHECK-NEXT: - (nullable instancetype)initWithCoder:(NSCoder * _Nonnull)aDecoder OBJC_DESIGNATED_INITIALIZER;
@@ -30,33 +54,102 @@ import Foundation
 
 
 public class SubClassOfSet: NSSet {
-  @available(*, deprecated,
-  message: "This method is deprecated in favor to the old anyObject method",
-  renamed: "anyObject()")
-  @objc func methodDeprecatedInFavorOfAnyObject() -> Any { return 0 }
-  
-  @available(*, deprecated,
-  message: "This property is deprecated in favor to the old count property",
-  renamed: "count")
-  @objc var deprecatedPropertyInFavorOfCount: Int {
-    get {
-      return 0
+    @available(*, deprecated,
+    message: "This method is deprecated in favor to the old anyObject method",
+    renamed: "anyObject()")
+    @objc func deprecatedMethodInFavorOfAnyObject() -> Any { return 0 }
+    @available(macOS, deprecated,
+    message: "This method is deprecated in favor to the old anyObject method",
+    renamed: "anyObject()")
+    @objc func deprecatedMethodOnMacOSInFavorOfAnyObject() -> Any { return 0 }
+    
+    @available(*, unavailable,
+    message: "This method is unavailable in favor to the old anyObject method",
+    renamed: "anyObject()")
+    @objc func unavailableMethodInFavorOfAnyObject() -> Any { return 0 }
+    @available(macOS, unavailable,
+    message: "This method is unavailable in favor to the old anyObject method",
+    renamed: "anyObject()")
+    @objc func unavailableMethodOnMacOSInFavorOfAnyObject() -> Any { return 0 }
+    
+    @available(*, deprecated,
+    message: "This property is deprecated in favor to the old count property",
+    renamed: "count")
+    @objc var deprecatedPropertyInFavorOfCount: Int {
+        get {
+            return 0
+        }
     }
-  }
+    @available(macOS, deprecated,
+    message: "This property is deprecated in favor to the old count property",
+    renamed: "count")
+    @objc var deprecatedOnMacOSPropertyInFavorOfCount: Int {
+        get {
+            return 0
+        }
+    }
+    @available(*, unavailable,
+    message: "This property is unavailable in favor to the old count property",
+    renamed: "count")
+    @objc var unavailablePropertyInFavorOfCount: Int {
+        get {
+            return 0
+        }
+    }
+    @available(macOS, unavailable,
+    message: "This property is unavailable in favor to the old count property",
+    renamed: "count")
+    @objc var unavailableOnMacOSPropertyInFavorOfCount: Int {
+        get {
+            return 0
+        }
+    }
 }
 
 
 extension NSArray {
-  @available(*, deprecated,
-  message: "This method is deprecated in favor to the old reverseObjectEnumerator method",
-  renamed: "reverseObjectEnumerator()")
-  @objc func methodDeprecatedInFavorOfReverseObjectEnumerator() -> Any { return 0 }
-  
-  @available(*, deprecated,
-  message: "This method is deprecated in favor to the old adding method",
-  renamed: "adding(_:)")
-  @objc func methodDeprecatedInFavorOfAddingObject(object: Any) -> NSArray {
-    return self.adding(object) as NSArray
-  }
+    @available(*, deprecated,
+    message: "This method is deprecated in favor to the old reverseObjectEnumerator method",
+    renamed: "reverseObjectEnumerator()")
+    @objc func deprecatedMethodInFavorOfReverseObjectEnumerator() -> Any { return 0 }
+    @available(macOS, deprecated,
+    message: "This method is deprecated in favor to the old reverseObjectEnumerator method",
+    renamed: "reverseObjectEnumerator()")
+    @objc func deprecatedMethodOnMacOSInFavorOfReverseObjectEnumerator() -> Any { return 0 }
+    
+    @available(*, unavailable,
+    message: "This method is unavailable in favor to the old reverseObjectEnumerator method",
+    renamed: "reverseObjectEnumerator()")
+    @objc func unavailableMethodInFavorOfReverseObjectEnumerator() -> Any { return 0 }
+    @available(macOS, unavailable,
+    message: "This method is unavailable in favor to the old reverseObjectEnumerator method",
+    renamed: "reverseObjectEnumerator()")
+    @objc func unavailableMethodOnMacOSInFavorOfReverseObjectEnumerator() -> Any { return 0 }
+    
+    
+    @available(*, deprecated,
+    message: "This method is deprecated in favor to the old adding method",
+    renamed: "adding(_:)")
+    @objc func deprecatedMethodInFavorOfAddingObject(object: Any) -> NSArray {
+        return self.adding(object) as NSArray
+    }
+    @available(macOS, deprecated,
+    message: "This method is deprecated in favor to the old adding method",
+    renamed: "adding(_:)")
+    @objc func deprecatedMethodOnMacOSInFavorOfAddingObject(object: Any) -> NSArray {
+        return self.adding(object) as NSArray
+    }
+    @available(*, unavailable,
+    message: "This method is unavailable in favor to the old adding method",
+    renamed: "adding(_:)")
+    @objc func unavailableMethodInFavorOfAddingObject(object: Any) -> NSArray {
+        return self.adding(object) as NSArray
+    }
+    @available(macOS, unavailable,
+    message: "This method is unavailable in favor to the old adding method",
+    renamed: "adding(_:)")
+    @objc func unavailableMethodOnMacOSInFavorOfAddingObject(object: Any) -> NSArray {
+        return self.adding(object) as NSArray
+    }
 }
 

--- a/test/PrintAsObjC/availability-real-sdk.swift
+++ b/test/PrintAsObjC/availability-real-sdk.swift
@@ -9,15 +9,17 @@
 
 // CHECK-LABEL: @interface NSArray<ObjectType> (SWIFT_EXTENSION(main))
 // CHECK-NEXT: - (id _Nonnull)methodDeprecatedInFavorOfReverseObjectEnumerator SWIFT_WARN_UNUSED_RESULT
-// CHECK-SAME: SWIFT_DEPRECATED_MSG("", "reverseObjectEnumerator");
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("This method is deprecated in favor to the old reverseObjectEnumerator method", "reverseObjectEnumerator");
 // CHECK-NEXT: - (NSArray * _Nonnull)methodDeprecatedInFavorOfAddingObjectWithObject:(id _Nonnull)object SWIFT_WARN_UNUSED_RESULT
-// CHECK-SAME: SWIFT_DEPRECATED_MSG("", "arrayByAddingObject:");
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("This method is deprecated in favor to the old adding method", "arrayByAddingObject:");
 
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: @interface SubClassOfSet : NSSet
 // CHECK-NEXT: - (id _Nonnull)methodDeprecatedInFavorOfAnyObject SWIFT_WARN_UNUSED_RESULT
-// CHECK-SAME: SWIFT_DEPRECATED_MSG("", "anyObject");
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("This method is deprecated in favor to the old anyObject method", "anyObject");
+// CHECK-NEXT: @property (nonatomic, readonly) NSInteger deprecatedPropertyInFavorOfCount
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("This property is deprecated in favor to the old count property", "count");
 // CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 // CHECK-NEXT: - (nonnull instancetype)initWithObjects:(id _Nonnull const * _Nullable)objects count:(NSUInteger)cnt OBJC_DESIGNATED_INITIALIZER;
 // CHECK-NEXT: - (nullable instancetype)initWithCoder:(NSCoder * _Nonnull)aDecoder OBJC_DESIGNATED_INITIALIZER;
@@ -28,16 +30,31 @@ import Foundation
 
 
 public class SubClassOfSet: NSSet {
-  @available(*, deprecated, renamed: "anyObject()")
+  @available(*, deprecated,
+  message: "This method is deprecated in favor to the old anyObject method",
+  renamed: "anyObject()")
   @objc func methodDeprecatedInFavorOfAnyObject() -> Any { return 0 }
+  
+  @available(*, deprecated,
+  message: "This property is deprecated in favor to the old count property",
+  renamed: "count")
+  @objc var deprecatedPropertyInFavorOfCount: Int {
+    get {
+      return 0
+    }
+  }
 }
 
 
 extension NSArray {
-  @available(*, deprecated, renamed: "reverseObjectEnumerator()")
+  @available(*, deprecated,
+  message: "This method is deprecated in favor to the old reverseObjectEnumerator method",
+  renamed: "reverseObjectEnumerator()")
   @objc func methodDeprecatedInFavorOfReverseObjectEnumerator() -> Any { return 0 }
   
-  @available(*, deprecated, renamed: "adding(_:)")
+  @available(*, deprecated,
+  message: "This method is deprecated in favor to the old adding method",
+  renamed: "adding(_:)")
   @objc func methodDeprecatedInFavorOfAddingObject(object: Any) -> NSArray {
     return self.adding(object) as NSArray
   }

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -45,6 +45,10 @@
 // CHECK-DAG: SWIFT_AVAILABILITY(ios_app_extension,unavailable)
 // CHECK-DAG: SWIFT_AVAILABILITY(tvos_app_extension,unavailable)
 // CHECK-DAG: SWIFT_AVAILABILITY(watchos_app_extension,unavailable)
+// CHECK-DAG: ;
+// CHECK-NEXT: - (void)methodRenamedToOverloadMethod1WithFirst:(NSInteger)first second:(NSInteger)second SWIFT_DEPRECATED_MSG("", "overloadMethodWithFirst:second:");
+// CHECK-NEXT: - (void)overloadMethodWithFirst:(NSInteger)first second:(NSInteger)second;
+// CHECK-NEXT: - (void)overloadMethod2WithFirst:(double)first second:(double)second;
 // CHECK-NEXT: + (void)deprecatedAvailabilityWithValue:(NSInteger)value;
 // CHECK-NEXT: + (void)makeDeprecatedAvailabilityWithValue:(NSInteger)value SWIFT_DEPRECATED_MSG("use something else", "deprecatedAvailabilityWithValue:");
 // CHECK-NEXT: + (void)unavailableAvailabilityWithValue:(NSInteger)value;
@@ -190,6 +194,12 @@
     @available(tvOSApplicationExtension, unavailable)
     @available(watchOSApplicationExtension, unavailable)
     @objc func extensionUnavailable() {}
+  
+    @available(*, deprecated, renamed: "overloadMethod1(first:second:)")
+    @objc func methodRenamedToOverloadMethod1(first: Int, second: Int) {}
+  
+    @objc(overloadMethodWithFirst:second:) func overloadMethod1(first: Int, second: Int) {}
+    @objc func overloadMethod2(first: Double, second: Double) {}
 
     @objc(deprecatedAvailabilityWithValue:)
     public class func makeDeprecatedAvailability(withValue value: Int) {}

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -45,11 +45,15 @@
 // CHECK-DAG: SWIFT_AVAILABILITY(ios_app_extension,unavailable)
 // CHECK-DAG: SWIFT_AVAILABILITY(tvos_app_extension,unavailable)
 // CHECK-DAG: SWIFT_AVAILABILITY(watchos_app_extension,unavailable)
+// CHECK-NEXT: + (void)creditCardFormViewControllerWithPublicKey:(NSInteger)publicKey;
+// CHECK-NEXT: + (void)makeCreditCardFormViewControllerWithPublicKey:(NSInteger)publicKey SWIFT_DEPRECATED_MSG("use something else", "creditCardFormViewControllerWithPublicKey:");
 // CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 // CHECK-NEXT: - (nonnull instancetype)initWithX:(NSInteger)_ OBJC_DESIGNATED_INITIALIZER SWIFT_AVAILABILITY(macos,introduced=10.10);
 // CHECK-NEXT: @property (nonatomic, readonly) NSInteger simpleProperty;
 // CHECK-NEXT: @property (nonatomic) NSInteger alwaysUnavailableProperty SWIFT_UNAVAILABLE_MSG("'alwaysUnavailableProperty' has been renamed to 'baz': whatever");
 // CHECK-NEXT: @property (nonatomic, readonly) NSInteger alwaysDeprecatedProperty SWIFT_DEPRECATED_MSG("use something else", "quux");
+// CHECK-NEXT: @property (nonatomic, readonly) NSInteger numberOfAlwaysDeprecatedObjCProperty SWIFT_DEPRECATED_MSG("use something else", "replaceForDeprecatedObjCProperty");
+// CHECK-NEXT: @property (nonatomic, readonly) NSInteger replaceForDeprecatedObjCProperty;
 // CHECK-NEXT: @property (nonatomic, readonly, strong) Availability * _Null_unspecified singlePlatCombinedPropertyClass SWIFT_AVAILABILITY(macos,introduced=10.7,deprecated=10.9,obsoleted=10.10);
 // CHECK-NEXT: @property (nonatomic, readonly) NSInteger platformUnavailableRenameWithMessageProperty SWIFT_AVAILABILITY(macos,unavailable,message="'platformUnavailableRenameWithMessageProperty' has been renamed to 'anotherPlea': still trapped");
 // CHECK-NEXT: @end
@@ -148,6 +152,15 @@
     @available(tvOSApplicationExtension, unavailable)
     @available(watchOSApplicationExtension, unavailable)
     @objc func extensionUnavailable() {}
+  
+  @objc(creditCardFormViewControllerWithPublicKey:)
+  public class func makeCreditCardFormViewController(withPublicKey publicKey: Int) {}
+  
+  @available(*, deprecated,
+  message: "use something else",
+  renamed: "makeCreditCardFormViewController(withPublicKey:)")
+  @objc(makeCreditCardFormViewControllerWithPublicKey:) public class func __makeCreditCardForm(withPublicKey publicKey: Int) {}
+
 
     @objc init() {}
     @available(macOS 10.10, *)
@@ -172,6 +185,19 @@
 		return -1
 	    }
     }
+  @available(*, deprecated, message: "use something else", renamed: "__replaceForDeprecatedObjCProperty")
+  @objc(numberOfAlwaysDeprecatedObjCProperty) var alwaysDeprecatedObjCProperty: Int {
+    get {
+      return -1
+    }
+  }
+
+  @objc(replaceForDeprecatedObjCProperty) var __replaceForDeprecatedObjCProperty: Int {
+    get {
+      return -1
+    }
+  }
+
     @available(macOS, introduced: 10.7, deprecated: 10.9, obsoleted: 10.10)
     @objc var singlePlatCombinedPropertyClass: Availability! {
 	get {

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -53,6 +53,7 @@
 // CHECK-NEXT: + (void)deprecatedClassMethodRenamedToInstanceMethodWithValue:(NSInteger)value SWIFT_DEPRECATED_MSG("This method has a renamed attribute point to instance method instead of a class method. It should show the Swift name here", "instanceMethodWithACustomObjCName(x:)");
 // CHECK-NEXT: - (void)customObjCNameInstanceMethodWithX:(NSInteger)x;
 // CHECK-NEXT: + (void)customObjCNameClassMethodWithX:(NSInteger)x;
+// CHECK-NEXT: - (void)methodRenamedToMethodNotAvailableToObjC SWIFT_DEPRECATED_MSG("", "methodNotAvailableToObjC()");
 // CHECK-NEXT: + (void)makeDeprecatedAvailabilityWithValue:(NSInteger)value SWIFT_DEPRECATED_MSG("use something else", "deprecatedAvailabilityWithValue:");
 // CHECK-NEXT: + (void)unavailableAvailabilityWithValue:(NSInteger)value;
 // CHECK-NEXT: + (void)makeUnavailableAvailabilityWithValue:(NSInteger)value
@@ -220,6 +221,11 @@
 
     @objc(customObjCNameClassMethodWithX:)
     public class func classMethodWithACustomObjCName(x: Int) {}
+  
+    @nonobjc func methodNotAvailableToObjC() {}
+  
+    @available(*, deprecated, renamed: "methodNotAvailableToObjC()")
+    @objc public func methodRenamedToMethodNotAvailableToObjC() {}
 
     @available(*, deprecated,
     message: "use something else",

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -48,37 +48,110 @@
 // CHECK-SAME: ;
 // CHECK-NEXT: - (void)overloadingMethodWithFirst:(NSInteger)first second:(NSInteger)second;
 // CHECK-NEXT: - (void)deprecatedMethodRenamedToOverloadMethodWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_DEPRECATED_MSG("", "overloadingMethodWithFirst:second:");
+// CHECK-NEXT: - (void)deprecatedOnMacOSMethodRenamedToOverloadMethodWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodRenamedToOverloadMethod' has been renamed to 'overloadingMethodWithFirst:second:'");
+// CHECK-NEXT: - (void)unavailableMethodRenamedToOverloadMethodWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_UNAVAILABLE_MSG("'unavailableMethodRenamedToOverloadMethod' has been renamed to 'overloadingMethodWithFirst:second:'");
+// CHECK-NEXT: - (void)unavailableOnMacOSMethodRenamedToOverloadMethodWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodRenamedToOverloadMethod' has been renamed to 'overloadingMethodWithFirst:second:'");
+
 // CHECK-NEXT: - (void)firstOverloadingMethodWithDiffernceNameWithFirst:(NSInteger)first second:(NSInteger)second;
 // CHECK-NEXT: - (void)secondOverloadingMethodWithDiffernceNameWithFirst:(double)first second:(double)second;
-// CHECK-NEXT: - (void)deprecatedMethodRenamedToOverloadMethodWithDifferenceNameWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_DEPRECATED_MSG("", "overloadMethodWithDifferenceObjCName(first:second:)");
+// CHECK-NEXT: - (void)deprecatedMethodRenamedToOverloadMethodWithDifferenceNameWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("", "overloadMethodWithDifferenceObjCName(first:second:)");
+// CHECK-NEXT: - (void)deprecatedOnMacOSMethodRenamedToOverloadMethodWithDifferenceNameWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodRenamedToOverloadMethodWithDifferenceName' has been renamed to 'overloadMethodWithDifferenceObjCName(first:second:)'");
+// CHECK-NEXT: - (void)unavailableMethodRenamedToOverloadMethodWithDifferenceNameWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodRenamedToOverloadMethodWithDifferenceName' has been renamed to 'overloadMethodWithDifferenceObjCName(first:second:)'");
+// CHECK-NEXT: - (void)unavailableOnMacOSMethodRenamedToOverloadMethodWithDifferenceNameWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodRenamedToOverloadMethodWithDifferenceName' has been renamed to 'overloadMethodWithDifferenceObjCName(first:second:)'");
+
 // CHECK-NEXT: + (void)deprecatedAvailabilityWithValue:(NSInteger)value;
-// CHECK-NEXT: - (void)deprecatedInstanceMethodRenamedToClassMethodWithValue:(NSInteger)value SWIFT_DEPRECATED_MSG("This method has a renamed attribute point to class method instead of a instance method. It should show the Swift name here", "classMethodWithACustomObjCName(x:)");
-// CHECK-NEXT: + (void)deprecatedClassMethodRenamedToInstanceMethodWithValue:(NSInteger)value SWIFT_DEPRECATED_MSG("This method has a renamed attribute point to instance method instead of a class method. It should show the Swift name here", "instanceMethodWithACustomObjCName(x:)");
+// CHECK-NEXT: - (void)deprecatedInstanceMethodRenamedToClassMethodWithValue:(NSInteger)value
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("This method has a renamed attribute point to class method instead of a instance method. It should show the Swift name here", "classMethodWithACustomObjCName(x:)");
+// CHECK-NEXT: - (void)deprecatedOnMacOSInstanceMethodRenamedToClassMethodWithValue:(NSInteger)value
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSInstanceMethodRenamedToClassMethod' has been renamed to 'classMethodWithACustomObjCName(x:)': This method has a renamed attribute point to class method instead of a instance method. It should show the Swift name here");
+// CHECK-NEXT: - (void)unavailableInstanceMethodRenamedToClassMethodWithValue:(NSInteger)value
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableInstanceMethodRenamedToClassMethod' has been renamed to 'classMethodWithACustomObjCName(x:)': This method has a renamed attribute point to class method instead of a instance method. It should show the Swift name here");
+// CHECK-NEXT: - (void)unavailableOnMacOSInstanceMethodRenamedToClassMethodWithValue:(NSInteger)value
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSInstanceMethodRenamedToClassMethod' has been renamed to 'classMethodWithACustomObjCName(x:)': This method has a renamed attribute point to class method instead of a instance method. It should show the Swift name here");
+// CHECK-NEXT: + (void)deprecatedClassMethodRenamedToInstanceMethodWithValue:(NSInteger)value
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("This method has a renamed attribute point to instance method instead of a class method. It should show the Swift name here", "instanceMethodWithACustomObjCName(x:)");
+// CHECK-NEXT: + (void)deprecatedOnMacOSClassMethodRenamedToInstanceMethodWithValue:(NSInteger)value
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSClassMethodRenamedToInstanceMethod' has been renamed to 'instanceMethodWithACustomObjCName(x:)': This method has a renamed attribute point to instance method instead of a class method. It should show the Swift name here");
+// CHECK-NEXT: + (void)unavailableClassMethodRenamedToInstanceMethodWithValue:(NSInteger)value
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableClassMethodRenamedToInstanceMethod' has been renamed to 'instanceMethodWithACustomObjCName(x:)': This method has a renamed attribute point to instance method instead of a class method. It should show the Swift name here");
+// CHECK-NEXT: + (void)unavailableOnMacOSClassMethodRenamedToInstanceMethodWithValue:(NSInteger)value
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSClassMethodRenamedToInstanceMethod' has been renamed to 'instanceMethodWithACustomObjCName(x:)': This method has a renamed attribute point to instance method instead of a class method. It should show the Swift name here");
+
 // CHECK-NEXT: - (void)customObjCNameInstanceMethodWithX:(NSInteger)x;
 // CHECK-NEXT: + (void)customObjCNameClassMethodWithX:(NSInteger)x;
-// CHECK-NEXT: - (void)methodRenamedToMethodNotAvailableToObjC SWIFT_DEPRECATED_MSG("", "methodNotAvailableToObjC()");
-// CHECK-NEXT: - (void)methodRenamedToSimpleProperty SWIFT_DEPRECATED_MSG("", "simpleProperty");
+
+// CHECK-NEXT: - (void)deprecatedMethodRenamedToMethodNotAvailableToObjC
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("", "methodNotAvailableToObjC()");
+// CHECK-NEXT: - (void)deprecatedOnMacOSMethodRenamedToMethodNotAvailableToObjC
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodRenamedToMethodNotAvailableToObjC' has been renamed to 'methodNotAvailableToObjC()'");
+// CHECK-NEXT: - (void)unavailableMethodRenamedToMethodNotAvailableToObjC
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodRenamedToMethodNotAvailableToObjC' has been renamed to 'methodNotAvailableToObjC()'");
+// CHECK-NEXT: - (void)unavailableOnMacOSMethodRenamedToMethodNotAvailableToObjC
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodRenamedToMethodNotAvailableToObjC' has been renamed to 'methodNotAvailableToObjC()'");
+
+// CHECK-NEXT: - (void)deprecatedMethodRenamedToSimpleProperty SWIFT_DEPRECATED_MSG("", "simpleProperty");
+// CHECK-NEXT: - (void)deprecatedOnMacOSMethodRenamedToSimpleProperty
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodRenamedToSimpleProperty' has been renamed to 'simpleProperty'");
+// CHECK-NEXT: - (void)unavailableMethodRenamedToSimpleProperty
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodRenamedToSimpleProperty' has been renamed to 'simpleProperty'");
+// CHECK-NEXT: - (void)unavailableOnMacOSMethodRenamedToSimpleProperty
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodRenamedToSimpleProperty' has been renamed to 'simpleProperty'");
+
 // CHECK-NEXT: - (NSInteger)methodReturningInt
-// CHECK-NEXT: - (NSInteger)methodRenamedToMethodWithouCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT SWIFT_DEPRECATED_MSG("", "methodWithoutCustomObjCNameWithValue:");
 // CHECK-NEXT: - (NSInteger)methodWithoutCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT;
-// CHECK-NEXT: + (void)makeDeprecatedAvailabilityWithValue:(NSInteger)value SWIFT_DEPRECATED_MSG("use something else", "deprecatedAvailabilityWithValue:");
+
+// CHECK-NEXT: - (NSInteger)deprecatedMethodRenamedToMethodWithouCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("", "methodWithoutCustomObjCNameWithValue:");
+// CHECK-NEXT: - (NSInteger)deprecatedOnMacOSMethodRenamedToMethodWithouCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodRenamedToMethodWithouCustomObjCName' has been renamed to 'methodWithoutCustomObjCNameWithValue:'");
+// CHECK-NEXT: - (NSInteger)unavailableMethodRenamedToMethodWithouCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodRenamedToMethodWithouCustomObjCName' has been renamed to 'methodWithoutCustomObjCNameWithValue:'");
+// CHECK-NEXT: - (NSInteger)unavailableOnMacOSMethodRenamedToMethodWithouCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodRenamedToMethodWithouCustomObjCName' has been renamed to 'methodWithoutCustomObjCNameWithValue:'");
+
 // CHECK-NEXT: + (void)unavailableAvailabilityWithValue:(NSInteger)value;
+// CHECK-NEXT: + (void)makeDeprecatedAvailabilityWithValue:(NSInteger)value
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("use something else", "deprecatedAvailabilityWithValue:");
+// CHECK-NEXT: + (void)makeDeprecatedOnMacOSAvailabilityWithValue:(NSInteger)value
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'__makeDeprecatedOnMacOSAvailability' has been renamed to 'deprecatedAvailabilityWithValue:': use something else");
 // CHECK-NEXT: + (void)makeUnavailableAvailabilityWithValue:(NSInteger)value
 // CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'__makeUnavailableAvailability' has been renamed to 'unavailableAvailabilityWithValue:': use something else");
+// CHECK-NEXT: + (void)makeUnavailableOnMacOSAvailabilityWithValue:(NSInteger)value
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'__makeUnavailableOnMacOSAvailability' has been renamed to 'unavailableAvailabilityWithValue:': use something else");
+
 // CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 // CHECK-NEXT: - (nonnull instancetype)initWithX:(NSInteger)_ OBJC_DESIGNATED_INITIALIZER SWIFT_AVAILABILITY(macos,introduced=10.10);
 // CHECK-NEXT: @property (nonatomic, readonly) NSInteger simpleProperty;
 // CHECK-NEXT: @property (nonatomic) NSInteger alwaysUnavailableProperty SWIFT_UNAVAILABLE_MSG("'alwaysUnavailableProperty' has been renamed to 'baz': whatever");
 // CHECK-NEXT: @property (nonatomic, readonly) NSInteger alwaysDeprecatedProperty SWIFT_DEPRECATED_MSG("use something else", "quux");
-// CHECK-NEXT: @property (nonatomic, readonly) NSInteger numberOfReplacableDeprecatedObjCProperty SWIFT_DEPRECATED_MSG("use something else", "replaceForDeprecatedObjCProperty");
 // CHECK-NEXT: @property (nonatomic, readonly) NSInteger replaceForDeprecatedObjCProperty;
+// CHECK-NEXT: @property (nonatomic, readonly) NSInteger numberOfReplacableDeprecatedObjCProperty
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("use something else", "replaceForDeprecatedObjCProperty");
+// CHECK-NEXT: @property (nonatomic, readonly) NSInteger numberOfReplacableDeprecatedOnMacOSObjCProperty
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'replacableDeprecatedOnMacOSObjCProperty' has been renamed to 'replaceForDeprecatedObjCProperty': use something else");
+// CHECK-NEXT: @property (nonatomic, readonly) NSInteger replaceForUnavailableObjCProperty;
 // CHECK-NEXT: @property (nonatomic, readonly) NSInteger numberOfReplacableUnavailableObjCProperty
 // CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'replacableUnavailableObjCProperty' has been renamed to 'replaceForUnavailableObjCProperty': use something else");
-// CHECK-NEXT: @property (nonatomic, readonly) NSInteger replaceForUnavailableObjCProperty;
-// CHECK-NEXT: @property (nonatomic, readonly, strong) Availability * _Null_unspecified singlePlatCombinedPropertyClass SWIFT_AVAILABILITY(macos,introduced=10.7,deprecated=10.9,obsoleted=10.10);
-// CHECK-NEXT: @property (nonatomic, readonly) NSInteger platformUnavailableRenameWithMessageProperty SWIFT_AVAILABILITY(macos,unavailable,message="'platformUnavailableRenameWithMessageProperty' has been renamed to 'anotherPlea': still trapped");
-// CHECK-NEXT: @property (nonatomic, readonly) NSInteger propertyRenamedToMethod
-// CHECK-SAME: SWIFT_DEPRECATED_MSG("", "simpleMethodReturningInt()")
+// CHECK-NEXT: @property (nonatomic, readonly) NSInteger numberOfReplacableUnavailableOnMacOSObjCProperty
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'replacableUnavailableOnMacOSObjCProperty' has been renamed to 'replaceForUnavailableObjCProperty': use something else");
+
+// CHECK-NEXT: @property (nonatomic, readonly, strong) Availability * _Null_unspecified singlePlatCombinedPropertyClass
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,introduced=10.7,deprecated=10.9,obsoleted=10.10);
+// CHECK-NEXT: @property (nonatomic, readonly) NSInteger platformUnavailableRenameWithMessageProperty
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'platformUnavailableRenameWithMessageProperty' has been renamed to 'anotherPlea': still trapped");
+
+// CHECK-NEXT: @property (nonatomic, readonly) NSInteger deprecatedPropertyRenamedToMethod
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("", "simpleMethodReturningInt()");
+// CHECK-NEXT: @property (nonatomic, readonly) NSInteger deprecatedOnMacOSPropertyRenamedToMethod
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSPropertyRenamedToMethod' has been renamed to 'simpleMethodReturningInt()'");
+// CHECK-NEXT: @property (nonatomic, readonly) NSInteger unavailablePropertyRenamedToMethod
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailablePropertyRenamedToMethod' has been renamed to 'simpleMethodReturningInt()'");
+// CHECK-NEXT: @property (nonatomic, readonly) NSInteger unavailableOnMacOSPropertyRenamedToMethod
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSPropertyRenamedToMethod' has been renamed to 'simpleMethodReturningInt()'");
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: {{^}}SWIFT_AVAILABILITY(macos,introduced=999){{$}}
@@ -98,33 +171,41 @@
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'DeprecatedAvailability' has been renamed to 'SWTReplacementAvailable'")
 // CHECK-LABEL: @interface DeprecatedAvailability
 // CHECK-NEXT: - (void)deprecatedMethodInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_DEPRECATED_MSG("use method in another class instead", "ReplacementAvailable.methodInDeprecatedClass(first:second:)")
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("use method in another class instead", "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)");
+// CHECK-NEXT: - (void)deprecatedOnMacOSMethodInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodInDeprecatedClass' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClass(first:second:)': use method in another class instead");
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'DeprecatedAvailabilityProtocol' has been renamed to 'SWTReplacementAvailableProtocol'")
 // CHECK-LABEL: @protocol DeprecatedAvailabilityProtocol
 // CHECK-NEXT: - (void)deprecatedMethodInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_DEPRECATED_MSG("use method in another class instead", "ReplacementAvailableProtocol.methodInDeprecatedClass(first:second:)")
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("use method in another class instead", "ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)");
+// CHECK-NEXT: - (void)deprecatedOnMacOSMethodInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'deprecatedOnMacOSMethodInDeprecatedClass' has been renamed to 'ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)': use method in another class instead");
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: @interface SWTReplacementAvailable
-// CHECK-NEXT: - (void)replacingMethodInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second;
+// CHECK-NEXT: - (void)replacingMethodInReplacementClassWithFirst:(NSInteger)first second:(NSInteger)second;
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: @protocol SWTReplacementAvailableProtocol
-// CHECK-NEXT: - (void)replacingMethodInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second;
+// CHECK-NEXT: - (void)replacingMethodInReplacementProtocolWithFirst:(NSInteger)first second:(NSInteger)second;
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,unavailable,message="'UnavailableAvailability' has been renamed to 'SWTReplacementAvailable'")
 // CHECK-LABEL: @interface UnavailableAvailability
 // CHECK-NEXT: - (void)unavailableMethodInUnavailableClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClass' has been renamed to 'ReplacementAvailable.methodInDeprecatedClass(first:second:)': use method in another class instead")
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClass' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClass(first:second:)': use method in another class instead");
+// CHECK-NEXT: - (void)unavailableOnMacOSMethodInUnavailableClassWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodInUnavailableClass' has been renamed to 'ReplacementAvailable.methodReplacingInReplacementClass(first:second:)': use method in another class instead");
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,unavailable,message="'UnavailableAvailabilityProtocol' has been renamed to 'SWTReplacementAvailableProtocol'")
 // CHECK-LABEL: @protocol UnavailableAvailabilityProtocol
 // CHECK-NEXT: - (void)unavailableMethodInUnavailableClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClass' has been renamed to 'ReplacementAvailableProtocol.methodInDeprecatedClass(first:second:)': use method in another class instead")
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClass' has been renamed to 'ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)': use method in another class instead");
+// CHECK-NEXT: - (void)unavailableOnMacOSMethodInUnavailableClassWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-SAME: SWIFT_AVAILABILITY(macos,unavailable,message="'unavailableOnMacOSMethodInUnavailableClass' has been renamed to 'ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)': use method in another class instead");
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: SWIFT_CLASS("{{.+}}WholeClassAvailability") 
@@ -215,7 +296,17 @@
 
     @available(*, deprecated, renamed: "overloadMethod(first:second:)")
     @objc func deprecatedMethodRenamedToOverloadMethod(first: Int, second: Int) {}
-  
+
+    @available(macOS, deprecated, renamed: "overloadMethod(first:second:)")
+    @objc func deprecatedOnMacOSMethodRenamedToOverloadMethod(first: Int, second: Int) {}
+
+    @available(*, unavailable, renamed: "overloadMethod(first:second:)")
+    @objc func unavailableMethodRenamedToOverloadMethod(first: Int, second: Int) {}
+
+    @available(macOS, unavailable, renamed: "overloadMethod(first:second:)")
+    @objc func unavailableOnMacOSMethodRenamedToOverloadMethod(first: Int, second: Int) {}
+
+
     @objc(firstOverloadingMethodWithDiffernceNameWithFirst:second:)
     func overloadMethodWithDifferenceObjCName(first: Int, second: Int) {}
     @objc(secondOverloadingMethodWithDiffernceNameWithFirst:second:)
@@ -223,15 +314,36 @@
 
     @available(*, deprecated, renamed: "overloadMethodWithDifferenceObjCName(first:second:)")
     @objc func deprecatedMethodRenamedToOverloadMethodWithDifferenceName(first: Int, second: Int) {}
+    @available(macOS, deprecated, renamed: "overloadMethodWithDifferenceObjCName(first:second:)")
+    @objc func deprecatedOnMacOSMethodRenamedToOverloadMethodWithDifferenceName(first: Int, second: Int) {}
+
+    @available(*, unavailable, renamed: "overloadMethodWithDifferenceObjCName(first:second:)")
+    @objc func unavailableMethodRenamedToOverloadMethodWithDifferenceName(first: Int, second: Int) {}
+    @available(macOS, unavailable, renamed: "overloadMethodWithDifferenceObjCName(first:second:)")
+    @objc func unavailableOnMacOSMethodRenamedToOverloadMethodWithDifferenceName(first: Int, second: Int) {}
 
     @objc(deprecatedAvailabilityWithValue:)
     public class func makeDeprecatedAvailability(withValue value: Int) {}
 
     @available(*, deprecated, message: "This method has a renamed attribute point to class method instead of a instance method. It should show the Swift name here", renamed: "classMethodWithACustomObjCName(x:)")
     @objc public func deprecatedInstanceMethodRenamedToClassMethod(value: Int) {}
-
+    @available(macOS, deprecated, message: "This method has a renamed attribute point to class method instead of a instance method. It should show the Swift name here", renamed: "classMethodWithACustomObjCName(x:)")
+    @objc public func deprecatedOnMacOSInstanceMethodRenamedToClassMethod(value: Int) {}
+    
+    @available(*, unavailable, message: "This method has a renamed attribute point to class method instead of a instance method. It should show the Swift name here", renamed: "classMethodWithACustomObjCName(x:)")
+    @objc public func unavailableInstanceMethodRenamedToClassMethod(value: Int) {}
+    @available(macOS, unavailable, message: "This method has a renamed attribute point to class method instead of a instance method. It should show the Swift name here", renamed: "classMethodWithACustomObjCName(x:)")
+    @objc public func unavailableOnMacOSInstanceMethodRenamedToClassMethod(value: Int) {}
+        
     @available(*, deprecated, message: "This method has a renamed attribute point to instance method instead of a class method. It should show the Swift name here", renamed: "instanceMethodWithACustomObjCName(x:)")
     @objc public class func deprecatedClassMethodRenamedToInstanceMethod(value: Int) {}
+    @available(macOS, deprecated, message: "This method has a renamed attribute point to instance method instead of a class method. It should show the Swift name here", renamed: "instanceMethodWithACustomObjCName(x:)")
+    @objc public class func deprecatedOnMacOSClassMethodRenamedToInstanceMethod(value: Int) {}
+
+    @available(*, unavailable, message: "This method has a renamed attribute point to instance method instead of a class method. It should show the Swift name here", renamed: "instanceMethodWithACustomObjCName(x:)")
+    @objc public class func unavailableClassMethodRenamedToInstanceMethod(value: Int) {}
+    @available(macOS, unavailable, message: "This method has a renamed attribute point to instance method instead of a class method. It should show the Swift name here", renamed: "instanceMethodWithACustomObjCName(x:)")
+    @objc public class func unavailableOnMacOSClassMethodRenamedToInstanceMethod(value: Int) {}
     
     @objc(customObjCNameInstanceMethodWithX:)
     public func instanceMethodWithACustomObjCName(x: Int) {}
@@ -242,29 +354,61 @@
     @nonobjc func methodNotAvailableToObjC() {}
   
     @available(*, deprecated, renamed: "methodNotAvailableToObjC()")
-    @objc public func methodRenamedToMethodNotAvailableToObjC() {}
+    @objc public func deprecatedMethodRenamedToMethodNotAvailableToObjC() {}
+    @available(macOS, deprecated, renamed: "methodNotAvailableToObjC()")
+    @objc public func deprecatedOnMacOSMethodRenamedToMethodNotAvailableToObjC() {}
+
+    @available(*, unavailable, renamed: "methodNotAvailableToObjC()")
+    @objc public func unavailableMethodRenamedToMethodNotAvailableToObjC() {}
+    @available(macOS, unavailable, renamed: "methodNotAvailableToObjC()")
+    @objc public func unavailableOnMacOSMethodRenamedToMethodNotAvailableToObjC() {}
 
     @available(*, deprecated, renamed: "simpleProperty")
-    @objc public func methodRenamedToSimpleProperty() {}
+    @objc public func deprecatedMethodRenamedToSimpleProperty() {}
+    @available(macOS, deprecated, renamed: "simpleProperty")
+    @objc public func deprecatedOnMacOSMethodRenamedToSimpleProperty() {}
+
+    @available(*, unavailable, renamed: "simpleProperty")
+    @objc public func unavailableMethodRenamedToSimpleProperty() {}
+    @available(macOS, unavailable, renamed: "simpleProperty")
+    @objc public func unavailableOnMacOSMethodRenamedToSimpleProperty() {}
 
     @objc(methodReturningInt) public func simpleMethodReturningInt() -> Int { return -1 }
   
-    @available(*, deprecated, renamed: "methodWithoutCustomObjCName(value:)")
-    @objc public func methodRenamedToMethodWithouCustomObjCName(value: Int) -> Int { return -1 }
     @objc public func methodWithoutCustomObjCName(value: Int) -> Int { return -1 }
+
+    @available(*, deprecated, renamed: "methodWithoutCustomObjCName(value:)")
+    @objc public func deprecatedMethodRenamedToMethodWithouCustomObjCName(value: Int) -> Int { return -1 }
+    @available(macOS, deprecated, renamed: "methodWithoutCustomObjCName(value:)")
+    @objc public func deprecatedOnMacOSMethodRenamedToMethodWithouCustomObjCName(value: Int) -> Int { return -1 }
+
+    @available(*, unavailable, renamed: "methodWithoutCustomObjCName(value:)")
+    @objc public func unavailableMethodRenamedToMethodWithouCustomObjCName(value: Int) -> Int { return -1 }
+    @available(macOS, unavailable, renamed: "methodWithoutCustomObjCName(value:)")
+    @objc public func unavailableOnMacOSMethodRenamedToMethodWithouCustomObjCName(value: Int) -> Int { return -1 }
+
+
+    @objc(unavailableAvailabilityWithValue:)
+    public class func makeUnavailableAvailability(withValue value: Int) {}
 
     @available(*, deprecated,
     message: "use something else",
     renamed: "makeDeprecatedAvailability(withValue:)")
     @objc(makeDeprecatedAvailabilityWithValue:) public class func __makeDeprecatedAvailability(withValue value: Int) {}
-
-    @objc(unavailableAvailabilityWithValue:)
-    public class func makeUnavailableAvailability(withValue value: Int) {}
+    @available(macOS, deprecated,
+    message: "use something else",
+    renamed: "makeDeprecatedAvailability(withValue:)")
+    @objc(makeDeprecatedOnMacOSAvailabilityWithValue:) public class func __makeDeprecatedOnMacOSAvailability(withValue value: Int) {}
 
     @available(*, unavailable,
     message: "use something else",
     renamed: "makeUnavailableAvailability(withValue:)")
     @objc(makeUnavailableAvailabilityWithValue:) public class func __makeUnavailableAvailability(withValue value: Int) {}
+    @available(macOS, unavailable,
+    message: "use something else",
+    renamed: "makeUnavailableAvailability(withValue:)")
+    @objc(makeUnavailableOnMacOSAvailabilityWithValue:) public class func __makeUnavailableOnMacOSAvailability(withValue value: Int) {}
+
 
     @objc init() {}
     @available(macOS 10.10, *)
@@ -289,31 +433,44 @@
             return -1
         }
     }
+
+    @objc(replaceForDeprecatedObjCProperty) var __replaceForDeprecatedObjCProperty: Int {
+        get {
+            return -1
+        }
+    }
     @available(*, deprecated, message: "use something else", renamed: "__replaceForDeprecatedObjCProperty")
     @objc(numberOfReplacableDeprecatedObjCProperty) var replacableDeprecatedObjCProperty: Int {
         get {
             return -1
         }
     }
-    
-    @objc(replaceForDeprecatedObjCProperty) var __replaceForDeprecatedObjCProperty: Int {
+    @available(macOS, deprecated, message: "use something else", renamed: "__replaceForDeprecatedObjCProperty")
+    @objc(numberOfReplacableDeprecatedOnMacOSObjCProperty) var replacableDeprecatedOnMacOSObjCProperty: Int {
         get {
             return -1
         }
     }
-  
-    @available(*, unavailable, message: "use something else", renamed: "__replaceForUnavailableObjCProperty")
-    @objc(numberOfReplacableUnavailableObjCProperty) var replacableUnavailableObjCProperty: Int {
-      get {
-        return -1
-      }
-    }
+
   
     @objc(replaceForUnavailableObjCProperty) var __replaceForUnavailableObjCProperty: Int {
       get {
         return -1
       }
     }
+    @available(*, unavailable, message: "use something else", renamed: "__replaceForUnavailableObjCProperty")
+    @objc(numberOfReplacableUnavailableObjCProperty) var replacableUnavailableObjCProperty: Int {
+      get {
+        return -1
+      }
+    }
+    @available(macOS, unavailable, message: "use something else", renamed: "__replaceForUnavailableObjCProperty")
+    @objc(numberOfReplacableUnavailableOnMacOSObjCProperty) var replacableUnavailableOnMacOSObjCProperty: Int {
+      get {
+        return -1
+      }
+    }
+  
   
     @available(macOS, introduced: 10.7, deprecated: 10.9, obsoleted: 10.10)
     @objc var singlePlatCombinedPropertyClass: Availability! {
@@ -329,7 +486,26 @@
     }
     
     @available(*, deprecated, renamed: "simpleMethodReturningInt()")
-    @objc var propertyRenamedToMethod: Int {
+    @objc var deprecatedPropertyRenamedToMethod: Int {
+        get {
+            return -1
+        }
+    }
+    @available(macOS, deprecated, renamed: "simpleMethodReturningInt()")
+    @objc var deprecatedOnMacOSPropertyRenamedToMethod: Int {
+        get {
+            return -1
+        }
+    }
+
+    @available(*, unavailable, renamed: "simpleMethodReturningInt()")
+    @objc var unavailablePropertyRenamedToMethod: Int {
+        get {
+            return -1
+        }
+    }
+    @available(macOS, unavailable, renamed: "simpleMethodReturningInt()")
+    @objc var unavailableOnMacOSPropertyRenamedToMethod: Int {
         get {
             return -1
         }
@@ -372,35 +548,43 @@ extension Availability {
 
 
 @objc(SWTReplacementAvailable) class ReplacementAvailable {
-    @objc(replacingMethodInDeprecatedClassWithFirst:second:) func methodReplacingInDeprecatedClass(first: Int, second: Int) -> Void {}
+    @objc(replacingMethodInReplacementClassWithFirst:second:) func methodReplacingInReplacementClass(first: Int, second: Int) -> Void {}
 }
 
 @available(macOS, deprecated, renamed: "ReplacementAvailable")
 @objc class DeprecatedAvailability {
-    @available(*, deprecated, message: "use method in another class instead", renamed: "ReplacementAvailable.methodInDeprecatedClass(first:second:)")
+    @available(*, deprecated, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
     @objc func deprecatedMethodInDeprecatedClass(first: Int, second: Int) -> Void {}
+    @available(macOS, deprecated, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
+    @objc func deprecatedOnMacOSMethodInDeprecatedClass(first: Int, second: Int) -> Void {}
 }
 
 @available(macOS, unavailable, renamed: "ReplacementAvailable")
 @objc class UnavailableAvailability {
-  @available(*, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailable.methodInDeprecatedClass(first:second:)")
+  @available(*, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
   @objc func unavailableMethodInUnavailableClass(first: Int, second: Int) -> Void {}
+  @available(macOS, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailable.methodReplacingInReplacementClass(first:second:)")
+  @objc func unavailableOnMacOSMethodInUnavailableClass(first: Int, second: Int) -> Void {}
 }
 
 @objc(SWTReplacementAvailableProtocol) protocol ReplacementAvailableProtocol {
-  @objc(replacingMethodInDeprecatedClassWithFirst:second:) func methodReplacingInDeprecatedClass(first: Int, second: Int) -> Void
+  @objc(replacingMethodInReplacementProtocolWithFirst:second:) func methodReplacingInReplacementProtocol(first: Int, second: Int) -> Void
 }
 
 @available(macOS, deprecated, renamed: "ReplacementAvailableProtocol")
 @objc protocol DeprecatedAvailabilityProtocol {
-  @available(*, deprecated, message: "use method in another class instead", renamed: "ReplacementAvailableProtocol.methodInDeprecatedClass(first:second:)")
+  @available(*, deprecated, message: "use method in another class instead", renamed: "ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)")
   @objc func deprecatedMethodInDeprecatedClass(first: Int, second: Int) -> Void
+  @available(macOS, deprecated, message: "use method in another class instead", renamed: "ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)")
+  @objc func deprecatedOnMacOSMethodInDeprecatedClass(first: Int, second: Int) -> Void
 }
 
 @available(macOS, unavailable, renamed: "ReplacementAvailableProtocol")
 @objc protocol UnavailableAvailabilityProtocol {
-  @available(*, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailableProtocol.methodInDeprecatedClass(first:second:)")
+  @available(*, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)")
   @objc func unavailableMethodInUnavailableClass(first: Int, second: Int) -> Void
+  @available(macOS, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailableProtocol.methodReplacingInReplacementProtocol(first:second:)")
+  @objc func unavailableOnMacOSMethodInUnavailableClass(first: Int, second: Int) -> Void
 }
 
 

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -54,6 +54,8 @@
 // CHECK-NEXT: - (void)customObjCNameInstanceMethodWithX:(NSInteger)x;
 // CHECK-NEXT: + (void)customObjCNameClassMethodWithX:(NSInteger)x;
 // CHECK-NEXT: - (void)methodRenamedToMethodNotAvailableToObjC SWIFT_DEPRECATED_MSG("", "methodNotAvailableToObjC()");
+// CHECK-NEXT: - (void)methodRenamedToSimpleProperty SWIFT_DEPRECATED_MSG("", "simpleProperty");
+// CHECK-NEXT: - (NSInteger)methodReturningInt
 // CHECK-NEXT: + (void)makeDeprecatedAvailabilityWithValue:(NSInteger)value SWIFT_DEPRECATED_MSG("use something else", "deprecatedAvailabilityWithValue:");
 // CHECK-NEXT: + (void)unavailableAvailabilityWithValue:(NSInteger)value;
 // CHECK-NEXT: + (void)makeUnavailableAvailabilityWithValue:(NSInteger)value
@@ -70,6 +72,8 @@
 // CHECK-NEXT: @property (nonatomic, readonly) NSInteger replaceForUnavailableObjCProperty;
 // CHECK-NEXT: @property (nonatomic, readonly, strong) Availability * _Null_unspecified singlePlatCombinedPropertyClass SWIFT_AVAILABILITY(macos,introduced=10.7,deprecated=10.9,obsoleted=10.10);
 // CHECK-NEXT: @property (nonatomic, readonly) NSInteger platformUnavailableRenameWithMessageProperty SWIFT_AVAILABILITY(macos,unavailable,message="'platformUnavailableRenameWithMessageProperty' has been renamed to 'anotherPlea': still trapped");
+// CHECK-NEXT: @property (nonatomic, readonly) NSInteger propertyRenamedToMethod
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("", "simpleMethodReturningInt()")
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: {{^}}SWIFT_AVAILABILITY(macos,introduced=999){{$}}
@@ -227,6 +231,11 @@
     @available(*, deprecated, renamed: "methodNotAvailableToObjC()")
     @objc public func methodRenamedToMethodNotAvailableToObjC() {}
 
+    @available(*, deprecated, renamed: "simpleProperty")
+    @objc public func methodRenamedToSimpleProperty() {}
+
+    @objc(methodReturningInt) public func simpleMethodReturningInt() -> Int { return -1 }
+
     @available(*, deprecated,
     message: "use something else",
     renamed: "makeDeprecatedAvailability(withValue:)")
@@ -297,6 +306,13 @@
     }
     @available(macOS, unavailable, renamed: "anotherPlea", message: "still trapped")
     @objc var platformUnavailableRenameWithMessageProperty: Int {
+        get {
+            return -1
+        }
+    }
+    
+    @available(*, deprecated, renamed: "simpleMethodReturningInt()")
+    @objc var propertyRenamedToMethod: Int {
         get {
             return -1
         }

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -46,7 +46,7 @@
 // CHECK-DAG: SWIFT_AVAILABILITY(tvos_app_extension,unavailable)
 // CHECK-DAG: SWIFT_AVAILABILITY(watchos_app_extension,unavailable)
 // CHECK-DAG: ;
-// CHECK-NEXT: - (void)methodRenamedToOverloadMethod1WithFirst:(NSInteger)first second:(NSInteger)second SWIFT_DEPRECATED_MSG("", "overloadMethodWithFirst:second:");
+// CHECK-NEXT: - (void)deprecatedMethodRenamedToOverloadMethod1WithFirst:(NSInteger)first second:(NSInteger)second SWIFT_DEPRECATED_MSG("", "overloadMethodWithFirst:second:");
 // CHECK-NEXT: - (void)overloadMethodWithFirst:(NSInteger)first second:(NSInteger)second;
 // CHECK-NEXT: - (void)overloadMethod2WithFirst:(double)first second:(double)second;
 // CHECK-NEXT: + (void)deprecatedAvailabilityWithValue:(NSInteger)value;
@@ -78,6 +78,8 @@
 // CHECK-NEXT: - (nonnull instancetype)init SWIFT_UNAVAILABLE;
 // CHECK-NEXT: + (nonnull instancetype)new SWIFT_DEPRECATED_MSG("-init is unavailable");
 // CHECK-NEXT: - (nonnull instancetype)initWithX:(NSInteger)_ SWIFT_UNAVAILABLE;
+// CHECK-NEXT: - (nonnull instancetype)initWithDeprecatedZ:(NSInteger)deprecatedZ OBJC_DESIGNATED_INITIALIZER SWIFT_DEPRECATED_MSG("init(deprecatedZ:) was deprecated. Use the new one instead", "initWithNewZ:")
+// CHECK-NEXT: - (nonnull instancetype)initWithNewZ:(NSInteger)z OBJC_DESIGNATED_INITIALIZER;
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'DeprecatedAvailability' has been renamed to 'SWTReplacementAvailable'")
@@ -196,7 +198,7 @@
     @objc func extensionUnavailable() {}
   
     @available(*, deprecated, renamed: "overloadMethod1(first:second:)")
-    @objc func methodRenamedToOverloadMethod1(first: Int, second: Int) {}
+    @objc func deprecatedMethodRenamedToOverloadMethod1(first: Int, second: Int) {}
   
     @objc(overloadMethodWithFirst:second:) func overloadMethod1(first: Int, second: Int) {}
     @objc func overloadMethod2(first: Double, second: Double) {}
@@ -216,7 +218,6 @@
     message: "use something else",
     renamed: "makeUnavailableAvailability(withValue:)")
     @objc(makeUnavailableAvailabilityWithValue:) public class func __makeUnavailableAvailability(withValue value: Int) {}
-
 
     @objc init() {}
     @available(macOS 10.10, *)
@@ -299,6 +300,9 @@ extension Availability {
     private override init() { super.init() }
     @available(macOS 10.10, *)
     private override init(x _: Int) { super.init() }
+    @available(*, deprecated, message: "init(deprecatedZ:) was deprecated. Use the new one instead", renamed: "init(z:)")
+    @objc init(deprecatedZ: Int) { super.init() }
+    @objc(initWithNewZ:) init(z: Int) { super.init() }
 }
 
 

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -51,6 +51,7 @@
 // CHECK-NEXT: - (void)overloadMethod2WithFirst:(double)first second:(double)second;
 // CHECK-NEXT: + (void)deprecatedAvailabilityWithValue:(NSInteger)value;
 // CHECK-NEXT: + (void)makeDeprecatedAvailabilityWithValue:(NSInteger)value SWIFT_DEPRECATED_MSG("use something else", "deprecatedAvailabilityWithValue:");
+// CHECK-Next: - (void)deprecatedInstanceMethodRenamedToClassMethodWithValue:(NSInteger)value SWIFT_DEPRECATED_MSG("This method has a renamed attribute point to class method instead of a class method. It should show the Swift name here", "makeDeprecatedAvailability(withValue:)");
 // CHECK-NEXT: + (void)unavailableAvailabilityWithValue:(NSInteger)value;
 // CHECK-NEXT: + (void)makeUnavailableAvailabilityWithValue:(NSInteger)value
 // CHECK-DAG: SWIFT_UNAVAILABLE_MSG("'__makeUnavailableAvailability' has been renamed to 'unavailableAvailabilityWithValue:': use something else");
@@ -205,6 +206,9 @@
 
     @objc(deprecatedAvailabilityWithValue:)
     public class func makeDeprecatedAvailability(withValue value: Int) {}
+
+    @available(*, deprecated, message: "This method has a renamed attribute point to class method instead of a class method. It should show the Swift name here", renamed: "makeDeprecatedAvailability(withValue:)")
+    public func deprecatedInstanceMethodRenamedToClassMethod(value: Int) {}
 
     @available(*, deprecated,
     message: "use something else",

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -50,8 +50,11 @@
 // CHECK-NEXT: - (void)overloadMethodWithFirst:(NSInteger)first second:(NSInteger)second;
 // CHECK-NEXT: - (void)overloadMethod2WithFirst:(double)first second:(double)second;
 // CHECK-NEXT: + (void)deprecatedAvailabilityWithValue:(NSInteger)value;
+// CHECK-NEXT: - (void)deprecatedInstanceMethodRenamedToClassMethodWithValue:(NSInteger)value SWIFT_DEPRECATED_MSG("This method has a renamed attribute point to class method instead of a instance method. It should show the Swift name here", "classMethodWithACustomObjCName(x:)");
+// CHECK-NEXT: + (void)deprecatedClassMethodRenamedToInstanceMethodWithValue:(NSInteger)value SWIFT_DEPRECATED_MSG("This method has a renamed attribute point to instance method instead of a class method. It should show the Swift name here", "instanceMethodWithACustomObjCName(x:)");
+// CHECK-NEXT: - (void)customObjCNameInstanceMethodWithX:(NSInteger)x;
+// CHECK-NEXT: + (void)customObjCNameClassMethodWithX:(NSInteger)x;
 // CHECK-NEXT: + (void)makeDeprecatedAvailabilityWithValue:(NSInteger)value SWIFT_DEPRECATED_MSG("use something else", "deprecatedAvailabilityWithValue:");
-// CHECK-Next: - (void)deprecatedInstanceMethodRenamedToClassMethodWithValue:(NSInteger)value SWIFT_DEPRECATED_MSG("This method has a renamed attribute point to class method instead of a class method. It should show the Swift name here", "makeDeprecatedAvailability(withValue:)");
 // CHECK-NEXT: + (void)unavailableAvailabilityWithValue:(NSInteger)value;
 // CHECK-NEXT: + (void)makeUnavailableAvailabilityWithValue:(NSInteger)value
 // CHECK-DAG: SWIFT_UNAVAILABLE_MSG("'__makeUnavailableAvailability' has been renamed to 'unavailableAvailabilityWithValue:': use something else");
@@ -207,8 +210,17 @@
     @objc(deprecatedAvailabilityWithValue:)
     public class func makeDeprecatedAvailability(withValue value: Int) {}
 
-    @available(*, deprecated, message: "This method has a renamed attribute point to class method instead of a class method. It should show the Swift name here", renamed: "makeDeprecatedAvailability(withValue:)")
-    public func deprecatedInstanceMethodRenamedToClassMethod(value: Int) {}
+    @available(*, deprecated, message: "This method has a renamed attribute point to class method instead of a instance method. It should show the Swift name here", renamed: "classMethodWithACustomObjCName(x:)")
+    @objc public func deprecatedInstanceMethodRenamedToClassMethod(value: Int) {}
+
+    @available(*, deprecated, message: "This method has a renamed attribute point to instance method instead of a class method. It should show the Swift name here", renamed: "instanceMethodWithACustomObjCName(x:)")
+    @objc public class func deprecatedClassMethodRenamedToInstanceMethod(value: Int) {}
+    
+    @objc(customObjCNameInstanceMethodWithX:)
+    public func instanceMethodWithACustomObjCName(x: Int) {}
+
+    @objc(customObjCNameClassMethodWithX:)
+    public class func classMethodWithACustomObjCName(x: Int) {}
 
     @available(*, deprecated,
     message: "use something else",

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -106,7 +106,7 @@
 
 @objc class Availability {
     @objc func alwaysAvailable() {}
-    
+
     @available(*, unavailable)
     @objc func alwaysUnavailable() {}
     @available(*, unavailable, message: "stuff happened")
@@ -115,7 +115,7 @@
     @objc func alwaysUnavailableThree() {}
     @available(*, unavailable, message: "whatever", renamed: "baz")
     @objc func alwaysUnavailableFour() {}
-    
+
     @available(*, deprecated)
     @objc func alwaysDeprecated() {}
     @available(*, deprecated, message: "it's old")
@@ -124,17 +124,17 @@
     @objc func alwaysDeprecatedThree() {}
     @available(*, deprecated, message: "use something else", renamed: "quux")
     @objc func alwaysDeprecatedFour() {}
-    
+
     @available(*, deprecated, message: "one\ntwo\tthree\rfour\\ \"five\"")
     @objc func escapeMessage() {}
     @available(*, deprecated, message: "über")
     @objc func unicodeMessage() {}
-    
+
     @available(macOS 10.10, *)
     @objc func singlePlatShorthand() {}
     @available(macOS 10.11, iOS 9.0, tvOS 9.0, watchOS 3.0, *)
     @objc func multiPlatShorthand() {}
-    
+
     @available(iOS, introduced: 9.0)
     @objc func singlePlatIntroduced() {}
     @available(macOS, deprecated: 10.10)
@@ -155,45 +155,45 @@
     @objc func singlePlatObsoleted() {}
     @available(macOS, introduced: 10.7, deprecated: 10.9, obsoleted: 10.10)
     @objc func singlePlatCombined() {}
-    
+
     @available(macOS, introduced: 10.6, deprecated: 10.8, obsoleted: 10.9)
     @available(iOS, introduced: 7.0, deprecated: 9.0, obsoleted: 10.0)
     @objc func multiPlatCombined() {}
-    
+
     @available(macOS, unavailable, message: "help I'm trapped in an availability factory")
     @objc func platUnavailableMessage() {}
     @available(macOS, unavailable, renamed: "plea")
     @objc func platUnavailableRename() {}
     @available(macOS, unavailable, renamed: "anotherPlea", message: "still trapped")
     @objc func platUnavailableRenameWithMessage() {}
-    
+
     @available(macOSApplicationExtension, unavailable)
     @available(iOSApplicationExtension, unavailable)
     @available(tvOSApplicationExtension, unavailable)
     @available(watchOSApplicationExtension, unavailable)
     @objc func extensionUnavailable() {}
-    
+
     @objc(deprecatedAvailabilityWithValue:)
     public class func makeDeprecatedAvailability(withValue value: Int) {}
-    
+
     @available(*, deprecated,
     message: "use something else",
     renamed: "makeDeprecatedAvailability(withValue:)")
     @objc(makeDeprecatedAvailabilityWithValue:) public class func __makeDeprecatedAvailability(withValue value: Int) {}
-  
+
     @objc(unavailableAvailabilityWithValue:)
     public class func makeUnavailableAvailability(withValue value: Int) {}
-  
+
     @available(*, unavailable,
     message: "use something else",
     renamed: "makeUnavailableAvailability(withValue:)")
     @objc(makeUnavailableAvailabilityWithValue:) public class func __makeUnavailableAvailability(withValue value: Int) {}
-  
-  
+
+
     @objc init() {}
     @available(macOS 10.10, *)
     @objc init(x _: Int) {}
-    
+
     @objc var simpleProperty: Int {
         get {
             return 100

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -76,18 +76,36 @@
 // CHECK-NEXT: - (nonnull instancetype)initWithX:(NSInteger)_ SWIFT_UNAVAILABLE;
 // CHECK-NEXT: @end
 
+// CHECK-LABEL: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'DeprecatedAvailability' has been renamed to 'SWTReplacementAvailable'")
 // CHECK-LABEL: @interface DeprecatedAvailability
 // CHECK-NEXT: - (void)deprecatedMethodInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second
 // CHECK-DAG: SWIFT_DEPRECATED_MSG("use method in another class instead", "ReplacementAvailable.methodInDeprecatedClass(first:second:)")
+// CHECK-NEXT: @end
+
+// CHECK-LABEL: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'DeprecatedAvailabilityProtocol' has been renamed to 'SWTReplacementAvailableProtocol'")
+// CHECK-LABEL: @protocol DeprecatedAvailabilityProtocol
+// CHECK-NEXT: - (void)deprecatedMethodInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-DAG: SWIFT_DEPRECATED_MSG("use method in another class instead", "ReplacementAvailableProtocol.methodInDeprecatedClass(first:second:)")
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: @interface SWTReplacementAvailable
 // CHECK-NEXT: - (void)methodReplacingInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second;
 // CHECK-NEXT: @end
 
+// CHECK-LABEL: @protocol SWTReplacementAvailableProtocol
+// CHECK-NEXT: - (void)methodReplacingInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second;
+// CHECK-NEXT: @end
+
+// CHECK-LABEL: SWIFT_AVAILABILITY(macos,unavailable,message="'UnavailableAvailability' has been renamed to 'SWTReplacementAvailable'")
 // CHECK-LABEL: @interface UnavailableAvailability
 // CHECK-NEXT: - (void)unavailableMethodInUnavailableClassWithFirst:(NSInteger)first second:(NSInteger)second
 // CHECK-DAG: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClass' has been renamed to 'ReplacementAvailable.methodInDeprecatedClass(first:second:)': use method in another class instead")
+// CHECK-NEXT: @end
+
+// CHECK-LABEL: SWIFT_AVAILABILITY(macos,unavailable,message="'UnavailableAvailabilityProtocol' has been renamed to 'SWTReplacementAvailableProtocol'")
+// CHECK-LABEL: @protocol UnavailableAvailabilityProtocol
+// CHECK-NEXT: - (void)unavailableMethodInUnavailableClassWithFirst:(NSInteger)first second:(NSInteger)second
+// CHECK-DAG: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClass' has been renamed to 'ReplacementAvailableProtocol.methodInDeprecatedClass(first:second:)': use method in another class instead")
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: SWIFT_CLASS("{{.+}}WholeClassAvailability") 
@@ -299,6 +317,22 @@ extension Availability {
 @objc class UnavailableAvailability {
   @available(*, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailable.methodInDeprecatedClass(first:second:)")
   @objc func unavailableMethodInUnavailableClass(first: Int, second: Int) -> Void {}
+}
+
+@objc(SWTReplacementAvailableProtocol) protocol ReplacementAvailableProtocol {
+  @objc(methodReplacingInDeprecatedClassWithFirst:second:) func methodReplacingInDeprecatedClass(first: Int, second: Int) -> Void
+}
+
+@available(macOS, deprecated, renamed: "ReplacementAvailableProtocol")
+@objc protocol DeprecatedAvailabilityProtocol {
+  @available(*, deprecated, message: "use method in another class instead", renamed: "ReplacementAvailableProtocol.methodInDeprecatedClass(first:second:)")
+  @objc func deprecatedMethodInDeprecatedClass(first: Int, second: Int) -> Void
+}
+
+@available(macOS, unavailable, renamed: "ReplacementAvailableProtocol")
+@objc protocol UnavailableAvailabilityProtocol {
+  @available(*, unavailable, message: "use method in another class instead", renamed: "ReplacementAvailableProtocol.methodInDeprecatedClass(first:second:)")
+  @objc func unavailableMethodInUnavailableClass(first: Int, second: Int) -> Void
 }
 
 

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -45,10 +45,9 @@
 // CHECK-DAG: SWIFT_AVAILABILITY(ios_app_extension,unavailable)
 // CHECK-DAG: SWIFT_AVAILABILITY(tvos_app_extension,unavailable)
 // CHECK-DAG: SWIFT_AVAILABILITY(watchos_app_extension,unavailable)
-// CHECK-DAG: ;
-// CHECK-NEXT: - (void)deprecatedMethodRenamedToOverloadMethod1WithFirst:(NSInteger)first second:(NSInteger)second SWIFT_DEPRECATED_MSG("", "overloadMethodWithFirst:second:");
-// CHECK-NEXT: - (void)overloadMethodWithFirst:(NSInteger)first second:(NSInteger)second;
-// CHECK-NEXT: - (void)overloadMethod2WithFirst:(double)first second:(double)second;
+// CHECK-SAME: ;
+// CHECK-NEXT: - (void)deprecatedMethodRenamedToOverloadMethodWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_DEPRECATED_MSG("", "overloadingMethodWithFirst:second:");
+// CHECK-NEXT: - (void)overloadingMethodWithFirst:(NSInteger)first second:(NSInteger)second;
 // CHECK-NEXT: + (void)deprecatedAvailabilityWithValue:(NSInteger)value;
 // CHECK-NEXT: - (void)deprecatedInstanceMethodRenamedToClassMethodWithValue:(NSInteger)value SWIFT_DEPRECATED_MSG("This method has a renamed attribute point to class method instead of a instance method. It should show the Swift name here", "classMethodWithACustomObjCName(x:)");
 // CHECK-NEXT: + (void)deprecatedClassMethodRenamedToInstanceMethodWithValue:(NSInteger)value SWIFT_DEPRECATED_MSG("This method has a renamed attribute point to instance method instead of a class method. It should show the Swift name here", "instanceMethodWithACustomObjCName(x:)");
@@ -57,7 +56,7 @@
 // CHECK-NEXT: + (void)makeDeprecatedAvailabilityWithValue:(NSInteger)value SWIFT_DEPRECATED_MSG("use something else", "deprecatedAvailabilityWithValue:");
 // CHECK-NEXT: + (void)unavailableAvailabilityWithValue:(NSInteger)value;
 // CHECK-NEXT: + (void)makeUnavailableAvailabilityWithValue:(NSInteger)value
-// CHECK-DAG: SWIFT_UNAVAILABLE_MSG("'__makeUnavailableAvailability' has been renamed to 'unavailableAvailabilityWithValue:': use something else");
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'__makeUnavailableAvailability' has been renamed to 'unavailableAvailabilityWithValue:': use something else");
 // CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 // CHECK-NEXT: - (nonnull instancetype)initWithX:(NSInteger)_ OBJC_DESIGNATED_INITIALIZER SWIFT_AVAILABILITY(macos,introduced=10.10);
 // CHECK-NEXT: @property (nonatomic, readonly) NSInteger simpleProperty;
@@ -66,7 +65,7 @@
 // CHECK-NEXT: @property (nonatomic, readonly) NSInteger numberOfReplacableDeprecatedObjCProperty SWIFT_DEPRECATED_MSG("use something else", "replaceForDeprecatedObjCProperty");
 // CHECK-NEXT: @property (nonatomic, readonly) NSInteger replaceForDeprecatedObjCProperty;
 // CHECK-NEXT: @property (nonatomic, readonly) NSInteger numberOfReplacableUnavailableObjCProperty
-// CHECK-DAG: SWIFT_UNAVAILABLE_MSG("'replacableUnavailableObjCProperty' has been renamed to 'replaceForUnavailableObjCProperty': use something else");
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'replacableUnavailableObjCProperty' has been renamed to 'replaceForUnavailableObjCProperty': use something else");
 // CHECK-NEXT: @property (nonatomic, readonly) NSInteger replaceForUnavailableObjCProperty;
 // CHECK-NEXT: @property (nonatomic, readonly, strong) Availability * _Null_unspecified singlePlatCombinedPropertyClass SWIFT_AVAILABILITY(macos,introduced=10.7,deprecated=10.9,obsoleted=10.10);
 // CHECK-NEXT: @property (nonatomic, readonly) NSInteger platformUnavailableRenameWithMessageProperty SWIFT_AVAILABILITY(macos,unavailable,message="'platformUnavailableRenameWithMessageProperty' has been renamed to 'anotherPlea': still trapped");
@@ -89,33 +88,33 @@
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'DeprecatedAvailability' has been renamed to 'SWTReplacementAvailable'")
 // CHECK-LABEL: @interface DeprecatedAvailability
 // CHECK-NEXT: - (void)deprecatedMethodInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-DAG: SWIFT_DEPRECATED_MSG("use method in another class instead", "ReplacementAvailable.methodInDeprecatedClass(first:second:)")
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("use method in another class instead", "ReplacementAvailable.methodInDeprecatedClass(first:second:)")
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,deprecated=0.0.1,message="'DeprecatedAvailabilityProtocol' has been renamed to 'SWTReplacementAvailableProtocol'")
 // CHECK-LABEL: @protocol DeprecatedAvailabilityProtocol
 // CHECK-NEXT: - (void)deprecatedMethodInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-DAG: SWIFT_DEPRECATED_MSG("use method in another class instead", "ReplacementAvailableProtocol.methodInDeprecatedClass(first:second:)")
+// CHECK-SAME: SWIFT_DEPRECATED_MSG("use method in another class instead", "ReplacementAvailableProtocol.methodInDeprecatedClass(first:second:)")
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: @interface SWTReplacementAvailable
-// CHECK-NEXT: - (void)methodReplacingInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second;
+// CHECK-NEXT: - (void)replacingMethodInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second;
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: @protocol SWTReplacementAvailableProtocol
-// CHECK-NEXT: - (void)methodReplacingInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second;
+// CHECK-NEXT: - (void)replacingMethodInDeprecatedClassWithFirst:(NSInteger)first second:(NSInteger)second;
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,unavailable,message="'UnavailableAvailability' has been renamed to 'SWTReplacementAvailable'")
 // CHECK-LABEL: @interface UnavailableAvailability
 // CHECK-NEXT: - (void)unavailableMethodInUnavailableClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-DAG: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClass' has been renamed to 'ReplacementAvailable.methodInDeprecatedClass(first:second:)': use method in another class instead")
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClass' has been renamed to 'ReplacementAvailable.methodInDeprecatedClass(first:second:)': use method in another class instead")
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: SWIFT_AVAILABILITY(macos,unavailable,message="'UnavailableAvailabilityProtocol' has been renamed to 'SWTReplacementAvailableProtocol'")
 // CHECK-LABEL: @protocol UnavailableAvailabilityProtocol
 // CHECK-NEXT: - (void)unavailableMethodInUnavailableClassWithFirst:(NSInteger)first second:(NSInteger)second
-// CHECK-DAG: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClass' has been renamed to 'ReplacementAvailableProtocol.methodInDeprecatedClass(first:second:)': use method in another class instead")
+// CHECK-SAME: SWIFT_UNAVAILABLE_MSG("'unavailableMethodInUnavailableClass' has been renamed to 'ReplacementAvailableProtocol.methodInDeprecatedClass(first:second:)': use method in another class instead")
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: SWIFT_CLASS("{{.+}}WholeClassAvailability") 
@@ -201,11 +200,11 @@
     @available(watchOSApplicationExtension, unavailable)
     @objc func extensionUnavailable() {}
   
-    @available(*, deprecated, renamed: "overloadMethod1(first:second:)")
-    @objc func deprecatedMethodRenamedToOverloadMethod1(first: Int, second: Int) {}
+    @available(*, deprecated, renamed: "overloadMethod(first:second:)")
+    @objc func deprecatedMethodRenamedToOverloadMethod(first: Int, second: Int) {}
   
-    @objc(overloadMethodWithFirst:second:) func overloadMethod1(first: Int, second: Int) {}
-    @objc func overloadMethod2(first: Double, second: Double) {}
+    @objc(overloadingMethodWithFirst:second:) func overloadMethod(first: Int, second: Int) {}
+    func overloadMethod(first: Double, second: Double) {}
 
     @objc(deprecatedAvailabilityWithValue:)
     public class func makeDeprecatedAvailability(withValue value: Int) {}
@@ -334,7 +333,7 @@ extension Availability {
 
 
 @objc(SWTReplacementAvailable) class ReplacementAvailable {
-    @objc(methodReplacingInDeprecatedClassWithFirst:second:) func methodReplacingInDeprecatedClass(first: Int, second: Int) -> Void {}
+    @objc(replacingMethodInDeprecatedClassWithFirst:second:) func methodReplacingInDeprecatedClass(first: Int, second: Int) -> Void {}
 }
 
 @available(macOS, deprecated, renamed: "ReplacementAvailable")
@@ -350,7 +349,7 @@ extension Availability {
 }
 
 @objc(SWTReplacementAvailableProtocol) protocol ReplacementAvailableProtocol {
-  @objc(methodReplacingInDeprecatedClassWithFirst:second:) func methodReplacingInDeprecatedClass(first: Int, second: Int) -> Void
+  @objc(replacingMethodInDeprecatedClassWithFirst:second:) func methodReplacingInDeprecatedClass(first: Int, second: Int) -> Void
 }
 
 @available(macOS, deprecated, renamed: "ReplacementAvailableProtocol")

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -46,8 +46,11 @@
 // CHECK-DAG: SWIFT_AVAILABILITY(tvos_app_extension,unavailable)
 // CHECK-DAG: SWIFT_AVAILABILITY(watchos_app_extension,unavailable)
 // CHECK-SAME: ;
-// CHECK-NEXT: - (void)deprecatedMethodRenamedToOverloadMethodWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_DEPRECATED_MSG("", "overloadingMethodWithFirst:second:");
 // CHECK-NEXT: - (void)overloadingMethodWithFirst:(NSInteger)first second:(NSInteger)second;
+// CHECK-NEXT: - (void)deprecatedMethodRenamedToOverloadMethodWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_DEPRECATED_MSG("", "overloadingMethodWithFirst:second:");
+// CHECK-NEXT: - (void)firstOverloadingMethodWithDiffernceNameWithFirst:(NSInteger)first second:(NSInteger)second;
+// CHECK-NEXT: - (void)secondOverloadingMethodWithDiffernceNameWithFirst:(double)first second:(double)second;
+// CHECK-NEXT: - (void)deprecatedMethodRenamedToOverloadMethodWithDifferenceNameWithFirst:(NSInteger)first second:(NSInteger)second SWIFT_DEPRECATED_MSG("", "overloadMethodWithDifferenceObjCName(first:second:)");
 // CHECK-NEXT: + (void)deprecatedAvailabilityWithValue:(NSInteger)value;
 // CHECK-NEXT: - (void)deprecatedInstanceMethodRenamedToClassMethodWithValue:(NSInteger)value SWIFT_DEPRECATED_MSG("This method has a renamed attribute point to class method instead of a instance method. It should show the Swift name here", "classMethodWithACustomObjCName(x:)");
 // CHECK-NEXT: + (void)deprecatedClassMethodRenamedToInstanceMethodWithValue:(NSInteger)value SWIFT_DEPRECATED_MSG("This method has a renamed attribute point to instance method instead of a class method. It should show the Swift name here", "instanceMethodWithACustomObjCName(x:)");
@@ -205,11 +208,19 @@
     @available(watchOSApplicationExtension, unavailable)
     @objc func extensionUnavailable() {}
   
+    @objc(overloadingMethodWithFirst:second:) func overloadMethod(first: Int, second: Int) {}
+    func overloadMethod(first: Double, second: Double) {}
+
     @available(*, deprecated, renamed: "overloadMethod(first:second:)")
     @objc func deprecatedMethodRenamedToOverloadMethod(first: Int, second: Int) {}
   
-    @objc(overloadingMethodWithFirst:second:) func overloadMethod(first: Int, second: Int) {}
-    func overloadMethod(first: Double, second: Double) {}
+    @objc(firstOverloadingMethodWithDiffernceNameWithFirst:second:)
+    func overloadMethodWithDifferenceObjCName(first: Int, second: Int) {}
+    @objc(secondOverloadingMethodWithDiffernceNameWithFirst:second:)
+    func overloadMethodWithDifferenceObjCName(first: Double, second: Double) {}
+
+    @available(*, deprecated, renamed: "overloadMethodWithDifferenceObjCName(first:second:)")
+    @objc func deprecatedMethodRenamedToOverloadMethodWithDifferenceName(first: Int, second: Int) {}
 
     @objc(deprecatedAvailabilityWithValue:)
     public class func makeDeprecatedAvailability(withValue value: Int) {}

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -59,6 +59,8 @@
 // CHECK-NEXT: - (void)methodRenamedToMethodNotAvailableToObjC SWIFT_DEPRECATED_MSG("", "methodNotAvailableToObjC()");
 // CHECK-NEXT: - (void)methodRenamedToSimpleProperty SWIFT_DEPRECATED_MSG("", "simpleProperty");
 // CHECK-NEXT: - (NSInteger)methodReturningInt
+// CHECK-NEXT: - (NSInteger)methodRenamedToMethodWithouCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT SWIFT_DEPRECATED_MSG("", "methodWithoutCustomObjCNameWithValue:");
+// CHECK-NEXT: - (NSInteger)methodWithoutCustomObjCNameWithValue:(NSInteger)value SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: + (void)makeDeprecatedAvailabilityWithValue:(NSInteger)value SWIFT_DEPRECATED_MSG("use something else", "deprecatedAvailabilityWithValue:");
 // CHECK-NEXT: + (void)unavailableAvailabilityWithValue:(NSInteger)value;
 // CHECK-NEXT: + (void)makeUnavailableAvailabilityWithValue:(NSInteger)value
@@ -246,6 +248,10 @@
     @objc public func methodRenamedToSimpleProperty() {}
 
     @objc(methodReturningInt) public func simpleMethodReturningInt() -> Int { return -1 }
+  
+    @available(*, deprecated, renamed: "methodWithoutCustomObjCName(value:)")
+    @objc public func methodRenamedToMethodWithouCustomObjCName(value: Int) -> Int { return -1 }
+    @objc public func methodWithoutCustomObjCName(value: Int) -> Int { return -1 }
 
     @available(*, deprecated,
     message: "use something else",


### PR DESCRIPTION
<!-- What's in this pull request? -->
Printing the custom `@objc` name in availability attributes in the generated Objective-C header files instead of printing the Swift name. This should help the compiler/fix-it to change the deprecated/unavailable API usage with the appropriate name

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-8231](https://bugs.swift.org/browse/SR-8231).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
