### PR TITLE
[IRGen] Emit type information for CodeView

### DIFF
--- a/stdlib/public/Platform/Windows/Swift.natvis
+++ b/stdlib/public/Platform/Windows/Swift.natvis
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+
+  <Type Name="Swift::Int">
+    <DisplayString>{_value}</DisplayString>
+    <Expand HideRawView="true"></Expand>
+  </Type>
+  <Type Name="Swift::Int8">
+    <DisplayString>{_value}</DisplayString>
+    <Expand HideRawView="true"></Expand>
+  </Type>
+  <Type Name="Swift::Int16">
+    <DisplayString>{_value}</DisplayString>
+    <Expand HideRawView="true"></Expand>
+  </Type>
+  <Type Name="Swift::Int32">
+    <DisplayString>{_value}</DisplayString>
+    <Expand HideRawView="true"></Expand>
+  </Type>
+  <Type Name="Swift::Int64">
+    <DisplayString>{_value}</DisplayString>
+    <Expand HideRawView="true"></Expand>
+  </Type>
+
+  <Type Name="Swift::UInt">
+    <DisplayString>{_value}</DisplayString>
+    <Expand HideRawView="true"></Expand>
+  </Type>
+  <Type Name="Swift::UInt8">
+    <DisplayString>{_value}</DisplayString>
+    <Expand HideRawView="true"></Expand>
+  </Type>
+  <Type Name="Swift::UInt16">
+    <DisplayString>{_value}</DisplayString>
+    <Expand HideRawView="true"></Expand>
+  </Type>
+  <Type Name="Swift::UInt32">
+    <DisplayString>{_value}</DisplayString>
+    <Expand HideRawView="true"></Expand>
+  </Type>
+  <Type Name="Swift::UInt64">
+    <DisplayString>{_value}</DisplayString>
+    <Expand HideRawView="true"></Expand>
+  </Type>
+
+  <Type Name="Swift::Bool">
+    <DisplayString>{_value}</DisplayString>
+    <Expand HideRawView="true"></Expand>
+  </Type>
+
+  <Type Name="Swift::Float">
+    <DisplayString>{_value}</DisplayString>
+    <Expand HideRawView="true"></Expand>
+  </Type>
+  <Type Name="Swift::Float32">
+    <DisplayString>{_value}</DisplayString>
+    <Expand HideRawView="true"></Expand>
+  </Type>
+  <Type Name="Swift::Float64">
+    <DisplayString>{_value}</DisplayString>
+    <Expand HideRawView="true"></Expand>
+  </Type>
+
+  <Type Name="Swift::Double">
+    <DisplayString>{_value}</DisplayString>
+    <Expand HideRawView="true"></Expand>
+  </Type>
+
+  <!--
+    TODO: It would be better to recognize ``Swift::[*]`` as a Swift Array,
+    but it looks like natvis will only recognize the type this way.
+  -->
+  <Type Name="Swift::Array&lt;*&gt;">
+    <!-- See lldb/source/Plugins/Language/Swift/SwiftArray.cpp -->
+    <DisplayString Condition="(_storage == 0) || (_storage->_count == 0)">
+      0 values
+    </DisplayString>
+    <DisplayString Condition="_storage->_count == 1">1 value</DisplayString>
+    <DisplayString>{_storage->_count} values</DisplayString>
+    <Expand HideRawView="true">
+      <ArrayItems>
+        <Size>_storage->_count</Size>
+        <ValuePointer>&amp;_storage->_firstElement</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
+
+  <!--
+    Currently, this will only tell you the number of characters in the string.
+    While it is probably possible to view the string, it would be very
+    difficult to maintain and natvis is probably not the best tool for this.
+    However, there is an extension for WinDbg that allows users to view Swift
+    Strings.
+  -->
+  <Type Name="Swift::String">
+    <!-- See lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp -->
+
+    <!-- Swift Native string -->
+    <DisplayString Condition="!((long long)_guts._object._object &amp; 0x6000000000000000)">
+      Count = {_guts._otherBits._value &amp; ((1ULL &lt;&lt; 48) - 1)}
+    </DisplayString>
+
+    <!-- NSStrings pointer -->
+    <DisplayString Condition="((long long)_guts._object._object &amp; 0x4000000000000000)
+                  &amp;&amp; !((long long)_guts._object._object &amp; 0x8000000000000000)">
+      Viewing NSString strings is not yet implemented
+    </DisplayString>
+
+    <!-- NSStrings inlined -->
+    <DisplayString Condition="((long long)_guts._object._object &amp; 0xC000000000000000)
+                  &amp;&amp; !((long long)_guts._object._object &amp; 0x2000000000000000)">
+      Viewing NSString inlined strings is not yet implemented
+    </DisplayString>
+
+    <!-- Small UTF-8 string -->
+    <DisplayString Condition="(long long)_guts._object._object &amp; 0xE000000000000000">
+      Count = {((long long)_guts._object._object &amp; 0x0F00000000000000) &gt;&gt; 56}
+    </DisplayString>
+
+    <Expand HideRawView="true">
+      <Item Name="Note">
+        "Viewing Swift Strings in Visual Studio is not yet implemented"
+      </Item>
+    </Expand>
+  </Type>
+
+  <!-- See lldb/source/Plugins/Language/Swift/SwiftOptional.cpp -->
+  <!--
+    FIXME: Optional enums with raw values are a special case and
+           do not render correctly.
+  -->
+  <Type Name="Swift::Optional&lt;Bool&gt;">
+    <!-- It looks like `Bool?` is a special case -->
+    <DisplayString Condition="*(long long *)this == 0">false</DisplayString>
+    <DisplayString Condition="*(long long *)this == 1">true</DisplayString>
+    <DisplayString>nil</DisplayString>
+    <Expand HideRawView="true"></Expand>
+  </Type>
+  <Type Name="Swift::Optional&lt;*&gt;">
+    <DisplayString Condition="*(long long *)this == 0">nil</DisplayString>
+    <DisplayString>{some}</DisplayString>
+    <Expand HideRawView="true">
+      <ExpandedItem Condition="*(long long *)this != 0">some</ExpandedItem>
+    </Expand>
+  </Type>
+
+  <!--
+    FIXME: This does not work in some cases, e.g., `[Float:Int?]`.
+  -->
+  <Type Name="Swift::Dictionary&lt;*&gt;">
+    <DisplayString Condition="_storage == 0 || _storage->count == 0">
+      0 key/value pairs
+    </DisplayString>
+    <DisplayString Condition="_storage->count == 1">
+      1 key/value pair
+    </DisplayString>
+    <DisplayString>{_storage->count} key/value pairs</DisplayString>
+    <Expand HideRawView="true">
+      <CustomListItems Condition="_storage != 0">
+        <Variable Name="index" InitialValue="(long long)0"/>
+        <Variable Name="HasKeyAtIndex" InitialValue="false"/>
+        <Variable Name="Word" InitialValue="(long long)0"/>
+        <Variable Name="BitMask" InitialValue="(long long)0"/>
+
+        <Size>_storage->count</Size>
+        <Loop>
+          <Break Condition="index &gt;= _storage->bucketCount"/>
+          <Exec>Word = index / 64</Exec>
+          <Exec>BitMask = 1ULL &lt;&lt; (index % 64)</Exec>
+          <Exec>
+            HasKeyAtIndex = _storage->initializedEntries[Word] &amp; BitMask
+          </Exec>
+          <If Condition="HasKeyAtIndex">
+            <Item Name="{_storage->keys[index]}">_storage->values[index]</Item>
+          </If>
+          <Exec>index++</Exec>
+        </Loop>
+      </CustomListItems>
+    </Expand>
+  </Type>
+</AutoVisualizer>

