### PR TITLE
[Runtime] Remove protocol descriptor overlap

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -1577,19 +1577,6 @@ using TupleTypeMetadata = TargetTupleTypeMetadata<InProcess>;
   
 template <typename Runtime> struct TargetProtocolDescriptor;
 
-#if SWIFT_OBJC_INTEROP
-/// Layout of a small prefix of an Objective-C protocol, used only to
-/// directly extract the name of the protocol.
-template <typename Runtime>
-struct TargetObjCProtocolPrefix {
-  /// Unused by the Swift runtime.
-  TargetPointer<Runtime, const void> _ObjC_Isa;
-
-  /// The mangled name of the protocol.
-  TargetPointer<Runtime, const char> Name;
-};
-#endif
-
 /// A reference to a protocol within the runtime, which may be either
 /// a Swift protocol or (when Objective-C interoperability is enabled) an
 /// Objective-C protocol.
@@ -1648,18 +1635,6 @@ public:
 
   explicit constexpr operator bool() const {
     return storage != 0;
-  }
-
-  /// The name of the protocol.
-  TargetPointer<Runtime, const char> getName() const {
-#if SWIFT_OBJC_INTEROP
-    if (isObjC()) {
-      return reinterpret_cast<TargetObjCProtocolPrefix<Runtime> *>(
-          getObjCProtocol())->Name;
-    }
-#endif
-
-    return getSwiftProtocol()->Name;
   }
 
   /// Determine what kind of protocol this is, Swift or Objective-C.

--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -1669,7 +1669,7 @@ public:
     }
 #endif
 
-    return getProtocolDescriptorUnchecked()->Flags.getClassConstraint();
+    return getSwiftProtocol()->Flags.getClassConstraint();
   }
 
   /// Determine whether this protocol needs a witness table.
@@ -1680,7 +1680,7 @@ public:
     }
 #endif
 
-    return getProtocolDescriptorUnchecked()->Flags.needsWitnessTable();
+    return true;
   }
 
   SpecialProtocol getSpecialProtocol() const {
@@ -1690,7 +1690,7 @@ public:
     }
 #endif
 
-    return getProtocolDescriptorUnchecked()->Flags.getSpecialProtocol();
+    return getSwiftProtocol()->Flags.getSpecialProtocol();
   }
 
   /// Retrieve the Swift protocol descriptor.
@@ -1710,8 +1710,6 @@ public:
 #if SWIFT_OBJC_INTEROP
   /// Whether this references an Objective-C protocol.
   bool isObjC() const {
-    assert(static_cast<bool>(storage & IsObjCBit) !=
-             getProtocolDescriptorUnchecked()->Flags.needsWitnessTable());
     return (storage & IsObjCBit) != 0;
   }
 

--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -1613,14 +1613,6 @@ class TargetProtocolDescriptorRef {
   /// is clear).
   StoredPointer storage;
 
-public:
-  /// Retrieve the protocol descriptor without checking whether we have an
-  /// Objective-C or Swift protocol.
-  /// FIXME: Temporarily public while we roll out TargetProtocolDescriptorRef.
-  ProtocolDescriptorPointer getProtocolDescriptorUnchecked() const {
-    return reinterpret_cast<ProtocolDescriptorPointer>(storage & ~IsObjCBit);
-  }
-
   constexpr TargetProtocolDescriptorRef(StoredPointer storage)
     : storage(storage) { }
 
@@ -1719,7 +1711,7 @@ public:
     assert(!isObjC());
 #endif
 
-    return getProtocolDescriptorUnchecked();
+    return reinterpret_cast<ProtocolDescriptorPointer>(storage & ~IsObjCBit);
   }
 
   /// Retrieve the raw stored pointer and discriminator bit.
@@ -1734,9 +1726,10 @@ public:
   }
 
   /// Retrieve the Objective-C protocol.
-  Protocol *getObjCProtocol() const {
+  TargetPointer<Runtime, Protocol> getObjCProtocol() const {
     assert(isObjC());
-    return reinterpret_cast<Protocol *>(storage & ~IsObjCBit);
+    return reinterpret_cast<TargetPointer<Runtime, Protocol> >(
+                                                         storage & ~IsObjCBit);
   }
 #endif
 };

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -83,6 +83,19 @@ struct delete_with_free {
   }
 };
 
