### PR TITLE
[stdlib] Build the standard library as Swift 5

### DIFF
--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -257,9 +257,9 @@ function(_compile_swift_files
                             "-Xfrontend" "${GROUP_INFO_JSON_FILE}")
   endif()
 
-  # Force swift 4 compatibility mode for Standard Library.
+  # Force swift 5 mode for Standard Library.
   if (SWIFTFILE_IS_STDLIB)
-    list(APPEND swift_flags "-swift-version" "4")
+    list(APPEND swift_flags "-swift-version" "5")
   endif()
   
   # Force swift 4 compatibility mode for overlays.

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -962,7 +962,10 @@ extension Array: RangeReplaceableCollection, ArrayProtocol {
   @inlinable
   public // @testable
   var _owner: AnyObject? {
-    return _buffer.owner
+    @inline(__always)
+    get {
+      return _buffer.owner      
+    }
   }
 
   /// If the elements are stored contiguously, a pointer to the first

--- a/stdlib/public/core/Codable.swift.gyb
+++ b/stdlib/public/core/Codable.swift.gyb
@@ -1116,7 +1116,6 @@ public struct CodingUserInfoKey : RawRepresentable, Equatable, Hashable {
 /// An error that occurs during the encoding of a value.
 public enum EncodingError : Error {
   /// The context in which the error occurred.
-  @_fixed_layout // FIXME(sil-serialize-all)
   public struct Context {
     /// The path of coding keys taken to get to the point of the failing encode
     /// call.
@@ -1137,7 +1136,6 @@ public enum EncodingError : Error {
     ///   debugging purposes.
     /// - parameter underlyingError: The underlying error which caused this
     ///   error, if any.
-    @inlinable // FIXME(sil-serialize-all)
     public init(
       codingPath: [CodingKey],
       debugDescription: String,
@@ -1163,19 +1161,16 @@ public enum EncodingError : Error {
   // access CustomNSError (which is defined in Foundation) from here, we can
   // use the "hidden" entry points.
 
-  @inlinable // FIXME(sil-serialize-all)
   public var _domain: String {
     return "NSCocoaErrorDomain"
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public var _code: Int {
     switch self {
-    case .invalidValue(_, _): return 4866
+    case .invalidValue: return 4866
     }
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public var _userInfo: AnyObject? {
     // The error dictionary must be returned as an AnyObject. We can do this
     // only on platforms with bridging, unfortunately.
@@ -1204,7 +1199,6 @@ public enum EncodingError : Error {
 /// An error that occurs during the decoding of a value.
 public enum DecodingError : Error {
   /// The context in which the error occurred.
-  @_fixed_layout // FIXME(sil-serialize-all)
   public struct Context {
     /// The path of coding keys taken to get to the point of the failing decode
     /// call.
@@ -1225,7 +1219,6 @@ public enum DecodingError : Error {
     ///   debugging purposes.
     /// - parameter underlyingError: The underlying error which caused this
     ///   error, if any.
-    @inlinable // FIXME(sil-serialize-all)
     public init(
       codingPath: [CodingKey],
       debugDescription: String,
@@ -1270,22 +1263,17 @@ public enum DecodingError : Error {
   // access CustomNSError (which is defined in Foundation) from here, we can
   // use the "hidden" entry points.
 
-  @inlinable // FIXME(sil-serialize-all)
   public var _domain: String {
     return "NSCocoaErrorDomain"
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public var _code: Int {
     switch self {
-    case .keyNotFound(_, _):   fallthrough
-    case .valueNotFound(_, _): return 4865
-    case .typeMismatch(_, _):  fallthrough
-    case .dataCorrupted(_):  return 4864
+    case .keyNotFound, .valueNotFound: return 4865
+    case .typeMismatch, .dataCorrupted:  return 4864
     }
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public var _userInfo: AnyObject? {
     // The error dictionary must be returned as an AnyObject. We can do this
     // only on platforms with bridging, unfortunately.

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -4347,6 +4347,7 @@ extension Dictionary.Index {
 #if _runtime(_ObjC)
 @usableFromInline
 final internal class _CocoaDictionaryIterator: IteratorProtocol {
+  @usableFromInline
   internal typealias Element = (AnyObject, AnyObject)
 
   // Cocoa Dictionary iterator has to be a class, otherwise we cannot

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1017,7 +1017,18 @@ extension ${Self}: BinaryFloatingPoint {
       _value = Builtin.int_ceil_FPIEEE${bits}(_value)
     case .down:
       _value = Builtin.int_floor_FPIEEE${bits}(_value)
+    @unknown default:
+      self._roundSlowPath(rule)
     }
+  }
+  
+  // Slow path for new cases that might have been inlined into an old
+  // ABI-stable version of round(_:) called from a newer version. If this is
+  // the case, this non-inlinable function will call into the _newer_ version
+  // which _will_ support this rounding rule.
+  @usableFromInline
+  internal mutating func _roundSlowPath(_ rule: FloatingPointRoundingRule) {
+    self.round(rule)
   }
 
   /// Replaces this value with its additive inverse.

--- a/stdlib/public/core/MigrationSupport.swift
+++ b/stdlib/public/core/MigrationSupport.swift
@@ -688,13 +688,13 @@ extension String.UTF8View {
   }
 }
 
-@available(swift,deprecated: 5.0, renamed: "Unicode.UTF8")
+// @available(swift,deprecated: 5.0, renamed: "Unicode.UTF8")
 public typealias UTF8 = Unicode.UTF8
-@available(swift, deprecated: 5.0, renamed: "Unicode.UTF16")
+// @available(swift, deprecated: 5.0, renamed: "Unicode.UTF16")
 public typealias UTF16 = Unicode.UTF16
-@available(swift, deprecated: 5.0, renamed: "Unicode.UTF32")
+// @available(swift, deprecated: 5.0, renamed: "Unicode.UTF32")
 public typealias UTF32 = Unicode.UTF32
-@available(swift, deprecated: 5.0, renamed: "Unicode.Scalar")
+// @available(swift, deprecated: 5.0, renamed: "Unicode.Scalar")
 public typealias UnicodeScalar = Unicode.Scalar
 
 

--- a/stdlib/public/core/MigrationSupport.swift
+++ b/stdlib/public/core/MigrationSupport.swift
@@ -694,7 +694,7 @@ public typealias UTF8 = Unicode.UTF8
 public typealias UTF16 = Unicode.UTF16
 @available(swift, deprecated: 5.0, renamed: "Unicode.UTF32")
 public typealias UTF32 = Unicode.UTF32
-@available(swift, obsoleted: 5.0, renamed: "Unicode.Scalar")
+@available(swift, deprecated: 5.0, renamed: "Unicode.Scalar")
 public typealias UnicodeScalar = Unicode.Scalar
 
 

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -3562,6 +3562,7 @@ extension Set.Index {
 #if _runtime(_ObjC)
 @usableFromInline
 final internal class _CocoaSetIterator: IteratorProtocol {
+  @usableFromInline
   internal typealias Element = AnyObject
 
   // Cocoa Set iterator has to be a class, otherwise we cannot

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -744,7 +744,6 @@ extension String {
   }
 
   @inlinable
-  @usableFromInline
   static func _fromWellFormedUTF16CodeUnits<C : RandomAccessCollection>(
     _ input: C, repair: Bool = false
   ) -> String where C.Element == UTF16.CodeUnit {


### PR DESCRIPTION
4.2 was a non-event so figured ¯\\_(ツ)_/¯ 

Not much needed changing over #17580, mostly warnings:
 - I've disabled deprecating the top-level `Unicode.*` typealiases, for a later patch
 - put a weirdly recursive slow-path handler for unknown `FloatingPointRoundingRule`
 - ~~removed `@inlinable` from debugger support – shouldn't be necessary~~ done in #18126 
 - made `EndodingError` and `DecodingError` resilient.

@itaiferber are you ok with making those two errors resilient? Seems like they'll only occur on slow paths so the perf hit shouldn't matter, and allows for future changes.

@slavapestov making them resilient causes `deserialize_coregraphics.swift` to fail:

```
SIL verification failed: Load must have a loadable type: !fnConv.useLoweredAddresses() || LI->getType().isLoadable(LI->getModule())
Verifying instruction:
     %31 = tuple_element_addr %28 : $*(@thick Any.Type, DecodingError.Context), 1 // user: %32
->   %32 = load %31 : $*DecodingError.Context     // users: %86, %81, %76, %58
     %58 = tuple (%30 : $@thick Any.Type, %32 : $DecodingError.Context) // user: %59
     %76 = struct_extract %32 : $DecodingError.Context, #DecodingError.Context.codingPath // user: %77
     %81 = struct_extract %32 : $DecodingError.Context, #DecodingError.Context.debugDescription // user: %82
     %86 = struct_extract %32 : $DecodingError.Context, #DecodingError.Context.underlyingError // user: %87
In function:
// protocol witness for Decodable.init(from:) in conformance CGFloat
```