--- a/stdlib/public/Platform/Windows/SwiftWinDbg/SwiftWinDbg.cpp
+++ b/stdlib/public/Platform/Windows/SwiftWinDbg/SwiftWinDbg.cpp
@@ -1,0 +1,134 @@
+//===-- Windows/SwiftWinDbg.cpp - Extension for WinDbg ----------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This is an extension used for reading Swift strings in WinDbg.
+///
+//===----------------------------------------------------------------------===//
+#define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
+#include <windows.h>
+#define KDEXT_64BIT
+#include <dbgeng.h>
+#include <wdbgexts.h>
+#include <stdint.h>
+
+WINDBG_EXTENSION_APIS ExtensionApis = {0};
+
+extern "C" _declspec(dllexport)
+LPEXT_API_VERSION WDBGAPI ExtensionApiVersion(void) {
+  static EXT_API_VERSION g_ExtApiVersion = {1, 0, EXT_API_VERSION_NUMBER64, 0};
+  return &g_ExtApiVersion;
+}
+
+extern "C" _declspec(dllexport)
+void WDBGAPI WinDbgExtensionDllInit(PWINDBG_EXTENSION_APIS64 lpExtensionApis,
+                                    unsigned short MajorVersion,
+                                    unsigned short MinorVersion) {
+  ExtensionApis = *lpExtensionApis;
+}
+
+/// Returns a pointer to the string extracted from a Swift String.
+/// If nullptr is returned, `PayloadAddress` holds the debugee address of the
+/// string if nonzero. If nullptr is returned and `PayloadAddress` is zero
+/// then the string was not successfully extracted. `Count` holds the number
+/// of characters in the string.
+char *extractString(uint64_t StringObject, uint64_t StringOtherBits,
+                    uint64_t &Count, uint64_t &PayloadAddress) {
+  // See StringGuts_SummaryProvider() at
+  // swift-lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+  PayloadAddress = 0;
+  bool isValue = StringObject & (1ULL << 63);
+  bool isCocoaOrSmall = StringObject & (1ULL << 62);
+  bool isOpaque = StringObject & (1ULL << 61);
+  bool isUTF16 = StringObject & (1ULL << 60);
+
+  if (!isOpaque && !isCocoaOrSmall) {
+    // Handle native Swift string
+    PayloadAddress = StringObject & ((1ULL << 56) - 1);
+    Count = StringOtherBits & ((1ULL << 48) - 1);
+    if (!isValue)
+      PayloadAddress += 32;
+    return nullptr;
+  } else if (isCocoaOrSmall && !isValue) {
+    dprintf("Strings which point to NSStrings are not implemented\n");
+    return nullptr;
+  } else if (isCocoaOrSmall && isValue && !isOpaque) {
+    dprintf("Strings which contain an NSString inline are not implemented\n");
+    return nullptr;
+  } // else if (isCocoaOrSmall && isValue && isOpaque)
+  // Handle UTF-8 string stored in registers
+  // _object = isSmallUTF8Nibble << 60 | count << 56 | c_14 << 48 | ... | c_8
+  // _otherBits = c_7 << 56 | c_6 << 48 | ... | c_0
+  Count = (StringObject & 0x0F00000000000000) >> 56;
+  char *StringBuffer = (char *)malloc(Count+1);
+  for (uint64_t idx = 0; idx < Count; idx++) {
+    if (idx < 8)
+      StringBuffer[idx] = (StringOtherBits >> (idx * 8)) & 0xFF;
+    else
+      StringBuffer[idx] = (StringObject >> ((idx - 8) * 8)) & 0xFF;
+  }
+  StringBuffer[Count] = '\0';
+  return StringBuffer;
+}
+
+extern "C" _declspec(dllexport)
+void help(void *hCurrentProcess, void *hCurrentThread, uint64_t dwCurrentPc,
+          unsigned long dwProcessor, const char *args) {
+  dprintf("Swift WinDbg Extension\n");
+  dprintf("Author: Ellis Hoag\n\n");
+  dprintf("\treadstring <variable> - Read the contents of a Swift String\n");
+}
+
+extern "C" _declspec(dllexport)
+void readstring(void *hCurrentProcess, void *hCurrentThread,
+                uint64_t dwCurrentPc, unsigned long dwProcessor,
+                const char *args) {
+  uint64_t StringGuts = GetExpression(args);
+  if (StringGuts == 0) {
+    dprintf("Could not find address of %s\n", args);
+    return;
+  }
+  const char *Name = args;
+
+  uint64_t StringObject;
+  if (GetFieldValue(StringGuts, "Swift::_StringGuts", "_object",
+                    StringObject)) {
+    dprintf("Unable to get _object field from Swift::_StringGuts at %p\n",
+            StringGuts);
+    return;
+  }
+
+  uint64_t StringOtherBits;
+  if (GetFieldValue(StringGuts, "Swift::_StringGuts", "_otherBits",
+                    StringOtherBits)) {
+    dprintf("Unable to get _otherBits field from Swift::_StringGuts at %p\n",
+            StringGuts);
+    return;
+  }
+
+  uint64_t Count, PayloadAddress;
+  char *StringContents = extractString(StringObject, StringOtherBits, Count,
+                                       PayloadAddress);
+  if (StringContents || PayloadAddress) {
+    if (PayloadAddress) {
+      StringContents = (char *)malloc(Count + 1);
+      if (!ReadMemory(PayloadAddress, StringContents, Count, NULL)) {
+        dprintf("Could not read string at %p\n", PayloadAddress);
+        free(StringContents);
+        return;
+      }
+      StringContents[Count] = '\0';
+    }
+    dprintf("%p %s = \"%s\"\n", StringGuts, Name, StringContents);
+    free(StringContents);
+  }
+}

