### PR TITLE
Bugfix: update the value mapping with the correct result of graphop.

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -2119,7 +2119,7 @@ GLStatus TFGraphLowering::visitGraphOperationInst(GraphOperationInst *inst) {
 
   // Remember each of the results.
   for (unsigned i = 0; i != numOpResults; ++i) {
-    addValueMapping({inst->getResult(0), 0}, {result, (int)i});
+    addValueMapping({inst->getResult(i), 0}, {result, (int)i});
   }
 
   return GLStatus::Success;


### PR DESCRIPTION
(1) Fixes SR-8298.
(2) Updates the test to run the frontend with strict deabstraction turned on and off. 

Some tests did not have any CHECKs. I have left it as is for now.