### PR TITLE
Factor out AbstractFunctionDecl's interface type computation

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -31,6 +31,7 @@
 #include "swift/AST/StorageImpl.h"
 #include "swift/AST/TypeAlignments.h"
 #include "swift/AST/TypeWalker.h"
+#include "swift/AST/Types.h"
 #include "swift/AST/Witness.h"
 #include "swift/Basic/ArrayRefView.h"
 #include "swift/Basic/Compiler.h"
@@ -2880,8 +2881,8 @@ public:
     TrailingWhere = trailingWhereClause;
   }
 
-  /// computeType - Compute the type (and declared type) of this associated
-  /// type; can only be called after the alias type has been resolved.
+  /// Set the interface type of this associated type declaration to a dependen
+  /// member type of 'Self'.
   void computeType();
 
   /// Retrieve the associated type "anchor", which is the associated type
@@ -3083,7 +3084,8 @@ public:
     Bits.NominalTypeDecl.HasValidatedLayout = true;
   }
 
-  /// Compute the type of this nominal type.
+  /// Set the interface type of this nominal type to the metatype of the
+  /// declared interface type.
   void computeType();
 
   /// getDeclaredType - Retrieve the type declared by this entity, without
@@ -4884,6 +4886,10 @@ public:
   TypeLoc &getElementTypeLoc() { return ElementTy; }
   const TypeLoc &getElementTypeLoc() const { return ElementTy; }
 
+  /// Compute the interface type of this subscript from the parameter and
+  /// element types.
+  void computeType();
+
   /// \brief Returns whether the result of the subscript operation can be set.
   bool isSettable() const;
 
@@ -5175,6 +5181,10 @@ private:
   void computeNeedsNewVTableEntry();
 
 public:
+  /// Compute the interface type of this function declaration from the
+  /// parameter types.
+  void computeType(AnyFunctionType::ExtInfo Info = FunctionType::ExtInfo());
+
   /// Retrieve the source range of the function body.
   SourceRange getBodySourceRange() const;
 
@@ -5735,8 +5745,8 @@ public:
     return hasName() ? getBaseName().getIdentifier().str() : "_";
   }
 
