### PR TITLE
[Sema] crasher fix in conditional conformance checking

### DIFF
--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1002,11 +1002,14 @@ static void sanitizeProtocolRequirements(
       if (auto depMemTy = dyn_cast<DependentMemberType>(type)) {
         if (!depMemTy->getAssocType() ||
             depMemTy->getAssocType()->getProtocol() != proto) {
+
           for (auto member : proto->lookupDirect(depMemTy->getName())) {
             if (auto assocType = dyn_cast<AssociatedTypeDecl>(member)) {
-              return Type(DependentMemberType::get(
-                                           sanitizeType(depMemTy->getBase()),
-                                           assocType));
+              Type sanitizedBase = sanitizeType(depMemTy->getBase());
+              if (!sanitizedBase)
+                return Type();
+              return Type(DependentMemberType::get(sanitizedBase,
+                                                   assocType));
             }
           }
 

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -396,3 +396,20 @@ extension SR6990: Sequence where T == Int {
     public typealias Iterator = IndexingIterator<[Float]>
     public func makeIterator() -> Iterator { fatalError() }
 }
+
+// SR-8324
+protocol ElementProtocol {
+  associatedtype BaseElement: BaseElementProtocol = Self
+}
+protocol BaseElementProtocol: ElementProtocol where BaseElement == Self {}
+protocol ArrayProtocol {
+  associatedtype Element: ElementProtocol
+}
+protocol NestedArrayProtocol: ArrayProtocol where Element: ArrayProtocol, Element.Element.BaseElement == Element.BaseElement {
+  associatedtype BaseElement = Element.BaseElement
+}
+extension Array: ArrayProtocol where Element: ElementProtocol {}
+extension Array: NestedArrayProtocol where Element: ElementProtocol, Element: ArrayProtocol, Element.Element.BaseElement == Element.BaseElement {
+  // with the typealias uncommented you do not get a crash.
+  // typealias BaseElement = Element.BaseElement
+}


### PR DESCRIPTION
Dependent member of dependent member of generic type param would crash here because of Type() not being passed back up through the recursion cleanly.

Resolves [SR-8324](https://bugs.swift.org/browse/SR-8324).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->