### PR TITLE
[test] Tweak class_getImageName to correctly handle 2018 OS betas

### DIFF
--- a/test/Interpreter/SDK/class_getImageName.swift
+++ b/test/Interpreter/SDK/class_getImageName.swift
@@ -22,18 +22,16 @@ func check(_ cls: AnyClass, in library: String) {
              "wrong library for \(cls)")
 }
 
-var cannotUseObjCRuntimeHook = false
-#if targetEnvironment(device) && !os(macOS)
-if #available(iOS 12, tvOS 12, watchOS 5, *) {
+var newOSButCannotUseObjCRuntimeHook = false
+if #available(macOS 10.14, iOS 12, tvOS 12, watchOS 5, *) {
   // The only place these tests will fail is on early versions of the 2018 OSs.
   // The final versions will have 'objc_setHook_getImageName'; anything earlier
   // will be handled by manually overwriting the original implementation of
   // 'class_getImageName'.
-  cannotUseObjCRuntimeHook =
+  newOSButCannotUseObjCRuntimeHook =
       (nil == dlsym(UnsafeMutableRawPointer(bitPattern: -2),
                     "objc_setHook_getImageName"))
 }
-#endif // targetEnvironment(device) && !os(macOS)
 
 var testSuite = TestSuite("class_getImageName")
 
@@ -43,7 +41,7 @@ testSuite.test("Simple") {
 }
 
 testSuite.test("Generic")
-    .xfail(.custom({ cannotUseObjCRuntimeHook },
+    .skip(.custom({ newOSButCannotUseObjCRuntimeHook },
                    reason: "hook for class_getImageName not present"))
     .code {
   check(GenericSwiftObject<Int>.self, in: "libGetImageNameHelper.dylib")
@@ -54,7 +52,7 @@ testSuite.test("Generic")
 }
 
 testSuite.test("GenericAncestry")
-    .xfail(.custom({ cannotUseObjCRuntimeHook },
+    .skip(.custom({ newOSButCannotUseObjCRuntimeHook },
                    reason: "hook for class_getImageName not present"))
     .code {
   check(GenericAncestrySwiftObject.self, in: "libGetImageNameHelper.dylib")


### PR DESCRIPTION
I messed up the condition here—`targetEnvironment(device)` is ignored and should be written `!targetEnvironment(simulator)`—but even besides that I didn't actually have the right conditions for which iOS devices this passes on and which it doesn't. Rather than trying to perfectly match this with an XFAIL, just skip the parts of the test that depend on having a new enough 2018 OS build if we, well, don't have it.

rdar://problem/42398849