-  /// \returns false if there was an error during the computation rendering the
-  /// EnumElementDecl invalid, true otherwise.
+  /// Set the interface type of this enum element to the constructor function
+  /// type; (Self) -> Result or (Self) -> (Args...) -> Result.
   bool computeType();
 
   Type getArgumentInterfaceType() const;

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -148,13 +148,6 @@ getBuiltinFunction(Identifier Id, ArrayRef<Type> argTypes, Type ResType,
                    FunctionType::ExtInfo Info = FunctionType::ExtInfo()) {
   auto &Context = ResType->getASTContext();
   
-  SmallVector<TupleTypeElt, 4> tupleElts;
-  for (Type argType : argTypes)
-    tupleElts.push_back(argType);
-  
-  Type ArgType = TupleType::get(tupleElts, Context);
-  Type FnType = FunctionType::get(ArgType, ResType, Info);
-
   ModuleDecl *M = Context.TheBuiltinModule;
   DeclContext *DC = &M->getMainFile(FileUnitKind::Builtin);
 
@@ -181,7 +174,7 @@ getBuiltinFunction(Identifier Id, ArrayRef<Type> argTypes, Type ResType,
                              /*SelfDecl=*/nullptr,
                              paramList,
                              TypeLoc::withoutLoc(ResType), DC);
-  FD->setInterfaceType(FnType);
+  FD->computeType(Info);
   FD->setValidationToChecked();
   FD->setImplicit();
   FD->setAccess(AccessLevel::Public);
@@ -192,34 +185,18 @@ getBuiltinFunction(Identifier Id, ArrayRef<Type> argTypes, Type ResType,
 static FuncDecl *
 getBuiltinGenericFunction(Identifier Id,
                           ArrayRef<TupleTypeElt> ArgParamTypes,
-                          ArrayRef<Type> ArgBodyTypes,
                           Type ResType,
-                          Type ResBodyType,
                           GenericParamList *GenericParams,
                           GenericEnvironment *Env) {
   assert(GenericParams && "Missing generic parameters");
   auto &Context = ResType->getASTContext();
-
-  Type ArgParamType = TupleType::get(ArgParamTypes, Context);
-
-  // Compute the interface type.
-  SmallVector<GenericTypeParamType *, 1> GenericParamTypes;
-  for (auto gp : *GenericParams) {
-    GenericParamTypes.push_back(gp->getDeclaredInterfaceType()
-                                  ->castTo<GenericTypeParamType>());
-  }
-  GenericSignature *Sig = Env->getGenericSignature();
-
-  Type InterfaceType = GenericFunctionType::get(Sig, ArgParamType, ResType,
-                                                AnyFunctionType::ExtInfo());
 
   ModuleDecl *M = Context.TheBuiltinModule;
   DeclContext *DC = &M->getMainFile(FileUnitKind::Builtin);
 
   SmallVector<ParamDecl*, 4> params;
   for (unsigned i = 0, e = ArgParamTypes.size(); i < e; i++) {
-    auto paramType = ArgBodyTypes[i];
-    auto paramIfaceType = ArgParamTypes[i].getType();
+    auto paramIfaceType = ArgParamTypes[i].getRawType();
     auto specifier = (ArgParamTypes[i].getParameterFlags().isInOut())
                          ? VarDecl::Specifier::InOut
                          : VarDecl::Specifier::Default;
@@ -227,14 +204,13 @@ getBuiltinGenericFunction(Identifier Id,
                                       SourceLoc(), SourceLoc(),
                                       Identifier(), SourceLoc(),
                                       Identifier(),
-                                      paramType->getInOutObjectType(), DC);
-    PD->setInterfaceType(paramIfaceType->getInOutObjectType());
+                                      Type(), DC);
+    PD->setInterfaceType(paramIfaceType);
     PD->setValidationToChecked();
     PD->setImplicit();
     params.push_back(PD);
   }
 
-  
   auto *paramList = ParameterList::create(Context, params);
   
   DeclName Name(Context, Id, paramList);
@@ -246,11 +222,11 @@ getBuiltinGenericFunction(Identifier Id,
                                GenericParams,
                                /*SelfDecl=*/nullptr,
                                paramList,
-                               TypeLoc::withoutLoc(ResBodyType), DC);
+                               TypeLoc::withoutLoc(ResType), DC);
     
-  func->setInterfaceType(InterfaceType);
-  func->setValidationToChecked();
   func->setGenericEnvironment(Env);
+  func->computeType();
+  func->setValidationToChecked();
   func->setImplicit();
   func->setAccess(AccessLevel::Public);
 
@@ -480,14 +456,9 @@ namespace {
   private:
     GenericParamList *TheGenericParamList;
     SmallVector<GenericTypeParamDecl*, 2> GenericTypeParams;
-
     GenericEnvironment *GenericEnv = nullptr;
-
     SmallVector<TupleTypeElt, 4> InterfaceParams;
-    SmallVector<Type, 4> BodyParams;
-
     Type InterfaceResult;
-    Type BodyResult;
 
   public:
     BuiltinGenericSignatureBuilder(ASTContext &ctx, unsigned numGenericParams = 1)
@@ -507,30 +478,27 @@ namespace {
 
     template <class G>
     void addParameter(const G &generator) {
-      Type gTyIface = generator.build(*this, false);
+      Type gTyIface = generator.build(*this);
       InterfaceParams.push_back({gTyIface->getInOutObjectType(),
                                  Identifier(), ParameterTypeFlags()});
-      BodyParams.push_back(generator.build(*this, true));
     }
 
     template <class G>
     void addInOutParameter(const G &generator) {
-      Type gTyIface = generator.build(*this, false);
+      Type gTyIface = generator.build(*this);
       auto iFaceflags = ParameterTypeFlags().withInOut(true);
       InterfaceParams.push_back(TupleTypeElt(gTyIface->getInOutObjectType(),
                                              Identifier(), iFaceflags));
-      BodyParams.push_back(generator.build(*this, true));
     }
     
     template <class G>
     void setResult(const G &generator) {
-      InterfaceResult = generator.build(*this, false);
-      BodyResult = generator.build(*this, true);
+      InterfaceResult = generator.build(*this);
     }
 
     ValueDecl *build(Identifier name) {
-      return getBuiltinGenericFunction(name, InterfaceParams, BodyParams,
-                                       InterfaceResult, BodyResult,
+      return getBuiltinGenericFunction(name, InterfaceParams,
+                                       InterfaceResult,
                                        TheGenericParamList,
                                        GenericEnv);
     }
@@ -540,27 +508,20 @@ namespace {
 
     struct ConcreteGenerator {
       Type TheType;
-      Type build(BuiltinGenericSignatureBuilder &builder, bool forBody) const {
+      Type build(BuiltinGenericSignatureBuilder &builder) const {
         return TheType;
       }
     };
     struct ParameterGenerator {
       unsigned Index;
-      Type build(BuiltinGenericSignatureBuilder &builder, bool forBody) const {
-        auto gpType =
-          builder.GenericTypeParams[Index]->getDeclaredInterfaceType();
-        if (forBody) {
-          return builder.GenericEnv->mapTypeIntoContext(
-                                        gpType->castTo<GenericTypeParamType>());
-        }
-
-        return gpType;
+      Type build(BuiltinGenericSignatureBuilder &builder) const {
+        return builder.GenericTypeParams[Index]->getDeclaredInterfaceType();
       }
     };
     struct LambdaGenerator {
-      std::function<Type(BuiltinGenericSignatureBuilder &,bool)> TheFunction;
-      Type build(BuiltinGenericSignatureBuilder &builder, bool forBody) const {
-        return TheFunction(builder, forBody);
+      std::function<Type(BuiltinGenericSignatureBuilder &)> TheFunction;
+      Type build(BuiltinGenericSignatureBuilder &builder) const {
+        return TheFunction(builder);
       }
     };
     template <class T, class U>
@@ -568,9 +529,9 @@ namespace {
       T Arg;
       U Result;
       FunctionType::ExtInfo ExtInfo;
-      Type build(BuiltinGenericSignatureBuilder &builder, bool forBody) const {
-        return FunctionType::get(Arg.build(builder, forBody),
-                                 Result.build(builder, forBody),
+      Type build(BuiltinGenericSignatureBuilder &builder) const {
+        return FunctionType::get(Arg.build(builder),
+                                 Result.build(builder),
                                  ExtInfo);
       }
     };
@@ -578,8 +539,8 @@ namespace {
     struct MetatypeGenerator {
       T Object;
       Optional<MetatypeRepresentation> Repr;
-      Type build(BuiltinGenericSignatureBuilder &builder, bool forBody) const {
-        return MetatypeType::get(Object.build(builder, forBody), Repr);
+      Type build(BuiltinGenericSignatureBuilder &builder) const {
+        return MetatypeType::get(Object.build(builder), Repr);
       }
     };
   };
@@ -599,9 +560,9 @@ template <class... Gs>
 static BuiltinGenericSignatureBuilder::LambdaGenerator
 makeTuple(const Gs & ...elementGenerators) {
   return {
-    [=](BuiltinGenericSignatureBuilder &builder, bool forBody) -> Type {
+    [=](BuiltinGenericSignatureBuilder &builder) -> Type {
       TupleTypeElt elts[] = {
-        elementGenerators.build(builder, forBody)...
+        elementGenerators.build(builder)...
       };
       return TupleType::get(elts, builder.Context);
     }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3006,18 +3006,7 @@ void ClassDecl::addImplicitDestructor() {
     recordObjCMethod(DD);
 
   // Assign DD the interface type (Self) -> () -> ()
-  ArrayRef<AnyFunctionType::Param> noParams;
-  AnyFunctionType::ExtInfo info;
-  Type selfTy = selfDecl->getInterfaceType();
-  Type voidTy = TupleType::getEmpty(ctx);
-  Type funcTy = FunctionType::get(noParams, voidTy, info);
-  if (auto *sig = DD->getGenericSignature()) {
-    DD->setInterfaceType(
-      GenericFunctionType::get(sig, {selfTy}, funcTy, info));
-  } else {
-    DD->setInterfaceType(
-      FunctionType::get({selfTy}, funcTy, info));
-  }
+  DD->computeType();
 }
 
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -159,15 +159,12 @@ createVarWithPattern(ASTContext &ctx, DeclContext *dc, Identifier name, Type ty,
 static FuncDecl *createFuncOrAccessor(ASTContext &ctx, SourceLoc funcLoc,
                                       Optional<AccessorInfo> accessorInfo,
                                       DeclName name, SourceLoc nameLoc,
-                                      ArrayRef<ParameterList*> bodyParams,
+                                      ParamDecl *selfDecl,
+                                      ParameterList *bodyParams,
                                       Type resultTy,
                                       bool throws,
                                       DeclContext *dc,
                                       ClangNode clangNode) {
-  ParamDecl *selfDecl = nullptr;
-  if (bodyParams.size() == 2)
-    selfDecl = bodyParams[0]->get(0);
-
   TypeLoc resultTypeLoc = resultTy ? TypeLoc::withoutLoc(resultTy) : TypeLoc();
   if (accessorInfo) {
     return AccessorDecl::create(ctx, funcLoc,
@@ -181,7 +178,7 @@ static FuncDecl *createFuncOrAccessor(ASTContext &ctx, SourceLoc funcLoc,
                                 /*ThrowsLoc=*/SourceLoc(),
                                 /*GenericParams=*/nullptr,
                                 selfDecl,
-                                bodyParams.back(),
+                                bodyParams,
                                 resultTypeLoc, dc, clangNode);
   } else {
     return FuncDecl::create(ctx, /*StaticLoc=*/SourceLoc(),
@@ -190,7 +187,7 @@ static FuncDecl *createFuncOrAccessor(ASTContext &ctx, SourceLoc funcLoc,
                             throws, /*ThrowsLoc=*/SourceLoc(),
                             /*GenericParams=*/nullptr,
                             selfDecl,
-                            bodyParams.back(),
+                            bodyParams,
                             resultTypeLoc, dc, clangNode);
   }
 }
@@ -422,7 +419,6 @@ makeEnumRawValueConstructor(ClangImporter::Implementation &Impl,
   ASTContext &C = Impl.SwiftContext;
   auto rawTy = enumDecl->getRawType();
   auto enumTy = enumDecl->getDeclaredInterfaceType();
-  auto metaTy = MetatypeType::get(enumTy);
   
   auto selfDecl = ParamDecl::createSelf(SourceLoc(), enumDecl,
                                         /*static*/false, /*inout*/true);
@@ -432,11 +428,11 @@ makeEnumRawValueConstructor(ClangImporter::Implementation &Impl,
                                  SourceLoc(), C.Id_rawValue,
                                  rawTy,
                                  enumDecl);
-  param->setInterfaceType(enumDecl->getRawType());
+  param->setInterfaceType(rawTy);
   param->setValidationToChecked();
 
   auto paramPL = ParameterList::createWithoutLoc(param);
-  
+
   DeclName name(C, DeclBaseName::createConstructor(), paramPL);
   auto *ctorDecl =
     new (C) ConstructorDecl(name, enumDecl->getLoc(),
@@ -447,13 +443,7 @@ makeEnumRawValueConstructor(ClangImporter::Implementation &Impl,
   ctorDecl->setImplicit();
   ctorDecl->setAccess(AccessLevel::Public);
 
-  auto optEnumTy = OptionalType::get(enumTy);
-
-  auto fnTy = FunctionType::get(paramPL->getType(C), optEnumTy);
-  auto allocFnTy = FunctionType::get(metaTy, fnTy);
-  auto initFnTy = FunctionType::get(enumTy, fnTy);
-  ctorDecl->setInterfaceType(allocFnTy);
-  ctorDecl->setInitializerInterfaceType(initFnTy);
+  ctorDecl->computeType();
   ctorDecl->setValidationToChecked();
 
   // Don't bother synthesizing the body if we've already finished type-checking.
@@ -536,13 +526,7 @@ static AccessorDecl *makeEnumRawValueGetter(ClangImporter::Implementation &Impl,
   getterDecl->setImplicit();
   getterDecl->setIsObjC(false);
 
-  ParameterList *paramLists[] = {
-    ParameterList::createWithoutLoc(selfDecl),
-    params
-  };
-  auto type = ParameterList::getFullInterfaceType(rawTy, paramLists, C);
-
-  getterDecl->setInterfaceType(type);
+  getterDecl->computeType();
   getterDecl->setValidationToChecked();
 
   getterDecl->setAccess(AccessLevel::Public);
@@ -621,13 +605,7 @@ static AccessorDecl *makeStructRawValueGetter(
   getterDecl->setImplicit();
   getterDecl->setIsObjC(false);
 
-  ParameterList *paramLists[] = {
-    ParameterList::createWithoutLoc(selfDecl),
-    params
-  };
-  auto type = ParameterList::getFullInterfaceType(computedType, paramLists, C);
-
-  getterDecl->setInterfaceType(type);
+  getterDecl->computeType();
   getterDecl->setValidationToChecked();
 
   getterDecl->setAccess(AccessLevel::Public);
@@ -676,7 +654,7 @@ static AccessorDecl *makeFieldGetterDecl(ClangImporter::Implementation &Impl,
 
   auto *params = ParameterList::createEmpty(C);
   
-  auto getterType = importedFieldDecl->getType();
+  auto getterType = importedFieldDecl->getInterfaceType();
   auto getterDecl = AccessorDecl::create(C,
                      /*FuncLoc=*/importedFieldDecl->getLoc(),
                      /*AccessorKeywordLoc=*/SourceLoc(),
@@ -692,12 +670,7 @@ static AccessorDecl *makeFieldGetterDecl(ClangImporter::Implementation &Impl,
   getterDecl->setAccess(AccessLevel::Public);
   getterDecl->setIsObjC(false);
 
-  ParameterList *paramLists[] = {
-    ParameterList::createWithoutLoc(selfDecl),
-    params
-  };
-  auto type = ParameterList::getFullInterfaceType(getterType, paramLists, C);
-  getterDecl->setInterfaceType(type);
+  getterDecl->computeType();
   getterDecl->setValidationToChecked();
 
   return getterDecl;
@@ -734,13 +707,9 @@ static AccessorDecl *makeFieldSetterDecl(ClangImporter::Implementation &Impl,
                      /*GenericParams=*/nullptr, selfDecl, params,
                      TypeLoc::withoutLoc(voidTy), importedDecl, clangNode);
   setterDecl->setIsObjC(false);
+  setterDecl->setSelfAccessKind(SelfAccessKind::Mutating);
 
-  ParameterList *paramLists[] = {
-    ParameterList::createWithoutLoc(selfDecl),
-    params
-  };
-  auto type = ParameterList::getFullInterfaceType(voidTy, paramLists, C);
-  setterDecl->setInterfaceType(type);
+  setterDecl->computeType();
   setterDecl->setValidationToChecked();
 
   setterDecl->setAccess(AccessLevel::Public);
@@ -1173,14 +1142,7 @@ createDefaultConstructor(ClangImporter::Implementation &Impl,
       /*GenericParams=*/nullptr, structDecl);
 
   // Set the constructor's type.
-  auto selfType = structDecl->getDeclaredInterfaceType();
-  auto selfMetatype = MetatypeType::get(selfType);
-  auto emptyTy = TupleType::getEmpty(context);
-  auto fnTy = FunctionType::get(emptyTy, selfType);
-  auto allocFnTy = FunctionType::get(selfMetatype, fnTy);
-  auto initFnTy = FunctionType::get(selfType, fnTy);
-  constructor->setInterfaceType(allocFnTy);
-  constructor->setInitializerInterfaceType(initFnTy);
+  constructor->computeType();
   constructor->setValidationToChecked();
 
   constructor->setAccess(AccessLevel::Public);
@@ -1196,6 +1158,7 @@ createDefaultConstructor(ClangImporter::Implementation &Impl,
   // Construct the left-hand reference to self.
   Expr *lhs = new (context) DeclRefExpr(selfDecl,
                                         DeclNameLoc(), /*Implicit=*/true);
+  auto selfType = structDecl->getDeclaredInterfaceType();
   lhs->setType(LValueType::get(selfType));
 
   auto emptyTuple = TupleType::getEmpty(context);
@@ -1278,27 +1241,17 @@ createValueConstructor(ClangImporter::Implementation &Impl,
     valueParameters.push_back(param);
   }
 
-  // self & param.
-  ParameterList *paramLists[] = {
-      ParameterList::createWithoutLoc(selfDecl),
-      ParameterList::create(context, valueParameters)};
+  auto *paramList = ParameterList::create(context, valueParameters);
 
   // Create the constructor
-  DeclName name(context, DeclBaseName::createConstructor(), paramLists[1]);
+  DeclName name(context, DeclBaseName::createConstructor(), paramList);
   auto constructor = new (context) ConstructorDecl(
       name, structDecl->getLoc(), OTK_None, /*FailabilityLoc=*/SourceLoc(),
-      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), selfDecl, paramLists[1],
+      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), selfDecl, paramList,
       /*GenericParams=*/nullptr, structDecl);
 
   // Set the constructor's type.
-  auto paramTy = paramLists[1]->getType(context);
-  auto selfType = structDecl->getDeclaredTypeInContext();
-  auto selfMetatype = MetatypeType::get(selfType);
-  auto fnTy = FunctionType::get(paramTy, selfType);
-  auto allocFnTy = FunctionType::get(selfMetatype, fnTy);
-  auto initFnTy = FunctionType::get(selfType, fnTy);
-  constructor->setInterfaceType(allocFnTy);
-  constructor->setInitializerInterfaceType(initFnTy);
+  constructor->computeType();
   constructor->setValidationToChecked();
 
   constructor->setAccess(AccessLevel::Public);
@@ -1603,19 +1556,6 @@ static void makeStructRawValuedWithBridge(
   addSynthesizedTypealias(structDecl, ctx.Id_RawValue, bridgedType);
 }
 
-static Type getGenericMethodType(DeclContext *dc, AnyFunctionType *fnType) {
-  assert(!fnType->hasArchetype());
-
-  auto *sig = dc->getGenericSignatureOfContext();
-  if (!sig)
-    return fnType;
-
-  Type interfaceType = GenericFunctionType::get(
-      sig, fnType->getParams(), fnType->getResult(), AnyFunctionType::ExtInfo());
-
-  return interfaceType;
-}
-
 /// Build a declaration for an Objective-C subscript getter.
 static AccessorDecl *
 buildSubscriptGetterDecl(ClangImporter::Implementation &Impl,
@@ -1627,17 +1567,6 @@ buildSubscriptGetterDecl(ClangImporter::Implementation &Impl,
   // self & index.
   auto *selfDecl = ParamDecl::createSelf(SourceLoc(), dc);
   auto *params = ParameterList::create(C, index);
-
-  // Form the type of the getter.
-  ParameterList *paramLists[] = {
-    ParameterList::createWithoutLoc(selfDecl),
-    params
-  };
-  auto getterType =
-      ParameterList::getFullInterfaceType(elementTy, paramLists, C);
-
-  auto interfaceType =
-      getGenericMethodType(dc, getterType->castTo<AnyFunctionType>());
 
   // Create the getter thunk.
   auto thunk = AccessorDecl::create(C,
@@ -1655,9 +1584,9 @@ buildSubscriptGetterDecl(ClangImporter::Implementation &Impl,
                      TypeLoc::withoutLoc(elementTy), dc,
                      getter->getClangNode());
 
-  thunk->setInterfaceType(interfaceType);
-  thunk->setValidationToChecked();
   thunk->setGenericEnvironment(dc->getGenericEnvironmentOfContext());
+  thunk->computeType();
+  thunk->setValidationToChecked();
 
   thunk->setAccess(getOverridableAccessLevel(dc));
 
@@ -1700,15 +1629,6 @@ buildSubscriptSetterDecl(ClangImporter::Implementation &Impl,
 
   auto valueIndicesPL = ParameterList::create(C, {paramVarDecl, index});
 
-  // Form the type of the setter.
-  ParameterList *setterArgs[] = {ParameterList::createWithoutLoc(selfDecl),
-                                 valueIndicesPL};
-  Type setterType = ParameterList::getFullInterfaceType(TupleType::getEmpty(C),
-                                                        setterArgs, C);
-
-  auto interfaceType =
-      getGenericMethodType(dc, setterType->castTo<AnyFunctionType>());
-
   // Create the setter thunk.
   auto thunk = AccessorDecl::create(C,
                      /*FuncLoc=*/setter->getLoc(),
@@ -1724,9 +1644,9 @@ buildSubscriptSetterDecl(ClangImporter::Implementation &Impl,
                      selfDecl, valueIndicesPL,
                      TypeLoc::withoutLoc(TupleType::getEmpty(C)), dc,
                      setter->getClangNode());
-  thunk->setInterfaceType(interfaceType);
-  thunk->setValidationToChecked();
   thunk->setGenericEnvironment(dc->getGenericEnvironmentOfContext());
+  thunk->computeType();
+  thunk->setValidationToChecked();
 
   thunk->setAccess(getOverridableAccessLevel(dc));
 
@@ -1881,11 +1801,6 @@ static bool addErrorDomain(NominalTypeDecl *swiftDecl,
       DeclRefExpr(ConcreteDeclRef(swiftValueDecl), {}, isImplicit);
   auto *selfDecl = ParamDecl::createSelf(SourceLoc(), swiftDecl, isStatic);
   auto *params = ParameterList::createEmpty(C);
-  ParameterList *paramLists[] = {
-    ParameterList::createWithoutLoc(selfDecl),
-    params
-  };
-  auto toStringTy = ParameterList::getFullInterfaceType(stringTy, paramLists, C);
 
   auto getterDecl = AccessorDecl::create(C,
                      /*FuncLoc=*/SourceLoc(),
@@ -1900,7 +1815,8 @@ static bool addErrorDomain(NominalTypeDecl *swiftDecl,
                      /*GenericParams=*/nullptr,
                      selfDecl, params,
                      TypeLoc::withoutLoc(stringTy), swiftDecl);
-  getterDecl->setInterfaceType(toStringTy);
+  getterDecl->setStatic(isStatic);
+  getterDecl->computeType();
   getterDecl->setValidationToChecked();
   getterDecl->setIsObjC(false);
 
@@ -3595,8 +3511,9 @@ namespace {
       auto nameLoc = Impl.importSourceLoc(decl->getLocation());
       FuncDecl *result = createFuncOrAccessor(Impl.SwiftContext, loc,
                                               accessorInfo, name, nameLoc,
-                                              bodyParams, resultTy,
-                                              /*throws*/ false, dc, decl);
+                                              /*selfDecl*/ nullptr, bodyParams,
+                                              resultTy, /*throws*/ false,
+                                              dc, decl);
 
       result->setInterfaceType(type);
       result->setValidationToChecked();
@@ -4042,14 +3959,9 @@ namespace {
 
       // Add the implicit 'self' parameter patterns.
       bool isInstance = decl->isInstanceMethod() && !forceClassMethod;
-      SmallVector<ParameterList *, 4> bodyParams;
+      ParameterList *bodyParams = nullptr;
       auto selfVar =
         ParamDecl::createSelf(SourceLoc(), dc, /*isStatic*/!isInstance);
-      bodyParams.push_back(ParameterList::createWithoutLoc(selfVar));
-      Type selfInterfaceType = dc->getSelfInterfaceType();
-      if (!isInstance) {
-        selfInterfaceType = MetatypeType::get(selfInterfaceType);
-      }
 
       SpecialMethodKind kind = SpecialMethodKind::Regular;
       if (isNSDictionaryMethod(decl, Impl.objectForKeyedSubscript))
@@ -4057,7 +3969,6 @@ namespace {
 
       // Import the type that this method will have.
       Optional<ForeignErrorConvention> errorConvention;
-      bodyParams.push_back(nullptr);
 
       // If we have a property accessor, find the corresponding property
       // declaration.
@@ -4087,17 +3998,15 @@ namespace {
           return nullptr;
         importedType =
             Impl.importAccessorMethodType(dc, prop, decl, isInSystemModule(dc),
-                                          importedName, &bodyParams.back());
+                                          importedName, &bodyParams);
       } else {
         importedType = Impl.importMethodType(
             dc, decl, decl->parameters(), decl->isVariadic(),
-            isInSystemModule(dc), &bodyParams.back(), importedName,
+            isInSystemModule(dc), &bodyParams, importedName,
             errorConvention, kind);
       }
       if (!importedType)
         return nullptr;
-
-      auto type = importedType.getType();
 
       // Check whether we recursively imported this method
       if (!forceClassMethod &&
@@ -4118,13 +4027,14 @@ namespace {
                                          accessorInfo,
                                          importedName.getDeclName(),
                                          /*nameLoc*/SourceLoc(),
-                                         bodyParams, Type(),
+                                         selfVar, bodyParams, Type(),
                                          importedName.getErrorInfo().hasValue(),
                                          dc, decl);
 
       result->setAccess(getOverridableAccessLevel(dc));
 
-      auto resultTy = type->castTo<FunctionType>()->getResult();
+      auto resultTy = importedType.getType()
+          ->castTo<FunctionType>()->getResult();
 
       auto isIUO = importedType.isImplicitlyUnwrapped();
 
@@ -4147,26 +4057,12 @@ namespace {
           resultTy = OptionalType::get(resultTy);
           isIUO = nullability == OTK_ImplicitlyUnwrappedOptional;
         }
-
-        // Update the method type with the new result type.
-        auto methodTy = type->castTo<FunctionType>();
-        type = FunctionType::get(methodTy->getParams(), resultTy,
-                                 methodTy->getExtInfo());
       }
 
-      // Add the 'self' parameter to the function type. NB. a method's formal
-      // type should be (Type) -> (Args...) -> Ret, not Type -> (Args...) ->
-      // Ret.
-      auto selfParam = AnyFunctionType::Param(selfInterfaceType,
-                                              Identifier(), ParameterTypeFlags());
-      type = FunctionType::get({selfParam}, type, AnyFunctionType::ExtInfo());
+      // Record the return type.
+      result->getBodyResultTypeLoc().setType(resultTy);
 
-      auto interfaceType = getGenericMethodType(dc, type->castTo<AnyFunctionType>());
-      result->setInterfaceType(interfaceType);
       result->setGenericEnvironment(dc->getGenericEnvironmentOfContext());
-      result->setValidationToChecked();
-
-      Impl.recordImplicitUnwrapForDecl(result, isIUO);
 
       // Optional methods in protocols.
       if (decl->getImplementationControl() == clang::ObjCMethodDecl::Optional &&
@@ -4179,6 +4075,12 @@ namespace {
         result->setStatic();
       if (forceClassMethod)
         result->setImplicit();
+
+      // Compute the interface type.
+      result->computeType();
+      result->setValidationToChecked();
+
+      Impl.recordImplicitUnwrapForDecl(result, isIUO);
 
       // Mark this method @objc.
       addObjCAttribute(result, selector);
@@ -5688,15 +5590,8 @@ Decl *SwiftDeclConverter::importGlobalAsInitializer(
   result->setInitKind(initKind);
   result->setImportAsStaticMember();
 
-  // Set the constructor's type(s).
-  Type argType = parameterList->getType(Impl.SwiftContext);
-  Type fnType = FunctionType::get(argType, importedType.getType());
-  Type selfType = selfParam->getType();
-  Type initType = FunctionType::get(selfType, fnType);
-  result->setInitializerInterfaceType(initType);
-  Type selfMetaType = MetatypeType::get(selfType);
-  Type allocType = FunctionType::get(selfMetaType, fnType);
-  result->setInterfaceType(allocType);
+  // Set the constructor's type.
+  result->computeType();
   Impl.recordImplicitUnwrapForDecl(result,
                                    importedType.isImplicitlyUnwrapped());
   result->setOverriddenDecls({ });
@@ -5736,8 +5631,6 @@ Decl *SwiftDeclConverter::importGlobalAsMethod(
       Impl.shouldAllowNSUIntegerAsInt(isInSystemModule(dc), decl);
 
   auto &C = Impl.SwiftContext;
-  SmallVector<ParameterList *, 2> bodyParams;
-
   // There is an inout 'self' when the parameter is a pointer to a non-const
   // instance of the type we're importing onto. Importing this as a method means
   // that the method should be treated as mutating in this situation.
@@ -5764,29 +5657,23 @@ Decl *SwiftDeclConverter::importGlobalAsMethod(
     }
   }
 
-  bodyParams.push_back(ParameterList::createWithoutLoc(ParamDecl::createSelf(
-      SourceLoc(), dc, !selfIdx.hasValue(), selfIsInOut)));
-  bodyParams.push_back(getNonSelfParamList(
-      dc, decl, selfIdx, name.getArgumentNames(), allowNSUIntegerAsInt, !name));
+  auto *selfDecl = ParamDecl::createSelf(
+      SourceLoc(), dc, !selfIdx.hasValue(), selfIsInOut);
+  auto *bodyParams = getNonSelfParamList(
+      dc, decl, selfIdx, name.getArgumentNames(), allowNSUIntegerAsInt, !name);
 
   auto importedType =
       Impl.importFunctionReturnType(dc, decl, allowNSUIntegerAsInt);
-
   Type swiftResultTy = importedType.getType();
-
-  auto fnType =
-      ParameterList::getFullInterfaceType(swiftResultTy, bodyParams, C);
 
   auto loc = Impl.importSourceLoc(decl->getLocation());
   auto nameLoc = Impl.importSourceLoc(decl->getLocation());
   auto result =
     createFuncOrAccessor(C, loc, accessorInfo, name, nameLoc,
-                         bodyParams, swiftResultTy, /*throws*/ false, dc, decl);
+                         selfDecl, bodyParams, swiftResultTy,
+                         /*throws*/ false, dc, decl);
 
-  auto interfaceType = getGenericMethodType(dc, fnType->castTo<AnyFunctionType>());
-  result->setInterfaceType(interfaceType);
   result->setGenericEnvironment(dc->getGenericEnvironmentOfContext());
-  result->setValidationToChecked();
 
   result->setAccess(AccessLevel::Public);
   if (selfIsInOut)
@@ -5797,6 +5684,9 @@ Decl *SwiftDeclConverter::importGlobalAsMethod(
     result->setStatic();
     result->setImportAsStaticMember();
   }
+
+  result->computeType();
+  result->setValidationToChecked();
 
   Impl.recordImplicitUnwrapForDecl(result,
                                    importedType.isImplicitlyUnwrapped());
@@ -6191,24 +6081,17 @@ ConstructorDecl *SwiftDeclConverter::importConstructor(
     }
   }
 
-  // Add the implicit 'self' parameter patterns.
-  SmallVector<ParameterList *, 4> bodyParams;
-  auto selfMetaVar = ParamDecl::createSelf(SourceLoc(), dc, /*static*/ true);
-  bodyParams.push_back(ParameterList::createWithoutLoc(selfMetaVar));
-
   // Import the type that this method will have.
   Optional<ForeignErrorConvention> errorConvention;
-  bodyParams.push_back(nullptr);
+  ParameterList *bodyParams;
   auto importedType = Impl.importMethodType(
-      dc, objcMethod, args, variadic, isInSystemModule(dc), &bodyParams.back(),
+      dc, objcMethod, args, variadic, isInSystemModule(dc), &bodyParams,
       importedName, errorConvention, SpecialMethodKind::Constructor);
   if (!importedType)
     return nullptr;
 
-  auto type = importedType.getType();
-
   // Determine the failability of this initializer.
-  auto oldFnType = type->castTo<AnyFunctionType>();
+  auto oldFnType = importedType.getType()->castTo<AnyFunctionType>();
   bool resultIsOptional = (bool) oldFnType->getResult()->getOptionalObjectType();
 
   // Update the failability appropriately based on the imported method type.
@@ -6225,27 +6108,9 @@ ConstructorDecl *SwiftDeclConverter::importConstructor(
   if (resultIsOptional)
     resultTy = OptionalType::get(resultTy);
 
-  type = FunctionType::get(oldFnType->getParams(), resultTy,
-                           oldFnType->getExtInfo());
-
-  // Add the 'self' parameter to the function types.
-  auto selfTy = dc->getSelfInterfaceType();
-  auto selfParam = AnyFunctionType::Param(selfTy,
-                                          Identifier(), ParameterTypeFlags());
-  auto selfMetaTy = MetatypeType::get(selfTy);
-  auto selfMetaParam = AnyFunctionType::Param(selfMetaTy, Identifier(),
-                                              ParameterTypeFlags());
-  Type allocType = FunctionType::get({selfMetaParam}, type,
-                                     AnyFunctionType::ExtInfo());
-  Type initType = FunctionType::get({selfParam}, type,
-                                    AnyFunctionType::ExtInfo());
-
   // Look for other imported constructors that occur in this context with
   // the same name.
-  Type allocParamType = allocType->castTo<AnyFunctionType>()
-                            ->getResult()
-                            ->castTo<AnyFunctionType>()
-                            ->getInput();
+  Type allocParamType = oldFnType->getInput();
   bool ignoreNewExtensions = isa<ClassDecl>(dc);
   for (auto other : ownerNominal->lookupDirect(importedName.getDeclName(),
                                                ignoreNewExtensions)) {
@@ -6328,7 +6193,7 @@ ConstructorDecl *SwiftDeclConverter::importConstructor(
       objcMethod, AccessLevel::Public, importedName.getDeclName(),
       /*NameLoc=*/SourceLoc(), failability, /*FailabilityLoc=*/SourceLoc(),
       /*Throws=*/importedName.getErrorInfo().hasValue(),
-      /*ThrowsLoc=*/SourceLoc(), selfVar, bodyParams.back(),
+      /*ThrowsLoc=*/SourceLoc(), selfVar, bodyParams,
       /*GenericParams=*/nullptr, dc);
 
   // Make the constructor declaration immediately visible in its
@@ -6338,14 +6203,8 @@ ConstructorDecl *SwiftDeclConverter::importConstructor(
   addObjCAttribute(result, selector);
 
   // Calculate the function type of the result.
-  auto interfaceAllocType =
-      getGenericMethodType(dc, allocType->castTo<AnyFunctionType>());
-  auto interfaceInitType =
-      getGenericMethodType(dc, initType->castTo<AnyFunctionType>());
-
-  result->setInitializerInterfaceType(interfaceInitType);
-  result->setInterfaceType(interfaceAllocType);
   result->setGenericEnvironment(dc->getGenericEnvironmentOfContext());
+  result->computeType();
 
   Impl.recordImplicitUnwrapForDecl(result,
                                    importedType.isImplicitlyUnwrapped());
@@ -6646,7 +6505,6 @@ SwiftDeclConverter::importSubscript(Decl *decl,
   // the implicit 'self' parameter and the normal function
   // parameters.
   auto elementTy = getter->getResultInterfaceType();
-  auto elementContextTy = getter->mapTypeIntoContext(elementTy);
 
   // Local function to mark the setter unavailable.
   auto makeSetterUnavailable = [&] {
@@ -6750,7 +6608,7 @@ SwiftDeclConverter::importSubscript(Decl *decl,
   auto subscript = Impl.createDeclWithClangNode<SubscriptDecl>(
       getter->getClangNode(), getOverridableAccessLevel(dc), name,
       decl->getLoc(), bodyParams, decl->getLoc(),
-      TypeLoc::withoutLoc(elementContextTy), dc,
+      TypeLoc::withoutLoc(elementTy), dc,
       /*GenericParams=*/nullptr);
 
   // Build the thunks.
@@ -6776,15 +6634,7 @@ SwiftDeclConverter::importSubscript(Decl *decl,
 
   subscript->setIsSetterMutating(false);
   makeComputed(subscript, getterThunk, setterThunk);
-  auto indicesType = bodyParams->getType(C);
-
-  AnyFunctionType *fnType;
-  if (auto *sig = dc->getGenericSignatureOfContext())
-    fnType = GenericFunctionType::get(sig, indicesType, elementTy,
-                                      AnyFunctionType::ExtInfo());
-  else
-    fnType = FunctionType::get(indicesType, elementTy);
-  subscript->setInterfaceType(fnType);
+  subscript->computeType();
 
   Impl.recordImplicitUnwrapForDecl(subscript, isIUO);
 
@@ -8345,22 +8195,11 @@ ClangImporter::Implementation::createConstant(Identifier name, DeclContext *dc,
   var->setInterfaceType(type);
   var->setIsObjC(false);
 
-  // Form the argument patterns.
-  SmallVector<ParameterList*, 3> getterArgs;
-  
   // 'self'
   ParamDecl *selfDecl = nullptr;
   auto *params = ParameterList::createEmpty(C);
-  if (dc->isTypeContext()) {
+  if (dc->isTypeContext())
     selfDecl = ParamDecl::createSelf(SourceLoc(), dc, isStatic);
-    getterArgs.push_back(ParameterList::createWithoutLoc(selfDecl));
-  }
-  
-  // empty tuple
-  getterArgs.push_back(params);
-
-  // Form the type of the getter.
-  auto getterType = ParameterList::getFullInterfaceType(type, getterArgs, C);
 
   // Create the getter function declaration.
   auto func = AccessorDecl::create(C,
@@ -8377,7 +8216,7 @@ ClangImporter::Implementation::createConstant(Identifier name, DeclContext *dc,
                      selfDecl, params,
                      TypeLoc::withoutLoc(type), dc);
   func->setStatic(isStatic);
-  func->setInterfaceType(getterType);
+  func->computeType();
   func->setAccess(getOverridableAccessLevel(dc));
   func->setValidationToChecked();
   func->setImplicit();

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -341,37 +341,11 @@ deriveRawRepresentable_init(DerivedConformance &derived) {
   initDecl->setImplicit();
   initDecl->setBodySynthesizer(&deriveBodyRawRepresentable_init);
 
-  // Compute the type of the initializer.
-  TupleTypeElt element(rawType, C.Id_rawValue);
-  TupleTypeElt interfaceElement(rawInterfaceType, C.Id_rawValue);
-  auto interfaceArgType = TupleType::get(interfaceElement, C);
-
   // Compute the interface type of the initializer.
-  Type retInterfaceType
-    = OptionalType::get(parentDC->getDeclaredInterfaceType());
-  Type interfaceType = FunctionType::get(interfaceArgType, retInterfaceType);
-  auto selfParam = computeSelfParam(initDecl);
-  auto initSelfParam = computeSelfParam(initDecl, /*init*/ true);
+  if (auto env = parentDC->getGenericEnvironmentOfContext())
+    initDecl->setGenericEnvironment(env);
+  initDecl->computeType();
 
-  Type allocIfaceType;
-  Type initIfaceType;
-  if (auto sig = parentDC->getGenericSignatureOfContext()) {
-    initDecl->setGenericEnvironment(parentDC->getGenericEnvironmentOfContext());
-
-    allocIfaceType = GenericFunctionType::get(sig, {selfParam},
-                                              interfaceType,
-                                              FunctionType::ExtInfo());
-    initIfaceType = GenericFunctionType::get(sig, {initSelfParam},
-                                             interfaceType,
-                                             FunctionType::ExtInfo());
-  } else {
-    allocIfaceType = FunctionType::get({selfParam},
-                                       interfaceType, FunctionType::ExtInfo());
-    initIfaceType = FunctionType::get({initSelfParam},
-                                      interfaceType, FunctionType::ExtInfo());
-  }
-  initDecl->setInterfaceType(allocIfaceType);
-  initDecl->setInitializerInterfaceType(initIfaceType);
   initDecl->copyFormalAccessFrom(enumDecl, /*sourceIsParentContext*/true);
   initDecl->setValidationToChecked();
 

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -309,19 +309,10 @@ DerivedConformance::declareDerivedPropertyGetter(TypeChecker &tc,
     getterDecl->getAttrs().add(new (C) FinalAttr(/*IsImplicit=*/true));
 
   // Compute the interface type of the getter.
-  Type interfaceType = FunctionType::get(TupleType::getEmpty(C),
-                                         propertyInterfaceType);
-  auto selfParam = computeSelfParam(getterDecl);
-  if (auto sig = parentDC->getGenericSignatureOfContext()) {
-    getterDecl->setGenericEnvironment(
-        parentDC->getGenericEnvironmentOfContext());
-    interfaceType = GenericFunctionType::get(sig, {selfParam},
-                                             interfaceType,
-                                             FunctionType::ExtInfo());
-  } else
-    interfaceType = FunctionType::get({selfParam}, interfaceType,
-                                      FunctionType::ExtInfo());
-  getterDecl->setInterfaceType(interfaceType);
+  if (auto env = parentDC->getGenericEnvironmentOfContext())
+    getterDecl->setGenericEnvironment(env);
+  getterDecl->computeType();
+
   getterDecl->copyFormalAccessFrom(property);
   getterDecl->setValidationToChecked();
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4177,16 +4177,15 @@ void TypeChecker::validateDecl(ValueDecl *D) {
       recordParamContextTypes(FD);
     } else {
       // We've inherited all of the type information already.
-      configureInterfaceType(FD,
-        FD->getDeclContext()->getGenericSignatureOfContext());
+      FD->setGenericEnvironment(
+        FD->getDeclContext()->getGenericEnvironmentOfContext());
+
+      FD->computeType();
 
       if (FD->getInterfaceType()->hasError()) {
         FD->setInterfaceType(ErrorType::get(Context));
         FD->setInvalid();
       }
-
-      FD->setGenericEnvironment(
-        FD->getDeclContext()->getGenericEnvironmentOfContext());
     }
 
     if (!isa<AccessorDecl>(FD) || cast<AccessorDecl>(FD)->isGetter()) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1264,10 +1264,6 @@ public:
   /// Revert the dependent types within a set of requirements.
   void revertGenericRequirements(MutableArrayRef<RequirementRepr> requirements);
 
-  /// Configure the interface type of a function declaration.
-  void configureInterfaceType(AbstractFunctionDecl *func,
-                              GenericSignature *sig);
-
   /// Compute the generic signature, generic environment and interface type
   /// of a generic function.
   void validateGenericFuncSignature(AbstractFunctionDecl *func);
@@ -1282,10 +1278,6 @@ public:
   /// Compute the generic signature, generic environment and interface type
   /// of a generic subscript.
   void validateGenericSubscriptSignature(SubscriptDecl *subscript);
-
-  /// Configure the interface type of a subscript declaration.
-  void configureInterfaceType(SubscriptDecl *subscript,
-                              GenericSignature *sig);
 
   /// Construct a new generic environment for the given declaration context.
   ///


### PR DESCRIPTION
The type of a function declaration is entirely determined by the type of its parameters and the type of its result. Sema already knows how to calculate the function type from the parameters and result for parsed definitions. Factor this out into a method on AbstractFunctionDecl, and use it for synthesized and imported declarations.