### PR TITLE
[4.2] [stdlib] Work-around incorrect name resolution with conditional BidirectionalCollections.

### DIFF
--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -147,7 +147,7 @@ extension BidirectionalCollection {
   }
 
   @inlinable // FIXME(sil-serialize-all)
-  public func index(_ i: Index, offsetBy n: Int) -> Index {
+  internal func _index(_ i: Index, offsetBy n: Int) -> Index {
     if n >= 0 {
       return _advanceForward(i, by: n)
     }
@@ -159,7 +159,12 @@ extension BidirectionalCollection {
   }
 
   @inlinable // FIXME(sil-serialize-all)
-  public func index(
+  public func index(_ i: Index, offsetBy n: Int) -> Index {
+    return _index(i, offsetBy: n)
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  internal func _index(
     _ i: Index, offsetBy n: Int, limitedBy limit: Index
   ) -> Index? {
     if n >= 0 {
@@ -173,6 +178,13 @@ extension BidirectionalCollection {
       formIndex(before: &i)
     }
     return i
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  public func index(
+    _ i: Index, offsetBy n: Int, limitedBy limit: Index
+  ) -> Index? {
+    return _index(i, offsetBy: n, limitedBy: limit)
   }
 
   @inlinable // FIXME(sil-serialize-all)
@@ -247,7 +259,9 @@ extension BidirectionalCollection where SubSequence == Self {
     _precondition(n >= 0, "Number of elements to remove should be non-negative")
     _precondition(count >= n,
       "Can't remove more items from a collection than it contains")
-    self = self[startIndex..<index(endIndex, offsetBy: -n)]
+    // FIXME: using non-_'d `index` incorrectly calls the Collection one for
+    // conditional conformances to BidirectionalCollections.
+    self = self[startIndex..<_index(endIndex, offsetBy: -n)]
   }
 }
 
@@ -273,7 +287,9 @@ extension BidirectionalCollection {
   public func dropLast(_ n: Int) -> SubSequence {
     _precondition(
       n >= 0, "Can't drop a negative number of elements from a collection")
-    let end = index(
+    // FIXME: using non-_'d `index` incorrectly calls the Collection one for
+    // conditional conformances to BidirectionalCollections.
+    let end = _index(
       endIndex,
       offsetBy: -n,
       limitedBy: startIndex) ?? startIndex
@@ -303,7 +319,9 @@ extension BidirectionalCollection {
     _precondition(
       maxLength >= 0,
       "Can't take a suffix of negative length from a collection")
-    let start = index(
+    // FIXME: using non-_'d `index` incorrectly calls the Collection one for
+    // conditional conformances to BidirectionalCollections.
+    let start = _index(
       endIndex,
       offsetBy: -maxLength,
       limitedBy: startIndex) ?? startIndex

--- a/test/stdlib/conditional_collections.swift
+++ b/test/stdlib/conditional_collections.swift
@@ -1,0 +1,38 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+
+struct X: BidirectionalCollection {
+  var startIndex: Int { return 0 }
+  var endIndex: Int { return 10 }
+  subscript(position: Int) -> String { return "element" }
+  subscript(range: Range<Int>) -> X { return X() }
+  func index(after i: Int) -> Int { return i + 1 }
+  func index(before i: Int) -> Int { return i - 1 }
+}
+struct A<C: Collection>: Collection {
+  let c: C
+  var startIndex: C.Index { return c.startIndex }
+  var endIndex: C.Index { return c.endIndex }
+  subscript(position: C.Index) -> C.Element { return c[position] }
+  subscript(range: Range<C.Index>) -> A<C.SubSequence> {
+    return A<C.SubSequence>(c: c[range])
+  }
+  func index(after i: C.Index) -> C.Index { return c.index(after: i) }
+}
+
+extension A: BidirectionalCollection where C: BidirectionalCollection {
+  func index(before i: C.Index) -> C.Index { return c.index(before: i) }
+}
+
+// SR-8022
+func sr8022() {
+  var c = A(c: X())
+  _ = c.popLast()
+  _ = c.removeLast()
+  c.removeLast(2)
+  _ = c.dropLast(2)
+  _ = c.suffix(2)
+}
+
+sr8022()


### PR DESCRIPTION
**Explanation**: If a type conditionally conforms to BidirectionalCollection, `suffix`'s (and the
others) use of `index` ends up dispatching through `Collection.index` seemingly
because it is a protocol requirement. The intended function is
BidirectionalCollection's overloaded `index` (which _isn't_ connected to a
protocol requirement), which is called for non-conditional conformances. As
such, this is a work-around to stop code crashing.
**Scope**: Any calls to `suffix` or `dropLast` or `removeLast` on a type that conditionally conforms to BidirectionalCollection will crash
**Radar/SR Issue**: rdar://problem/42408692
**Risk**: Low, this is just adding an internal layer of functions with public callers, without changing behaviour.
**Testing**: CI testing.
**Reviewer**: @moiseev 

4.2 merge of https://github.com/apple/swift/pull/18066
