### PR TITLE
Enable benchmark test only when the binary is present

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -519,6 +519,10 @@ elif swift_test_subset == 'only_stress':
 else:
     lit_config.fatal("Unknown test mode %r" % swift_test_subset)
 
+# Enable benchmark testing when the binary is found (has fully qualified path).
+if config.benchmark_o != 'Benchmark_O':
+    config.available_features.add('benchmark')
+
 # Add substitutions for the run target triple, CPU, OS, and pointer size.
 config.substitutions.append(('%target-triple', config.variant_triple))
 

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -88,9 +88,6 @@ config.available_features.add("CMAKE_GENERATOR=@CMAKE_GENERATOR@")
 if "@SWIFT_ENABLE_SOURCEKIT_TESTS@" == "TRUE":
     config.available_features.add('sourcekit')
 
-if "@SWIFT_BUILD_PERF_TESTSUITE@" == "TRUE":
-    config.available_features.add('benchmark')
-
 if "@SWIFT_ENABLE_GUARANTEED_NORMAL_ARGUMENTS@" == "TRUE":
    config.available_features.add('plus_zero_runtime')
 else:


### PR DESCRIPTION
As requested by @jrose-apple [in the discussion](https://github.com/apple/swift/pull/12415#discussion_r203211849) after the #12415 has landed:

Changed the condition that enables `benchmark` feature, to depend on the presence of the `Benchmark_O` binary directly, instead of the `@SWIFT_BUILD_PERF_TESTSUITE@`.