### PR TITLE
Lower undefs introduced by SESE loop canonicalization in graph lowering

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -283,6 +283,8 @@ PASS(TFPartitionTest, "tf-partition",
      "Partition accelerator operations out of mainline control flow")
 PASS(TFXLACFGCanonicalize, "tf-xla-cfg-canonicalize",
      "Canonicalize the control flow graph into SESE region for XLA")
+PASS(TFLowerGraph, "tf-lower-graph",
+     "Lower the given control flow graph into a TF graph")
 // SWIFT_ENABLE_TENSORFLOW End
 PASS(UnsafeGuaranteedPeephole, "unsafe-guaranteed-peephole",
      "SIL retain/release Peephole Removal for Builtin.unsafeGuaranteed")

--- a/lib/SILOptimizer/Mandatory/TFDevicePartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDevicePartition.cpp
@@ -841,6 +841,8 @@ class DevicePartitionerImpl
 
     // BB args are replicated on all devices, so no transfer is needed.
     if (isa<SILArgument>(opValue)) return;
+    // Undefs will be handled later.
+    if (isa<SILUndef>(opValue)) return;
 
     auto *operandInst = opValue->getDefiningInstruction();
     assert(operandInst && "value must be defined by an instruction");

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -437,8 +437,14 @@ public:
 
   TF_DataType getTensorFlowDataType(SILType type, SILLocation loc);
 
+  /// Creates a constant node for an undef value in the input function.
+  /// These values will never be used for any calculations and therefore,
+  /// can be an any arbitrary value.
+  TF_Output createUndefNode(SILType type);
+
   TF_Output createParameter(SILOpResult value, TF_Output passedValue,
                             GraphFunctionBody &fn);
+
 
   /// Add an available value for the specified SILOpResult (a SILValue+result#)
   /// to the value mapping.  This defaults to setting its scope to the current
