### PR TITLE
[AST] explicit PrintOptions default constructor

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -363,6 +363,9 @@ struct PrintOptions {
 
   BracketOptions BracketOptions;
 
+  // This is explicit to guarantee that it can be called from LLDB.
+  PrintOptions() {}
+
   bool excludeAttrKind(AnyAttrKind K) const {
     if (std::any_of(ExcludeAttrList.begin(), ExcludeAttrList.end(),
                     [K](AnyAttrKind other) { return other == K; }))


### PR DESCRIPTION
<!-- What's in this pull request? -->

This PR add default constructor of `PrintOptions` explicitly.
This is already implemented by c++ compiler implicitly.
But, it can not be called from lldb session.

```
(lldb) p f->getLoweredFunctionType()->getString(PrintOptions())
error: call to implicitly-deleted default constructor of 'swift::PrintOptions'
default constructor of 'PrintOptions' is implicitly deleted because field 'BracketOptions' has no default constructor
```

If I add this explicitly, it become available.

```
(lldb) p f->getLoweredFunctionType()->getString(PrintOptions())
(std::__1::string) $1 = "@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32"
```

This is very useful for reading and studying swift compiler source code with debugger.


## supplement

If I add default constructor of `BracketOptions` to follow error message,
It still can not be called because of another error.

```
(lldb) p PrintOptions()
error: Couldn't lookup symbols:
  __ZNSt3__18functionIFNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEPKN5swift9ValueDeclEEEC1Ev
  __ZNSt3__18functionIFbPKN5swift13ExtensionDeclEEEC1Ev
  __ZNSt3__16vectorIN5swift11AnyAttrKindENS_9allocatorIS2_EEEC1Ev
  __ZNSt3__110shared_ptrIN5swift18ShouldPrintCheckerEEC1Ev
```

lldb seems can not call templated symbol which has not been instantiated.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