--- a/stdlib/public/Platform/Windows/SwiftWinDbg/SwiftWinDbgTest.cpp
+++ b/stdlib/public/Platform/Windows/SwiftWinDbg/SwiftWinDbgTest.cpp
@@ -1,0 +1,98 @@
+//===-- Windows/SwiftWinDbgTest.cpp - Tests SwiftWinDbg.cpp -----*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This contains tests for SwiftWinDbg.cpp
+///
+//===----------------------------------------------------------------------===//
+#include "CppUnitTest.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+char *extractString(uint64_t StringObject, uint64_t StringOtherBits,
+                    uint64_t &Count, uint64_t &PayloadAddress);
+
+namespace SwiftWinDbgTest {
+
+TEST_CLASS(StringUnitTest) {
+public:
+  // NOTE: Use this Swift function to get the internal bits of a `String` and
+  //       generate new testcases.
+  // // Print out the internal type and internal bits of a Swift String.
+  // func printStringGuts(_ str: String) {
+  //   var strCopy = str
+  //   let _guts = UnsafeMutableRawPointer(&strCopy)
+  //   let _object = _guts.load(as: UInt64.self)
+  //   let _otherBits = _guts.load(fromByteOffset: 8, as: UInt64.self)
+  //   let objectHex = String(_object, radix: 16).uppercased()
+  //   let otherBitsHex = String(_otherBits, radix: 16).uppercased()
+  // 
+  //   func getStringType(_ bits: UInt64) -> String {
+  //     let isValue = bits & (1 << 63) != 0
+  //     let isCocoaOrSmall = bits & (1 << 62) != 0
+  //     let isOpaque = bits & (1 << 61) != 0
+  //     if (!isOpaque && !isCocoaOrSmall) {
+  //       return "Native"
+  //     } else if (isCocoaOrSmall && !isValue) {
+  //       return "NSString"
+  //     } else if (isCocoaOrSmall && isValue && !isOpaque) {
+  //       return "NSString Inlined"
+  //     } else {
+  //       return "UTF-8 Inlined"
+  //     }
+  //   }
+  //   let type = getStringType(_object)
+  // 
+  //   print("\"\(str)\" (\(type)) = {_object = 0x\(objectHex), " +
+  //                                 "_otherBits = 0x\(otherBitsHex)}")
+  // }
+
+  TEST_METHOD(InlinedString){
+    uint64_t StringObject, StringOtherBits, Count, PayloadAddress;
+    char *StringBuffer;
+
+    // printStringGuts("<= 15 chars")
+    StringObject = 0xEB00000000737261;
+    StringOtherBits = 0x6863203531203D3C;
+
+    StringBuffer = extractString(StringObject, StringOtherBits,
+                                 Count, PayloadAddress);
+    Assert::AreEqual("<= 15 chars", StringBuffer);
+    Assert::AreEqual((uint64_t)11, Count);
+
+    // printStringGuts("Hello ...World?")
+    StringObject = 0xEF3F646C726F572E;
+    StringOtherBits = 0x2E2E206F6C6C6548;
+
+    StringBuffer = extractString(StringObject, StringOtherBits,
+                                 Count, PayloadAddress);
+    Assert::AreEqual("Hello ...World?", StringBuffer);
+    Assert::AreEqual((uint64_t)15, Count);
+  }
+
+  TEST_METHOD(NativeString) {
+    uint64_t StringObject, StringOtherBits, Count, PayloadAddress;
+    char *StringBuffer;
+
+    // printStringGuts("This is a very long Native Swift String")
+    StringObject = 0x80007F4DD4E2B040;
+    StringOtherBits = 0x27;
+
+    StringBuffer = extractString(StringObject, StringOtherBits,
+                                 Count, PayloadAddress);
+    Assert::AreEqual(nullptr, StringBuffer);
+    Assert::AreEqual((uint64_t)39, Count);
+    Assert::AreEqual((uint64_t)0x00007F4DD4E2B040, PayloadAddress);
+  }
+};
+
+}

