### PR TITLE
Generalize the recording of parsed accessors

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -257,13 +257,15 @@ ERROR(getset_nontrivial_pattern,none,
       "getter/setter can only be defined for a single variable", ())
 ERROR(expected_rbrace_in_getset,none,
       "expected '}' at end of variable get/set clause", ())
-ERROR(duplicate_property_accessor,none,
-      "duplicate definition of %0", (StringRef))
+ERROR(duplicate_accessor,none,
+      "%select{variable|subscript}0 already has %1", (unsigned, StringRef))
+ERROR(conflicting_accessor,none,
+      "%select{variable|subscript}0 cannot provide both %1 and %2",
+      (unsigned, StringRef, StringRef))
+ERROR(modify_mutatingness_different_from_setter,none,
+      "mutating-ness of 'modify' accessor cannot differ from setter", ())
 NOTE(previous_accessor,none,
-     "previous definition of %0 is here", (StringRef))
-ERROR(conflicting_property_addressor,none,
-      "%select{variable|subscript}0 already has a "
-      "%select{addressor|mutable addressor}1", (unsigned, unsigned))
+     "%select{|previous definition of }1%0 %select{defined |}1here", (StringRef, bool))
 ERROR(expected_accessor_name,none,
       "expected %select{%error|setter|%error|willSet|didSet}0 parameter name",
       (unsigned))
