### PR TITLE
Fix a dangling reference by just copying the error convention

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -2395,7 +2395,7 @@ class ArgEmitter {
 
   SILGenFunction &SGF;
   SILFunctionTypeRepresentation Rep;
-  const Optional<ForeignErrorConvention> &ForeignError;
+  Optional<ForeignErrorConvention> ForeignError;
   ImportAsMemberStatus ForeignSelf;
   ClaimedParamsRef ParamInfos;
   SmallVectorImpl<ManagedValue> &Args;


### PR DESCRIPTION
...this isn't even an expensive type to copy, I have no idea why I wrote ArgEmitter to hold it by reference.