### PR TITLE
Bug fix in the SESE loop canonicalization.

### DIFF
--- a/test/TensorFlow/sese_loop_canonicalization.sil
+++ b/test/TensorFlow/sese_loop_canonicalization.sil
@@ -37,6 +37,7 @@ public func loopTest(breakCount:Int32) -> Int32 {
 
 //-- Preheader sets up the undefs, exit index, and stayInLoop flag.
 // CHECK: bb0(%0 : $Builtin.Int32):
+// CHECK: [[CONST_ONE:%.*]] =  integer_literal $Builtin.Int32, 1
 // CHECK: [[PHDR_EXIT:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.Int32, value$tensor: i32 0, __device: "ALL_DEVICES"}
 // CHECK: [[PHDR_FLAG:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.Int1, value$tensor: i1 -1, __device: "ALL_DEVICES"}
 // CHECK: br bb9({{.*}} : $Builtin.Int32, {{.*}} : $Builtin.Int32, undef : $Builtin.Int32, [[PHDR_EXIT]] : $TensorHandle<Builtin.Int32>, [[PHDR_FLAG]] : $TensorHandle<Builtin.Int1>)
@@ -48,34 +49,37 @@ public func loopTest(breakCount:Int32) -> Int32 {
 //   cond_br {{.*}}, bb4, bb2
 
 // CHECK: bb2:
-// CHECK:  br bb10({{.*}}, [[LOCAL_EXIT_INDEX]] : $TensorHandle<Builtin.Int32>, [[LOCAL_STAY_FLAG]] : $TensorHandle<Builtin.Int1>)
+// CHECK:  br bb10([[SUM_AT_HDR:%.*]] : $Builtin.Int32, [[COUNT_AT_HDR:%.*]] : $Builtin.Int32, [[SUM_ESCAPING_AT_HDR:%.*]] : $Builtin.Int32, [[LOCAL_EXIT_INDEX]] : $TensorHandle<Builtin.Int32>, [[LOCAL_STAY_FLAG]] : $TensorHandle<Builtin.Int1>)
 
 //-- Exit block from header uses original argument.
 // CHECK: bb3:
-// CHECK-NEXT:  br bb8([[HDR_ORIG_ARG:%.*]] : $Builtin.Int32)
+// CHECK-NEXT:  br bb8([[SUM_AT_HDR]] : $Builtin.Int32)
 
 //- Sets up index to 1 and flag to false on the true branch of the if with break to latch.
 // CHECK: bb4:
+// CHECK:  [[SUM_ESCAPING:%.*]] = builtin "sadd_with_overflow_Int32"([[SUM_AT_HDR]] : $Builtin.Int32, [[COUNT_AT_HDR]] : $Builtin.Int32) : $Builtin.Int32 
+// CHECK:  [[COUNT_ESCAPING:%.*]] = builtin "sadd_with_overflow_Int32"([[COUNT_AT_HDR]] : $Builtin.Int32, [[CONST_ONE]] : $Builtin.Int32) : $Builtin.Int32 
 // CHECK:  [[LOCAL_EXIT_INDEX:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.Int32, value$tensor: i32 1, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int32>
 // CHECK:  [[LOCAL_STAY_FLAG:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.Int1, value$tensor: i1 0, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int1>
 // CHECK: cond_br {{.*}}, bb5, bb6
 
+// Original exit block
 // CHECK: bb5:                                              // Preds: bb4
-// CHECK:  br bb10({{.*}}, [[LOCAL_EXIT_INDEX]] : $TensorHandle<Builtin.Int32>, [[LOCAL_STAY_FLAG]] : $TensorHandle<Builtin.Int1>)
+// CHECK:  br bb10([[SUM_AT_HDR]] : $Builtin.Int32, [[COUNT_AT_HDR]] : $Builtin.Int32, [[SUM_ESCAPING]] : $Builtin.Int32, [[LOCAL_EXIT_INDEX]] : $TensorHandle<Builtin.Int32>, [[LOCAL_STAY_FLAG]] : $TensorHandle<Builtin.Int1>)
 
 
 //- Sets up index to 0 and flag to true on the false branch of the if with break to latch.
 // CHECK: bb6:
 // CHECK: [[LOCAL_EXIT_INDEX:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.Int32, value$tensor: i32 0, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int32>
 // CHECK: [[LOCAL_STAY_FLAG:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.Int1, value$tensor: i1 -1, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int1>
-// CHECK:  br bb10({{.*}}, [[LOCAL_EXIT_INDEX]] : $TensorHandle<Builtin.Int32>, [[LOCAL_STAY_FLAG]] : $TensorHandle<Builtin.Int1>)
+// CHECK:  br bb10([[SUM_ESCAPING]] : $Builtin.Int32, [[COUNT_ESCAPING]] : $Builtin.Int32, [[SUM_ESCAPING]] : $Builtin.Int32, [[LOCAL_EXIT_INDEX]] : $TensorHandle<Builtin.Int32>, [[LOCAL_STAY_FLAG]] : $TensorHandle<Builtin.Int1>)
 
 //- Exit block from a non-header uses escaping arg.
 // CHECK: bb7:
-// CHECK-NEXT:  br bb8([[HDR_ESCAPING_ARG:%.*]] : $Builtin.Int32)
+// CHECK-NEXT:  br bb8([[SUM_ESCAPING_AT_HDR]] : $Builtin.Int32)
 
 //-- New Header simply checks flag
-// CHECK: bb9([[HDR_ORIG_ARG]] : $Builtin.Int32, {{.*}} : $Builtin.Int32, [[HDR_ESCAPING_ARG]] : $Builtin.Int32, [[HDR_EXIT_ARG:%.*]] : $TensorHandle<Builtin.Int32>, [[HDR_FLAG_ARG:%.*]] : $TensorHandle<Builtin.Int1>):
+// CHECK: bb9([[SUM_AT_HDR]] : $Builtin.Int32, [[COUNT_AT_HDR]] : $Builtin.Int32, [[SUM_ESCAPING_AT_HDR]] : $Builtin.Int32, [[HDR_EXIT_ARG:%.*]] : $TensorHandle<Builtin.Int32>, [[HDR_FLAG_ARG:%.*]] : $TensorHandle<Builtin.Int1>):
 // CHECK:  [[B:%.*]] = graph_op "tf_tensor_to_i1"([[HDR_FLAG_ARG]] : $TensorHandle<Builtin.Int1>) : $Builtin.Int1
 // CHECK:  cond_br [[B]], bb1, bb11
 


### PR DESCRIPTION

<!-- What's in this pull request? -->
Fix a bug that results in semantically incorrect code. 
Uses of the escaping values within the loop body should not be replaced with the newly added phi argument of the new header. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-7765](https://bugs.swift.org/browse/SR-7765).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
