### PR TITLE
[arc-codemotion] Eliminate retains that we move next to fatalErrors a…

### DIFF
--- a/include/swift/Strings.h
+++ b/include/swift/Strings.h
@@ -13,6 +13,9 @@
 #ifndef SWIFT_STRINGS_H
 #define SWIFT_STRINGS_H
 
+#include "swift/Basic/LLVM.h"
+#include "llvm/ADT/StringRef.h"
+
 namespace swift {
 
 /// The extension for serialized modules.
@@ -89,6 +92,8 @@ constexpr static const char BUILTIN_TYPE_NAME_VEC[] = "Builtin.Vec";
 constexpr static const char BUILTIN_TYPE_NAME_SILTOKEN[] = "Builtin.SILToken";
 /// The name of the Builtin type for Word
 constexpr static const char BUILTIN_TYPE_NAME_WORD[] = "Builtin.Word";
+constexpr static StringLiteral SEMANTICS_ARC_PROGRAMTERMINATION_POINT =
+    "arc.programtermination_point";
 } // end namespace swift
 
 #endif // SWIFT_STRINGS_H

--- a/lib/SILOptimizer/Transforms/ARCCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/ARCCodeMotion.cpp
@@ -71,15 +71,17 @@
 
 #define DEBUG_TYPE "sil-rr-code-motion"
 #include "swift/SIL/SILBuilder.h"
-#include "swift/SILOptimizer/Analysis/AliasAnalysis.h"
 #include "swift/SILOptimizer/Analysis/ARCAnalysis.h"
+#include "swift/SILOptimizer/Analysis/AliasAnalysis.h"
 #include "swift/SILOptimizer/Analysis/EscapeAnalysis.h"
 #include "swift/SILOptimizer/Analysis/PostOrderAnalysis.h"
 #include "swift/SILOptimizer/Analysis/RCIdentityAnalysis.h"
+#include "swift/SILOptimizer/Analysis/ProgramTerminationAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/CFG.h"
 #include "swift/SILOptimizer/Utils/Local.h"
