### PR TITLE
[Lexer] Don't include backtick length into comment length

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -279,10 +279,16 @@ void Lexer::formToken(tok Kind, const char *TokStart, bool MultilineString) {
   }
   unsigned CommentLength = 0;
   if (RetainComments == CommentRetentionMode::AttachToNextToken) {
+    // 'CommentLength' here is the length from the *first* comment to the
+    // token text (or its backtick if exist).
     auto Iter = llvm::find_if(LeadingTrivia, [](const TriviaPiece &Piece) {
       return Piece.isComment();
     });
     for (auto End = LeadingTrivia.end(); Iter != End; Iter++) {
+      if (Iter->getKind() == TriviaKind::Backtick)
+        // Since Token::getCommentRange() doesn't take backtick into account,
+        // we cannot include length of backtick.
+        break;
       CommentLength += Iter->getTextLength();
     }
   }

--- a/validation-test/IDE/crashers_2/0021-lexer-commentlength.swift
+++ b/validation-test/IDE/crashers_2/0021-lexer-commentlength.swift
@@ -1,5 +1,0 @@
-/*comment*/`init`()
-foo();/*comment*/`var`()
-
-// RUN: not --crash %target-swift-ide-test -syntax-coloring -source-filename %s
-// REQUIRES: asserts

--- a/validation-test/IDE/crashers_2/0021-lexer-commentlength.swift
+++ b/validation-test/IDE/crashers_2/0021-lexer-commentlength.swift
@@ -1,0 +1,5 @@
+/*comment*/`init`()
+foo();/*comment*/`var`()
+
+// RUN: not --crash %target-swift-ide-test -syntax-coloring -source-filename %s
+// REQUIRES: asserts

--- a/validation-test/IDE/crashers_2_fixed/0021-lexer-commentlength.swift
+++ b/validation-test/IDE/crashers_2_fixed/0021-lexer-commentlength.swift
@@ -1,0 +1,4 @@
+/*comment*/`init`()
+foo();/*comment*/`var`()
+
+// RUN: %target-swift-ide-test -syntax-coloring -source-filename %s


### PR DESCRIPTION
Although "backtick" is a kind of trivia piece, `Token::getCommentRange` doesn't take it into account. Invalid `Token::getCommentRange` used to cause compiler crash.

rdar://problem/42492793
https://bugs.swift.org/browse/SR-8315