### PR TITLE
[4.2] SILGen: Pick UIApplicationMain by looking directly in the Clang module.

### DIFF
--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -438,30 +438,25 @@ void SILGenFunction::emitArtificialTopLevel(ClassDecl *mainClass) {
     // we're getting away with it because the types are guaranteed to already
     // be imported.
     ASTContext &ctx = getASTContext();
-    ModuleDecl *UIKit = ctx.getLoadedModule(ctx.getIdentifier("UIKit"));
+    
+    std::pair<Identifier, SourceLoc> UIKitName =
+      {ctx.getIdentifier("UIKit"), SourceLoc()};
+    
+    ModuleDecl *UIKit = ctx
+      .getClangModuleLoader()
+      ->loadModule(SourceLoc(), UIKitName);
+    assert(UIKit && "couldn't find UIKit objc module?!");
     SmallVector<ValueDecl *, 1> results;
     UIKit->lookupQualified(UIKit->getInterfaceType(),
                            ctx.getIdentifier("UIApplicationMain"),
                            NL_QualifiedDefault,
                            /*resolver*/nullptr,
                            results);
-    assert(!results.empty() && "couldn't find UIApplicationMain in UIKit");
+    assert(results.size() == 1
+           && "couldn't find a unique UIApplicationMain in the UIKit ObjC "
+              "module?!");
 
-    // We want the original UIApplicationMain() declaration from Objective-C,
-    // not any overlay overloads.
-    ValueDecl *UIApplicationMainDecl = nullptr;
-    for (auto *result : results) {
-      if (result->hasClangNode()) {
-        assert(!UIApplicationMainDecl
-               && "more than one UIApplicationMain defined in ObjC?!");
-        UIApplicationMainDecl = result;
-#ifndef NDEBUG
-        break;
-#endif
-      }
-    }
-    
-    assert(UIApplicationMainDecl && "no UIApplicationMain defined in ObjC?!");
+    ValueDecl *UIApplicationMainDecl = results.front();
 
     auto mainRef = SILDeclRef(UIApplicationMainDecl).asForeign();
     auto UIApplicationMainFn = SGM.M.getOrCreateFunction(mainClass, mainRef,

--- a/test/SILGen/Inputs/UIKit.swift
+++ b/test/SILGen/Inputs/UIKit.swift
@@ -2,3 +2,9 @@ import Foundation
 @_exported import UIKit
 
 public func UIApplicationMain() {}
+public func UIApplicationMain(_ argc: Int32,
+                              _ argv: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>!,
+                              _ principalClassName: String?,
+                              _ delegateClassName: String?) -> Int32 {
+  return 0
+}


### PR DESCRIPTION
Explanation: The previous fix for rdar://problem/42352695 did not work when the UIKit overlay contained a UIApplicationMain overload that exactly matched the imported signature of UIApplicationMain from ObjC. This avoids the issue by looking for UIApplicationMain directly in the Clang module.

Scope: Makes compiler more resilient to SDK overlay changes

Issue: rdar://problem/42352695

Risk: Low, improves specificity of existing logic to find UIApplicationMain

Testing: Swift CI, compatibility suite

Reviewed by: @jrose-apple 