### PR TITLE
[4.2] SILGen: Delay function conversions to types with opened archetype arguments.

### DIFF
--- a/test/SILGen/inout-existential-opened-type-function-conversion.swift
+++ b/test/SILGen/inout-existential-opened-type-function-conversion.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -emit-silgen -verify %s
+
+protocol P {
+  mutating func foo(_: (Self) -> Void)
+}
+
+func foo(x: inout P) {
+  x.foo { y in return }
+}


### PR DESCRIPTION
Explanation: Fixes a crash when invoking a protocol method with function arguments that take `Self` on an existential type.

Scope: Regression introduced in 4.2 beta 3 by fix for 39524104

Issue: rdar://problem/42215661

Risk: Low, targeted fix for a specific case

Testing: Swift CI, compatibility suite

Reviewed by: @slavapestov 
