### PR TITLE
Extend SILCombiner code to handle existential self concrete type propagation using ProtocolConformanceAnalysis

### DIFF
--- a/include/swift/SILOptimizer/Utils/Existential.h
+++ b/include/swift/SILOptimizer/Utils/Existential.h
@@ -88,9 +88,11 @@ struct ConcreteExistentialInfo {
 
   ConcreteExistentialInfo(ConcreteExistentialInfo &) = delete;
 
+  /// We do not not need to check for InitExistential not being not null
+  /// since if that were the case, we would have everything else null too.
   bool isValid() const {
-    return OpenedArchetype && OpenedArchetypeDef && InitExistential
-           && ConcreteType && !ExistentialSubs.empty() && ConcreteValue;
+    return OpenedArchetype && OpenedArchetypeDef && ConcreteType &&
+           !ExistentialSubs.empty() && ConcreteValue;
   }
 
   // Do a conformance lookup on ConcreteType with the given requirement, P. If P

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -291,6 +291,13 @@ private:
                                          WitnessMethodInst *WMI);
   SILInstruction *propagateConcreteTypeOfInitExistential(FullApplySite Apply);
 
+  // Common utility function to replace the WitnessMethodInst using a
+  // BuilderCtx.
+  void replaceWitnessMethodInst(FullApplySite Apply, WitnessMethodInst *WMI,
+                                SILBuilderContext &BuilderCtx,
+                                const CanType &ConcreteType,
+                                const ProtocolConformanceRef ConformanceRef);
+
   /// Perform one SILCombine iteration.
   bool doOneIteration(SILFunction &F, unsigned Iteration);
 


### PR DESCRIPTION
Extend SILCombiner code to handle existential self concrete type propagation using ProtocolConformanceAnalysis.

Prior PR: 

