### PR TITLE
Add more tests for ranking and disambiguation.

### DIFF
--- a/test/Constraints/ranking.swift
+++ b/test/Constraints/ranking.swift
@@ -1,4 +1,107 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-emit-silgen %s -verify | %FileCheck %s
+
+protocol P {
+  var p: P { get set }
+  var q: P? { get set }
+  func p(_: P)
+  func q(_: P)
+}
+
+struct S : P {
+  var p: P
+  var q: P?
+  func p(_: P) {}
+  func q(_: P) {}
+}
+
+class Base : P {
+  var p: P
+  var q: P?
+  func p(_: P) {}
+  func q(_: P) {}
+  init(_ p: P) { self.p = p }
+}
+
+class Derived : Base {
+}
+
+func generic<T>(_: T) {}
+func generic<T>(_: T?) {}
+func genericOpt<T>(_: T?) {}
+
+// CHECK-LABEL: sil hidden @$S7ranking22propertyVersusFunctionyyAA1P_p_xtAaCRzlF
+func propertyVersusFunction<T : P>(_ p: P, _ t: T) {
+  // CHECK: witness_method $@opened("{{.*}}") P, #P.p!getter.1
+  let _ = p.p
+  // CHECK: witness_method $@opened("{{.*}}") P, #P.p!getter.1
+  let _: P = p.p
+  // CHECK: function_ref @$S7ranking1PP1pyyAaB_pFTc
+  let _: (P) -> () = p.p
+  // CHECK: witness_method $@opened("{{.*}}") P, #P.p!getter.1
+  let _: P? = p.p
+  // CHECK: witness_method $@opened("{{.*}}") P, #P.p!getter.1
+  let _: Any = p.p
+  // CHECK: witness_method $@opened("{{.*}}") P, #P.p!getter.1
+  let _: Any? = p.p
+
+  // CHECK: witness_method $@opened("{{.*}}") P, #P.p!getter.1
+  // CHECK: function_ref @$S7ranking7genericyyxlF
+  generic(p.p)
+  // CHECK: witness_method $@opened("{{.*}}") P, #P.q!getter.1
+  // CHECK: function_ref @$S7ranking7genericyyxSglF
+  generic(p.q)
+  // CHECK: witness_method $@opened("{{.*}}") P, #P.p!getter.1
+  // CHECK: function_ref @$S7ranking10genericOptyyxSglF
+  genericOpt(p.p)
+  // CHECK: witness_method $@opened("{{.*}}") P, #P.q!getter.1
+  // CHECK: function_ref @$S7ranking10genericOptyyxSglF
+  genericOpt(p.q)
+
+  // CHECK: witness_method $T, #P.p!getter.1
+  let _ = t.p
+  // CHECK: witness_method $T, #P.p!getter.1
+  let _: P = t.p
+  // CHECK: function_ref @$S7ranking1PP1pyyAaB_pFTc
+  let _: (P) -> () = t.p
+  // CHECK: witness_method $T, #P.p!getter.1
+  let _: P? = t.p
+  // CHECK: witness_method $T, #P.p!getter.1
+  let _: Any = t.p
+  // CHECK: witness_method $T, #P.p!getter.1
+  let _: Any? = t.p
+
+  // CHECK: witness_method $T, #P.p!getter.1
+  // CHECK: function_ref @$S7ranking7genericyyxlF
+  generic(t.p)
+  // CHECK: witness_method $T, #P.q!getter.1
+  // CHECK: function_ref @$S7ranking7genericyyxSglF
+  generic(t.q)
+  // CHECK: witness_method $T, #P.p!getter.1
+  // CHECK: function_ref @$S7ranking10genericOptyyxSglF
+  genericOpt(t.p)
+  // CHECK: witness_method $T, #P.q!getter.1
+  // CHECK: function_ref @$S7ranking10genericOptyyxSglF
+  genericOpt(t.q)
+}
+
+extension P {
+  func propertyVersusFunction() {
+    // CHECK: witness_method $Self, #P.p!getter.1
+    let _ = self.p
+    // CHECK: witness_method $Self, #P.p!getter.1
+    let _: P = self.p
+    // CHECK: function_ref @$S7ranking1PP1pyyAaB_pFTc
+    let _: (P) -> () = self.p
+    // CHECK: witness_method $Self, #P.p!getter.1
+    let _: P? = self.p
+    // CHECK: witness_method $Self, #P.p!getter.1
+    let _: Any = self.p
+    // CHECK: witness_method $Self, #P.p!getter.1
+    let _: Any? = self.p
+  }
+}
+
+//--------------------------------------------------------------------
 
 func f0<T>(_ x: T) {}
 
