### PR TITLE
Finish killing multiple parameter lists

### DIFF
--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -62,12 +62,6 @@ public:
     getCaptureInfo().getLocalCaptures(Result);
   }
 
-  ArrayRef<ParameterList *> getParameterLists() const {
-    if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>())
-      return AFD->getParameterLists();
-    return TheFunction.get<AbstractClosureExpr *>()->getParameterLists();
-  }
-  
   bool hasType() const {
     if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>())
       return AFD->hasInterfaceType();

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3447,14 +3447,6 @@ public:
   }
   enum : unsigned { InvalidDiscriminator = 0xFFFF };
 
-  ArrayRef<ParameterList *> getParameterLists() {
-    return parameterList ? parameterList : ArrayRef<ParameterList *>();
-  }
-  
-  ArrayRef<const ParameterList *> getParameterLists() const {
-    return parameterList ? parameterList : ArrayRef<const ParameterList *>();
-  }
-
   /// \brief Retrieve the result type of this closure.
   Type getResultType(llvm::function_ref<Type(const Expr *)> getType =
                          [](const Expr *E) -> Type {

--- a/include/swift/AST/Initializer.h
+++ b/include/swift/AST/Initializer.h
@@ -167,7 +167,7 @@ public:
   /// Change the parent of this context.  This is necessary because
   /// the function signature is parsed before the function
   /// declaration/expression itself is built.
-  void changeFunction(DeclContext *parent, ArrayRef<ParameterList *> paramLists);
+  void changeFunction(DeclContext *parent, ParameterList *paramLists);
 
   static bool classof(const DeclContext *DC) {
     if (auto init = dyn_cast<Initializer>(DC))

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1009,10 +1009,10 @@ public:
 
     /// Set the parsed context for all the initializers to the given
     /// function.
-    void setFunctionContext(DeclContext *DC, ArrayRef<ParameterList *> paramList);
+    void setFunctionContext(DeclContext *DC, ParameterList *paramList);
     
-    DefaultArgumentInfo(bool inTypeContext) {
-      NextIndex = inTypeContext ? 1 : 0;
+    DefaultArgumentInfo() {
+      NextIndex = 0;
       HasDefaultArgument = false;
     }
   };

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2333,7 +2333,7 @@ void PrintAST::printFunctionParameters(AbstractFunctionDecl *AFD) {
   auto curTy = AFD->hasInterfaceType() ? AFD->getInterfaceType() : nullptr;
 
   // Skip over the implicit 'self'.
-  if (AFD->getImplicitSelfDecl()) {
+  if (AFD->hasImplicitSelfDecl()) {
     if (curTy)
       if (auto funTy = curTy->getAs<AnyFunctionType>())
         curTy = funTy->getResult();

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -643,7 +643,7 @@ findNextParameter(AbstractFunctionDecl *func, unsigned listIndex,
                   unsigned paramIndex) {
   unsigned paramOffset = 1;
 
-  if (func->getImplicitSelfDecl()) {
+  if (func->hasImplicitSelfDecl()) {
     if (listIndex > 1)
       return None;
 
@@ -939,7 +939,7 @@ ASTScope *ASTScope::createIfNeeded(const ASTScope *parent, Decl *decl) {
                           parent->abstractFunctionParams.listIndex,
                           parent->abstractFunctionParams.paramIndex);
 
-    } else if (abstractFunction->getImplicitSelfDecl() ||
+    } else if (abstractFunction->hasImplicitSelfDecl() ||
                abstractFunction->getParameters()->size() > 0) {
       nextParameter = std::make_pair(0, 0);
     }

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -617,27 +617,51 @@ ASTScope *ASTScope::createRoot(SourceFile *sourceFile) {
   return scope;
 }
 
+// FIXME: This is a vestige of multiple parameter lists.
+static ParamDecl *getParameter(AbstractFunctionDecl *func,
+                               unsigned listIndex,
+                               unsigned paramIndex) {
+  // Dig out the actual parameter.
+  if (auto *selfDecl = func->getImplicitSelfDecl()) {
+    if (listIndex == 0) {
+      assert(paramIndex == 0);
+      return selfDecl;
+    }
+
+    assert(listIndex == 1);
+    return func->getParameters()->get(paramIndex);
+  }
+
+  assert(listIndex == 0);
+  return func->getParameters()->get(paramIndex);
+}
+
 /// Find the parameter list and parameter index (into that list) corresponding
 /// to the next parameter.
 static Optional<std::pair<unsigned, unsigned>>
 findNextParameter(AbstractFunctionDecl *func, unsigned listIndex,
                   unsigned paramIndex) {
-  auto paramLists = func->getParameterLists();
   unsigned paramOffset = 1;
-  while (listIndex < paramLists.size()) {
-    auto currentList = paramLists[listIndex];
 
-    // If there is a parameter in this list, return it.
-    if (paramIndex + paramOffset < currentList->size()) {
-      return std::make_pair(listIndex, paramIndex + paramOffset);
+  if (func->getImplicitSelfDecl()) {
+    if (listIndex > 1)
+      return None;
+
+    if (listIndex == 0) {
+      ++listIndex;
+      paramIndex = 0;
+      paramOffset = 0;
     }
 
-    // Move on to the next list.
-    ++listIndex;
-    paramIndex = 0;
-    paramOffset = 0;
+  } else {
+    if (listIndex > 0)
+      return None;
   }
 
+  if (paramIndex + paramOffset < func->getParameters()->size())
+    return std::make_pair(listIndex, paramIndex + paramOffset);
+
+  ++listIndex;
   return None;
 }
 
@@ -907,7 +931,7 @@ ASTScope *ASTScope::createIfNeeded(const ASTScope *parent, Decl *decl) {
     }
 
     // Figure out which parameter is next is the next one down.
-    Optional<std::pair<unsigned, unsigned>> nextParameter;
+    Optional<std::pair<unsigned, unsigned>> nextParameter = None;
     if (parent->getKind() == ASTScopeKind::AbstractFunctionParams &&
         parent->abstractFunctionParams.decl == decl) {
       nextParameter =
@@ -915,17 +939,15 @@ ASTScope *ASTScope::createIfNeeded(const ASTScope *parent, Decl *decl) {
                           parent->abstractFunctionParams.listIndex,
                           parent->abstractFunctionParams.paramIndex);
 
-    } else if (abstractFunction->getParameterList(0)->size() > 0) {
+    } else if (abstractFunction->getImplicitSelfDecl() ||
+               abstractFunction->getParameters()->size() > 0) {
       nextParameter = std::make_pair(0, 0);
-    } else {
-      nextParameter = findNextParameter(abstractFunction, 0, 0);
     }
 
     if (nextParameter) {
-      // Dig out the actual parameter.
-      ParamDecl *currentParam =
-        abstractFunction->getParameterList(nextParameter->first)
-          ->get(nextParameter->second);
+      auto *currentParam = getParameter(abstractFunction,
+                                        nextParameter->first,
+                                        nextParameter->second);
 
       // Determine whether there is a default argument.
       ASTScope *defaultArgumentScope = nullptr;
@@ -1405,15 +1427,14 @@ SourceRange ASTScope::getSourceRangeImpl() const {
       if (isa<DestructorDecl>(abstractFunctionParams.decl)) {
         startLoc = abstractFunctionParams.decl->getNameLoc();
       } else {
-        startLoc = abstractFunctionParams.decl->getParameterList(1)
+        startLoc = abstractFunctionParams.decl->getParameters()
                      ->getLParenLoc();
       }
       return SourceRange(startLoc, endLoc);
     }
 
     // Otherwise, find the end of this parameter.
-    auto param = abstractFunctionParams.decl->getParameterList(
-                   abstractFunctionParams.listIndex)
+    auto param = abstractFunctionParams.decl->getParameters()
                      ->get(abstractFunctionParams.paramIndex);
     return SourceRange(param->getEndLoc(), endLoc);
   }
@@ -1754,9 +1775,10 @@ SmallVector<ValueDecl *, 4> ASTScope::getLocalBindings() const {
     break;
 
   case ASTScopeKind::AbstractFunctionParams:
-    result.push_back(abstractFunctionParams.decl->getParameterList(
-                         abstractFunctionParams.listIndex)
-                       ->get(abstractFunctionParams.paramIndex));
+    result.push_back(
+      getParameter(abstractFunctionParams.decl,
+                   abstractFunctionParams.listIndex,
+                   abstractFunctionParams.paramIndex));
     break;
 
   case ASTScopeKind::AfterPatternBinding:

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2830,7 +2830,7 @@ public:
 
       // Check that type members have an interface type of the form
       // (Self) -> (Args...) -> Result.
-      if (AFD->getImplicitSelfDecl()) {
+      if (AFD->hasImplicitSelfDecl()) {
         if (!interfaceTy->castTo<AnyFunctionType>()
               ->getResult()->is<FunctionType>()) {
           Out << "Interface type of method must return a function";
@@ -2866,7 +2866,7 @@ public:
       // If a decl has the Throws bit set, the function type should throw,
       // and vice versa.
       auto fnTy = AFD->getInterfaceType()->castTo<AnyFunctionType>();
-      if (AFD->getImplicitSelfDecl())
+      if (AFD->hasImplicitSelfDecl())
         fnTy = fnTy->getResult()->castTo<FunctionType>();
 
       if (AFD->hasThrows() != fnTy->getExtInfo().throws()) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4647,22 +4647,14 @@ void ParamDecl::setDefaultArgumentInitContext(Initializer *initContext) {
 }
 
 void DefaultArgumentInitializer::changeFunction(
-    DeclContext *parent, ArrayRef<ParameterList *> paramLists) {
+    DeclContext *parent, ParameterList *paramList) {
   if (parent->isLocalContext()) {
     setParent(parent);
   }
 
-  unsigned offset = getIndex();
-  for (auto list : paramLists) {
-    if (offset < list->size()) {
-      auto param = list->get(offset);
-      if (param->getDefaultValue())
-        param->setDefaultArgumentInitContext(this);
-      return;
-    }
-
-    offset -= list->size();
-  }
+  auto param = paramList->get(getIndex());
+  if (param->getDefaultValue())
+    param->setDefaultArgumentInitContext(this);
 }
 
 /// Determine whether the given Swift type is an integral type, i.e.,

--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -340,17 +340,14 @@ static void doDynamicLookup(VisibleDeclConsumer &Consumer,
       case DeclKind::Accessor:
       case DeclKind::Func: {
         auto FD = cast<FuncDecl>(D);
-        assert(FD->getImplicitSelfDecl() && "should not find free functions");
+        assert(FD->hasImplicitSelfDecl() && "should not find free functions");
         (void)FD;
 
         if (FD->isInvalid())
           break;
 
         // Get the type without the first uncurry level with 'self'.
-        CanType T = D->getInterfaceType()
-                        ->castTo<AnyFunctionType>()
-                        ->getResult()
-                        ->getCanonicalType();
+        CanType T = FD->getMethodInterfaceType()->getCanonicalType();
 
         auto Signature = std::make_pair(D->getBaseName(), T);
         if (!FunctionsReported.insert(Signature).second)

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -841,8 +841,11 @@ swift::computeDefaultMap(ArrayRef<AnyFunctionType::Param> params,
   // Find the corresponding parameter list.
   const ParameterList *paramList = nullptr;
   if (auto *func = dyn_cast<AbstractFunctionDecl>(paramOwner)) {
-    if (level < func->getNumParameterLists())
-      paramList = func->getParameterList(level);
+    if (func->getImplicitSelfDecl()) {
+      if (level == 1)
+        paramList = func->getParameters();
+    } else if (level == 0)
+      paramList = func->getParameters();
   } else if (auto *subscript = dyn_cast<SubscriptDecl>(paramOwner)) {
     if (level == 1)
       paramList = subscript->getIndices();

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -841,7 +841,7 @@ swift::computeDefaultMap(ArrayRef<AnyFunctionType::Param> params,
   // Find the corresponding parameter list.
   const ParameterList *paramList = nullptr;
   if (auto *func = dyn_cast<AbstractFunctionDecl>(paramOwner)) {
-    if (func->getImplicitSelfDecl()) {
+    if (func->hasImplicitSelfDecl()) {
       if (level == 1)
         paramList = func->getParameters();
     } else if (level == 0)

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2402,7 +2402,7 @@ public:
     assert(FunctionType);
 
     unsigned NumParamLists;
-    if (FD->getImplicitSelfDecl()) {
+    if (FD->hasImplicitSelfDecl()) {
       if (IsImplicitlyCurriedInstanceMethod)
         NumParamLists = 2;
       else {

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -601,12 +601,9 @@ class FormatWalker : public SourceEntityWalker {
 
       if (auto AFD = dyn_cast_or_null<AbstractFunctionDecl>(Node.dyn_cast<Decl*>())) {
         // Function parameters are siblings.
-        for (auto P : AFD->getParameterLists()) {
-          for (ParamDecl* param : *P) {
-            if (!param->isSelfParameter())
-              addPair(param->getEndLoc(), FindAlignLoc(param->getStartLoc()),
-                      tok::comma);
-          }
+        for (auto *param : *AFD->getParameters()) {
+          addPair(param->getEndLoc(), FindAlignLoc(param->getStartLoc()),
+                  tok::comma);
         }
       }
 

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -118,9 +118,8 @@ bool SemaAnnotator::walkToDeclPre(Decl *D) {
     };
 
     if (auto AF = dyn_cast<AbstractFunctionDecl>(VD)) {
-      for (auto *PL : AF->getParameterLists())
-        if (ReportParamList(PL))
-          return false;
+      if (ReportParamList(AF->getParameters()))
+        return false;
     }
     if (auto SD = dyn_cast<SubscriptDecl>(VD)) {
       if (ReportParamList(SD->getIndices()))

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -380,11 +380,8 @@ bool NameMatcher::walkToDeclPre(Decl *D) {
   } else if (AbstractFunctionDecl *AFD = dyn_cast<AbstractFunctionDecl>(D)) {
     std::vector<CharSourceRange> LabelRanges;
     if (AFD->getNameLoc() == nextLoc()) {
-      for(auto ParamList: AFD->getParameterLists()) {
-        LabelRanges = getLabelRanges(ParamList, getSourceMgr());
-        if (LabelRanges.size() == ParamList->size())
-          break;
-      }
+      auto ParamList = AFD->getParameters();
+      LabelRanges = getLabelRanges(ParamList, getSourceMgr());
     }
     tryResolve(ASTWalker::ParentTy(D), D->getLoc(), LabelRangeType::Param,
                LabelRanges);

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -1028,8 +1028,8 @@ bool IndexSwiftASTWalker::initFuncDeclIndexSymbol(FuncDecl *D,
 
   if (D->getAttrs().hasAttribute<IBActionAttr>()) {
     // Relate with type of the first parameter using RelationIBTypeOf.
-    if (D->getParameterLists().size() >= 2) {
-      auto paramList = D->getParameterList(1);
+    if (D->getImplicitSelfDecl()) {
+      auto paramList = D->getParameters();
       if (!paramList->getArray().empty()) {
         auto param = paramList->get(0);
         if (auto nominal = param->getType()->getAnyNominal()) {

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -1028,7 +1028,7 @@ bool IndexSwiftASTWalker::initFuncDeclIndexSymbol(FuncDecl *D,
 
   if (D->getAttrs().hasAttribute<IBActionAttr>()) {
     // Relate with type of the first parameter using RelationIBTypeOf.
-    if (D->getImplicitSelfDecl()) {
+    if (D->hasImplicitSelfDecl()) {
       auto paramList = D->getParameters();
       if (!paramList->getArray().empty()) {
         auto param = paramList->get(0);

--- a/lib/Index/IndexSymbol.cpp
+++ b/lib/Index/IndexSymbol.cpp
@@ -62,9 +62,7 @@ static bool isUnitTest(const ValueDecl *D) {
     return false;
 
   // 4. ...takes no parameters...
-  if (FD->getParameterLists().size() != 2)
-    return false;
-  if (FD->getParameterList(1)->size() != 0)
+  if (FD->getParameters()->size() != 0)
     return false;
 
   // 5. ...is of at least 'internal' access (unless we can use

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -71,13 +71,9 @@ public:
       return {SourceRange(), false, false, false};
     }
 
-    for (auto *Params: Parent->getParameterLists()) {
-      for (auto *Param: Params->getArray()) {
-        if (Param->isImplicit())
-          continue;
-        if (!--NextIndex) {
-          return findChild(Param->getTypeLoc());
-        }
+    for (auto *Param: *Parent->getParameters()) {
+      if (!--NextIndex) {
+        return findChild(Param->getTypeLoc());
       }
     }
     llvm_unreachable("child index out of bounds");
@@ -1131,13 +1127,8 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
 
   static void collectParamters(AbstractFunctionDecl *AFD,
                                SmallVectorImpl<ParamDecl*> &Results) {
-    for (auto PL : AFD->getParameterLists()) {
-      for (auto *PD: *PL) {
-        // Self parameter should not be updated.
-        if (PD->isSelfParameter())
-          continue;
-        Results.push_back(PD);
-      }
+    for (auto PD : *AFD->getParameters()) {
+      Results.push_back(PD);
     }
   }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5255,7 +5255,7 @@ Parser::parseDeclFunc(SourceLoc StaticLoc, StaticSpellingKind StaticSpelling,
   if (HasContainerType)
     SelfDecl = ParamDecl::createUnboundSelf(NameLoc, CurDeclContext);
 
-  DefaultArgumentInfo DefaultArgs(HasContainerType);
+  DefaultArgumentInfo DefaultArgs;
   TypeRepr *FuncRetTy = nullptr;
   DeclName FullName;
   ParameterList *BodyParams;
@@ -5322,7 +5322,7 @@ Parser::parseDeclFunc(SourceLoc StaticLoc, StaticSpellingKind StaticSpelling,
     if (SignatureHasCodeCompletion)
       CodeCompletion->setParsedDecl(FD);
 
-    DefaultArgs.setFunctionContext(FD, FD->getParameterLists());
+    DefaultArgs.setFunctionContext(FD, FD->getParameters());
     if (auto *P = FD->getImplicitSelfDecl())
       addToScope(P);
     addParametersToScope(FD->getParameters());
@@ -6177,7 +6177,7 @@ Parser::parseDeclInit(ParseDeclOptions Flags, DeclAttributes &Attributes) {
     return makeParserCodeCompletionStatus();
 
   // Parse the parameters.
-  DefaultArgumentInfo DefaultArgs(/*inTypeContext*/true);
+  DefaultArgumentInfo DefaultArgs;
   llvm::SmallVector<Identifier, 4> namePieces;
   bool SignatureHasCodeCompletion = false;
   ParserResult<ParameterList> Params
@@ -6237,7 +6237,7 @@ Parser::parseDeclInit(ParseDeclOptions Flags, DeclAttributes &Attributes) {
 
   // No need to setLocalDiscriminator.
 
-  DefaultArgs.setFunctionContext(CD, CD->getParameterLists());
+  DefaultArgs.setFunctionContext(CD, CD->getParameters());
 
   // Pass the function signature to code completion.
   if (SignatureHasCodeCompletion)

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -57,7 +57,7 @@ static DefaultArgumentKind getDefaultArgKind(Expr *init) {
 }
 
 void Parser::DefaultArgumentInfo::setFunctionContext(
-    DeclContext *DC, ArrayRef<ParameterList *> paramList){
+    DeclContext *DC, ParameterList *paramList){
   for (auto context : ParsedContexts) {
     context->changeFunction(DC, paramList);
   }

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -808,7 +808,7 @@ unsigned SILDeclRef::getParameterListCount() const {
   auto *vd = getDecl();
 
   if (auto *func = dyn_cast<AbstractFunctionDecl>(vd)) {
-    return func->getImplicitSelfDecl() ? 2 : 1;
+    return func->hasImplicitSelfDecl() ? 2 : 1;
   } else if (auto *ed = dyn_cast<EnumElementDecl>(vd)) {
     return ed->hasAssociatedValues() ? 2 : 1;
   } else if (isa<ClassDecl>(vd)) {

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -4352,7 +4352,7 @@ static bool mayLieAboutNonOptionalReturn(SILModule &M, Expr *expr) {
       // Only consider a full application of a method. Partial applications
       // never lie.
       if (auto func = dyn_cast<AbstractFunctionDecl>(fnRef->getDecl()))
-        if (func->getImplicitSelfDecl() == nullptr)
+        if (!func->hasImplicitSelfDecl())
           method = fnRef->getDecl();
     }
     if (method && mayLieAboutNonOptionalReturn(M, method))

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3421,11 +3421,15 @@ static bool candidatesHaveAnyDefaultValues(
     auto function = dyn_cast_or_null<AbstractFunctionDecl>(cand.getDecl());
     if (!function) continue;
 
-    auto paramLists = function->getParameterLists();
-    if (cand.level >= paramLists.size()) continue;
+    if (function->getImplicitSelfDecl()) {
+      if (cand.level != 1)
+        return false;
+    } else {
+      if (cand.level != 0)
+        return false;
+    }
 
-    auto paramList = paramLists[cand.level];
-    for (auto param : *paramList) {
+    for (auto param : *function->getParameters()) {
       if (param->getDefaultArgumentKind() != DefaultArgumentKind::None)
         return true;
     }
@@ -3456,11 +3460,15 @@ static Optional<unsigned> getElementForScalarInitOfArg(
   auto function = dyn_cast_or_null<AbstractFunctionDecl>(cand.getDecl());
   if (!function) return getElementForScalarInitSimple(tupleTy);
 
-  auto paramLists = function->getParameterLists();
-  if (cand.level >= paramLists.size())
-    return getElementForScalarInitSimple(tupleTy);
+  if (function->getImplicitSelfDecl()) {
+    if (cand.level != 1)
+      return getElementForScalarInitSimple(tupleTy);
+  } else {
+    if (cand.level != 0)
+      return getElementForScalarInitSimple(tupleTy);
+  }
 
-  auto paramList = paramLists[cand.level];
+  auto paramList = function->getParameters();
   if (tupleTy->getNumElements() != paramList->size()) 
     return getElementForScalarInitSimple(tupleTy);
 

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -782,7 +782,7 @@ static void diagnoseSubElementFailure(Expr *destExpr,
     message += "'";
 
     if (auto *AFD = dyn_cast<AbstractFunctionDecl>(VD)) {
-      if (AFD->getImplicitSelfDecl()) {
+      if (AFD->hasImplicitSelfDecl()) {
         message += " is a method";
         diagID = diag::assignment_lhs_is_immutable_variable;
       } else {
@@ -3421,7 +3421,7 @@ static bool candidatesHaveAnyDefaultValues(
     auto function = dyn_cast_or_null<AbstractFunctionDecl>(cand.getDecl());
     if (!function) continue;
 
-    if (function->getImplicitSelfDecl()) {
+    if (function->hasImplicitSelfDecl()) {
       if (cand.level != 1)
         return false;
     } else {
@@ -3460,7 +3460,7 @@ static Optional<unsigned> getElementForScalarInitOfArg(
   auto function = dyn_cast_or_null<AbstractFunctionDecl>(cand.getDecl());
   if (!function) return getElementForScalarInitSimple(tupleTy);
 
-  if (function->getImplicitSelfDecl()) {
+  if (function->hasImplicitSelfDecl()) {
     if (cand.level != 1)
       return getElementForScalarInitSimple(tupleTy);
   } else {

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -682,7 +682,7 @@ namespace {
     size_t nNoDefault = 0;
     
     if (auto AFD = dyn_cast<AbstractFunctionDecl>(VD)) {
-      assert(AFD->getImplicitSelfDecl() == nullptr);
+      assert(!AFD->hasImplicitSelfDecl());
       for (auto param : *AFD->getParameters()) {
         if (!param->isDefaultArgument())
           nNoDefault++;
@@ -780,7 +780,7 @@ namespace {
         // Figure out the parameter type, accounting for the implicit 'self' if
         // necessary.
         if (auto *FD = dyn_cast<AbstractFunctionDecl>(value)) {
-          if (FD->getImplicitSelfDecl()) {
+          if (FD->hasImplicitSelfDecl()) {
             if (auto resFnTy = fnTy->getResult()->getAs<AnyFunctionType>()) {
               fnTy = resFnTy;
             }

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -90,7 +90,7 @@ ArrayRef<Identifier> UncurriedCandidate::getArgumentLabels(
   scratch.clear();
   if (auto decl = getDecl()) {
     if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
-      if (func->getImplicitSelfDecl()) {
+      if (func->hasImplicitSelfDecl()) {
         if (level == 0) {
           scratch.push_back(Identifier());
           return scratch;

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -90,10 +90,18 @@ ArrayRef<Identifier> UncurriedCandidate::getArgumentLabels(
   scratch.clear();
   if (auto decl = getDecl()) {
     if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
-      // Retrieve the argument labels of the corresponding parameter list.
-      if (level < func->getNumParameterLists()) {
-        auto paramList = func->getParameterList(level);
-        for (auto param : *paramList) {
+      if (func->getImplicitSelfDecl()) {
+        if (level == 0) {
+          scratch.push_back(Identifier());
+          return scratch;
+        }
+
+        --level;
+      }
+
+      if (level == 0) {
+        // Retrieve the argument labels of the corresponding parameter list.
+        for (auto param : *func->getParameters()) {
           scratch.push_back(param->getArgumentName());
         }
         return scratch;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -899,7 +899,7 @@ static unsigned getNumRemovedArgumentLabels(TypeChecker &TC, ValueDecl *decl,
   // Only applicable to functions. Nothing else should have argument labels in
   // the type.
   } else if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
-    numParameterLists = func->getImplicitSelfDecl() ? 2 : 1;
+    numParameterLists = func->hasImplicitSelfDecl() ? 2 : 1;
   } else {
     return 0;
   }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4304,8 +4304,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
       }
     }
 
-    if (CD->getDeclContext()->isTypeContext())
-      configureImplicitSelf(*this, CD);
+    configureImplicitSelf(*this, CD);
 
     validateGenericFuncSignature(CD);
     recordParamContextTypes(CD);

--- a/lib/Sema/TypeCheckError.cpp
+++ b/lib/Sema/TypeCheckError.cpp
@@ -54,7 +54,7 @@ public:
   explicit AbstractFunction(AbstractFunctionDecl *fn)
     : TheKind(Kind::Function),
       IsRethrows(fn->getAttrs().hasAttribute<RethrowsAttr>()),
-      ParamCount(fn->getImplicitSelfDecl() ? 2 : 1) {
+      ParamCount(fn->hasImplicitSelfDecl() ? 2 : 1) {
     TheFunction = fn;
   }
 
@@ -926,7 +926,7 @@ public:
     }
 
     return Context(getKindForFunctionBody(
-        D->getInterfaceType(), D->getImplicitSelfDecl() ? 2 : 1));
+        D->getInterfaceType(), D->hasImplicitSelfDecl() ? 2 : 1));
   }
 
   static Context forInitializer(Initializer *init) {

--- a/lib/Sema/TypeCheckError.cpp
+++ b/lib/Sema/TypeCheckError.cpp
@@ -41,7 +41,7 @@ private:
   };
   unsigned TheKind : 2;
   unsigned IsRethrows : 1;
-  unsigned ParamCount : 28;
+  unsigned ParamCount : 2;
 
 public:
   explicit AbstractFunction(Kind kind, Expr *fn)
@@ -54,7 +54,7 @@ public:
   explicit AbstractFunction(AbstractFunctionDecl *fn)
     : TheKind(Kind::Function),
       IsRethrows(fn->getAttrs().hasAttribute<RethrowsAttr>()),
-      ParamCount(fn->getNumParameterLists()) {
+      ParamCount(fn->getImplicitSelfDecl() ? 2 : 1) {
     TheFunction = fn;
   }
 
@@ -926,7 +926,7 @@ public:
     }
 
     return Context(getKindForFunctionBody(
-        D->getInterfaceType(), D->getNumParameterLists()));
+        D->getInterfaceType(), D->getImplicitSelfDecl() ? 2 : 1));
   }
 
   static Context forInitializer(Initializer *init) {

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -886,7 +886,7 @@ void TypeChecker::validateGenericFuncSignature(AbstractFunctionDecl *func) {
 
 void TypeChecker::configureInterfaceType(AbstractFunctionDecl *func,
                                          GenericSignature *sig) {
-  bool hasSelf = func->getDeclContext()->isTypeContext();
+  bool hasSelf = func->hasImplicitSelfDecl();
 
   // Result
   Type resultTy;

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -141,17 +141,10 @@ void TBDGenVisitor::visitAbstractFunctionDecl(AbstractFunctionDecl *AFD) {
   // functions) are public symbols, as the default values are computed at the
   // call site.
   auto index = 0;
-  auto paramLists = AFD->getParameterLists();
-  // Skip the first arguments, which contains Self (etc.), can't be defaulted,
-  // and are ignored for the purposes of default argument indices.
-  if (AFD->getDeclContext()->isTypeContext())
-    paramLists = paramLists.slice(1);
-  for (auto *paramList : paramLists) {
-    for (auto *param : *paramList) {
-      if (param->getDefaultValue())
-        addSymbol(SILDeclRef::getDefaultArgGenerator(AFD, index));
-      index++;
-    }
+  for (auto *param : *AFD->getParameters()) {
+    if (param->getDefaultValue())
+      addSymbol(SILDeclRef::getDefaultArgGenerator(AFD, index));
+    index++;
   }
 }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -839,19 +839,13 @@ static void addParameters(const AbstractFunctionDecl *FD,
                           TextEntity &Ent,
                           SourceManager &SM,
                           unsigned BufferID) {
-  auto params = FD->getParameterLists();
-  // Ignore 'self'.
-  if (FD->getDeclContext()->isTypeContext())
-    params = params.slice(1);
-
   ArrayRef<Identifier> ArgNames;
   DeclName Name = FD->getFullName();
   if (Name) {
     ArgNames = Name.getArgumentNames();
   }
-  for (auto paramList : params) {
-    addParameters(ArgNames, paramList, Ent, SM, BufferID);
-  }
+  auto paramList = FD->getParameters();
+  addParameters(ArgNames, paramList, Ent, SM, BufferID);
 }
 
 static void addParameters(const SubscriptDecl *D,

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -1475,20 +1475,16 @@ static SDKNode *constructTypeNode(SDKContext &Ctx, Type T,
 }
 
 static std::vector<SDKNode*>
-createParameterNodes(SDKContext &Ctx, ArrayRef<ParameterList*> AllParamLists) {
+createParameterNodes(SDKContext &Ctx, ParameterList *PL) {
   std::vector<SDKNode*> Result;
-  for (auto PL: AllParamLists) {
-    for (auto param: *PL) {
-      if (param->isSelfParameter())
-        continue;
-      TypeInitInfo TypeInfo;
-      TypeInfo.IsImplicitlyUnwrappedOptional = param->getAttrs().
-        hasAttribute<ImplicitlyUnwrappedOptionalAttr>();
-      TypeInfo.hasDefaultArgument = param->getDefaultArgumentKind() !=
-        DefaultArgumentKind::None;
-      Result.push_back(constructTypeNode(Ctx, param->getInterfaceType(),
-                                         TypeInfo));
-    }
+  for (auto param: *PL) {
+    TypeInitInfo TypeInfo;
+    TypeInfo.IsImplicitlyUnwrappedOptional = param->getAttrs().
+      hasAttribute<ImplicitlyUnwrappedOptionalAttr>();
+    TypeInfo.hasDefaultArgument = param->getDefaultArgumentKind() !=
+      DefaultArgumentKind::None;
+    Result.push_back(constructTypeNode(Ctx, param->getInterfaceType(),
+                                       TypeInfo));
   }
   return Result;
 }
@@ -1504,7 +1500,7 @@ static SDKNode *constructFunctionNode(SDKContext &Ctx, FuncDecl* FD,
   TypeInfo.IsImplicitlyUnwrappedOptional = FD->getAttrs().
     hasAttribute<ImplicitlyUnwrappedOptionalAttr>();
   Func->addChild(constructTypeNode(Ctx, FD->getResultInterfaceType(), TypeInfo));
-  for (auto *Node : createParameterNodes(Ctx, FD->getParameterLists()))
+  for (auto *Node : createParameterNodes(Ctx, FD->getParameters()))
     Func->addChild(Node);
   return Func;
 }
@@ -1512,7 +1508,7 @@ static SDKNode *constructFunctionNode(SDKContext &Ctx, FuncDecl* FD,
 static SDKNode* constructInitNode(SDKContext &Ctx, ConstructorDecl *CD) {
   auto Func = SDKNodeInitInfo(Ctx, CD).createSDKNode(SDKNodeKind::DeclConstructor);
   Func->addChild(constructTypeNode(Ctx, CD->getResultInterfaceType()));
-  for (auto *Node : createParameterNodes(Ctx, CD->getParameterLists()))
+  for (auto *Node : createParameterNodes(Ctx, CD->getParameters()))
     Func->addChild(Node);
   return Func;
 }


### PR DESCRIPTION
Final installment in the series after https://github.com/apple/swift/pull/18128.

In a few places I had to hack things up a bit because the multiple parameter list and uncurry level terminology is so ingrained, in particular in CSDiag. We can clean this up later.

Fixes <https://bugs.swift.org/browse/SR-5832>.