### PR TITLE
[Sema] Fix assert with incorrectly allowing optional injection into operator inout argument.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2293,7 +2293,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
     if (auto *lvt = type1->getAs<LValueType>()) {
       if (auto *iot = type2->getAs<InOutType>()) {
         return matchTypes(lvt->getObjectType(), iot->getObjectType(),
-                          kind, subflags,
+                          ConstraintKind::Equal, subflags,
                           locator.withPathElement(
                                   ConstraintLocator::LValueConversion));
       }

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -201,3 +201,10 @@ struct S_37290898: P_37290898 {}
 func rdar37290898(_ arr: inout [P_37290898], _ element: S_37290898?) {
   arr += [element].compactMap { $0 } // Ok
 }
+
+// SR-8221
+infix operator ??=
+func ??= <T>(lhs: inout T?, rhs: T?) {}
+var c: Int = 0
+c ??= 5 // expected-error{{binary operator '??=' cannot be applied to two 'Int' operands}}
+// expected-note@-1{{expected an argument list of type '(inout T?, T?)'}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
When matching types on an operator 'inout' param and lvalue argument, be more restrictive with the inner match by changing the match kind. Allowing optional injection here is a no no.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-8221](https://bugs.swift.org/browse/SR-8221).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
