### PR TITLE
[Sema] NFC: Refactor AllowIUODeprecated into InCastOrCoercionExpression

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2567,9 +2567,7 @@ namespace {
       // Validate the resulting type.
       TypeResolutionOptions options = TypeResolutionFlags::AllowUnboundGenerics;
       options |= TypeResolutionFlags::InExpression;
-      // Prior to Swift 5, we allow 'as T!' and turn it into a disjunction.
-      if (!CS.getASTContext().isSwiftVersionAtLeast(5))
-        options |= TypeResolutionFlags::AllowIUODeprecated;
+      options |= TypeResolutionFlags::InCastOrCoercionExpression;
       if (tc.validateType(expr->getCastTypeLoc(), CS.DC, options))
         return nullptr;
 
@@ -2599,9 +2597,7 @@ namespace {
       // Validate the resulting type.
       TypeResolutionOptions options = TypeResolutionFlags::AllowUnboundGenerics;
       options |= TypeResolutionFlags::InExpression;
-      // Prior to Swift 5, we allow 'as T!' and turn it into a disjunction.
-      if (!CS.getASTContext().isSwiftVersionAtLeast(5))
-        options |= TypeResolutionFlags::AllowIUODeprecated;
+      options |= TypeResolutionFlags::InCastOrCoercionExpression;
       if (tc.validateType(expr->getCastTypeLoc(), CS.DC, options))
         return nullptr;
 
@@ -2636,9 +2632,7 @@ namespace {
       // Validate the resulting type.
       TypeResolutionOptions options = TypeResolutionFlags::AllowUnboundGenerics;
       options |= TypeResolutionFlags::InExpression;
-      // Prior to Swift 5, we allow 'as T!' and turn it into a disjunction.
-      if (!CS.getASTContext().isSwiftVersionAtLeast(5))
-        options |= TypeResolutionFlags::AllowIUODeprecated;
+      options |= TypeResolutionFlags::InCastOrCoercionExpression;
       if (tc.validateType(expr->getCastTypeLoc(), CS.DC, options))
         return nullptr;
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2689,19 +2689,19 @@ Type TypeResolver::resolveImplicitlyUnwrappedOptionalType(
        ImplicitlyUnwrappedOptionalTypeRepr *repr,
        TypeResolutionOptions options) {
   if (!options.contains(TypeResolutionFlags::AllowIUO)) {
-    if (options.contains(TypeResolutionFlags::AllowIUODeprecated)) {
+    // Prior to Swift 5, we allow 'as T!' and turn it into a disjunction.
+    if (TC.Context.isSwiftVersionAtLeast(5)) {
+      TC.diagnose(repr->getStartLoc(),
+                  diag::implicitly_unwrapped_optional_in_illegal_position)
+          .fixItReplace(repr->getExclamationLoc(), "?");
+    } else if (options.contains(TypeResolutionFlags::InCastOrCoercionExpression)) {
       TC.diagnose(
           repr->getStartLoc(),
           diag::implicitly_unwrapped_optional_deprecated_in_this_position);
-    } else if (!TC.Context.isSwiftVersionAtLeast(5)) {
-      TC.diagnose(
-            repr->getStartLoc(),
-            diag::
-                implicitly_unwrapped_optional_in_illegal_position_interpreted_as_optional)
-          .fixItReplace(repr->getExclamationLoc(), "?");
     } else {
-      TC.diagnose(repr->getStartLoc(),
-                  diag::implicitly_unwrapped_optional_in_illegal_position)
+      TC.diagnose(
+          repr->getStartLoc(),
+          diag::implicitly_unwrapped_optional_in_illegal_position_interpreted_as_optional)
           .fixItReplace(repr->getExclamationLoc(), "?");
     }
   }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -537,8 +537,8 @@ enum class TypeResolutionFlags : unsigned {
   /// Is it okay to resolve an IUO sigil ("!") here?
   AllowIUO = 1 << 24,
 
-  /// Is it okay to resolve an IUO sigil ("!") here with a deprecation warning?
-  AllowIUODeprecated = 1 << 25,
+  /// Whether this type is being used in a cast or coercion expression.
+  InCastOrCoercionExpression = 1 << 25,
 
   /// Whether we are in a requirement of a generic declaration
   GenericRequirement = 1 << 26,


### PR DESCRIPTION
`InCastOrCoercionExpression` is useful beyond IUO checking.