### PR TITLE
benchmarks: make benchmarks more stable

### DIFF
--- a/benchmark/single-source/Array2D.swift
+++ b/benchmark/single-source/Array2D.swift
@@ -15,18 +15,21 @@ import TestsUtils
 public let Array2D = BenchmarkInfo(
   name: "Array2D",
   runFunction: run_Array2D,
-  tags: [.validation, .api, .Array])
+  tags: [.validation, .api, .Array],
+  setUpFunction: { blackHole(inputArray) },
+  tearDownFunction: { inputArray = nil })
+
+var inputArray: [[Int]]! = {
+  var A: [[Int]] = []
+  A.reserveCapacity(1024)
+  for _ in 0 ..< 1024 {
+    A.append(Array(0 ..< 1024))
+  }
+  return A
+}()
 
 @inline(never)
-public func run_Array2D(_ N: Int) {
-  var A: [[Int]] = []
-  for _ in 0 ..< 1024 {
-    var B: [Int] = []
-    for y in 0 ..< 1024 {
-      B.append(y)
-    }
-    A.append(B)
-  }
+func modifyArray(_ A: inout [[Int]], _ N: Int) {
   for _ in 0..<N {
     for i in 0 ..< 1024 {
       for y in 0 ..< 1024 {
@@ -35,4 +38,9 @@ public func run_Array2D(_ N: Int) {
       }
     }
   }
+}
+
+@inline(never)
+public func run_Array2D(_ N: Int) {
+  modifyArray(&inputArray, N)
 }

--- a/benchmark/single-source/ArrayOfGenericPOD.swift
+++ b/benchmark/single-source/ArrayOfGenericPOD.swift
@@ -40,7 +40,7 @@ class RefArray<T> {
 // elements should be a nop.
 @inline(never)
 func genEnumArray() {
-  _ = RefArray<Int?>(3)
+  blackHole(RefArray<Int?>(3))
   // should be a nop
 }
 
@@ -53,7 +53,7 @@ struct S<T> {
 }
 @inline(never)
 func genStructArray() {
-  _ = RefArray<S<Int>>(S(x:3, y:4))
+  blackHole(RefArray<S<Int>>(S(x:3, y:4)))
   // should be a nop
 }
 

--- a/benchmark/single-source/ArrayOfGenericPOD.swift
+++ b/benchmark/single-source/ArrayOfGenericPOD.swift
@@ -59,7 +59,7 @@ func genStructArray() {
 
 @inline(never)
 public func run_ArrayOfGenericPOD(_ N: Int) {
-  for _ in 0...N {
+  for _ in 0..<N {
     genEnumArray()
     genStructArray()
   }

--- a/benchmark/single-source/ArrayOfGenericRef.swift
+++ b/benchmark/single-source/ArrayOfGenericRef.swift
@@ -94,7 +94,7 @@ func genRefStructArray() {
 
 @inline(never)
 public func run_ArrayOfGenericRef(_ N: Int) {
-  for _ in 0...N {
+  for _ in 0..<N {
     genPODRefArray()
     genCommonRefArray()
     genRefEnumArray()

--- a/benchmark/single-source/ArrayOfGenericRef.swift
+++ b/benchmark/single-source/ArrayOfGenericRef.swift
@@ -47,7 +47,7 @@ class GenericRef<T> : Constructible {
 // Reference to a POD class.
 @inline(never)
 func genPODRefArray() {
-  _ = ConstructibleArray<GenericRef<Int>>(3)
+  blackHole(ConstructibleArray<GenericRef<Int>>(3))
   // should be a nop
 }
 
@@ -57,7 +57,7 @@ class Dummy {}
 @inline(never)
 func genCommonRefArray() {
   let d = Dummy()
-  _ = ConstructibleArray<GenericRef<Dummy>>(d)
+  blackHole(ConstructibleArray<GenericRef<Dummy>>(d))
   // should be a nop
 }
 
@@ -74,7 +74,7 @@ class RefArray<T> {
 @inline(never)
 func genRefEnumArray() {
   let d = Dummy()
-  _ = RefArray<Dummy?>(d)
+  blackHole(RefArray<Dummy?>(d))
   // should be a nop
 }
 
@@ -88,7 +88,7 @@ struct GenericVal<T> : Constructible {
 @inline(never)
 func genRefStructArray() {
   let d = Dummy()
-  _ = ConstructibleArray<GenericVal<Dummy>>(d)
+  blackHole(ConstructibleArray<GenericVal<Dummy>>(d))
   // should be a nop
 }
 

--- a/benchmark/single-source/ArrayOfPOD.swift
+++ b/benchmark/single-source/ArrayOfPOD.swift
@@ -61,7 +61,7 @@ func genStructArray() {
 
 @inline(never)
 public func run_ArrayOfPOD(_ N: Int) {
-  for _ in 0...N {
+  for _ in 0..<N {
     genIntArray()
     genEnumArray()
     genStructArray()

--- a/benchmark/single-source/ArrayOfPOD.swift
+++ b/benchmark/single-source/ArrayOfPOD.swift
@@ -33,7 +33,7 @@ class RefArray<T> {
 
 @inline(never)
 func genIntArray() {
-  _ = RefArray<Int>(3, count:200_000)
+  blackHole(RefArray<Int>(3, count:200_000))
   // should be a nop
 }
 
@@ -45,7 +45,7 @@ enum PODEnum {
 
 @inline(never)
 func genEnumArray() {
-  _ = RefArray<PODEnum>(PODEnum.Some(3))
+  blackHole(RefArray<PODEnum>(PODEnum.Some(3)))
   // should be a nop
 }
 
@@ -55,7 +55,7 @@ struct S {
 }
 @inline(never)
 func genStructArray() {
-  _ = RefArray<S>(S(x:3, y:4))
+  blackHole(RefArray<S>(S(x:3, y:4)))
   // should be a nop
 }
 

--- a/benchmark/single-source/ArrayOfRef.swift
+++ b/benchmark/single-source/ArrayOfRef.swift
@@ -48,7 +48,7 @@ class POD : Constructible {
 
 @inline(never)
 func genPODRefArray() {
-  _ = ConstructibleArray<POD>(3)
+  blackHole(ConstructibleArray<POD>(3))
   // should be a nop
 }
 
@@ -64,7 +64,7 @@ class CommonRef : Constructible {
 @inline(never)
 func genCommonRefArray() {
   let d = Dummy()
-  _ = ConstructibleArray<CommonRef>(d)
+  blackHole(ConstructibleArray<CommonRef>(d))
   // should be a nop
 }
 
@@ -85,7 +85,7 @@ class RefArray<T> {
 @inline(never)
 func genRefEnumArray() {
   let e = RefEnum.Some(Dummy())
-  _ = RefArray<RefEnum>(e)
+  blackHole(RefArray<RefEnum>(e))
   // should be a nop
 }
 
@@ -99,7 +99,7 @@ struct S : Constructible {
 @inline(never)
 func genRefStructArray() {
   let d = Dummy()
-  _ = ConstructibleArray<S>(d)
+  blackHole(ConstructibleArray<S>(d))
   // should be a nop
 }
 

--- a/benchmark/single-source/ArrayOfRef.swift
+++ b/benchmark/single-source/ArrayOfRef.swift
@@ -105,7 +105,7 @@ func genRefStructArray() {
 
 @inline(never)
 public func run_ArrayOfRef(_ N: Int) {
-  for _ in 0...N {
+  for _ in 0..<N {
     genPODRefArray()
     genCommonRefArray()
     genRefEnumArray()

--- a/benchmark/single-source/CSVParsing.swift
+++ b/benchmark/single-source/CSVParsing.swift
@@ -1,18 +1,18 @@
 import TestsUtils
 public let CSVParsing = BenchmarkInfo(
-    name: "CSVParsing",
+    name: "CSVParsing2",
     runFunction: run_CSVParsing,
     tags: [.miniapplication, .api, .String],
     setUpFunction: { buildWorkload() },
     tearDownFunction: nil)
 public let CSVParsingAlt = BenchmarkInfo(
-    name: "CSVParsingAlt",
+    name: "CSVParsingAlt2",
     runFunction: run_CSVParsingAlt,
     tags: [.miniapplication, .api, .String],
     setUpFunction: { buildWorkload() },
     tearDownFunction: nil)
 public let CSVParsingAltIndices = BenchmarkInfo(
-    name: "CSVParsingAltIndices",
+    name: "CSVParsingAltIndices2",
     runFunction: run_CSVParsingAltIndices,
     tags: [.miniapplication, .api, .String],
     setUpFunction: { buildWorkload() },
@@ -198,7 +198,7 @@ let workloadBase = """
     一,二,三,四,五,六,七,
     saquui,ta'lo,tso'i,nvgi,hisgi,sudali,galiquogi
     """
-let targetRowNumber = 200_000
+let targetRowNumber = 500
 let repeatCount = targetRowNumber / workloadBase.split(separator: "\n").count
 let workload: String = repeatElement(workloadBase, count: repeatCount).joined()
 

--- a/benchmark/single-source/CString.swift
+++ b/benchmark/single-source/CString.swift
@@ -28,7 +28,7 @@ public let CString = [
 let ascii = "Swift is a multi-paradigm, compiled programming language created for iOS, OS X, watchOS, tvOS and Linux development by Apple Inc. Swift is designed to work with Apple's Cocoa and Cocoa Touch frameworks and the large body of existing Objective-C code written for Apple products. Swift is intended to be more resilient to erroneous code (\"safer\") than Objective-C and also more concise. It is built with the LLVM compiler framework included in Xcode 6 and later and uses the Objective-C runtime, which allows C, Objective-C, C++ and Swift code to run within a single program."
 let japanese = "日本語（にほんご、にっぽんご）は、主に日本国内や日本人同士の間で使われている言語である。"
 
-var repeatedStr: String! = String(repeating: "x", count: 100 * (1 << 16))
+var repeatedStr: String! = String(repeating: "x", count: 5 * (1 << 16))
 
 @inline(never)
 public func run_StringWithCString(_ N: Int) {

--- a/benchmark/single-source/CString.swift
+++ b/benchmark/single-source/CString.swift
@@ -21,15 +21,18 @@ public let CString = [
   BenchmarkInfo(name: "CStringLongAscii", runFunction: run_CStringLongAscii, tags: [.validation, .api, .String, .bridging]),
   BenchmarkInfo(name: "CStringLongNonAscii", runFunction: run_CStringLongNonAscii, tags: [.validation, .api, .String, .bridging]),
   BenchmarkInfo(name: "CStringShortAscii", runFunction: run_CStringShortAscii, tags: [.validation, .api, .String, .bridging]),
-  BenchmarkInfo(name: "StringWithCString", runFunction: run_StringWithCString, tags: [.validation, .api, .String, .bridging]),
+  BenchmarkInfo(name: "StringWithCString2", runFunction: run_StringWithCString, tags: [.validation, .api, .String, .bridging],
+      setUpFunction: { blackHole(repeatedStr) }, tearDownFunction: { repeatedStr = nil })
 ]
 
 let ascii = "Swift is a multi-paradigm, compiled programming language created for iOS, OS X, watchOS, tvOS and Linux development by Apple Inc. Swift is designed to work with Apple's Cocoa and Cocoa Touch frameworks and the large body of existing Objective-C code written for Apple products. Swift is intended to be more resilient to erroneous code (\"safer\") than Objective-C and also more concise. It is built with the LLVM compiler framework included in Xcode 6 and later and uses the Objective-C runtime, which allows C, Objective-C, C++ and Swift code to run within a single program."
 let japanese = "日本語（にほんご、にっぽんご）は、主に日本国内や日本人同士の間で使われている言語である。"
 
+var repeatedStr: String! = String(repeating: "x", count: 100 * (1 << 16))
+
 @inline(never)
 public func run_StringWithCString(_ N: Int) {
-  let str = String(repeating: "x", count: 100 * (1 << 16))
+  let str: String = repeatedStr
   for _ in 0 ..< N {
     str.withCString { blackHole($0) }
   }

--- a/benchmark/single-source/CharacterProperties.swift
+++ b/benchmark/single-source/CharacterProperties.swift
@@ -22,26 +22,26 @@ import Foundation
 public let CharacterPropertiesFetch = BenchmarkInfo(
   name: "CharacterPropertiesFetch",
   runFunction: run_CharacterPropertiesFetch,
-  tags: [.validation, .api, .String])
+  tags: [.validation, .api, .String],
+  setUpFunction: { blackHole(workload) })
 
 public let CharacterPropertiesStashed = BenchmarkInfo(
   name: "CharacterPropertiesStashed",
   runFunction: run_CharacterPropertiesStashed,
   tags: [.validation, .api, .String],
-  setUpFunction: { run_CharacterPropertiesStashed(1) },
-  tearDownFunction: nil)
+  setUpFunction: { setupStash() })
 
 public let CharacterPropertiesStashedMemo = BenchmarkInfo(
   name: "CharacterPropertiesStashedMemo",
   runFunction: run_CharacterPropertiesStashedMemo,
-  tags: [.validation, .api, .String])
+  tags: [.validation, .api, .String],
+  setUpFunction: { setupMemo() })
 
 public let CharacterPropertiesPrecomputed = BenchmarkInfo(
   name: "CharacterPropertiesPrecomputed",
   runFunction: run_CharacterPropertiesPrecomputed,
   tags: [.validation, .api, .String],
-  setUpFunction: { run_CharacterPropertiesPrecomputed(1) },
-  tearDownFunction: nil)
+  setUpFunction: { setupPrecomputed() })
 
 extension Character {
   var firstScalar: UnicodeScalar { return unicodeScalars.first! }
@@ -120,6 +120,20 @@ func isNewlineStashed(_ c: Character) -> Bool {
 let capitalizedLetters = CharacterSet.capitalizedLetters
 func isCapitalizedStashed(_ c: Character) -> Bool {
   return capitalizedLetters.contains(c.firstScalar)
+}
+
+func setupStash() {
+  blackHole(workload)
+    blackHole(controlCharacters)
+    blackHole(alphanumerics)
+    blackHole(lowercaseLetters)
+    blackHole(punctuationCharacters)
+    blackHole(whitespaces)
+    blackHole(letters)
+    blackHole(uppercaseLetters)
+    blackHole(decimalDigits)
+    blackHole(newlines)
+    blackHole(capitalizedLetters)
 }
 
 // Memoize the stashed set
@@ -222,6 +236,20 @@ func isCapitalizedStashedMemo(_ c: Character) -> Bool {
     return true
   }
   return false
+}
+
+func setupMemo() {
+  blackHole(workload)
+    blackHole(controlCharactersMemo)
+    blackHole(alphanumericsMemo)
+    blackHole(lowercaseLettersMemo)
+    blackHole(punctuationCharactersMemo)
+    blackHole(whitespacesMemo)
+    blackHole(lettersMemo)
+    blackHole(uppercaseLettersMemo)
+    blackHole(decimalDigitsMemo)
+    blackHole(newlinesMemo)
+    blackHole(capitalizedLettersMemo)
 }
 
 // Precompute whole scalar set
@@ -354,6 +382,20 @@ var capitalizedLettersPrecomputed: Set<UInt32> = {
 }()
 func isCapitalizedPrecomputed(_ c: Character) -> Bool {
   return capitalizedLettersPrecomputed.contains(c.firstScalar.value)
+}
+
+func setupPrecomputed() {
+  blackHole(workload)
+    blackHole(controlCharactersPrecomputed)
+    blackHole(alphanumericsPrecomputed)
+    blackHole(lowercaseLettersPrecomputed)
+    blackHole(punctuationCharactersPrecomputed)
+    blackHole(whitespacesPrecomputed)
+    blackHole(lettersPrecomputed)
+    blackHole(uppercaseLettersPrecomputed)
+    blackHole(decimalDigitsPrecomputed)
+    blackHole(newlinesPrecomputed)
+    blackHole(capitalizedLettersPrecomputed)
 }
 
 // Compute on the fly

--- a/benchmark/single-source/CharacterProperties.swift.gyb
+++ b/benchmark/single-source/CharacterProperties.swift.gyb
@@ -23,26 +23,26 @@ import Foundation
 public let CharacterPropertiesFetch = BenchmarkInfo(
   name: "CharacterPropertiesFetch",
   runFunction: run_CharacterPropertiesFetch,
-  tags: [.validation, .api, .String])
+  tags: [.validation, .api, .String],
+  setUpFunction: { blackHole(workload) })
 
 public let CharacterPropertiesStashed = BenchmarkInfo(
   name: "CharacterPropertiesStashed",
   runFunction: run_CharacterPropertiesStashed,
   tags: [.validation, .api, .String],
-  setUpFunction: { run_CharacterPropertiesStashed(1) },
-  tearDownFunction: nil)
+  setUpFunction: { setupStash() })
 
 public let CharacterPropertiesStashedMemo = BenchmarkInfo(
   name: "CharacterPropertiesStashedMemo",
   runFunction: run_CharacterPropertiesStashedMemo,
-  tags: [.validation, .api, .String])
+  tags: [.validation, .api, .String],
+  setUpFunction: { setupMemo() })
 
 public let CharacterPropertiesPrecomputed = BenchmarkInfo(
   name: "CharacterPropertiesPrecomputed",
   runFunction: run_CharacterPropertiesPrecomputed,
   tags: [.validation, .api, .String],
-  setUpFunction: { run_CharacterPropertiesPrecomputed(1) },
-  tearDownFunction: nil)
+  setUpFunction: { setupPrecomputed() })
 
 extension Character {
   var firstScalar: UnicodeScalar { return unicodeScalars.first! }
@@ -75,6 +75,13 @@ func is${Property}Stashed(_ c: Character) -> Bool {
 }
 % end
 
+func setupStash() {
+  blackHole(workload)
+% for Property, Set in Properties.items():
+    blackHole(${Set})
+% end
+}
+
 // Memoize the stashed set
 % for Property, Set in Properties.items():
 var ${Set}Memo = Set<UInt32>()
@@ -88,6 +95,13 @@ func is${Property}StashedMemo(_ c: Character) -> Bool {
   return false
 }
 % end
+
+func setupMemo() {
+  blackHole(workload)
+% for Property, Set in Properties.items():
+    blackHole(${Set}Memo)
+% end
+}
 
 // Precompute whole scalar set
 % for Property, Set in Properties.items():
@@ -105,6 +119,13 @@ func is${Property}Precomputed(_ c: Character) -> Bool {
   return ${Set}Precomputed.contains(c.firstScalar.value)
 }
 % end
+
+func setupPrecomputed() {
+  blackHole(workload)
+% for Property, Set in Properties.items():
+    blackHole(${Set}Precomputed)
+% end
+}
 
 // Compute on the fly
 //

--- a/benchmark/single-source/Chars.swift
+++ b/benchmark/single-source/Chars.swift
@@ -30,7 +30,7 @@ public func run_Chars(_ N: Int) {
     "2", "a", "t", "i", "o", "e", "q", "n", "X", "Y", "Z", "?", "m", "Z", ","
     ]
 
-  for _ in 0...N {
+  for _ in 0..<N {
     for firstChar in alphabet {
       for middleChar in alphabet {
         for lastChar in alphabet {

--- a/benchmark/single-source/Chars.swift
+++ b/benchmark/single-source/Chars.swift
@@ -16,12 +16,10 @@ import TestsUtils
 public let Chars = BenchmarkInfo(
   name: "Chars",
   runFunction: run_Chars,
-  tags: [.validation, .api, .String])
+  tags: [.validation, .api, .String],
+  setUpFunction: { blackHole(alphabetInput) })
 
-@inline(never)
-public func run_Chars(_ N: Int) {
-  // Permute some characters.
-  let alphabet: [Character] = [
+var alphabetInput: [Character] = [
     "A", "B", "C", "D", "E", "F", "G",
     "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R",
     "S", "T", "U",
@@ -29,6 +27,11 @@ public func run_Chars(_ N: Int) {
     "g", "g", "I", "J", "K", "c", "x", "i", ".",
     "2", "a", "t", "i", "o", "e", "q", "n", "X", "Y", "Z", "?", "m", "Z", ","
     ]
+
+@inline(never)
+public func run_Chars(_ N: Int) {
+  // Permute some characters.
+  let alphabet: [Character] = alphabetInput
 
   for _ in 0..<N {
     for firstChar in alphabet {

--- a/benchmark/single-source/ClassArrayGetter.swift
+++ b/benchmark/single-source/ClassArrayGetter.swift
@@ -15,7 +15,9 @@ import TestsUtils
 public let ClassArrayGetter = BenchmarkInfo(
   name: "ClassArrayGetter",
   runFunction: run_ClassArrayGetter,
-  tags: [.validation, .api, .Array])
+  tags: [.validation, .api, .Array],
+  setUpFunction: { blackHole(inputArray) },
+  tearDownFunction: { inputArray = nil })
 
 class Box {
   var v: Int
@@ -31,13 +33,18 @@ func sumArray(_ a: [Box]) -> Int {
   return s
 }
 
-public func run_ClassArrayGetter(_ N: Int) {
+var inputArray: [Box]! = {
   let aSize = 10_000
   var a: [Box] = []
   a.reserveCapacity(aSize)
   for i in 1...aSize {
     a.append(Box(v:i))
   }
+  return a
+}()
+
+public func run_ClassArrayGetter(_ N: Int) {
+  let a: [Box] = inputArray
   for _ in 1...N {
     _ = sumArray(a)
   }

--- a/benchmark/single-source/ClassArrayGetter.swift
+++ b/benchmark/single-source/ClassArrayGetter.swift
@@ -13,7 +13,7 @@
 import TestsUtils
 
 public let ClassArrayGetter = BenchmarkInfo(
-  name: "ClassArrayGetter",
+  name: "ClassArrayGetter2",
   runFunction: run_ClassArrayGetter,
   tags: [.validation, .api, .Array],
   setUpFunction: { blackHole(inputArray) },
@@ -34,7 +34,7 @@ func sumArray(_ a: [Box]) -> Int {
 }
 
 var inputArray: [Box]! = {
-  let aSize = 10_000
+  let aSize = 100_000
   var a: [Box] = []
   a.reserveCapacity(aSize)
   for i in 1...aSize {

--- a/benchmark/single-source/DictionaryGroup.swift
+++ b/benchmark/single-source/DictionaryGroup.swift
@@ -14,7 +14,9 @@ import TestsUtils
 
 public let DictionaryGroup = [
   BenchmarkInfo(name: "DictionaryGroup", runFunction: run_DictionaryGroup, tags: [.validation, .api, .Dictionary]),
-  BenchmarkInfo(name: "DictionaryGroupOfObjects", runFunction: run_DictionaryGroupOfObjects, tags: [.validation, .api, .Dictionary]),
+  BenchmarkInfo(name: "DictionaryGroupOfObjects", runFunction: run_DictionaryGroupOfObjects, tags: [.validation, .api, .Dictionary],
+    setUpFunction: { blackHole(inputObjects) },
+    tearDownFunction: { inputObjects = nil }),
 ]
 
 let count = 10_000
@@ -45,9 +47,11 @@ class Box<T : Hashable> : Hashable {
   }
 }
 
+var inputObjects: [Box<Int>]! = (0..<count).map { Box($0) }
+
 @inline(never)
 public func run_DictionaryGroupOfObjects(_ N: Int) {
-  let objects = (0..<count).map { Box($0) }
+  let objects: [Box<Int>] = inputObjects
   for _ in 1...N {
     let dict = Dictionary(grouping: objects, by: { Box($0.value % 10) })
     CheckResults(dict.count == 10)

--- a/benchmark/single-source/LazyFilter.swift
+++ b/benchmark/single-source/LazyFilter.swift
@@ -15,7 +15,7 @@
 import TestsUtils
 
 public let LazyFilter = [
-  BenchmarkInfo(name: "LazilyFilteredArrays", runFunction: run_LazilyFilteredArrays, tags: [.validation, .api, .Array],
+  BenchmarkInfo(name: "LazilyFilteredArrays2", runFunction: run_LazilyFilteredArrays, tags: [.validation, .api, .Array],
       setUpFunction: { blackHole(filteredRange) }),
   BenchmarkInfo(name: "LazilyFilteredRange", runFunction: run_LazilyFilteredRange, tags: [.validation, .api, .Array]),
   BenchmarkInfo(
@@ -37,7 +37,7 @@ public func run_LazilyFilteredRange(_ N: Int) {
   CheckResults(res == 123)
 }
 
-let filteredRange = (1..<1_000_000).map({[$0]}).lazy.filter { $0.first! % 7 == 0 }
+let filteredRange = (1..<100_000).map({[$0]}).lazy.filter { $0.first! % 7 == 0 }
 
 @inline(never)
 public func run_LazilyFilteredArrays(_ N: Int) {

--- a/benchmark/single-source/LazyFilter.swift
+++ b/benchmark/single-source/LazyFilter.swift
@@ -15,7 +15,8 @@
 import TestsUtils
 
 public let LazyFilter = [
-  BenchmarkInfo(name: "LazilyFilteredArrays", runFunction: run_LazilyFilteredArrays, tags: [.validation, .api, .Array]),
+  BenchmarkInfo(name: "LazilyFilteredArrays", runFunction: run_LazilyFilteredArrays, tags: [.validation, .api, .Array],
+      setUpFunction: { blackHole(filteredRange) }),
   BenchmarkInfo(name: "LazilyFilteredRange", runFunction: run_LazilyFilteredRange, tags: [.validation, .api, .Array]),
   BenchmarkInfo(
     name: "LazilyFilteredArrayContains",
@@ -36,10 +37,12 @@ public func run_LazilyFilteredRange(_ N: Int) {
   CheckResults(res == 123)
 }
 
+let filteredRange = (1..<1_000_000).map({[$0]}).lazy.filter { $0.first! % 7 == 0 }
+
 @inline(never)
 public func run_LazilyFilteredArrays(_ N: Int) {
   var res = 123
-  let c = (1..<1_000_000).map({[$0]}).lazy.filter { $0.first! % 7 == 0 }
+  let c = filteredRange
   for _ in 1...N {
     res += Array(c).count
     res -= Array(c).count

--- a/benchmark/single-source/RandomShuffle.swift
+++ b/benchmark/single-source/RandomShuffle.swift
@@ -19,9 +19,13 @@ import TestsUtils
 
 public let RandomShuffle = [
   BenchmarkInfo(name: "RandomShuffleDef", runFunction: run_RandomShuffleDef,
-    tags: [.api], setUpFunction: setup_RandomShuffle),
+    tags: [.api],
+    setUpFunction: { blackHole(numbersDef) },
+    tearDownFunction: { numbersDef = nil }),
   BenchmarkInfo(name: "RandomShuffleLCG", runFunction: run_RandomShuffleLCG,
-    tags: [.api], setUpFunction: setup_RandomShuffle),
+    tags: [.api],
+    setUpFunction: { blackHole(numbersLCG) },
+    tearDownFunction: { numbersLCG = nil }),
 ]
 
 /// A linear congruential PRNG.
@@ -39,15 +43,12 @@ struct LCRNG: RandomNumberGenerator {
   }
 }
 
-var numbers = Array(0...3_000_000)
-
-@inline(never)
-func setup_RandomShuffle() {
-  _ = numbers.count
-}
+var numbersDef: [Int]! = Array(0...3_000_000)
+var numbersLCG: [Int]! = Array(0...3_000_000)
 
 @inline(never)
 public func run_RandomShuffleDef(_ N: Int) {
+  var numbers: [Int] = numbersDef
   for _ in 0 ..< N {
     numbers.shuffle()
     blackHole(numbers.first!)
@@ -56,6 +57,7 @@ public func run_RandomShuffleDef(_ N: Int) {
 
 @inline(never)
 public func run_RandomShuffleLCG(_ N: Int) {
+  var numbers: [Int] = numbersLCG
   var generator = LCRNG(seed: 0)
   for _ in 0 ..< N {
     numbers.shuffle(using: &generator)

--- a/benchmark/single-source/RandomShuffle.swift
+++ b/benchmark/single-source/RandomShuffle.swift
@@ -18,11 +18,11 @@ import TestsUtils
 //
 
 public let RandomShuffle = [
-  BenchmarkInfo(name: "RandomShuffleDef", runFunction: run_RandomShuffleDef,
+  BenchmarkInfo(name: "RandomShuffleDef2", runFunction: run_RandomShuffleDef,
     tags: [.api],
     setUpFunction: { blackHole(numbersDef) },
     tearDownFunction: { numbersDef = nil }),
-  BenchmarkInfo(name: "RandomShuffleLCG", runFunction: run_RandomShuffleLCG,
+  BenchmarkInfo(name: "RandomShuffleLCG2", runFunction: run_RandomShuffleLCG,
     tags: [.api],
     setUpFunction: { blackHole(numbersLCG) },
     tearDownFunction: { numbersLCG = nil }),
@@ -43,8 +43,8 @@ struct LCRNG: RandomNumberGenerator {
   }
 }
 
-var numbersDef: [Int]! = Array(0...3_000_000)
-var numbersLCG: [Int]! = Array(0...3_000_000)
+var numbersDef: [Int]! = Array(0...10_000)
+var numbersLCG: [Int]! = Array(0...100_000)
 
 @inline(never)
 public func run_RandomShuffleDef(_ N: Int) {

--- a/benchmark/single-source/RemoveWhere.swift
+++ b/benchmark/single-source/RemoveWhere.swift
@@ -115,9 +115,9 @@ let ints = Array(0..<n)
 let str = String(repeating: "A very long ASCII string.", count: n/50)
 
 func buildWorkload() {
-  _ = strings.count
-  _ = ints.count
-  _ = str.count
+  blackHole(strings)
+  blackHole(ints)
+  blackHole(str)
 }
 
 

--- a/benchmark/single-source/ReversedCollections.swift
+++ b/benchmark/single-source/ReversedCollections.swift
@@ -13,58 +13,65 @@
 import TestsUtils
 
 public let ReversedCollections = [
-  BenchmarkInfo(name: "ReversedArray", runFunction: run_ReversedArray, tags: [.validation, .api, .Array]),
+  BenchmarkInfo(name: "ReversedArray2", runFunction: run_ReversedArray, tags: [.validation, .api, .Array],
+      setUpFunction: { blackHole(arrayInput) },
+      tearDownFunction: { arrayInput = nil }),
   BenchmarkInfo(name: "ReversedBidirectional", runFunction: run_ReversedBidirectional, tags: [.validation, .api]),
-  BenchmarkInfo(name: "ReversedDictionary", runFunction: run_ReversedDictionary, tags: [.validation, .api, .Dictionary]),
+  BenchmarkInfo(name: "ReversedDictionary2", runFunction: run_ReversedDictionary, tags: [.validation, .api, .Dictionary],
+      setUpFunction: { blackHole(dictionaryInput) },
+      tearDownFunction: { dictionaryInput = nil })
 ]
 
 // These benchmarks compare the performance of iteration through several
 // collection types after being reversed.
-var x = 0
 let length = 100_000
+
+var arrayInput: [Int]! = Array(repeating: 1, count: length).reversed()
 
 @inline(never)
 public func run_ReversedArray(_ N: Int) {
-  let array = Array(repeating: 1, count: length)
-  let reversedArray = array.reversed()
+  let reversedArray: [Int] = arrayInput
 
   // Iterate over the underlying type
   // ReversedRandomAccessCollection<Array<Int>>
   for _ in 1...N {
     for item in reversedArray {
-      x = item
+      blackHole(item)
     }
   }
 }
 
 @inline(never)
 public func run_ReversedBidirectional(_ N: Int) {
-  let bidirectional = AnyBidirectionalCollection(0..<length)
-  let reversedBidirectional = bidirectional.reversed()
-
   // Iterate over the underlying type
   // ReversedCollection<AnyBidirectionalCollection<Int>>
   for _ in 1...N {
+    let bidirectional = AnyBidirectionalCollection(0..<length)
+    let reversedBidirectional = bidirectional.reversed()
     for item in reversedBidirectional {
-      x = item
+      blackHole(item)
     }
   }
 }
 
-@inline(never)
-public func run_ReversedDictionary(_ N: Int) {
+var dictionaryInput: [(Int, Int)]! = {
   var dictionary = [Int: Int]()
   for k in 0..<length {
-    dictionary[k] = x
+    dictionary[k] = k
   }
-  let reversedDictionary = dictionary.reversed()
+  return dictionary.reversed()
+}()
+
+@inline(never)
+public func run_ReversedDictionary(_ N: Int) {
+  let reversedDictionary: [(Int, Int)] = dictionaryInput
 
   // Iterate over the underlying type
   // Array<(Int, Int)>
   for _ in 1...N {
     for (key, value) in reversedDictionary {
-      x = key
-      x = value
+      blackHole(key)
+      blackHole(value)
     }
   }
 }

--- a/benchmark/single-source/SequenceAlgos.swift
+++ b/benchmark/single-source/SequenceAlgos.swift
@@ -64,11 +64,11 @@ let y = AnySequence(0..<n)
 let s = sequence(first: 0, next: { $0 < n&-1 ? $0&+1 : nil})
 
 func buildWorkload() {
-  _ = l.makeIterator()
-  _ = c.makeIterator()
-  _ = a.makeIterator()
-  _ = y.makeIterator()
-  _ = s.makeIterator()
+  blackHole(l.makeIterator())
+  blackHole(c.makeIterator())
+  blackHole(a.makeIterator())
+  blackHole(y.makeIterator())
+  blackHole(s.makeIterator())
 }
 
 func benchmarkEquatableSequenceAlgos<S: Sequence>(s: S, n: Int) where S.Element == Int, S: Equatable {

--- a/benchmark/single-source/StringComparison.swift
+++ b/benchmark/single-source/StringComparison.swift
@@ -35,102 +35,103 @@ public let StringComparison = [
     name: "StringComparison_ascii",
     runFunction: run_StringComparison_ascii,
     tags: [.validation, .api, .String],
-    setUpFunction: setup_StringComparison_ascii),
+    setUpFunction: { blackHole(Workload_ascii) }),
   BenchmarkInfo(
     name: "StringComparison_latin1",
     runFunction: run_StringComparison_latin1,
     tags: [.validation, .api, .String],
-    setUpFunction: setup_StringComparison_latin1),
+    setUpFunction: { blackHole(Workload_latin1) }),
   BenchmarkInfo(
     name: "StringComparison_fastPrenormal",
     runFunction: run_StringComparison_fastPrenormal,
     tags: [.validation, .api, .String],
-    setUpFunction: setup_StringComparison_fastPrenormal),
+    setUpFunction: { blackHole(Workload_fastPrenormal) }),
   BenchmarkInfo(
     name: "StringComparison_slowerPrenormal",
     runFunction: run_StringComparison_slowerPrenormal,
     tags: [.validation, .api, .String],
-    setUpFunction: setup_StringComparison_slowerPrenormal),
+    setUpFunction: { blackHole(Workload_slowerPrenormal) }),
   BenchmarkInfo(
     name: "StringComparison_nonBMPSlowestPrenormal",
     runFunction: run_StringComparison_nonBMPSlowestPrenormal,
     tags: [.validation, .api, .String],
-    setUpFunction: setup_StringComparison_nonBMPSlowestPrenormal),
+    setUpFunction: { blackHole(Workload_nonBMPSlowestPrenormal) }),
   BenchmarkInfo(
     name: "StringComparison_emoji",
     runFunction: run_StringComparison_emoji,
     tags: [.validation, .api, .String],
-    setUpFunction: setup_StringComparison_emoji),
+    setUpFunction: { blackHole(Workload_emoji) }),
   BenchmarkInfo(
     name: "StringComparison_abnormal",
     runFunction: run_StringComparison_abnormal,
     tags: [.validation, .api, .String],
-    setUpFunction: setup_StringComparison_abnormal),
+    setUpFunction: { blackHole(Workload_abnormal) }),
   BenchmarkInfo(
     name: "StringComparison_zalgo",
     runFunction: run_StringComparison_zalgo,
     tags: [.validation, .api, .String],
-    setUpFunction: setup_StringComparison_zalgo),
+    setUpFunction: { blackHole(Workload_zalgo) }),
   BenchmarkInfo(
     name: "StringComparison_longSharedPrefix",
     runFunction: run_StringComparison_longSharedPrefix,
     tags: [.validation, .api, .String],
-    setUpFunction: setup_StringComparison_longSharedPrefix),
+    setUpFunction: { blackHole(Workload_longSharedPrefix) }),
 ]
 
 public let StringHashing = [
   BenchmarkInfo(
     name: "StringHashing_ascii",
     runFunction: run_StringHashing_ascii,
-    tags: [.validation, .api, .String]),    
+    tags: [.validation, .api, .String],
+    setUpFunction: { blackHole(Workload_ascii) }),
   BenchmarkInfo(
     name: "StringHashing_latin1",
     runFunction: run_StringHashing_latin1,
-    tags: [.validation, .api, .String]),    
+    tags: [.validation, .api, .String],
+    setUpFunction: { blackHole(Workload_latin1) }),
   BenchmarkInfo(
     name: "StringHashing_fastPrenormal",
     runFunction: run_StringHashing_fastPrenormal,
-    tags: [.validation, .api, .String]),    
+    tags: [.validation, .api, .String],
+    setUpFunction: { blackHole(Workload_fastPrenormal) }),
   BenchmarkInfo(
     name: "StringHashing_slowerPrenormal",
     runFunction: run_StringHashing_slowerPrenormal,
-    tags: [.validation, .api, .String]),    
+    tags: [.validation, .api, .String],
+    setUpFunction: { blackHole(Workload_slowerPrenormal) }),
   BenchmarkInfo(
     name: "StringHashing_nonBMPSlowestPrenormal",
     runFunction: run_StringHashing_nonBMPSlowestPrenormal,
-    tags: [.validation, .api, .String]),    
+    tags: [.validation, .api, .String],
+    setUpFunction: { blackHole(Workload_nonBMPSlowestPrenormal) }),
   BenchmarkInfo(
     name: "StringHashing_emoji",
     runFunction: run_StringHashing_emoji,
-    tags: [.validation, .api, .String]),    
+    tags: [.validation, .api, .String],
+    setUpFunction: { blackHole(Workload_emoji) }),
   BenchmarkInfo(
     name: "StringHashing_abnormal",
     runFunction: run_StringHashing_abnormal,
-    tags: [.validation, .api, .String]),    
+    tags: [.validation, .api, .String],
+    setUpFunction: { blackHole(Workload_abnormal) }),
   BenchmarkInfo(
     name: "StringHashing_zalgo",
     runFunction: run_StringHashing_zalgo,
-    tags: [.validation, .api, .String]),    
+    tags: [.validation, .api, .String],
+    setUpFunction: { blackHole(Workload_zalgo) }),
   BenchmarkInfo(
     name: "StringHashing_longSharedPrefix",
     runFunction: run_StringHashing_longSharedPrefix,
-    tags: [.validation, .api, .String]),    
+    tags: [.validation, .api, .String],
+    setUpFunction: { blackHole(Workload_longSharedPrefix) }),
 ]
 
 
-var Workload_ascii: Workload? = nil
-
-@inline(never)
-public func setup_StringComparison_ascii() {
-  if Workload_ascii != nil {
-    return
-  }
-  Workload_ascii = Workload.ascii
-}
+var Workload_ascii: Workload! = Workload.ascii
 
 @inline(never)
 public func run_StringComparison_ascii(_ N: Int) {
-  let workload = Workload_ascii.unsafelyUnwrapped
+  let workload: Workload = Workload_ascii
   let tripCount = workload.tripCount
   let payload = workload.payload
   for _ in 1...tripCount*N {
@@ -144,7 +145,7 @@ public func run_StringComparison_ascii(_ N: Int) {
 
 @inline(never)
 public func run_StringHashing_ascii(_ N: Int) {
-  let workload = Workload.ascii
+  let workload: Workload = Workload.ascii
   let tripCount = workload.tripCount
   let payload = workload.payload
   for _ in 1...tripCount*N {
@@ -155,19 +156,11 @@ public func run_StringHashing_ascii(_ N: Int) {
 }
   
 
-var Workload_latin1: Workload? = nil
-
-@inline(never)
-public func setup_StringComparison_latin1() {
-  if Workload_latin1 != nil {
-    return
-  }
-  Workload_latin1 = Workload.latin1
-}
+var Workload_latin1: Workload! = Workload.latin1
 
 @inline(never)
 public func run_StringComparison_latin1(_ N: Int) {
-  let workload = Workload_latin1.unsafelyUnwrapped
+  let workload: Workload = Workload_latin1
   let tripCount = workload.tripCount
   let payload = workload.payload
   for _ in 1...tripCount*N {
@@ -181,7 +174,7 @@ public func run_StringComparison_latin1(_ N: Int) {
 
 @inline(never)
 public func run_StringHashing_latin1(_ N: Int) {
-  let workload = Workload.latin1
+  let workload: Workload = Workload.latin1
   let tripCount = workload.tripCount
   let payload = workload.payload
   for _ in 1...tripCount*N {
@@ -192,19 +185,11 @@ public func run_StringHashing_latin1(_ N: Int) {
 }
   
 
-var Workload_fastPrenormal: Workload? = nil
-
-@inline(never)
-public func setup_StringComparison_fastPrenormal() {
-  if Workload_fastPrenormal != nil {
-    return
-  }
-  Workload_fastPrenormal = Workload.fastPrenormal
-}
+var Workload_fastPrenormal: Workload! = Workload.fastPrenormal
 
 @inline(never)
 public func run_StringComparison_fastPrenormal(_ N: Int) {
-  let workload = Workload_fastPrenormal.unsafelyUnwrapped
+  let workload: Workload = Workload_fastPrenormal
   let tripCount = workload.tripCount
   let payload = workload.payload
   for _ in 1...tripCount*N {
@@ -218,7 +203,7 @@ public func run_StringComparison_fastPrenormal(_ N: Int) {
 
 @inline(never)
 public func run_StringHashing_fastPrenormal(_ N: Int) {
-  let workload = Workload.fastPrenormal
+  let workload: Workload = Workload.fastPrenormal
   let tripCount = workload.tripCount
   let payload = workload.payload
   for _ in 1...tripCount*N {
@@ -229,19 +214,11 @@ public func run_StringHashing_fastPrenormal(_ N: Int) {
 }
   
 
-var Workload_slowerPrenormal: Workload? = nil
-
-@inline(never)
-public func setup_StringComparison_slowerPrenormal() {
-  if Workload_slowerPrenormal != nil {
-    return
-  }
-  Workload_slowerPrenormal = Workload.slowerPrenormal
-}
+var Workload_slowerPrenormal: Workload! = Workload.slowerPrenormal
 
 @inline(never)
 public func run_StringComparison_slowerPrenormal(_ N: Int) {
-  let workload = Workload_slowerPrenormal.unsafelyUnwrapped
+  let workload: Workload = Workload_slowerPrenormal
   let tripCount = workload.tripCount
   let payload = workload.payload
   for _ in 1...tripCount*N {
@@ -255,7 +232,7 @@ public func run_StringComparison_slowerPrenormal(_ N: Int) {
 
 @inline(never)
 public func run_StringHashing_slowerPrenormal(_ N: Int) {
-  let workload = Workload.slowerPrenormal
+  let workload: Workload = Workload.slowerPrenormal
   let tripCount = workload.tripCount
   let payload = workload.payload
   for _ in 1...tripCount*N {
@@ -266,19 +243,11 @@ public func run_StringHashing_slowerPrenormal(_ N: Int) {
 }
   
 
-var Workload_nonBMPSlowestPrenormal: Workload? = nil
-
-@inline(never)
-public func setup_StringComparison_nonBMPSlowestPrenormal() {
-  if Workload_nonBMPSlowestPrenormal != nil {
-    return
-  }
-  Workload_nonBMPSlowestPrenormal = Workload.nonBMPSlowestPrenormal
-}
+var Workload_nonBMPSlowestPrenormal: Workload! = Workload.nonBMPSlowestPrenormal
 
 @inline(never)
 public func run_StringComparison_nonBMPSlowestPrenormal(_ N: Int) {
-  let workload = Workload_nonBMPSlowestPrenormal.unsafelyUnwrapped
+  let workload: Workload = Workload_nonBMPSlowestPrenormal
   let tripCount = workload.tripCount
   let payload = workload.payload
   for _ in 1...tripCount*N {
@@ -292,7 +261,7 @@ public func run_StringComparison_nonBMPSlowestPrenormal(_ N: Int) {
 
 @inline(never)
 public func run_StringHashing_nonBMPSlowestPrenormal(_ N: Int) {
-  let workload = Workload.nonBMPSlowestPrenormal
+  let workload: Workload = Workload.nonBMPSlowestPrenormal
   let tripCount = workload.tripCount
   let payload = workload.payload
   for _ in 1...tripCount*N {
@@ -303,19 +272,11 @@ public func run_StringHashing_nonBMPSlowestPrenormal(_ N: Int) {
 }
   
 
-var Workload_emoji: Workload? = nil
-
-@inline(never)
-public func setup_StringComparison_emoji() {
-  if Workload_emoji != nil {
-    return
-  }
-  Workload_emoji = Workload.emoji
-}
+var Workload_emoji: Workload! = Workload.emoji
 
 @inline(never)
 public func run_StringComparison_emoji(_ N: Int) {
-  let workload = Workload_emoji.unsafelyUnwrapped
+  let workload: Workload = Workload_emoji
   let tripCount = workload.tripCount
   let payload = workload.payload
   for _ in 1...tripCount*N {
@@ -329,7 +290,7 @@ public func run_StringComparison_emoji(_ N: Int) {
 
 @inline(never)
 public func run_StringHashing_emoji(_ N: Int) {
-  let workload = Workload.emoji
+  let workload: Workload = Workload.emoji
   let tripCount = workload.tripCount
   let payload = workload.payload
   for _ in 1...tripCount*N {
@@ -340,19 +301,11 @@ public func run_StringHashing_emoji(_ N: Int) {
 }
   
 
-var Workload_abnormal: Workload? = nil
-
-@inline(never)
-public func setup_StringComparison_abnormal() {
-  if Workload_abnormal != nil {
-    return
-  }
-  Workload_abnormal = Workload.abnormal
-}
+var Workload_abnormal: Workload! = Workload.abnormal
 
 @inline(never)
 public func run_StringComparison_abnormal(_ N: Int) {
-  let workload = Workload_abnormal.unsafelyUnwrapped
+  let workload: Workload = Workload_abnormal
   let tripCount = workload.tripCount
   let payload = workload.payload
   for _ in 1...tripCount*N {
@@ -366,7 +319,7 @@ public func run_StringComparison_abnormal(_ N: Int) {
 
 @inline(never)
 public func run_StringHashing_abnormal(_ N: Int) {
-  let workload = Workload.abnormal
+  let workload: Workload = Workload.abnormal
   let tripCount = workload.tripCount
   let payload = workload.payload
   for _ in 1...tripCount*N {
@@ -377,19 +330,11 @@ public func run_StringHashing_abnormal(_ N: Int) {
 }
   
 
-var Workload_zalgo: Workload? = nil
-
-@inline(never)
-public func setup_StringComparison_zalgo() {
-  if Workload_zalgo != nil {
-    return
-  }
-  Workload_zalgo = Workload.zalgo
-}
+var Workload_zalgo: Workload! = Workload.zalgo
 
 @inline(never)
 public func run_StringComparison_zalgo(_ N: Int) {
-  let workload = Workload_zalgo.unsafelyUnwrapped
+  let workload: Workload = Workload_zalgo
   let tripCount = workload.tripCount
   let payload = workload.payload
   for _ in 1...tripCount*N {
@@ -403,7 +348,7 @@ public func run_StringComparison_zalgo(_ N: Int) {
 
 @inline(never)
 public func run_StringHashing_zalgo(_ N: Int) {
-  let workload = Workload.zalgo
+  let workload: Workload = Workload.zalgo
   let tripCount = workload.tripCount
   let payload = workload.payload
   for _ in 1...tripCount*N {
@@ -414,19 +359,11 @@ public func run_StringHashing_zalgo(_ N: Int) {
 }
   
 
-var Workload_longSharedPrefix: Workload? = nil
-
-@inline(never)
-public func setup_StringComparison_longSharedPrefix() {
-  if Workload_longSharedPrefix != nil {
-    return
-  }
-  Workload_longSharedPrefix = Workload.longSharedPrefix
-}
+var Workload_longSharedPrefix: Workload! = Workload.longSharedPrefix
 
 @inline(never)
 public func run_StringComparison_longSharedPrefix(_ N: Int) {
-  let workload = Workload_longSharedPrefix.unsafelyUnwrapped
+  let workload: Workload = Workload_longSharedPrefix
   let tripCount = workload.tripCount
   let payload = workload.payload
   for _ in 1...tripCount*N {
@@ -440,7 +377,7 @@ public func run_StringComparison_longSharedPrefix(_ N: Int) {
 
 @inline(never)
 public func run_StringHashing_longSharedPrefix(_ N: Int) {
-  let workload = Workload.longSharedPrefix
+  let workload: Workload = Workload.longSharedPrefix
   let tripCount = workload.tripCount
   let payload = workload.payload
   for _ in 1...tripCount*N {

--- a/benchmark/single-source/StringComparison.swift.gyb
+++ b/benchmark/single-source/StringComparison.swift.gyb
@@ -38,7 +38,7 @@ public let StringComparison = [
     name: "StringComparison_${Name}",
     runFunction: run_StringComparison_${Name},
     tags: [.validation, .api, .String],
-    setUpFunction: setup_StringComparison_${Name}),
+    setUpFunction: { blackHole(Workload_${Name}) }),
 % end # Names
 ]
 
@@ -47,25 +47,18 @@ public let StringHashing = [
   BenchmarkInfo(
     name: "StringHashing_${Name}",
     runFunction: run_StringHashing_${Name},
-    tags: [.validation, .api, .String]),    
+    tags: [.validation, .api, .String],
+    setUpFunction: { blackHole(Workload_${Name}) }),
 % end # Names
 ]
 
 % for Name in Names:
 
-var Workload_${Name}: Workload? = nil
-
-@inline(never)
-public func setup_StringComparison_${Name}() {
-  if Workload_${Name} != nil {
-    return
-  }
-  Workload_${Name} = Workload.${Name}
-}
+var Workload_${Name}: Workload! = Workload.${Name}
 
 @inline(never)
 public func run_StringComparison_${Name}(_ N: Int) {
-  let workload = Workload_${Name}.unsafelyUnwrapped
+  let workload: Workload = Workload_${Name}
   let tripCount = workload.tripCount
   let payload = workload.payload
   for _ in 1...tripCount*N {
@@ -79,7 +72,7 @@ public func run_StringComparison_${Name}(_ N: Int) {
 
 @inline(never)
 public func run_StringHashing_${Name}(_ N: Int) {
-  let workload = Workload.${Name}
+  let workload: Workload = Workload.${Name}
   let tripCount = workload.tripCount
   let payload = workload.payload
   for _ in 1...tripCount*N {

--- a/benchmark/single-source/SuperChars.swift
+++ b/benchmark/single-source/SuperChars.swift
@@ -35,7 +35,7 @@ public func run_SuperChars(_ N: Int) {
     "2", "a", "t", "i", "o", "e", "q", "n", "X", "Y", "Z", "?", "m", "Z", ","
     ]
 
-  for _ in 0...N {
+  for _ in 0..<N {
     for firstChar in alphabet {
       for middleChar in alphabet {
         for lastChar in alphabet {

--- a/benchmark/single-source/SuperChars.swift
+++ b/benchmark/single-source/SuperChars.swift
@@ -16,24 +16,28 @@ import TestsUtils
 public let SuperChars = BenchmarkInfo(
   name: "SuperChars",
   runFunction: run_SuperChars,
-  tags: [.validation, .api, .String])
+  tags: [.validation, .api, .String],
+  setUpFunction: { blackHole(alphabetInput) })
+
+// Permute some characters.
+let alphabetInput: [Character] = [
+  "A", "B", "C", "D", "E", "F", "G",
+   "«", // throw in some unicode to make it slower
+  "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R",
+  "á", "お",
+  "S", "T", "U",
+  "🇯🇵",
+  "V", "W", "X", "Y", "Z", "/", "f", "Z", "z", "6", "7", "C", "j", "f", "9",
+  "🇯🇵🇺🇸", "🇯🇵🇺🇸🇨🇳", "🇯🇵🇺🇸🇨🇳🇩🇪",
+  "g", "g", "I", "J", "K", "c", "x", "i", ".",
+  "🇯🇵🇺🇸🇨🇳🇩🇪", "🇯🇵🇺🇸", "🇯🇵🇺🇸🇨🇳",
+  "2", "a", "t", "i", "o", "e", "q", "n", "X", "Y", "Z", "?", "m", "Z", ","
+  ]
 
 @inline(never)
 public func run_SuperChars(_ N: Int) {
   // Permute some characters.
-  let alphabet: [Character] = [
-    "A", "B", "C", "D", "E", "F", "G",
-     "«", // throw in some unicode to make it slower
-    "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R",
-    "á", "お",
-    "S", "T", "U",
-    "🇯🇵",
-    "V", "W", "X", "Y", "Z", "/", "f", "Z", "z", "6", "7", "C", "j", "f", "9",
-    "🇯🇵🇺🇸", "🇯🇵🇺🇸🇨🇳", "🇯🇵🇺🇸🇨🇳🇩🇪",
-    "g", "g", "I", "J", "K", "c", "x", "i", ".",
-    "🇯🇵🇺🇸🇨🇳🇩🇪", "🇯🇵🇺🇸", "🇯🇵🇺🇸🇨🇳",
-    "2", "a", "t", "i", "o", "e", "q", "n", "X", "Y", "Z", "?", "m", "Z", ","
-    ]
+  let alphabet: [Character] = alphabetInput
 
   for _ in 0..<N {
     for firstChar in alphabet {

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -341,8 +341,9 @@ func runBench(_ test: BenchmarkInfo, _ c: TestConfig) -> BenchResults? {
   }
 
   let sampler = SampleRunner(c)
+  test.setUpFunction?()
+
   for s in 0..<c.numSamples {
-    test.setUpFunction?()
     let nsPerSecond = 1_000_000_000.0 // nanoseconds
     let time_per_sample = UInt64(c.sampleTime * nsPerSecond)
 
@@ -385,8 +386,8 @@ func runBench(_ test: BenchmarkInfo, _ c: TestConfig) -> BenchResults? {
     if c.verbose {
       print("    Sample \(s),\(samples[s])")
     }
-    test.tearDownFunction?()
   }
+  test.tearDownFunction?()
 
   let (mean, sd) = internalMeanSD(samples)
 

--- a/benchmark/utils/TestsUtils.swift
+++ b/benchmark/utils/TestsUtils.swift
@@ -143,8 +143,7 @@ public struct BenchmarkInfo {
   /// Shadow static variable for computed property tearDownFunction.
   private var _tearDownFunction: (() -> ())?
 
-  /// An optional function that if non-null is run immediately after a sample is
-  /// taken.
+  /// An optional function that if non-null is run after samples are taken.
   public var tearDownFunction: (() -> ())? {
     if !shouldRun {
       return nil


### PR DESCRIPTION
The time per iteration should roughly stay constant and not depend on the number of iterations.

*) for benchmarks with a significant setup time, move the setup to the setUpFunction
*) some benchmarks wrongly executed the loop N+1 times ("0...N" instead of "0..<N")
*) added some blackHole calls to prevent the optimizer removing important parts of a benchmark
*) lowered the workload for the CSVParsing benchmarks because 1 single iteration took too long
*) moved the setup and teardown function calls outside the sample loop

For a few benchmarks this changed the benchmark score. I renamed those benchmarks so that they are now treated as "new" benchmarks.
