### PR TITLE
[ConstExpr] Emit traceback when failing during nested call evaluation

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -221,6 +221,9 @@ WARNING(designated_init_in_cross_module_extension,none,
 NOTE(designated_init_c_struct_fix,none,
      "use \"self.init()\" to initialize the struct with zero values", ())
 
+NOTE(constexpr_called_from, none, "when called from here", ())
+NOTE(constexpr_not_evaluable, none,
+     "expression not evaluable as constant here", ())
 
 // SWIFT_ENABLE_TENSORFLOW
 // TensorFlow Support Diagnostics.
@@ -262,7 +265,6 @@ ERROR(tf_op_misuse, none,
       "%0", (StringRef))
 NOTE(tf_op_misuse_note, none,
      "%0", (StringRef))
-
 
 // Control flow diagnostics.
 ERROR(missing_return,none,

--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -26,12 +26,13 @@ class SILValue;
 class SILBuilder;
 class SerializedSILLoader;
 
-struct APIntSymbolicValue;
 struct APFloatSymbolicValue;
-struct EnumWithPayloadSymbolicValue;
+struct APIntSymbolicValue;
 struct ArraySymbolicValue;
 struct DerivedAddressValue;
+struct EnumWithPayloadSymbolicValue;
 struct SymbolicValueMemoryObject;
+struct UnknownSymbolicValue;
 
 /// When we fail to constant fold a value, this captures a reason why,
 /// allowing the caller to produce a specific diagnostic.  The "Unknown"
@@ -65,6 +66,7 @@ enum class UnknownReason {
 /// symbolic values (e.g. to save memory).  It provides a simpler public
 /// interface though.
 class SymbolicValue {
+private:
   enum RepresentationKind {
     /// This value is an alloc stack that is has not (yet) been initialized
     /// by flow-sensitive analysis.
@@ -132,11 +134,9 @@ class SymbolicValue {
   };
 
   union {
-    /// When the value is Unknown, this contains the value that was the
+    /// When the value is Unknown, this contains information about the
     /// unfoldable part of the computation.
-    ///
-    /// TODO: make this a more rich representation.
-    SILNode *unknown;
+    UnknownSymbolicValue *unknown;
 
     /// This is always a SILType with an object category.  This is the value
     /// of the underlying instance type, not the MetatypeType.
@@ -268,23 +268,21 @@ public:
     return kind != Unknown && kind != UninitMemory;
   }
 
-  static SymbolicValue getUnknown(SILNode *node, UnknownReason reason) {
-    assert(node && "node must be present");
-    SymbolicValue result;
-    result.representationKind = RK_Unknown;
-    result.value.unknown = node;
-    result.aux.unknown_reason = reason;
-    return result;
-  }
+  static SymbolicValue getUnknown(SILNode *node, UnknownReason reason,
+                                  llvm::ArrayRef<SourceLoc> callStack,
+                                  llvm::BumpPtrAllocator &allocator);
 
+  /// Return true if this represents an unknown result.
   bool isUnknown() const { return getKind() == Unknown; }
 
-  /// Return information about an unknown result, including the SIL node that
-  /// is a problem, and the reason it is an issue.
-  std::pair<SILNode *, UnknownReason> getUnknownValue() const {
-    assert(representationKind == RK_Unknown);
-    return {value.unknown, aux.unknown_reason};
-  }
+  /// Return the call stack for an unknown result.
+  ArrayRef<SourceLoc> getUnknownCallStack() const;
+
+  /// Return the node that triggered an unknown result.
+  SILNode *getUnknownNode() const;
+
+  /// Return the reason an unknown result was generated.
+  UnknownReason getUnknownReason() const;
 
   static SymbolicValue getUninitMemory() {
     SymbolicValue result;

--- a/test/SILOptimizer/pound_assert.swift
+++ b/test/SILOptimizer/pound_assert.swift
@@ -64,6 +64,7 @@ func loops1(a: Int) -> Int {
 // @constexpr
 func loops2(a: Int) -> Int {
   var x = 42
+  // expected-note @+1 {{expression not evaluable as constant here}}
   for i in 0 ... a {
     x += i
   }
@@ -173,5 +174,22 @@ public func weighPet(pet: Pet) -> Int {
 
 #assert(weighPet(pet: .dog(9, 10)) == 19)
 
+func foo() -> Bool {
+  // expected-note @+1 {{could not fold operation}}
+  print("not constexpr")
+  return true
+}
+
+func baz() -> Bool {
+  return foo() // expected-note {{when called from here}}
+}
+
+func bar() -> Bool {
+  return baz() // expected-note {{when called from here}}
+}
+
+func testCallStack() {
+  #assert(bar()) // expected-error{{#assert condition not constant}}
+}
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Note that this is an updated version of PR17517 (https://github.com/apple/swift/pull/17517), which I accidentally submitted and subsequently reverted.

When emitting a constexpr-evaluation failure message, this change emits
a trace of the calls the evaluator followed to generate the failure.

To make the output easier to read, calls on the same source line as the
failing location are elided from the output. So for example:

func foo() -> Bool {
  print("Un-constant")
  return true
}

test.swift:6:1: error: #assert condition not constant
^
test.swift:2:9: note: expression not evaluable as constant here
  print("Un-constant")

Notice there is no stack trace for the evaluation of the lambda.