+#include "swift/Strings.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/Statistic.h"
@@ -296,6 +298,8 @@ class RetainCodeMotionContext : public CodeMotionContext {
   /// All the retain block state for all the basic blocks in the function. 
   llvm::SmallDenseMap<SILBasicBlock *, RetainBlockState *> BlockStates;
 
+  ProgramTerminationFunctionInfo PTFI;
+
   /// Return true if the instruction blocks the Ptr to be moved further.
   bool mayBlockCodeMotion(SILInstruction *II, SILValue Ptr) override {
     // NOTE: If more checks are to be added, place the most expensive in the
@@ -334,7 +338,7 @@ public:
   RetainCodeMotionContext(llvm::SpecificBumpPtrAllocator<BlockState> &BPA,
                           SILFunction *F, PostOrderFunctionInfo *PO,
                           AliasAnalysis *AA, RCIdentityFunctionInfo *RCFI)
-      : CodeMotionContext(BPA, F, PO, AA, RCFI) {}
+      : CodeMotionContext(BPA, F, PO, AA, RCFI), PTFI(F) {}
 
   /// virtual destructor.
   ~RetainCodeMotionContext() override {}
@@ -473,10 +477,18 @@ bool RetainCodeMotionContext::performCodeMotion() {
     auto Iter = InsertPoints.find(RC);
     if (Iter == InsertPoints.end())
       continue;
+
     for (auto IP : Iter->second) {
-      // we are about to insert a new retain instruction before the insertion
-      // point. Check if the previous instruction is reusable, reuse it, do
-      // not insert new instruction and delete old one.
+      // Check if the insertion point is in a block that we had previously
+      // identified as a program termination point. In such a case, we know that
+      // there are no releases or anything beyond a fatalError call. In such a
+      // case, do not insert the retain. It is ok if we leak.
+      if (PTFI.isProgramTerminatingBlock(IP->getParent()))
+        continue;
+
+      // We are about to insert a new retain instruction before the insertion
+      // point. Check if the previous instruction is reusable, reuse it, do not
+      // insert new instruction and delete old one.
       if (auto I = getPrevReusableInst(IP, Iter->first)) {
         RCInstructions.erase(I);
         continue;
@@ -1046,6 +1058,73 @@ void ReleaseCodeMotionContext::computeCodeMotionInsertPoints() {
 }
 
 //===----------------------------------------------------------------------===//
+//            Eliminate Retains Before Program Termination Points
+//===----------------------------------------------------------------------===//
+
+static void eliminateRetainsPrecedingProgramTerminationPoints(SILFunction *f) {
+  for (auto &block : *f) {
+    auto *term = block.getTerminator();
+    // If we don't have an unreachable or an unreachable that is the only
+    // element in the block, bail.
+    if (!isa<UnreachableInst>(term) || term == &*block.begin())
+      continue;
+
+    auto iter = std::prev(term->getIterator());
+
+    // If we have an apply next, see if it is a program termination point. In
+    // such a case, we can ignore it. All other functions though imply we must
+    // bail. If we don't have a function here, check for side
+    if (auto apply = FullApplySite::isa(&*iter)) {
+      SILFunction *callee = apply.getCalleeFunction();
+      if (!callee ||
+          !callee->hasSemanticsAttr(SEMANTICS_ARC_PROGRAMTERMINATION_POINT)) {
+        continue;
+      }
+    } else {
+      // If we didn't have an apply, move back onto the unreachable so that we
+      // can begin the loop in a proper state where we the current position of
+      // the iterator has already been tested.
+      ++iter;
+    }
+
+    while (iter != block.begin()) {
+      // Move iter back to the prev instruction and see if iter is a retain
+      // instruction. If it is not, then break out of the loop. We found a
+      // non-retain instruction so can not optimize further since we do not want
+      // to shorten the lifetime of any values that may be used before the
+      // program termination.
+      --iter;
+
+      // First check if iter has side-effects. If iter doesn't have
+      // side-effects, then ignore it.
+      //
+      // TODO: Use SideEffectsAnalysis here.
+      if (!iter->mayHaveSideEffects())
+        continue;
+
+      if (!isa<StrongRetainInst>(&*iter) && !isa<RetainValueInst>(&*iter)) {
+        break;
+      }
+
+      // Since we are going to delete this instruction, we grab the pointer to
+      // the instruction, move iter to the prev instruction and erase the
+      // instruction.
+      auto *i = &*iter;
+      auto tmp = prev_or_default(iter, block.begin(), block.end());
+      i->eraseFromParent();
+
+      // If tmp is the end of the block, then we wrapped... break out of the
+      // loop we did all of the work that we could.
+      if (tmp == block.end())
+        break;
+
+      // Otherwise, set iter to point at the next instruction.
+      iter = std::next(tmp);
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
 //                           Top Level Entry Point
 //===----------------------------------------------------------------------===//
 
@@ -1116,6 +1195,13 @@ public:
       RetainCodeMotionContext RetCM(BPA, F, PO, AA, RCFI);
       // Run retain sinking.
       InstChanged |= RetCM.run();
+      // Eliminate any retains that are right before program termination
+      // points. We assume that any retains before semantic calls marked as
+      // program termination points can be eliminated since by assumption we are
+      // going to be leaking these objects and any releases that were afterwards
+      // were already eliminated. Assuming that the IR is correctly balanced
+      // from an ARC perspective.
+      eliminateRetainsPrecedingProgramTerminationPoints(F);
     }
 
     if (EdgeChanged) {

--- a/test/SILOptimizer/earlycodemotion.sil
+++ b/test/SILOptimizer/earlycodemotion.sil
@@ -1194,7 +1194,7 @@ bb3:
 // CHECK: bb0(
 // CHECK-NOT: retain_value
 // CHECK: bb1:
-// CHECK: retain_value
+// CHECK-NEXT: unreachable
 // CHECK: bb2:
 // CHECK: retain_value
 sil @delete_instead_of_sinkretainsintounreachable_bb : $@convention(thin) (Optional<Builtin.NativeObject>) -> () {

--- a/test/SILOptimizer/retain_release_code_motion.sil
+++ b/test/SILOptimizer/retain_release_code_motion.sil
@@ -129,8 +129,8 @@ bb3:
 
 // Make sure that we do not move retains over unreachable terminator.
 // CHECK-LABEL: sil @no_return_stops_codemotion : $@convention(thin) (Builtin.NativeObject) -> () {
-// CHECK: strong_retain
-// CHECK-NEXT: unreachable
+// CHECK-NOT: strong_retain
+// CHECK: } // end sil function 'no_return_stops_codemotion'
 sil @no_return_stops_codemotion : $@convention(thin) (Builtin.NativeObject) -> () {
 bb0(%0 : $Builtin.NativeObject):
   %1 = alloc_ref $C
@@ -666,3 +666,55 @@ bb1:
   %5 = tuple()
   return %5 : $()
 }
+
+sil [_semantics "arc.programtermination_point"] @fatalError : $@convention(thin) () -> Never
+
+// This should eliminate all retains except for the first one b/c of user.
+// CHECK-LABEL: sil @eliminate_retains_on_fatalError_path_single_bb : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+// CHECK: strong_retain
+// CHECK-NOT: strong_retain
+// CHECK: } // end sil function 'eliminate_retains_on_fatalError_path_single_bb'
+sil @eliminate_retains_on_fatalError_path_single_bb : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject):
+  strong_retain %0 : $Builtin.NativeObject
+  %2 = function_ref @user : $@convention(thin) (Builtin.NativeObject) -> ()
+  apply %2(%0) : $@convention(thin) (Builtin.NativeObject) -> ()
+  strong_retain %0 : $Builtin.NativeObject
+  %1 = function_ref @fatalError : $@convention(thin) () -> Never
+  strong_retain %0 : $Builtin.NativeObject
+  apply %1() : $@convention(thin) () -> Never
+  unreachable
+}
+
+// We should eliminate all retains except for the one that we sink into the
+// return block.
+//
+// CHECK-LABEL: sil @eliminate_retains_on_fatalError_path_diamond : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+// CHECK-NOT: strong_retain
+// CHECK: bb4:
+// CHECK: strong_retain
+// CHECK-NOT: strong_retain
+// CHECK: } // end sil function 'eliminate_retains_on_fatalError_path_diamond'
+sil @eliminate_retains_on_fatalError_path_diamond : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject):
+  strong_retain %0 : $Builtin.NativeObject
+  cond_br undef, bb1, bb2
+
+bb1:
+  cond_br undef, bb3, bb4
+
+bb3:
+  strong_retain %0 : $Builtin.NativeObject
+  %1 = function_ref @fatalError : $@convention(thin) () -> Never
+  strong_retain %0 : $Builtin.NativeObject
+  apply %1() : $@convention(thin) () -> Never
+  unreachable
+
+bb4:
+  unreachable
+
+bb2:
+  %9999 = tuple()
+  return %9999 : $()
+}
+


### PR DESCRIPTION
…nd unreachables.

The reason to do this is that otherwise, retain code motion can increase the
size of the IR by large amounts as it pushes tons and tons of retains/releases
into these sorts of blocks. One one test case, it increased the amount of raw
instructions by 2-3 orders of magnitude.

rdar://42347024