@@ -278,32 +280,22 @@ ERROR(expected_lbrace_accessor,PointsToFirstBadToken,
 ERROR(expected_accessor_kw,none,
       "expected 'get', 'set', 'willSet', or 'didSet' keyword to "
       "start an accessor definition",())
-ERROR(var_set_without_get,none,
-      "variable with a setter must also have a getter", ())
-ERROR(observingproperty_with_getset,none,
-      "%select{willSet|didSet}0 variable must not also have a "
-      "%select{get|set}1 specifier", (unsigned, unsigned))
-ERROR(observingproperty_with_address,none,
-      "variable with addressor may not have %select{willSet|didSet}0",
-      (unsigned))
-ERROR(observingproperty_in_subscript,none,
-      "%select{willSet|didSet}0 is not allowed in subscripts", (unsigned))
+ERROR(missing_getter,none,
+      "%select{variable|subscript}0 with %1 must also have a getter",
+      (unsigned, StringRef))
+ERROR(missing_reading_accessor,none,
+      "%select{variable|subscript}0 with %1 must also have "
+      "a getter or an addressor",
+      (unsigned, StringRef))
+ERROR(observing_accessor_conflicts_with_accessor,none,
+      "%select{'willSet'|'didSet'}0 cannot be provided together with %1",
+      (unsigned, StringRef))
+ERROR(observing_accessor_in_subscript,none,
+      "%select{'willSet'|'didSet'}0 is not allowed in subscripts", (unsigned))
 ERROR(getset_init,none,
       "variable with getter/setter cannot have an initial value", ())
 ERROR(getset_cannot_be_implied,none,
       "variable with implied type cannot have implied getter/setter", ())
-ERROR(mutableaddressor_without_address,none,
-      "%select{variable|subscript}0 must provide either a getter or "
-      "'address' if it provides 'mutableAddress'", (unsigned))
-ERROR(mutableaddressor_with_setter,none,
-      "%select{variable|subscript}0 cannot provide both 'mutableAddress' "
-      " and a setter", (unsigned))
-ERROR(addressor_with_getter,none,
-      "%select{variable|subscript}0 cannot provide both 'address' and "
-      "a getter", (unsigned))
-ERROR(addressor_with_setter,none,
-      "%select{variable|subscript}0 cannot provide both 'address' and "
-      "a setter; use an ordinary getter instead", (unsigned))
 ERROR(behavior_multiple_vars,none,
       "applying property behavior with parameter to multiple variables is "
       "not supported", ())

--- a/include/swift/AST/StorageImpl.h
+++ b/include/swift/AST/StorageImpl.h
@@ -274,7 +274,8 @@ public:
       return;
 
     case WriteImplKind::Set:
-      assert(readImpl == ReadImplKind::Get);
+      assert(readImpl == ReadImplKind::Get ||
+             readImpl == ReadImplKind::Address);
       assert(readWriteImpl == ReadWriteImplKind::MaterializeToTemporary ||
              readWriteImpl == ReadWriteImplKind::MaterializeForSet);
       return;

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -876,33 +876,9 @@ public:
 
   void consumeGetSetBody(AbstractFunctionDecl *AFD, SourceLoc LBLoc);
 
-  struct ParsedAccessors {
-    SourceLoc LBLoc, RBLoc;
-    SmallVector<AccessorDecl*, 16> Accessors;
-
-#define ACCESSOR(ID) AccessorDecl *ID = nullptr;
-#include "swift/AST/AccessorKinds.def"
-
-    void record(Parser &P, AbstractStorageDecl *storage, bool invalid,
-                ParseDeclOptions flags, SourceLoc staticLoc,
-                const DeclAttributes &attrs,
-                TypeLoc elementTy, ParameterList *indices,
-                SmallVectorImpl<Decl *> &decls);
-
-    StorageImplInfo
-    classify(Parser &P, AbstractStorageDecl *storage, bool invalid,
-             ParseDeclOptions flags, SourceLoc staticLoc,
-             const DeclAttributes &attrs,
-             TypeLoc elementTy, ParameterList *indices);
-
-    /// Add an accessor.  If there's an existing accessor of this kind,
-    /// return it.  The new accessor is still remembered but will be
-    /// ignored.
-    AccessorDecl *add(AccessorDecl *accessor);
-  };
-
   void parseAccessorAttributes(DeclAttributes &Attributes);
 
+  struct ParsedAccessors;
   bool parseGetSetImpl(ParseDeclOptions Flags,
                        GenericParamList *GenericParams,
                        ParameterList *Indices,

--- a/test/decl/subscript/addressors.swift
+++ b/test/decl/subscript/addressors.swift
@@ -32,7 +32,7 @@ struct OnlyMutable {
   var base: UnsafeMutablePointer<Int>
 
   subscript(index: Int) -> Int {
-    unsafeMutableAddress { // expected-error {{subscript must provide either a getter or 'address' if it provides 'mutableAddress'}}
+    unsafeMutableAddress { // expected-error {{subscript with a mutable addressor must also have a getter or an addressor}}
       return base
     }
   }
@@ -45,7 +45,7 @@ struct Repeated {
     unsafeAddress { // expected-note {{previous definition}}
       return UnsafePointer(base)
     }
-    unsafeAddress { // expected-error {{duplicate definition}}
+    unsafeAddress { // expected-error {{subscript already has an addressor}}
       return base // expected-error {{cannot convert return expression of type 'UnsafeMutablePointer<Int>' to return type 'UnsafePointer<Int>'}}
     }
   }
@@ -61,7 +61,7 @@ struct RepeatedMutable {
     unsafeMutableAddress { // expected-note {{previous definition}}
       return base
     }
-    unsafeMutableAddress { // expected-error {{duplicate definition}}
+    unsafeMutableAddress { // expected-error {{subscript already has a mutable addressor}}
       return base
     }
   }
@@ -71,10 +71,10 @@ struct AddressorAndGet {
   var base: UnsafePointer<Int>
 
   subscript(index: Int) -> Int {
-    unsafeAddress { // expected-error {{subscript cannot provide both 'address' and a getter}}
+    unsafeAddress { // expected-error {{subscript cannot provide both an addressor and a getter}}
       return base
     }
-    get {
+    get { // expected-note {{getter defined here}}
       return base.get() // expected-error {{value of type 'UnsafePointer<Int>' has no member 'get'}}
     }
   }
@@ -87,7 +87,7 @@ struct AddressorAndSet {
     unsafeAddress {
       return base
     }
-    set { // expected-error {{subscript cannot provide both 'address' and a setter; use an ordinary getter instead}}
+    set {
     }
   }
 }
@@ -184,22 +184,22 @@ struct ObedientNonMutatingMutableAddressor: HasNonMutatingMutableSubscript {
 struct RedundantAddressors1 {
   var owner : Builtin.NativeObject
   subscript(index: Int) -> Int {
-    unsafeAddress { return someValidAddress() } // expected-note {{previous definition of addressor is here}}
-    addressWithNativeOwner { return (someValidAddress(), owner)  } // expected-error {{subscript already has a addressor}}
+    unsafeAddress { return someValidAddress() } // expected-note {{previous definition of addressor here}}
+    addressWithNativeOwner { return (someValidAddress(), owner)  } // expected-error {{subscript already has an addressor}}
   }
 }
 struct RedundantAddressors2 {
   var owner : Builtin.NativeObject
   subscript(index: Int) -> Int {
-    unsafeAddress { return someValidAddress() } // expected-note {{previous definition of addressor is here}}
-    addressWithPinnedNativeOwner { return (someValidAddress(), owner)  } // expected-error {{subscript already has a addressor}}
+    unsafeAddress { return someValidAddress() } // expected-note {{previous definition of addressor here}}
+    addressWithPinnedNativeOwner { return (someValidAddress(), owner)  } // expected-error {{subscript already has an addressor}}
   }
 }
 struct RedundantAddressors3 {
   var owner : Builtin.NativeObject
   subscript(index: Int) -> Int {
-    addressWithNativeOwner { return (someValidAddress(), owner) } // expected-note {{previous definition of addressor is here}}
-    addressWithPinnedNativeOwner { return (someValidAddress(), owner)  } // expected-error {{subscript already has a addressor}}
+    addressWithNativeOwner { return (someValidAddress(), owner) } // expected-note {{previous definition of addressor here}}
+    addressWithPinnedNativeOwner { return (someValidAddress(), owner)  } // expected-error {{subscript already has an addressor}}
   }
 }
 
@@ -207,7 +207,7 @@ struct RedundantMutableAddressors1 {
   var owner : Builtin.NativeObject
   subscript(index: Int) -> Int {
     unsafeAddress { return someValidAddress() }
-    unsafeMutableAddress { return someValidAddress() } // expected-note {{previous definition of mutable addressor is here}}
+    unsafeMutableAddress { return someValidAddress() } // expected-note {{previous definition of mutable addressor here}}
     mutableAddressWithNativeOwner { return (someValidAddress(), owner)  } // expected-error {{subscript already has a mutable addressor}}
   }
 }
@@ -215,7 +215,7 @@ struct RedundantMutableAddressors2 {
   var owner : Builtin.NativeObject
   subscript(index: Int) -> Int {
     unsafeAddress { return someValidAddress() }
-    unsafeMutableAddress { return someValidAddress() } // expected-note {{previous definition of mutable addressor is here}}
+    unsafeMutableAddress { return someValidAddress() } // expected-note {{previous definition of mutable addressor here}}
     mutableAddressWithNativeOwner { return (someValidAddress(), owner)  } // expected-error {{subscript already has a mutable addressor}}
   }
 }
@@ -223,7 +223,7 @@ struct RedundantMutableAddressors3 {
   var owner : Builtin.NativeObject
   subscript(index: Int) -> Int {
     unsafeAddress { return someValidAddress() }
-    unsafeMutableAddress { return someValidAddress() } // expected-note {{previous definition of mutable addressor is here}}
+    unsafeMutableAddress { return someValidAddress() } // expected-note {{previous definition of mutable addressor here}}
     mutableAddressWithNativeOwner { return (someValidAddress(), owner)  } // expected-error {{subscript already has a mutable addressor}}
   }
 }

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -92,7 +92,7 @@ protocol ProtocolGetSet1 {
   subscript(i: Int) -> Int { get }
 }
 protocol ProtocolGetSet2 {
-  subscript(i: Int) -> Int { set } // expected-error {{subscript declarations must have a getter}}
+  subscript(i: Int) -> Int { set } // expected-error {{subscript with a setter must also have a getter}}
 }
 protocol ProtocolGetSet3 {
   subscript(i: Int) -> Int { get set }
@@ -116,7 +116,7 @@ protocol ProtocolWillSetDidSet4 {
 
 class DidSetInSubscript {
   subscript(_: Int) -> Int {
-    didSet { // expected-error {{didSet is not allowed in subscripts}}
+    didSet { // expected-error {{'didSet' is not allowed in subscripts}}
       print("eek")
     }
     get {}
@@ -125,7 +125,7 @@ class DidSetInSubscript {
 
 class WillSetInSubscript {
   subscript(_: Int) -> Int {
-    willSet { // expected-error {{willSet is not allowed in subscripts}}
+    willSet { // expected-error {{'willSet' is not allowed in subscripts}}
       print("eek")
     }
     get {}
@@ -175,8 +175,8 @@ struct MissingGetterSubscript1 {
   } // expected-error {{subscript must have accessors specified}}
 }
 struct MissingGetterSubscript2 {
-  subscript (i : Int, j : Int) -> Int { // expected-error{{subscript declarations must have a getter}}
-    set {}
+  subscript (i : Int, j : Int) -> Int {
+    set {} // expected-error{{subscript with a setter must also have a getter}}
   }
 }
 

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -280,28 +280,28 @@ var (x3): X { // expected-error{{getter/setter can only be defined for a single 
 }
 
 var duplicateAccessors1: X {
-  get { // expected-note {{previous definition of getter is here}}
+  get { // expected-note {{previous definition of getter here}}
     return _x
   }
-  set { // expected-note {{previous definition of setter is here}}
+  set { // expected-note {{previous definition of setter here}}
     _x = newValue
   }
-  get { // expected-error {{duplicate definition of getter}}
+  get { // expected-error {{variable already has a getter}}
     return _x
   }
-  set(v) { // expected-error {{duplicate definition of setter}}
+  set(v) { // expected-error {{variable already has a setter}}
     _x = v
   }
 }
 
 var duplicateAccessors2: Int = 0 {
-  willSet { // expected-note {{previous definition of willSet is here}}
+  willSet { // expected-note {{previous definition of 'willSet' here}}
   }
-  didSet { // expected-note {{previous definition of didSet is here}}
+  didSet { // expected-note {{previous definition of 'didSet' here}}
   }
-  willSet { // expected-error {{duplicate definition of willSet}}
+  willSet { // expected-error {{variable already has 'willSet'}}
   }
-  didSet { // expected-error {{duplicate definition of didSet}}
+  didSet { // expected-error {{variable already has 'didSet'}}
   }
 }
 
@@ -328,10 +328,10 @@ var extraTokensInAccessorBlock5: X {
   set blah wibble // expected-error{{expected '{' to start setter definition}}
 }
 var extraTokensInAccessorBlock6: X { // expected-error{{non-member observing properties require an initializer}}
-  willSet blah wibble // expected-error{{expected '{' to start willSet definition}}
+  willSet blah wibble // expected-error{{expected '{' to start 'willSet' definition}}
 }
 var extraTokensInAccessorBlock7: X { // expected-error{{non-member observing properties require an initializer}}
-  didSet blah wibble // expected-error{{expected '{' to start didSet definition}}
+  didSet blah wibble // expected-error{{expected '{' to start 'didSet' definition}}
 }
 
 var extraTokensInAccessorBlock8: X {
@@ -724,19 +724,19 @@ struct WillSetDidSetProperties {
   }
 
   var d: Int {
-    didSet {
+    didSet { // expected-error {{'didSet' cannot be provided together with a getter}}
       markUsed("woot")
     }
-    get { // expected-error {{didSet variable must not also have a get specifier}}
+    get {
       return 4
     }
   }
 
   var e: Int {
-    willSet {
+    willSet { // expected-error {{'willSet' cannot be provided together with a setter}}
       markUsed("woot")
     }
-    set { // expected-error {{willSet variable must not also have a set specifier}}
+    set { // expected-error {{variable with a setter must also have a getter}}
       return 4 // expected-error {{unexpected non-void return value in void function}}
     }
   }
@@ -748,11 +748,11 @@ struct WillSetDidSetProperties {
 
   var g: Int {
     willSet(newValue 5) {} // expected-error {{expected ')' after willSet parameter name}} expected-note {{to match this opening '('}}
-    // expected-error@-1 {{expected '{' to start willSet definition}}
+    // expected-error@-1 {{expected '{' to start 'willSet' definition}}
   }
   var h: Int {
     didSet(oldValue ^) {} // expected-error {{expected ')' after didSet parameter name}} expected-note {{to match this opening '('}}
-    // expected-error@-1 {{expected '{' to start didSet definition}}
+    // expected-error@-1 {{expected '{' to start 'didSet' definition}}
   }
 
   // didSet/willSet with initializers.
@@ -817,13 +817,13 @@ struct WillSetDidSetProperties {
 struct WillSetDidSetDisambiguate1 {
   var willSet: Int
   var x: (() -> ()) -> Int = takeTrailingClosure {
-    willSet = 42 // expected-error {{expected '{' to start willSet definition}}
+    willSet = 42 // expected-error {{expected '{' to start 'willSet' definition}}
   }
 }
 struct WillSetDidSetDisambiguate1Attr {
   var willSet: Int
   var x: (() -> ()) -> Int = takeTrailingClosure {
-    willSet = 42 // expected-error {{expected '{' to start willSet definition}}
+    willSet = 42 // expected-error {{expected '{' to start 'willSet' definition}}
   }
 }
 


### PR DESCRIPTION
As part of this, lift the now-unnecessary restriction against combining a non-mutable addressor with a setter.  I've also tweaked some of the diagnostics.

This is in preparation for generalized accessors.