### PR TITLE
Bug fixes in SESE loop canonicalization for nested loops 

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
+++ b/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
@@ -461,8 +461,7 @@ SingleExitLoopTransformer::createNewHeader() {
     SILValue newValue = newHeader->createPHIArgument(
         escapingValue->getType(), escapingValue.getOwnershipKind());
     // Replace uses *outside* of the loop with the new value.
-    ValueBase::use_iterator UI = escapingValue->use_begin(),
-                            E = escapingValue->use_end();
+    auto UI = escapingValue->use_begin(), E = escapingValue->use_end();
     while (UI != E) {
       Operand *use = *UI;
       // Increment iterator before we invalidate it

--- a/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
+++ b/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
@@ -378,7 +378,7 @@ void SingleExitLoopTransformer::initialize() {
     auto saveEscaping = [this](SILValue value) {
       for (const auto *use : value->getUses()) {
         const SILInstruction *useInst = use->getUser();
-        if (!this->loop->contains(useInst->getParent())) {
+        if (!loop->contains(useInst->getParent())) {
           escapingValues.insert(value);
           break;
         }
@@ -461,7 +461,13 @@ SingleExitLoopTransformer::createNewHeader() {
     SILValue newValue = newHeader->createPHIArgument(
         escapingValue->getType(), escapingValue.getOwnershipKind());
     // Replace uses *outside* of the loop with the new value.
-    for (Operand *use : escapingValue->getUses()) {
+    ValueBase::use_iterator UI = escapingValue->use_begin(),
+                            E = escapingValue->use_end();
+    while (UI != E) {
+      Operand *use = *UI;
+      // Increment iterator before we invalidate it
+      // when we invoke Operand::Set below.
+      ++UI;
       if (loop->contains(use->getUser()->getParent())) {
         continue;
       }
@@ -722,13 +728,16 @@ void SESERegionBuilder::ensureSingleExitFromLoops() {
       continue;
     }
     SingleExitLoopTransformer transformer(&deviceInfo, &LI, &DI, loop);
-    changed |= transformer.transform();
+    bool loopChanged = transformer.transform();
+    if (loopChanged) {
+      // Recalculate dominator information as it is stale now.
+      DI.recalculate(*F);
+      PDI.recalculate(*F);
+    }
+    changed |= loopChanged;
   }
   if (changed) {
     splitAllCondBrCriticalEdgesWithNonTrivialArgs(*F, nullptr, &LI);
-
-    DI.recalculate(*F);
-    PDI.recalculate(*F);
   }
 }
 

--- a/test/TensorFlowRuntime/sese_loop_canonicalization.swift
+++ b/test/TensorFlowRuntime/sese_loop_canonicalization.swift
@@ -45,4 +45,51 @@ ControlFlowTests.testAllBackends("natSumWithBreak") {
   expectEqualWithScalarTensor(5050, natSumWithBreak(200))
 }
 
+func sumOfProducts(_ M : Int32, _ N : Int32) -> Tensor<Float> {
+  // Effectively computes natSum(M)*natSum(N)
+  var sum = Tensor<Float>(0)
+  for i in 0..<M {
+    for j in 0..<N {
+      // i + 1 and j + 1 is a workaround for
+      // https://bugs.swift.org/browse/SR-8256
+      let prod = Tensor<Float>(Float((i + 1) * (j + 1)));
+      sum += prod
+    }
+  }
+  return sum
+}
+
+ControlFlowTests.testAllBackends("sumOfProducts") {
+  expectNearlyEqualWithScalarTensor(18.0, sumOfProducts(2, 3))
+  expectNearlyEqualWithScalarTensor(1980.0,sumOfProducts(10, 8))
+  expectNearlyEqualWithScalarTensor(11550.0,sumOfProducts(20, 10))
+}
+
+// A contrived example to test labeled breaks
+func sumOfProductsWithBound(_ M : Int32, _ N : Int32, _ Bound : Float) -> Tensor<Float> {
+  // Effectively computes natSum(M)*natSum(N) upto Bound
+  var sum = Tensor<Float>(0)
+outer_loop:for i in 0..<M {
+    for j in 0..<N {
+      // i + 1 and j + 1 is a workaround for
+      // https://bugs.swift.org/browse/SR-8256
+      let prod = Tensor<Float>(Float((i + 1) * (j + 1)));
+      sum += prod
+      if (sum.scalarized() >= Bound) {
+        break outer_loop;
+      }
+    }
+  }
+  return sum
+}
+
+ControlFlowTests.testAllBackends("sumOfProductsWithBound") {
+  expectNearlyEqualWithScalarTensor(6, sumOfProductsWithBound(3, 3, 4))
+  expectNearlyEqualWithScalarTensor(8, sumOfProductsWithBound(2, 3, 7))
+  expectNearlyEqualWithScalarTensor(8, sumOfProductsWithBound(3, 3, 7))
+  expectNearlyEqualWithScalarTensor(18, sumOfProductsWithBound(3, 3, 18))
+  // Effectively no bound as natSum(3) * natSum(3) is 36.
+  expectNearlyEqualWithScalarTensor(36, sumOfProductsWithBound(3, 3, 100))
+}
+
 runAllTests()

--- a/test/TensorFlowRuntime/sese_loop_canonicalization.swift
+++ b/test/TensorFlowRuntime/sese_loop_canonicalization.swift
@@ -25,16 +25,16 @@ ControlFlowTests.testAllBackends("powerOfTwo") {
 
 func natSumWithBreak(_ breakIndex: Int32) -> Tensor<Int32> {
   var i: Int32 = 1
-  var sum = Tensor<Int32>(0);
+  var sum = Tensor<Int32>(0)
   let maxCount: Int32 = 100
   while i <= maxCount {
     sum += i
     if (i == breakIndex) {
-      break;
+      break
     }
     i += 1
   }
-  return sum;
+  return sum
 }
 
 ControlFlowTests.testAllBackends("natSumWithBreak") {
@@ -52,7 +52,7 @@ func sumOfProducts(_ M : Int32, _ N : Int32) -> Tensor<Float> {
     for j in 0..<N {
       // i + 1 and j + 1 is a workaround for
       // https://bugs.swift.org/browse/SR-8256
-      let prod = Tensor<Float>(Float((i + 1) * (j + 1)));
+      let prod = Tensor<Float>(Float((i + 1) * (j + 1)))
       sum += prod
     }
   }
@@ -73,10 +73,10 @@ outer_loop:for i in 0..<M {
     for j in 0..<N {
       // i + 1 and j + 1 is a workaround for
       // https://bugs.swift.org/browse/SR-8256
-      let prod = Tensor<Float>(Float((i + 1) * (j + 1)));
+      let prod = Tensor<Float>(Float((i + 1) * (j + 1)))
       sum += prod
       if (sum.scalarized() >= Bound) {
-        break outer_loop;
+        break outer_loop
       }
     }
   }


### PR DESCRIPTION
<!-- What's in this pull request? -->
This patch contains the following changes
  - Avoid invalidating the use_iterator when updating use of escaping values.
  - Recompute dominator information after every loop change as it stale.

This effectively takes care of SESE loop canonicalization. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-7765](https://bugs.swift.org/browse/SR-7765).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
