### PR TITLE
[Diagnostics] Improve contextual member unexpected arguments diagnostic

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -103,10 +103,10 @@ ERROR(expected_result_in_contextual_member,none,
       "member %0 in %2 produces result of type %1, but context expects %2",
       (DeclName, Type, Type))
 
-ERROR(unexpected_argument_in_contextual_member,none,
-      "member %0 takes no arguments", (DeclName))
-ERROR(unexpected_parens_in_contextual_member,none,
-      "member %0 is not a function", (DeclName))
+ERROR(unexpected_arguments_in_enum_case,none,
+      "enum case %0 has no associated values", (DeclName))
+ERROR(unexpected_arguments_in_contextual_member,none,
+      "%0 %1 is not a function", (DescriptiveDeclKind, DeclName))
 
 ERROR(could_not_use_value_member,none,
       "member %1 cannot be used on value of type %0", (Type, DeclName))

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -421,6 +421,7 @@ enum Color {
   static func overload(b : Int) -> Color {}
   
   static func frob(_ a : Int, b : inout Int) -> Color {}
+  static var svar: Color { return .Red }
 }
 let _: (Int, Color) = [1,2].map({ ($0, .Unknown("")) }) // expected-error {{'map' produces '[T]', not the expected contextual result type '(Int, Color)'}}
 
@@ -452,6 +453,8 @@ let _: Color = .frob(1, &d) // expected-error {{missing argument label 'b:' in c
 let _: Color = .frob(1, b: &d) // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
 var someColor : Color = .red // expected-error {{enum type 'Color' has no case 'red'; did you mean 'Red'}}
 someColor = .red  // expected-error {{enum type 'Color' has no case 'red'; did you mean 'Red'}}
+someColor = .svar() // expected-error {{static var 'svar' is not a function}}
+someColor = .svar(1) // expected-error {{static var 'svar' is not a function}}
 
 func testTypeSugar(_ a : Int) {
   typealias Stride = Int

--- a/test/decl/enum/enumtest.swift
+++ b/test/decl/enum/enumtest.swift
@@ -222,8 +222,8 @@ func f() {
 }
 
 func union_error(_ a: ZeroOneTwoThree) {
-  var _ : ZeroOneTwoThree = .Zero(1) // expected-error {{member 'Zero' takes no arguments}}
-  var _ : ZeroOneTwoThree = .Zero() // expected-error {{member 'Zero' is not a function}} {{34-36=}}
+  var _ : ZeroOneTwoThree = .Zero(1) // expected-error {{enum case 'Zero' has no associated values}}
+  var _ : ZeroOneTwoThree = .Zero() // expected-error {{enum case 'Zero' has no associated values}} {{34-36=}}
   var _ : ZeroOneTwoThree = .One // expected-error {{member 'One' expects argument of type 'Int'}}
   var _ : ZeroOneTwoThree = .foo // expected-error {{type 'ZeroOneTwoThree' has no member 'foo'}}
   var _ : ZeroOneTwoThree = .foo() // expected-error {{type 'ZeroOneTwoThree' has no member 'foo'}}


### PR DESCRIPTION
This improves the diagnostic reported in [SR-4270](https://bugs.swift.org/browse/SR-4270).

With this code:

```swift
enum A { 
	case a
	static var b: A { return .a }
}
let _: A = .a()
let _: A = .b()
```

Before:

```
4270.swift:5:13: error: member 'a' is not a function
let _: A = .a()
            ^~~
             
4270.swift:6:13: error: member 'b' is not a function
let _: A = .b()
            ^~~
```

After:

```
4270.swift:5:13: error: enum case 'a' has no associated values
let _: A = .a()
            ^~~
             
4270.swift:6:13: error: static var 'b' is not a function
let _: A = .b()
            ^~~
```