@@ -13,4 +116,10 @@ class B : A {
 func f1(_ a: A) -> A { return a }
 func f1(_ b: B) -> B { return b }
 
-f0(f1(B()))
+func testDerived(b: B) {
+  // CHECK-LABEL: sil hidden @$S7ranking11testDerived1byAA1BC_tF
+  // CHECK: function_ref @$S7ranking2f1yAA1BCADF
+  // CHECK: function_ref @$S7ranking2f0yyxlF
+  f0(f1(b))
+  // CHECK: end sil function '$S7ranking11testDerived1byAA1BC_tF'
+}

--- a/test/Constraints/ranking.swift
+++ b/test/Constraints/ranking.swift
@@ -25,9 +25,10 @@ class Base : P {
 class Derived : Base {
 }
 
-func generic<T>(_: T) {}
-func generic<T>(_: T?) {}
-func genericOpt<T>(_: T?) {}
+func genericOverload<T>(_: T) {}
+func genericOverload<T>(_: T?) {}
+func genericOptional<T>(_: T?) {}
+func genericNoOptional<T>(_: T) {}
 
 // CHECK-LABEL: sil hidden @$S7ranking22propertyVersusFunctionyyAA1P_p_xtAaCRzlF
 func propertyVersusFunction<T : P>(_ p: P, _ t: T) {
@@ -45,17 +46,23 @@ func propertyVersusFunction<T : P>(_ p: P, _ t: T) {
   let _: Any? = p.p
 
   // CHECK: witness_method $@opened("{{.*}}") P, #P.p!getter.1
-  // CHECK: function_ref @$S7ranking7genericyyxlF
-  generic(p.p)
+  // CHECK: function_ref @$S7ranking15genericOverloadyyxlF
+  genericOverload(p.p)
   // CHECK: witness_method $@opened("{{.*}}") P, #P.q!getter.1
-  // CHECK: function_ref @$S7ranking7genericyyxSglF
-  generic(p.q)
+  // CHECK: function_ref @$S7ranking15genericOverloadyyxSglF
+  genericOverload(p.q)
   // CHECK: witness_method $@opened("{{.*}}") P, #P.p!getter.1
-  // CHECK: function_ref @$S7ranking10genericOptyyxSglF
-  genericOpt(p.p)
+  // CHECK: function_ref @$S7ranking15genericOptionalyyxSglF
+  genericOptional(p.p)
   // CHECK: witness_method $@opened("{{.*}}") P, #P.q!getter.1
-  // CHECK: function_ref @$S7ranking10genericOptyyxSglF
-  genericOpt(p.q)
+  // CHECK: function_ref @$S7ranking15genericOptionalyyxSglF
+  genericOptional(p.q)
+  // CHECK: witness_method $@opened("{{.*}}") P, #P.p!getter.1
+  // CHECK: function_ref @$S7ranking17genericNoOptionalyyxlF
+  genericNoOptional(p.p)
+  // CHECK: witness_method $@opened("{{.*}}") P, #P.q!getter.1
+  // CHECK: function_ref @$S7ranking17genericNoOptionalyyxlF
+  genericNoOptional(p.q)
 
   // CHECK: witness_method $T, #P.p!getter.1
   let _ = t.p
@@ -71,17 +78,23 @@ func propertyVersusFunction<T : P>(_ p: P, _ t: T) {
   let _: Any? = t.p
 
   // CHECK: witness_method $T, #P.p!getter.1
-  // CHECK: function_ref @$S7ranking7genericyyxlF
-  generic(t.p)
+  // CHECK: function_ref @$S7ranking15genericOverloadyyxlF
+  genericOverload(t.p)
   // CHECK: witness_method $T, #P.q!getter.1
-  // CHECK: function_ref @$S7ranking7genericyyxSglF
-  generic(t.q)
+  // CHECK: function_ref @$S7ranking15genericOverloadyyxSglF
+  genericOverload(t.q)
   // CHECK: witness_method $T, #P.p!getter.1
-  // CHECK: function_ref @$S7ranking10genericOptyyxSglF
-  genericOpt(t.p)
+  // CHECK: function_ref @$S7ranking15genericOptionalyyxSglF
+  genericOptional(t.p)
   // CHECK: witness_method $T, #P.q!getter.1
-  // CHECK: function_ref @$S7ranking10genericOptyyxSglF
-  genericOpt(t.q)
+  // CHECK: function_ref @$S7ranking15genericOptionalyyxSglF
+  genericOptional(t.q)
+  // CHECK: witness_method $T, #P.p!getter.1
+  // CHECK: function_ref @$S7ranking17genericNoOptionalyyxlF
+  genericNoOptional(t.p)
+  // CHECK: witness_method $T, #P.q!getter.1
+  // CHECK: function_ref @$S7ranking17genericNoOptionalyyxlF
+  genericNoOptional(t.q)
 }
 
 extension P {
@@ -98,6 +111,25 @@ extension P {
     let _: Any = self.p
     // CHECK: witness_method $Self, #P.p!getter.1
     let _: Any? = self.p
+
+    // CHECK: witness_method $Self, #P.p!getter.1
+    // CHECK: function_ref @$S7ranking15genericOverloadyyxlF
+    genericOverload(self.p)
+    // CHECK: witness_method $Self, #P.q!getter.1
+    // CHECK: function_ref @$S7ranking15genericOverloadyyxSglF
+    genericOverload(self.q)
+    // CHECK: witness_method $Self, #P.p!getter.1
+    // CHECK: function_ref @$S7ranking15genericOptionalyyxSglF
+    genericOptional(self.p)
+    // CHECK: witness_method $Self, #P.q!getter.1
+    // CHECK: function_ref @$S7ranking15genericOptionalyyxSglF
+    genericOptional(self.q)
+    // CHECK: witness_method $Self, #P.p!getter.1
+    // CHECK: function_ref @$S7ranking17genericNoOptionalyyxlF
+    genericNoOptional(self.p)
+    // CHECK: witness_method $Self, #P.q!getter.1
+    // CHECK: function_ref @$S7ranking17genericNoOptionalyyxlF
+    genericNoOptional(self.q)
   }
 }
 


### PR DESCRIPTION
We don't have a great collection of tests for the ranking that we do
in the constraint solver. This is a very simple beginning that I will
build on in further commits.

The primary aim here is to document the current state of how we're
selecting things, and make note of anything that doesn't seem like the
right long term choice so that we can begin to address the issues.

This is largely motivated at the moment by the changes I had to revert
for dealing with Optional and Any in ranking, which on both ranking
changes and scoring changes, the latter of which inadvertantly changed
other behavior about how we ultimately select a final solution in type
checking.

This is not comprehensive, but it's a small start to documenting the current
behavior of some simple cases.