### PR TITLE
[Reflection] Make getSubstMap and visitDependentMemberTypeRef more robust against unexpected data.

### DIFF
--- a/include/swift/Reflection/TypeRef.h
+++ b/include/swift/Reflection/TypeRef.h
@@ -158,7 +158,7 @@ public:
   const TypeRef *
   subst(TypeRefBuilder &Builder, const GenericArgumentMap &Subs) const;
 
-  GenericArgumentMap getSubstMap() const;
+  llvm::Optional<GenericArgumentMap> getSubstMap() const;
 
   virtual ~TypeRef() = default;
 

--- a/stdlib/public/Reflection/TypeRefBuilder.cpp
+++ b/stdlib/public/Reflection/TypeRefBuilder.cpp
@@ -131,7 +131,10 @@ lookupSuperclass(const TypeRef *TR) {
   if (!Unsubstituted)
     return nullptr;
 
-  return Unsubstituted->subst(*this, TR->getSubstMap());
+  auto SubstMap = TR->getSubstMap();
+  if (!SubstMap)
+    return nullptr;
+  return Unsubstituted->subst(*this, *SubstMap);
 }
 
 std::pair<const FieldDescriptor *, const ReflectionInfo *>
@@ -180,6 +183,8 @@ bool TypeRefBuilder::getFieldTypeRefs(
     return false;
 
   auto Subs = TR->getSubstMap();
+  if (!Subs)
+    return false;
 
   for (auto &Field : *FD.first) {
     auto TypeRefOffset = FD.second->Field.SectionOffset
@@ -199,7 +204,7 @@ bool TypeRefBuilder::getFieldTypeRefs(
     if (!Unsubstituted)
       return false;
 
-    auto Substituted = Unsubstituted->subst(*this, Subs);
+    auto Substituted = Unsubstituted->subst(*this, *Subs);
 
     if (FD.first->isEnum() && Field.isIndirectCase()) {
       Fields.push_back(FieldTypeInfo::forIndirectCase(FieldName, Substituted));


### PR DESCRIPTION
Remote mirrors was hitting an assertion failure due to a generic parameter not being concrete. This check catches that case early and returns a clean failure from getSubstMap, which callers can then handle appropriately.

It also hit a casting failure in visitDependentMemberTypeRef, which assumed that SubstBase was either a NominalTypeRef or a BoundGenericTypeRef. This does a dynamic cast with a graceful failure.

In general there is a tension in this code between its use in the runtime, where we usually want to treat bad data as a horrible bug and fail loudly, and its use in remote mirrors, where we need to assume that the data we're examining might be horribly broken and we just want to do the best we can. Longer term we might want to make this code configurable so that we can have an "assert and die" mode for the runtime, and a "fail gracefully" mode for remote mirrors.

rdar://problem/40136609