--- a/test/DebugInfo/array-codeview.swift
+++ b/test/DebugInfo/array-codeview.swift
@@ -1,0 +1,17 @@
+// RUN: %swiftc_driver %s -g -debug-info-format=codeview -emit-ir -o - | %FileCheck %s
+
+func foo() {
+  var myArray: [Int64] = [101, 102, 103]
+}
+
+// CHECK-DAG: ![[INT64:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Int64"
+// CHECK-DAG: ![[INT64BASE:[0-9]+]] = !DIBasicType(name: "$SBi64_D", size: 64, encoding: DW_ATE_unsigned)
+
+// CHECK-DAG: !DILocalVariable(name: "myArray",{{.*}} type: ![[ARRAY:[0-9]+]])
+// CHECK-DAG: ![[ARRAY]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Array<Int64>",{{.*}} size: 64,
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "_storage",{{.*}} baseType: ![[ARRAYSTORAGEPTR:[0-9]+]], size: 64)
+// CHECK-DAG: ![[ARRAYSTORAGEPTR]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[ARRAYSTORAGE:[0-9]+]], size: 64)
+
+// CHECK-DAG: ![[ARRAYSTORAGE]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Array<Int64>_storage",{{.*}} size: 256,
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "_count",{{.*}} baseType: ![[INT64BASE]], size: 64, offset: 128)
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "_firstElement",{{.*}} baseType: ![[INT64]], offset: 256)

