### PR TITLE
Fix a warning in AD runtime IRGen

### DIFF
--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -1007,7 +1007,7 @@ if (Builtin.ID == BuiltinValueKind::id) { \
       getLoweredTypeAndTypeInfo(
         IGF.IGM, substitutions.getReplacementTypes().front());
     auto *metadata =
-      IGF.emitTypeMetadataRef(valueTy.first.getSwiftRValueType());
+      IGF.emitTypeMetadataRef(valueTy.first.getASTType());
     out.add(IGF.Builder.CreateCall(IGF.IGM.getAutoDiffCreateTapeFn(),
                                    { metadata }));
     return;


### PR DESCRIPTION
This is just to suppress a warning. Much of AD runtime needs to be revamped soon.