### PR TITLE
[4.2][Lexer] Don't include backtick length into comment length

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -279,10 +279,16 @@ void Lexer::formToken(tok Kind, const char *TokStart, bool MultilineString) {
   }
   unsigned CommentLength = 0;
   if (RetainComments == CommentRetentionMode::AttachToNextToken) {
+    // 'CommentLength' here is the length from the *first* comment to the
+    // token text (or its backtick if exist).
     auto Iter = llvm::find_if(LeadingTrivia, [](const TriviaPiece &Piece) {
       return Piece.isComment();
     });
     for (auto End = LeadingTrivia.end(); Iter != End; Iter++) {
+      if (Iter->getKind() == TriviaKind::Backtick)
+        // Since Token::getCommentRange() doesn't take backtick into account,
+        // we cannot include length of backtick.
+        break;
       CommentLength += Iter->getTextLength();
     }
   }

--- a/validation-test/IDE/crashers_2/0021-lexer-commentlength.swift
+++ b/validation-test/IDE/crashers_2/0021-lexer-commentlength.swift
@@ -1,5 +1,0 @@
-/*comment*/`init`()
-foo();/*comment*/`var`()
-
-// RUN: not --crash %target-swift-ide-test -syntax-coloring -source-filename %s
-// REQUIRES: asserts

--- a/validation-test/IDE/crashers_2/0021-lexer-commentlength.swift
+++ b/validation-test/IDE/crashers_2/0021-lexer-commentlength.swift
@@ -1,0 +1,5 @@
+/*comment*/`init`()
+foo();/*comment*/`var`()
+
+// RUN: not --crash %target-swift-ide-test -syntax-coloring -source-filename %s
+// REQUIRES: asserts

--- a/validation-test/IDE/crashers_2_fixed/0021-lexer-commentlength.swift
+++ b/validation-test/IDE/crashers_2_fixed/0021-lexer-commentlength.swift
@@ -1,0 +1,4 @@
+/*comment*/`init`()
+foo();/*comment*/`var`()
+
+// RUN: %target-swift-ide-test -syntax-coloring -source-filename %s


### PR DESCRIPTION
Cherry-pick of #18144 reviewed by @nkcsgexi  

- **Explaination**: Lexer tokenizes comments and whitespaces as libSyntax Trivia first. For compatibility, it calculates comment length from trivia for legacy Parser logic. Previously, the length included backslash length attached to escaped identifier as a trivia piece. However `Token::getCommentRange` assumes it does *not* contain comment backslash. This mismatch used to cause compiler crash.
- **Scope**: Affect SourceKit  functionality for handling escaped identifier with comments.
- **Issue**: rdar://problem/42492793 https://bugs.swift.org/browse/SR-8315
- **Risk**: Low. Pre-fix logic was obviously incorrect, and fix is simple.
- **Testing**: Added regression test cases.
- **Reviewed By**: Xi Ge (https://github.com/apple/swift/pull/18144)