--- a/test/DebugInfo/dictionary-codeview.swift
+++ b/test/DebugInfo/dictionary-codeview.swift
@@ -1,0 +1,25 @@
+// RUN: %swiftc_driver %s -g -debug-info-format=codeview -emit-ir -o - | %FileCheck %s
+
+func foo() {
+  var myDictionary: [Int64 : Float] = [1729: 2.718]
+}
+
+// CHECK-DAG: ![[INT64:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Int64"
+// CHECK-DAG: ![[INT64PTR:[0-9]+]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[INT64]], size: 64)
+// CHECK-DAG: ![[FLOAT:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Float"
+// CHECK-DAG: ![[FLOATPTR:[0-9]+]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[FLOAT]], size: 64)
+
+// CHECK-DAG: ![[INT64BASE:[0-9]+]] = !DIBasicType(name: "$SBi64_D", size: 64, encoding: DW_ATE_unsigned)
+// CHECK-DAG: ![[INT64BASEPTR:[0-9]+]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[INT64BASE]], size: 64)
+
+// CHECK-DAG: !DILocalVariable(name: "myDictionary",{{.*}} type: ![[DICTIONARY:[0-9]+]])
+// CHECK-DAG: ![[DICTIONARY]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Dictionary<Int64,Float>",{{.*}} size: 64
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "_storage",{{.*}}, baseType: ![[STORAGEPTR:[0-9]+]], size: 64)
+// CHECK-DAG: ![[STORAGEPTR]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[STORAGETYPE:[0-9]+]], size: 64)
+
+// CHECK-DAG: ![[STORAGETYPE]] = !DICompositeType(tag: DW_TAG_structure_type, name: "_RawNativeDictionaryStorage<Int64,Float>",{{.*}} size: 576
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "bucketCount",{{.*}} baseType: ![[INT64BASE]], size: 64, offset: 128)
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "count",{{.*}} baseType: ![[INT64BASE]], size: 64, offset: 192)
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "initializedEntries",{{.*}} baseType: ![[INT64BASEPTR]], size: 64, offset: 256)
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "keys",{{.*}} baseType: ![[INT64PTR]], size: 64, offset: 384)
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "values",{{.*}} baseType: ![[FLOATPTR]], size: 64, offset: 448)

