### PR TITLE
[master-next] Update some recent code for LLVM r334221

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -2291,7 +2291,8 @@ void verifyIncrementalParse(SwiftEditorDocumentRef EditorDoc,
       // Write the incremental syntax tree
       auto IncrTreeFilename = DirectoryName + "/incrementalTree.json";
       llvm::raw_fd_ostream IncrementalFilestream(
-          IncrTreeFilename.str(), ErrorCode, llvm::sys::fs::F_RW);
+          IncrTreeFilename.str(), ErrorCode,
+          llvm::sys::fs::FA_Read | llvm::sys::fs::FA_Write);
       IncrementalFilestream << IncrTreeStream.str();
       if (ErrorCode) {
         Log->getOS() << "Failed to write incremental syntax tree to "
@@ -2305,7 +2306,8 @@ void verifyIncrementalParse(SwiftEditorDocumentRef EditorDoc,
       // Write from-scratch syntax tree
       auto ScratchTreeFilename = DirectoryName + "/fromScratchTree.json";
       llvm::raw_fd_ostream ScratchTreeFilestream(
-          ScratchTreeFilename.str(), ErrorCode, llvm::sys::fs::F_RW);
+          ScratchTreeFilename.str(), ErrorCode,
+          llvm::sys::fs::FA_Read | llvm::sys::fs::FA_Write);
       ScratchTreeFilestream << ScratchTreeStream.str();
       if (ErrorCode) {
         Log->getOS() << "Failed to write from-scratch syntax tree to "
@@ -2320,7 +2322,7 @@ void verifyIncrementalParse(SwiftEditorDocumentRef EditorDoc,
       // Write source file
       auto SourceFilename = DirectoryName + "/postEditSource.swift";
       llvm::raw_fd_ostream SourceFilestream(SourceFilename.str(), ErrorCode,
-                                            llvm::sys::fs::F_RW);
+                              llvm::sys::fs::FA_Read | llvm::sys::fs::FA_Write);
       auto FileBuffer = EditorDoc->getLatestSnapshot()->getBuffer();
       SourceFilestream << FileBuffer->getText();
     }


### PR DESCRIPTION
The LLVM change happened a while ago, but some new uses of the old
F_RW flag were introduced recently in 57ccdd89b6.