### PR TITLE
[Syntax] Fix typo in code example in libSyntax README

### DIFF
--- a/lib/Syntax/README.md
+++ b/lib/Syntax/README.md
@@ -428,7 +428,7 @@ auto ReturnKW = SyntaxFactory::makeReturnKeyword({}, Trivia::spaces(1));
 auto Return = SyntaxFactory::makeReturnStmt(ReturnKW, Integer,
                                             /*Semicolon=*/ None);
 
-auto RightBrace = SyntaxFactory::makeLeftBraceToken({}, {});
+auto RightBrace = SyntaxFactory::makeRightBraceToken({}, {});
 
 auto Statements = SyntaxFactory::makeBlankStmtList()
   .addStmt(Return);


### PR DESCRIPTION
The code example for building a return statement is using a `makeLeftBraceToken` when it should be using a `makeRightBraceToken`.