--- a/test/DebugInfo/enum-codeview.swift
+++ b/test/DebugInfo/enum-codeview.swift
@@ -1,0 +1,40 @@
+// RUN: %swiftc_driver %s -g -debug-info-format=codeview -emit-ir -o - | %FileCheck %s
+
+func foo() {
+  enum MyRawEnum { case Alpha, Beta } // Swift enum with no associated values.
+  var myRawEnumVar: MyRawEnum = .Beta
+
+  enum MyEnum { // Swift enum with associated values.
+  case Power(Float)
+  case Wisdom(Int64)
+  case Courage(Float)
+  }
+  var myEnumVar: MyEnum = .Courage(1.1)
+}
+
+// CHECK-DAG: ![[INT8BASE:[0-9]+]] = !DIBasicType(name: "$SBi8_D", size: 8, encoding: DW_ATE_unsigned)
+// CHECK-DAG: ![[INT64:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Int64"
+// CHECK-DAG: ![[FLOAT:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Float"
+
+// CHECK-DAG: !DILocalVariable(name: "myRawEnumVar",{{.*}} type: ![[MYRAWENUM:[0-9]+]])
+// CHECK-DAG: ![[MYRAWENUM]] = !DICompositeType(tag: DW_TAG_enumeration_type, name: "MyRawEnum",{{.*}} baseType: ![[INT8BASE]], size: 8, elements: ![[RAWENUMCASES:[0-9]+]],
+// CHECK-DAG: ![[RAWENUMCASES]] = !{![[ALPHA:[0-9]+]], ![[BETA:[0-9]+]]}
+// CHECK-DAG: ![[ALPHA]] = !DIEnumerator(name: "Alpha", value: 0)
+// CHECK-DAG: ![[BETA]] = !DIEnumerator(name: "Beta", value: 1)
+
+// CHECK-DAG: !DILocalVariable(name: "myEnumVar",{{.*}} type: ![[MYENUM:[0-9]+]])
+// CHECK-DAG: ![[MYENUM]] = !DICompositeType(tag: DW_TAG_structure_type, name: "MyEnum",{{.*}} size: 72, elements: ![[ENUMELEMS:[0-9]+]],
+// CHECK-DAG: ![[ENUMELEMS]] = !{![[VALUETYPE:[0-9]+]], ![[ASSOCIATEDVALUE:[0-9]+]]}
+
+// CHECK-DAG: ![[VALUETYPE]] = !DIDerivedType(tag: DW_TAG_member, name: "Case",{{.*}} baseType: ![[ENUM:[0-9]+]], size: 8, offset: 64)
+// CHECK-DAG: ![[ENUM]] = !DICompositeType(tag: DW_TAG_enumeration_type,{{.*}} baseType: ![[INT8BASE]], size: 8, elements: ![[ENUMCASES:[0-9]+]])
+// CHECK-DAG: ![[ENUMCASES]] = !{![[PCASE:[0-9]+]], ![[WCASE:[0-9]+]], ![[CCASE:[0-9]+]]}
+// CHECK-DAG: ![[PCASE]] = !DIEnumerator(name: "Power", value: 0)
+// CHECK-DAG: ![[WCASE]] = !DIEnumerator(name: "Wisdom", value: 1)
+// CHECK-DAG: ![[CCASE]] = !DIEnumerator(name: "Courage", value: 2)
+
+// CHECK-DAG: ![[ASSOCIATEDVALUE]] = !DIDerivedType(tag: DW_TAG_member, name: "AssociatedValue",{{.*}} baseType: ![[UNION:[0-9]+]], size: 64)
+// CHECK-DAG: ![[UNION]] = !DICompositeType(tag: DW_TAG_union_type,{{.*}} size: 64, elements: ![[ENUMVALUES:[0-9]+]],
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "Power",{{.*}} baseType: ![[FLOAT]], size: 32)
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "Wisdom",{{.*}} baseType: ![[INT64]], size: 64)
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "Courage",{{.*}} baseType: ![[FLOAT]], size: 32)

