### PR TITLE
Add -track-system-dependencies Flag

### DIFF
--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -44,7 +44,7 @@ class DependencyTracker {
   std::shared_ptr<clang::DependencyCollector> clangCollector;
 public:
 
-  DependencyTracker();
+  explicit DependencyTracker(bool TrackSystemDeps);
 
   /// Adds a file as a dependency.
   ///

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -117,7 +117,7 @@ public:
   /// \brief Create a new clang::DependencyCollector customized to
   /// ClangImporter's specific uses.
   static std::shared_ptr<clang::DependencyCollector>
-  createDependencyCollector();
+  createDependencyCollector(bool TrackSystemDeps);
 
   /// \brief Check whether the module with a given name can be imported without
   /// importing it.

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -421,9 +421,9 @@ public:
     Diagnostics.addConsumer(*DC);
   }
 
-  void createDependencyTracker() {
+  void createDependencyTracker(bool TrackSystemDeps) {
     assert(!Context && "must be called before setup()");
-    DepTracker = llvm::make_unique<DependencyTracker>();
+    DepTracker = llvm::make_unique<DependencyTracker>(TrackSystemDeps);
   }
   DependencyTracker *getDependencyTracker() { return DepTracker.get(); }
 

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -243,6 +243,10 @@ public:
   /// variables by name when we print it out. This eases diffing of SIL files.
   bool EmitSortedSIL = false;
 
+  /// Indices whether the dependency tracker should track system
+  /// dependencies as well.
+  bool TrackSystemDeps = false;
+
   /// The different modes for validating TBD against the LLVM IR.
   enum class TBDValidationMode {
     Default,        ///< Do the default validation for the current platform.

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -232,6 +232,9 @@ def profile_stats_entities: Flag<["-"], "profile-stats-entities">,
 def emit_dependencies : Flag<["-"], "emit-dependencies">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Emit basic Make-compatible dependencies files">;
+def track_system_dependencies : Flag<["-"], "track-system-dependencies">,
+  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Track system dependencies while emitting Make-style dependencies">;
 
 def emit_loaded_module_trace : Flag<["-"], "emit-loaded-module-trace">,
   Flags<[FrontendOption, NoInteractiveOption]>,

--- a/lib/AST/ModuleLoader.cpp
+++ b/lib/AST/ModuleLoader.cpp
@@ -20,13 +20,13 @@
 
 namespace swift {
 
-DependencyTracker::DependencyTracker()
+DependencyTracker::DependencyTracker(bool TrackSystemDeps)
   // NB: The ClangImporter believes it's responsible for the construction of
   // this instance, and it static_cast<>s the instance pointer to its own
   // subclass based on that belief. If you change this to be some other
   // instance, you will need to change ClangImporter's code to handle the
   // difference.
-  : clangCollector(ClangImporter::createDependencyCollector())
+  : clangCollector(ClangImporter::createDependencyCollector(TrackSystemDeps))
 {
 }
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -318,8 +318,11 @@ private:
 class ClangImporterDependencyCollector : public clang::DependencyCollector
 {
   llvm::StringSet<> ExcludedPaths;
+  const bool TrackSystemDeps;
+
 public:
-  ClangImporterDependencyCollector() = default;
+  ClangImporterDependencyCollector(bool TrackSystemDeps)
+    : TrackSystemDeps(TrackSystemDeps) {}
 
   void excludePath(StringRef filename) {
     ExcludedPaths.insert(filename);
@@ -331,9 +334,7 @@ public:
             || Filename == ImporterImpl::bridgingHeaderBufferName);
   }
 
-  // Currently preserving older ClangImporter behavior of ignoring system
-  // dependencies, but possibly revisit?
-  bool needSystemDependencies() override { return false; }
+  bool needSystemDependencies() override { return TrackSystemDeps; }
 
   bool sawDependency(StringRef Filename, bool FromClangModule,
                      bool IsSystem, bool IsClangModuleFile,
@@ -354,9 +355,9 @@ public:
 } // end anonymous namespace
 
 std::shared_ptr<clang::DependencyCollector>
-ClangImporter::createDependencyCollector()
+ClangImporter::createDependencyCollector(bool TrackSystemDeps)
 {
-  return std::make_shared<ClangImporterDependencyCollector>();
+  return std::make_shared<ClangImporterDependencyCollector>(TrackSystemDeps);
 }
 
 void ClangImporter::Implementation::addBridgeHeaderTopLevelDecls(

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -72,6 +72,8 @@ bool ArgsToFrontendOptionsConverter::convert(
   Opts.EnableTesting |= Args.hasArg(OPT_enable_testing);
   Opts.EnableResilience |= Args.hasArg(OPT_enable_resilience);
 
+  Opts.TrackSystemDeps |= Args.hasArg(OPT_track_system_dependencies);
+
   computePrintStatsOptions();
   computeDebugTimeOptions();
   computeTBDOptions();

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1805,7 +1805,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
   if (Invocation.getFrontendOptions()
           .InputsAndOutputs.hasDependencyTrackerPath() ||
       !Invocation.getFrontendOptions().IndexStorePath.empty())
-    Instance->createDependencyTracker();
+    Instance->createDependencyTracker(Invocation.getFrontendOptions().TrackSystemDeps);
 
   if (Instance->setup(Invocation)) {
     return finishDiagProcessing(1);

--- a/test/Frontend/dependencies.swift
+++ b/test/Frontend/dependencies.swift
@@ -39,6 +39,7 @@
 // CHECK-MULTIPLE-OUTPUTS-NOT: :
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-dependencies-path - -resolve-imports %s | %FileCheck -check-prefix=CHECK-IMPORT %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/dependencies/extra-header.h -track-system-dependencies -emit-dependencies-path - -resolve-imports %s | %FileCheck -check-prefix=CHECK-IMPORT-TRACK-SYSTEM %s
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/dependencies/extra-header.h -emit-reference-dependencies-path - -typecheck -primary-file %s | %FileCheck -check-prefix=CHECK-IMPORT-YAML %s
 
 // CHECK-IMPORT-LABEL: - :
@@ -52,6 +53,27 @@
 // CHECK-IMPORT-DAG: Foundation.swift
 // CHECK-IMPORT-DAG: CoreGraphics.swift
 // CHECK-IMPORT-NOT: :
+
+// CHECK-IMPORT-TRACK-SYSTEM-LABEL: - :
+// CHECK-IMPORT-TRACK-SYSTEM: dependencies.swift
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: CoreFoundation.swift
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: CoreGraphics.swift
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: Foundation.swift
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: ObjectiveC.swift
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: Inputs/dependencies/$$$$$$$$$$.h
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: Inputs/dependencies/UserClangModule.h
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: Inputs/dependencies/extra-header.h
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: Inputs/dependencies/module.modulemap
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: swift/shims/module.modulemap
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: usr/include/CoreFoundation.h
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: usr/include/CoreGraphics.apinotes
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: usr/include/CoreGraphics.h
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: usr/include/Foundation.h
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: usr/include/objc/NSObject.h
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: usr/include/objc/ObjectiveC.apinotes
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: usr/include/objc/module.map
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: usr/include/objc/objc.h
+// CHECK-IMPORT-TRACK-SYSTEM-NOT: :
 
 // CHECK-IMPORT-YAML-LABEL: depends-external:
 // CHECK-IMPORT-YAML-NOT: dependencies.swift


### PR DESCRIPTION
Add a flag to configure the behavior of the Clang Importer's dependency tracker with respect to system dependencies.