### PR TITLE
[Type checker] Make sure that validating a class requests member layout.

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2868,8 +2868,9 @@ public:
                        DescriptiveDeclKind::Class, path);
     }
 
-    for (Decl *Member : CD->getMembers())
+    for (Decl *Member : CD->getMembers()) {
       visit(Member);
+    }
 
     // If this class requires all of its stored properties to have
     // in-class initializers, diagnose this now.
@@ -2978,6 +2979,11 @@ public:
 
     TC.checkDeclCircularity(CD);
     TC.ConformanceContexts.push_back(CD);
+
+    for (auto Member : CD->getMembers()) {
+      if (auto VD = dyn_cast<ValueDecl>(Member))
+        TC.requestMemberLayout(VD);
+    }
   }
 
   void visitProtocolDecl(ProtocolDecl *PD) {
@@ -5528,6 +5534,9 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
                         *this, classDecl, superclassCtor, kind)) {
         Context.addSynthesizedDecl(ctor);
         classDecl->addMember(ctor);
+
+        if (classDecl->hasValidatedLayout())
+          requestMemberLayout(ctor);
       }
     }
 


### PR DESCRIPTION
This ensures that we can compute the vtable of such classes without
triggering the type checker. Fixes rdar://problem/42394591.