--- a/test/DebugInfo/type-codeview.swift
+++ b/test/DebugInfo/type-codeview.swift
@@ -1,0 +1,46 @@
+// RUN: %swiftc_driver %s -g -debug-info-format=codeview -emit-ir -o - | %FileCheck %s
+
+struct MyStruct { // NOTE: Classes do not work in Windows yet.
+  init(_ arg: Int64) {
+    // CHECK-DAG: !DILocalVariable(name: "self",{{.*}} type: ![[MYSTRUCT:[0-9]+]])
+    // CHECK-DAG: ![[MYSTRUCT]] = !DICompositeType(tag: DW_TAG_structure_type, name: "MyStruct",{{.*}} size: 128, elements: ![[MYSTRUCTELEMS:[0-9]+]],
+    // CHECK-DAG: ![[MYSTRUCTELEMS]] = !{![[MYVAL:[0-9]+]], ![[MYBOOL:[0-9]+]], ![[MYFLOAT32:[0-9]+]]}
+    self.myVal = arg
+    // CHECK-DAG: !DILocalVariable(name: "arg",{{.*}} type: ![[INT64:[0-9]+]])
+    // CHECK-DAG: ![[INT64]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Int64",{{.*}} size: 64, elements:
+  }
+  var myVal: Int64
+  // CHECK-DAG: ![[MYVAL]] = !DIDerivedType(tag: DW_TAG_member, name: "myVal",{{.*}} size: 64)
+  // CHECK-DAG: ![[BASICINT64:[0-9]+]] = !DIBasicType(name: "$SBi64_D", size: 64, encoding: DW_ATE_unsigned)
+  var myBool: Bool = false
+  // CHECK-DAG: ![[MYBOOL]] = !DIDerivedType(tag: DW_TAG_member, name: "myBool",{{.*}} size: 8, offset: 64)
+  // NOTE: CodeView only recognizes boolean variables with 8 bits.
+  // CHECK-DAG: !DIBasicType(name: "$SBi1_D", size: 8, encoding: DW_ATE_boolean)
+  var myFloat: Float32 = 1.234
+  // CHECK-DAG: ![[MYFLOAT32]] = !DIDerivedType(tag: DW_TAG_member, name: "myFloat",{{.*}} baseType: ![[FLOAT32:[0-9]+]], size: 32, offset: 72)
+  // CHECK-DAG: !DIBasicType(name: "$SBf32_D", size: 32, encoding: DW_ATE_float)
+}
+func foo() {
+  var myTuple: (real: Double, imaginary: Double, String) = (1.1, 2.2, "number")
+  // CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "(real: Swift.Double, imaginary: Swift.Double, Swift.String)",{{.*}} elements: ![[TUPLEELEMS:[0-9]+]],{{.*}} identifier: "$SSd4real_Sd9imaginarySStD"
+  // CHECK-DAG: ![[TUPLEELEMS]] = !{![[REALTYPE:[0-9]+]], ![[IMAGINARYTYPE:[0-9]+]], ![[STRINGTYPE:[0-9]+]]}
+  // CHECK-DAG: ![[REALTYPE]] = !DIDerivedType(tag: DW_TAG_member, name: "real",
+  // CHECK-DAG: ![[IMAGINARYTYPE]] = !DIDerivedType(tag: DW_TAG_member, name: "imaginary",
+  // NOTE: If the name of the element was not specified, use the element index.
+  // CHECK-DAG: ![[STRINGTYPE]] = !DIDerivedType(tag: DW_TAG_member, name: "2",
+
+  var myOptional: Int64? = nil
+  // CHECK-DAG: !DILocalVariable(name: "myOptional",{{.*}} type: ![[OPTIONAL:[0-9]+]])
+  // CHECK-DAG: ![[OPTIONAL]] = !DICompositeType(tag: DW_TAG_union_type, name: "Optional<Int64>",
+  // CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "some",{{.*}} baseType: ![[INT64]], size: 64, align: 64)
+  // FIXME: Optional enums with raw values are apparently a special case and
+  //        do not render correctly in Visual Studio.
+}
+
+// TODO: Character: In LLDB, a Swift Character is shown as an integral type and
+// the same behavior appears in WinDbg. I'm not sure if WinDbg can handle UTF-16
+// characters but if it can it might be nice to figure out how to get WinDbg to
+// display a Swift Character.
+
+// TODO: Globals are not shown in WinDbg, but they are not shown in LLDB either.
+// This is probably because they are declared as hidden in the LLVM-IR.

