### PR TITLE
os_log test failing

### DIFF
--- a/test/stdlib/os_log_format.m
+++ b/test/stdlib/os_log_format.m
@@ -1,7 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %clang %target-cc-options -g -O0 -isysroot %sdk -I %swift_src_root/stdlib/public/SDK/os -framework Foundation %swift_src_root/stdlib/public/SDK/os/format.m %swift_src_root/stdlib/public/SDK/os/os_trace_blob.c %s -o %t/os_log_format
 // RUN: %target-run %t/os_log_format | %FileCheck %s
-// REQUIRES: rdar41380265
 
 // REQUIRES: objc_interop
 
@@ -134,7 +133,9 @@ main(int argc, char **argv)
   ACCEPT("simple float %f", (float)1.5);
   ACCEPT("simple double %f", 1.5);
 #ifdef __LP64__
-  ACCEPT("simple long double %Lf", (long double)1.5);
+  // Disabled because the upstream clang output for long double changed
+  // and causes CI fallout
+  // ACCEPT("simple long double %Lf", (long double)1.5);
 #endif
 
   ACCEPT("integer with a static width %666d", 10);


### PR DESCRIPTION
Rather than have the entire log format test disabled because of the
long-double test, disable just the long-double test itself.

Fixes: rdar://41380265