### PR TITLE
SILGen: Pick UIApplicationMain by looking directly in the Clang module.

### DIFF
--- a/test/SILGen/Inputs/UIKit.swift
+++ b/test/SILGen/Inputs/UIKit.swift
@@ -2,3 +2,9 @@ import Foundation
 @_exported import UIKit
 
 public func UIApplicationMain() {}
+public func UIApplicationMain(_ argc: Int32,
+                              _ argv: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>!,
+                              _ principalClassName: String?,
+                              _ delegateClassName: String?) -> Int32 {
+  return 0
+}


### PR DESCRIPTION
This saves us from having to do overload resolution on the overlay module, which fails if an overlay declaration exactly matches the imported signature of the original ObjC declaration. Fixes rdar://problem/42352695 harder.