### PR TITLE
[AutoDiff] Part 3: Revamp DifferentiationTask

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -137,19 +137,19 @@ static inline SILGradientOptions operator|(SILGradientFlags lhs,
 }
 
 /// SIL-level automatic differentiation configuration.
-struct SILReverseAutoDiffConfiguration {
+struct SILReverseAutoDiffConfig {
   SILReverseAutoDiffIndices indices;
   SILGradientOptions options;
 
   /*implicit*/
-  SILReverseAutoDiffConfiguration(SILReverseAutoDiffIndices indices,
+  SILReverseAutoDiffConfig(const SILReverseAutoDiffIndices &indices,
                                   SILGradientOptions options)
     : indices(indices), options(options) {}
 
   /*implicit*/
-  SILReverseAutoDiffConfiguration(SILReverseAutoDiffIndices indices,
+  SILReverseAutoDiffConfig(const SILReverseAutoDiffIndices &indices,
                                   bool seedable, bool preservingResult)
-    : SILReverseAutoDiffConfiguration(indices, getCanonicalGradientOptions()) {}
+    : SILReverseAutoDiffConfig(indices, getCanonicalGradientOptions()) {}
 
   unsigned getSourceIndex() const {
     return indices.source;
@@ -182,14 +182,15 @@ struct SILReverseAutoDiffConfiguration {
   /// Returns the "master" configuration, which all variants with the same
   /// parameter indices can derive from.
   static
-  SILReverseAutoDiffConfiguration getMaster(SILReverseAutoDiffIndices indices) {
+  SILReverseAutoDiffConfig getMaster(
+      const SILReverseAutoDiffIndices &indices) {
     return {
       indices,
       getCanonicalGradientOptions()
     };
   }
 
-  SILReverseAutoDiffConfiguration getWithCanonicalOptions() const {
+  SILReverseAutoDiffConfig getWithCanonicalOptions() const {
     return getMaster(indices);
   }
 
@@ -197,7 +198,7 @@ struct SILReverseAutoDiffConfiguration {
     return options.toRaw() == getCanonicalGradientOptions().toRaw();
   }
 
-  bool operator==(const SILReverseAutoDiffConfiguration &other) const {
+  bool operator==(const SILReverseAutoDiffConfig &other) const {
     return indices == other.indices &&
            options.toRaw() == other.options.toRaw();
   }
@@ -208,7 +209,7 @@ struct SILReverseAutoDiffConfiguration {
 namespace llvm {
 
 using swift::SILReverseAutoDiffIndices;
-using swift::SILReverseAutoDiffConfiguration;
+using swift::SILReverseAutoDiffConfig;
 using swift::SILGradientFlags;
 using swift::OptionSet;
 
@@ -238,27 +239,27 @@ template<> struct DenseMapInfo<SILReverseAutoDiffIndices> {
   }
 };
 
-template<> struct DenseMapInfo<SILReverseAutoDiffConfiguration> {
-  static SILReverseAutoDiffConfiguration getEmptyKey() {
+template<> struct DenseMapInfo<SILReverseAutoDiffConfig> {
+  static SILReverseAutoDiffConfig getEmptyKey() {
     return { DenseMapInfo<SILReverseAutoDiffIndices>::getEmptyKey(), None };
   }
 
-  static SILReverseAutoDiffConfiguration getTombstoneKey() {
+  static SILReverseAutoDiffConfig getTombstoneKey() {
     return {
       DenseMapInfo<SILReverseAutoDiffIndices>::getTombstoneKey(),
       SILGradientFlags::Delayed
     };
   }
 
-  static unsigned getHashValue(const SILReverseAutoDiffConfiguration &Val) {
+  static unsigned getHashValue(const SILReverseAutoDiffConfig &Val) {
     return hash_combine(
       DenseMapInfo<SILReverseAutoDiffIndices>::getHashValue(Val.indices),
       DenseMapInfo<unsigned>::getHashValue(Val.options.toRaw())
     );
   }
 
-  static bool isEqual(const SILReverseAutoDiffConfiguration &LHS,
-                      const SILReverseAutoDiffConfiguration &RHS) {
+  static bool isEqual(const SILReverseAutoDiffConfig &LHS,
+                      const SILReverseAutoDiffConfig &RHS) {
     return DenseMapInfo<SILReverseAutoDiffIndices>
              ::isEqual(LHS.indices, RHS.indices) &&
            LHS.options.toRaw() == RHS.options.toRaw();

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -352,15 +352,32 @@ ERROR(pound_assert_failure,none,
        "%0", (StringRef))
 
 // Automatic differentiation diagnostics
-
 ERROR(autodiff_opaque_function_unsupported,none,
       "differentiating an opaque function is not supported yet", ())
-
-// AD-related "unsupported" errors
 ERROR(autodiff_cannot_synthesize_primal_yet,none,
-      "automatic differentiation cannot synthesize primal yet; define the primal function using a '@differentiable' attribute", ())
+      "automatic differentiation cannot synthesize primals yet; define the "
+      "primal function using a '@differentiable' attribute", ())
 ERROR(autodiff_unsupported_type,none,
       "differentiating '%0' is not supported yet", (Type))
+ERROR(autodiff_function_not_differentiable,none,
+      "function is not differentiable", ())
+ERROR(autodiff_differential_operator_applied_to_nondifferentiable,none,
+      "applying differential operator on a non-differentiable function", ())
+ERROR(autodiff_differentiable_attr_applied_to_nondifferentiable,none,
+      "This function is not differentiable but marked "
+      "'@differentiable(reverse)', would you like to make it differentiable by "
+      "defining a custom adjoint using '@differentiable(reverse, adjoint:)'?",
+      ())
+NOTE(autodiff_when_differentiating_function_call, none,
+     "when differentiating this function call", ())
+NOTE(autodiff_expression_is_not_differentiable, none,
+     "expression is not differentiable", ())
+NOTE(autodiff_nested_function_call_multiple_return_active,none,
+     "function call is being differentiated from multiple return values", ())
+NOTE(autodiff_control_flow_not_supported,none,
+     "differentiating control flow is not supported yet", ())
+NOTE(autodiff_nested_not_supported,none,
+     "nested differentiation is not supported yet", ())
 
 ERROR(non_physical_addressof,none,
       "addressof only works with purely physical lvalues; "

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3967,8 +3967,8 @@ public:
   CanType getSelfInstanceType() const;
 
   /// SWIFT_ENABLE_TENSORFLOW
-  CanSILFunctionType getGradientType(SILReverseAutoDiffConfiguration config,
-                                     SILModule &M);
+  CanSILFunctionType getGradientType(
+    const SILReverseAutoDiffConfig &config, SILModule &M);
 
   /// If this is a @convention(witness_method) function with a protocol
   /// constrained self parameter, return the protocol constraint for

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -476,10 +476,9 @@ public:
 
   /// SWIFT_ENABLE_TENSORFLOW
   GradientInst *createGradient(SILLocation loc, SILValue original,
-                               SILReverseAutoDiffIndices indices,
-                               SILGradientOptions options) {
+                               const SILReverseAutoDiffConfig &config) {
     return insert(GradientInst::create(getModule(), getSILDebugLocation(loc),
-                                       original, indices, options));
+                                       original, config));
   }
 
   BuiltinInst *createBuiltin(SILLocation Loc, Identifier Name, SILType ResultTy,
@@ -2115,7 +2114,21 @@ private:
         unsigned NumBits = BuiltinIntTy->getWidth().getFixedWidth();
         Name += "_Int" + llvm::utostr(NumBits);
       }
-    } else {
+    }
+    // SWIFT_ENABLE_TENSORFLOW
+    else if (auto BuiltinFloatTy =
+                 dyn_cast<BuiltinFloatType>(OpdTy.getASTType())) {
+      Name += "_FP";
+      switch (BuiltinFloatTy->getFPKind()) {
+      case BuiltinFloatType::IEEE16: Name += "IEEE16"; break;
+      case BuiltinFloatType::IEEE32: Name += "IEEE32"; break;
+      case BuiltinFloatType::IEEE64: Name += "IEEE64"; break;
+      case BuiltinFloatType::IEEE80: Name += "IEEE80"; break;
+      case BuiltinFloatType::IEEE128: Name += "IEEE128"; break;
+      case BuiltinFloatType::PPC128: Name += "PPC128"; break;
+      }
+    }
+    else {
       assert(OpdTy.getASTType() == getASTContext().TheRawPointerType);
       Name += "_RawPointer";
     }

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -2114,21 +2114,7 @@ private:
         unsigned NumBits = BuiltinIntTy->getWidth().getFixedWidth();
         Name += "_Int" + llvm::utostr(NumBits);
       }
-    }
-    // SWIFT_ENABLE_TENSORFLOW
-    else if (auto BuiltinFloatTy =
-                 dyn_cast<BuiltinFloatType>(OpdTy.getASTType())) {
-      Name += "_FP";
-      switch (BuiltinFloatTy->getFPKind()) {
-      case BuiltinFloatType::IEEE16: Name += "IEEE16"; break;
-      case BuiltinFloatType::IEEE32: Name += "IEEE32"; break;
-      case BuiltinFloatType::IEEE64: Name += "IEEE64"; break;
-      case BuiltinFloatType::IEEE80: Name += "IEEE80"; break;
-      case BuiltinFloatType::IEEE128: Name += "IEEE128"; break;
-      case BuiltinFloatType::PPC128: Name += "PPC128"; break;
-      }
-    }
-    else {
+    } else {
       assert(OpdTy.getASTType() == getASTContext().TheRawPointerType);
       Name += "_RawPointer";
     }

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -659,8 +659,7 @@ SILCloner<ImplClass>::visitGradientInst(GradientInst *Inst) {
   doPostProcess(Inst,
     getBuilder().createGradient(getOpLocation(Inst->getLoc()),
                                 getOpValue(Inst->getOriginal()),
-                                Inst->getIndices(),
-                                Inst->getOptions()));
+                                Inst->getConfig()));
 }
 
 template<typename ImplClass>

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -118,14 +118,14 @@ private:
   SILReverseAutoDiffIndices indices;
   /// The primal and adjoint function names.
   StringRef PrimalName, AdjointName;
-  /// Constructor, copying parameter indices to the trailing buffer.
-  SILReverseDifferentiableAttr(SILReverseAutoDiffIndices indices,
+  
+  SILReverseDifferentiableAttr(const SILReverseAutoDiffIndices &indices,
                                StringRef primalName,
                                StringRef adjointName);
 
 public:
   static SILReverseDifferentiableAttr *create(
-      SILModule &M, SILReverseAutoDiffIndices indices,
+      SILModule &M, const SILReverseAutoDiffIndices &indices,
       StringRef primalName = StringRef(), StringRef adjointName = StringRef());
   
   bool hasPrimal() const { return !PrimalName.empty(); }
@@ -136,7 +136,7 @@ public:
   StringRef getAdjointName() const { assert(hasAdjoint()); return AdjointName; }
   void setAdjointName(StringRef name) { AdjointName = name; }
 
-  SILReverseAutoDiffIndices getIndices() const { return indices; }
+  const SILReverseAutoDiffIndices &getIndices() const { return indices; }
 
   void print(llvm::raw_ostream &OS) const;
 };

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7839,29 +7839,26 @@ class GradientInst final
                            SingleValueInstruction> {
 private:
   friend SILBuilder;
-  /// The reverse-mode AD indices.
-  SILReverseAutoDiffIndices Indices;
-  /// Gradient options.
-  SILGradientOptions Options;
+  /// The reverse-mode AD configuration.
+  SILReverseAutoDiffConfig Config;
   /// Space for 1 operand: the original function to be differentiated.
   FixedOperandList<1> Operands;
 
   GradientInst(SILModule &module, SILDebugLocation debugLoc, SILValue original,
-               SILReverseAutoDiffIndices indices, SILGradientOptions options);
+               const SILReverseAutoDiffConfig &config);
 
   /// A utility function for computing the SIL type of the gradient of a
   /// function, given the specified differentiation configuration options.
-  static SILType getGradientSILType(SILModule &module, SILValue original,
-                                    SILReverseAutoDiffIndices indices,
-                                    SILGradientOptions options);
+  static SILType getGradientSILType(
+      SILModule &module, SILValue original,
+      const SILReverseAutoDiffConfig &config);
 
 public:
   ~GradientInst() {};
 
   static GradientInst *create(SILModule &M, SILDebugLocation debugLoc,
                               SILValue original,
-                              SILReverseAutoDiffIndices indices,
-                              SILGradientOptions options);
+                              const SILReverseAutoDiffConfig &config);
 
   SILValue getOriginal() const { return Operands[0].get(); }
 
@@ -7869,28 +7866,16 @@ public:
     return getOriginal()->getType().getAs<SILFunctionType>();
   }
 
+  const SILReverseAutoDiffConfig &getConfig() const {
+    return Config;
+  }
+
+  const SILReverseAutoDiffIndices &getIndices() const {
+    return Config.indices;
+  }
+
   SILGradientOptions getOptions() const {
-    return Options;
-  }
-
-  bool isSeedable() const {
-    return Options.contains(SILGradientFlags::Seedable);
-  }
-
-  bool isPreservingResult() const {
-    return Options.contains(SILGradientFlags::PreservingResult);
-  }
-
-  bool isDelayed() const {
-    return Options.contains(SILGradientFlags::Delayed);
-  }
-
-  SILReverseAutoDiffIndices getIndices() const {
-    return Indices;
-  }
-
-  SILReverseAutoDiffConfiguration getConfiguration() const {
-    return { Indices, Options };
+    return Config.options;
   }
 
   ArrayRef<Operand> getAllOperands() const {

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -2869,8 +2869,9 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     SILValue original = getLocalValue(originalName, originalTy, InstLoc, B);
     if (parseSILDebugLocation(InstLoc, B))
       return true;
-    SILReverseAutoDiffIndices indices(sourceIndex, paramIndices);
-    ResultVal = B.createGradient(InstLoc, original, indices, existingOptions);
+    SILReverseAutoDiffConfig config(
+      {sourceIndex, paramIndices}, existingOptions);
+    ResultVal = B.createGradient(InstLoc, original, config);
     break;
   }
 

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -58,14 +58,14 @@ void SILFunction::addSpecializeAttr(SILSpecializeAttr *Attr) {
 
 /// SWIFT_ENABLE_TENSORFLOW
 SILReverseDifferentiableAttr::
-SILReverseDifferentiableAttr(SILReverseAutoDiffIndices indices,
+SILReverseDifferentiableAttr(const SILReverseAutoDiffIndices &indices,
                              StringRef primalName,
                              StringRef adjointName)
   : indices(indices), PrimalName(primalName), AdjointName(adjointName) {}
 
 SILReverseDifferentiableAttr *
 SILReverseDifferentiableAttr::create(SILModule &M,
-                                     SILReverseAutoDiffIndices indices,
+                                     const SILReverseAutoDiffIndices &indices,
                                      StringRef primalName,
                                      StringRef adjointName) {
   void *mem = M.allocate(sizeof(SILReverseDifferentiableAttr),

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -100,8 +100,8 @@ CanType SILFunctionType::getSelfInstanceType() const {
 
 /// SWIFT_ENABLE_TENSORFLOW
 CanSILFunctionType
-SILFunctionType::getGradientType(SILReverseAutoDiffConfiguration config,
-                                 SILModule &M) {
+SILFunctionType::getGradientType(
+    const SILReverseAutoDiffConfig &config, SILModule &M) {
   // FIXME: Handle `Delayed` gradient option.
   auto originalParams = getParameters();
   auto originalResult = getResults()[config.getSourceIndex()];

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1151,7 +1151,7 @@ public:
 
   /// SWIFT_ENABLE_TENSORFLOW
   void visitGradientInst(GradientInst *GI) {
-    auto indices = GI->getIndices();
+    auto &indices = GI->getIndices();
     *this << "[source " << indices.source << "] ";
     if (!indices.parameters.empty()) {
       *this << "[wrt ";
@@ -1162,10 +1162,13 @@ public:
       });
       *this << "] ";
     }
-    if (GI->isSeedable())
+    auto options = GI->getOptions();
+    if (options.contains(SILGradientFlags::Seedable))
       *this << "[seedable] ";
-    if (GI->isPreservingResult())
+    if (options.contains(SILGradientFlags::PreservingResult))
       *this << "[preserving_result] ";
+    if (options.contains(SILGradientFlags::Delayed))
+      *this << "[delayed] ";
     *this << getIDAndType(GI->getOriginal());
   }
 
@@ -3177,7 +3180,7 @@ void SILSpecializeAttr::print(llvm::raw_ostream &OS) const {
 
 /// SWIFT_ENABLE_TENSORFLOW
 void SILReverseDifferentiableAttr::print(llvm::raw_ostream &OS) const {
-  auto indices = getIndices();
+  auto &indices = getIndices();
   OS << "source " << indices.source << " wrt ";
   interleave(indices.parameters.set_bits(),
              [&](unsigned index) { OS << index; },

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1210,7 +1210,7 @@ public:
   void checkGradientInst(GradientInst *GI) {
     CanSILFunctionType origFnTy = GI->getOriginalType();
     require(origFnTy, "Original function value must have function type");
-    auto config = GI->getConfiguration();
+    auto config = GI->getConfig();
     require(config.getSourceIndex() < origFnTy->getNumResults(),
             "Differentiation source index out of bounds");
     llvm::SmallBitVector paramIndices = config.getParameterIndices();

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2811,9 +2811,10 @@ static RValue emitGradientInst(RValueEmitter &RVE, const SGFContext &C,
       RVE.SGF.SGM.getLoweredFunctionParameterIndex(param.index, origTy);
     loweredParamIndices.append(silParamIndices.begin(), silParamIndices.end());
   }
-  SILReverseAutoDiffIndices indices(/*sourceIndex*/ 0, loweredParamIndices);
-  auto gradInst = RVE.SGF.B.createGradient(loc, origVal.forward(RVE.SGF),
-                                           indices, options);
+  SILReverseAutoDiffConfig config(
+    {/*sourceIndex*/ 0, loweredParamIndices}, options);
+  auto gradInst =
+    RVE.SGF.B.createGradient(loc, origVal.forward(RVE.SGF), config);
   ManagedValue v = RVE.SGF.emitManagedRValueWithCleanup(gradInst);
   return RValue(RVE.SGF, E, v);
 }

--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -1163,10 +1163,10 @@ isActive(SILValue value, const SILReverseAutoDiffIndices &indices) const {
   return isVaried(value, indices.parameters) && isUseful(value, indices.source);
 }
 
-static inline void dumpActivityInfo(SILValue value,
-                                    const SILReverseAutoDiffIndices &indices,
-                                    DifferentiableActivityInfo &activityInfo,
-                                    llvm::raw_ostream &s = llvm::dbgs()) {
+static void dumpActivityInfo(SILValue value,
+                             const SILReverseAutoDiffIndices &indices,
+                             DifferentiableActivityInfo &activityInfo,
+                             llvm::raw_ostream &s = llvm::dbgs()) {
   s << '[';
   if (activityInfo.isActive(value, indices))
     s << "ACTIVE";
@@ -1177,10 +1177,10 @@ static inline void dumpActivityInfo(SILValue value,
   s << "] " << value;
 }
 
-static inline void dumpActivityInfo(SILFunction &fn,
-                                    const SILReverseAutoDiffIndices &indices,
-                                    DifferentiableActivityInfo &activityInfo,
-                                    llvm::raw_ostream &s = llvm::dbgs()) {
+static void dumpActivityInfo(SILFunction &fn,
+                             const SILReverseAutoDiffIndices &indices,
+                             DifferentiableActivityInfo &activityInfo,
+                             llvm::raw_ostream &s = llvm::dbgs()) {
   s << "Activity info for " << fn.getName() << " at " << indices << '\n';
   for (auto &bb : fn) {
     for (auto *arg : bb.getArguments())

--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -56,7 +56,7 @@ using llvm::SmallSet;
 //===----------------------------------------------------------------------===//
 
 /// Prints an "[AD] " prefix to `llvm::dbgs()` and returns the debug stream.
-/// This is being used to print short debug messages with the AD pass.
+/// This is being used to print short debug messages within the AD pass.
 static raw_ostream &getADDebugStream() {
   return llvm::dbgs() << "[AD] ";
 }
@@ -809,7 +809,7 @@ void ADContext::emitNondifferentiabilityError(SILInstruction *inst,
 
   // For indirect differentiation, emit a "not differentiable" note on the
   // expression first. Then emit an error at the source invoker of
-  // differentiation, and a "when differentiating this"  note at each indirect
+  // differentiation, and a "when differentiating this" note at each indirect
   // invoker.
   case DifferentiationInvoker::Kind::IndirectDifferentiation: {
     // Emit a default note at the innermost differentiation invoker.
@@ -825,7 +825,7 @@ void ADContext::emitNondifferentiabilityError(SILInstruction *inst,
       if (applyLoc.isValid())
         diagnose(applyLoc, diag::autodiff_when_differentiating_function_call);
     }
-    // Now we've reached a direct task, recursive once to emit an error.
+    // Now we've reached a direct task, recurse once to emit an error.
     emitNondifferentiabilityError(inst, outerTask);
     return;
   }

--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -717,8 +717,8 @@ public:
     const llvm::SmallBitVector *supersetParamIndices;
     const auto &indexSet = indices.parameters;
     for (auto *rda : original->getReverseDifferentiableAttrs())
-      if (all_of(rda->getIndices().parameters.set_bits(),
-                 [&](unsigned idx) -> bool { return indexSet[idx]; }))
+      if (llvm::all_of(rda->getIndices().parameters.set_bits(),
+                       [&](unsigned idx) -> bool { return indexSet[idx]; }))
         supersetParamIndices = &rda->getIndices().parameters;
     auto existing = enqueuedTaskIndices.find(
       {original, {indices.source, *supersetParamIndices}});

--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -44,7 +44,6 @@
 #include "swift/SILOptimizer/Utils/Local.h"
 #include "llvm/ADT/BreadthFirstIterator.h"
 #include "llvm/ADT/DenseSet.h"
-#include "llvm/ADT/STLExtras.h"
 
 using namespace swift;
 using llvm::DenseMap;
@@ -718,8 +717,7 @@ public:
     const llvm::SmallBitVector *supersetParamIndices;
     const auto &indexSet = indices.parameters;
     for (auto *rda : original->getReverseDifferentiableAttrs())
-      if (llvm::all_of(rda->getIndices().parameters.set_bits(),
-                       [&](unsigned idx) -> bool { return indexSet[idx]; }))
+      if (!indexSet.test(indexSet & rda->getIndices().parameters))
         supersetParamIndices = &rda->getIndices().parameters;
     auto existing = enqueuedTaskIndices.find(
       {original, {indices.source, *supersetParamIndices}});

--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -44,6 +44,7 @@
 #include "swift/SILOptimizer/Utils/Local.h"
 #include "llvm/ADT/BreadthFirstIterator.h"
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
 
 using namespace swift;
 using llvm::DenseMap;

--- a/test/AutoDiff/autodiff_basic.sil
+++ b/test/AutoDiff/autodiff_basic.sil
@@ -29,12 +29,11 @@ bb0(%0 : $Float):
 
 // CHECK-LABEL: sil hidden @bar :
 // CHECK: bb0
-// CHECK:   %1 = function_ref @foo : $@convention(thin) (Float) -> Float
-// CHECK:   %2 = function_ref @foo__grad_src_0_wrt_0 : $@convention(thin) (Float) -> Float
-// CHECK:   %3 = apply %2(%0) : $@convention(thin) (Float) -> Float
-// CHECK:   %4 = function_ref @foo__grad_src_0_wrt_0_p : $@convention(thin) (Float) -> (Float, Float)
-// CHECK:   %5 = apply %4(%3) : $@convention(thin) (Float) -> (Float, Float)
-// CHECK:   return %5 : $(Float, Float)
+// CHECK:   %1 = function_ref @foo__grad_src_0_wrt_0 : $@convention(thin) (Float) -> Float
+// CHECK:   %2 = apply %1(%0) : $@convention(thin) (Float) -> Float
+// CHECK:   %3 = function_ref @foo__grad_src_0_wrt_0_p : $@convention(thin) (Float) -> (Float, Float)
+// CHECK:   %4 = apply %3(%2) : $@convention(thin) (Float) -> (Float, Float)
+// CHECK:   return %4 : $(Float, Float)
 // CHECK: }
 
 // CHECK-LABEL:sil hidden @foo__grad_src_0_wrt_0_s_p :


### PR DESCRIPTION
(Split from of #17901)

* Completely revamp `DifferentiationTask`. The new `DifferentiationTask` manages a `[reverse_differentiable]` attribute, stores the invoker of this task, and stores tasks associated with the current one.

* Make gradient function synthesis delete dead instructions such as the `function_ref` of the original function.

* Make `SILReverseAutoDiffIndices` and `SILReverseAutoDiffConfig` parameters pass by reference.

* Use `SILModule::lookUpWitnessTable` instead of holding a list of serialized witness tables locally.

* Move some local helper functions to the top of the file to eliminate declarations.

* Add underpinnings for differentiability diagnostics (backed by `DifferentiationInvoker`).

**Note:** The next patch, primal synthesis, will make unused function warnings go away.