--- a/test/DebugInfo/type-codeview.swift
+++ b/test/DebugInfo/type-codeview.swift
@@ -20,6 +20,15 @@ struct MyStruct { // NOTE: Classes do not work in Windows yet.
   // CHECK-DAG: ![[MYFLOAT32]] = !DIDerivedType(tag: DW_TAG_member, name: "myFloat",{{.*}} baseType: ![[FLOAT32:[0-9]+]], size: 32, offset: 72)
   // CHECK-DAG: !DIBasicType(name: "$SBf32_D", size: 32, encoding: DW_ATE_float)
 }
+func useReference(_ inoutArg: inout Int64) {
+  // CHECK-DAG: distinct !DISubprogram(name: "useReference",{{.*}} type: ![[USEREFTYPE:[0-9]+]],
+  // CHECK-DAG: ![[USEREFTYPE]] = !DISubroutineType(types: ![[USEREFLIST:[0-9]+]])
+  // CHECK-DAG: ![[USEREFLIST]] = !{!{{[0-9]+}}, ![[INT64REF:[0-9]+]]}
+  // CHECK-DAG: ![[INT64REF]] = !DIDerivedType(tag: DW_TAG_reference_type, baseType: ![[INT64]], size: 64)
+  inoutArg += 1
+  // CHECK-DAG: ![[INOUTARG:[0-9]+]] = !DILocalVariable(name: "inoutArg", arg: 1,{{.*}} type: ![[INT64REF]])
+  // CHECK-DAG: call void @llvm.dbg.declare(metadata {{.*}}, metadata ![[INOUTARG:[0-9]+]], metadata !DIExpression())
+}
 func foo() {
   var myTuple: (real: Double, imaginary: Double, String) = (1.1, 2.2, "number")
   // CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "(real: Swift.Double, imaginary: Swift.Double, Swift.String)",{{.*}} elements: ![[TUPLEELEMS:[0-9]+]],{{.*}} identifier: "$SSd4real_Sd9imaginarySStD"


### PR DESCRIPTION
Summary:
1. Emit type information for structs (including Int, Float, Bool),
inout types, tuples, enums with raw values, Arrays, Optionals,
and Dictionaries.

2. Add natvis file for Visual Studio to read the type information from 1.

3. Add a WinDbg extension to read Swift Strings.

Test Plan:
test/DebugInfo/type-codeview.swift
test/DebugInfo/dictionary-codeview.swift
test/DebugInfo/array-codeview.swift
test/DebugInfo/enum-codeview.swift
stdlib/public/Platform/Windows/SwiftWinDbg/SwiftWinDbgTest.cpp