### PR TITLE
Don’t dive into null parts of AST.

### DIFF
--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -226,7 +226,7 @@ bool ide::printDeclUSR(const ValueDecl *D, raw_ostream &OS) {
     return printObjCUSR(D, OS);
   }
 
-  if (!D->hasInterfaceType() || D->getInterfaceType()->is<ErrorType>())
+  if (!D->hasInterfaceType())
     return true;
 
   // Invalid code.

--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -226,7 +226,7 @@ bool ide::printDeclUSR(const ValueDecl *D, raw_ostream &OS) {
     return printObjCUSR(D, OS);
   }
 
-  if (!D->hasInterfaceType())
+  if (!D->hasInterfaceType() || D->getInterfaceType()->is<ErrorType>())
     return true;
 
   // Invalid code.

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -247,6 +247,8 @@ static SemaReferenceKind getReferenceKind(Expr *Parent, Expr *E) {
 }
 
 std::pair<bool, Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
+  assert(E);
+
   if (isDone())
     return { false, nullptr };
 
@@ -409,11 +411,11 @@ std::pair<bool, Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
       llvm::SaveAndRestore<Optional<AccessKind>>
         C(this->OpAccess, AccessKind::Write);
 
-      if (!AE->getDest()->walk(*this))
+      if (AE->getDest() && !AE->getDest()->walk(*this))
         return { false, nullptr };
     }
 
-    if (!AE->getSrc()->walk(*this))
+    if (AE->getSrc() && !AE->getSrc()->walk(*this))
       return { false, nullptr };
 
     // We already visited the children.


### PR DESCRIPTION
<!-- What's in this pull request? -->
When compiling code with certain errors, it is possible to get null pointers in the AST.
The compiler indexes even when there are errors, and the indexing code then tries to walk into the null pointers, causing a crash. As a result, the frontend crashes, and the developer does not get to see the errors. This PR adds a null check for this specific case. It does not solve the general problem.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://42314665

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
