### PR TITLE
[Stdlib] Make the comparison operatosr on concrete Int types transparent

### DIFF
--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -3882,20 +3882,17 @@ ${assignmentOperatorComment(x.operator, True)}
     return !(lhs == rhs)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
+  @_transparent
   public static func <= (lhs: ${Self}, rhs: ${Self}) -> Bool {
     return !(rhs < lhs)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
+  @_transparent
   public static func >= (lhs: ${Self}, rhs: ${Self}) -> Bool {
     return !(lhs < rhs)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
+  @_transparent
   public static func > (lhs: ${Self}, rhs: ${Self}) -> Bool {
     return rhs < lhs
   }

--- a/test/SILOptimizer/unreachable_code.swift
+++ b/test/SILOptimizer/unreachable_code.swift
@@ -15,6 +15,49 @@ func ifTrue() -> Int {
   return 0 // expected-warning {{will never be executed}}
 }
 
+func testUnreachableIfBranch() -> Int {
+  let a = 2
+  let c: Int
+  if a < 2 {  // expected-note {{condition always evaluates to false}}
+    c = 3     // expected-warning {{will never be executed}}
+  } else {
+    c = 4
+  }
+  return c
+}
+
+func testUnreachableIfBranch2() -> Int {
+  let a = 2
+  let c: Int
+  if a > 2 { // expected-note {{condition always evaluates to false}}
+    c = 3    // expected-warning {{will never be executed}}
+  } else {
+    c = 4
+  }
+  return c
+}
+
+func testUnreachableElseBranch() -> Int {
+  let a = 2
+  let c: Int
+  if a == 2 { // expected-note {{condition always evaluates to true}}
+    c = 3
+  } else {
+    c = 4     // expected-warning {{will never be executed}}
+  }
+  return c
+}
+
+// FIXME: False Negative: <rdar://39516135>. No warnings are produced here
+// as the statements along the unreachable branches are marked implicit.
+// Unreachable code analysis suppresses warnings in such cases.
+func testQuestionMarkOperator() -> Int {
+  let a = 2
+  let c: Int
+  c = (a < 2) ? 3 : 4
+  return c
+}
+
 // Work-around <rdar://problem/17687851> by ensuring there is
 // something that appears to be user code in unreachable blocks.
 func userCode() {}


### PR DESCRIPTION
This makes them symmetrical to (<) operators, and makes constant folding
and unreachable code analysis more precise and consistent.

<rdar://39516135>