### PR TITLE
[stdlib] Add supportedVersion property to Unicode namespace.

### DIFF
--- a/stdlib/public/SwiftShims/UnicodeShims.h
+++ b/stdlib/public/SwiftShims/UnicodeShims.h
@@ -552,6 +552,9 @@ __swift_int32_t __swift_stdlib_u_strToUpper(
 SWIFT_RUNTIME_STDLIB_INTERFACE
 double __swift_stdlib_u_getNumericValue(__swift_stdlib_UChar32 c);
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
+void __swift_stdlib_u_getUnicodeVersion(__swift_stdlib_UVersionInfo _Nonnull);
+
 
 #ifdef __cplusplus
 }} // extern "C", namespace swift

--- a/stdlib/public/stubs/UnicodeNormalization.cpp
+++ b/stdlib/public/stubs/UnicodeNormalization.cpp
@@ -68,6 +68,7 @@ int32_t u_strToTitle(UChar *, int32_t, const UChar *, int32_t,
 int32_t u_strToUpper(UChar *, int32_t, const UChar *, int32_t, const char *,
                      UErrorCode *);
 double u_getNumericValue(UChar32);
+void u_getUnicodeVersion(UVersionInfo);
 }
 
 #else
@@ -302,6 +303,11 @@ __swift_int32_t swift::__swift_stdlib_u_strToUpper(
 
 double swift::__swift_stdlib_u_getNumericValue(__swift_stdlib_UChar32 c) {
   return u_getNumericValue(c);
+}
+
+void swift::__swift_stdlib_u_getUnicodeVersion(
+    __swift_stdlib_UVersionInfo versionInfo) {
+  return u_getUnicodeVersion(versionInfo);
 }
 
 


### PR DESCRIPTION
cc: @milseman 

Floating these changes based on discussion in #17992. Preventing clients from using properties that aren't supported by the platform's underlying version of ICU isn't straightforward, since this varies wildly based on platform (Darwin vs. Linux) and OS version.

Rather than harm the ergonomics of the properties in general (e.g., by making them all return `Optional`), this PR adds a `Unicode.supportedVersion` static property that the user can query to determine whether certain properties are available. Since the `Unicode.Scalar.Properties` APIs are meant to be for "advanced" users, this seems like a reasonable balance. If users know their code will only run on certain OSes, they can skip the checks; otherwise, they can protect themselves by gating accesses on the version that they know supports what they're using.

This change ends up dual-purposing the `Unicode.Version` type used by the `age` property by extending it to three components and using it for `supportedVersion`. I changed it from a tuple typealias to a struct since users may want to create instances of this for purposes of comparison, and we benefit from things like defaulted arguments in initializers.
