### PR TITLE
[stdlib] Some minor cleanup

### DIFF
--- a/benchmark/single-source/ArrayAppend.swift
+++ b/benchmark/single-source/ArrayAppend.swift
@@ -202,7 +202,7 @@ public func run_ArrayAppendRepeatCol(_ N: Int) {
 @inline(never)
 public func appendFromGeneric<
   S: Sequence
->(array: inout [S.Iterator.Element], sequence: S) {
+>(array: inout [S.Element], sequence: S) {
   array.append(contentsOf: sequence)
 }
 
@@ -224,7 +224,7 @@ public func run_ArrayAppendFromGeneric(_ N: Int) {
 @inline(never)
 public func appendToGeneric<
   R: RangeReplaceableCollection
->(collection: inout R, array: [R.Iterator.Element]) {
+>(collection: inout R, array: [R.Element]) {
   collection.append(contentsOf: array)
 }
 
@@ -248,7 +248,7 @@ public func run_ArrayAppendToGeneric(_ N: Int) {
 public func appendToFromGeneric<
   R: RangeReplaceableCollection, S: Sequence
 >(collection: inout R, sequence: S) 
-where R.Iterator.Element == S.Iterator.Element {
+where R.Element == S.Element {
   collection.append(contentsOf: sequence)
 }
 

--- a/benchmark/single-source/COWTree.swift
+++ b/benchmark/single-source/COWTree.swift
@@ -69,7 +69,7 @@ public struct Tree<T: Comparable> {
   public init() { }
 
   // constructor from a sequence
-  public init<S: Sequence>(_ seq: S) where S.Iterator.Element == T {
+  public init<S: Sequence>(_ seq: S) where S.Element == T {
     var g = seq.makeIterator()
     while let x = g.next() {
       self.insert(x)

--- a/benchmark/single-source/CaptureProp.swift
+++ b/benchmark/single-source/CaptureProp.swift
@@ -24,7 +24,7 @@ func sum(_ x:Int, y:Int) -> Int {
 @inline(never)
 func benchCaptureProp<S : Sequence
 >(
-  _ s: S, _ f: (S.Iterator.Element, S.Iterator.Element) -> S.Iterator.Element) -> S.Iterator.Element {
+  _ s: S, _ f: (S.Element, S.Element) -> S.Element) -> S.Element {
 
   var it = s.makeIterator()
   let initial = it.next()!

--- a/benchmark/single-source/Combos.swift
+++ b/benchmark/single-source/Combos.swift
@@ -33,7 +33,7 @@ public func run_Combos(_ N: Int) {
 func combinations
 <First: Sequence, Second: Collection>
 (_ first: First, _ second: Second)
--> AnyIterator<(First.Iterator.Element, Second.Iterator.Element)> {
+-> AnyIterator<(First.Element, Second.Element)> {
   var first_gen = first.makeIterator()
   var second_gen = second.makeIterator()
   var current_first = first_gen.next()

--- a/benchmark/single-source/Histogram.swift
+++ b/benchmark/single-source/Histogram.swift
@@ -22,7 +22,7 @@ public let Histogram = BenchmarkInfo(
 typealias rrggbb_t = UInt32
 
 func output_sorted_sparse_rgb_histogram<S: Sequence>(_ samples: S, _ N: Int)
-  where S.Iterator.Element == rrggbb_t {
+  where S.Element == rrggbb_t {
   var histogram = Dictionary<rrggbb_t, Int>()
   for  _ in 1...50*N {
     for sample in samples {   // This part is really awful, I agree

--- a/benchmark/single-source/LuhnAlgoEager.swift
+++ b/benchmark/single-source/LuhnAlgoEager.swift
@@ -46,7 +46,7 @@ public func run_LuhnAlgoEager(_ N: Int) {
 // sequence and the transform function
 struct MapSomeSequenceView<Base: Sequence, T> {
     fileprivate let _base: Base
-    fileprivate let _transform: (Base.Iterator.Element) -> T?
+    fileprivate let _transform: (Base.Element) -> T?
 }
 
 // extend it to implement Sequence
@@ -77,7 +77,7 @@ extension LazyCollectionProtocol {
     // I might be missing a trick with this super-ugly return type, is there a
     // better way?
     func mapSome<U>(
-        _ transform: @escaping (Elements.Iterator.Element) -> U?
+        _ transform: @escaping (Elements.Element) -> U?
     ) -> LazySequence<MapSomeSequenceView<Elements, U>> {
         return MapSomeSequenceView(_base: elements, _transform: transform).lazy
     }
@@ -97,12 +97,12 @@ func isMultipleOf<T: FixedWidthInteger>(_ of: T)->(T)->Bool {
 extension LazySequenceProtocol {
   func mapEveryN(
     _ n: Int,
-    _ transform: @escaping (Iterator.Element) -> Iterator.Element
-  ) -> LazyMapSequence<EnumeratedSequence<Self>, Iterator.Element> {
+    _ transform: @escaping (Element) -> Element
+  ) -> LazyMapSequence<EnumeratedSequence<Self>, Element> {
     let isNth = isMultipleOf(n)
     func transform2(
-      _ pair: EnumeratedSequence<Self>.Iterator.Element
-    ) -> Iterator.Element {
+      _ pair: EnumeratedSequence<Self>.Element
+    ) -> Element {
       return isNth(pair.0 + 1) ? transform(pair.1) : pair.1
     }
     return self.enumerated().lazy.map(transform2)
@@ -143,7 +143,7 @@ let stringToInt = freeMemberFunc(String.toInt)
 let charToString = { (c: Character) -> String in String(c) }
 let charToInt = stringToInt • charToString
 
-func sum<S: Sequence>(_ nums: S)->S.Iterator.Element where S.Iterator.Element: FixedWidthInteger {
+func sum<S: Sequence>(_ nums: S)->S.Element where S.Element: FixedWidthInteger {
     return nums.reduce(0, +)
 }
 
@@ -154,29 +154,29 @@ func reverse<C: LazyCollectionProtocol>(
 }
 
 func map<S: LazySequenceProtocol, U>(
-  _ source: S, _ transform: @escaping (S.Elements.Iterator.Element)->U
+  _ source: S, _ transform: @escaping (S.Elements.Element)->U
 ) -> LazyMapSequence<S.Elements,U> {
   return source.map(transform)
 }
 
 func mapSome<C: LazyCollectionProtocol, U>(
     _ source: C,
-    _ transform: @escaping (C.Elements.Iterator.Element)->U?
+    _ transform: @escaping (C.Elements.Element)->U?
 ) -> LazySequence<MapSomeSequenceView<C.Elements, U>> {
     return source.mapSome(transform)
 }
 
 func mapEveryN<S: LazySequenceProtocol>(
     _ source: S, _ n: Int,
-    _ transform: @escaping (S.Iterator.Element)->S.Iterator.Element
-) -> LazyMapSequence<EnumeratedSequence<S>, S.Iterator.Element> {
+    _ transform: @escaping (S.Element)->S.Element
+) -> LazyMapSequence<EnumeratedSequence<S>, S.Element> {
     return source.mapEveryN(n, transform)
 }
 
 // Non-lazy version of mapSome:
 func mapSome<S: Sequence, C: RangeReplaceableCollection>(
     _ source: S,
-    _ transform: @escaping (S.Iterator.Element)->C.Iterator.Element?
+    _ transform: @escaping (S.Element)->C.Element?
 ) -> C {
     var result = C()
     for x in source {
@@ -191,7 +191,7 @@ func mapSome<S: Sequence, C: RangeReplaceableCollection>(
 // forcing the user having to specify:
 func mapSome<S: Sequence,U>(
     _ source: S,
-    _ transform: @escaping (S.Iterator.Element
+    _ transform: @escaping (S.Element
 )->U?)->[U] {
     // just calls the more generalized version
     return mapSome(source, transform)
@@ -200,11 +200,11 @@ func mapSome<S: Sequence,U>(
 // Non-lazy version of mapEveryN:
 func mapEveryN<S: Sequence>(
     _ source: S, _ n: Int,
-    _ transform: @escaping (S.Iterator.Element) -> S.Iterator.Element
-) -> [S.Iterator.Element] {
+    _ transform: @escaping (S.Element) -> S.Element
+) -> [S.Element] {
     let isNth = isMultipleOf(n)
     return source.enumerated().map {
-        (pair: (index: Int, elem: S.Iterator.Element)) in
+        (pair: (index: Int, elem: S.Element)) in
         isNth(pair.index+1)
             ? transform(pair.elem)
             : pair.elem

--- a/benchmark/single-source/LuhnAlgoLazy.swift
+++ b/benchmark/single-source/LuhnAlgoLazy.swift
@@ -46,7 +46,7 @@ public func run_LuhnAlgoLazy(_ N: Int) {
 // sequence and the transform function
 struct MapSomeSequenceView<Base: Sequence, T> {
     fileprivate let _base: Base
-    fileprivate let _transform: (Base.Iterator.Element) -> T?
+    fileprivate let _transform: (Base.Element) -> T?
 }
 
 // extend it to implement Sequence
@@ -77,7 +77,7 @@ extension LazyCollectionProtocol {
     // I might be missing a trick with this super-ugly return type, is there a
     // better way?
     func mapSome<U>(
-        _ transform: @escaping (Elements.Iterator.Element) -> U?
+        _ transform: @escaping (Elements.Element) -> U?
     ) -> LazySequence<MapSomeSequenceView<Elements, U>> {
         return MapSomeSequenceView(_base: elements, _transform: transform).lazy
     }
@@ -97,12 +97,12 @@ func isMultipleOf<T: FixedWidthInteger>(_ of: T)->(T)->Bool {
 extension LazySequenceProtocol {
   func mapEveryN(
     _ n: Int,
-    _ transform: @escaping (Iterator.Element) -> Iterator.Element
-  ) -> LazyMapSequence<EnumeratedSequence<Self>, Iterator.Element> {
+    _ transform: @escaping (Element) -> Element
+  ) -> LazyMapSequence<EnumeratedSequence<Self>, Element> {
     let isNth = isMultipleOf(n)
     func transform2(
-      _ pair: EnumeratedSequence<Self>.Iterator.Element
-    ) -> Iterator.Element {
+      _ pair: EnumeratedSequence<Self>.Element
+    ) -> Element {
       return isNth(pair.0 + 1) ? transform(pair.1) : pair.1
     }
     return self.enumerated().lazy.map(transform2)
@@ -168,15 +168,15 @@ func mapSome<C: LazyCollectionProtocol, U>(
 
 func mapEveryN<S: LazySequenceProtocol>(
     _ source: S, _ n: Int,
-    _ transform: @escaping (S.Iterator.Element)->S.Iterator.Element
-) -> LazyMapSequence<EnumeratedSequence<S>, S.Iterator.Element> {
+    _ transform: @escaping (S.Element)->S.Element
+) -> LazyMapSequence<EnumeratedSequence<S>, S.Element> {
     return source.mapEveryN(n, transform)
 }
 
 // Non-lazy version of mapSome:
 func mapSome<S: Sequence, C: RangeReplaceableCollection>(
     _ source: S,
-    _ transform: @escaping (S.Iterator.Element)->C.Iterator.Element?
+    _ transform: @escaping (S.Element)->C.Element?
 ) -> C {
     var result = C()
     for x in source {
@@ -191,7 +191,7 @@ func mapSome<S: Sequence, C: RangeReplaceableCollection>(
 // forcing the user having to specify:
 func mapSome<S: Sequence,U>(
     _ source: S,
-    _ transform: @escaping (S.Iterator.Element
+    _ transform: @escaping (S.Element
 )->U?)->[U] {
     // just calls the more generalized version
     return mapSome(source, transform)
@@ -200,11 +200,11 @@ func mapSome<S: Sequence,U>(
 // Non-lazy version of mapEveryN:
 func mapEveryN<S: Sequence>(
     _ source: S, _ n: Int,
-    _ transform: @escaping (S.Iterator.Element) -> S.Iterator.Element
-) -> [S.Iterator.Element] {
+    _ transform: @escaping (S.Element) -> S.Element
+) -> [S.Element] {
     let isNth = isMultipleOf(n)
     return source.enumerated().map {
-        (pair: (index: Int, elem: S.Iterator.Element)) in
+        (pair: (index: Int, elem: S.Element)) in
         isNth(pair.index+1)
             ? transform(pair.elem)
             : pair.elem

--- a/benchmark/single-source/NibbleSort.swift
+++ b/benchmark/single-source/NibbleSort.swift
@@ -28,22 +28,15 @@ public func run_NibbleSort(_ N: Int) {
   CheckResults(c.val == vRef)
 }
 
-struct NibbleCollection: RandomAccessCollection, MutableCollection {
+struct NibbleCollection {
   var val: UInt64
   init(_ val: UInt64) { self.val = val }
+}
 
+extension NibbleCollection: RandomAccessCollection, MutableCollection {
   typealias Index = UInt64
-  let startIndex: UInt64 = 0
-  let endIndex: UInt64 = 16
-
-  subscript(bounds: Range<Index>) -> Slice<NibbleCollection> {
-    get {
-      fatalError("Should not be called. Added here to please the type checker")
-    }
-    set {
-      fatalError("Should not be called. Added here to please the type checker")
-    }
-  }
+  var startIndex: UInt64 { return 0 }
+  var endIndex: UInt64 { return 16 }
 
   subscript(idx: UInt64) -> UInt64 {
     get {
@@ -55,7 +48,4 @@ struct NibbleCollection: RandomAccessCollection, MutableCollection {
       val |= n << (idx * 4)
     }
   }
-
-  typealias Iterator = IndexingIterator<NibbleCollection>
-  func makeIterator() -> Iterator { return Iterator(_elements: self) }
 }

--- a/benchmark/single-source/PopFrontGeneric.swift
+++ b/benchmark/single-source/PopFrontGeneric.swift
@@ -26,14 +26,14 @@ protocol MyArrayBufferProtocol : MutableCollection, RandomAccessCollection {
   mutating func myReplace<C>(
     _ subRange: Range<Int>,
     with newValues: C
-  ) where C : Collection, C.Iterator.Element == Element
+  ) where C : Collection, C.Element == Element
 }
 
 extension Array : MyArrayBufferProtocol {
   mutating func myReplace<C>(
     _ subRange: Range<Int>,
     with newValues: C
-  ) where C : Collection, C.Iterator.Element == Element {
+  ) where C : Collection, C.Element == Element {
     replaceSubrange(subRange, with: newValues)
   }
 }
@@ -42,7 +42,7 @@ func myArrayReplace<
   B: MyArrayBufferProtocol,
   C: Collection
 >(_ target: inout B, _ subRange: Range<Int>, _ newValues: C)
-  where C.Iterator.Element == B.Element, B.Index == Int {
+  where C.Element == B.Element, B.Index == Int {
   target.myReplace(subRange, with: newValues)
 }
 

--- a/benchmark/single-source/RGBHistogram.swift
+++ b/benchmark/single-source/RGBHistogram.swift
@@ -99,7 +99,7 @@ func isCorrectHistogram(_ histogram: [(key: rrggbb_t, value: Int)]) -> Bool {
 func createSortedSparseRGBHistogram<S : Sequence>(
   _ samples: S
 ) -> [(key: rrggbb_t, value: Int)]
-  where S.Iterator.Element == rrggbb_t
+  where S.Element == rrggbb_t
 {
     var histogram = Dictionary<rrggbb_t, Int>()
 
@@ -142,7 +142,7 @@ func isCorrectHistogramOfObjects(_ histogram: [(key: Box<rrggbb_t>, value: Box<I
 func createSortedSparseRGBHistogramOfObjects<S : Sequence>(
   _ samples: S
 ) -> [(key: Box<rrggbb_t>, value: Box<Int>)]
-  where S.Iterator.Element == rrggbb_t
+  where S.Element == rrggbb_t
 {
     var histogram = Dictionary<Box<rrggbb_t>, Box<Int>>()
 

--- a/benchmark/single-source/RangeReplaceableCollectionPlusDefault.swift
+++ b/benchmark/single-source/RangeReplaceableCollectionPlusDefault.swift
@@ -40,7 +40,7 @@ func compareRef(_ a: [Int], _ b: [Int], _ ref: [Int]) -> Bool {
 // that can be any kind of range-replaceable collection:
 func mapSome
 <S: Sequence, C: RangeReplaceableCollection>
-(_ source: S, _ transform: (S.Iterator.Element)->C.Iterator.Element?) -> C {
+(_ source: S, _ transform: (S.Element)->C.Element?) -> C {
   var result = C()
   for x in source {
     if let y = transform(x) {
@@ -52,7 +52,7 @@ func mapSome
 
 // If you write a second version that returns an array,
 // you can call the more general version for implementation:
-func mapSome<S: Sequence,U>(_ source: S, _ transform: (S.Iterator.Element)->U?)->[U] {
+func mapSome<S: Sequence,U>(_ source: S, _ transform: (S.Element)->U?)->[U] {
   // just calls the more generalized version
   // (works because here, the return type
   // is now of a specific type, an Array)

--- a/benchmark/single-source/StringRemoveDupes.swift
+++ b/benchmark/single-source/StringRemoveDupes.swift
@@ -37,8 +37,8 @@ public func run_StringRemoveDupes(_ N: Int) {
 // of using contains is very inefficient
 // alternatively, could require comparable, sort, and remove adjacent dupes
 func uniq<S: Sequence,
-          E: Hashable>(_ seq: S) -> [E] where E == S.Iterator.Element {
-  var seen: [S.Iterator.Element:Int] = [:]
+          E: Hashable>(_ seq: S) -> [E] where E == S.Element {
+  var seen: [S.Element:Int] = [:]
   return seq.filter { seen.updateValue(1, forKey: $0) == nil }
 }
 

--- a/benchmark/single-source/Substring.swift
+++ b/benchmark/single-source/Substring.swift
@@ -42,7 +42,7 @@ public func run_SubstringFromLongString(_ N: Int) {
 
 func create<T : RangeReplaceableCollection, U : Collection>(
   _: T.Type, from source: U
-) where T.Iterator.Element == U.Iterator.Element {
+) where T.Element == U.Element {
   blackHole(T(source))
 }
 

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionInstance.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionInstance.swift
@@ -234,8 +234,8 @@ public func checkRandomAccessIndex<Instances, Distances, BaseCollection>(
     (Instances.Index, Instances.Index) -> Distances.Element,
   advanceOracle:
     (Instances.Index, Distances.Index) -> Instances.Element,
-  startIndex: Instances.Iterator.Element,
-  endIndex: Instances.Iterator.Element,
+  startIndex: Instances.Element,
+  endIndex: Instances.Element,
 
   _ message: @autoclosure () -> String = "",
   stackTrace: SourceLocStack = SourceLocStack(),

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift
@@ -557,18 +557,18 @@ extension TestSuite {
   >(
 
   _ testNamePrefix: String = "",
-  makeCollection: @escaping ([C.Iterator.Element]) -> C,
-  wrapValue: @escaping (OpaqueValue<Int>) -> C.Iterator.Element,
-  extractValue: @escaping (C.Iterator.Element) -> OpaqueValue<Int>,
+  makeCollection: @escaping ([C.Element]) -> C,
+  wrapValue: @escaping (OpaqueValue<Int>) -> C.Element,
+  extractValue: @escaping (C.Element) -> OpaqueValue<Int>,
 
   makeCollectionOfEquatable: @escaping (
-    [CollectionWithEquatableElement.Iterator.Element]
+    [CollectionWithEquatableElement.Element]
   ) -> CollectionWithEquatableElement,
 
   wrapValueIntoEquatable: @escaping (
-    MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
+    MinimalEquatableValue) -> CollectionWithEquatableElement.Element,
 
-  extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Iterator.Element) -> MinimalEquatableValue),
+  extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Element) -> MinimalEquatableValue),
 
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
   outOfBoundsIndexOffset: Int = 1,
@@ -579,7 +579,7 @@ extension TestSuite {
 
   C : Collection,
   CollectionWithEquatableElement : Collection,
-  CollectionWithEquatableElement.Iterator.Element : Equatable
+  CollectionWithEquatableElement.Element : Equatable
  {
 
     var testNamePrefix = testNamePrefix
@@ -1255,18 +1255,18 @@ extension TestSuite {
   >(
 
   _ testNamePrefix: String = "",
-  makeCollection: @escaping ([C.Iterator.Element]) -> C,
-  wrapValue: @escaping (OpaqueValue<Int>) -> C.Iterator.Element,
-  extractValue: @escaping (C.Iterator.Element) -> OpaqueValue<Int>,
+  makeCollection: @escaping ([C.Element]) -> C,
+  wrapValue: @escaping (OpaqueValue<Int>) -> C.Element,
+  extractValue: @escaping (C.Element) -> OpaqueValue<Int>,
 
   makeCollectionOfEquatable: @escaping (
-    [CollectionWithEquatableElement.Iterator.Element]
+    [CollectionWithEquatableElement.Element]
   ) -> CollectionWithEquatableElement,
 
   wrapValueIntoEquatable: @escaping (
-    MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
+    MinimalEquatableValue) -> CollectionWithEquatableElement.Element,
 
-  extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Iterator.Element) -> MinimalEquatableValue),
+  extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Element) -> MinimalEquatableValue),
 
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
   outOfBoundsIndexOffset: Int = 1,
@@ -1277,7 +1277,7 @@ extension TestSuite {
 
   C : BidirectionalCollection,
   CollectionWithEquatableElement : BidirectionalCollection,
-  CollectionWithEquatableElement.Iterator.Element : Equatable
+  CollectionWithEquatableElement.Element : Equatable
  {
 
     var testNamePrefix = testNamePrefix
@@ -1710,18 +1710,18 @@ extension TestSuite {
   >(
 
   _ testNamePrefix: String = "",
-  makeCollection: @escaping ([C.Iterator.Element]) -> C,
-  wrapValue: @escaping (OpaqueValue<Int>) -> C.Iterator.Element,
-  extractValue: @escaping (C.Iterator.Element) -> OpaqueValue<Int>,
+  makeCollection: @escaping ([C.Element]) -> C,
+  wrapValue: @escaping (OpaqueValue<Int>) -> C.Element,
+  extractValue: @escaping (C.Element) -> OpaqueValue<Int>,
 
   makeCollectionOfEquatable: @escaping (
-    [CollectionWithEquatableElement.Iterator.Element]
+    [CollectionWithEquatableElement.Element]
   ) -> CollectionWithEquatableElement,
 
   wrapValueIntoEquatable: @escaping (
-    MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
+    MinimalEquatableValue) -> CollectionWithEquatableElement.Element,
 
-  extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Iterator.Element) -> MinimalEquatableValue),
+  extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Element) -> MinimalEquatableValue),
 
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
   outOfBoundsIndexOffset: Int = 1,
@@ -1732,7 +1732,7 @@ extension TestSuite {
 
   C : RandomAccessCollection,
   CollectionWithEquatableElement : RandomAccessCollection,
-  CollectionWithEquatableElement.Iterator.Element : Equatable
+  CollectionWithEquatableElement.Element : Equatable
  {
 
     var testNamePrefix = testNamePrefix
@@ -1810,18 +1810,18 @@ extension TestSuite {
   >(
 
   _ testNamePrefix: String = "",
-  makeCollection: @escaping ([C.Iterator.Element]) -> C,
-  wrapValue: @escaping (OpaqueValue<Int>) -> C.Iterator.Element,
-  extractValue: @escaping (C.Iterator.Element) -> OpaqueValue<Int>,
+  makeCollection: @escaping ([C.Element]) -> C,
+  wrapValue: @escaping (OpaqueValue<Int>) -> C.Element,
+  extractValue: @escaping (C.Element) -> OpaqueValue<Int>,
 
   makeCollectionOfEquatable: @escaping (
-    [CollectionWithEquatableElement.Iterator.Element]
+    [CollectionWithEquatableElement.Element]
   ) -> CollectionWithEquatableElement,
 
   wrapValueIntoEquatable: @escaping (
-    MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
+    MinimalEquatableValue) -> CollectionWithEquatableElement.Element,
 
-  extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Iterator.Element) -> MinimalEquatableValue),
+  extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Element) -> MinimalEquatableValue),
 
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
   outOfBoundsIndexOffset: Int = 1,
@@ -1832,7 +1832,7 @@ extension TestSuite {
 
   C : Collection,
   CollectionWithEquatableElement : Collection,
-  CollectionWithEquatableElement.Iterator.Element : Equatable
+  CollectionWithEquatableElement.Element : Equatable
  {
 
     if !checksAdded.insert(
@@ -2059,18 +2059,18 @@ extension TestSuite {
   >(
 
   _ testNamePrefix: String = "",
-  makeCollection: @escaping ([C.Iterator.Element]) -> C,
-  wrapValue: @escaping (OpaqueValue<Int>) -> C.Iterator.Element,
-  extractValue: @escaping (C.Iterator.Element) -> OpaqueValue<Int>,
+  makeCollection: @escaping ([C.Element]) -> C,
+  wrapValue: @escaping (OpaqueValue<Int>) -> C.Element,
+  extractValue: @escaping (C.Element) -> OpaqueValue<Int>,
 
   makeCollectionOfEquatable: @escaping (
-    [CollectionWithEquatableElement.Iterator.Element]
+    [CollectionWithEquatableElement.Element]
   ) -> CollectionWithEquatableElement,
 
   wrapValueIntoEquatable: @escaping (
-    MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
+    MinimalEquatableValue) -> CollectionWithEquatableElement.Element,
 
-  extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Iterator.Element) -> MinimalEquatableValue),
+  extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Element) -> MinimalEquatableValue),
 
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
   outOfBoundsIndexOffset: Int = 1,
@@ -2081,7 +2081,7 @@ extension TestSuite {
 
   C : BidirectionalCollection,
   CollectionWithEquatableElement : BidirectionalCollection,
-  CollectionWithEquatableElement.Iterator.Element : Equatable
+  CollectionWithEquatableElement.Element : Equatable
  {
 
     if !checksAdded.insert(
@@ -2308,18 +2308,18 @@ extension TestSuite {
   >(
 
   _ testNamePrefix: String = "",
-  makeCollection: @escaping ([C.Iterator.Element]) -> C,
-  wrapValue: @escaping (OpaqueValue<Int>) -> C.Iterator.Element,
-  extractValue: @escaping (C.Iterator.Element) -> OpaqueValue<Int>,
+  makeCollection: @escaping ([C.Element]) -> C,
+  wrapValue: @escaping (OpaqueValue<Int>) -> C.Element,
+  extractValue: @escaping (C.Element) -> OpaqueValue<Int>,
 
   makeCollectionOfEquatable: @escaping (
-    [CollectionWithEquatableElement.Iterator.Element]
+    [CollectionWithEquatableElement.Element]
   ) -> CollectionWithEquatableElement,
 
   wrapValueIntoEquatable: @escaping (
-    MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
+    MinimalEquatableValue) -> CollectionWithEquatableElement.Element,
 
-  extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Iterator.Element) -> MinimalEquatableValue),
+  extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Element) -> MinimalEquatableValue),
 
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
   outOfBoundsIndexOffset: Int = 1,
@@ -2330,7 +2330,7 @@ extension TestSuite {
 
   C : RandomAccessCollection,
   CollectionWithEquatableElement : RandomAccessCollection,
-  CollectionWithEquatableElement.Iterator.Element : Equatable
+  CollectionWithEquatableElement.Element : Equatable
  {
 
     if !checksAdded.insert(

--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift
@@ -76,7 +76,7 @@ public func withInvalidOrderings(_ body: (@escaping (Int, Int) -> Bool) -> Void)
 
 internal func _mapInPlace<C : MutableCollection>(
   _ elements: inout C,
-  _ transform: (C.Iterator.Element) -> C.Iterator.Element
+  _ transform: (C.Element) -> C.Element
 ) {
   for i in elements.indices {
     elements[i] = transform(elements[i])
@@ -102,17 +102,17 @@ extension TestSuite {
     CollectionWithComparableElement : MutableCollection
   >(
     _ testNamePrefix: String = "",
-    makeCollection: @escaping ([C.Iterator.Element]) -> C,
-    wrapValue: @escaping (OpaqueValue<Int>) -> C.Iterator.Element,
-    extractValue: @escaping (C.Iterator.Element) -> OpaqueValue<Int>,
+    makeCollection: @escaping ([C.Element]) -> C,
+    wrapValue: @escaping (OpaqueValue<Int>) -> C.Element,
+    extractValue: @escaping (C.Element) -> OpaqueValue<Int>,
 
-    makeCollectionOfEquatable: @escaping ([CollectionWithEquatableElement.Iterator.Element]) -> CollectionWithEquatableElement,
-    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
-    extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Iterator.Element) -> MinimalEquatableValue),
+    makeCollectionOfEquatable: @escaping ([CollectionWithEquatableElement.Element]) -> CollectionWithEquatableElement,
+    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> CollectionWithEquatableElement.Element,
+    extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Element) -> MinimalEquatableValue),
 
-    makeCollectionOfComparable: @escaping ([CollectionWithComparableElement.Iterator.Element]) -> CollectionWithComparableElement,
-    wrapValueIntoComparable: @escaping (MinimalComparableValue) -> CollectionWithComparableElement.Iterator.Element,
-    extractValueFromComparable: @escaping ((CollectionWithComparableElement.Iterator.Element) -> MinimalComparableValue),
+    makeCollectionOfComparable: @escaping ([CollectionWithComparableElement.Element]) -> CollectionWithComparableElement,
+    wrapValueIntoComparable: @escaping (MinimalComparableValue) -> CollectionWithComparableElement.Element,
+    extractValueFromComparable: @escaping ((CollectionWithComparableElement.Element) -> MinimalComparableValue),
 
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
     outOfBoundsIndexOffset: Int = 1,
@@ -121,8 +121,8 @@ extension TestSuite {
     isFixedLengthCollection: Bool,
     collectionIsBidirectional: Bool = false
   ) where
-    CollectionWithEquatableElement.Iterator.Element : Equatable,
-    CollectionWithComparableElement.Iterator.Element : Comparable {
+    CollectionWithEquatableElement.Element : Equatable,
+    CollectionWithComparableElement.Element : Comparable {
 
     var testNamePrefix = testNamePrefix
 
@@ -474,7 +474,7 @@ func checkSortedPredicateThrow(
     zip(sequence, 0..<sequence.count).map {
       OpaqueValue($0, identity: $1)
     }
-  var result: [C.Iterator.Element] = []
+  var result: [C.Element] = []
   let c = makeWrappedCollection(elements)
   let closureLifetimeTracker = LifetimeTracked(0)
   do {
@@ -842,17 +842,17 @@ self.test("\(testNamePrefix).partition/InvalidOrderings") {
     CollectionWithComparableElement : BidirectionalCollection & MutableCollection
   >(
     _ testNamePrefix: String = "",
-    makeCollection: @escaping ([C.Iterator.Element]) -> C,
-    wrapValue: @escaping (OpaqueValue<Int>) -> C.Iterator.Element,
-    extractValue: @escaping (C.Iterator.Element) -> OpaqueValue<Int>,
+    makeCollection: @escaping ([C.Element]) -> C,
+    wrapValue: @escaping (OpaqueValue<Int>) -> C.Element,
+    extractValue: @escaping (C.Element) -> OpaqueValue<Int>,
 
-    makeCollectionOfEquatable: @escaping ([CollectionWithEquatableElement.Iterator.Element]) -> CollectionWithEquatableElement,
-    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
-    extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Iterator.Element) -> MinimalEquatableValue),
+    makeCollectionOfEquatable: @escaping ([CollectionWithEquatableElement.Element]) -> CollectionWithEquatableElement,
+    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> CollectionWithEquatableElement.Element,
+    extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Element) -> MinimalEquatableValue),
 
-    makeCollectionOfComparable: @escaping ([CollectionWithComparableElement.Iterator.Element]) -> CollectionWithComparableElement,
-    wrapValueIntoComparable: @escaping (MinimalComparableValue) -> CollectionWithComparableElement.Iterator.Element,
-    extractValueFromComparable: @escaping ((CollectionWithComparableElement.Iterator.Element) -> MinimalComparableValue),
+    makeCollectionOfComparable: @escaping ([CollectionWithComparableElement.Element]) -> CollectionWithComparableElement,
+    wrapValueIntoComparable: @escaping (MinimalComparableValue) -> CollectionWithComparableElement.Element,
+    extractValueFromComparable: @escaping ((CollectionWithComparableElement.Element) -> MinimalComparableValue),
 
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
     outOfBoundsIndexOffset: Int = 1,
@@ -860,8 +860,8 @@ self.test("\(testNamePrefix).partition/InvalidOrderings") {
     withUnsafeMutableBufferPointerIsSupported: Bool,
     isFixedLengthCollection: Bool
   ) where
-    CollectionWithEquatableElement.Iterator.Element : Equatable,
-    CollectionWithComparableElement.Iterator.Element : Comparable {
+    CollectionWithEquatableElement.Element : Equatable,
+    CollectionWithComparableElement.Element : Comparable {
 
     var testNamePrefix = testNamePrefix
 
@@ -986,17 +986,17 @@ self.test("\(testNamePrefix).partition/DispatchesThrough_withUnsafeMutableBuffer
     CollectionWithComparableElement : RandomAccessCollection & MutableCollection
   >(
     _ testNamePrefix: String = "",
-    makeCollection: @escaping ([C.Iterator.Element]) -> C,
-    wrapValue: @escaping (OpaqueValue<Int>) -> C.Iterator.Element,
-    extractValue: @escaping (C.Iterator.Element) -> OpaqueValue<Int>,
+    makeCollection: @escaping ([C.Element]) -> C,
+    wrapValue: @escaping (OpaqueValue<Int>) -> C.Element,
+    extractValue: @escaping (C.Element) -> OpaqueValue<Int>,
 
-    makeCollectionOfEquatable: @escaping ([CollectionWithEquatableElement.Iterator.Element]) -> CollectionWithEquatableElement,
-    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
-    extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Iterator.Element) -> MinimalEquatableValue),
+    makeCollectionOfEquatable: @escaping ([CollectionWithEquatableElement.Element]) -> CollectionWithEquatableElement,
+    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> CollectionWithEquatableElement.Element,
+    extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Element) -> MinimalEquatableValue),
 
-    makeCollectionOfComparable: @escaping ([CollectionWithComparableElement.Iterator.Element]) -> CollectionWithComparableElement,
-    wrapValueIntoComparable: @escaping (MinimalComparableValue) -> CollectionWithComparableElement.Iterator.Element,
-    extractValueFromComparable: @escaping ((CollectionWithComparableElement.Iterator.Element) -> MinimalComparableValue),
+    makeCollectionOfComparable: @escaping ([CollectionWithComparableElement.Element]) -> CollectionWithComparableElement,
+    wrapValueIntoComparable: @escaping (MinimalComparableValue) -> CollectionWithComparableElement.Element,
+    extractValueFromComparable: @escaping ((CollectionWithComparableElement.Element) -> MinimalComparableValue),
 
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
     outOfBoundsIndexOffset: Int = 1,
@@ -1004,8 +1004,8 @@ self.test("\(testNamePrefix).partition/DispatchesThrough_withUnsafeMutableBuffer
     withUnsafeMutableBufferPointerIsSupported: Bool,
     isFixedLengthCollection: Bool
   ) where
-    CollectionWithEquatableElement.Iterator.Element : Equatable,
-    CollectionWithComparableElement.Iterator.Element : Comparable {
+    CollectionWithEquatableElement.Element : Equatable,
+    CollectionWithComparableElement.Element : Comparable {
 
     var testNamePrefix = testNamePrefix
 

--- a/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableCollectionType.swift
@@ -450,19 +450,19 @@ extension TestSuite {
     CollectionWithEquatableElement : RangeReplaceableCollection
   >(
     _ testNamePrefix: String = "",
-    makeCollection: @escaping ([C.Iterator.Element]) -> C,
-    wrapValue: @escaping (OpaqueValue<Int>) -> C.Iterator.Element,
-    extractValue: @escaping (C.Iterator.Element) -> OpaqueValue<Int>,
+    makeCollection: @escaping ([C.Element]) -> C,
+    wrapValue: @escaping (OpaqueValue<Int>) -> C.Element,
+    extractValue: @escaping (C.Element) -> OpaqueValue<Int>,
 
-    makeCollectionOfEquatable: @escaping ([CollectionWithEquatableElement.Iterator.Element]) -> CollectionWithEquatableElement,
-    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
-    extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Iterator.Element) -> MinimalEquatableValue),
+    makeCollectionOfEquatable: @escaping ([CollectionWithEquatableElement.Element]) -> CollectionWithEquatableElement,
+    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> CollectionWithEquatableElement.Element,
+    extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Element) -> MinimalEquatableValue),
 
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
     outOfBoundsIndexOffset: Int = 1,
     collectionIsBidirectional: Bool = false
   ) where
-    CollectionWithEquatableElement.Iterator.Element : Equatable {
+    CollectionWithEquatableElement.Element : Equatable {
 
     var testNamePrefix = testNamePrefix
 
@@ -1166,18 +1166,18 @@ self.test("\(testNamePrefix).OperatorPlus") {
     CollectionWithEquatableElement : BidirectionalCollection & RangeReplaceableCollection
   >(
     _ testNamePrefix: String = "",
-    makeCollection: @escaping ([C.Iterator.Element]) -> C,
-    wrapValue: @escaping (OpaqueValue<Int>) -> C.Iterator.Element,
-    extractValue: @escaping (C.Iterator.Element) -> OpaqueValue<Int>,
+    makeCollection: @escaping ([C.Element]) -> C,
+    wrapValue: @escaping (OpaqueValue<Int>) -> C.Element,
+    extractValue: @escaping (C.Element) -> OpaqueValue<Int>,
 
-    makeCollectionOfEquatable: @escaping ([CollectionWithEquatableElement.Iterator.Element]) -> CollectionWithEquatableElement,
-    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
-    extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Iterator.Element) -> MinimalEquatableValue),
+    makeCollectionOfEquatable: @escaping ([CollectionWithEquatableElement.Element]) -> CollectionWithEquatableElement,
+    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> CollectionWithEquatableElement.Element,
+    extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Element) -> MinimalEquatableValue),
 
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
     outOfBoundsIndexOffset: Int = 1
   ) where
-    CollectionWithEquatableElement.Iterator.Element : Equatable {
+    CollectionWithEquatableElement.Element : Equatable {
 
     var testNamePrefix = testNamePrefix
 
@@ -1286,18 +1286,18 @@ self.test("\(testNamePrefix).removeLast(n: Int)/whereIndexIsBidirectional/remove
     CollectionWithEquatableElement : RandomAccessCollection & RangeReplaceableCollection
   >(
     _ testNamePrefix: String = "",
-    makeCollection: @escaping ([C.Iterator.Element]) -> C,
-    wrapValue: @escaping (OpaqueValue<Int>) -> C.Iterator.Element,
-    extractValue: @escaping (C.Iterator.Element) -> OpaqueValue<Int>,
+    makeCollection: @escaping ([C.Element]) -> C,
+    wrapValue: @escaping (OpaqueValue<Int>) -> C.Element,
+    extractValue: @escaping (C.Element) -> OpaqueValue<Int>,
 
-    makeCollectionOfEquatable: @escaping ([CollectionWithEquatableElement.Iterator.Element]) -> CollectionWithEquatableElement,
-    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
-    extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Iterator.Element) -> MinimalEquatableValue),
+    makeCollectionOfEquatable: @escaping ([CollectionWithEquatableElement.Element]) -> CollectionWithEquatableElement,
+    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> CollectionWithEquatableElement.Element,
+    extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Element) -> MinimalEquatableValue),
 
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
     outOfBoundsIndexOffset: Int = 1
   ) where
-    CollectionWithEquatableElement.Iterator.Element : Equatable {
+    CollectionWithEquatableElement.Element : Equatable {
 
     var testNamePrefix = testNamePrefix
 

--- a/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableSliceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckRangeReplaceableSliceType.swift
@@ -20,13 +20,13 @@ extension TestSuite {
     CollectionWithEquatableElement : RangeReplaceableCollection
   >(
     _ testNamePrefix: String = "",
-    makeCollection: @escaping ([C.Iterator.Element]) -> C,
-    wrapValue: @escaping (OpaqueValue<Int>) -> C.Iterator.Element,
-    extractValue: @escaping (C.Iterator.Element) -> OpaqueValue<Int>,
+    makeCollection: @escaping ([C.Element]) -> C,
+    wrapValue: @escaping (OpaqueValue<Int>) -> C.Element,
+    extractValue: @escaping (C.Element) -> OpaqueValue<Int>,
 
-    makeCollectionOfEquatable: @escaping ([CollectionWithEquatableElement.Iterator.Element]) -> CollectionWithEquatableElement,
-    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
-    extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Iterator.Element) -> MinimalEquatableValue),
+    makeCollectionOfEquatable: @escaping ([CollectionWithEquatableElement.Element]) -> CollectionWithEquatableElement,
+    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> CollectionWithEquatableElement.Element,
+    extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Element) -> MinimalEquatableValue),
 
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
     outOfBoundsIndexOffset: Int = 1,
@@ -34,7 +34,7 @@ extension TestSuite {
   ) where
     C.SubSequence == C,
     CollectionWithEquatableElement.SubSequence == CollectionWithEquatableElement,
-    CollectionWithEquatableElement.Iterator.Element : Equatable {
+    CollectionWithEquatableElement.Element : Equatable {
 
     var testNamePrefix = testNamePrefix
 
@@ -152,20 +152,20 @@ extension TestSuite {
     CollectionWithEquatableElement : BidirectionalCollection & RangeReplaceableCollection
   >(
     _ testNamePrefix: String = "",
-    makeCollection: @escaping ([C.Iterator.Element]) -> C,
-    wrapValue: @escaping (OpaqueValue<Int>) -> C.Iterator.Element,
-    extractValue: @escaping (C.Iterator.Element) -> OpaqueValue<Int>,
+    makeCollection: @escaping ([C.Element]) -> C,
+    wrapValue: @escaping (OpaqueValue<Int>) -> C.Element,
+    extractValue: @escaping (C.Element) -> OpaqueValue<Int>,
 
-    makeCollectionOfEquatable: @escaping ([CollectionWithEquatableElement.Iterator.Element]) -> CollectionWithEquatableElement,
-    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
-    extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Iterator.Element) -> MinimalEquatableValue),
+    makeCollectionOfEquatable: @escaping ([CollectionWithEquatableElement.Element]) -> CollectionWithEquatableElement,
+    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> CollectionWithEquatableElement.Element,
+    extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Element) -> MinimalEquatableValue),
 
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
     outOfBoundsIndexOffset: Int = 1
   ) where
     C.SubSequence == C,
     CollectionWithEquatableElement.SubSequence == CollectionWithEquatableElement,
-    CollectionWithEquatableElement.Iterator.Element : Equatable {
+    CollectionWithEquatableElement.Element : Equatable {
 
     var testNamePrefix = testNamePrefix
 
@@ -296,20 +296,20 @@ extension TestSuite {
     CollectionWithEquatableElement : RandomAccessCollection & RangeReplaceableCollection
   >(
     _ testNamePrefix: String = "",
-    makeCollection: @escaping ([C.Iterator.Element]) -> C,
-    wrapValue: @escaping (OpaqueValue<Int>) -> C.Iterator.Element,
-    extractValue: @escaping (C.Iterator.Element) -> OpaqueValue<Int>,
+    makeCollection: @escaping ([C.Element]) -> C,
+    wrapValue: @escaping (OpaqueValue<Int>) -> C.Element,
+    extractValue: @escaping (C.Element) -> OpaqueValue<Int>,
 
-    makeCollectionOfEquatable: @escaping ([CollectionWithEquatableElement.Iterator.Element]) -> CollectionWithEquatableElement,
-    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> CollectionWithEquatableElement.Iterator.Element,
-    extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Iterator.Element) -> MinimalEquatableValue),
+    makeCollectionOfEquatable: @escaping ([CollectionWithEquatableElement.Element]) -> CollectionWithEquatableElement,
+    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> CollectionWithEquatableElement.Element,
+    extractValueFromEquatable: @escaping ((CollectionWithEquatableElement.Element) -> MinimalEquatableValue),
 
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
     outOfBoundsIndexOffset: Int = 1
   ) where
     C.SubSequence == C,
     CollectionWithEquatableElement.SubSequence == CollectionWithEquatableElement,
-    CollectionWithEquatableElement.Iterator.Element : Equatable {
+    CollectionWithEquatableElement.Element : Equatable {
 
     var testNamePrefix = testNamePrefix
 

--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceInstance.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceInstance.swift
@@ -27,11 +27,11 @@ public func checkIterator<
   showFrame: Bool = true,
   file: String = #file, line: UInt = #line,
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
-  sameValue: (Expected.Iterator.Element, Expected.Iterator.Element) -> Bool
-) where I.Element == Expected.Iterator.Element {
+  sameValue: (Expected.Element, Expected.Element) -> Bool
+) where I.Element == Expected.Element {
   // Copying a `IteratorProtocol` is allowed.
   var mutableGen = iterator
-  var actual: [Expected.Iterator.Element] = []
+  var actual: [Expected.Element] = []
   while let e = mutableGen.next() {
     actual.append(e)
   }
@@ -57,7 +57,7 @@ public func checkIterator<
   showFrame: Bool = true,
   file: String = #file, line: UInt = #line,
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all
-) where I.Element == Expected.Iterator.Element, Expected.Iterator.Element : Equatable {
+) where I.Element == Expected.Element, Expected.Element : Equatable {
   checkIterator(
     expected, iterator, message(),
     stackTrace: stackTrace.pushIf(showFrame, file: file, line: line), showFrame: false,
@@ -75,8 +75,8 @@ public func checkSequence<
   showFrame: Bool = true,
   file: String = #file, line: UInt = #line,
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
-  sameValue: (Expected.Iterator.Element, Expected.Iterator.Element) -> Bool
-) where S.Iterator.Element == Expected.Iterator.Element {
+  sameValue: (Expected.Element, Expected.Element) -> Bool
+) where S.Element == Expected.Element {
   let expectedCount: Int = numericCast(expected.count)
   checkIterator(
     expected, sequence.makeIterator(), message(),
@@ -93,7 +93,7 @@ public func checkSequence<
   _ = sequence._preprocessingPass { () -> Void in
     var count = 0
     for _ in sequence { count += 1 }
-    let ptr = UnsafeMutablePointer<S.Iterator.Element>.allocate(capacity: count)
+    let ptr = UnsafeMutablePointer<S.Element>.allocate(capacity: count)
     let buf = UnsafeMutableBufferPointer(start: ptr, count: count)
     var (remainders,writtenUpTo) = sequence._copyContents(initializing: buf)
     expectTrue(remainders.next() == nil,
@@ -126,8 +126,8 @@ public func checkSequence<
   file: String = #file, line: UInt = #line,
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all
 ) where
-  S.Iterator.Element == Expected.Iterator.Element,
-  S.Iterator.Element : Equatable {
+  S.Element == Expected.Element,
+  S.Element : Equatable {
 
   checkSequence(
     expected, sequence, message(),
@@ -195,7 +195,7 @@ public func checkSequence<
   file: String = #file, line: UInt = #line,
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all,
   sameValue: (Element, Element) -> Bool
-) where S.Iterator.Element == Element {
+) where S.Element == Element {
   let expectedCount: Int = numericCast(expected.count)
   checkIterator(
     expected, sequence.makeIterator(), message(),
@@ -212,7 +212,7 @@ public func checkSequence<
   _ = sequence._preprocessingPass { () -> Void in
     var count = 0
     for _ in sequence { count += 1 }
-    let ptr = UnsafeMutablePointer<S.Iterator.Element>.allocate(capacity: count)
+    let ptr = UnsafeMutablePointer<S.Element>.allocate(capacity: count)
     let buf = UnsafeMutableBufferPointer(start: ptr, count: count)
     var (remainders,writtenUpTo) = sequence._copyContents(initializing: buf)
     expectTrue(remainders.next() == nil,
@@ -245,8 +245,8 @@ public func checkSequence<
   file: String = #file, line: UInt = #line,
   resiliencyChecks: CollectionMisuseResiliencyChecks = .all
 ) where
-  S.Iterator.Element == Element,
-  S.Iterator.Element : Equatable {
+  S.Element == Element,
+  S.Element : Equatable {
 
   checkSequence(
     expected, sequence, message(),

--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
@@ -1577,17 +1577,17 @@ extension TestSuite {
     SequenceWithEquatableElement : Sequence
   >(
     _ testNamePrefix: String = "",
-    makeSequence: @escaping ([S.Iterator.Element]) -> S,
-    wrapValue: @escaping (OpaqueValue<Int>) -> S.Iterator.Element,
-    extractValue: @escaping (S.Iterator.Element) -> OpaqueValue<Int>,
+    makeSequence: @escaping ([S.Element]) -> S,
+    wrapValue: @escaping (OpaqueValue<Int>) -> S.Element,
+    extractValue: @escaping (S.Element) -> OpaqueValue<Int>,
 
-    makeSequenceOfEquatable: @escaping ([SequenceWithEquatableElement.Iterator.Element]) -> SequenceWithEquatableElement,
-    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> SequenceWithEquatableElement.Iterator.Element,
-    extractValueFromEquatable: @escaping ((SequenceWithEquatableElement.Iterator.Element) -> MinimalEquatableValue),
+    makeSequenceOfEquatable: @escaping ([SequenceWithEquatableElement.Element]) -> SequenceWithEquatableElement,
+    wrapValueIntoEquatable: @escaping (MinimalEquatableValue) -> SequenceWithEquatableElement.Element,
+    extractValueFromEquatable: @escaping ((SequenceWithEquatableElement.Element) -> MinimalEquatableValue),
 
     resiliencyChecks: CollectionMisuseResiliencyChecks = .all
   ) where
-    SequenceWithEquatableElement.Iterator.Element : Equatable {
+    SequenceWithEquatableElement.Element : Equatable {
 
     var testNamePrefix = testNamePrefix
 

--- a/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift
+++ b/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift
@@ -32,7 +32,7 @@ internal class _MinimalIteratorSharedState<T> {
 ///
 /// This generator will return `nil` only once.
 public struct MinimalIterator<T> : IteratorProtocol {
-  public init<S : Sequence>(_ s: S) where S.Iterator.Element == T {
+  public init<S : Sequence>(_ s: S) where S.Element == T {
     self._sharedState = _MinimalIteratorSharedState(Array(s))
   }
 
@@ -86,7 +86,7 @@ public struct MinimalSequence<T> : Sequence, CustomDebugStringConvertible {
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == T {
+  ) where S.Element == T {
     let data = Array(elements)
     self._sharedState = _MinimalIteratorSharedState(data)
 
@@ -594,7 +594,7 @@ public struct MinimalCollection<T> : Collection {
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == T {
+  ) where S.Element == T {
     self._elements = Array(elements)
 
     self._collectionState = _CollectionState(
@@ -756,7 +756,7 @@ public struct MinimalRangeReplaceableCollection<T> : Collection, RangeReplaceabl
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == T {
+  ) where S.Element == T {
     self._elements = Array(elements)
 
     self._collectionState = _CollectionState(
@@ -784,7 +784,7 @@ public struct MinimalRangeReplaceableCollection<T> : Collection, RangeReplaceabl
       _CollectionState(name: "\(type(of: self))", elementCount: 0)
   }
 
-  public init<S : Sequence>(_ elements: S) where S.Iterator.Element == T {
+  public init<S : Sequence>(_ elements: S) where S.Element == T {
     self.underestimatedCount = 0
     self._elements = Array(elements)
     self._collectionState =
@@ -928,7 +928,7 @@ public struct MinimalRangeReplaceableCollection<T> : Collection, RangeReplaceabl
   }
 
   public mutating func append<S : Sequence>(contentsOf newElements: S)
-    where S.Iterator.Element == T {
+    where S.Element == T {
     let oldCount = count
     _elements.append(contentsOf: newElements)
     let newCount = count
@@ -938,7 +938,7 @@ public struct MinimalRangeReplaceableCollection<T> : Collection, RangeReplaceabl
   public mutating func replaceSubrange<C>(
     _ subRange: Range<MinimalIndex>,
     with newElements: C
-  ) where C : Collection, C.Iterator.Element == T {
+  ) where C : Collection, C.Element == T {
     let oldCount = count
     _elements.replaceSubrange(
       subRange.lowerBound.position..<subRange.upperBound.position,
@@ -958,7 +958,7 @@ public struct MinimalRangeReplaceableCollection<T> : Collection, RangeReplaceabl
 
   public mutating func insert<S : Collection>(
     contentsOf newElements: S, at i: MinimalIndex
-  ) where S.Iterator.Element == T {
+  ) where S.Element == T {
     let oldCount = count
     _elements.insert(contentsOf: newElements, at: i.position)
     let newCount = count
@@ -1019,7 +1019,7 @@ public struct MinimalMutableCollection<T> : Collection, MutableCollection {
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == T {
+  ) where S.Element == T {
     self._elements = Array(elements)
 
     self._collectionState = _CollectionState(
@@ -1189,7 +1189,7 @@ public struct MinimalMutableRangeReplaceableCollection<T> : Collection, MutableC
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == T {
+  ) where S.Element == T {
     self._elements = Array(elements)
 
     self._collectionState = _CollectionState(
@@ -1217,7 +1217,7 @@ public struct MinimalMutableRangeReplaceableCollection<T> : Collection, MutableC
       _CollectionState(name: "\(type(of: self))", elementCount: 0)
   }
 
-  public init<S : Sequence>(_ elements: S) where S.Iterator.Element == T {
+  public init<S : Sequence>(_ elements: S) where S.Element == T {
     self.underestimatedCount = 0
     self._elements = Array(elements)
     self._collectionState =
@@ -1369,7 +1369,7 @@ public struct MinimalMutableRangeReplaceableCollection<T> : Collection, MutableC
   }
 
   public mutating func append<S : Sequence>(contentsOf newElements: S)
-    where S.Iterator.Element == T {
+    where S.Element == T {
     let oldCount = count
     _elements.append(contentsOf: newElements)
     let newCount = count
@@ -1379,7 +1379,7 @@ public struct MinimalMutableRangeReplaceableCollection<T> : Collection, MutableC
   public mutating func replaceSubrange<C>(
     _ subRange: Range<MinimalIndex>,
     with newElements: C
-  ) where C : Collection, C.Iterator.Element == T {
+  ) where C : Collection, C.Element == T {
     let oldCount = count
     _elements.replaceSubrange(
       subRange.lowerBound.position..<subRange.upperBound.position,
@@ -1399,7 +1399,7 @@ public struct MinimalMutableRangeReplaceableCollection<T> : Collection, MutableC
 
   public mutating func insert<S : Collection>(
     contentsOf newElements: S, at i: MinimalIndex
-  ) where S.Iterator.Element == T {
+  ) where S.Element == T {
     let oldCount = count
     _elements.insert(contentsOf: newElements, at: i.position)
     let newCount = count
@@ -1460,7 +1460,7 @@ public struct MinimalBidirectionalCollection<T> : BidirectionalCollection {
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == T {
+  ) where S.Element == T {
     self._elements = Array(elements)
 
     self._collectionState = _CollectionState(
@@ -1623,7 +1623,7 @@ public struct MinimalRangeReplaceableBidirectionalCollection<T> : BidirectionalC
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == T {
+  ) where S.Element == T {
     self._elements = Array(elements)
 
     self._collectionState = _CollectionState(
@@ -1651,7 +1651,7 @@ public struct MinimalRangeReplaceableBidirectionalCollection<T> : BidirectionalC
       _CollectionState(name: "\(type(of: self))", elementCount: 0)
   }
 
-  public init<S : Sequence>(_ elements: S) where S.Iterator.Element == T {
+  public init<S : Sequence>(_ elements: S) where S.Element == T {
     self.underestimatedCount = 0
     self._elements = Array(elements)
     self._collectionState =
@@ -1796,7 +1796,7 @@ public struct MinimalRangeReplaceableBidirectionalCollection<T> : BidirectionalC
   }
 
   public mutating func append<S : Sequence>(contentsOf newElements: S)
-    where S.Iterator.Element == T {
+    where S.Element == T {
     let oldCount = count
     _elements.append(contentsOf: newElements)
     let newCount = count
@@ -1806,7 +1806,7 @@ public struct MinimalRangeReplaceableBidirectionalCollection<T> : BidirectionalC
   public mutating func replaceSubrange<C>(
     _ subRange: Range<MinimalIndex>,
     with newElements: C
-  ) where C : Collection, C.Iterator.Element == T {
+  ) where C : Collection, C.Element == T {
     let oldCount = count
     _elements.replaceSubrange(
       subRange.lowerBound.position..<subRange.upperBound.position,
@@ -1826,7 +1826,7 @@ public struct MinimalRangeReplaceableBidirectionalCollection<T> : BidirectionalC
 
   public mutating func insert<S : Collection>(
     contentsOf newElements: S, at i: MinimalIndex
-  ) where S.Iterator.Element == T {
+  ) where S.Element == T {
     let oldCount = count
     _elements.insert(contentsOf: newElements, at: i.position)
     let newCount = count
@@ -1887,7 +1887,7 @@ public struct MinimalMutableBidirectionalCollection<T> : BidirectionalCollection
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == T {
+  ) where S.Element == T {
     self._elements = Array(elements)
 
     self._collectionState = _CollectionState(
@@ -2058,7 +2058,7 @@ public struct MinimalMutableRangeReplaceableBidirectionalCollection<T> : Bidirec
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == T {
+  ) where S.Element == T {
     self._elements = Array(elements)
 
     self._collectionState = _CollectionState(
@@ -2086,7 +2086,7 @@ public struct MinimalMutableRangeReplaceableBidirectionalCollection<T> : Bidirec
       _CollectionState(name: "\(type(of: self))", elementCount: 0)
   }
 
-  public init<S : Sequence>(_ elements: S) where S.Iterator.Element == T {
+  public init<S : Sequence>(_ elements: S) where S.Element == T {
     self.underestimatedCount = 0
     self._elements = Array(elements)
     self._collectionState =
@@ -2239,7 +2239,7 @@ public struct MinimalMutableRangeReplaceableBidirectionalCollection<T> : Bidirec
   }
 
   public mutating func append<S : Sequence>(contentsOf newElements: S)
-    where S.Iterator.Element == T {
+    where S.Element == T {
     let oldCount = count
     _elements.append(contentsOf: newElements)
     let newCount = count
@@ -2249,7 +2249,7 @@ public struct MinimalMutableRangeReplaceableBidirectionalCollection<T> : Bidirec
   public mutating func replaceSubrange<C>(
     _ subRange: Range<MinimalIndex>,
     with newElements: C
-  ) where C : Collection, C.Iterator.Element == T {
+  ) where C : Collection, C.Element == T {
     let oldCount = count
     _elements.replaceSubrange(
       subRange.lowerBound.position..<subRange.upperBound.position,
@@ -2269,7 +2269,7 @@ public struct MinimalMutableRangeReplaceableBidirectionalCollection<T> : Bidirec
 
   public mutating func insert<S : Collection>(
     contentsOf newElements: S, at i: MinimalIndex
-  ) where S.Iterator.Element == T {
+  ) where S.Element == T {
     let oldCount = count
     _elements.insert(contentsOf: newElements, at: i.position)
     let newCount = count
@@ -2330,7 +2330,7 @@ public struct MinimalRandomAccessCollection<T> : RandomAccessCollection {
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == T {
+  ) where S.Element == T {
     self._elements = Array(elements)
 
     self._collectionState = _CollectionState(
@@ -2495,7 +2495,7 @@ public struct MinimalRandomAccessCollectionWithStrideableIndex<T> : RandomAccess
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == T {
+  ) where S.Element == T {
     self._elements = Array(elements)
 
     self._collectionState = _CollectionState(
@@ -2659,7 +2659,7 @@ public struct MinimalRangeReplaceableRandomAccessCollection<T> : RandomAccessCol
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == T {
+  ) where S.Element == T {
     self._elements = Array(elements)
 
     self._collectionState = _CollectionState(
@@ -2687,7 +2687,7 @@ public struct MinimalRangeReplaceableRandomAccessCollection<T> : RandomAccessCol
       _CollectionState(name: "\(type(of: self))", elementCount: 0)
   }
 
-  public init<S : Sequence>(_ elements: S) where S.Iterator.Element == T {
+  public init<S : Sequence>(_ elements: S) where S.Element == T {
     self.underestimatedCount = 0
     self._elements = Array(elements)
     self._collectionState =
@@ -2834,7 +2834,7 @@ public struct MinimalRangeReplaceableRandomAccessCollection<T> : RandomAccessCol
   }
 
   public mutating func append<S : Sequence>(contentsOf newElements: S)
-    where S.Iterator.Element == T {
+    where S.Element == T {
     let oldCount = count
     _elements.append(contentsOf: newElements)
     let newCount = count
@@ -2844,7 +2844,7 @@ public struct MinimalRangeReplaceableRandomAccessCollection<T> : RandomAccessCol
   public mutating func replaceSubrange<C>(
     _ subRange: Range<MinimalIndex>,
     with newElements: C
-  ) where C : Collection, C.Iterator.Element == T {
+  ) where C : Collection, C.Element == T {
     let oldCount = count
     _elements.replaceSubrange(
       subRange.lowerBound.position..<subRange.upperBound.position,
@@ -2864,7 +2864,7 @@ public struct MinimalRangeReplaceableRandomAccessCollection<T> : RandomAccessCol
 
   public mutating func insert<S : Collection>(
     contentsOf newElements: S, at i: MinimalIndex
-  ) where S.Iterator.Element == T {
+  ) where S.Element == T {
     let oldCount = count
     _elements.insert(contentsOf: newElements, at: i.position)
     let newCount = count
@@ -2925,7 +2925,7 @@ public struct MinimalRangeReplaceableRandomAccessCollectionWithStrideableIndex<T
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == T {
+  ) where S.Element == T {
     self._elements = Array(elements)
 
     self._collectionState = _CollectionState(
@@ -2953,7 +2953,7 @@ public struct MinimalRangeReplaceableRandomAccessCollectionWithStrideableIndex<T
       _CollectionState(name: "\(type(of: self))", elementCount: 0)
   }
 
-  public init<S : Sequence>(_ elements: S) where S.Iterator.Element == T {
+  public init<S : Sequence>(_ elements: S) where S.Element == T {
     self.underestimatedCount = 0
     self._elements = Array(elements)
     self._collectionState =
@@ -3099,7 +3099,7 @@ public struct MinimalRangeReplaceableRandomAccessCollectionWithStrideableIndex<T
   }
 
   public mutating func append<S : Sequence>(contentsOf newElements: S)
-    where S.Iterator.Element == T {
+    where S.Element == T {
     let oldCount = count
     _elements.append(contentsOf: newElements)
     let newCount = count
@@ -3109,7 +3109,7 @@ public struct MinimalRangeReplaceableRandomAccessCollectionWithStrideableIndex<T
   public mutating func replaceSubrange<C>(
     _ subRange: Range<MinimalStrideableIndex>,
     with newElements: C
-  ) where C : Collection, C.Iterator.Element == T {
+  ) where C : Collection, C.Element == T {
     let oldCount = count
     _elements.replaceSubrange(
       subRange.lowerBound.position..<subRange.upperBound.position,
@@ -3129,7 +3129,7 @@ public struct MinimalRangeReplaceableRandomAccessCollectionWithStrideableIndex<T
 
   public mutating func insert<S : Collection>(
     contentsOf newElements: S, at i: MinimalStrideableIndex
-  ) where S.Iterator.Element == T {
+  ) where S.Element == T {
     let oldCount = count
     _elements.insert(contentsOf: newElements, at: i.position)
     let newCount = count
@@ -3190,7 +3190,7 @@ public struct MinimalMutableRandomAccessCollection<T> : RandomAccessCollection, 
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == T {
+  ) where S.Element == T {
     self._elements = Array(elements)
 
     self._collectionState = _CollectionState(
@@ -3363,7 +3363,7 @@ public struct MinimalMutableRangeReplaceableRandomAccessCollection<T> : RandomAc
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == T {
+  ) where S.Element == T {
     self._elements = Array(elements)
 
     self._collectionState = _CollectionState(
@@ -3391,7 +3391,7 @@ public struct MinimalMutableRangeReplaceableRandomAccessCollection<T> : RandomAc
       _CollectionState(name: "\(type(of: self))", elementCount: 0)
   }
 
-  public init<S : Sequence>(_ elements: S) where S.Iterator.Element == T {
+  public init<S : Sequence>(_ elements: S) where S.Element == T {
     self.underestimatedCount = 0
     self._elements = Array(elements)
     self._collectionState =
@@ -3546,7 +3546,7 @@ public struct MinimalMutableRangeReplaceableRandomAccessCollection<T> : RandomAc
   }
 
   public mutating func append<S : Sequence>(contentsOf newElements: S)
-    where S.Iterator.Element == T {
+    where S.Element == T {
     let oldCount = count
     _elements.append(contentsOf: newElements)
     let newCount = count
@@ -3556,7 +3556,7 @@ public struct MinimalMutableRangeReplaceableRandomAccessCollection<T> : RandomAc
   public mutating func replaceSubrange<C>(
     _ subRange: Range<MinimalIndex>,
     with newElements: C
-  ) where C : Collection, C.Iterator.Element == T {
+  ) where C : Collection, C.Element == T {
     let oldCount = count
     _elements.replaceSubrange(
       subRange.lowerBound.position..<subRange.upperBound.position,
@@ -3576,7 +3576,7 @@ public struct MinimalMutableRangeReplaceableRandomAccessCollection<T> : RandomAc
 
   public mutating func insert<S : Collection>(
     contentsOf newElements: S, at i: MinimalIndex
-  ) where S.Iterator.Element == T {
+  ) where S.Element == T {
     let oldCount = count
     _elements.insert(contentsOf: newElements, at: i.position)
     let newCount = count
@@ -3642,7 +3642,7 @@ public struct DefaultedSequence<Element> : Sequence {
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == Element {
+  ) where S.Element == Element {
     self.init(base: MinimalSequence(
       elements: elements, underestimatedCount: underestimatedCount))
   }
@@ -3682,7 +3682,7 @@ public struct DefaultedCollection<Element> : Collection {
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == Element {
+  ) where S.Element == Element {
     self.init(base:
       MinimalCollection(elements: elements, underestimatedCount: underestimatedCount))
   }
@@ -3809,7 +3809,7 @@ public struct DefaultedForwardRangeReplaceableSlice<Element>
   >(
     _ subRange: Range<Index>,
     with newElements: C
-  ) where C.Iterator.Element == Element {
+  ) where C.Element == Element {
     let startOffset = startIndex.position
     let endOffset =
       endIndex.position
@@ -3853,7 +3853,7 @@ public struct DefaultedRangeReplaceableCollection<Element> : Collection, RangeRe
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == Element {
+  ) where S.Element == Element {
     self.init(base:
       MinimalRangeReplaceableCollection(elements: elements, underestimatedCount: underestimatedCount))
   }
@@ -3917,7 +3917,7 @@ public struct DefaultedRangeReplaceableCollection<Element> : Collection, RangeRe
   public mutating func replaceSubrange<C>(
     _ subRange: Range<DefaultedRangeReplaceableCollection<Element>.Index>,
     with newElements: C
-  ) where C : Collection, C.Iterator.Element == Element {
+  ) where C : Collection, C.Element == Element {
     base.replaceSubrange(subRange, with: newElements)
   }
 }
@@ -3990,7 +3990,7 @@ public struct DefaultedForwardRangeReplaceableSlice<Element>
   >(
     _ subRange: Range<Index>,
     with newElements: C
-  ) where C.Iterator.Element == Element {
+  ) where C.Element == Element {
     let startOffset = startIndex.position
     let endOffset =
       endIndex.position
@@ -4034,7 +4034,7 @@ public struct DefaultedMutableCollection<Element> : Collection, MutableCollectio
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == Element {
+  ) where S.Element == Element {
     self.init(base:
       MinimalMutableCollection(elements: elements, underestimatedCount: underestimatedCount))
   }
@@ -4167,7 +4167,7 @@ public struct DefaultedForwardRangeReplaceableSlice<Element>
   >(
     _ subRange: Range<Index>,
     with newElements: C
-  ) where C.Iterator.Element == Element {
+  ) where C.Element == Element {
     let startOffset = startIndex.position
     let endOffset =
       endIndex.position
@@ -4211,7 +4211,7 @@ public struct DefaultedMutableRangeReplaceableCollection<Element> : Collection, 
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == Element {
+  ) where S.Element == Element {
     self.init(base:
       MinimalMutableRangeReplaceableCollection(elements: elements, underestimatedCount: underestimatedCount))
   }
@@ -4281,7 +4281,7 @@ public struct DefaultedMutableRangeReplaceableCollection<Element> : Collection, 
   public mutating func replaceSubrange<C>(
     _ subRange: Range<DefaultedMutableRangeReplaceableCollection<Element>.Index>,
     with newElements: C
-  ) where C : Collection, C.Iterator.Element == Element {
+  ) where C : Collection, C.Element == Element {
     base.replaceSubrange(subRange, with: newElements)
   }
 }
@@ -4354,7 +4354,7 @@ public struct DefaultedForwardRangeReplaceableSlice<Element>
   >(
     _ subRange: Range<Index>,
     with newElements: C
-  ) where C.Iterator.Element == Element {
+  ) where C.Element == Element {
     let startOffset = startIndex.position
     let endOffset =
       endIndex.position
@@ -4398,7 +4398,7 @@ public struct DefaultedBidirectionalCollection<Element> : BidirectionalCollectio
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == Element {
+  ) where S.Element == Element {
     self.init(base:
       MinimalBidirectionalCollection(elements: elements, underestimatedCount: underestimatedCount))
   }
@@ -4531,7 +4531,7 @@ public struct DefaultedBidirectionalRangeReplaceableSlice<Element>
   >(
     _ subRange: Range<Index>,
     with newElements: C
-  ) where C.Iterator.Element == Element {
+  ) where C.Element == Element {
     let startOffset = startIndex.position
     let endOffset =
       endIndex.position
@@ -4575,7 +4575,7 @@ public struct DefaultedRangeReplaceableBidirectionalCollection<Element> : Bidire
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == Element {
+  ) where S.Element == Element {
     self.init(base:
       MinimalRangeReplaceableBidirectionalCollection(elements: elements, underestimatedCount: underestimatedCount))
   }
@@ -4645,7 +4645,7 @@ public struct DefaultedRangeReplaceableBidirectionalCollection<Element> : Bidire
   public mutating func replaceSubrange<C>(
     _ subRange: Range<DefaultedRangeReplaceableBidirectionalCollection<Element>.Index>,
     with newElements: C
-  ) where C : Collection, C.Iterator.Element == Element {
+  ) where C : Collection, C.Element == Element {
     base.replaceSubrange(subRange, with: newElements)
   }
 }
@@ -4718,7 +4718,7 @@ public struct DefaultedBidirectionalRangeReplaceableSlice<Element>
   >(
     _ subRange: Range<Index>,
     with newElements: C
-  ) where C.Iterator.Element == Element {
+  ) where C.Element == Element {
     let startOffset = startIndex.position
     let endOffset =
       endIndex.position
@@ -4762,7 +4762,7 @@ public struct DefaultedMutableBidirectionalCollection<Element> : BidirectionalCo
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == Element {
+  ) where S.Element == Element {
     self.init(base:
       MinimalMutableBidirectionalCollection(elements: elements, underestimatedCount: underestimatedCount))
   }
@@ -4901,7 +4901,7 @@ public struct DefaultedBidirectionalRangeReplaceableSlice<Element>
   >(
     _ subRange: Range<Index>,
     with newElements: C
-  ) where C.Iterator.Element == Element {
+  ) where C.Element == Element {
     let startOffset = startIndex.position
     let endOffset =
       endIndex.position
@@ -4945,7 +4945,7 @@ public struct DefaultedMutableRangeReplaceableBidirectionalCollection<Element> :
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == Element {
+  ) where S.Element == Element {
     self.init(base:
       MinimalMutableRangeReplaceableBidirectionalCollection(elements: elements, underestimatedCount: underestimatedCount))
   }
@@ -5021,7 +5021,7 @@ public struct DefaultedMutableRangeReplaceableBidirectionalCollection<Element> :
   public mutating func replaceSubrange<C>(
     _ subRange: Range<DefaultedMutableRangeReplaceableBidirectionalCollection<Element>.Index>,
     with newElements: C
-  ) where C : Collection, C.Iterator.Element == Element {
+  ) where C : Collection, C.Element == Element {
     base.replaceSubrange(subRange, with: newElements)
   }
 }
@@ -5094,7 +5094,7 @@ public struct DefaultedBidirectionalRangeReplaceableSlice<Element>
   >(
     _ subRange: Range<Index>,
     with newElements: C
-  ) where C.Iterator.Element == Element {
+  ) where C.Element == Element {
     let startOffset = startIndex.position
     let endOffset =
       endIndex.position
@@ -5140,7 +5140,7 @@ public struct DefaultedRandomAccessCollection<Element> : RandomAccessCollection 
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == Element {
+  ) where S.Element == Element {
     self.init(base:
       MinimalRandomAccessCollection(elements: elements, underestimatedCount: underestimatedCount))
   }
@@ -5281,7 +5281,7 @@ public struct DefaultedRandomAccessRangeReplaceableSlice<Element>
   >(
     _ subRange: Range<Index>,
     with newElements: C
-  ) where C.Iterator.Element == Element {
+  ) where C.Element == Element {
     let startOffset = startIndex.position
     let endOffset =
       endIndex.position
@@ -5326,7 +5326,7 @@ public struct DefaultedRandomAccessCollectionWithStrideableIndex<Element> : Rand
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == Element {
+  ) where S.Element == Element {
     self.init(base:
       MinimalRandomAccessCollectionWithStrideableIndex(elements: elements, underestimatedCount: underestimatedCount))
   }
@@ -5443,7 +5443,7 @@ public struct DefaultedRandomAccessRangeReplaceableSlice<Element>
   >(
     _ subRange: Range<Index>,
     with newElements: C
-  ) where C.Iterator.Element == Element {
+  ) where C.Element == Element {
     let startOffset = startIndex.position
     let endOffset =
       endIndex.position
@@ -5489,7 +5489,7 @@ public struct DefaultedRangeReplaceableRandomAccessCollection<Element> : RandomA
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == Element {
+  ) where S.Element == Element {
     self.init(base:
       MinimalRangeReplaceableRandomAccessCollection(elements: elements, underestimatedCount: underestimatedCount))
   }
@@ -5567,7 +5567,7 @@ public struct DefaultedRangeReplaceableRandomAccessCollection<Element> : RandomA
   public mutating func replaceSubrange<C>(
     _ subRange: Range<DefaultedRangeReplaceableRandomAccessCollection<Element>.Index>,
     with newElements: C
-  ) where C : Collection, C.Iterator.Element == Element {
+  ) where C : Collection, C.Element == Element {
     base.replaceSubrange(subRange, with: newElements)
   }
 }
@@ -5640,7 +5640,7 @@ public struct DefaultedRandomAccessRangeReplaceableSlice<Element>
   >(
     _ subRange: Range<Index>,
     with newElements: C
-  ) where C.Iterator.Element == Element {
+  ) where C.Element == Element {
     let startOffset = startIndex.position
     let endOffset =
       endIndex.position
@@ -5686,7 +5686,7 @@ public struct DefaultedMutableRandomAccessCollection<Element> : RandomAccessColl
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == Element {
+  ) where S.Element == Element {
     self.init(base:
       MinimalMutableRandomAccessCollection(elements: elements, underestimatedCount: underestimatedCount))
   }
@@ -5833,7 +5833,7 @@ public struct DefaultedRandomAccessRangeReplaceableSlice<Element>
   >(
     _ subRange: Range<Index>,
     with newElements: C
-  ) where C.Iterator.Element == Element {
+  ) where C.Element == Element {
     let startOffset = startIndex.position
     let endOffset =
       endIndex.position
@@ -5879,7 +5879,7 @@ public struct DefaultedMutableRangeReplaceableRandomAccessCollection<Element> : 
   public init<S : Sequence>(
     elements: S,
     underestimatedCount: UnderestimatedCountBehavior = .value(0)
-  ) where S.Iterator.Element == Element {
+  ) where S.Element == Element {
     self.init(base:
       MinimalMutableRangeReplaceableRandomAccessCollection(elements: elements, underestimatedCount: underestimatedCount))
   }
@@ -5963,7 +5963,7 @@ public struct DefaultedMutableRangeReplaceableRandomAccessCollection<Element> : 
   public mutating func replaceSubrange<C>(
     _ subRange: Range<DefaultedMutableRangeReplaceableRandomAccessCollection<Element>.Index>,
     with newElements: C
-  ) where C : Collection, C.Iterator.Element == Element {
+  ) where C : Collection, C.Element == Element {
     base.replaceSubrange(subRange, with: newElements)
   }
 }
@@ -6036,7 +6036,7 @@ public struct DefaultedRandomAccessRangeReplaceableSlice<Element>
   >(
     _ subRange: Range<Index>,
     with newElements: C
-  ) where C.Iterator.Element == Element {
+  ) where C.Element == Element {
     let startOffset = startIndex.position
     let endOffset =
       endIndex.position

--- a/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
+++ b/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
@@ -227,7 +227,7 @@ public func forAllPermutations(_ size: Int, _ body: ([Int]) -> Void) {
 
 /// Generate all permutations.
 public func forAllPermutations<S : Sequence>(
-  _ sequence: S, _ body: ([S.Iterator.Element]) -> Void
+  _ sequence: S, _ body: ([S.Element]) -> Void
 ) {
   let data = Array(sequence)
   forAllPermutations(data.count) {
@@ -239,8 +239,8 @@ public func forAllPermutations<S : Sequence>(
 
 public func cartesianProduct<C1 : Collection, C2 : Collection>(
   _ c1: C1, _ c2: C2
-) -> [(C1.Iterator.Element, C2.Iterator.Element)] {
-  var result: [(C1.Iterator.Element, C2.Iterator.Element)] = []
+) -> [(C1.Element, C2.Element)] {
+  var result: [(C1.Element, C2.Element)] = []
   for e1 in c1 {
     for e2 in c2 {
       result.append((e1, e2))

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -865,7 +865,7 @@ extension ProcessTerminationStatus {
       // This default case is needed for standard library builds where
       // resilience is enabled.
       // FIXME: Add the .exit case when there is a way to suppress when not.
-      //   case .exit(_): return false
+      //   case .exit: return false
       return false
     }
   }
@@ -1272,11 +1272,11 @@ struct _ParentProcess {
       testPassed = false
       print("expecting a crash, but the test did not crash")
 
-    case (.some(_), false):
+    case (.some, false):
       testPassed = false
       print("the test crashed unexpectedly")
 
-    case (.some(_), true):
+    case (.some, true):
       testPassed = !_anyExpectFailed
     }
     if testPassed && t.crashOutputMatches.count > 0 {

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -2320,7 +2320,7 @@ public func checkEquatable<Instances : Collection>(
   showFrame: Bool = true,
   file: String = #file, line: UInt = #line
 ) where
-  Instances.Iterator.Element : Equatable
+  Instances.Element : Equatable
 {
   let indices = Array(instances.indices)
   _checkEquatableImpl(
@@ -2462,7 +2462,7 @@ public func checkHashable<Instances: Collection>(
   stackTrace: SourceLocStack = SourceLocStack(),
   showFrame: Bool = true,
   file: String = #file, line: UInt = #line
-) where Instances.Iterator.Element: Hashable {
+) where Instances.Element: Hashable {
   checkHashable(
     instances,
     equalityOracle: equalityOracle,
@@ -2486,7 +2486,7 @@ public func checkHashable<Instances: Collection>(
   showFrame: Bool = true,
   file: String = #file, line: UInt = #line
 ) where
-  Instances.Iterator.Element: Hashable {
+  Instances.Element: Hashable {
   checkEquatable(
     instances,
     oracle: equalityOracle,
@@ -2645,7 +2645,7 @@ public func checkComparable<Instances : Collection>(
   showFrame: Bool = true,
   file: String = #file, line: UInt = #line
 ) where
-  Instances.Iterator.Element : Comparable {
+  Instances.Element : Comparable {
 
   // Also checks that equality is consistent with comparison and that
   // the oracle obeys the equality laws
@@ -2752,17 +2752,17 @@ public func checkComparable<T : Comparable>(
 public func checkStrideable<Instances : Collection, Strides : Collection>(
   _ instances: Instances, strides: Strides,
   distanceOracle:
-    (Instances.Index, Instances.Index) -> Strides.Iterator.Element,
+    (Instances.Index, Instances.Index) -> Strides.Element,
   advanceOracle:
-    (Instances.Index, Strides.Index) -> Instances.Iterator.Element,
+    (Instances.Index, Strides.Index) -> Instances.Element,
 
   _ message: @autoclosure () -> String = "",
   stackTrace: SourceLocStack = SourceLocStack(),
   showFrame: Bool = true,
   file: String = #file, line: UInt = #line
 ) where
-  Instances.Iterator.Element : Strideable,
-  Instances.Iterator.Element.Stride == Strides.Iterator.Element {
+  Instances.Element : Strideable,
+  Instances.Element.Stride == Strides.Element {
 
   checkComparable(
     instances,
@@ -2799,7 +2799,7 @@ public func nthIndex<C: Collection>(_ x: C, _ n: Int) -> C.Index {
   return x.index(x.startIndex, offsetBy: numericCast(n))
 }
 
-public func nth<C: Collection>(_ x: C, _ n: Int) -> C.Iterator.Element {
+public func nth<C: Collection>(_ x: C, _ n: Int) -> C.Element {
   return x[nthIndex(x, n)]
 }
 
@@ -2813,8 +2813,8 @@ public func expectEqualSequence<
   showFrame: Bool = true,
   file: String = #file, line: UInt = #line
 ) where
-  Expected.Iterator.Element == Actual.Iterator.Element,
-  Expected.Iterator.Element : Equatable {
+  Expected.Element == Actual.Element,
+  Expected.Element : Equatable {
 
   expectEqualSequence(expected, actual, message(),
       stackTrace: stackTrace.pushIf(showFrame, file: file, line: line)) { $0 == $1 }
@@ -2832,8 +2832,8 @@ public func expectEqualSequence<
   showFrame: Bool = true,
   file: String = #file, line: UInt = #line
 ) where
-  Expected.Iterator.Element == Actual.Iterator.Element,
-  Expected.Iterator.Element == (T, U) {
+  Expected.Element == Actual.Element,
+  Expected.Element == (T, U) {
 
   expectEqualSequence(
     expected, actual, message(),
@@ -2852,9 +2852,9 @@ public func expectEqualSequence<
   stackTrace: SourceLocStack = SourceLocStack(),
   showFrame: Bool = true,
   file: String = #file, line: UInt = #line,
-  sameValue: (Expected.Iterator.Element, Expected.Iterator.Element) -> Bool
+  sameValue: (Expected.Element, Expected.Element) -> Bool
 ) where
-  Expected.Iterator.Element == Actual.Iterator.Element {
+  Expected.Element == Actual.Element {
 
   if !expected.elementsEqual(actual, by: sameValue) {
     expectationFailure("expected elements: \"\(expected)\"\n"
@@ -2873,14 +2873,14 @@ public func expectEqualsUnordered<
   stackTrace: SourceLocStack = SourceLocStack(),
   showFrame: Bool = true,
   file: String = #file, line: UInt = #line,
-  compare: @escaping (Expected.Iterator.Element, Expected.Iterator.Element)
+  compare: @escaping (Expected.Element, Expected.Element)
     -> ExpectedComparisonResult
 ) where
-  Expected.Iterator.Element == Actual.Iterator.Element {
+  Expected.Element == Actual.Element {
 
-  let x: [Expected.Iterator.Element] =
+  let x: [Expected.Element] =
     expected.sorted { compare($0, $1).isLT() }
-  let y: [Actual.Iterator.Element] =
+  let y: [Actual.Element] =
     actual.sorted { compare($0, $1).isLT() }
   expectEqualSequence(
     x, y, message(),
@@ -2897,8 +2897,8 @@ public func expectEqualsUnordered<
   showFrame: Bool = true,
   file: String = #file, line: UInt = #line
 ) where
-  Expected.Iterator.Element == Actual.Iterator.Element,
-  Expected.Iterator.Element : Comparable {
+  Expected.Element == Actual.Element,
+  Expected.Element : Comparable {
 
   expectEqualsUnordered(expected, actual, message(),
       stackTrace: stackTrace.pushIf(showFrame, file: file, line: line)) {
@@ -2976,8 +2976,8 @@ public func expectEqualsUnordered<
   showFrame: Bool = true,
   file: String = #file, line: UInt = #line
 ) where
-  Actual.Iterator.Element == (key: T, value: T),
-  Expected.Iterator.Element == (T, T) {
+  Actual.Element == (key: T, value: T),
+  Expected.Element == (T, T) {
 
   func comparePairLess(_ lhs: (T, T), rhs: (T, T)) -> Bool {
     return [lhs.0, lhs.1].lexicographicallyPrecedes([rhs.0, rhs.1])

--- a/stdlib/private/SwiftPrivate/PRNG.swift
+++ b/stdlib/private/SwiftPrivate/PRNG.swift
@@ -54,7 +54,7 @@ public func randArray(_ count: Int) -> [Int] {
 
 public func pickRandom<
   C : RandomAccessCollection
->(_ c: C) -> C.Iterator.Element {
+>(_ c: C) -> C.Element {
   let i = Int(rand32(exclusiveUpperBound: numericCast(c.count)))
   return c[c.index(c.startIndex, offsetBy: numericCast(i))]
 }

--- a/stdlib/private/SwiftPrivate/SwiftPrivate.swift
+++ b/stdlib/private/SwiftPrivate/SwiftPrivate.swift
@@ -23,14 +23,14 @@ public func asHex<T : FixedWidthInteger>(_ x: T) -> String {
   // FIXME(integers): support a more general BinaryInteger protocol
 public func asHex<S : Sequence>(_ x: S) -> String
   where
-  S.Iterator.Element : FixedWidthInteger {
+  S.Element : FixedWidthInteger {
   return "[ " + x.lazy.map { asHex($0) }.joined(separator: ", ") + " ]"
 }
 
 /// Compute the prefix sum of `seq`.
 public func scan<
   S : Sequence, U
->(_ seq: S, _ initial: U, _ combine: (U, S.Iterator.Element) -> U) -> [U] {
+>(_ seq: S, _ initial: U, _ combine: (U, S.Element) -> U) -> [U] {
   var result: [U] = []
   result.reserveCapacity(seq.underestimatedCount)
   var runningResult = initial
@@ -55,8 +55,8 @@ public func randomShuffle<T>(_ a: [T]) -> [T] {
 
 public func gather<C : Collection, IndicesSequence : Sequence>(
   _ collection: C, _ indices: IndicesSequence
-) -> [C.Iterator.Element]
-  where IndicesSequence.Iterator.Element == C.Index {
+) -> [C.Element]
+  where IndicesSequence.Element == C.Index {
   return Array(indices.map { collection[$0] })
 }
 

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -158,7 +158,7 @@ extension ClosedRange.Index : Comparable {
     switch (lhs, rhs) {
     case (.inRange(let l), .inRange(let r)):
       return l < r
-    case (.inRange(_), .pastEnd):
+    case (.inRange, .pastEnd):
       return true
     default:
       return false

--- a/stdlib/public/core/Codable.swift.gyb
+++ b/stdlib/public/core/Codable.swift.gyb
@@ -851,7 +851,7 @@ public protocol UnkeyedEncodingContainer {
   /// - parameter sequence: The sequences whose contents to encode.
   /// - throws: An error if any of the contained values throws an error.
   mutating func encode<T : Sequence>(
-    contentsOf sequence: T) throws where T.Iterator.Element == ${type}
+    contentsOf sequence: T) throws where T.Element == ${type}
 % end
 
   /// Encodes the elements of the given sequence.
@@ -859,7 +859,7 @@ public protocol UnkeyedEncodingContainer {
   /// - parameter sequence: The sequences whose contents to encode.
   /// - throws: An error if any of the contained values throws an error.
   mutating func encode<T : Sequence>(
-    contentsOf sequence: T) throws where T.Iterator.Element : Encodable
+    contentsOf sequence: T) throws where T.Element : Encodable
 
   /// Encodes a nested container keyed by the given type and returns it.
   ///
@@ -2138,7 +2138,7 @@ public extension UnkeyedEncodingContainer {
 % for type in codable_types:
   @inlinable // FIXME(sil-serialize-all)
   public mutating func encode<T : Sequence>(
-    contentsOf sequence: T) throws where T.Iterator.Element == ${type}
+    contentsOf sequence: T) throws where T.Element == ${type}
   {
     for element in sequence {
       try self.encode(element)
@@ -2148,7 +2148,7 @@ public extension UnkeyedEncodingContainer {
 
   @inlinable // FIXME(sil-serialize-all)
   public mutating func encode<T : Sequence>(
-    contentsOf sequence: T) throws where T.Iterator.Element : Encodable
+    contentsOf sequence: T) throws where T.Element : Encodable
   {
     for element in sequence {
       try self.encode(element)

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1244,7 +1244,7 @@ extension Collection {
   /// - Complexity: Hopefully less than O(`count`).
   @inlinable
   public // dispatching
-  func _customIndexOfEquatableElement(_: Iterator.Element) -> Index?? {
+  func _customIndexOfEquatableElement(_: Element) -> Index?? {
     return nil
   }
 

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -409,7 +409,7 @@ internal class _AnyRandomAccessCollectionBox<Element>
 
 @_fixed_layout
 @usableFromInline
-internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Element>
+internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Element>
 {
   @usableFromInline
   internal typealias Element = S.Element

--- a/stdlib/public/core/LazyCollection.swift
+++ b/stdlib/public/core/LazyCollection.swift
@@ -94,20 +94,20 @@ extension LazyCollection : Sequence {
 
   @inlinable
   public func _copyToContiguousArray()
-     -> ContiguousArray<Base.Iterator.Element> {
+     -> ContiguousArray<Base.Element> {
     return _base._copyToContiguousArray()
   }
 
   @inlinable
   public func _copyContents(
-    initializing buf: UnsafeMutableBufferPointer<Iterator.Element>
-  ) -> (Iterator,UnsafeMutableBufferPointer<Iterator.Element>.Index) {
+    initializing buf: UnsafeMutableBufferPointer<Element>
+  ) -> (Iterator,UnsafeMutableBufferPointer<Element>.Index) {
     return _base._copyContents(initializing: buf)
   }
 
   @inlinable
   public func _customContainsEquatableElement(
-    _ element: Base.Iterator.Element
+    _ element: Base.Element
   ) -> Bool? {
     return _base._customContainsEquatableElement(element)
   }

--- a/stdlib/public/core/LazySequence.swift
+++ b/stdlib/public/core/LazySequence.swift
@@ -132,8 +132,7 @@ public protocol LazySequenceProtocol : Sequence {
   /// possibly with a simpler type.
   ///
   /// - See also: `elements`
-  associatedtype Elements : Sequence = Self
-  where Elements.Iterator.Element == Iterator.Element
+  associatedtype Elements: Sequence = Self where Elements.Element == Element
 
   /// A sequence containing the same elements as this one, possibly with
   /// a simpler type.

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -469,7 +469,7 @@ extension Optional {
   @_transparent
   public static func ~=(lhs: _OptionalNilComparisonType, rhs: Wrapped?) -> Bool {
     switch rhs {
-    case .some(_):
+    case .some:
       return false
     case .none:
       return true
@@ -503,7 +503,7 @@ extension Optional {
   @_transparent
   public static func ==(lhs: Wrapped?, rhs: _OptionalNilComparisonType) -> Bool {
     switch lhs {
-    case .some(_):
+    case .some:
       return false
     case .none:
       return true
@@ -534,7 +534,7 @@ extension Optional {
   @_transparent
   public static func !=(lhs: Wrapped?, rhs: _OptionalNilComparisonType) -> Bool {
     switch lhs {
-    case .some(_):
+    case .some:
       return true
     case .none:
       return false
@@ -565,7 +565,7 @@ extension Optional {
   @_transparent
   public static func ==(lhs: _OptionalNilComparisonType, rhs: Wrapped?) -> Bool {
     switch rhs {
-    case .some(_):
+    case .some:
       return false
     case .none:
       return true
@@ -596,7 +596,7 @@ extension Optional {
   @_transparent
   public static func !=(lhs: _OptionalNilComparisonType, rhs: Wrapped?) -> Bool {
     switch rhs {
-    case .some(_):
+    case .some:
       return true
     case .none:
       return false

--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -292,7 +292,7 @@ extension _StringObject {
     @inline(__always)
     get {
 #if arch(i386) || arch(arm)
-      if case .strong(_) = _variant {
+      if case .strong = _variant {
         _sanityCheckFailure("internal error: expected a tagged String")
       }
       return _bits
@@ -557,7 +557,7 @@ extension _StringObject {
     @inline(__always)
     get {
 #if arch(i386) || arch(arm)
-      guard case .strong(_) = _variant else { return false }
+      guard case .strong = _variant else { return false }
       return _bits & _StringObject._isCocoaBit == 0
 #else
       return _variantBits == 0
@@ -571,7 +571,7 @@ extension _StringObject {
     @inline(__always)
     get {
 #if arch(i386) || arch(arm)
-      guard case .strong(_) = _variant else { return false }
+      guard case .strong = _variant else { return false }
       return _bits & _StringObject._isCocoaBit != 0
 #else
       return _variantBits == _StringObject._subVariantBit
@@ -599,7 +599,7 @@ extension _StringObject {
     get {
 #if arch(i386) || arch(arm)
       switch _variant {
-      case .strong(_): return false
+      case .strong: return false
       default:
         return true
       }
@@ -673,7 +673,7 @@ extension _StringObject {
     get {
 #if arch(i386) || arch(arm)
       switch _variant {
-      case .strong(_):
+      case .strong:
         return _bits & _StringObject._isOpaqueBit == 0
       case .unmanagedSingleByte, .unmanagedDoubleByte:
         return true
@@ -713,7 +713,7 @@ extension _StringObject {
     get {
 #if arch(i386) || arch(arm)
       switch _variant {
-      case .strong(_):
+      case .strong:
         return _bits & _StringObject._twoByteBit == 0
       case .unmanagedSingleByte, .smallSingleByte:
         return true


### PR DESCRIPTION
Some minor cleanups:

 - remove unnecessary uses of `case .enumcase(_)`
 - modernize a couple of benchmarks in ways that shouldn't touch perf
 - replace lots of cases of `Iterator.Element` with `Element`