+#if SWIFT_OBJC_INTEROP
+/// Layout of a small prefix of an Objective-C protocol, used only to
+/// directly extract the name of the protocol.
+template <typename Runtime>
+struct TargetObjCProtocolPrefix {
+  /// Unused by the Swift runtime.
+  TargetPointer<Runtime, const void> _ObjC_Isa;
+
+  /// The mangled name of the protocol.
+  TargetPointer<Runtime, const char> Name;
+};
+#endif
+
 /// A generic reader of metadata.
 ///
 /// BuilderType must implement a particular interface which is currently

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -21,6 +21,7 @@
 #include "swift/Remote/MemoryReader.h"
 #include "swift/Demangling/Demangler.h"
 #include "swift/Demangling/TypeDecoder.h"
+#include "swift/Basic/Defer.h"
 #include "swift/Basic/Range.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Runtime/Unreachable.h"
@@ -359,8 +360,31 @@ public:
 
       std::vector<BuiltProtocolDecl> Protocols;
       for (auto ProtocolAddress : Exist->getProtocols()) {
-        auto ProtocolDescriptor = readProtocolDescriptor(
-            ProtocolAddress.getProtocolDescriptorUnchecked());
+#if SWIFT_OBJC_INTEROP
+        // Check whether we have an Objective-C protocol.
+        if (ProtocolAddress.isObjC()) {
+          auto MangledNameStr =
+            readObjCProtocolName(ProtocolAddress.getObjCProtocol());
+
+          StringRef MangledName =
+            Demangle::dropSwiftManglingPrefix(MangledNameStr);
+
+          Demangle::Context DCtx;
+          auto Demangled = DCtx.demangleTypeAsNode(MangledName);
+          if (!Demangled)
+            return BuiltType();
+
+          auto Protocol = Builder.createProtocolDecl(Demangled);
+          if (!Protocol)
+            return BuiltType();
+
+          Protocols.push_back(Protocol);
+          continue;
+        }
+#endif
+
+        auto ProtocolDescriptor = readSwiftProtocolDescriptor(
+            ProtocolAddress.getSwiftProtocol());
         if (!ProtocolDescriptor)
           return BuiltType();
 
@@ -1270,7 +1294,7 @@ private:
   }
 
   OwnedProtocolDescriptorRef
-  readProtocolDescriptor(StoredPointer Address) {
+  readSwiftProtocolDescriptor(StoredPointer Address) {
     auto Size = sizeof(TargetProtocolDescriptor<Runtime>);
     auto Buffer = (uint8_t *)malloc(Size);
     if (!Reader->readBytes(RemoteAddress(Address), Buffer, Size)) {
@@ -1281,6 +1305,27 @@ private:
       = reinterpret_cast<TargetProtocolDescriptor<Runtime> *>(Buffer);
     return OwnedProtocolDescriptorRef(Casted);
   }
+
+#if SWIFT_OBJC_INTEROP
+  std::string readObjCProtocolName(StoredPointer Address) {
+    auto Size = sizeof(TargetObjCProtocolPrefix<Runtime>);
+    auto Buffer = (uint8_t *)malloc(Size);
+    SWIFT_DEFER {
+      free(Buffer);
+    };
+
+    if (!Reader->readBytes(RemoteAddress(Address), Buffer, Size))
+      return std::string();
+
+    auto ProtocolDescriptor
+      = reinterpret_cast<TargetObjCProtocolPrefix<Runtime> *>(Buffer);
+    std::string Name;
+    if (!Reader->readString(RemoteAddress(ProtocolDescriptor->Name), Name))
+      return std::string();
+
+    return Name;
+  }
+#endif
 
   // TODO: We need to be able to produce protocol conformances for each
   // substitution type as well in order to accurately rebuild bound generic

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -393,7 +393,20 @@ swift::_swift_buildDemanglingForMetadata(const Metadata *type,
 
     for (auto protocol : protocols) {
       // The protocol name is mangled as a type symbol, with the _Tt prefix.
-      StringRef ProtoName(protocol.getName());
+      StringRef ProtoName;
+      std::string ProtoNameScratch;
+#if SWIFT_OBJC_INTEROP
+      // For Objective-C protocols, retrieve the protocol name from the
+      // runtime.
+      if (protocol.isObjC()) {
+        ProtoNameScratch = protocol_getName(protocol.getObjCProtocol());
+        ProtoName = ProtoNameScratch;
+      } else {
+        ProtoName = protocol.getSwiftProtocol()->Name;
+      }
+#else
+      ProtoName = protocol.getSwiftProtocol()->Name;
+#endif
       NodePointer protocolNode = Dem.demangleSymbol(ProtoName);
 
       // ObjC protocol names aren't mangled.


### PR DESCRIPTION
In all of the places where we look into protocol descriptors in the runtime, remote AST, and remote mirrors, separate out of the code paths and data structures for Objective-C and Swift protocols. After this, there should be nothing remaining that relies on the layouts being identical (even though they still are).