### PR TITLE
[ABI] Distinguish @objc from Swift protocol descriptor references

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -1613,7 +1613,6 @@ public:
 
 public:
   constexpr TargetProtocolDescriptorRef() : storage() { }
-  constexpr TargetProtocolDescriptorRef(nullptr_t) : storage() { }
 
   TargetProtocolDescriptorRef(
                         ProtocolDescriptorPointer protocol,

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -656,7 +656,10 @@ public:
 
 /// Flags in an existential type metadata record.
 class ExistentialTypeFlags {
-  typedef size_t int_type;
+public:
+  typedef uint32_t int_type;
+
+private:
   enum : int_type {
     NumWitnessTablesMask  = 0x00FFFFFFU,
     ClassConstraintMask   = 0x80000000U,

--- a/include/swift/ABI/TrailingObjects.h
+++ b/include/swift/ABI/TrailingObjects.h
@@ -259,16 +259,6 @@ class TrailingObjects : private trailing_objects_internal::TrailingObjectsImpl<
 
   using ParentType::getTrailingObjectsImpl;
 
-  // This function contains only a static_assert BaseTy is final. The
-  // static_assert must be in a function, and not at class-level
-  // because BaseTy isn't complete at class instantiation time, but
-  // will be by the time this function is instantiated.
-  static void verifyTrailingObjectsAssertions() {
-#ifdef LLVM_IS_FINAL
-    static_assert(LLVM_IS_FINAL(BaseTy), "BaseTy must be final.");
-#endif
-  }
-
   // These two methods are the base of the recursion for this method.
   static const BaseTy *
   getTrailingObjectsImpl(const BaseTy *Obj,
@@ -316,7 +306,6 @@ public:
   /// (which must be one of those specified in the class template). The
   /// array may have zero or more elements in it.
   template <typename T> const T *getTrailingObjects() const {
-    verifyTrailingObjectsAssertions();
     // Forwards to an impl function with overloads, since member
     // function templates can't be specialized.
     return this->getTrailingObjectsImpl(
@@ -328,7 +317,6 @@ public:
   /// (which must be one of those specified in the class template). The
   /// array may have zero or more elements in it.
   template <typename T> T *getTrailingObjects() {
-    verifyTrailingObjectsAssertions();
     // Forwards to an impl function with overloads, since member
     // function templates can't be specialized.
     return this->getTrailingObjectsImpl(

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -568,7 +568,7 @@ const ExistentialTypeMetadata *
 swift_getExistentialTypeMetadata(ProtocolClassConstraint classConstraint,
                                  const Metadata *superclassConstraint,
                                  size_t numProtocols,
-                                 const ProtocolDescriptor * const *protocols);
+                                 const ProtocolDescriptorRef *protocols);
 
 /// \brief Perform a copy-assignment from one existential container to another.
 /// Both containers must be of the same existential type representable with the

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -643,9 +643,10 @@ FUNCTION(GetForeignTypeMetadata, swift_getForeignTypeMetadata, C_CC,
          ARGS(TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone)) // only writes to runtime-private fields
 
-// WitnessTable *swift_getForeignWitnessTable(const WitnessTable *candidate,
-//                                            const TypeContextDescriptor
-//                                            *forType);
+// WitnessTable *swift_getForeignWitnessTable(
+//                                  const WitnessTable *candidate,
+//                                  const TypeContextDescriptor *forType,
+//                                  const ProtocolDescriptor *forProtocol);
 FUNCTION(GetForeignWitnessTable, swift_getForeignWitnessTable, C_CC,
          RETURNS(WitnessTablePtrTy),
          ARGS(WitnessTablePtrTy, TypeContextDescriptorPtrTy,
@@ -762,14 +763,14 @@ FUNCTION(GetTupleMetadata3, swift_getTupleTypeMetadata3, SwiftCC,
 //                              ProtocolClassConstraint classConstraint,
 //                              const Metadata *superclassConstraint,
 //                              size_t numProtocols,
-//                              const protocol_descriptor_t * const *protocols);
+//                              const ProtocolDescriptorRef *protocols);
 //
 // Note: ProtocolClassConstraint::Class is 0, ::Any is 1.
 FUNCTION(GetExistentialMetadata,
          swift_getExistentialTypeMetadata, C_CC,
          RETURNS(TypeMetadataPtrTy),
          ARGS(Int1Ty, TypeMetadataPtrTy, SizeTy,
-              ProtocolDescriptorPtrTy->getPointerTo()),
+              ProtocolDescriptorRefTy->getPointerTo()),
          ATTRS(NoUnwind, ReadOnly))
 
 // Metadata *swift_relocateClassMetadata(Metadata *self,

--- a/lib/IRGen/GenCast.cpp
+++ b/lib/IRGen/GenCast.cpp
@@ -535,7 +535,7 @@ void irgen::emitScalarExistentialDowncast(IRGenFunction &IGF,
     }
 
     if (Lowering::TypeConverter::protocolRequiresWitnessTable(protoDecl)) {
-      auto descriptor = emitProtocolDescriptorRef(IGF, protoDecl);
+      auto descriptor = IGF.IGM.getAddrOfProtocolDescriptor(protoDecl);
       witnessTableProtos.push_back(descriptor);
     }
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -3853,7 +3853,15 @@ GenericRequirementsMetadata irgen::addGenericRequirements(
         IGM.getConstantReferenceForProtocolDescriptor(protocol);
       addGenericRequirement(IGM, B, metadata, sig, flags,
                             requirement.getFirstType(),
-        [&]{ B.addRelativeAddress(descriptorRef); });
+        [&]{
+          unsigned tag = unsigned(descriptorRef.isIndirect());
+          if (protocol->isObjC())
+            tag |= 0x02;
+          
+          B.addTaggedRelativeOffset(IGM.RelativeAddressTy,
+                                    descriptorRef.getValue(),
+                                    tag);
+        });
       break;
     }
 

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -54,6 +54,7 @@
 #include "FixedTypeInfo.h"
 #include "Fulfillment.h"
 #include "GenArchetype.h"
+#include "GenCast.h"
 #include "GenClass.h"
 #include "GenEnum.h"
 #include "GenHeap.h"
@@ -3374,15 +3375,23 @@ IRGenModule::getAssociatedTypeWitnessTableAccessFunctionSignature() {
 /// For ObjC protocols, descriptors are uniqued at runtime by the ObjC runtime.
 /// We need to load the unique reference from a global variable fixed up at
 /// startup.
+///
+/// The result is always a ProtocolDescriptorRefTy whose low bit will be
+/// set to indicate when this is an Objective-C protocol.
 llvm::Value *irgen::emitProtocolDescriptorRef(IRGenFunction &IGF,
                                               ProtocolDecl *protocol) {
-  if (!protocol->isObjC())
-    return IGF.IGM.getAddrOfProtocolDescriptor(protocol);
-  
-  auto refVar = IGF.IGM.getAddrOfObjCProtocolRef(protocol, NotForDefinition);
-  llvm::Value *val
-    = IGF.Builder.CreateLoad(refVar, IGF.IGM.getPointerAlignment());
-  val = IGF.Builder.CreateBitCast(val,
-                          IGF.IGM.ProtocolDescriptorStructTy->getPointerTo());
+  if (!protocol->isObjC()) {
+    return IGF.Builder.CreatePtrToInt(
+      IGF.IGM.getAddrOfProtocolDescriptor(protocol),
+      IGF.IGM.ProtocolDescriptorRefTy);
+  }
+
+  llvm::Value *val = emitReferenceToObjCProtocol(IGF, protocol);
+  val = IGF.Builder.CreatePtrToInt(val, IGF.IGM.ProtocolDescriptorRefTy);
+
+  // Set the low bit to indicate that this is an Objective-C protocol.
+  auto *isObjCBit = llvm::ConstantInt::get(IGF.IGM.ProtocolDescriptorRefTy, 1);
+  val = IGF.Builder.CreateOr(val, isObjCBit);
+
   return val;
 }

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -501,6 +501,7 @@ public:
     llvm::IntegerType *MetadataKindTy;
     llvm::IntegerType *OnceTy;
     llvm::IntegerType *FarRelativeAddressTy;
+    llvm::IntegerType *ProtocolDescriptorRefTy;
   };
   llvm::IntegerType *ObjCBoolTy;       /// i8 or i1
   union {

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -1149,7 +1149,7 @@ namespace {
 
       // Collect references to the protocol descriptors.
       auto descriptorArrayTy
-        = llvm::ArrayType::get(IGF.IGM.ProtocolDescriptorPtrTy,
+        = llvm::ArrayType::get(IGF.IGM.ProtocolDescriptorRefTy,
                                protocols.size());
       Address descriptorArray = IGF.createAlloca(descriptorArrayTy,
                                                  IGF.IGM.getPointerAlignment(),
@@ -1157,12 +1157,13 @@ namespace {
       IGF.Builder.CreateLifetimeStart(descriptorArray,
                                    IGF.IGM.getPointerSize() * protocols.size());
       descriptorArray = IGF.Builder.CreateBitCast(descriptorArray,
-                               IGF.IGM.ProtocolDescriptorPtrTy->getPointerTo());
+                               IGF.IGM.ProtocolDescriptorRefTy->getPointerTo());
       
       unsigned index = 0;
       for (auto *protoTy : protocols) {
         auto *protoDecl = protoTy->getDecl();
         llvm::Value *ref = emitProtocolDescriptorRef(IGF, protoDecl);
+
         Address slot = IGF.Builder.CreateConstArrayGEP(descriptorArray,
                                                index, IGF.IGM.getPointerSize());
         IGF.Builder.CreateStore(ref, slot);

--- a/stdlib/public/runtime/ErrorObject.mm
+++ b/stdlib/public/runtime/ErrorObject.mm
@@ -476,7 +476,8 @@ swift::tryDynamicCastNSErrorObjectToValue(HeapObject *object,
   // A _SwiftNativeNSError box can always be unwrapped to cast the value back
   // out as an Error existential.
   if (!reinterpret_cast<SwiftError*>(srcInstance)->isPureNSError()) {
-    auto theErrorProtocol = &PROTOCOL_DESCR_SYM(s5Error);
+    ProtocolDescriptorRef theErrorProtocol(&PROTOCOL_DESCR_SYM(s5Error),
+                                           ProtocolDispatchStrategy::Swift);
     auto theErrorTy =
       swift_getExistentialTypeMetadata(ProtocolClassConstraint::Any,
                                        nullptr, 1, &theErrorProtocol);

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -323,7 +323,7 @@ public:
   ///   table will be placed here
   bool _conformsToProtocol(const OpaqueValue *value,
                            const Metadata *type,
-                           const ProtocolDescriptor *protocol,
+                           ProtocolDescriptorRef protocol,
                            const WitnessTable **conformance);
 
   void _swift_getFieldAt(

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -77,10 +77,10 @@ public:
 
 #if SWIFT_OBJC_INTEROP
   bool objectConformsToObjCProtocol(const void *theObject,
-                                    const ProtocolDescriptor *theProtocol);
+                                    ProtocolDescriptorRef protocol);
   
   bool classConformsToObjCProtocol(const void *theClass,
-                                    const ProtocolDescriptor *theProtocol);
+                                   ProtocolDescriptorRef protocol);
 #endif
 
   /// Is the given value a valid alignment mask?

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -711,7 +711,7 @@ bool swift::_checkGenericRequirements(
         return true;
 
       // If we need a witness table, add it.
-      if (req.getProtocol()->Flags.needsWitnessTable()) {
+      if (req.getProtocol().needsWitnessTable()) {
         assert(witnessTable);
         extraArguments.push_back(witnessTable);
       }

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -1114,16 +1114,16 @@ swift_dynamicCastForeignClassUnconditionalImpl(
 }
 
 bool swift::objectConformsToObjCProtocol(const void *theObject,
-                                         const ProtocolDescriptor *protocol) {
+                                         ProtocolDescriptorRef protocol) {
   return [id_const_cast(theObject)
-          conformsToProtocol: protocol_const_cast(protocol)];
+          conformsToProtocol: protocol.getObjCProtocol()];
 }
 
 
 bool swift::classConformsToObjCProtocol(const void *theClass,
-                                        const ProtocolDescriptor *protocol) {
+                                        ProtocolDescriptorRef protocol) {
   return [class_const_cast(theClass)
-          conformsToProtocol: protocol_const_cast(protocol)];
+          conformsToProtocol: protocol.getObjCProtocol()];
 }
 
 SWIFT_RUNTIME_EXPORT

--- a/stdlib/public/runtime/SwiftValue.mm
+++ b/stdlib/public/runtime/SwiftValue.mm
@@ -219,16 +219,12 @@ swift::findSwiftValueConformances(const ExistentialTypeMetadata *existentialType
   if (existentialType->getSuperclassConstraint() != nullptr)
     return false;
 
-  auto &protocols = existentialType->Protocols;
-
   Class cls = nullptr;
 
   // Note that currently we never modify tablesBuffer because
   // _SwiftValue doesn't conform to any protocols that need witness tables.
 
-  for (size_t i = 0, e = protocols.NumProtocols; i != e; ++i) {
-    auto protocol = protocols[i];
-
+  for (auto protocol : existentialType->getProtocols()) {
     // _SwiftValue only conforms to ObjC protocols.  We specifically
     // don't want to say that _SwiftValue conforms to the Swift protocols
     // that NSObject conforms to because that would create a situation
@@ -236,13 +232,13 @@ swift::findSwiftValueConformances(const ExistentialTypeMetadata *existentialType
     // by way of coercion through _SwiftValue.  Eventually we want to
     // change _SwiftValue to not be an NSObject subclass at all.
 
-    if (protocol->Flags.getDispatchStrategy() != ProtocolDispatchStrategy::ObjC)
+    if (!protocol.isObjC())
       return false;
 
     if (!cls) cls = _getSwiftValueClass();
 
     // Check whether the class conforms to the protocol.
-    if (![cls conformsToProtocol: protocol_const_cast(protocol)])
+    if (![cls conformsToProtocol: protocol.getObjCProtocol()])
       return false;
   }
 

--- a/test/IRGen/generic_requirement_objc.sil
+++ b/test/IRGen/generic_requirement_objc.sil
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import Builtin
+
+@objc protocol ObjCProto { }
+
+// CHECK: @"$S24generic_requirement_objc13GenericStructVMn" = 
+// CHECK-SAME: i32 add {{.*}} ptrtoint (i8** @"\01l_OBJC_PROTOCOL_REFERENCE_$__TtP24generic_requirement_objc9ObjCProto_" {{.*}} @"$S24generic_requirement_objc13GenericStructVMn", {{.*}} i32 3)
+
+struct GenericStruct<T: ObjCProto> { }

--- a/test/IRGen/protocol_metadata.swift
+++ b/test/IRGen/protocol_metadata.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s -DINT=i%target-ptrsize
 
 // REQUIRES: CPU=x86_64
 
@@ -118,21 +118,22 @@ func reify_metadata<T>(_ x: T) {}
 func protocol_types(_ a: A,
                     abc: A & B & C,
                     abco: A & B & C & O) {
-  // CHECK: store %swift.protocol* @"$S17protocol_metadata1AMp"
-  // CHECK: call %swift.type* @swift_getExistentialTypeMetadata(i1 true, %swift.type* null, i64 1, %swift.protocol** {{%.*}})
+  // CHECK: store [[INT]] ptrtoint (%swift.protocol* @"$S17protocol_metadata1AMp" to [[INT]])
+  // CHECK: call %swift.type* @swift_getExistentialTypeMetadata(i1 true, %swift.type* null, i64 1, [[INT]]* {{%.*}})
   reify_metadata(a)
-  // CHECK: store %swift.protocol* @"$S17protocol_metadata1AMp"
-  // CHECK: store %swift.protocol* @"$S17protocol_metadata1BMp"
-  // CHECK: store %swift.protocol* @"$S17protocol_metadata1CMp"
-  // CHECK: call %swift.type* @swift_getExistentialTypeMetadata(i1 false, %swift.type* null, i64 3, %swift.protocol** {{%.*}})
+  // CHECK: store [[INT]] ptrtoint (%swift.protocol* @"$S17protocol_metadata1AMp"
+  // CHECK: store [[INT]] ptrtoint (%swift.protocol* @"$S17protocol_metadata1BMp"
+  // CHECK: store [[INT]] ptrtoint (%swift.protocol* @"$S17protocol_metadata1CMp"
+  // CHECK: call %swift.type* @swift_getExistentialTypeMetadata(i1 false, %swift.type* null, i64 3, [[INT]]* {{%.*}})
   reify_metadata(abc)
-  // CHECK: store %swift.protocol* @"$S17protocol_metadata1AMp"
-  // CHECK: store %swift.protocol* @"$S17protocol_metadata1BMp"
-  // CHECK: store %swift.protocol* @"$S17protocol_metadata1CMp"
+  // CHECK: store [[INT]] ptrtoint (%swift.protocol* @"$S17protocol_metadata1AMp"
+  // CHECK: store [[INT]] ptrtoint (%swift.protocol* @"$S17protocol_metadata1BMp"
+  // CHECK: store [[INT]] ptrtoint (%swift.protocol* @"$S17protocol_metadata1CMp"
   // CHECK: [[O_REF:%.*]] = load i8*, i8** @"\01l_OBJC_PROTOCOL_REFERENCE_$__TtP17protocol_metadata1O_"
-  // CHECK: [[O_REF_BITCAST:%.*]] = bitcast i8* [[O_REF]] to %swift.protocol*
-  // CHECK: store %swift.protocol* [[O_REF_BITCAST]]
-  // CHECK: call %swift.type* @swift_getExistentialTypeMetadata(i1 false, %swift.type* null, i64 4, %swift.protocol** {{%.*}})
+  // CHECK: [[O_REF_INT:%.*]] = ptrtoint i8* [[O_REF]] to [[INT]]
+  // CHECK: [[O_REF_DESCRIPTOR:%.*]] = or [[INT]] [[O_REF_INT]], 1
+  // CHECK: store [[INT]] [[O_REF_DESCRIPTOR]]
+  // CHECK: call %swift.type* @swift_getExistentialTypeMetadata(i1 false, %swift.type* null, i64 4, [[INT]]* {{%.*}})
   reify_metadata(abco)
 }
 

--- a/test/IRGen/subclass_existentials.sil
+++ b/test/IRGen/subclass_existentials.sil
@@ -49,15 +49,15 @@ sil @takesMetadata : $@convention(thin) <T> (@thick T.Type) -> ()
 // CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$S21subclass_existentials1P_AA1CCXcMa"
 // CHECK-SAME:    ([[INT]])
 // CHECK:      entry:
-// CHECK-NEXT:   [[PROTOCOL_ARRAY:%.*]] = alloca [1 x %swift.protocol*]
+// CHECK-NEXT:   [[PROTOCOL_ARRAY:%.*]] = alloca [1 x [[INT]]]
 // CHECK:      cacheIsNull:
-// CHECK:        [[PROTOCOLS:%.*]] = bitcast [1 x %swift.protocol*]* [[PROTOCOL_ARRAY]] to %swift.protocol**
-// CHECK-NEXT:   [[PROTOCOL:%.*]] = getelementptr inbounds %swift.protocol*, %swift.protocol** [[PROTOCOLS]], i32 0
-// CHECK-NEXT:   store %swift.protocol* @"$S21subclass_existentials1PMp", %swift.protocol** [[PROTOCOL]]
+// CHECK:        [[PROTOCOLS:%.*]] = bitcast [1 x [[INT]]]* [[PROTOCOL_ARRAY]] to [[INT]]*
+// CHECK-NEXT:   [[PROTOCOL:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[PROTOCOLS]], i32 0
+// CHECK-NEXT:   store [[INT]] ptrtoint (%swift.protocol* @"$S21subclass_existentials1PMp" to [[INT]]), [[INT]]* [[PROTOCOL]]
 // CHECK-NEXT:   [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S21subclass_existentials1CCMa"([[INT]] 255)
 // CHECK-NEXT:   [[SUPERCLASS:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
 // CHECK-NEXT:   extractvalue %swift.metadata_response [[TMP]], 1
-// CHECK-NEXT:   [[METATYPE:%.*]] = call %swift.type* @swift_getExistentialTypeMetadata(i1 false, %swift.type* [[SUPERCLASS]], {{i32|i64}} 1, %swift.protocol** [[PROTOCOLS]])
+// CHECK-NEXT:   [[METATYPE:%.*]] = call %swift.type* @swift_getExistentialTypeMetadata(i1 false, %swift.type* [[SUPERCLASS]], {{i32|i64}} 1, [[INT]]* [[PROTOCOLS]])
 // CHECK:        ret
 
 sil @checkMetadata : $@convention(thin) () -> () {

--- a/unittests/runtime/Metadata.cpp
+++ b/unittests/runtime/Metadata.cpp
@@ -313,8 +313,8 @@ TEST(MetadataTest, getExistentialMetadata) {
       return any;
     });
 
-  const ProtocolDescriptor *protoList2[] = {
-    &ProtocolA
+  ProtocolDescriptorRef protoList2[] = {
+    ProtocolDescriptorRef::forSwift(&ProtocolA)
   };
   auto exA = RaceTest_ExpectEqual<const ExistentialTypeMetadata *>(
     [&]() -> const ExistentialTypeMetadata * {
@@ -334,8 +334,8 @@ TEST(MetadataTest, getExistentialMetadata) {
       return a;
     });
 
-  const ProtocolDescriptor *protoList3[] = {
-    &ProtocolB
+  ProtocolDescriptorRef protoList3[] = {
+    ProtocolDescriptorRef::forSwift(&ProtocolB)
   };
   RaceTest_ExpectEqual<const ExistentialTypeMetadata *>(
     [&]() -> const ExistentialTypeMetadata * {
@@ -356,8 +356,8 @@ TEST(MetadataTest, getExistentialMetadata) {
       return b;
     });
 
-  const ProtocolDescriptor *protoList6[] = {
-    &ProtocolClassConstrained,
+  ProtocolDescriptorRef protoList6[] = {
+    ProtocolDescriptorRef::forSwift(&ProtocolClassConstrained)
   };
   RaceTest_ExpectEqual<const ExistentialTypeMetadata *>(
     [&]() -> const ExistentialTypeMetadata * {
@@ -379,8 +379,8 @@ TEST(MetadataTest, getExistentialMetadata) {
       return classConstrained;
     });
 
-  const ProtocolDescriptor *protoList7[] = {
-    &ProtocolNoWitnessTable
+  ProtocolDescriptorRef protoList7[] = {
+    ProtocolDescriptorRef::forObjC((Protocol *)&ProtocolNoWitnessTable)
   };
   RaceTest_ExpectEqual<const ExistentialTypeMetadata *>(
     [&]() -> const ExistentialTypeMetadata * {
@@ -404,10 +404,10 @@ TEST(MetadataTest, getExistentialMetadata) {
 
   RaceTest_ExpectEqual<const ExistentialTypeMetadata *>(
     [&]() -> const ExistentialTypeMetadata * {
-      const ProtocolDescriptor *protoList8[] = {
-        &ProtocolNoWitnessTable,
-        &ProtocolA,
-        &ProtocolB
+      ProtocolDescriptorRef protoList8[] = {
+        ProtocolDescriptorRef::forObjC((Protocol*)&ProtocolNoWitnessTable),
+        ProtocolDescriptorRef::forSwift(&ProtocolA),
+        ProtocolDescriptorRef::forSwift(&ProtocolB)
       };
 
       auto mixedWitnessTable
@@ -433,8 +433,8 @@ TEST(MetadataTest, getExistentialMetadata) {
   ExpectedErrorValueWitnesses = &VALUE_WITNESS_SYM(Bo);
 #endif
 
-  const ProtocolDescriptor *protoList9[] = {
-    &ProtocolError
+  ProtocolDescriptorRef protoList9[] = {
+    ProtocolDescriptorRef::forSwift(&ProtocolError)
   };
   RaceTest_ExpectEqual<const ExistentialTypeMetadata *>(
     [&]() -> const ExistentialTypeMetadata * {
@@ -455,9 +455,9 @@ TEST(MetadataTest, getExistentialMetadata) {
 
   RaceTest_ExpectEqual<const ExistentialTypeMetadata *>(
     [&]() -> const ExistentialTypeMetadata * {
-      const ProtocolDescriptor *protoList10[] = {
-        &ProtocolError,
-        &ProtocolA
+      ProtocolDescriptorRef protoList10[] = {
+        ProtocolDescriptorRef::forSwift(&ProtocolError),
+        ProtocolDescriptorRef::forSwift(&ProtocolA)
       };
 
       auto special
@@ -499,8 +499,8 @@ static ProtocolDescriptor ClassProto1 = { "ClassProto1", nullptr,
 };
 
 TEST(MetadataTest, getExistentialTypeMetadata_opaque) {
-  const ProtocolDescriptor *protoList1[] = {
-    &OpaqueProto1
+  ProtocolDescriptorRef protoList1[] = {
+    ProtocolDescriptorRef::forSwift(&OpaqueProto1)
   };
   RaceTest_ExpectEqual<const ExistentialTypeMetadata *>(
     [&]() -> const ExistentialTypeMetadata * {
@@ -517,8 +517,9 @@ TEST(MetadataTest, getExistentialTypeMetadata_opaque) {
       return ex1;
     });
 
-  const ProtocolDescriptor *protoList2[] = {
-    &OpaqueProto1, &OpaqueProto2
+  ProtocolDescriptorRef protoList2[] = {
+    ProtocolDescriptorRef::forSwift(&OpaqueProto1),
+    ProtocolDescriptorRef::forSwift(&OpaqueProto2)
   };
   RaceTest_ExpectEqual<const ExistentialTypeMetadata *>(
     [&]() -> const ExistentialTypeMetadata * {
@@ -535,8 +536,10 @@ TEST(MetadataTest, getExistentialTypeMetadata_opaque) {
       return ex2;
     });
 
-  const ProtocolDescriptor *protoList3[] = {
-    &OpaqueProto1, &OpaqueProto2, &OpaqueProto3
+  ProtocolDescriptorRef protoList3[] = {
+    ProtocolDescriptorRef::forSwift(&OpaqueProto1),
+    ProtocolDescriptorRef::forSwift(&OpaqueProto2),
+    ProtocolDescriptorRef::forSwift(&OpaqueProto3)
   };
   RaceTest_ExpectEqual<const ExistentialTypeMetadata *>(
     [&]() -> const ExistentialTypeMetadata * {
@@ -555,8 +558,8 @@ TEST(MetadataTest, getExistentialTypeMetadata_opaque) {
 }
 
 TEST(MetadataTest, getExistentialTypeMetadata_class) {
-  const ProtocolDescriptor *protoList1[] = {
-    &ClassProto1
+  ProtocolDescriptorRef protoList1[] = {
+    ProtocolDescriptorRef::forSwift(&ClassProto1)
   };
   RaceTest_ExpectEqual<const ExistentialTypeMetadata *>(
     [&]() -> const ExistentialTypeMetadata * {
@@ -573,8 +576,9 @@ TEST(MetadataTest, getExistentialTypeMetadata_class) {
       return ex1;
     });
 
-  const ProtocolDescriptor *protoList2[] = {
-    &OpaqueProto1, &ClassProto1
+  ProtocolDescriptorRef protoList2[] = {
+    ProtocolDescriptorRef::forSwift(&OpaqueProto1),
+    ProtocolDescriptorRef::forSwift(&ClassProto1)
   };
   RaceTest_ExpectEqual<const ExistentialTypeMetadata *>(
     [&]() -> const ExistentialTypeMetadata * {
@@ -591,8 +595,10 @@ TEST(MetadataTest, getExistentialTypeMetadata_class) {
       return ex2;
     });
 
-  const ProtocolDescriptor *protoList3[] = {
-    &OpaqueProto1, &OpaqueProto2, &ClassProto1
+  ProtocolDescriptorRef protoList3[] = {
+    ProtocolDescriptorRef::forSwift(&OpaqueProto1),
+    ProtocolDescriptorRef::forSwift(&OpaqueProto2),
+    ProtocolDescriptorRef::forSwift(&ClassProto1)
   };
   RaceTest_ExpectEqual<const ExistentialTypeMetadata *>(
     [&]() -> const ExistentialTypeMetadata * {
@@ -613,8 +619,8 @@ TEST(MetadataTest, getExistentialTypeMetadata_class) {
 TEST(MetadataTest, getExistentialTypeMetadata_subclass) {
   RaceTest_ExpectEqual<const ExistentialTypeMetadata *>(
     [&]() -> const ExistentialTypeMetadata * {
-      const ProtocolDescriptor *protoList1[] = {
-        &OpaqueProto1
+      ProtocolDescriptorRef protoList1[] = {
+        ProtocolDescriptorRef::forSwift(&OpaqueProto1)
       };
       auto ex1 = swift_getExistentialTypeMetadata(ProtocolClassConstraint::Class,
                                                   /*superclass=*/&MetadataTest2,
@@ -635,9 +641,9 @@ TEST(MetadataTest, getExistentialTypeMetadata_subclass) {
 
   RaceTest_ExpectEqual<const ExistentialTypeMetadata *>(
     [&]() -> const ExistentialTypeMetadata * {
-      const ProtocolDescriptor *protoList2[] = {
-        &OpaqueProto1,
-        &ClassProto1
+      ProtocolDescriptorRef protoList2[] = {
+        ProtocolDescriptorRef::forSwift(&OpaqueProto1),
+        ProtocolDescriptorRef::forSwift(&ClassProto1)
       };
       auto ex2 = swift_getExistentialTypeMetadata(ProtocolClassConstraint::Class,
                                                   /*superclass=*/&MetadataTest2,

--- a/unittests/runtime/Metadata.cpp
+++ b/unittests/runtime/Metadata.cpp
@@ -287,6 +287,7 @@ ProtocolDescriptor ProtocolClassConstrained{
     .withDispatchStrategy(ProtocolDispatchStrategy::Swift)
 };
 
+#if SWIFT_OBJC_INTEROP
 ProtocolDescriptor ProtocolNoWitnessTable{
   "_TMp8Metadata22ProtocolNoWitnessTable",
   nullptr,
@@ -295,6 +296,7 @@ ProtocolDescriptor ProtocolNoWitnessTable{
     .withClassConstraint(ProtocolClassConstraint::Class)
     .withDispatchStrategy(ProtocolDispatchStrategy::ObjC)
 };
+#endif
 
 TEST(MetadataTest, getExistentialMetadata) {
   RaceTest_ExpectEqual<const ExistentialTypeMetadata *>(
@@ -379,6 +381,7 @@ TEST(MetadataTest, getExistentialMetadata) {
       return classConstrained;
     });
 
+#if SWIFT_OBJC_INTEROP
   ProtocolDescriptorRef protoList7[] = {
     ProtocolDescriptorRef::forObjC((Protocol *)&ProtocolNoWitnessTable)
   };
@@ -425,6 +428,7 @@ TEST(MetadataTest, getExistentialMetadata) {
                 mixedWitnessTable->getSuperclassConstraint());
       return mixedWitnessTable;
     });
+#endif
 
   const ValueWitnessTable *ExpectedErrorValueWitnesses;
 #if SWIFT_OBJC_INTEROP

--- a/unittests/runtime/Metadata.cpp
+++ b/unittests/runtime/Metadata.cpp
@@ -305,7 +305,7 @@ TEST(MetadataTest, getExistentialMetadata) {
       EXPECT_EQ(MetadataKind::Existential, any->getKind());
       EXPECT_EQ(0U, any->Flags.getNumWitnessTables());
       EXPECT_EQ(ProtocolClassConstraint::Any, any->Flags.getClassConstraint());
-      EXPECT_EQ(0U, any->Protocols.NumProtocols);
+      EXPECT_EQ(0U, any->NumProtocols);
       EXPECT_EQ(SpecialProtocol::None,
                 any->Flags.getSpecialProtocol());
       EXPECT_EQ(nullptr,
@@ -324,8 +324,9 @@ TEST(MetadataTest, getExistentialMetadata) {
       EXPECT_EQ(MetadataKind::Existential, a->getKind());
       EXPECT_EQ(1U, a->Flags.getNumWitnessTables());
       EXPECT_EQ(ProtocolClassConstraint::Any, a->Flags.getClassConstraint());
-      EXPECT_EQ(1U, a->Protocols.NumProtocols);
-      EXPECT_EQ(&ProtocolA, a->Protocols[0]);
+      EXPECT_EQ(1U, a->NumProtocols);
+      EXPECT_EQ(&ProtocolA,
+                a->getProtocols()[0].getProtocolDescriptorUnchecked());
       EXPECT_EQ(SpecialProtocol::None,
                 a->Flags.getSpecialProtocol());
       EXPECT_EQ(nullptr,
@@ -345,8 +346,9 @@ TEST(MetadataTest, getExistentialMetadata) {
       EXPECT_EQ(MetadataKind::Existential, b->getKind());
       EXPECT_EQ(1U, b->Flags.getNumWitnessTables());
       EXPECT_EQ(ProtocolClassConstraint::Any, b->Flags.getClassConstraint());
-      EXPECT_EQ(1U, b->Protocols.NumProtocols);
-      EXPECT_EQ(&ProtocolB, b->Protocols[0]);
+      EXPECT_EQ(1U, b->NumProtocols);
+      EXPECT_EQ(&ProtocolB,
+                b->getProtocols()[0].getProtocolDescriptorUnchecked());
       EXPECT_EQ(SpecialProtocol::None,
                 b->Flags.getSpecialProtocol());
       EXPECT_EQ(nullptr,
@@ -367,10 +369,11 @@ TEST(MetadataTest, getExistentialMetadata) {
       EXPECT_EQ(1U, classConstrained->Flags.getNumWitnessTables());
       EXPECT_EQ(ProtocolClassConstraint::Class,
                 classConstrained->Flags.getClassConstraint());
-      EXPECT_EQ(1U, classConstrained->Protocols.NumProtocols);
+      EXPECT_EQ(1U, classConstrained->NumProtocols);
       EXPECT_EQ(SpecialProtocol::None,
                 classConstrained->Flags.getSpecialProtocol());
-      EXPECT_EQ(&ProtocolClassConstrained, classConstrained->Protocols[0]);
+      EXPECT_EQ(&ProtocolClassConstrained,
+                classConstrained->getProtocols()[0].getProtocolDescriptorUnchecked());
       EXPECT_EQ(nullptr,
                 classConstrained->getSuperclassConstraint());
       return classConstrained;
@@ -389,10 +392,11 @@ TEST(MetadataTest, getExistentialMetadata) {
       EXPECT_EQ(0U, noWitnessTable->Flags.getNumWitnessTables());
       EXPECT_EQ(ProtocolClassConstraint::Class,
                 noWitnessTable->Flags.getClassConstraint());
-      EXPECT_EQ(1U, noWitnessTable->Protocols.NumProtocols);
+      EXPECT_EQ(1U, noWitnessTable->NumProtocols);
       EXPECT_EQ(SpecialProtocol::None,
                 noWitnessTable->Flags.getSpecialProtocol());
-      EXPECT_EQ(&ProtocolNoWitnessTable, noWitnessTable->Protocols[0]);
+      EXPECT_EQ(&ProtocolNoWitnessTable,
+                noWitnessTable->getProtocols()[0].getProtocolDescriptorUnchecked());
       EXPECT_EQ(nullptr,
                 noWitnessTable->getSuperclassConstraint());
       return noWitnessTable;
@@ -414,7 +418,7 @@ TEST(MetadataTest, getExistentialMetadata) {
       EXPECT_EQ(2U, mixedWitnessTable->Flags.getNumWitnessTables());
       EXPECT_EQ(ProtocolClassConstraint::Class,
                 mixedWitnessTable->Flags.getClassConstraint());
-      EXPECT_EQ(3U, mixedWitnessTable->Protocols.NumProtocols);
+      EXPECT_EQ(3U, mixedWitnessTable->NumProtocols);
       EXPECT_EQ(SpecialProtocol::None,
                 mixedWitnessTable->Flags.getSpecialProtocol());
       EXPECT_EQ(nullptr,
@@ -622,8 +626,8 @@ TEST(MetadataTest, getExistentialTypeMetadata_subclass) {
       EXPECT_TRUE(ex1->getValueWitnesses()->isBitwiseTakable());
       EXPECT_EQ(ProtocolClassConstraint::Class,
                 ex1->Flags.getClassConstraint());
-      EXPECT_EQ(1U, ex1->Protocols.NumProtocols);
-      EXPECT_EQ(&OpaqueProto1, ex1->Protocols[0]);
+      EXPECT_EQ(1U, ex1->NumProtocols);
+      EXPECT_EQ(&OpaqueProto1, ex1->getProtocols()[0].getProtocolDescriptorUnchecked());
       EXPECT_EQ(&MetadataTest2, ex1->getSuperclassConstraint());
       return ex1;
     });
@@ -645,9 +649,11 @@ TEST(MetadataTest, getExistentialTypeMetadata_subclass) {
       EXPECT_TRUE(ex2->getValueWitnesses()->isBitwiseTakable());
       EXPECT_EQ(ProtocolClassConstraint::Class,
                 ex2->Flags.getClassConstraint());
-      EXPECT_EQ(2U, ex2->Protocols.NumProtocols);
-      EXPECT_TRUE(ex2->Protocols[0] == &OpaqueProto1 &&
-                  ex2->Protocols[1] == &ClassProto1);
+      EXPECT_EQ(2U, ex2->NumProtocols);
+      EXPECT_TRUE(ex2->getProtocols()[0].getProtocolDescriptorUnchecked()
+                    == &OpaqueProto1 &&
+                  ex2->getProtocols()[1].getProtocolDescriptorUnchecked()
+                    == &ClassProto1);
       EXPECT_EQ(&MetadataTest2, ex2->getSuperclassConstraint());
       return ex2;
     });


### PR DESCRIPTION
Introduce `TargetProtocolDescriptorRef` for the runtime, which provides
a reference to either a Swift or an Objective-C protocol, using a spare bit
to indicate which kind of protocol it is. This is staging for separating
the runtime layout of Swift protocols from @objc protocols.

`TargetProtocolDescriptorRef` shows up in a few places in the runtime
and it's interaction with IRGen:

* `swift_getExistentialTypeMetadata()`, which passes an array of `TargetProtocolDescriptorRef`s, and `TargetExistentialTypeMetadata`, which stores a copy of that array.
* `TargetGenericRequirement`, for conformance constraints in generic requirement lists
