### PR TITLE
[TF] Teach the partitioner to not ignore debug_value for -Onone builds.

### DIFF
--- a/test/TensorFlow/debugging.swift
+++ b/test/TensorFlow/debugging.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -Xllvm -tf-strict-deabstraction %s  | %FileCheck %s
+
+import TensorFlow
+
+public func basicDebugValues(_ x: Tensor<Float>) {
+  let y = x + 1
+  let z = y.squared()
+}
+
+// CHECK-LABEL: @{{.*}}basicDebugValues{{.*}}
+// CHECK: debug_value %{{.*}} : $Tensor<Float>, let, name "x", argno 1
+//
+// FIXME(SR-8375): Deabstraction is currently removing `debug_value` for `y`. 
+// This should be fixed.
+// HECK: debug_value %{{.*}} : $Tensor<Float>, let, name "y"
+//
+// CHECK: debug_value %{{.*}} : $Tensor<Float>, let, name "z"
+


### PR DESCRIPTION
This enables debuging-time value inspection on loadable tensor values.

**Note:** This is not testable today since TensorFlow deabstraction still requires `-O`, but it should fall out when we can compile tensor code with `-Onone`.

Next: need to fix [SR-8375](https://bugs.swift.org/browse/SR-8375).