### PR TITLE
Make sure we handle a supplementary output list with no outputs in it

### DIFF
--- a/include/swift/Frontend/OutputFileMap.h
+++ b/include/swift/Frontend/OutputFileMap.h
@@ -30,6 +30,11 @@ namespace swift {
 
 using TypeToPathMap = llvm::DenseMap<file_types::ID, std::string>;
 
+/// A two-tiered map used to specify paths for multiple output files associated
+/// with each input file in a compilation job.
+///
+/// The structure is a map from input paths to sub-maps, each of which maps
+/// file types to output paths.
 class OutputFileMap {
 private:
   llvm::StringMap<TypeToPathMap> InputToOutputsMap;
@@ -73,7 +78,10 @@ public:
   /// Dump the OutputFileMap to the given \p os.
   void dump(llvm::raw_ostream &os, bool Sort = false) const;
 
-  /// Write the OutputFilemap for the \p inputs so it can be parsed.
+  /// Write the OutputFileMap for the \p inputs so it can be parsed.
+  ///
+  /// It is not an error if the map does not contain an entry for a particular
+  /// input. Instead, an empty sub-map will be written into the output.
   void write(llvm::raw_ostream &os, ArrayRef<StringRef> inputs) const;
 
 private:

--- a/lib/Frontend/OutputFileMap.cpp
+++ b/lib/Frontend/OutputFileMap.cpp
@@ -110,11 +110,19 @@ static void writeQuotedEscaped(llvm::raw_ostream &os,
 void OutputFileMap::write(llvm::raw_ostream &os,
                           ArrayRef<StringRef> inputs) const {
   for (const auto input : inputs) {
-    const TypeToPathMap *outputMap = getOutputMapForInput(input);
-    if (!outputMap)
-      continue;
     writeQuotedEscaped(os, input);
-    os << ":\n";
+    os << ":";
+
+    const TypeToPathMap *outputMap = getOutputMapForInput(input);
+    if (!outputMap) {
+      // The map doesn't have an entry for this input. (Perhaps there were no
+      // outputs and thus the entry was never created.) Put an empty sub-map
+      // into the output and move on.
+      os << " {}\n";
+      continue;
+    }
+
+    os << "\n";
     for (auto &typeAndOutputPath : *outputMap) {
       file_types::ID type = typeAndOutputPath.getFirst();
       StringRef output = typeAndOutputPath.getSecond();

--- a/test/Driver/supplementary-filelist-empty.swift
+++ b/test/Driver/supplementary-filelist-empty.swift
@@ -1,0 +1,2 @@
+// Check that we can handle /no/ supplementary outputs.
+// RUN: %target-build-swift -typecheck -driver-filelist-threshold=0 %s


### PR DESCRIPTION
Ran across this while modifying command lines to build the standard library.