@@ -489,6 +495,9 @@ public:
   /// SILValue+result #).  Note that this can return a null value if an error
   /// occurred lowering the operand in question.
   TF_Output getOperandValue(SILOpResult v) {
+    if (isa<SILUndef>(v.first) ) {
+      return createUndefNode(v.first->getType());
+    }
     std::pair<TF_Output, unsigned> valueInfo = valueMapping.lookup(v);
     assert(valueInfo.first.oper != nullptr && "didn't find live-in value?");
 
@@ -813,6 +822,89 @@ static TF_Tensor *convertValuesToTensor(ArrayRef<APInt> elts,
   }
 
   return tensor;
+}
+
+TF_Output TFGraphLowering::createUndefNode(SILType type) {
+  // Create some magic constant. Actual value does not matter as it will
+  // not be used in any calculations.
+  // FIXME: Is there a better way to model undefs in TF Graph if we
+  // don't have a way of getting rid of undefs during canonicalization.
+  APInt value;
+  TF_DataType dtype = getTensorFlowDataType(type, SILFn.getLocation());
+  switch (dtype) {
+  case TF_FLOAT:
+    value = APFloat((float)1.0).bitcastToAPInt();
+    break;
+  case TF_DOUBLE:
+    value = APFloat((double)2.0).bitcastToAPInt();
+    break;
+  case TF_BOOL:
+    value = APInt(1, "0", 10);
+    break;
+  case TF_INT8:
+  case TF_UINT8:
+    value = APInt(8, "aa", 16);
+    break;
+  case TF_INT16:
+  case TF_UINT16:
+    value = APInt(16, "aaaa", 16);
+    break;
+  case TF_INT32:
+  case TF_UINT32:
+    value = APInt(32, "aaaaaa", 16);
+    break;
+  case TF_INT64:
+  case TF_UINT64:
+    value = APInt(64, "aaaaaaaa", 16);
+    break;
+  case TF_STRING:
+  case TF_COMPLEX64:  // Single-precision complex
+  case TF_QINT8:      // Quantized int8
+  case TF_QUINT8:     // Quantized uint8
+  case TF_QINT32:     // Quantized int32
+  case TF_BFLOAT16:   // Float32 truncated to 16 bits.  Only for cast ops.
+  case TF_QINT16:     // Quantized int16
+  case TF_QUINT16:    // Quantized uint16
+  case TF_COMPLEX128: // Double-precision complex
+  case TF_HALF:
+  case TF_RESOURCE:
+  case TF_VARIANT:
+    llvm_unreachable("Cannot deal with other undef node types at this point");
+  }
+
+  // Create a graph node
+  auto &graphFn = getCurrentGraphFunction();
+  std::string nodeName("UndefConst" + type.getAsString());
+  // escape the node name.
+  for (std::string::size_type i = 0; i < nodeName.size(); ++i) {
+    switch (nodeName[i]) {
+    case '$':
+      nodeName[i] = 'D';
+      break;
+    case '<':
+      nodeName[i] = 'L';
+      break;
+    case '>':
+      nodeName[i] = 'G';
+      break;
+    }
+  }
+  auto *result = TF_NewOperation(graphFn.getGraph(), "Const", nodeName.c_str());
+  TF_SetAttrType(result, "dtype", dtype);
+
+  // Make an uninitialized tensor that is big enough for our value.
+  SmallVector<int64_t, 4> shape; // 0d shape
+  auto dtypeSize = TF_DataTypeSize(dtype);
+  auto *tensor =
+      TF_AllocateTensor(dtype, shape.data(), shape.size(), dtypeSize);
+
+  // Set up its contents, element-wise.
+  memcpy((char *)TF_TensorData(tensor), value.getRawData(), dtypeSize);
+  TF_SetAttrTensor(result, "value", tensor, status);
+  TF_Operation *finalResult =
+      graphFn.finishOp(result, /*hasSideEffects*/ false,
+                       /*isEligibleForTPU*/ true, status);
+  return {finalResult, 0};
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/TensorFlow/undef_lowering.sil
+++ b/test/TensorFlow/undef_lowering.sil
@@ -1,0 +1,359 @@
+// RUN: %target-sil-opt -tf-lower-graph -tf-ensure-single-loop-exit -assume-parsing-unqualified-ownership-sil %s -o /dev/null | %FileCheck %s
+
+import Builtin
+import Swift
+import TensorFlow
+
+// sil @$undefInt32 : $@convention(thin) () -> Builtin.Int32  {
+// bb0:
+//  return undef : $Builtin.Int32
+// }
+
+sil @$undefTFBool : $@convention(thin) () -> TensorHandle<Bool>  {
+bb0:
+ return undef : $TensorHandle<Bool>
+}
+// CHECK-LABEL: --- TFPartition GraphDef Proto: $undefTFBool
+// CHECK: library {
+// CHECK:  function {
+// CHECK:  node_def {
+// CHECK:      name: "UndefConst$TensorHandle<Bool>"
+// CHECK:      op: "Const"
+// CHECK:      attr {
+// CHECK:        key: "dtype"
+// CHECK:        value {
+// CHECK:          type: DT_BOOL
+// CHECK:        }
+// CHECK:      }
+// CHECK:      attr {
+// CHECK:        key: "value"
+// CHECK:        value {
+// CHECK:          tensor {
+// CHECK:            dtype: DT_BOOL
+// CHECK:            tensor_shape {
+// CHECK:            }
+// CHECK:            bool_val: false
+// CHECK:          }
+// CHECK:        }
+// CHECK:      }
+// CHECK:    }
+// CHECK:  }
+// CHECK:}
+
+sil @$undefTFInt8 : $@convention(thin) () -> TensorHandle<Int8>  {
+bb0:
+ return undef : $TensorHandle<Int8>
+}
+// CHECK-LABEL: --- TFPartition GraphDef Proto: $undefTFInt8
+// CHECK: library {
+// CHECK:  function {
+// CHECK:  node_def {
+// CHECK:      name: "UndefConst$TensorHandle<Int8>"
+// CHECK:      op: "Const"
+// CHECK:      attr {
+// CHECK:        key: "dtype"
+// CHECK:        value {
+// CHECK:          type: DT_INT8
+// CHECK:        }
+// CHECK:      }
+// CHECK:      attr {
+// CHECK:        key: "value"
+// CHECK:        value {
+// CHECK:          tensor {
+// CHECK:            dtype: DT_INT8
+// CHECK:            tensor_shape {
+// CHECK:            }
+// CHECK:            int_val: -86
+// CHECK:          }
+// CHECK:        }
+// CHECK:      }
+// CHECK:    }
+// CHECK:  }
+// CHECK:}
+
+sil @$undefTFUInt8 : $@convention(thin) () -> TensorHandle<UInt8>  {
+bb0:
+ return undef : $TensorHandle<UInt8>
+}
+// CHECK-LABEL: --- TFPartition GraphDef Proto: $undefTFUInt8
+// CHECK: library {
+// CHECK:  function {
+// CHECK:  node_def {
+// CHECK:      name: "UndefConst$TensorHandle<UInt8>"
+// CHECK:      op: "Const"
+// CHECK:      attr {
+// CHECK:        key: "dtype"
+// CHECK:        value {
+// CHECK:          type: DT_UINT8
+// CHECK:        }
+// CHECK:      }
+// CHECK:      attr {
+// CHECK:        key: "value"
+// CHECK:        value {
+// CHECK:          tensor {
+// CHECK:            dtype: DT_UINT8
+// CHECK:            tensor_shape {
+// CHECK:            }
+// CHECK:            int_val: 170
+// CHECK:          }
+// CHECK:        }
+// CHECK:      }
+// CHECK:    }
+// CHECK:  }
+// CHECK:}
+
+sil @$undefTFInt16 : $@convention(thin) () -> TensorHandle<Int16>  {
+bb0:
+ return undef : $TensorHandle<Int16>
+}
+// CHECK-LABEL: --- TFPartition GraphDef Proto: $undefTFInt16
+// CHECK: library {
+// CHECK:  function {
+// CHECK:  node_def {
+// CHECK:      name: "UndefConst$TensorHandle<Int16>"
+// CHECK:      op: "Const"
+// CHECK:      attr {
+// CHECK:        key: "dtype"
+// CHECK:        value {
+// CHECK:          type: DT_INT16
+// CHECK:        }
+// CHECK:      }
+// CHECK:      attr {
+// CHECK:        key: "value"
+// CHECK:        value {
+// CHECK:          tensor {
+// CHECK:            dtype: DT_INT16
+// CHECK:            tensor_shape {
+// CHECK:            }
+// CHECK:            int_val: -21846
+// CHECK:          }
+// CHECK:        }
+// CHECK:      }
+// CHECK:    }
+// CHECK:  }
+// CHECK:}
+
+sil @$undefTFUInt16 : $@convention(thin) () -> TensorHandle<UInt16>  {
+bb0:
+ return undef : $TensorHandle<UInt16>
+}
+// CHECK-LABEL: --- TFPartition GraphDef Proto: $undefTFUInt16
+// CHECK: library {
+// CHECK:  function {
+// CHECK:  node_def {
+// CHECK:      name: "UndefConst$TensorHandle<UInt16>"
+// CHECK:      op: "Const"
+// CHECK:      attr {
+// CHECK:        key: "dtype"
+// CHECK:        value {
+// CHECK:          type: DT_UINT16
+// CHECK:        }
+// CHECK:      }
+// CHECK:      attr {
+// CHECK:        key: "value"
+// CHECK:        value {
+// CHECK:          tensor {
+// CHECK:            dtype: DT_UINT16
+// CHECK:            tensor_shape {
+// CHECK:            }
+// CHECK:            int_val: 43690
+// CHECK:          }
+// CHECK:        }
+// CHECK:      }
+// CHECK:    }
+// CHECK:  }
+// CHECK:}
+
+
+sil @$undefTFInt32 : $@convention(thin) () -> TensorHandle<Int32>  {
+bb0:
+ return undef : $TensorHandle<Int32>
+}
+// CHECK-LABEL: --- TFPartition GraphDef Proto: $undefTFInt32
+// CHECK: library {
+// CHECK:  function {
+// CHECK:  node_def {
+// CHECK:      name: "UndefConst$TensorHandle<Int32>"
+// CHECK:      op: "Const"
+// CHECK:      attr {
+// CHECK:        key: "dtype"
+// CHECK:        value {
+// CHECK:          type: DT_INT32
+// CHECK:        }
+// CHECK:      }
+// CHECK:      attr {
+// CHECK:        key: "value"
+// CHECK:        value {
+// CHECK:          tensor {
+// CHECK:            dtype: DT_INT32
+// CHECK:            tensor_shape {
+// CHECK:            }
+// CHECK:            int_val: 11184810
+// CHECK:          }
+// CHECK:        }
+// CHECK:      }
+// CHECK:    }
+// CHECK:  }
+// CHECK:}
+
+sil @$undefTFUInt32 : $@convention(thin) () -> TensorHandle<UInt32>  {
+bb0:
+ return undef : $TensorHandle<UInt32>
+}
+// CHECK-LABEL: --- TFPartition GraphDef Proto: $undefTFUInt32
+// CHECK: library {
+// CHECK:  function {
+// CHECK:  node_def {
+// CHECK:      name: "UndefConst$TensorHandle<UInt32>"
+// CHECK:      op: "Const"
+// CHECK:      attr {
+// CHECK:        key: "dtype"
+// CHECK:        value {
+// CHECK:          type: DT_UINT32
+// CHECK:        }
+// CHECK:      }
+// CHECK:      attr {
+// CHECK:        key: "value"
+// CHECK:        value {
+// CHECK:          tensor {
+// CHECK:            dtype: DT_UINT32
+// CHECK:            tensor_shape {
+// CHECK:            }
+// CHECK:            uint32_val: 11184810
+// CHECK:          }
+// CHECK:        }
+// CHECK:      }
+// CHECK:    }
+// CHECK:  }
+// CHECK:}
+
+sil @$undefTFInt64: $@convention(thin) () -> TensorHandle<Int64>  {
+bb0:
+ return undef : $TensorHandle<Int64>
+}
+// CHECK-LABEL: --- TFPartition GraphDef Proto: $undefTFInt64
+// CHECK: library {
+// CHECK:  function {
+// CHECK:  node_def {
+// CHECK:      name: "UndefConst$TensorHandle<Int64>"
+// CHECK:      op: "Const"
+// CHECK:      attr {
+// CHECK:        key: "dtype"
+// CHECK:        value {
+// CHECK:          type: DT_INT64
+// CHECK:        }
+// CHECK:      }
+// CHECK:      attr {
+// CHECK:        key: "value"
+// CHECK:        value {
+// CHECK:          tensor {
+// CHECK:            dtype: DT_INT64
+// CHECK:            tensor_shape {
+// CHECK:            }
+// CHECK:            int64_val: 2863311530
+// CHECK:          }
+// CHECK:        }
+// CHECK:      }
+// CHECK:    }
+// CHECK:  }
+// CHECK:}
+
+sil @$undefTFUInt64 : $@convention(thin) () -> TensorHandle<UInt64>  {
+bb0:
+ return undef : $TensorHandle<UInt64>
+}
+// CHECK-LABEL: --- TFPartition GraphDef Proto: $undefTFUInt64
+// CHECK: library {
+// CHECK:  function {
+// CHECK:  node_def {
+// CHECK:      name: "UndefConst$TensorHandle<UInt64>"
+// CHECK:      op: "Const"
+// CHECK:      attr {
+// CHECK:        key: "dtype"
+// CHECK:        value {
+// CHECK:          type: DT_UINT64
+// CHECK:        }
+// CHECK:      }
+// CHECK:      attr {
+// CHECK:        key: "value"
+// CHECK:        value {
+// CHECK:          tensor {
+// CHECK:            dtype: DT_UINT64
+// CHECK:            tensor_shape {
+// CHECK:            }
+// CHECK:            uint64_val: 2863311530
+// CHECK:          }
+// CHECK:        }
+// CHECK:      }
+// CHECK:    }
+// CHECK:  }
+// CHECK:}
+
+
+sil @$undefTFFloat : $@convention(thin) () -> TensorHandle<Float>  {
+bb0:
+ return undef : $TensorHandle<Float>
+}
+// CHECK-LABEL: --- TFPartition GraphDef Proto: $undefTFFloat
+// CHECK: library {
+// CHECK:  function {
+// CHECK:  node_def {
+// CHECK:      name: "UndefConst$TensorHandle<Float>"
+// CHECK:      op: "Const"
+// CHECK:      attr {
+// CHECK:        key: "dtype"
+// CHECK:        value {
+// CHECK:          type: DT_FLOAT
+// CHECK:        }
+// CHECK:      }
+// CHECK:      attr {
+// CHECK:        key: "value"
+// CHECK:        value {
+// CHECK:          tensor {
+// CHECK:            dtype: DT_FLOAT
+// CHECK:            tensor_shape {
+// CHECK:            }
+// CHECK:            float_val: 1
+// CHECK:          }
+// CHECK:        }
+// CHECK:      }
+// CHECK:    }
+// CHECK:  }
+// CHECK:}
+
+sil @$undefTFDouble : $@convention(thin) () -> TensorHandle<Double>  {
+bb0:
+ return undef : $TensorHandle<Double>
+}
+// CHECK-LABEL: --- TFPartition GraphDef Proto: $undefTFDouble
+// CHECK: library {
+// CHECK:  function {
+// CHECK:  node_def {
+// CHECK:      name: "UndefConst$TensorHandle<Double>"
+// CHECK:      op: "Const"
+// CHECK:      attr {
+// CHECK:        key: "dtype"
+// CHECK:        value {
+// CHECK:          type: DT_DOUBLE
+// CHECK:        }
+// CHECK:      }
+// CHECK:      attr {
+// CHECK:        key: "value"
+// CHECK:        value {
+// CHECK:          tensor {
+// CHECK:            dtype: DT_DOUBLE
+// CHECK:            tensor_shape {
+// CHECK:            }
+// CHECK:            double_val: 2
+// CHECK:          }
+// CHECK:        }
+// CHECK:      }
+// CHECK:    }
+// CHECK:  }
+// CHECK:}
+
+sil @$undefTFIntdd : $@convention(thin) () -> TensorHandle<UInt64>  {
+bb0:
+ return undef : $TensorHandle<UInt64>
+}
+

--- a/test/TensorFlow/undef_lowering.sil
+++ b/test/TensorFlow/undef_lowering.sil
@@ -17,7 +17,7 @@ bb0:
 // CHECK: library {
 // CHECK:  function {
 // CHECK:  node_def {
-// CHECK:      name: "UndefConst$TensorHandle<Bool>"
+// CHECK:      name: "UndefConstDTensorHandleLBoolG"
 // CHECK:      op: "Const"
 // CHECK:      attr {
 // CHECK:        key: "dtype"
@@ -48,7 +48,7 @@ bb0:
 // CHECK: library {
 // CHECK:  function {
 // CHECK:  node_def {
-// CHECK:      name: "UndefConst$TensorHandle<Int8>"
+// CHECK:      name: "UndefConstDTensorHandleLInt8G"
 // CHECK:      op: "Const"
 // CHECK:      attr {
 // CHECK:        key: "dtype"
@@ -79,7 +79,7 @@ bb0:
 // CHECK: library {
 // CHECK:  function {
 // CHECK:  node_def {
-// CHECK:      name: "UndefConst$TensorHandle<UInt8>"
+// CHECK:      name: "UndefConstDTensorHandleLUInt8G"
 // CHECK:      op: "Const"
 // CHECK:      attr {
 // CHECK:        key: "dtype"
@@ -110,7 +110,7 @@ bb0:
 // CHECK: library {
 // CHECK:  function {
 // CHECK:  node_def {
-// CHECK:      name: "UndefConst$TensorHandle<Int16>"
+// CHECK:      name: "UndefConstDTensorHandleLInt16G"
 // CHECK:      op: "Const"
 // CHECK:      attr {
 // CHECK:        key: "dtype"
@@ -141,7 +141,7 @@ bb0:
 // CHECK: library {
 // CHECK:  function {
 // CHECK:  node_def {
-// CHECK:      name: "UndefConst$TensorHandle<UInt16>"
+// CHECK:      name: "UndefConstDTensorHandleLUInt16G"
 // CHECK:      op: "Const"
 // CHECK:      attr {
 // CHECK:        key: "dtype"
@@ -173,7 +173,7 @@ bb0:
 // CHECK: library {
 // CHECK:  function {
 // CHECK:  node_def {
-// CHECK:      name: "UndefConst$TensorHandle<Int32>"
+// CHECK:      name: "UndefConstDTensorHandleLInt32G"
 // CHECK:      op: "Const"
 // CHECK:      attr {
 // CHECK:        key: "dtype"
@@ -204,7 +204,7 @@ bb0:
 // CHECK: library {
 // CHECK:  function {
 // CHECK:  node_def {
-// CHECK:      name: "UndefConst$TensorHandle<UInt32>"
+// CHECK:      name: "UndefConstDTensorHandleLUInt32G"
 // CHECK:      op: "Const"
 // CHECK:      attr {
 // CHECK:        key: "dtype"
@@ -235,7 +235,7 @@ bb0:
 // CHECK: library {
 // CHECK:  function {
 // CHECK:  node_def {
-// CHECK:      name: "UndefConst$TensorHandle<Int64>"
+// CHECK:      name: "UndefConstDTensorHandleLInt64G"
 // CHECK:      op: "Const"
 // CHECK:      attr {
 // CHECK:        key: "dtype"
@@ -266,7 +266,7 @@ bb0:
 // CHECK: library {
 // CHECK:  function {
 // CHECK:  node_def {
-// CHECK:      name: "UndefConst$TensorHandle<UInt64>"
+// CHECK:      name: "UndefConstDTensorHandleLUInt64G"
 // CHECK:      op: "Const"
 // CHECK:      attr {
 // CHECK:        key: "dtype"
@@ -298,7 +298,7 @@ bb0:
 // CHECK: library {
 // CHECK:  function {
 // CHECK:  node_def {
-// CHECK:      name: "UndefConst$TensorHandle<Float>"
+// CHECK:      name: "UndefConstDTensorHandleLFloatG"
 // CHECK:      op: "Const"
 // CHECK:      attr {
 // CHECK:        key: "dtype"
@@ -329,7 +329,7 @@ bb0:
 // CHECK: library {
 // CHECK:  function {
 // CHECK:  node_def {
-// CHECK:      name: "UndefConst$TensorHandle<Double>"
+// CHECK:      name: "UndefConstDTensorHandleLDoubleG"
 // CHECK:      op: "Const"
 // CHECK:      attr {
 // CHECK:        key: "dtype"
@@ -352,8 +352,4 @@ bb0:
 // CHECK:  }
 // CHECK:}
 
-sil @$undefTFIntdd : $@convention(thin) () -> TensorHandle<UInt64>  {
-bb0:
- return undef : $TensorHandle<UInt64>
-}
 

--- a/test/TensorFlowRuntime/sese_loop_canonicalization.swift
+++ b/test/TensorFlowRuntime/sese_loop_canonicalization.swift
@@ -1,0 +1,48 @@
+// RUN: %target-run-sese-loops-swift
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize
+
+import TensorFlow
+import TensorFlowUnittest
+import StdlibUnittest
+
+var ControlFlowTests = TestSuite("ControlFlow")
+
+func powerOfTwo(_ N: Int32) -> Tensor<Float>{
+  var a = Tensor<Float>(1.0)
+  for _ in 0..<N {
+    a += a
+  }
+  return a
+}
+
+ControlFlowTests.testAllBackends("powerOfTwo") {
+  expectNearlyEqualWithScalarTensor(2.0, powerOfTwo(1))
+  expectNearlyEqualWithScalarTensor(4.0, powerOfTwo(2))
+  expectNearlyEqualWithScalarTensor(8.0, powerOfTwo(3))
+  expectNearlyEqualWithScalarTensor(1024.0, powerOfTwo(10))
+}
+
+func natSumWithBreak(_ breakIndex: Int32) -> Tensor<Int32> {
+  var i: Int32 = 1
+  var sum = Tensor<Int32>(0);
+  let maxCount: Int32 = 100
+  while i <= maxCount {
+    sum += i
+    if (i == breakIndex) {
+      break;
+    }
+    i += 1
+  }
+  return sum;
+}
+
+ControlFlowTests.testAllBackends("natSumWithBreak") {
+  expectEqualWithScalarTensor(3, natSumWithBreak(2))
+  expectEqualWithScalarTensor(55, natSumWithBreak(10))
+  expectEqualWithScalarTensor(5050, natSumWithBreak(-300))
+  expectEqualWithScalarTensor(5050, natSumWithBreak(100))
+  expectEqualWithScalarTensor(5050, natSumWithBreak(200))
+}
+
+runAllTests()

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -711,6 +711,9 @@ if run_vendor == 'apple':
             # SWIFT_ENABLE_TENSORFLOW
             config.target_run_simple_swift_strict_da = (
                 "%s %%s -Xllvm -tf-strict-deabstraction" % (target_run_base))
+            # SWIFT_ENABLE_TENSORFLOW
+            config.target_run_simple_swift_sese_loops = (
+                "%s %%s -Xllvm -tf-ensure-single-loop-exit" % (target_run_base))
             config.target_run_simple_swiftgyb = (
                 '%%empty-directory(%%t) && '
                 '%%gyb %%s -o %%t/main.swift && '
@@ -831,6 +834,8 @@ elif run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'wi
         # SWIFT_ENABLE_TENSORFLOW
         config.target_run_simple_swift_strict_da = (
             '%s %%s -Xllvm -tf-strict-deabstraction' % (target_run_base))
+        config.target_run_simple_swift_sese_loops = (
+            '%s %%s -Xllvm -tf-ensure-single-loop-exit' % (target_run_base))
         config.target_run_simple_swiftgyb = (
             '%%empty-directory(%%t) && '
             '%%gyb %%s -o %%t/main.swift && '
@@ -1014,6 +1019,14 @@ if not getattr(config, 'target_run_simple_swift', None):
         '%s %%t/a.out &&'
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, swift_tensorflow_linker_options, config.target_codesign, config.target_run))
+    # SWIFT_ENABLE_TENSORFLOW
+    config.target_run_simple_swift_sese_loops = (
+        '%%empty-directory(%%t) && '
+        '%s %s %%s -Xllvm -tf-ensure-single-loop-exit -o %%t/a.out -module-name main %s && '
+        '%s %%t/a.out &&'
+        '%s %%t/a.out'
+        % (config.target_build_swift, mcp_opt, swift_tensorflow_linker_options, config.target_codesign, config.target_run))
+
     config.target_run_simple_opt_O_swift = (
         '%%empty-directory(%%t) && '
         '%s %s -O %%s -o %%t/a.out -module-name main %s && '
@@ -1151,6 +1164,8 @@ config.substitutions.append(('%target-run-simple-swift-swift3', config.target_ru
 config.substitutions.append(('%target-run-simple-swift', config.target_run_simple_swift))
 # SWIFT_ENABLE_TENSORFLOW
 config.substitutions.append(('%target-run-strict-da-swift', config.target_run_simple_swift_strict_da))
+# SWIFT_ENABLE_TENSORFLOW
+config.substitutions.append(('%target-run-sese-loops-swift', config.target_run_simple_swift_sese_loops))
 config.substitutions.append(('%target-run-simple-opt-O-swift', config.target_run_simple_opt_O_swift))
 config.substitutions.append(('%target-run-simple-opt-Osize-swift', config.target_run_simple_opt_Osize_swift))
 config.substitutions.append(('%target-run-stdlib-swiftgyb-swift3', config.target_run_stdlib_swiftgyb_swift3))


### PR DESCRIPTION
<!-- What's in this pull request? -->
The lowering graph just converts undefs that are encountered into some arbitrary constants. These values should not matter as they will never be used in the calculations. This is a stop gap solution until we get rid of undefs during SESE canonicalization pass. 

This patch also introduces the following:
  -  a LowerGraph pass to test out the undef lowering. 
  - a new configuration in lit.cfg that enables -tf-ensure-single-loop-exit, which will be removed once the sese code stabilizes and the flag is removed. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-7765](https://bugs.swift.org/browse/SR-7765).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
