### PR TITLE
[ownership] Always print out ownership argument annotations whether o…

### DIFF
--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -5090,7 +5090,6 @@ bool SILParser::parseSILBasicBlock(SILBuilder &B) {
         if (!F->getModule()
                  .getOptions()
                  .AssumeUnqualifiedOwnershipWhenParsing &&
-            F->getModule().getOptions().EnableSILOwnership &&
             parseSILOwnership(OwnershipKind))
           return true;
 

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -581,8 +581,7 @@ public:
 
     // If SIL ownership is enabled and the given function has not had ownership
     // stripped out, print out ownership of SILArguments.
-    if (BB->getModule().getOptions().EnableSILOwnership &&
-        BB->getParent()->hasQualifiedOwnership()) {
+    if (BB->getParent()->hasQualifiedOwnership()) {
       *this << getIDAndTypeAndOwnership(Args[0]);
       for (SILArgument *Arg : Args.drop_front()) {
         *this << ", " << getIDAndTypeAndOwnership(Arg);

--- a/test/ClangImporter/static_inline.swift
+++ b/test/ClangImporter/static_inline.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-swift-frontend -parse-as-library -module-name=static_inline -emit-sil %S/Inputs/static_inline.swift -enable-objc-interop -import-objc-header %S/Inputs/static_inline.h -o %t/static_inline.sil
 // RUN: %FileCheck < %t/static_inline.sil %s
-// RUN: %target-swift-frontend -parse-as-library -module-name=static_inline -O -emit-ir %t/static_inline.sil -enable-objc-interop -import-objc-header %S/Inputs/static_inline.h | %FileCheck --check-prefix=CHECK-IR %s
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -parse-as-library -module-name=static_inline -O -emit-ir %t/static_inline.sil -enable-objc-interop -import-objc-header %S/Inputs/static_inline.h | %FileCheck --check-prefix=CHECK-IR %s
 
 // CHECK: sil shared [serializable] [clang c_inline_func] @c_inline_func : $@convention(c) (Int32) -> Int32
 

--- a/test/DebugInfo/simple.sil
+++ b/test/DebugInfo/simple.sil
@@ -6,7 +6,7 @@ import Builtin
 import Swift
 
 sil @square : $@convention(thin) (Int32) -> Int32 {
-bb0(%0 : $Int32):
+bb0(%0 : @trivial $Int32):
   debug_value %0 : $Int32, let, name "x" // id: %1
   %3 = struct_extract %0 : $Int32, #Int32._value       // user: %6
   %4 = struct_extract %0 : $Int32, #Int32._value       // user: %6

--- a/test/IRGen/archetype_resilience.sil
+++ b/test/IRGen/archetype_resilience.sil
@@ -20,7 +20,7 @@ public enum EnumWithClassArchetypeAndDynamicSize<T : AnyObject> {
 // CHECK: call %T20archetype_resilience36EnumWithClassArchetypeAndDynamicSizeO* @"$S20archetype_resilience36EnumWithClassArchetypeAndDynamicSizeOyxGRlzCr0_lWOc"(%T20archetype_resilience36EnumWithClassArchetypeAndDynamicSizeO* %0, %T20archetype_resilience36EnumWithClassArchetypeAndDynamicSizeO* {{.*}}, %swift.type* %"EnumWithClassArchetypeAndDynamicSize<T>")
 // CHECK: ret void
 sil @copyDynamicMultiEnum : $@convention(method) <T, U where T: AnyObject> (@in_guaranteed EnumWithClassArchetypeAndDynamicSize<T>) -> () {
-bb0(%0 : $*EnumWithClassArchetypeAndDynamicSize<T>):
+bb0(%0 : @trivial $*EnumWithClassArchetypeAndDynamicSize<T>):
   %1 = alloc_stack $EnumWithClassArchetypeAndDynamicSize<T> 
   copy_addr %0 to [initialization] %1 : $*EnumWithClassArchetypeAndDynamicSize<T>
   dealloc_stack %1 : $*EnumWithClassArchetypeAndDynamicSize<T>

--- a/test/IRGen/autorelease.sil
+++ b/test/IRGen/autorelease.sil
@@ -15,13 +15,13 @@ import Swift
 class C {}
 sil_vtable C {}
 sil @_TFC11autorelease1Cd : $@convention(method) (@owned C) -> @owned Builtin.NativeObject {
-bb0(%0 : $C):
+bb0(%0 : @owned $C):
   %1 = unchecked_ref_cast %0 : $C to $Builtin.NativeObject // user: %2
   return %1 : $Builtin.NativeObject              // id: %2
 }
 
 sil @foo : $@convention(thin) (@owned C?) -> @autoreleased C? {
-bb0(%0 : $C?):
+bb0(%0 : @owned $C?):
   return %0 : $C?
 }
 // x86_64:    define{{( dllexport| protected)?}} swiftcc i64 @foo(i64) {{.*}} {
@@ -49,7 +49,7 @@ bb0(%0 : $C?):
 // armv7k-NEXT: ret i32 [[T0]]
 
 sil @bar : $@convention(thin) (@owned C?) -> @owned C? {
-bb0(%0 : $C?):
+bb0(%0 : @owned $C?):
   %1 = function_ref @foo : $@convention(thin) (@owned C?) -> @autoreleased C?
   %2 = apply %1(%0) : $@convention(thin) (@owned C?) -> @autoreleased C?
   return %2 : $C?

--- a/test/IRGen/autorelease_optimized_aarch64.sil
+++ b/test/IRGen/autorelease_optimized_aarch64.sil
@@ -13,7 +13,7 @@ class C {}
 sil_vtable C {}
 
 sil @_TFC21autorelease_optimized1Cd : $@convention(method) (@owned C) -> @owned Builtin.NativeObject {
-bb0(%0 : $C):
+bb0(%0 : @owned $C):
   %1 = unchecked_ref_cast %0 : $C to $Builtin.NativeObject // user: %2
   return %1 : $Builtin.NativeObject              // id: %2
 }
@@ -22,7 +22,7 @@ sil public_external @foo : $@convention(thin) (@owned C) -> @autoreleased C
 sil public_external @bar : $@convention(thin) (@owned C) -> ()
 
 sil @baz : $@convention(thin) (@owned C) -> () {
-bb0(%0 : $C):
+bb0(%0 : @owned $C):
   %1 = function_ref @foo : $@convention(thin) (@owned C) -> @autoreleased C
   %2 = apply %1(%0) : $@convention(thin) (@owned C) -> @autoreleased C
 

--- a/test/IRGen/autorelease_optimized_armv7.sil
+++ b/test/IRGen/autorelease_optimized_armv7.sil
@@ -13,7 +13,7 @@ class C {}
 sil_vtable C {}
 
 sil @_TFC21autorelease_optimized1Cd : $@convention(method) (@owned C) -> @owned Builtin.NativeObject {
-bb0(%0 : $C):
+bb0(%0 : @owned $C):
   %1 = unchecked_ref_cast %0 : $C to $Builtin.NativeObject // user: %2
   return %1 : $Builtin.NativeObject              // id: %2
 }
@@ -22,7 +22,7 @@ sil public_external @foo : $@convention(thin) (@owned C) -> @autoreleased C
 sil public_external @bar : $@convention(thin) (@owned C) -> ()
 
 sil @baz : $@convention(thin) (@owned C) -> () {
-bb0(%0 : $C):
+bb0(%0 : @owned $C):
   %1 = function_ref @foo : $@convention(thin) (@owned C) -> @autoreleased C
   %2 = apply %1(%0) : $@convention(thin) (@owned C) -> @autoreleased C
 

--- a/test/IRGen/autorelease_optimized_x86_64.sil
+++ b/test/IRGen/autorelease_optimized_x86_64.sil
@@ -13,7 +13,7 @@ class C {}
 sil_vtable C {}
 
 sil @_TFC21autorelease_optimized1Cd : $@convention(method) (@owned C) -> @owned Builtin.NativeObject {
-bb0(%0 : $C):
+bb0(%0 : @owned $C):
   %1 = unchecked_ref_cast %0 : $C to $Builtin.NativeObject // user: %2
   return %1 : $Builtin.NativeObject              // id: %2
 }
@@ -22,7 +22,7 @@ sil public_external @foo : $@convention(thin) (@owned C) -> @autoreleased C
 sil public_external @bar : $@convention(thin) (@owned C) -> ()
 
 sil @baz : $@convention(thin) (@owned C) -> () {
-bb0(%0 : $C):
+bb0(%0 : @owned $C):
   %1 = function_ref @foo : $@convention(thin) (@owned C) -> @autoreleased C
   %2 = apply %1(%0) : $@convention(thin) (@owned C) -> @autoreleased C
 

--- a/test/IRGen/big_types_tests.sil
+++ b/test/IRGen/big_types_tests.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -I %S/Inputs/abi %s -emit-ir -enable-large-loadable-types | %FileCheck %s
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -I %S/Inputs/abi %s -emit-ir -enable-large-loadable-types | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: OS=macosx
@@ -21,11 +21,11 @@ public struct BigStruct {
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testDestroyValue(%T15big_types_tests9BigStructV* noalias nocapture dereferenceable({{.*}}) #0 {
 // CHECK-NEXT: entry
-// CHECK-NEXT: call %T15big_types_tests9BigStructV* @"$S15big_types_tests9BigStructVWOh"(%T15big_types_tests9BigStructV* %0)
+// CHECK-NEXT: call %T15big_types_tests9BigStructV* @"$S15big_types_tests9BigStructVWOs"(%T15big_types_tests9BigStructV* %0)
 // CHECK-NEXT: ret void
 sil @testDestroyValue : $@convention(thin) (@owned BigStruct) -> ()  {
 entry(%x : $BigStruct):
-  destroy_value %x : $BigStruct
+  release_value %x : $BigStruct
   %ret = tuple ()
   return %ret : $()
 }

--- a/test/IRGen/builtin_word.sil
+++ b/test/IRGen/builtin_word.sil
@@ -36,7 +36,7 @@ entry:
 // ARM32:   ret { i32, i64 } %4
 // ARM32: }
 sil @word_zextOrBitCast : $(Builtin.Int32, Builtin.Word) -> (Builtin.Word, Builtin.Int64) {
-entry(%i : $Builtin.Int32, %w : $Builtin.Word):
+entry(%i : @trivial $Builtin.Int32, %w : @trivial $Builtin.Word):
   %j = builtin "zextOrBitCast_Int32_Word"(%i : $Builtin.Int32) : $Builtin.Word
   %v = builtin "zextOrBitCast_Word_Int64"(%w : $Builtin.Word) : $Builtin.Int64
   %t = tuple (%j : $Builtin.Word, %v : $Builtin.Int64)
@@ -58,7 +58,7 @@ entry(%i : $Builtin.Int32, %w : $Builtin.Word):
 // ARM32:   ret { i32, i32 } %4
 // ARM32: }
 sil @word_truncOrBitCast : $(Builtin.Word, Builtin.Int64) -> (Builtin.Int32, Builtin.Word) {
-entry(%w : $Builtin.Word, %i : $Builtin.Int64):
+entry(%w : @trivial $Builtin.Word, %i : @trivial $Builtin.Int64):
   %v = builtin "truncOrBitCast_Word_Int32"(%w : $Builtin.Word) : $Builtin.Int32
   %j = builtin "truncOrBitCast_Int64_Word"(%i : $Builtin.Int64) : $Builtin.Word
   %t = tuple (%v : $Builtin.Int32, %j : $Builtin.Word)

--- a/test/IRGen/class_isa_pointers.sil
+++ b/test/IRGen/class_isa_pointers.sil
@@ -23,7 +23,7 @@ sil_vtable Purebred {}
 // CHECK:         [[VTABLE:%.*]] = bitcast %swift.type* [[ISA]]
 // CHECK:         getelementptr inbounds {{.*}} [[VTABLE]]
 sil @purebred_method : $@convention(thin) (@owned Purebred) -> () {
-entry(%0 : $Purebred):
+entry(%0 : @owned $Purebred):
   %m = class_method %0 : $Purebred, #Purebred.method!1 : (Purebred) -> () -> (), $@convention(method) (@guaranteed Purebred) -> ()
   %z = apply %m(%0) : $@convention(method) (@guaranteed Purebred) -> ()
   return %z : $()
@@ -47,7 +47,7 @@ sil_vtable Mongrel {}
 // CHECK:         [[VTABLE:%.*]] = bitcast %swift.type* [[ISA]]
 // CHECK:         getelementptr inbounds {{.*}} [[VTABLE]]
 sil @mongrel_method : $@convention(thin) (@owned Mongrel) -> () {
-entry(%0 : $Mongrel):
+entry(%0 : @owned $Mongrel):
   %m = class_method %0 : $Mongrel, #Mongrel.method!1 : (Mongrel) -> () -> (), $@convention(method) (@guaranteed Mongrel) -> ()
   %z = apply %m(%0) : $@convention(method) (@guaranteed Mongrel) -> ()
   return %z : $()
@@ -56,14 +56,14 @@ entry(%0 : $Mongrel):
 // ObjC stubs expected by ObjC metadata emission
 
 sil private @$S18class_isa_pointers7MongrelC6methodyyFTo : $@convention(objc_method) (Purebred) -> () {
-entry(%0 : $Purebred):
+entry(%0 : @unowned $Purebred):
   unreachable
 }
 sil private @$S18class_isa_pointers7MongrelC7bellsOnACSgSi_tcfcTo : $@convention(objc_method) (Int, Purebred) -> () {
-entry(%0 : $Int, %1 : $Purebred):
+entry(%0 : @trivial $Int, %1 : @unowned $Purebred):
   unreachable
 }
 sil private @$S18class_isa_pointers7MongrelCACycfcTo : $@convention(objc_method) (Purebred) -> () {
-entry(%0 : $Purebred):
+entry(%0 : @unowned $Purebred):
   unreachable
 }

--- a/test/IRGen/copy_value_destroy_value.sil
+++ b/test/IRGen/copy_value_destroy_value.sil
@@ -20,7 +20,7 @@ struct Foo {
 // CHECK-NEXT: entry
 // CHECK-NEXT: ret void
 sil @trivial : $@convention(thin) (Builtin.Int32) -> () {
-bb0(%0 : $Builtin.Int32):
+bb0(%0 : @trivial $Builtin.Int32):
   %1 = copy_value %0 : $Builtin.Int32
   destroy_value %1 : $Builtin.Int32
   %2 = tuple()
@@ -37,7 +37,7 @@ bb0(%0 : $Builtin.Int32):
 // CHECK: call void @swift_release(%swift.refcounted* [[VAL1]])
 // CHECK: call void @swift_release(%swift.refcounted* [[VAL2]])
 sil @non_trivial : $@convention(thin) (@guaranteed Foo) -> () {
-bb0(%0 : $Foo):
+bb0(%0 : @guaranteed $Foo):
   %1 = copy_value %0 : $Foo
   destroy_value %1 : $Foo
   %2 = tuple()
@@ -48,7 +48,7 @@ bb0(%0 : $Foo):
 // CHECK: call %swift.refcounted* @swift_unownedRetainStrong(%swift.refcounted* returned %0)
 // CHECK: call void @swift_release(%swift.refcounted* %0)
 sil @non_trivial_unowned : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
-bb0(%0 : $Builtin.NativeObject):
+bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1 = ref_to_unowned %0 : $Builtin.NativeObject to $@sil_unowned Builtin.NativeObject
   %2 = copy_unowned_value %1 : $@sil_unowned Builtin.NativeObject
   destroy_value %2 : $Builtin.NativeObject

--- a/test/IRGen/enum_32_bit.sil
+++ b/test/IRGen/enum_32_bit.sil
@@ -1,5 +1,5 @@
-// RUN: %swift -target i386-apple-ios7 %s -gnone -emit-ir | %FileCheck %s
-// RUN: %swift -target armv7-apple-ios7 %s -gnone -emit-ir | %FileCheck %s
+// RUN: %swift -assume-parsing-unqualified-ownership-sil -target i386-apple-ios7 %s -gnone -emit-ir | %FileCheck %s
+// RUN: %swift -assume-parsing-unqualified-ownership-sil -target armv7-apple-ios7 %s -gnone -emit-ir | %FileCheck %s
 
 // REQUIRES: CODEGENERATOR=X86
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/IRGen/enum_spare_bits.sil
+++ b/test/IRGen/enum_spare_bits.sil
@@ -74,7 +74,7 @@ entry:
   return undef : $()
 }
 
-sil @$S15enum_spare_bits1DCACycfcTo : $(@owned D) -> @owned D {
-entry(%x : $D):
+sil @$S15enum_spare_bits1DCACycfcTo : $@convention(thin) (@owned D) -> @owned D {
+entry(%x : @owned $D):
   return undef : $D
 }

--- a/test/IRGen/exclusivity.sil
+++ b/test/IRGen/exclusivity.sil
@@ -14,7 +14,7 @@ sil public_external @changeInt : $@convention(thin) (@inout Int) -> ()
 
 // CHECK-LABEL: define {{.*}} @test1(
 sil @test1 : $@convention(thin) (@owned A) -> Int {
-bb0(%0 : $A):
+bb0(%0 : @owned $A):
   // CHECK: [[SCRATCH0:%.*]] = alloca [[BUFFER_T:\[.* x i8\]]],
   // CHECK: [[SCRATCH1:%.*]] = alloca [[BUFFER_T:\[.* x i8\]]],
 

--- a/test/IRGen/generic_classes.sil
+++ b/test/IRGen/generic_classes.sil
@@ -265,7 +265,7 @@ entry:
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc i8 @RootGeneric_concrete_fragile_dependent_member_access_x
 // CHECK:   getelementptr inbounds [[ROOTGENERIC]], [[ROOTGENERIC]]* %0, i32 0, i32 1
 sil @RootGeneric_concrete_fragile_dependent_member_access_x : $<F> (RootGeneric<F>) -> UInt8 {
-entry(%c : $RootGeneric<F>):
+entry(%c : @unowned $RootGeneric<F>):
   %p = ref_element_addr %c : $RootGeneric<F>, #RootGeneric.x
   %x = load_borrow %p : $*UInt8
   return %x : $UInt8
@@ -280,7 +280,7 @@ entry(%c : $RootGeneric<F>):
 // CHECK:   [[Y_ADDR:%.*]] = getelementptr inbounds i8, i8* [[CLASS_BYTE_ARRAY]], i64 [[Y_OFFSET]]
 // CHECK:   bitcast i8* [[Y_ADDR]] to %swift.opaque*
 sil @RootGeneric_concrete_fragile_dependent_member_access_y : $<F> (RootGeneric<F>) -> @out F {
-entry(%z : $*F, %c : $RootGeneric<F>):
+entry(%z : @trivial $*F, %c : @unowned $RootGeneric<F>):
   %p = ref_element_addr %c : $RootGeneric<F>, #RootGeneric.y
   copy_addr %p to [initialization] %z : $*F
   %t = tuple ()
@@ -291,7 +291,7 @@ entry(%z : $*F, %c : $RootGeneric<F>):
 // CHECK:   [[Y_ADDR:%.*]] = getelementptr inbounds {{.*}}, {{.*}}* %1, i32 0, i32 3
 // CHECK:   bitcast %TSi* [[Y_ADDR]] to i8*
 sil @RootGeneric_subst_concrete_fragile_dependent_member_access_y : $(RootGeneric<Int>) -> @out Int {
-entry(%z : $*Int, %c : $RootGeneric<Int>):
+entry(%z : @trivial $*Int, %c : @unowned $RootGeneric<Int>):
   %p = ref_element_addr %c : $RootGeneric<Int>, #RootGeneric.y
   copy_addr %p to [initialization] %z : $*Int
   %t = tuple ()
@@ -307,7 +307,7 @@ entry(%z : $*Int, %c : $RootGeneric<Int>):
 // CHECK:   [[Z_ADDR:%.*]] = getelementptr inbounds i8, i8* [[CLASS_BYTE_ARRAY]], i64 [[Z_OFFSET]]
 // CHECK:   bitcast i8* [[Z_ADDR]] to %Ts5UInt8V*
 sil @RootGeneric_concrete_fragile_dependent_member_access_z : $<F> (RootGeneric<F>) -> UInt8 {
-entry(%c : $RootGeneric<F>):
+entry(%c : @unowned $RootGeneric<F>):
   %p = ref_element_addr %c : $RootGeneric<F>, #RootGeneric.z
   %z = load_borrow %p : $*UInt8
   return %z : $UInt8
@@ -318,7 +318,7 @@ entry(%c : $RootGeneric<F>):
 // CHECK:   [[T0:%.*]] = getelementptr inbounds %Ts5UInt8V, %Ts5UInt8V* [[Z_ADDR]], i32 0, i32 0
 // CHECK:   load i8, i8* [[T0]], align
 sil @RootGeneric_subst_concrete_fragile_dependent_member_access_z : $(RootGeneric<Int>) -> UInt8 {
-entry(%c : $RootGeneric<Int>):
+entry(%c : @unowned $RootGeneric<Int>):
   %p = ref_element_addr %c : $RootGeneric<Int>, #RootGeneric.z
   %z = load_borrow %p : $*UInt8
   return %z : $UInt8

--- a/test/IRGen/generic_classes_objc.sil
+++ b/test/IRGen/generic_classes_objc.sil
@@ -22,18 +22,18 @@ sil_vtable GenericInheritsObjC {}
 
 // __deallocating_deinit
 sil @$S20generic_classes_objc19GenericInheritsObjCCfD : $@convention(method) <T> (GenericInheritsObjC<T>) -> () {
-bb0(%0 : $GenericInheritsObjC<T>):
+bb0(%0 : @unowned $GenericInheritsObjC<T>):
   unreachable
 }
 
 // @objc init
 sil @$S20generic_classes_objc19GenericInheritsObjCCACyxGycfcTo : $@convention(objc_method) <T> (@owned GenericInheritsObjC<T>) -> @owned GenericInheritsObjC<T> {
-bb0(%0 : $GenericInheritsObjC<T>):
+bb0(%0 : @owned $GenericInheritsObjC<T>):
   unreachable
 }
 
 sil @$S20generic_classes_objc19GenericInheritsObjCC7bellsOnACyxGSgSi_tcfcTo : $@convention(objc_method) <T> (Int, @owned GenericInheritsObjC<T>) -> @owned GenericInheritsObjC<T> {
-bb0(%0 : $Int, %1 : $GenericInheritsObjC<T>):
+bb0(%0 : @trivial $Int, %1 : @owned $GenericInheritsObjC<T>):
   unreachable
 }
 
@@ -50,18 +50,18 @@ sil_vtable GenericInheritsObjC2 {}
 
 // __deallocating_deinit
 sil @$S20generic_classes_objc20GenericInheritsObjC2CfD : $@convention(method) <T> (GenericInheritsObjC2<T>) -> () {
-bb0(%0 : $GenericInheritsObjC2<T>):
+bb0(%0 : @unowned $GenericInheritsObjC2<T>):
   unreachable
 }
 
 // @objc init
 sil @$S20generic_classes_objc20GenericInheritsObjC2CACyxGycfcTo : $@convention(objc_method) <T> (@owned GenericInheritsObjC2<T>) -> @owned GenericInheritsObjC2<T> {
-bb0(%0 : $GenericInheritsObjC2<T>):
+bb0(%0 : @owned $GenericInheritsObjC2<T>):
   unreachable
 }
 
 sil @$S20generic_classes_objc20GenericInheritsObjC2C7bellsOnACyxGSgSi_tcfcTo : $@convention(objc_method) <T> (Int, @owned GenericInheritsObjC<T>) -> @owned GenericInheritsObjC<T> {
-bb0(%0 : $Int, %1 : $GenericInheritsObjC<T>):
+bb0(%0 : @trivial $Int, %1 : @owned $GenericInheritsObjC<T>):
   unreachable
 }
 

--- a/test/IRGen/invariant_load.sil
+++ b/test/IRGen/invariant_load.sil
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
 
-sil_stage canonical
+sil_stage lowered
 
 import Builtin
 
@@ -11,7 +11,7 @@ struct X {
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @invariant_load
 sil @invariant_load : $@convention(thin) (Builtin.RawPointer) -> () {
-entry(%p : $Builtin.RawPointer):
+entry(%p : @trivial $Builtin.RawPointer):
   %a = pointer_to_address %p : $Builtin.RawPointer to [invariant] $*X
   // CHECK: load i32, {{.*}} !invariant.load
   // CHECK: load i32, {{.*}} !invariant.load

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -317,7 +317,7 @@ sil @n_get : $@convention(thin) <UU, TT> (@in_guaranteed TT) -> @out UU
 sil @n_set : $@convention(thin) <UU, TT> (@in_guaranteed UU, @in_guaranteed TT) -> ()
 
 sil @computed_property_indices : $@convention(thin) (C, S, C, S, C, S) -> () {
-entry(%0 : $C, %1 : $S, %2 : $C, %3 : $S, %4 : $C, %5 : $S):
+entry(%0 : @unowned $C, %1 : @unowned $S, %2 : @unowned $C, %3 : @unowned $S, %4 : @unowned $C, %5 : @unowned $S):
   %o = keypath $WritableKeyPath<S, C>, (
     root $S;
     settable_property $C,
@@ -368,7 +368,7 @@ sil @r_get : $@convention(thin) (@in_guaranteed C, UnsafeRawPointer) -> @out S
 sil @r_set : $@convention(thin) (@in_guaranteed S, @in_guaranteed C, UnsafeRawPointer) -> ()
 
 sil @generic_computed_property_indices : $@convention(thin) <A: Hashable, B: Hashable> (@in_guaranteed A, @in_guaranteed B, @in_guaranteed A, @in_guaranteed B, @in_guaranteed A, @in_guaranteed B) -> () {
-entry(%0 : $*A, %1 : $*B, %2 : $*A, %3 : $*B, %4 : $*A, %5 : $*B):
+entry(%0 : @trivial $*A, %1 : @trivial $*B, %2 : @trivial $*A, %3 : @trivial $*B, %4 : @trivial $*A, %5 : @trivial $*B):
   %s = keypath $WritableKeyPath<A, B>, <X: Hashable, Y: Hashable> (
     root $X;
     settable_property $Y,

--- a/test/IRGen/keypaths_objc.sil
+++ b/test/IRGen/keypaths_objc.sil
@@ -36,12 +36,12 @@ entry:
 }
 
 sil hidden @$S13keypaths_objc1CC1xSo8NSStringCvgTo : $@convention(objc_method) (@guaranteed C) -> NSString {
-entry(%0 : $C):
+entry(%0 : @guaranteed $C):
   unreachable
 }
 
 sil hidden @$S13keypaths_objc1CCACycfcTo : $@convention(objc_method) (@objc_metatype C.Type) -> @owned C {
-entry(%0 : $@objc_metatype C.Type):
+entry(%0 : @trivial $@objc_metatype C.Type):
   unreachable
 }
 

--- a/test/IRGen/objc_attr_NSManaged.sil
+++ b/test/IRGen/objc_attr_NSManaged.sil
@@ -32,27 +32,27 @@ sil_vtable X {}
   @objc @NSManaged func kvc()
 }
 sil @$S19objc_attr_NSManaged1XCACycfcTo : $@convention(objc_method) (@owned X) -> @owned X {
-bb0(%0 : $X):
+bb0(%0 : @owned $X):
   return %0 : $X
 }
 
 sil @$S19objc_attr_NSManaged10SwiftGizmoCACycfcTo : $@convention(objc_method) (@owned SwiftGizmo) -> @owned SwiftGizmo {
-bb0(%0 : $SwiftGizmo):
+bb0(%0 : @owned $SwiftGizmo):
   return %0 : $SwiftGizmo
 }
 
 sil @$S19objc_attr_NSManaged10SwiftGizmoC7bellsOnACSgSi_tcfcTo : $@convention(objc_method) (Int, @owned SwiftGizmo) -> @owned SwiftGizmo? {
-bb0(%0 : $Int, %1 : $SwiftGizmo):
+bb0(%0 : @trivial $Int, %1 : @owned $SwiftGizmo):
   unreachable
 }
 
 sil @$S19objc_attr_NSManaged10SwiftGizmoCACycfc : $@convention(method) (@owned SwiftGizmo) -> @owned SwiftGizmo {
-bb0(%0 : $SwiftGizmo):
+bb0(%0 : @owned $SwiftGizmo):
   return %0 : $SwiftGizmo
 }
 
 sil @$S19objc_attr_NSManaged10SwiftGizmoC7bellsOnACSi_tcfc : $@convention(method) (Int, @owned SwiftGizmo) -> @owned SwiftGizmo {
-bb0(%0 : $Int, %1 : $SwiftGizmo):
+bb0(%0 : @trivial $Int, %1 : @owned $SwiftGizmo):
   return %1 : $SwiftGizmo
 }
 

--- a/test/IRGen/objc_errors.sil
+++ b/test/IRGen/objc_errors.sil
@@ -10,7 +10,7 @@ import Foundation
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.error* @errortype_from_nserror(%TSo7NSErrorC*)
 // CHECK:         %1 = bitcast %TSo7NSErrorC* %0 to %swift.error*
 sil @errortype_from_nserror : $@convention(thin) (@owned NSError) -> @owned Error {
-entry(%0 : $NSError):
+entry(%0 : @owned $NSError):
   %1 = init_existential_ref %0 : $NSError : $NSError, $Error
   return %1 : $Error
 }

--- a/test/IRGen/objc_factory_method.sil
+++ b/test/IRGen/objc_factory_method.sil
@@ -18,7 +18,7 @@ bb0:
 
 // CHECK-LABEL: define {{.*}} @_TFCSo4HiveCfMS_FT5queenGSQCSo3Bee__S_
 sil @_TFCSo4HiveCfMS_FT5queenGSQCSo3Bee__S_ : $@convention(thin) (@owned Optional<Bee>, @thick Hive.Type) -> @owned Optional<Hive> {
-bb0(%0 : $Optional<Bee>, %1 : $@thick Hive.Type):
+bb0(%0 : @owned $Optional<Bee>, %1 : @trivial $@thick Hive.Type):
   %2 = thick_to_objc_metatype %1 : $@thick Hive.Type to $@objc_metatype Hive.Type // users: %3, %4
   // CHECK: load i8*, i8** @"\01L_selector(hiveWithQueen:)"
   %3 = objc_method %2 : $@objc_metatype Hive.Type, #Hive.init!allocator.1.foreign : (Hive.Type) -> (Bee!) -> Hive!, $@convention(objc_method) (Optional<Bee>, @objc_metatype Hive.Type) -> @autoreleased Optional<Hive> // user: %4

--- a/test/IRGen/objc_generic_class_convention.sil
+++ b/test/IRGen/objc_generic_class_convention.sil
@@ -15,12 +15,12 @@ import objc_generics
 
 // CHECK-LABEL: define swiftcc void @method(i64, %TSo12GenericClassC* swiftself)
 sil @method : $@convention(method) @pseudogeneric <T: AnyObject> (Int64, @guaranteed GenericClass<T>) -> () {
-entry(%0 : $Int64, %1 : $GenericClass<T>):
+entry(%0 : @trivial $Int64, %1 : @guaranteed $GenericClass<T>):
   return undef : $()
 }
 
 // CHECK-LABEL: define void @objcMethod(i8*, i8*, i64)
 sil @objcMethod : $@convention(objc_method) @pseudogeneric <T: AnyObject> (Int64, @guaranteed GenericClass<T>) -> () {
-entry(%0 : $Int64, %1 : $GenericClass<T>):
+entry(%0 : @trivial $Int64, %1 : @guaranteed $GenericClass<T>):
   return undef : $()
 }

--- a/test/IRGen/objc_generic_class_metadata.sil
+++ b/test/IRGen/objc_generic_class_metadata.sil
@@ -59,22 +59,22 @@ entry:
 }
 
 sil @$S27objc_generic_class_metadata8SubclassC5thingACSgSo8NSStringCSg_tcfcTo : $@convention(objc_method) (Optional<NSString>, @owned Subclass) -> @owned Optional<Subclass> {
-entry(%0: $Optional<NSString>, %1: $Subclass):
+entry(%0 : @unowned $Optional<NSString>, %1 : @owned $Subclass):
   unreachable
 }
 
 sil @$S27objc_generic_class_metadata8SubclassC13arrayOfThingsACSgSaySo8NSStringCG_tcfcTo : $@convention(objc_method) (NSArray, @owned Subclass) -> @owned Optional<Subclass> {
-entry(%0: $NSArray, %1: $Subclass):
+entry(%0 : @unowned $NSArray, %1 : @owned $Subclass):
   unreachable
 }
 
 sil @$S27objc_generic_class_metadata8SubclassCACycfcTo : $@convention(objc_method) (@owned Subclass) -> @owned Subclass {
-entry(%0: $Subclass):
+entry(%0 : @owned $Subclass):
   unreachable
 }
 
 sil @$S27objc_generic_class_metadata8SubclassC7optionsACSgSDySo13GenericOptionaypGSg_tcfcTo : $@convention(objc_method) (@owned Subclass, @owned NSDictionary) -> @owned Subclass {
-entry(%0: $Subclass, %1: $NSDictionary):
+entry(%0: @owned $Subclass, %1: @owned $NSDictionary):
   unreachable
 }
 

--- a/test/IRGen/objc_implicit_with.sil
+++ b/test/IRGen/objc_implicit_with.sil
@@ -23,26 +23,26 @@ class SwiftGizmo : Gizmo {
 sil_vtable SwiftGizmo {}
 
 sil @$S18objc_implicit_with10SwiftGizmoC3red5green4blueACSf_S2ftcfcTo : $@convention(objc_method) (Float, Float, Float, @owned SwiftGizmo) -> @owned SwiftGizmo {
-bb0(%0 : $Float, %1 : $Float, %2 : $Float, %3 : $SwiftGizmo):
+bb0(%0 : @trivial $Float, %1 : @trivial $Float, %2 : @trivial $Float, %3 : @owned $SwiftGizmo):
   return %3 : $SwiftGizmo
 }
 
 sil @$S18objc_implicit_with10SwiftGizmoC7bellsOnACSgSi_tcfcTo : $@convention(objc_method) (Int, @owned SwiftGizmo) -> @owned SwiftGizmo? {
-bb0(%0 : $Int, %1 : $SwiftGizmo):
+bb0(%0 : @trivial $Int, %1 : @owned $SwiftGizmo):
   unreachable
 }
 
 sil @$S18objc_implicit_with10SwiftGizmoCACycfcTo : $@convention(objc_method) (@owned SwiftGizmo) -> @owned SwiftGizmo {
-bb0(%0 : $SwiftGizmo):
+bb0(%0 : @owned $SwiftGizmo):
   return %0 : $SwiftGizmo
 }
 
 sil @$S18objc_implicit_with10SwiftGizmoC5color3red5green4blueySf_S2ftFTo : $@convention(objc_method) (Float, Float, Float, @owned SwiftGizmo) -> @owned SwiftGizmo {
-bb0(%0 : $Float, %1 : $Float, %2 : $Float, %3 : $SwiftGizmo):
+bb0(%0 : @trivial $Float, %1 : @trivial $Float, %2 : @trivial $Float, %3 : @owned $SwiftGizmo):
   return %3 : $SwiftGizmo
 }
 
 sil @$S18objc_implicit_with10SwiftGizmoC13otherColorFor3red5green4blueySf_S2ftFTo : $@convention(objc_method) (Float, Float, Float, @owned SwiftGizmo) -> @owned SwiftGizmo {
-bb0(%0 : $Float, %1 : $Float, %2 : $Float, %3 : $SwiftGizmo):
+bb0(%0 : @trivial $Float, %1 : @trivial $Float, %2 : @trivial $Float, %3 : @owned $SwiftGizmo):
   return %3 : $SwiftGizmo
 }

--- a/test/IRGen/objc_int_encoding.sil
+++ b/test/IRGen/objc_int_encoding.sil
@@ -20,11 +20,11 @@ class Foo: NSObject {
 }
 
 sil hidden @$S17objc_int_encoding3FooC3foo1xSuSi_tFTo : $@convention(objc_method) (Int, @guaranteed Foo) -> UInt {
-entry(%0 : $Int, %1 : $Foo):
+entry(%0 : @trivial $Int, %1 : @owned $Foo):
   unreachable
 }
 sil @$S17objc_int_encoding3FooCACycfcTo : $@convention(objc_method) (@owned Foo) -> @owned Foo {
-entry(%1 : $Foo):
+entry(%1 : @owned $Foo):
   unreachable
 }
 

--- a/test/IRGen/objc_simd.sil
+++ b/test/IRGen/objc_simd.sil
@@ -25,7 +25,7 @@ func forceStuff(x: float4, y: float3) -> (Float, Float, Float, Float) {
 // powerpc64le-LABEL: define{{( dllexport)?}}{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
 // s390x-LABEL: define{{( dllexport)?}}{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
 sil @simd_c_args : $@convention(c) (float4) -> float4 {
-entry(%x : $float4):
+entry(%x : @trivial $float4):
   return %x : $float4
 }
 
@@ -41,7 +41,7 @@ entry(%x : $float4):
 // powerpc64le-LABEL: define{{( dllexport)?}}{{( protected)?}} <3 x float> @simd_c_args_float3(<3 x float>)
 // s390x-LABEL: define{{( dllexport)?}}{{( protected)?}} <3 x float> @simd_c_args_float3(<3 x float>)
 sil @simd_c_args_float3 : $@convention(c) (float3) -> float3 {
-entry(%x : $float3):
+entry(%x : @trivial $float3):
 // x86_64: [[COERCE:%.*]] = alloca <3 x float>, align 16
 // x86_64: store <3 x float> %0, <3 x float>* [[COERCE]]
 // x86_64: [[COERCED:%.*]] = bitcast <3 x float>* [[COERCE]] to %T4simd6float3V*
@@ -60,7 +60,7 @@ entry(%x : $float3):
 // powerpc64le-LABEL: define{{( dllexport)?}}{{( protected)?}} void @simd_native_args(%T4simd6float4V* noalias nocapture sret, %T4simd6float4V* noalias nocapture dereferenceable({{.*}}))
 // s390x-LABEL: define{{( dllexport)?}}{{( protected)?}} void @simd_native_args(%T4simd6float4V* noalias nocapture sret, %T4simd6float4V* noalias nocapture dereferenceable({{.*}}))
 sil @simd_native_args : $@convention(thin) (float4) -> float4 {
-entry(%x : $float4):
+entry(%x : @trivial $float4):
   %f = function_ref @simd_c_args : $@convention(c) (float4) -> float4
   %y = apply %f(%x) : $@convention(c) (float4) -> float4
   return %y : $float4
@@ -78,7 +78,7 @@ entry(%x : $float4):
 // powerpc64le-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float, float, float)
 // s390x-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float, float, float)
 sil @simd_native_args_float3 : $@convention(thin) (float3) -> float3 {
-entry(%x : $float3):
+entry(%x : @trivial $float3):
   %f = function_ref @simd_c_args_float3 : $@convention(c) (float3) -> float3
   %y = apply %f(%x) : $@convention(c) (float3) -> float3
   return %y : $float3

--- a/test/IRGen/objc_types_as_member.sil
+++ b/test/IRGen/objc_types_as_member.sil
@@ -15,7 +15,7 @@ sil @use_metatype : $@convention(thin) <T> (@thin T.Type) -> ()
 // CHECK:   ret void
 
 sil @test : $@convention(witness_method: NSRuncing) (@guaranteed OuterType.InnerType) -> () {
-bb0(%0 : $OuterType.InnerType):
+bb0(%0 : @guaranteed $OuterType.InnerType):
   %1 = function_ref @use_metatype : $@convention(thin) <τ_0_0> (@thin τ_0_0.Type) -> ()
   %2 = metatype $@thin OuterType.Type
   %3 = apply %1<OuterType>(%2) : $@convention(thin) <τ_0_0> (@thin τ_0_0.Type) -> ()

--- a/test/IRGen/ownership_qualified_memopts.sil
+++ b/test/IRGen/ownership_qualified_memopts.sil
@@ -9,7 +9,7 @@ import Builtin
 // CHECK-NOT: retain
 // CHECK: ret void
 sil @take_load : $@convention(thin) (@in Builtin.NativeObject) -> () {
-bb0(%0 : $*Builtin.NativeObject):
+bb0(%0 : @trivial $*Builtin.NativeObject):
   load [take] %0 : $*Builtin.NativeObject
   %1 = tuple()
   return %1 : $()
@@ -20,7 +20,7 @@ bb0(%0 : $*Builtin.NativeObject):
 // CHECK: retain
 // CHECK: ret void
 sil @copy_load : $@convention(thin) (@in Builtin.NativeObject) -> () {
-bb0(%0 : $*Builtin.NativeObject):
+bb0(%0 : @trivial $*Builtin.NativeObject):
   load [copy] %0 : $*Builtin.NativeObject
   %1 = tuple()
   return %1 : $()
@@ -32,7 +32,7 @@ bb0(%0 : $*Builtin.NativeObject):
 // CHECK-NOT: retain
 // CHECK: ret void
 sil @trivial_load : $@convention(thin) (@in Builtin.Int32) -> () {
-bb0(%0 : $*Builtin.Int32):
+bb0(%0 : @trivial $*Builtin.Int32):
   load [trivial] %0 : $*Builtin.Int32
   %1 = tuple()
   return %1 : $()
@@ -46,7 +46,7 @@ bb0(%0 : $*Builtin.Int32):
 // CHECK-NOT: release
 // CHECK: ret void
 sil @init_store : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
-bb0(%0 : $*Builtin.NativeObject, %1 : $Builtin.NativeObject):
+bb0(%0 : @trivial $*Builtin.NativeObject, %1 : @trivial $Builtin.NativeObject):
   store %1 to [init] %0 : $*Builtin.NativeObject
   %2 = tuple()
   return %2 : $()
@@ -58,7 +58,7 @@ bb0(%0 : $*Builtin.NativeObject, %1 : $Builtin.NativeObject):
 // CHECK: release
 // CHECK: ret void
 sil @assign_store : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
-bb0(%0 : $*Builtin.NativeObject, %1 : $Builtin.NativeObject):
+bb0(%0 : @trivial $*Builtin.NativeObject, %1 : @unowned $Builtin.NativeObject):
   store %1 to [assign] %0 : $*Builtin.NativeObject
   %2 = tuple()
   return %2 : $()
@@ -70,7 +70,7 @@ struct Foo {
 }
 
 sil @assign_store_2 : $@convention(thin) (@in Foo, Foo) -> () {
-bb0(%0 : $*Foo, %1 : $Foo):
+bb0(%0 : @trivial $*Foo, %1 : @trivial $Foo):
   %2 = load [copy] %0 : $*Foo
   store %1 to [assign] %0 : $*Foo
   %3 = tuple()
@@ -85,7 +85,7 @@ bb0(%0 : $*Foo, %1 : $Foo):
 // CHECK-NOT: release
 // CHECK: ret void
 sil @trivial_store : $@convention(thin) (@in Builtin.Int32, Builtin.Int32) -> () {
-bb0(%0 : $*Builtin.Int32, %1 : $Builtin.Int32):
+bb0(%0 : @trivial $*Builtin.Int32, %1 : @trivial $Builtin.Int32):
   store %1 to [trivial] %0 : $*Builtin.Int32
   %2 = tuple()
   return %2 : $()

--- a/test/IRGen/protocol_with_superclass.sil
+++ b/test/IRGen/protocol_with_superclass.sil
@@ -29,7 +29,7 @@ class MoreDerived : Concrete, SubProto {}
 // CHECK-objc-LABEL: define hidden swiftcc void @checkExistentialDowncast(%T24protocol_with_superclass8ConcreteC*, %objc_object*, i8**, %T24protocol_with_superclass8ConcreteC*, i8**, %T24protocol_with_superclass8ConcreteC*, i8**, %T24protocol_with_superclass8ConcreteC*, i8**) {{.*}} {
 // CHECK-native-LABEL: define hidden swiftcc void @checkExistentialDowncast(%T24protocol_with_superclass8ConcreteC*, %swift.refcounted*, i8**, %T24protocol_with_superclass8ConcreteC*, i8**, %T24protocol_with_superclass8ConcreteC*, i8**, %T24protocol_with_superclass8ConcreteC*, i8**) {{.*}} {
 sil hidden @checkExistentialDowncast : $@convention(thin) (@owned Concrete, @owned SuperProto, @owned SuperProto & Concrete, @owned ProtoRefinesClass, @owned SubProto) -> () {
-bb0(%0 : $Concrete, %1 : $SuperProto, %2 : $SuperProto & Concrete, %3 : $ProtoRefinesClass, %4 : $SubProto):
+bb0(%0 : @owned $Concrete, %1 : @owned $SuperProto, %2 : @owned $SuperProto & Concrete, %3 : @owned $ProtoRefinesClass, %4 : @owned $SubProto):
 
   // CHECK:             [[ISA_ADDR:%.*]] = bitcast %T24protocol_with_superclass8ConcreteC* %0 to %swift.type**
   // CHECK-NEXT:        [[ISA:%.*]] = load %swift.type*, %swift.type** [[ISA_ADDR]]

--- a/test/IRGen/subclass_existentials.sil
+++ b/test/IRGen/subclass_existentials.sil
@@ -27,7 +27,7 @@ protocol R {}
 // CHECK-NEXT:   ret void
 
 sil @checkRefcounting : $@convention(thin) (@owned C & P, @owned AnyObject & P) -> () {
-bb0(%0 : $C & P, %1 : $AnyObject & P):
+bb0(%0 : @owned $C & P, %1 : @owned $AnyObject & P):
   destroy_value %1 : $AnyObject & P
   destroy_value %0 : $C & P
   %6 = tuple ()
@@ -76,7 +76,7 @@ bb0:
 // CHECK-NEXT:  [[RESULT2:%.*]] = insertvalue { %T21subclass_existentials1CC*, i8** } [[RESULT1]], i8** @"$S21subclass_existentials1DCAA1PAAWP", 1
 // CHECK-NEXT:  ret { %T21subclass_existentials1CC*, i8** } [[RESULT2]]
 sil @eraseToExistential : $@convention(thin) (@owned D) -> @owned C & P {
-bb0(%0 : $D):
+bb0(%0 : @owned $D):
   %2 = init_existential_ref %0 : $D : $D, $C & P
   return %2 : $C & P
 }
@@ -87,14 +87,14 @@ bb0(%0 : $D):
 // CHECK-NEXT:  [[RESULT2:%.*]] = insertvalue { %T21subclass_existentials1GC*, i8** } [[RESULT1]], i8** @"$S21subclass_existentials1ECyxGAA1PAAWP", 1
 // CHECK-NEXT:  ret { %T21subclass_existentials1GC*, i8** } [[RESULT2]]
 sil @eraseToExistentialWithGeneric : $@convention(thin) <τ_0_0> (@owned E<τ_0_0>) -> @owned G<τ_0_0> & P {
-bb0(%0 : $E<τ_0_0>):
+bb0(%0 : @owned $E<τ_0_0>):
   %2 = init_existential_ref %0 : $E<τ_0_0> : $E<τ_0_0>, $G<τ_0_0> & P
   return %2 : $G<τ_0_0> & P
 }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @checkExistentialDowncast(%T21subclass_existentials1CC*, %T21subclass_existentials1CC*, i8**)
 sil @checkExistentialDowncast : $@convention(thin) (@owned C, @owned C & P) -> () {
-bb0(%0 : $C, %1 : $C & P):
+bb0(%0 : @owned $C, %1 : @owned $C & P):
 
 // CHECK:       [[METATYPE_PTR:%.*]] = bitcast %T21subclass_existentials1CC* %0 to %swift.type**
 // CHECK-NEXT:  [[METATYPE:%.*]] = load %swift.type*, %swift.type** [[METATYPE_PTR]], align {{4|8}}
@@ -146,7 +146,7 @@ bb0(%0 : $C, %1 : $C & P):
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @checkExistentialSameClassDowncast(%T21subclass_existentials1CC*)
 sil @checkExistentialSameClassDowncast : $@convention(thin) (@owned C) -> () {
-bb0(%0 : $C):
+bb0(%0 : @owned $C):
 
 // CHECK:       [[METATYPE_PTR:%.*]] = bitcast %T21subclass_existentials1CC* %0 to %swift.type**
 // CHECK-NEXT:  [[METATYPE:%.*]] = load %swift.type*, %swift.type** [[METATYPE_PTR]], align {{4|8}}
@@ -182,7 +182,7 @@ bb0(%0 : $C):
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @checkExistentialMetatypeDowncast(%swift.type*, %swift.type*, i8**)
 sil @checkExistentialMetatypeDowncast : $@convention(thin) (@owned @thick C.Type, @owned @thick (C & P).Type) -> () {
-bb0(%0 : $@thick C.Type, %1 : $@thick (C & P).Type):
+bb0(%0 : @trivial $@thick C.Type, %1 : @trivial $@thick (C & P).Type):
 
 // CHECK:       [[METATYPE:%.*]] = bitcast %swift.type* %0 to i8*
 // CHECK-NEXT:  [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S21subclass_existentials1DCMa"([[INT]] 0)
@@ -203,7 +203,7 @@ bb0(%0 : $@thick C.Type, %1 : $@thick (C & P).Type):
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @checkExistentialSameClassMetatypeDowncast(%swift.type*)
 sil @checkExistentialSameClassMetatypeDowncast : $@convention(thin) (@owned @thick C.Type) -> () {
-bb0(%0 : $@thick C.Type):
+bb0(%0 : @trivial $@thick C.Type):
 
 // CHECK:       [[METATYPE:%.*]] = bitcast %swift.type* %0 to i8*
 // CHECK-NEXT:  [[RESULT:%.*]] = call { i8*, i8** } @dynamic_cast_existential_1_unconditional(i8* [[METATYPE]], %swift.type* %0, %swift.protocol* @"$S21subclass_existentials1PMp")

--- a/test/IRGen/unknown_object.sil
+++ b/test/IRGen/unknown_object.sil
@@ -6,7 +6,7 @@ import Builtin
 
 // CHECK-LABEL: @retain_release_unknown_object
 sil @retain_release_unknown_object : $@convention(thin) (@guaranteed Builtin.UnknownObject) -> () {
-entry(%x : $Builtin.UnknownObject):
+entry(%x : @guaranteed $Builtin.UnknownObject):
   // CHECK-native: swift_retain
   // CHECK-objc: swift_unknownRetain
   %y = copy_value %x : $Builtin.UnknownObject

--- a/test/IRGen/yield_once.sil
+++ b/test/IRGen/yield_once.sil
@@ -47,7 +47,7 @@ unwind:
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_simple_call(i1)
 sil @test_simple_call : $(Builtin.Int1) -> () {
-entry(%flag : $Builtin.Int1):
+entry(%flag : @trivial $Builtin.Int1):
   //   Allocate the buffer.
   // CHECK:         [[T0:%.*]] = alloca {{\[}}[[BUFFER_SIZE]] x i8], align [[BUFFER_ALIGN]]
   // CHECK-NEXT:    [[BUFFER:%.*]] = getelementptr inbounds {{\[}}[[BUFFER_SIZE]] x i8], {{\[}}[[BUFFER_SIZE]] x i8]* [[T0]], i32 0, i32 0

--- a/test/IRGen/yield_once_big.sil
+++ b/test/IRGen/yield_once_big.sil
@@ -91,7 +91,7 @@ unwind:
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_simple_call(i1)
 sil @test_simple_call : $(Builtin.Int1) -> () {
-entry(%flag : $Builtin.Int1):
+entry(%flag : @trivial $Builtin.Int1):
   //   Allocate the buffer.
   // CHECK:         [[T0:%.*]] = alloca {{\[}}[[BUFFER_SIZE]] x i8], align [[BUFFER_ALIGN]]
   // CHECK-NEXT:    [[BUFFER:%.*]] = getelementptr inbounds {{\[}}[[BUFFER_SIZE]] x i8], {{\[}}[[BUFFER_SIZE]] x i8]* [[T0]], i32 0, i32 0

--- a/test/IRGen/yield_once_biggish.sil
+++ b/test/IRGen/yield_once_biggish.sil
@@ -99,7 +99,7 @@ unwind:
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_simple_call(i1)
 sil @test_simple_call : $(Builtin.Int1) -> () {
-entry(%flag : $Builtin.Int1):
+entry(%flag : @trivial $Builtin.Int1):
   //   Allocate the buffer.
   // CHECK:         [[T0:%.*]] = alloca {{\[}}[[BUFFER_SIZE]] x i8], align [[BUFFER_ALIGN]]
   // CHECK-NEXT:    [[BUFFER:%.*]] = getelementptr inbounds {{\[}}[[BUFFER_SIZE]] x i8], {{\[}}[[BUFFER_SIZE]] x i8]* [[T0]], i32 0, i32 0

--- a/test/IRGen/yield_once_indirect.sil
+++ b/test/IRGen/yield_once_indirect.sil
@@ -88,7 +88,7 @@ unwind:
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_simple_call(i1)
 sil @test_simple_call : $(Builtin.Int1) -> () {
-entry(%flag : $Builtin.Int1):
+entry(%flag : @trivial $Builtin.Int1):
   //   Allocate the buffer.
   // CHECK:         [[T0:%.*]] = alloca {{\[}}[[BUFFER_SIZE]] x i8], align [[BUFFER_ALIGN]]
   // CHECK-NEXT:    [[BUFFER:%.*]] = getelementptr inbounds {{\[}}[[BUFFER_SIZE]] x i8], {{\[}}[[BUFFER_SIZE]] x i8]* [[T0]], i32 0, i32 0

--- a/test/Reflection/capture_descriptors.sil
+++ b/test/Reflection/capture_descriptors.sil
@@ -19,13 +19,13 @@ protocol P {}
 extension Int: P {}
 
 sil @concrete_callee1 : $@convention(thin) (Int, @owned <τ_0_0> { var τ_0_0 } <Int>, @thin Int.Type, @thick P.Type) -> () {
-bb0(%i: $Int, %b: $<τ_0_0> { var τ_0_0 } <Int>, %m: $@thin Int.Type, %p: $@thick P.Type):
+bb0(%i : @trivial $Int, %b : @owned $<τ_0_0> { var τ_0_0 } <Int>, %m : @trivial $@thin Int.Type, %p : @trivial $@thick P.Type):
   %12 = tuple ()
   return %12 : $()
 }
 
 sil @concrete_caller1 : $@convention(thin) (Int, @thick P.Type) -> @owned @callee_guaranteed () -> () {
-bb0(%i: $Int, %p: $@thick P.Type):
+bb0(%i : @trivial $Int, %p : @trivial $@thick P.Type):
   %f = function_ref @concrete_callee1 : $@convention(thin) (Int, @owned <τ_0_0> { var τ_0_0 } <Int>, @thin Int.Type, @thick P.Type) -> ()
   %b = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
   %m = metatype $@thin Int.Type
@@ -52,7 +52,7 @@ bb0(%i: $Int, %p: $@thick P.Type):
 // and there are no metadata bindings
 
 sil @generic_callee2 : $@convention(thin) <T, U> (@in T, @owned <τ_0_0> { var τ_0_0 } <U>) -> () {
-bb0(%i: $*T, %b: $<τ_0_0> { var τ_0_0 } <U>):
+bb0(%i : @trivial $*T, %b : @owned $<τ_0_0> { var τ_0_0 } <U>):
   %12 = tuple ()
   return %12 : $()
 }
@@ -85,7 +85,7 @@ bb0:
 // contain the caller's generic parameters.
 
 sil @generic_callee3 : $@convention(thin) <T, U> (@in_guaranteed T) -> () {
-bb0(%t: $*T):
+bb0(%t : @trivial $*T):
   %12 = tuple ()
   return %12 : $()
 }
@@ -123,7 +123,7 @@ bb0:
 // fulfilled by a thick metatype value.
 
 sil @generic_callee4 : $@convention(thin) <T, U> (@thick Optional<T>.Type) -> () {
-bb0(%t: $@thick Optional<T>.Type):
+bb0(%t : @trivial $@thick Optional<T>.Type):
   %12 = tuple ()
   return %12 : $()
 }
@@ -160,13 +160,13 @@ bb0:
 class GenericClass<T, U> {}
 
 sil @generic_callee5 : $@convention(thin) <T, U, V> (@owned GenericClass<T, U>) -> () {
-bb0(%t: $GenericClass<T, U>):
+bb0(%t : @owned $GenericClass<T, U>):
   %12 = tuple ()
   return %12 : $()
 }
 
 sil @generic_caller5 : $@convention(thin) <A, B, C> (@owned GenericClass<(A, B), (B, C)>) -> @owned @callee_guaranteed () -> () {
-bb0(%g: $GenericClass<(A, B), (B, C)>):
+bb0(%g : @owned $GenericClass<(A, B), (B, C)>):
   %f = function_ref @generic_callee5 : $@convention(thin) <T, U, V> (@owned GenericClass<T, U>) -> ()
   %c = partial_apply [callee_guaranteed] %f<(A, B), (B, C), (C, A)>(%g) : $@convention(thin) <T, U, V> (@owned GenericClass<T, U>) -> ()
   return %c : $@callee_guaranteed () -> ()
@@ -203,13 +203,13 @@ sil_vtable GenericClass {}
 // erased at runtime.
 
 sil @pseudogeneric_callee : $@convention(thin) @pseudogeneric <T : AnyObject, U : AnyObject> (@owned T, @owned U) -> () {
-bb0(%t: $T, %u: $U):
+bb0(%t : @owned $T, %u : @owned $U):
   %12 = tuple ()
   return %12 : $()
 }
 
 sil @pseudogeneric_caller : $@convention(thin) @pseudogeneric <A : AnyObject, B : AnyObject, C : AnyObject> (@owned A, @owned B) -> @owned @callee_guaranteed () -> () {
-bb0(%a: $A, %b: $B):
+bb0(%a : @owned $A, %b : @owned $B):
   %f = function_ref @pseudogeneric_callee : $@convention(thin) @pseudogeneric <T : AnyObject, U : AnyObject> (@owned T, @owned U) -> ()
   %c = partial_apply [callee_guaranteed] %f<A, B>(%a, %b) : $@convention(thin) @pseudogeneric <A : AnyObject, B : AnyObject> (@owned A, @owned B) -> ()
   return %c : $@callee_guaranteed () -> ()
@@ -224,13 +224,13 @@ bb0(%a: $A, %b: $B):
 // Capturing lowered function types
 
 sil @function_callee : $@convention(thin) (@convention(thin) () -> (), @convention(c) () -> (), @convention(block) () -> (), @convention(thick) () -> (), @convention(method) () -> (), @convention(witness_method: P) (Int) -> ()) -> () {
-bb0(%thin: $@convention(thin) () -> (), %c: $@convention(c) () -> (), %block: $@convention(block) () -> (), %thick: $@convention(thick) () -> (), %method: $@convention(method) () -> (), %witness_method: $@convention(witness_method: P) (Int) -> ()):
+bb0(%thin : @trivial $@convention(thin) () -> (), %c : @trivial $@convention(c) () -> (), %block : @unowned $@convention(block) () -> (), %thick : @unowned $@convention(thick) () -> (), %method : @trivial $@convention(method) () -> (), %witness_method : @trivial $@convention(witness_method: P) (Int) -> ()):
   %12 = tuple ()
   return %12 : $()
 }
 
 sil @function_caller : $@convention(thin) (@convention(thin) () -> (), @convention(c) () -> (), @convention(block) () -> (), @convention(thick) () -> (), @convention(method) () -> (), @convention(witness_method: P) (Int) -> ()) -> @owned @callee_guaranteed () -> () {
-bb0(%thin: $@convention(thin) () -> (), %c: $@convention(c) () -> (), %block: $@convention(block) () -> (), %thick: $@convention(thick) () -> (), %method: $@convention(method) () -> (), %witness_method: $@convention(witness_method: P) (Int) -> ()):
+bb0(%thin: @trivial $@convention(thin) () -> (), %c: @trivial $@convention(c) () -> (), %block: @unowned $@convention(block) () -> (), %thick: @unowned $@convention(thick) () -> (), %method: @trivial $@convention(method) () -> (), %witness_method: @trivial $@convention(witness_method: P) (Int) -> ()):
   %f = function_ref @function_callee : $@convention(thin) (@convention(thin) () -> (), @convention(c) () -> (), @convention(block) () -> (), @convention(thick) () -> (), @convention(method) () -> (), @convention(witness_method: P) (Int) -> ()) -> ()
   %result = partial_apply [callee_guaranteed] %f(%thin, %c, %block, %thick, %method, %witness_method) : $@convention(thin) (@convention(thin) () -> (), @convention(c) () -> (), @convention(block) () -> (), @convention(thick) () -> (), @convention(method) () -> (), @convention(witness_method: P) (Int) -> ()) -> ()
   return %result : $@callee_guaranteed () -> ()
@@ -271,13 +271,13 @@ bb0(%thin: $@convention(thin) () -> (), %c: $@convention(c) () -> (), %block: $@
 // for this case.
 
 sil @existential_callee : $@convention(thin) <τ_0_0 where τ_0_0 : P> () -> @out P {
-bb0(%0 : $*P):
+bb0(%0 : @trivial $*P):
   unreachable
 }
 
 
 sil @existential_caller : $@convention(thin) (@in P) -> () {
-bb0(%0 : $*P):
+bb0(%0 : @trivial $*P):
   %payload = open_existential_addr immutable_access %0 : $*P to $*@opened("2D7A8F84-2973-11E7-838D-34363BD08DA0") P
   %f = function_ref @existential_callee : $@convention(thin) <τ_0_0 where τ_0_0 : P> () -> @out P
   %result = partial_apply [callee_guaranteed] %f<@opened("2D7A8F84-2973-11E7-838D-34363BD08DA0") P>() : $@convention(thin) <τ_0_0 where τ_0_0 : P> () -> @out P

--- a/test/SIL/Parser/apply_with_conformance.sil
+++ b/test/SIL/Parser/apply_with_conformance.sil
@@ -22,7 +22,7 @@ sil @_TFV4test1S3foofS0_US_1P__FQ_T_ : $@convention(method) <T where T : P> (@in
 // CHECK: call
 // test.bar (test.S, test.X) -> ()
 sil @_TF4test3barFTVS_1SVS_1X_T_ : $@convention(thin) (S, X) -> () {
-bb0(%0 : $S, %1 : $X):
+bb0(%0 : @unowned $S, %1 : @unowned $X):
   debug_value %0 : $S  // let s                   // id: %2
   debug_value %1 : $X  // let x                   // id: %3
   // function_ref test.S.foo (test.S)<A : test.P>(A) -> ()

--- a/test/SIL/Parser/apply_with_substitution.sil
+++ b/test/SIL/Parser/apply_with_substitution.sil
@@ -9,7 +9,7 @@ import Swift
 
 // CHECK-LABEL: sil @_TF4test3fooFT1fGSqFT_T___T_ : $@convention(thin) (@guaranteed Optional<@callee_guaranteed (@in_guaranteed ()) -> @out ()>) -> ()
 sil @_TF4test3fooFT1fGSqFT_T___T_ : $@convention(thin) (@guaranteed Optional<@callee_guaranteed (@in_guaranteed ()) -> @out ()>) -> () {
-bb0(%0 : $Optional<@callee_guaranteed (@in_guaranteed ()) -> @out ()>):
+bb0(%0 : @guaranteed $Optional<@callee_guaranteed (@in_guaranteed ()) -> @out ()>):
   %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Optional<@callee_guaranteed (@in_guaranteed ()) -> @out ()>>  // var f    // users: %2, %6, %32
   %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Optional<@callee_guaranteed (@in_guaranteed ()) -> @out ()>>, 0
   store %0 to [init] %1a : $*Optional<@callee_guaranteed (@in_guaranteed ()) -> @out ()>         // id: %2

--- a/test/SIL/Parser/basic2.sil
+++ b/test/SIL/Parser/basic2.sil
@@ -3,24 +3,24 @@
 import Builtin
 
 // CHECK-LABEL: sil @test_copy_release_value
-// CHECK: bb0([[T0:%[0-9]+]] : $Builtin.NativeObject):
+// CHECK: bb0([[T0:%[0-9]+]] : @unowned $Builtin.NativeObject):
 // CHECK-NEXT: [[COPY_RESULT:%.*]] = copy_value [[T0]] : $Builtin.NativeObject
 // CHECK-NEXT: destroy_value [[T0]] : $Builtin.NativeObject
 // CHECK-NEXT: return [[COPY_RESULT]]
 sil @test_copy_release_value : $@convention(thin) (Builtin.NativeObject) -> Builtin.NativeObject {
-bb0(%0 : $Builtin.NativeObject):
+bb0(%0 : @unowned $Builtin.NativeObject):
   %1 = copy_value %0 : $Builtin.NativeObject
   destroy_value %0 : $Builtin.NativeObject
   return %1 : $Builtin.NativeObject
 }
 
 // CHECK-LABEL: sil @test_copy_unowned_value : $@convention(thin) (@owned @sil_unowned Builtin.NativeObject) -> @owned Builtin.NativeObject {
-// CHECK: bb0([[T0:%[0-9]+]] : $@sil_unowned Builtin.NativeObject):
+// CHECK: bb0([[T0:%[0-9]+]] : @owned $@sil_unowned Builtin.NativeObject):
 // CHECK-NEXT: [[COPY_RESULT:%.*]] = copy_unowned_value [[T0]] : $@sil_unowned Builtin.NativeObject
 // CHECK-NEXT: destroy_value [[T0]] : $@sil_unowned Builtin.NativeObject
 // CHECK-NEXT: return [[COPY_RESULT]] : $Builtin.NativeObject
 sil @test_copy_unowned_value : $@convention(thin) (@owned @sil_unowned Builtin.NativeObject) -> @owned Builtin.NativeObject {
-bb0(%0 : $@sil_unowned Builtin.NativeObject):
+bb0(%0 : @owned $@sil_unowned Builtin.NativeObject):
   %1 = copy_unowned_value %0 : $@sil_unowned Builtin.NativeObject
   destroy_value %0 : $@sil_unowned Builtin.NativeObject
   return %1 : $Builtin.NativeObject

--- a/test/SIL/Parser/basic_objc.sil
+++ b/test/SIL/Parser/basic_objc.sil
@@ -25,7 +25,7 @@ protocol SomeClassProtocol : class {}
 // CHECK:         {{%.*}} = objc_metatype_to_object {{%.*}} : $@objc_metatype SomeClass.Type to $AnyObject
 // CHECK:         {{%.*}} = objc_existential_metatype_to_object {{%.*}} : $@objc_metatype SomeClassProtocol.Type to $AnyObject
 sil @metatype_to_object : $@convention(thin) (@objc_metatype SomeClass.Type, @objc_metatype SomeClassProtocol.Type) -> @owned (AnyObject, AnyObject) {
-entry(%a : $@objc_metatype SomeClass.Type, %b : $@objc_metatype SomeClassProtocol.Type):
+entry(%a : @trivial $@objc_metatype SomeClass.Type, %b : @trivial $@objc_metatype SomeClassProtocol.Type):
   %x = objc_metatype_to_object %a : $@objc_metatype SomeClass.Type to $AnyObject
   %y = objc_existential_metatype_to_object %b : $@objc_metatype SomeClassProtocol.Type to $AnyObject
   %z = tuple (%x : $AnyObject, %y : $AnyObject)
@@ -35,7 +35,7 @@ entry(%a : $@objc_metatype SomeClass.Type, %b : $@objc_metatype SomeClassProtoco
 sil @requires_any_object : $@convention(thin) <T: AnyObject> (@owned T) -> ()
 
 sil @foo : $@convention(thin) (@owned ObjCProto) -> () {
-entry(%a : $ObjCProto):
+entry(%a : @owned $ObjCProto):
   %f = function_ref @requires_any_object : $@convention(thin) <T: AnyObject> (@owned T) -> ()
   %0 = apply %f<ObjCProto>(%a) : $@convention(thin) <T: AnyObject> (@owned T) -> ()
   return %0 : $()

--- a/test/SIL/Parser/borrow.sil
+++ b/test/SIL/Parser/borrow.sil
@@ -6,7 +6,7 @@ import Builtin
 
 // We do not verify here, but just make sure that all of the combinations parse and print correctly.
 // CHECK-LABEL: sil @borrow_test : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
-// CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : $Builtin.NativeObject):
+// CHECK: bb0([[ARG1:%[0-9]+]] : @trivial $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : @unowned $Builtin.NativeObject):
 // CHECK: begin_borrow [[ARG2]]
 // CHECK: [[MEM:%.*]] = alloc_stack $Builtin.NativeObject
 // CHECK: store_borrow [[ARG2]] to [[MEM]] : $*Builtin.NativeObject
@@ -15,7 +15,7 @@ import Builtin
 // CHECK: end_borrow [[ARG1]] from [[ARG1]] : $*Builtin.NativeObject, $*Builtin.NativeObject
 // CHECK: end_borrow [[ARG2]] from [[ARG2]] : $Builtin.NativeObject, $Builtin.NativeObject
 sil @borrow_test : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
-bb0(%0 : $*Builtin.NativeObject, %1 : $Builtin.NativeObject):
+bb0(%0 : @trivial $*Builtin.NativeObject, %1 : @unowned $Builtin.NativeObject):
   %2 = begin_borrow %1 : $Builtin.NativeObject
   end_borrow %2 from %1 : $Builtin.NativeObject, $Builtin.NativeObject
 

--- a/test/SIL/Parser/bound_generic.sil
+++ b/test/SIL/Parser/bound_generic.sil
@@ -9,7 +9,7 @@ import Swift
 
 // CHECK-LABEL: sil @_TF9optional3fooFT1fGSqFT_T___T_ : $@convention(thin) (@guaranteed Optional<@callee_guaranteed (@in_guaranteed ()) -> @out ()>) -> ()
 sil @_TF9optional3fooFT1fGSqFT_T___T_ : $@convention(thin) (@guaranteed Optional<@callee_guaranteed (@in_guaranteed ()) -> (@out ())>) -> () {
-bb0(%0 : $Optional<@callee_guaranteed (@in_guaranteed ()) -> (@out ())>):
+bb0(%0 : @guaranteed $Optional<@callee_guaranteed (@in_guaranteed ()) -> (@out ())>):
   %1 = alloc_box $<τ_0_0> { var τ_0_0 } <Optional<@callee_guaranteed (@in_guaranteed ()) -> (@out ())>>
   %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Optional<@callee_guaranteed (@in_guaranteed ()) -> (@out ())>>, 0
   store %0 to [init] %1a : $*Optional<@callee_guaranteed (@in_guaranteed ()) -> (@out ())>

--- a/test/SIL/Parser/boxes.sil
+++ b/test/SIL/Parser/boxes.sil
@@ -29,7 +29,7 @@ sil @box_type_parsing : $@convention(thin) (
   <X, Y, Z>{ var X, let Z }<Int, String, Optional<Double>>
 // CHECK: ) -> ()
 ) -> () {
-entry(%0 : $<E>{ var E }<F>, %1 : $<F: P>{ let F }<G>, %2 : $<G: P>{ var G }<Q>, %3 : ${ let Int }, %4 : ${ var Int, let String }, %5 : ${}, %6 : $<XX, YY, ZZ>{ var XX, let ZZ }<Int, String, Optional<Double>>):
+entry(%0 : @unowned $<E>{ var E }<F>, %1 : @unowned $<F: P>{ let F }<G>, %2 : @unowned $<G: P>{ var G }<Q>, %3 : @unowned ${ let Int }, %4 : @unowned ${ var Int, let String }, %5 : @unowned ${}, %6 : @unowned $<XX, YY, ZZ>{ var XX, let ZZ }<Int, String, Optional<Double>>):
   unreachable
 }
 
@@ -51,7 +51,7 @@ sil @box_type_parsing_in_generic_function : $@convention(thin) <F, G: P> (
   <X, Y, Z>{ var X, let Z }<Int, String, Optional<Double>>
 // CHECK: ) -> ()
 ) -> () {
-entry(%0 : $<E>{ var E }<F>, %1 : $<F: P>{ let F }<G>, %2 : $<G: P>{ var G }<Q>, %3 : ${ let Int }, %4 : ${ var Int, let String }, %5 : ${}, %6 : $<XX, YY, ZZ>{ var XX, let ZZ }<Int, String, Optional<Double>>):
+entry(%0 : @unowned $<E>{ var E }<F>, %1 : @unowned $<F: P>{ let F }<G>, %2 : @unowned $<G: P>{ var G }<Q>, %3 : @unowned ${ let Int }, %4 : @unowned ${ var Int, let String }, %5 : @unowned ${}, %6 : @unowned $<XX, YY, ZZ>{ var XX, let ZZ }<Int, String, Optional<Double>>):
   unreachable
 }
 
@@ -63,7 +63,7 @@ sil @same_generic_param_name_in_multiple_box_signatures : $@convention(thin) (
   <A> { var A } <String>
 // CHECK: ) -> ()
 ) -> () {
-entry(%0 : $<A> { var A } <Int>, %1 : $<A> { var A } <String>):
+entry(%0 : @unowned $<A> { var A } <Int>, %1 : @unowned $<A> { var A } <String>):
   unreachable
 }
 
@@ -73,19 +73,19 @@ sil @same_generic_param_name_in_outer_scope : $@convention(thin) <A> (
   <A> { var A } <A>
 // CHECK: ) -> ()
 ) -> () {
-entry(%0 : $<B> { var B } <A>):
+entry(%0 : @unowned $<B> { var B } <A>):
   unreachable
 }
 
 // CHECK-LABEL: sil @box_ownership : $@convention(thin) (@owned { var Int }, @guaranteed <τ_0_0> { let τ_0_0 } <Int>) -> ()
 sil @box_ownership : $@convention(thin) (@owned { var Int }, @guaranteed <T> { let T } <Int>) -> () {
-entry(%0 : ${ var Int }, %1 : $<T> { let T } <Int>):
+entry(%0 : @owned ${ var Int }, %1 : @guaranteed $<T> { let T } <Int>):
   unreachable
 }
 
 // CHECK-LABEL: sil @address_of_box
 sil @address_of_box : $@convention(thin) (@in { var Int }, @in <T> { let T } <Int>) -> () {
-// CHECK: %0 : $*{ var Int }, %1 : $*<τ_0_0> { let τ_0_0 } <Int>
-entry(%0 : $*{ var Int }, %1 : $*<T> { let T } <Int>):
+// CHECK: %0 : @trivial $*{ var Int }, %1 : @trivial $*<τ_0_0> { let τ_0_0 } <Int>
+entry(%0 : @trivial $*{ var Int }, %1 : @trivial $*<T> { let T } <Int>):
   unreachable
 }

--- a/test/SIL/Parser/coroutines.sil
+++ b/test/SIL/Parser/coroutines.sil
@@ -20,7 +20,7 @@ bb0:
 }
 
 sil @yield : $@yield_once (Int, Float) -> (@yields Int, @yields Float) {
-bb0(%0 : $Int, %1 : $Float):
+bb0(%0 : @trivial $Int, %1 : @trivial $Float):
   yield (%0 : $Int, %1 : $Float), resume bb1, unwind bb2
 
 bb1:
@@ -32,7 +32,7 @@ bb2:
 }
 
 sil @yield_many : $@yield_many (Int, Float) -> (@yields Int, @yields Float) {
-bb0(%0 : $Int, %1 : $Float):
+bb0(%0 : @trivial $Int, %1 : @trivial $Float):
   yield (%0 : $Int, %1 : $Float), resume bb1, unwind bb3
 
 bb1:
@@ -50,7 +50,7 @@ bb4:
 }
 
 sil @begin_apply : $(Int, Float) -> () {
-bb0(%0 : $Int, %1 : $Float):
+bb0(%0 : @trivial $Int, %1 : @trivial $Float):
   %coro = function_ref @yield : $@convention(thin) @yield_once (Int, Float) -> (@yields Int, @yields Float)
   (%int, %float, %token) = begin_apply %coro(%0, %1) : $@convention(thin) @yield_once (Int, Float) -> (@yields Int, @yields Float)
 

--- a/test/SIL/Parser/coroutines_failure_merge.sil
+++ b/test/SIL/Parser/coroutines_failure_merge.sil
@@ -6,7 +6,7 @@ sil_stage raw
 import Swift
 
 sil @yield : $@yield_many (Int, Float) -> (@yields Int, @yields Float) {
-bb0(%0 : $Int, %1 : $Float):
+bb0(%0 : @trivial $Int, %1 : @trivial $Float):
   yield (%0 : $Int, %1 : $Float), resume bb1, unwind bb2
 
 bb1:

--- a/test/SIL/Parser/coroutines_failure_unwind_return.sil
+++ b/test/SIL/Parser/coroutines_failure_unwind_return.sil
@@ -6,7 +6,7 @@ sil_stage raw
 import Swift
 
 sil @yield : $@yield_once (Int, Float) -> (@yields Int, @yields Float) {
-bb0(%0 : $Int, %1 : $Float):
+bb0(%0 : @trivial $Int, %1 : @trivial $Float):
   yield (%0 : $Int, %1 : $Float), resume bb1, unwind bb2
 
 bb1:

--- a/test/SIL/Parser/coroutines_failure_unwind_reuse.sil
+++ b/test/SIL/Parser/coroutines_failure_unwind_reuse.sil
@@ -6,7 +6,7 @@ sil_stage raw
 import Swift
 
 sil @yield : $@yield_many (Int, Float) -> (@yields Int, @yields Float) {
-bb0(%0 : $Int, %1 : $Float):
+bb0(%0 : @trivial $Int, %1 : @trivial $Float):
   yield (%0 : $Int, %1 : $Float), resume bb1, unwind bb3
 
 bb1:

--- a/test/SIL/Parser/coroutines_failure_yieldonce_twice.sil
+++ b/test/SIL/Parser/coroutines_failure_yieldonce_twice.sil
@@ -6,7 +6,7 @@ sil_stage canonical
 import Swift
 
 sil @yield : $@yield_once (Int, Float) -> (@yields Int, @yields Float) {
-bb0(%0 : $Int, %1 : $Float):
+bb0(%0 : @trivial $Int, %1 : @trivial $Float):
   yield (%0 : $Int, %1 : $Float), resume bb1, unwind bb3
 
 bb1:

--- a/test/SIL/Parser/enum_in_class.sil
+++ b/test/SIL/Parser/enum_in_class.sil
@@ -15,7 +15,7 @@ class Task {
 
 // CHECK: @test_declref_enum
 sil [transparent] @test_declref_enum : $@convention(thin) (UInt8, @thin Task.State.Type) -> Task.State {
-bb0(%0 : $UInt8, %1 : $@thin Task.State.Type):
+bb0(%0 : @trivial $UInt8, %1 : @trivial $@thin Task.State.Type):
 // CHECK: enum $Task.State, #Task.State.Bits!enumelt
   %2 = enum $Task.State, #Task.State.Bits!enumelt.1, %0 : $UInt8
   return %2 : $Task.State

--- a/test/SIL/Parser/errors.sil
+++ b/test/SIL/Parser/errors.sil
@@ -47,7 +47,7 @@ bb0:
 sil_stage nonsense // expected-error {{expected 'raw' or 'canonical' after 'sil_stage'}}
 
 sil @missing_type : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   br bb3(%0) // expected-error {{expected ':' before type in SIL value reference}}
   // FIXME: The next error is unexpected.
 } // expected-error {{extraneous '}' at top level}} {{1-3=}}

--- a/test/SIL/Parser/function_named_subscript.sil
+++ b/test/SIL/Parser/function_named_subscript.sil
@@ -13,7 +13,7 @@ class SubscriptAsFunction {
 }
 
 sil hidden @$S4test19SubscriptAsFunctionC9subscriptyyF : $@convention(method) (@guaranteed SubscriptAsFunction) -> () {
-bb0(%0 : $SubscriptAsFunction):
+bb0(%0 : @guaranteed $SubscriptAsFunction):
   return undef : $()
 }
 

--- a/test/SIL/Parser/generics.sil
+++ b/test/SIL/Parser/generics.sil
@@ -4,12 +4,12 @@ sil_stage raw
 import Builtin
 
 // CHECK-LABEL: sil @foo : $@convention(thin) <T> (@in T) -> @out T {
-// CHECK: bb0(%0 : $*T, %1 : $*T):
+// CHECK: bb0(%0 : @trivial $*T, %1 : @trivial $*T):
 // CHECK:   copy_addr [take] %1 to [initialization] %0 : $*T
 // CHECK:   return undef : $()
 // CHECK: }
 sil @foo : $@convention(thin) <T> (@in T) -> @out T {
-entry(%o : $*T, %i : $*T):
+entry(%o : @trivial $*T, %i : @trivial $*T):
   copy_addr [take] %i to [initialization] %o : $*T
   return undef : $()
 }
@@ -97,7 +97,7 @@ protocol FooProto {
 
 // These generic parameters used to crash the compiler.
 sil @protocol_extension_with_constrained_associated_type : $@convention(method) <Self where Self : FooProto, Self.Assoc : FooProtoHelper><I where I : FooProto, I.Assoc == Self.Assoc> (@in I, @in_guaranteed Self) -> () {
-bb0(%0 : $*I, %1 : $*Self):
+bb0(%0 : @trivial $*I, %1 : @trivial $*Self):
   %2 = alloc_stack $I                             // users: %3, %6, %7, %9
   copy_addr %0 to [initialization] %2 : $*I     // id: %3
   %4 = witness_method $I, #FooProto.value!getter.1 : $@convention(witness_method: FooProto) <τ_0_0 where τ_0_0 : FooProto, τ_0_0.Assoc : FooProtoHelper> (@in_guaranteed τ_0_0) -> @out τ_0_0.Assoc // user: %6

--- a/test/SIL/Parser/indirect_enum.sil
+++ b/test/SIL/Parser/indirect_enum.sil
@@ -22,7 +22,7 @@ enum TreeInt {
 }
 
 sil @indirect_enum : $@convention(thin) <T> (@owned TreeA<T>) -> () {
-entry(%e : $TreeA<T>):
+entry(%e : @owned $TreeA<T>):
   %a = unchecked_enum_data %e : $TreeA<T>, #TreeA.Leaf!enumelt.1
   %b = project_box %a : $<τ_0_0> { var τ_0_0 } <T>, 0
 
@@ -33,7 +33,7 @@ entry(%e : $TreeA<T>):
 }
 
 sil @indirect_enum_case_addr_only : $@convention(thin) <T> (@in TreeB<T>) -> () {
-entry(%e : $*TreeB<T>):
+entry(%e : @trivial $*TreeB<T>):
   %a = unchecked_take_enum_data_addr %e : $*TreeB<T>, #TreeB.Leaf!enumelt.1
   destroy_addr %a : $*T
 
@@ -44,7 +44,7 @@ entry(%e : $*TreeB<T>):
 }
 
 sil @indirect_enum_case_loadable : $@convention(thin) (@owned TreeInt) -> () {
-entry(%e : $TreeInt):
+entry(%e : @owned $TreeInt):
   %a = unchecked_enum_data %e : $TreeInt, #TreeInt.Leaf!enumelt.1
   store %a to [trivial] undef : $*Int
 

--- a/test/SIL/Parser/keypath.sil
+++ b/test/SIL/Parser/keypath.sil
@@ -126,8 +126,8 @@ entry:
 
 // CHECK-LABEL: sil @indexes
 sil @indexes : $@convention(thin) (S, C) -> () {
-// CHECK: bb0([[S:%.*]] : $S, [[C:%.*]] : $C):
-entry(%s : $S, %c : $C):
+// CHECK: bb0([[S:%.*]] : @unowned $S, [[C:%.*]] : @unowned $C):
+entry(%s : @unowned $S, %c : @unowned $C):
   // CHECK: keypath $KeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int_subs : $@convention(thin) (@in_guaranteed S, UnsafeRawPointer) -> @out Int, setter @set_s_int_subs : $@convention(thin) (@in_guaranteed Int, @in_guaranteed S, UnsafeRawPointer) -> (), indices [%$0 : $S : $S, %$1 : $C : $C], indices_equals @subs_eq : $@convention(thin) (UnsafeRawPointer, UnsafeRawPointer) -> Bool, indices_hash @subs_hash : $@convention(thin) (UnsafeRawPointer) -> Int) ([[S]], [[C]])
   %a = keypath $KeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int_subs : $@convention(thin) (@in_guaranteed S, UnsafeRawPointer) -> @out Int, setter @set_s_int_subs : $@convention(thin) (@in_guaranteed Int, @in_guaranteed S, UnsafeRawPointer) -> (), indices [%$0 : $S : $S, %$1 : $C : $C], indices_equals @subs_eq : $@convention(thin) (UnsafeRawPointer, UnsafeRawPointer) -> Bool, indices_hash @subs_hash : $@convention(thin) (UnsafeRawPointer) -> Int) (%s, %c)
   // CHECK: [[T:%.*]] = alloc_stack

--- a/test/SIL/Parser/overloaded_member.sil
+++ b/test/SIL/Parser/overloaded_member.sil
@@ -17,7 +17,7 @@ struct A {
 
 // CHECK-LABEL: sil @_TFCSo1XcfMS_FT1aV11peer_method1A_S_
 sil @_TFCSo1XcfMS_FT1aV11peer_method1A_S_ : $@convention(method) (A, @owned X) -> @owned X {
-bb0(%0 : $A, %1 : $X):
+bb0(%0 : @trivial $A, %1 : @owned $X):
   %2 = alloc_box $<τ_0_0> { var τ_0_0 } <X>
   %2a = project_box %2 : $<τ_0_0> { var τ_0_0 } <X>, 0
   %3 = alloc_box $<τ_0_0> { var τ_0_0 } <A>

--- a/test/SIL/Parser/ownership_qualified_memopts.sil
+++ b/test/SIL/Parser/ownership_qualified_memopts.sil
@@ -4,13 +4,13 @@
 import Builtin
 
 // CHECK-LABEL: sil @non_trivial : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
-// CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : $Builtin.NativeObject):
+// CHECK: bb0([[ARG1:%[0-9]+]] : @trivial $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : @unowned $Builtin.NativeObject):
 // CHECK: load [take] [[ARG1]] : $*Builtin.NativeObject
 // CHECK: load [copy] [[ARG1]] : $*Builtin.NativeObject
 // CHECK: store [[ARG2]] to [init] [[ARG1]] : $*Builtin.NativeObject
 // CHECK: store [[ARG2]] to [assign] [[ARG1]] : $*Builtin.NativeObject
 sil @non_trivial : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
-bb0(%0 : $*Builtin.NativeObject, %1 : $Builtin.NativeObject):
+bb0(%0 : @trivial $*Builtin.NativeObject, %1 : @unowned $Builtin.NativeObject):
   load [take] %0 : $*Builtin.NativeObject
   load [copy] %0 : $*Builtin.NativeObject
   store %1 to [init] %0 : $*Builtin.NativeObject
@@ -20,11 +20,11 @@ bb0(%0 : $*Builtin.NativeObject, %1 : $Builtin.NativeObject):
 }
 
 // CHECK-LABEL: sil @trivial : $@convention(thin) (@in Builtin.Int32, Builtin.Int32) -> () {
-// CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.Int32, [[ARG2:%[0-9]+]] : $Builtin.Int32):
+// CHECK: bb0([[ARG1:%[0-9]+]] : @trivial $*Builtin.Int32, [[ARG2:%[0-9]+]] : @trivial $Builtin.Int32):
 // CHECK: load [trivial] [[ARG1]] : $*Builtin.Int32
 // CHECK: store [[ARG2]] to [trivial] [[ARG1]] : $*Builtin.Int32
 sil @trivial : $@convention(thin) (@in Builtin.Int32, Builtin.Int32) -> () {
-bb0(%0 : $*Builtin.Int32, %1 : $Builtin.Int32):
+bb0(%0 : @trivial $*Builtin.Int32, %1 : @trivial $Builtin.Int32):
   load [trivial] %0 : $*Builtin.Int32
   store %1 to [trivial] %0 : $*Builtin.Int32
   %2 = tuple()

--- a/test/SIL/Parser/self.sil
+++ b/test/SIL/Parser/self.sil
@@ -15,7 +15,7 @@ class SelfTest {}
 sil_vtable SelfTest {}
 
 sil @test_stuff : $@convention(method) (@owned SelfTest) -> () {
-bb0(%0 : $SelfTest):
+bb0(%0 : @owned $SelfTest):
   // CHECK: metatype $@thick @dynamic_self SelfTest
   %2 = metatype $@thick @dynamic_self SelfTest.Type
   // CHECK: metatype $@thick Optional<@dynamic_self SelfTest>.Type

--- a/test/SIL/Parser/typed_boxes.sil
+++ b/test/SIL/Parser/typed_boxes.sil
@@ -4,7 +4,7 @@ import Swift
 
 // CHECK-LABEL: sil @alloc_dealloc : $@convention(thin) (Int) -> () {
 sil @alloc_dealloc : $@convention(thin) (Int) -> () {
-entry(%x : $Int):
+entry(%x : @trivial $Int):
   // CHECK: [[B:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
   %b = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
   // CHECK: [[PB:%.*]] = project_box [[B]] : $<τ_0_0> { var τ_0_0 } <Int>, 0

--- a/test/SIL/Parser/unmanaged.sil
+++ b/test/SIL/Parser/unmanaged.sil
@@ -6,7 +6,7 @@ import Builtin
 class C {}
 
 sil @test : $@convention(thin) <U where U : AnyObject> (@inout Optional<U>) -> () {
-bb0(%0 : $*Optional<U>):
+bb0(%0 : @trivial $*Optional<U>):
   %1 = load [copy] %0 : $*Optional<U>
   %2 = ref_to_unmanaged %1 : $Optional<U> to $@sil_unmanaged Optional<U>
   %3 = unmanaged_to_ref %2 : $@sil_unmanaged Optional<U> to $Optional<U>
@@ -16,7 +16,7 @@ bb0(%0 : $*Optional<U>):
 }
 
 sil @retain_release : $@convention(thin) (@sil_unmanaged Optional<C>) -> () {
-bb0(%0 : $@sil_unmanaged Optional<C>):
+bb0(%0 : @unowned $@sil_unmanaged Optional<C>):
   %1 = unmanaged_to_ref %0 : $@sil_unmanaged Optional<C> to $Optional<C>
   unmanaged_retain_value %1 : $Optional<C>
   unmanaged_autorelease_value %1 : $Optional<C>

--- a/test/SIL/Parser/where_clause.sil
+++ b/test/SIL/Parser/where_clause.sil
@@ -12,6 +12,6 @@ struct Spoon<T: Runcible> {}
 
 // CHECK: sil @foo : $@convention(thin) <T where T : Runcible, T == T.Mince> () -> @out Spoon<T>
 sil @foo : $@convention(thin) <T where T: Runcible, T == T.Mince> () -> @out Spoon<T> {
-entry(%0 : $*Spoon<T>):
+entry(%0 : @trivial $*Spoon<T>):
   return undef : $()
 }

--- a/test/SIL/Serialization/Inputs/function_param_convention_input.sil
+++ b/test/SIL/Serialization/Inputs/function_param_convention_input.sil
@@ -4,7 +4,7 @@ struct X {}
 // Make sure that we can deserialize an apply with various parameter calling
 // conventions.
 sil [serialized] @foo : $@convention(thin) (@in X, @inout X, @in_guaranteed X, @owned X, X, @guaranteed X) -> @out X {
-bb0(%0 : $*X, %1 : $*X, %2 : $*X, %3 : $*X, %4 : $X, %5 : $X, %6 : $X):
+bb0(%0 : @trivial $*X, %1 : @trivial $*X, %2 : @trivial $*X, %3 : @trivial $*X, %4 : @owned $X, %5 : @unowned $X, %6 : @guaranteed $X):
   %9999 = tuple()
   return %9999 : $()
 }

--- a/test/SIL/Serialization/Inputs/generic_shared_function_helper.sil
+++ b/test/SIL/Serialization/Inputs/generic_shared_function_helper.sil
@@ -6,7 +6,7 @@ import Swift
 sil public_external @impl_func : $@convention(thin) <T> () -> @out Optional<T>
 
 sil shared [serialized] @shared_func : $@convention(thin) <T> () -> @out Optional<T> {
-bb0(%0 : $*Optional<T>):
+bb0(%0 : @trivial $*Optional<T>):
   %1 = function_ref @impl_func : $@convention(thin) <τ_0_0> () -> @out Optional<τ_0_0> // user: %2
   %2 = apply %1<T>(%0) : $@convention(thin) <τ_0_0> () -> @out Optional<τ_0_0>
   %3 = tuple ()                                   // user: %4
@@ -14,7 +14,7 @@ bb0(%0 : $*Optional<T>):
 }
 
 sil public [serialized] @public_func : $@convention(thin) <T> () -> @out Optional<T> {
-bb0(%0 : $*Optional<T>):
+bb0(%0 : @trivial $*Optional<T>):
   %1 = function_ref @shared_func : $@convention(thin) <τ_0_0> () -> @out Optional<τ_0_0> // user: %2
   %2 = apply %1<T>(%0) : $@convention(thin) <τ_0_0> () -> @out Optional<τ_0_0>
   %3 = tuple ()                                   // user: %4

--- a/test/SIL/Serialization/Recovery/function.sil
+++ b/test/SIL/Serialization/Recovery/function.sil
@@ -13,7 +13,7 @@ import Types
 // CHECK-LABEL: sil @missingParam : $@convention(thin) (SoonToBeMissing) -> () {
 // CHECK-RECOVERY-NEGATIVE-NOT: sil @missingParam
 sil @missingParam : $@convention(thin) (SoonToBeMissing) -> () {
-entry(%arg: $SoonToBeMissing):
+entry(%arg : @unowned $SoonToBeMissing):
   %9999 = tuple()
   return %9999 : $()
 }

--- a/test/SIL/Serialization/basic.sil
+++ b/test/SIL/Serialization/basic.sil
@@ -9,7 +9,7 @@ import Builtin
 // CHECK-LABEL: sil [serialized] @test_unchecked_ownership_conversion : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 // CHECK: unchecked_ownership_conversion {{%.*}} : $Builtin.NativeObject, @guaranteed to @owned
 sil [serialized] @test_unchecked_ownership_conversion : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
-bb0(%0 : $Builtin.NativeObject):
+bb0(%0 : @guaranteed $Builtin.NativeObject):
   unchecked_ownership_conversion %0 : $Builtin.NativeObject, @guaranteed to @owned
   return undef : $()
 }
@@ -17,7 +17,7 @@ bb0(%0 : $Builtin.NativeObject):
 // CHECK-LABEL: sil [serialized] @test_end_lifetime : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 // CHECK: end_lifetime {{%.*}} : $Builtin.NativeObject
 sil [serialized] @test_end_lifetime : $@convention(thin) (@owned Builtin.NativeObject) -> () {
-bb0(%0 : $Builtin.NativeObject):
+bb0(%0 : @owned $Builtin.NativeObject):
   end_lifetime %0 : $Builtin.NativeObject
   return undef : $()
 }
@@ -38,7 +38,7 @@ struct Int32 {
 }
 
 sil @test_destructure_struct_tuple : $@convention(thin) (@owned (Builtin.NativeObject, Builtin.Int32), @owned TestArray2) -> @owned (Builtin.NativeObject, Builtin.Int32, TestArrayStorage, Int32, TestArrayStorage) {
-bb0(%0 : $(Builtin.NativeObject, Builtin.Int32), %1 : $TestArray2):
+bb0(%0 : @owned $(Builtin.NativeObject, Builtin.Int32), %1 : @owned $TestArray2):
   (%2, %3) = destructure_tuple %0 : $(Builtin.NativeObject, Builtin.Int32)
   (%4, %5, %6) = destructure_struct %1 : $TestArray2
   %7 = tuple(%2 : $Builtin.NativeObject, %3 : $Builtin.Int32, %4 : $TestArrayStorage, %5 : $Int32, %6 : $TestArrayStorage)

--- a/test/SIL/Serialization/borrow.sil
+++ b/test/SIL/Serialization/borrow.sil
@@ -10,7 +10,7 @@ import Builtin
 
 // We do not verify here, but just make sure that all of the combinations parse and print correctly.
 // CHECK-LABEL: sil [serialized] @borrow_test : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
-// CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : $Builtin.NativeObject):
+// CHECK: bb0([[ARG1:%[0-9]+]] : @trivial $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : @unowned $Builtin.NativeObject):
 // CHECK: begin_borrow [[ARG2]]
 // CHECK: [[MEM:%.*]] = alloc_stack $Builtin.NativeObject
 // CHECK: store_borrow [[ARG2]] to [[MEM]] : $*Builtin.NativeObject
@@ -19,7 +19,7 @@ import Builtin
 // CHECK: end_borrow [[ARG1]] from [[ARG1]] : $*Builtin.NativeObject, $*Builtin.NativeObject
 // CHECK: end_borrow [[ARG2]] from [[ARG2]] : $Builtin.NativeObject, $Builtin.NativeObject
 sil [serialized] @borrow_test : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
-bb0(%0 : $*Builtin.NativeObject, %1 : $Builtin.NativeObject):
+bb0(%0 : @trivial $*Builtin.NativeObject, %1 : @unowned $Builtin.NativeObject):
   %2 = begin_borrow %1 : $Builtin.NativeObject
   end_borrow %2 from %1 : $Builtin.NativeObject, $Builtin.NativeObject
 

--- a/test/SIL/Serialization/boxes.sil
+++ b/test/SIL/Serialization/boxes.sil
@@ -33,7 +33,7 @@ sil hidden [serialized] @box_type_parsing : $@convention(thin) (
   <X, Y, Z>{ var X, let Z }<Int, String, Optional<Double>>
 // CHECK: ) -> ()
 ) -> () {
-entry(%0 : $<E>{ var E }<F>, %1 : $<F: P>{ let F }<G>, %2 : $<G: P>{ var G }<Q>, %3 : ${ let Int }, %4 : ${ var Int, let String }, %5 : ${}, %6 : $<XX, YY, ZZ>{ var XX, let ZZ }<Int, String, Optional<Double>>):
+entry(%0 : @unowned $<E>{ var E }<F>, %1 : @unowned $<F: P>{ let F }<G>, %2 : @unowned $<G: P>{ var G }<Q>, %3 : @unowned ${ let Int }, %4 : @unowned ${ var Int, let String }, %5 : @unowned ${}, %6 : @unowned $<XX, YY, ZZ>{ var XX, let ZZ }<Int, String, Optional<Double>>):
   unreachable
 }
 
@@ -55,7 +55,7 @@ sil hidden [serialized] @box_type_parsing_in_generic_function : $@convention(thi
   <X, Y, Z>{ var X, let Z }<Int, String, Optional<Double>>
 // CHECK: ) -> ()
 ) -> () {
-entry(%0 : $<E>{ var E }<F>, %1 : $<F: P>{ let F }<G>, %2 : $<G: P>{ var G }<Q>, %3 : ${ let Int }, %4 : ${ var Int, let String }, %5 : ${}, %6 : $<XX, YY, ZZ>{ var XX, let ZZ }<Int, String, Optional<Double>>):
+entry(%0 : @unowned $<E>{ var E }<F>, %1 : @unowned $<F: P>{ let F }<G>, %2 : @unowned $<G: P>{ var G }<Q>, %3 : @unowned ${ let Int }, %4 : @unowned ${ var Int, let String }, %5 : @unowned ${}, %6 : @unowned $<XX, YY, ZZ>{ var XX, let ZZ }<Int, String, Optional<Double>>):
   unreachable
 }
 
@@ -67,7 +67,7 @@ sil hidden [serialized] @same_generic_param_name_in_multiple_box_signatures : $@
   <A> { var A } <String>
 // CHECK: ) -> ()
 ) -> () {
-entry(%0 : $<A> { var A } <Int>, %1 : $<A> { var A } <String>):
+entry(%0 : @unowned $<A> { var A } <Int>, %1 : @unowned $<A> { var A } <String>):
   unreachable
 }
 
@@ -77,20 +77,20 @@ sil hidden [serialized] @same_generic_param_name_in_outer_scope : $@convention(t
   <A> { var A } <A>
 // CHECK: ) -> ()
 ) -> () {
-entry(%0 : $<B> { var B } <A>):
+entry(%0 : @unowned $<B> { var B } <A>):
   unreachable
 }
 
 // CHECK-LABEL: sil hidden [serialized] @box_ownership : $@convention(thin) (@owned { var Int }, @guaranteed <τ_0_0> { let τ_0_0 } <Int>) -> ()
 sil hidden [serialized ]@box_ownership : $@convention(thin) (@owned { var Int }, @guaranteed <T> { let T } <Int>) -> () {
-entry(%0 : ${ var Int }, %1 : $<T> { let T } <Int>):
+entry(%0 : @owned ${ var Int }, %1 : @guaranteed $<T> { let T } <Int>):
   unreachable
 }
 
 // CHECK-LABEL: sil hidden [serialized] @address_of_box
 sil hidden [serialized] @address_of_box : $@convention(thin) (@in { var Int }, @in <T> { let T } <Int>) -> () {
-// CHECK: %0 : $*{ var Int }, %1 : $*<τ_0_0> { let τ_0_0 } <Int>
-entry(%0 : $*{ var Int }, %1 : $*<T> { let T } <Int>):
+// CHECK: %0 : @trivial $*{ var Int }, %1 : @trivial $*<τ_0_0> { let τ_0_0 } <Int>
+entry(%0 : @trivial $*{ var Int }, %1 : @trivial $*<T> { let T } <Int>):
   unreachable
 }
 

--- a/test/SIL/Serialization/copy_value_destroy_value.sil
+++ b/test/SIL/Serialization/copy_value_destroy_value.sil
@@ -10,24 +10,24 @@ import Builtin
 
 
 // CHECK-LABEL: sil [serialized] @test_copy_unowned_value : $@convention(thin) (@owned @sil_unowned Builtin.NativeObject) -> @owned Builtin.NativeObject {
-// CHECK: bb0([[T0:%[0-9]+]] : $@sil_unowned Builtin.NativeObject):
+// CHECK: bb0([[T0:%[0-9]+]] : @owned $@sil_unowned Builtin.NativeObject):
 // CHECK-NEXT: [[COPY_RESULT:%.*]] = copy_unowned_value [[T0]] : $@sil_unowned Builtin.NativeObject
 // CHECK-NEXT: destroy_value [[T0]] : $@sil_unowned Builtin.NativeObject
 // CHECK-NEXT: return [[COPY_RESULT]] : $Builtin.NativeObject
 sil [serialized] @test_copy_unowned_value : $@convention(thin) (@owned @sil_unowned Builtin.NativeObject) -> @owned Builtin.NativeObject {
-bb0(%0 : $@sil_unowned Builtin.NativeObject):
+bb0(%0 : @owned $@sil_unowned Builtin.NativeObject):
   %1 = copy_unowned_value %0 : $@sil_unowned Builtin.NativeObject
   destroy_value %0 : $@sil_unowned Builtin.NativeObject
   return %1 : $Builtin.NativeObject
 }
 
 // CHECK-LABEL: sil [serialized] @test : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
-// CHECK: bb0([[ARG1:%[0-9]+]] : $Builtin.NativeObject):
+// CHECK: bb0([[ARG1:%[0-9]+]] : @owned $Builtin.NativeObject):
 // CHECK: [[COPY_VALUE_RESULT:%[0-9]+]] = copy_value [[ARG1]] : $Builtin.NativeObject
 // CHECK: destroy_value [[ARG1]]
 // CHECK: return [[COPY_VALUE_RESULT]]
 sil [serialized] @test : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
-bb0(%0 : $Builtin.NativeObject):
+bb0(%0 : @owned $Builtin.NativeObject):
   %1 = copy_value %0 : $Builtin.NativeObject
   destroy_value %0 : $Builtin.NativeObject
   return %1 : $Builtin.NativeObject

--- a/test/SIL/Serialization/keypath.sil
+++ b/test/SIL/Serialization/keypath.sil
@@ -131,8 +131,8 @@ entry:
 
 // CHECK-LABEL: sil shared [serialized] @indexes
 sil shared [serialized] @indexes : $@convention(thin) (S, C) -> () {
-// CHECK: bb0([[S:%.*]] : $S, [[C:%.*]] : $C):
-entry(%s : $S, %c : $C):
+// CHECK: bb0([[S:%.*]] : @unowned $S, [[C:%.*]] : @unowned $C):
+entry(%s : @unowned $S, %c : @unowned $C):
   // CHECK: keypath $KeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int_subs : $@convention(thin) (@in_guaranteed S, UnsafeRawPointer) -> @out Int, setter @set_s_int_subs : $@convention(thin) (@in_guaranteed Int, @in_guaranteed S, UnsafeRawPointer) -> (), indices [%$0 : $S : $S, %$1 : $C : $C], indices_equals @subs_eq : $@convention(thin) (UnsafeRawPointer, UnsafeRawPointer) -> Bool, indices_hash @subs_hash : $@convention(thin) (UnsafeRawPointer) -> Int) ([[S]], [[C]])
   %a = keypath $KeyPath<S, Int>, (root $S; settable_property $Int, id @id_a : $@convention(thin) () -> (), getter @get_s_int_subs : $@convention(thin) (@in_guaranteed S, UnsafeRawPointer) -> @out Int, setter @set_s_int_subs : $@convention(thin) (@in_guaranteed Int, @in_guaranteed S, UnsafeRawPointer) -> (), indices [%$0 : $S : $S, %$1 : $C : $C], indices_equals @subs_eq : $@convention(thin) (UnsafeRawPointer, UnsafeRawPointer) -> Bool, indices_hash @subs_hash : $@convention(thin) (UnsafeRawPointer) -> Int) (%s, %c)
   // CHECK: [[T:%.*]] = alloc_stack

--- a/test/SIL/Serialization/ownership_qualified_memopts.sil
+++ b/test/SIL/Serialization/ownership_qualified_memopts.sil
@@ -10,11 +10,11 @@ import Builtin
 
 
 // CHECK-LABEL: sil [serialized] @trivial : $@convention(thin) (@in Builtin.Int32, Builtin.Int32) -> () {
-// CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.Int32, [[ARG2:%[0-9]+]] : $Builtin.Int32):
+// CHECK: bb0([[ARG1:%[0-9]+]] : @trivial $*Builtin.Int32, [[ARG2:%[0-9]+]] : @trivial $Builtin.Int32):
 // CHECK: load [trivial] [[ARG1]] : $*Builtin.Int32
 // CHECK: store [[ARG2]] to [trivial] [[ARG1]] : $*Builtin.Int32
 sil [serialized] @trivial : $@convention(thin) (@in Builtin.Int32, Builtin.Int32) -> () {
-bb0(%0 : $*Builtin.Int32, %1 : $Builtin.Int32):
+bb0(%0 : @trivial $*Builtin.Int32, %1 : @trivial $Builtin.Int32):
   load [trivial] %0 : $*Builtin.Int32
   store %1 to [trivial] %0 : $*Builtin.Int32
   %2 = tuple()
@@ -22,13 +22,13 @@ bb0(%0 : $*Builtin.Int32, %1 : $Builtin.Int32):
 }
 
 // CHECK-LABEL: sil [serialized] @non_trivial : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
-// CHECK: bb0([[ARG1:%[0-9]+]] : $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : $Builtin.NativeObject):
+// CHECK: bb0([[ARG1:%[0-9]+]] : @trivial $*Builtin.NativeObject, [[ARG2:%[0-9]+]] : @unowned $Builtin.NativeObject):
 // CHECK: load [take] [[ARG1]] : $*Builtin.NativeObject
 // CHECK: load [copy] [[ARG1]] : $*Builtin.NativeObject
 // CHECK: store [[ARG2]] to [init] [[ARG1]] : $*Builtin.NativeObject
 // CHECK: store [[ARG2]] to [assign] [[ARG1]] : $*Builtin.NativeObject
 sil [serialized] @non_trivial : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
-bb0(%0 : $*Builtin.NativeObject, %1 : $Builtin.NativeObject):
+bb0(%0 : @trivial $*Builtin.NativeObject, %1 : @unowned $Builtin.NativeObject):
   load [take] %0 : $*Builtin.NativeObject
   load [copy] %0 : $*Builtin.NativeObject
   store %1 to [init] %0 : $*Builtin.NativeObject

--- a/test/SIL/Serialization/unmanaged.sil
+++ b/test/SIL/Serialization/unmanaged.sil
@@ -10,13 +10,13 @@ import Builtin
 class C {}
 
 // CHECK-LABEL: sil [serialized] @retain_release : $@convention(thin) (@sil_unmanaged Optional<C>) -> () {
-// CHECK: bb0([[ARG:%.*]] : $@sil_unmanaged Optional<C>):
+// CHECK: bb0([[ARG:%.*]] : @trivial $@sil_unmanaged Optional<C>):
 // CHECK: [[REF:%.*]] = unmanaged_to_ref [[ARG]] : $@sil_unmanaged Optional<C> to $Optional<C>
 // CHECK: unmanaged_retain_value [[REF]]
 // CHECK: unmanaged_autorelease_value [[REF]]
 // CHECK: unmanaged_release_value [[REF]]
 sil [serialized] @retain_release : $@convention(thin) (@sil_unmanaged Optional<C>) -> () {
-bb0(%0 : $@sil_unmanaged Optional<C>):
+bb0(%0 : @unowned $@sil_unmanaged Optional<C>):
   %1 = unmanaged_to_ref %0 : $@sil_unmanaged Optional<C> to $Optional<C>
   unmanaged_retain_value %1 : $Optional<C>
   unmanaged_autorelease_value %1 : $Optional<C>
@@ -26,13 +26,13 @@ bb0(%0 : $@sil_unmanaged Optional<C>):
 }
 
 // CHECK-LABEL: sil [serialized] @test : $@convention(thin) <U where U : AnyObject> (@inout Optional<U>) -> () {
-// CHECK: bb0([[ARG:%.*]] : $*Optional<U>):
+// CHECK: bb0([[ARG:%.*]] : @trivial $*Optional<U>):
 // CHECK: [[LOADED_ARG:%.*]] = load [copy] [[ARG]]
 // CHECK: [[UNMANAGED_LOADED_ARG:%.*]] = ref_to_unmanaged [[LOADED_ARG]] : $Optional<U> to $@sil_unmanaged Optional<U>
 // CHECK: {{%.*}} = unmanaged_to_ref [[UNMANAGED_LOADED_ARG]] : $@sil_unmanaged Optional<U> to $Optional<U>
 // CHECK: destroy_value [[LOADED_ARG]]
 sil [serialized] @test : $@convention(thin) <U where U : AnyObject> (@inout Optional<U>) -> () {
-bb0(%0 : $*Optional<U>):
+bb0(%0 : @trivial $*Optional<U>):
   %1 = load [copy] %0 : $*Optional<U>
   %2 = ref_to_unmanaged %1 : $Optional<U> to $@sil_unmanaged Optional<U>
   %3 = unmanaged_to_ref %2 : $@sil_unmanaged Optional<U> to $Optional<U>

--- a/test/SIL/restricted-partial-apply.sil
+++ b/test/SIL/restricted-partial-apply.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -module-name main -disable-sil-partial-apply -emit-sil -verify %s
+// RUN: %target-swift-frontend -module-name main -disable-sil-partial-apply -emit-sil -sil-verify-all %s
 sil_stage canonical
 import Builtin
 
@@ -13,7 +13,7 @@ sil @g_box_context : $@convention(thin) (@guaranteed <τ_0_0> { var τ_0_0 } <Bu
 sil @g_class_context : $@convention(thin) (@guaranteed C) -> ()
 
 sil @limited_partial_applies : $@convention(thin) (Builtin.NativeObject, <τ_0_0> { var τ_0_0 } <Builtin.Word>, C) -> () {
-entry(%0 : $Builtin.NativeObject, %1 : $<τ_0_0> { var τ_0_0 } <Builtin.Word>, %2 : $C):
+entry(%0 : @unowned $Builtin.NativeObject, %1 : @unowned $<τ_0_0> { var τ_0_0 } <Builtin.Word>, %2 : @unowned $C):
   %a = function_ref @native_object_context : $@convention(thin) (@owned Builtin.NativeObject) -> ()
   %b = function_ref @box_context : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Builtin.Word>) -> ()
   %c = function_ref @class_context : $@convention(thin) (@owned C) -> ()

--- a/test/SILGen/accessibility_vtables.swift
+++ b/test/SILGen/accessibility_vtables.swift
@@ -13,7 +13,7 @@ class Sub : Base {
 }
 
 // CHECK-LABEL: sil hidden @$S21accessibility_vtables3SubCACycfc : $@convention(method) (@owned Sub) -> @owned Sub
-// CHECK:       bb0(%0 : $Sub):
+// CHECK:       bb0(%0 : @owned $Sub):
 // CHECK:         function_ref @$Ss25_unimplementedInitializer9className04initD04file4line6columns5NeverOs12StaticStringV_A2JS2utF
 
 // CHECK-LABEL: sil_vtable Sub {

--- a/test/SILGen/cf.swift
+++ b/test/SILGen/cf.swift
@@ -3,7 +3,7 @@
 import CoreCooling
 
 // CHECK: sil hidden @$S2cf8useEmAllyySo16CCMagnetismModelCF :
-// CHECK: bb0([[ARG:%.*]] : $CCMagnetismModel):
+// CHECK: bb0([[ARG:%.*]] : @guaranteed $CCMagnetismModel):
 func useEmAll(_ model: CCMagnetismModel) {
 // CHECK: function_ref @CCPowerSupplyGetDefault : $@convention(c) () -> @autoreleased Optional<CCPowerSupply>
   let power = CCPowerSupplyGetDefault()

--- a/test/SILGen/class_bound_protocols.swift
+++ b/test/SILGen/class_bound_protocols.swift
@@ -35,7 +35,7 @@ class ConcreteSubclass : ConcreteClass { }
 // CHECK-LABEL: sil hidden @$Ss19class_bound_generic{{[_0-9a-zA-Z]*}}F
 func class_bound_generic<T : ClassBound>(x: T) -> T {
   var x = x
-  // CHECK: bb0([[X:%.*]] : $T):
+  // CHECK: bb0([[X:%.*]] : @guaranteed $T):
   // CHECK:   [[X_ADDR:%.*]] = alloc_box $<τ_0_0 where τ_0_0 : ClassBound> { var τ_0_0 } <T>
   // CHECK:   [[PB:%.*]] = project_box [[X_ADDR]]
   // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
@@ -50,7 +50,7 @@ func class_bound_generic<T : ClassBound>(x: T) -> T {
 // CHECK-LABEL: sil hidden @$Ss21class_bound_generic_2{{[_0-9a-zA-Z]*}}F
 func class_bound_generic_2<T : ClassBound & NotClassBound>(x: T) -> T {
   var x = x
-  // CHECK: bb0([[X:%.*]] : $T):
+  // CHECK: bb0([[X:%.*]] : @guaranteed $T):
   // CHECK:   [[X_ADDR:%.*]] = alloc_box $<τ_0_0 where τ_0_0 : ClassBound, τ_0_0 : NotClassBound> { var τ_0_0 } <T>
   // CHECK:   [[PB:%.*]] = project_box [[X_ADDR]]
   // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
@@ -64,7 +64,7 @@ func class_bound_generic_2<T : ClassBound & NotClassBound>(x: T) -> T {
 // CHECK-LABEL: sil hidden @$Ss20class_bound_protocol{{[_0-9a-zA-Z]*}}F
 func class_bound_protocol(x: ClassBound) -> ClassBound {
   var x = x
-  // CHECK: bb0([[X:%.*]] : $ClassBound):
+  // CHECK: bb0([[X:%.*]] : @guaranteed $ClassBound):
   // CHECK:   [[X_ADDR:%.*]] = alloc_box ${ var ClassBound }
   // CHECK:   [[PB:%.*]] = project_box [[X_ADDR]]
   // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
@@ -79,7 +79,7 @@ func class_bound_protocol(x: ClassBound) -> ClassBound {
 func class_bound_protocol_composition(x: ClassBound & NotClassBound)
 -> ClassBound & NotClassBound {
   var x = x
-  // CHECK: bb0([[X:%.*]] : $ClassBound & NotClassBound):
+  // CHECK: bb0([[X:%.*]] : @guaranteed $ClassBound & NotClassBound):
   // CHECK:   [[X_ADDR:%.*]] = alloc_box ${ var ClassBound & NotClassBound }
   // CHECK:   [[PB:%.*]] = project_box [[X_ADDR]]
   // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
@@ -101,7 +101,7 @@ func class_bound_erasure(x: ConcreteClass) -> ClassBound {
 func class_bound_existential_upcast(x: ClassBound & ClassBound2)
 -> ClassBound {
   return x
-  // CHECK: bb0([[ARG:%.*]] : $ClassBound & ClassBound2):
+  // CHECK: bb0([[ARG:%.*]] : @guaranteed $ClassBound & ClassBound2):
   // CHECK:   [[OPENED:%.*]] = open_existential_ref [[ARG]] : $ClassBound & ClassBound2 to [[OPENED_TYPE:\$@opened(.*) ClassBound & ClassBound2]]
   // CHECK:   [[OPENED_COPY:%.*]] = copy_value [[OPENED]]
   // CHECK:   [[PROTO:%.*]] = init_existential_ref [[OPENED_COPY]] : [[OPENED_TYPE]] : [[OPENED_TYPE]], $ClassBound
@@ -110,7 +110,7 @@ func class_bound_existential_upcast(x: ClassBound & ClassBound2)
 // CHECK: } // end sil function '$Ss30class_bound_existential_upcast1xs10ClassBound_psAC_s0E6Bound2p_tF'
 
 // CHECK-LABEL: sil hidden @$Ss41class_bound_to_unbound_existential_upcast1xs13NotClassBound_ps0hI0_sACp_tF :
-// CHECK: bb0([[ARG0:%.*]] : $*NotClassBound, [[ARG1:%.*]] : $ClassBound & NotClassBound):
+// CHECK: bb0([[ARG0:%.*]] : @trivial $*NotClassBound, [[ARG1:%.*]] : @guaranteed $ClassBound & NotClassBound):
 // CHECK:   [[X_OPENED:%.*]] = open_existential_ref [[ARG1]] : $ClassBound & NotClassBound to [[OPENED_TYPE:\$@opened(.*) ClassBound & NotClassBound]]
 // CHECK:   [[PAYLOAD_ADDR:%.*]] = init_existential_addr [[ARG0]] : $*NotClassBound, [[OPENED_TYPE]]
 // CHECK:   [[X_OPENED_COPY:%.*]] = copy_value [[X_OPENED]]
@@ -121,7 +121,7 @@ func class_bound_to_unbound_existential_upcast
 }
 
 // CHECK-LABEL: sil hidden @$Ss18class_bound_method1xys10ClassBound_p_tF :
-// CHECK: bb0([[ARG:%.*]] : $ClassBound):
+// CHECK: bb0([[ARG:%.*]] : @guaranteed $ClassBound):
 func class_bound_method(x: ClassBound) {
   var x = x
   x.classBoundMethod()

--- a/test/SILGen/collection_downcast.swift
+++ b/test/SILGen/collection_downcast.swift
@@ -42,7 +42,7 @@ struct BridgedSwift : Hashable, _ObjectiveCBridgeable {
 func == (x: BridgedSwift, y: BridgedSwift) -> Bool { return true }
 
 // CHECK-LABEL: sil hidden @$S19collection_downcast17testArrayDowncast{{.*}}F
-// CHECK: bb0([[ARRAY:%[0-9]+]] : $Array<AnyObject>):
+// CHECK: bb0([[ARRAY:%[0-9]+]] : @guaranteed $Array<AnyObject>):
 func testArrayDowncast(_ array: [AnyObject]) -> [BridgedObjC] {
   // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[ARRAY]]
   // CHECK: [[DOWNCAST_FN:%[0-9]+]] = function_ref @$Ss15_arrayForceCast{{.*}}F
@@ -51,21 +51,21 @@ func testArrayDowncast(_ array: [AnyObject]) -> [BridgedObjC] {
 }
 
 // CHECK-LABEL: sil hidden @$S19collection_downcast27testArrayDowncastFromObject{{.*}}F
-// CHECK: bb0([[OBJ:%[0-9]+]] : $AnyObject):
+// CHECK: bb0([[OBJ:%[0-9]+]] : @guaranteed $AnyObject):
 func testArrayDowncastFromObject(_ obj: AnyObject) -> [BridgedObjC] {
   // CHECK: unconditional_checked_cast_addr AnyObject in [[OBJECT_ALLOC:%[0-9]+]] : $*AnyObject to Array<BridgedObjC> in [[VALUE_ALLOC:%[0-9]+]] : $*Array<BridgedObjC>
   return obj as! [BridgedObjC]
 }
 
 // CHECK-LABEL: sil hidden @$S19collection_downcast28testArrayDowncastFromNSArray{{.*}}F
-// CHECK: bb0([[NSARRAY_OBJ:%[0-9]+]] : $NSArray):
+// CHECK: bb0([[NSARRAY_OBJ:%[0-9]+]] : @guaranteed $NSArray):
 func testArrayDowncastFromNSArray(_ obj: NSArray) -> [BridgedObjC] {
   // CHECK: unconditional_checked_cast_addr NSArray in [[OBJECT_ALLOC:%[0-9]+]] : $*NSArray to Array<BridgedObjC> in [[VALUE_ALLOC:%[0-9]+]] : $*Array<BridgedObjC>
   return obj as! [BridgedObjC]
 }
 
 // CHECK-LABEL: sil hidden @$S19collection_downcast28testArrayDowncastConditional{{.*}}F
-// CHECK: bb0([[ARRAY:%[0-9]+]] : $Array<AnyObject>):
+// CHECK: bb0([[ARRAY:%[0-9]+]] : @guaranteed $Array<AnyObject>):
 func testArrayDowncastConditional(_ array: [AnyObject]) -> [BridgedObjC]? {
   // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[ARRAY]]
   // CHECK: [[DOWNCAST_FN:%[0-9]+]] = function_ref @$Ss21_arrayConditionalCast{{.*}}F
@@ -75,7 +75,7 @@ func testArrayDowncastConditional(_ array: [AnyObject]) -> [BridgedObjC]? {
 // CHECK: } // end sil function '$S19collection_downcast28testArrayDowncastConditional{{.*}}F'
 
 // CHECK-LABEL: sil hidden @$S19collection_downcast12testArrayIsa{{.*}}F
-// CHECK: bb0([[ARRAY:%[0-9]+]] : $Array<AnyObject>)
+// CHECK: bb0([[ARRAY:%[0-9]+]] : @guaranteed $Array<AnyObject>)
 func testArrayIsa(_ array: [AnyObject]) -> Bool {
   // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[ARRAY]]
   // CHECK: [[DOWNCAST_FN:%[0-9]+]] = function_ref @$Ss21_arrayConditionalCast{{.*}}F
@@ -85,7 +85,7 @@ func testArrayIsa(_ array: [AnyObject]) -> Bool {
 }
 
 // CHECK-LABEL: sil hidden @$S19collection_downcast24testArrayDowncastBridged{{.*}}F
-// CHECK: bb0([[ARRAY:%[0-9]+]] : $Array<AnyObject>):
+// CHECK: bb0([[ARRAY:%[0-9]+]] : @guaranteed $Array<AnyObject>):
 func testArrayDowncastBridged(_ array: [AnyObject]) -> [BridgedSwift] {
   // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[ARRAY]]
   // CHECK: [[BRIDGE_FN:%[0-9]+]] = function_ref @$Ss15_arrayForceCast{{.*}}F
@@ -95,7 +95,7 @@ func testArrayDowncastBridged(_ array: [AnyObject]) -> [BridgedSwift] {
 }
 
 // CHECK-LABEL: sil hidden @$S19collection_downcast35testArrayDowncastBridgedConditional{{.*}}F
-// CHECK: bb0([[ARRAY:%[0-9]+]] : $Array<AnyObject>):
+// CHECK: bb0([[ARRAY:%[0-9]+]] : @guaranteed $Array<AnyObject>):
 func testArrayDowncastBridgedConditional(_ array: [AnyObject]) -> [BridgedSwift]?{
   // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[ARRAY]]
   // CHECK: [[BRIDGE_FN:%[0-9]+]] = function_ref @$Ss21_arrayConditionalCast{{.*}}F
@@ -105,7 +105,7 @@ func testArrayDowncastBridgedConditional(_ array: [AnyObject]) -> [BridgedSwift]
 }
 
 // CHECK-LABEL: sil hidden @$S19collection_downcast19testArrayIsaBridged{{.*}}F
-// CHECK: bb0([[ARRAY:%[0-9]+]] : $Array<AnyObject>)
+// CHECK: bb0([[ARRAY:%[0-9]+]] : @guaranteed $Array<AnyObject>)
 func testArrayIsaBridged(_ array: [AnyObject]) -> Bool {
   // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[ARRAY]]
   // CHECK: [[DOWNCAST_FN:%[0-9]+]] = function_ref @$Ss21_arrayConditionalCast{{.*}}F
@@ -115,7 +115,7 @@ func testArrayIsaBridged(_ array: [AnyObject]) -> Bool {
 }
 
 // CHECK-LABEL: sil hidden @$S19collection_downcast32testDictionaryDowncastFromObject{{.*}}F
-// CHECK: bb0([[OBJ:%[0-9]+]] : $AnyObject):
+// CHECK: bb0([[OBJ:%[0-9]+]] : @guaranteed $AnyObject):
 func testDictionaryDowncastFromObject(_ obj: AnyObject) 
        -> Dictionary<BridgedObjC, BridgedObjC> {
   // CHECK: unconditional_checked_cast_addr AnyObject in [[OBJECT_ALLOC:%[0-9]+]] : $*AnyObject to Dictionary<BridgedObjC, BridgedObjC> in [[VALUE_ALLOC:%[0-9]+]] : $*Dictionary<BridgedObjC, BridgedObjC>
@@ -123,7 +123,7 @@ func testDictionaryDowncastFromObject(_ obj: AnyObject)
 }
 
 // CHECK-LABEL: sil hidden @$S19collection_downcast22testDictionaryDowncast{{.*}}F
-// CHECK: bb0([[DICT:%[0-9]+]] : $Dictionary<NSObject, AnyObject>)
+// CHECK: bb0([[DICT:%[0-9]+]] : @guaranteed $Dictionary<NSObject, AnyObject>)
 func testDictionaryDowncast(_ dict: Dictionary<NSObject, AnyObject>) 
        -> Dictionary<BridgedObjC, BridgedObjC> {
   // CHECK: [[DICT_COPY:%.*]] = copy_value [[DICT]]
@@ -134,7 +134,7 @@ func testDictionaryDowncast(_ dict: Dictionary<NSObject, AnyObject>)
 }
 
 // CHECK-LABEL: sil hidden @$S19collection_downcast33testDictionaryDowncastConditional{{.*}}F
-// CHECK: bb0([[DICT:%[0-9]+]] : $Dictionary<NSObject, AnyObject>)
+// CHECK: bb0([[DICT:%[0-9]+]] : @guaranteed $Dictionary<NSObject, AnyObject>)
 func testDictionaryDowncastConditional(_ dict: Dictionary<NSObject, AnyObject>) 
 -> Dictionary<BridgedObjC, BridgedObjC>? {
   // CHECK: [[DICT_COPY:%.*]] = copy_value [[DICT]]
@@ -145,7 +145,7 @@ func testDictionaryDowncastConditional(_ dict: Dictionary<NSObject, AnyObject>)
 }
 
 // CHECK-LABEL: sil hidden @$S19collection_downcast41testDictionaryDowncastBridgedVConditional{{.*}}F
-// CHECK: bb0([[DICT:%[0-9]+]] : $Dictionary<NSObject, AnyObject>)
+// CHECK: bb0([[DICT:%[0-9]+]] : @guaranteed $Dictionary<NSObject, AnyObject>)
 func testDictionaryDowncastBridgedVConditional(_ dict: Dictionary<NSObject, AnyObject>) 
        -> Dictionary<BridgedObjC, BridgedSwift>? {
   // CHECK: [[DICT_COPY:%.*]] = copy_value [[DICT]]
@@ -156,7 +156,7 @@ func testDictionaryDowncastBridgedVConditional(_ dict: Dictionary<NSObject, AnyO
 }
 
 // CHECK-LABEL: sil hidden @$S19collection_downcast41testDictionaryDowncastBridgedKConditional{{.*}}F
-// CHECK: bb0([[DICT:%[0-9]+]] : $Dictionary<NSObject, AnyObject>)
+// CHECK: bb0([[DICT:%[0-9]+]] : @guaranteed $Dictionary<NSObject, AnyObject>)
 func testDictionaryDowncastBridgedKConditional(_ dict: Dictionary<NSObject, AnyObject>) 
 -> Dictionary<BridgedSwift, BridgedObjC>? {
   // CHECK: [[DICT_COPY:%.*]] = copy_value [[DICT]]
@@ -167,7 +167,7 @@ func testDictionaryDowncastBridgedKConditional(_ dict: Dictionary<NSObject, AnyO
 }
 
 // CHECK-LABEL: sil hidden @$S19collection_downcast31testDictionaryDowncastBridgedKV{{.*}}F
-// CHECK: bb0([[DICT:%[0-9]+]] : $Dictionary<NSObject, AnyObject>)
+// CHECK: bb0([[DICT:%[0-9]+]] : @guaranteed $Dictionary<NSObject, AnyObject>)
 func testDictionaryDowncastBridgedKV(_ dict: Dictionary<NSObject, AnyObject>) 
 -> Dictionary<BridgedSwift, BridgedSwift> {
   // CHECK: [[DICT_COPY:%.*]] = copy_value [[DICT]]
@@ -178,7 +178,7 @@ func testDictionaryDowncastBridgedKV(_ dict: Dictionary<NSObject, AnyObject>)
 }
 
 // CHECK-LABEL: sil hidden @$S19collection_downcast42testDictionaryDowncastBridgedKVConditional{{.*}}F
-// CHECK: bb0([[DICT:%[0-9]+]] : $Dictionary<NSObject, AnyObject>)
+// CHECK: bb0([[DICT:%[0-9]+]] : @guaranteed $Dictionary<NSObject, AnyObject>)
 func testDictionaryDowncastBridgedKVConditional(_ dict: Dictionary<NSObject, AnyObject>) 
        -> Dictionary<BridgedSwift, BridgedSwift>? {
   // CHECK: [[DICT_COPY:%.*]] = copy_value [[DICT]]
@@ -189,7 +189,7 @@ func testDictionaryDowncastBridgedKVConditional(_ dict: Dictionary<NSObject, Any
 }
 
 // CHECK-LABEL: sil hidden @$S19collection_downcast25testSetDowncastFromObject{{.*}}F
-// CHECK: bb0([[OBJ:%[0-9]+]] : $AnyObject):
+// CHECK: bb0([[OBJ:%[0-9]+]] : @guaranteed $AnyObject):
 func testSetDowncastFromObject(_ obj: AnyObject) 
        -> Set<BridgedObjC> {
   // CHECK: unconditional_checked_cast_addr AnyObject in [[OBJECT_ALLOC:%[0-9]+]] : $*AnyObject to Set<BridgedObjC> in [[VALUE_ALLOC:%[0-9]+]] : $*Set<BridgedObjC>
@@ -197,7 +197,7 @@ func testSetDowncastFromObject(_ obj: AnyObject)
 }
 
 // CHECK-LABEL: sil hidden @$S19collection_downcast15testSetDowncast{{.*}}F
-// CHECK: bb0([[SET:%[0-9]+]] : $Set<NSObject>)
+// CHECK: bb0([[SET:%[0-9]+]] : @guaranteed $Set<NSObject>)
 func testSetDowncast(_ dict: Set<NSObject>) 
        -> Set<BridgedObjC> {
   // CHECK: [[SET_COPY:%.*]] = copy_value [[SET]]
@@ -208,7 +208,7 @@ func testSetDowncast(_ dict: Set<NSObject>)
 }
 
 // CHECK-LABEL: sil hidden @$S19collection_downcast26testSetDowncastConditional{{.*}}F
-// CHECK: bb0([[SET:%[0-9]+]] : $Set<NSObject>)
+// CHECK: bb0([[SET:%[0-9]+]] : @guaranteed $Set<NSObject>)
 func testSetDowncastConditional(_ dict: Set<NSObject>) 
        -> Set<BridgedObjC>? {
   // CHECK: [[SET_COPY:%.*]] = copy_value [[SET]]
@@ -219,7 +219,7 @@ func testSetDowncastConditional(_ dict: Set<NSObject>)
 }
 
 // CHECK-LABEL: sil hidden @$S19collection_downcast22testSetDowncastBridged{{.*}}F
-// CHECK: bb0([[SET:%[0-9]+]] : $Set<NSObject>)
+// CHECK: bb0([[SET:%[0-9]+]] : @guaranteed $Set<NSObject>)
 func testSetDowncastBridged(_ dict: Set<NSObject>) 
        -> Set<BridgedSwift> {
   // CHECK: [[SET_COPY:%.*]] = copy_value [[SET]]
@@ -230,7 +230,7 @@ func testSetDowncastBridged(_ dict: Set<NSObject>)
 }
 
 // CHECK-LABEL: sil hidden @$S19collection_downcast33testSetDowncastBridgedConditional{{.*}}F
-// CHECK: bb0([[SET:%[0-9]+]] : $Set<NSObject>)
+// CHECK: bb0([[SET:%[0-9]+]] : @guaranteed $Set<NSObject>)
 func testSetDowncastBridgedConditional(_ dict: Set<NSObject>) 
        -> Set<BridgedSwift>? {
   // CHECK: [[SET_COPY:%.*]] = copy_value [[SET]]

--- a/test/SILGen/collection_upcast.swift
+++ b/test/SILGen/collection_upcast.swift
@@ -43,7 +43,7 @@ struct BridgedSwift : Hashable, _ObjectiveCBridgeable {
 func == (x: BridgedSwift, y: BridgedSwift) -> Bool { return true }
 
 // CHECK-LABEL: sil hidden @$S17collection_upcast15testArrayUpcast{{.*}}F :
-// CHECK: bb0([[ARRAY:%[0-9]+]] : $Array<BridgedObjC>): 
+// CHECK: bb0([[ARRAY:%[0-9]+]] : @guaranteed $Array<BridgedObjC>): 
 func testArrayUpcast(_ array: [BridgedObjC]) {
   // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[ARRAY]]
   // CHECK: [[UPCAST_FN:%[0-9]+]] = function_ref @$Ss15_arrayForceCast{{.*}}F : $@convention(thin) <τ_0_0, τ_0_1> (@guaranteed Array<τ_0_0>) -> @owned Array<τ_0_1>
@@ -55,7 +55,7 @@ func testArrayUpcast(_ array: [BridgedObjC]) {
 // CHECK: } // end sil function '$S17collection_upcast15testArrayUpcast{{.*}}F'
 
 // CHECK-LABEL: sil hidden @$S17collection_upcast22testArrayUpcastBridged{{.*}}F
-// CHECK: bb0([[ARRAY:%[0-9]+]] : $Array<BridgedSwift>):
+// CHECK: bb0([[ARRAY:%[0-9]+]] : @guaranteed $Array<BridgedSwift>):
 func testArrayUpcastBridged(_ array: [BridgedSwift]) {
   // CHECK: [[ARRAY_COPY:%.*]] = copy_value [[ARRAY]]
   // CHECK: [[BRIDGE_FN:%[0-9]+]] = function_ref @$Ss15_arrayForceCast{{.*}}F : $@convention(thin) <τ_0_0, τ_0_1> (@guaranteed Array<τ_0_0>) -> @owned Array<τ_0_1>
@@ -67,7 +67,7 @@ func testArrayUpcastBridged(_ array: [BridgedSwift]) {
 // CHECK: } // end sil function '$S17collection_upcast22testArrayUpcastBridged{{.*}}F'
 
 // CHECK-LABEL: sil hidden @$S17collection_upcast20testDictionaryUpcast{{.*}}F
-// CHECK: bb0([[DICT:%[0-9]+]] : $Dictionary<BridgedObjC, BridgedObjC>):
+// CHECK: bb0([[DICT:%[0-9]+]] : @guaranteed $Dictionary<BridgedObjC, BridgedObjC>):
 func testDictionaryUpcast(_ dict: Dictionary<BridgedObjC, BridgedObjC>) {
   // CHECK: [[DICT_COPY:%.*]] = copy_value [[DICT]]
   // CHECK: [[UPCAST_FN:%[0-9]+]] = function_ref @$Ss17_dictionaryUpCast{{.*}}F : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
@@ -78,7 +78,7 @@ func testDictionaryUpcast(_ dict: Dictionary<BridgedObjC, BridgedObjC>) {
 }
 
 // CHECK-LABEL: sil hidden @$S17collection_upcast27testDictionaryUpcastBridged{{.*}}F
-// CHECK: bb0([[DICT:%[0-9]+]] : $Dictionary<BridgedSwift, BridgedSwift>):
+// CHECK: bb0([[DICT:%[0-9]+]] : @guaranteed $Dictionary<BridgedSwift, BridgedSwift>):
 func testDictionaryUpcastBridged(_ dict: Dictionary<BridgedSwift, BridgedSwift>) {
   // CHECK: [[DICT_COPY:%.*]] = copy_value [[DICT]]
   // CHECK: [[BRIDGE_FN:%[0-9]+]] = function_ref @$Ss17_dictionaryUpCast{{.*}}F
@@ -89,7 +89,7 @@ func testDictionaryUpcastBridged(_ dict: Dictionary<BridgedSwift, BridgedSwift>)
 }
 
 // CHECK-LABEL: sil hidden @$S17collection_upcast13testSetUpcast{{.*}}F
-// CHECK: bb0([[SET:%[0-9]+]] : $Set<BridgedObjC>):
+// CHECK: bb0([[SET:%[0-9]+]] : @guaranteed $Set<BridgedObjC>):
 func testSetUpcast(_ dict: Set<BridgedObjC>) {
   // CHECK: [[SET_COPY:%.*]] = copy_value [[SET]]
   // CHECK: [[BRIDGE_FN:%[0-9]+]] = function_ref @$Ss10_setUpCast{{.*}}F : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Hashable, τ_0_1 : Hashable> (@guaranteed Set<τ_0_0>) -> @owned Set<τ_0_1>
@@ -100,7 +100,7 @@ func testSetUpcast(_ dict: Set<BridgedObjC>) {
 }
 
 // CHECK-LABEL: sil hidden @$S17collection_upcast20testSetUpcastBridged{{.*}}F
-// CHECK: bb0([[SET:%.*]] : $Set<BridgedSwift>):
+// CHECK: bb0([[SET:%.*]] : @guaranteed $Set<BridgedSwift>):
 func testSetUpcastBridged(_ set: Set<BridgedSwift>) {
   // CHECK: [[SET_COPY:%.*]] = copy_value [[SET]]
   // CHECK: [[BRIDGE_FN:%[0-9]+]] = function_ref @$Ss10_setUpCast{{.*}}F

--- a/test/SILGen/dynamic.swift
+++ b/test/SILGen/dynamic.swift
@@ -351,7 +351,7 @@ extension Gizmo {
 }
 
 // CHECK-LABEL: sil hidden @$S7dynamic24foreignExtensionDispatchyySo5GizmoCF
-// CHECK: bb0([[ARG:%.*]] : $Gizmo):
+// CHECK: bb0([[ARG:%.*]] : @guaranteed $Gizmo):
 func foreignExtensionDispatch(_ g: Gizmo) {
   // CHECK: objc_method [[ARG]] : $Gizmo, #Gizmo.foreignObjCExtension!1.foreign : (Gizmo)
   g.foreignObjCExtension()
@@ -443,7 +443,7 @@ public class Base {
 
 public class Sub : Base {
   // CHECK-LABEL: sil hidden @$S7dynamic3SubC1xSbvg : $@convention(method) (@guaranteed Sub) -> Bool {
-  // CHECK: bb0([[SELF:%.*]] : $Sub):
+  // CHECK: bb0([[SELF:%.*]] : @guaranteed $Sub):
   // CHECK:     [[AUTOCLOSURE:%.*]] = function_ref @$S7dynamic3SubC1xSbvgSbyKXKfu_ : $@convention(thin) (@guaranteed Sub) -> (Bool, @error Error)
   // CHECK:     [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:     = partial_apply [callee_guaranteed] [[AUTOCLOSURE]]([[SELF_COPY]])
@@ -451,7 +451,7 @@ public class Sub : Base {
   // CHECK: } // end sil function '$S7dynamic3SubC1xSbvg'
 
   // CHECK-LABEL: sil private [transparent] @$S7dynamic3SubC1xSbvgSbyKXKfu_ : $@convention(thin) (@guaranteed Sub) -> (Bool, @error Error) {
-  // CHECK: bb0([[VALUE:%.*]] : $Sub):
+  // CHECK: bb0([[VALUE:%.*]] : @guaranteed $Sub):
   // CHECK:     [[VALUE_COPY:%.*]] = copy_value [[VALUE]]
   // CHECK:     [[CASTED_VALUE_COPY:%.*]] = upcast [[VALUE_COPY]]
   // CHECK:     [[BORROWED_CASTED_VALUE_COPY:%.*]] = begin_borrow [[CASTED_VALUE_COPY]]
@@ -491,7 +491,7 @@ public class ConcreteDerived : GenericBase<Int> {
 // thunk.
 
 // CHECK-LABEL: sil private @$S7dynamic15ConcreteDerivedC6methodyySiFAA11GenericBaseCADyyxFTV : $@convention(method) (@in_guaranteed Int, @guaranteed ConcreteDerived) -> ()
-// CHECK: bb0(%0 : $*Int, %1 : $ConcreteDerived):
+// CHECK: bb0(%0 : @trivial $*Int, %1 : @guaranteed $ConcreteDerived):
 // CHECK-NEXT:  [[VALUE:%.*]] = load [trivial] %0 : $*Int
 // CHECK:       [[DYNAMIC_THUNK:%.*]] = function_ref @$S7dynamic15ConcreteDerivedC6methodyySiFTD : $@convention(method) (Int, @guaranteed ConcreteDerived) -> ()
 // CHECK-NEXT:  apply [[DYNAMIC_THUNK]]([[VALUE]], %1) : $@convention(method) (Int, @guaranteed ConcreteDerived) -> ()

--- a/test/SILGen/dynamic_lookup.swift
+++ b/test/SILGen/dynamic_lookup.swift
@@ -22,7 +22,7 @@ class X {
 
 // CHECK-LABEL: sil hidden @$S14dynamic_lookup15direct_to_class{{[_0-9a-zA-Z]*}}F
 func direct_to_class(_ obj: AnyObject) {
-  // CHECK: bb0([[ARG:%.*]] : $AnyObject):
+  // CHECK: bb0([[ARG:%.*]] : @guaranteed $AnyObject):
   // CHECK: [[OPENED_ARG:%[0-9]+]] = open_existential_ref [[ARG]] : $AnyObject to $@opened({{.*}}) AnyObject
   // CHECK: [[OPENED_ARG_COPY:%.*]] = copy_value [[OPENED_ARG]]
   // CHECK: [[METHOD:%[0-9]+]] = objc_method [[OPENED_ARG_COPY]] : $@opened({{.*}}) AnyObject, #X.f!1.foreign : (X) -> () -> (), $@convention(objc_method) (@opened({{.*}}) AnyObject) -> ()
@@ -34,7 +34,7 @@ func direct_to_class(_ obj: AnyObject) {
 
 // CHECK-LABEL: sil hidden @$S14dynamic_lookup18direct_to_protocol{{[_0-9a-zA-Z]*}}F
 func direct_to_protocol(_ obj: AnyObject) {
-  // CHECK: bb0([[ARG:%.*]] : $AnyObject):
+  // CHECK: bb0([[ARG:%.*]] : @guaranteed $AnyObject):
   // CHECK:   [[OPENED_ARG:%[0-9]+]] = open_existential_ref [[ARG]] : $AnyObject to $@opened({{.*}}) AnyObject
   // CHECK:   [[OPENED_ARG_COPY:%.*]] = copy_value [[OPENED_ARG]]
   // CHECK:   [[METHOD:%[0-9]+]] = objc_method [[OPENED_ARG_COPY]] : $@opened({{.*}}) AnyObject, #P.g!1.foreign : <Self where Self : P> (Self) -> () -> (), $@convention(objc_method) (@opened({{.*}}) AnyObject) -> ()
@@ -46,7 +46,7 @@ func direct_to_protocol(_ obj: AnyObject) {
 
 // CHECK-LABEL: sil hidden @$S14dynamic_lookup23direct_to_static_method{{[_0-9a-zA-Z]*}}F
 func direct_to_static_method(_ obj: AnyObject) {
-  // CHECK: bb0([[ARG:%.*]] : $AnyObject):
+  // CHECK: bb0([[ARG:%.*]] : @guaranteed $AnyObject):
   var obj = obj
   // CHECK: [[OBJBOX:%[0-9]+]] = alloc_box ${ var AnyObject }
   // CHECK-NEXT: [[PBOBJ:%[0-9]+]] = project_box [[OBJBOX]]
@@ -66,7 +66,7 @@ func direct_to_static_method(_ obj: AnyObject) {
 
 // CHECK-LABEL: sil hidden @$S14dynamic_lookup12opt_to_class{{[_0-9a-zA-Z]*}}F
 func opt_to_class(_ obj: AnyObject) {
-  // CHECK: bb0([[ARG:%.*]] : $AnyObject):
+  // CHECK: bb0([[ARG:%.*]] : @guaranteed $AnyObject):
   var obj = obj
   // CHECK:   [[EXISTBOX:%[0-9]+]] = alloc_box ${ var AnyObject } 
   // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[EXISTBOX]]
@@ -81,7 +81,7 @@ func opt_to_class(_ obj: AnyObject) {
   // CHECK:   dynamic_method_br [[OBJ_SELF]] : $@opened({{.*}}) AnyObject, #X.f!1.foreign, [[HASBB:[a-zA-z0-9]+]], [[NOBB:[a-zA-z0-9]+]]
 
   // Has method BB:
-  // CHECK: [[HASBB]]([[UNCURRIED:%[0-9]+]] : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> ()):
+  // CHECK: [[HASBB]]([[UNCURRIED:%[0-9]+]] : @trivial $@convention(objc_method) (@opened({{.*}}) AnyObject) -> ()):
   // CHECK:   [[OBJ_SELF_COPY:%.*]] = copy_value [[OBJ_SELF]]
   // CHECK:   [[PARTIAL:%[0-9]+]] = partial_apply [callee_guaranteed] [[UNCURRIED]]([[OBJ_SELF_COPY]]) : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> ()
   // CHECK:   [[THUNK_PAYLOAD:%.*]] = init_enum_data_addr [[OPT_TMP]]
@@ -118,7 +118,7 @@ func forced_without_outer(_ obj: AnyObject) {
 // CHECK-LABEL: sil hidden @$S14dynamic_lookup20opt_to_static_method{{[_0-9a-zA-Z]*}}F
 func opt_to_static_method(_ obj: AnyObject) {
   var obj = obj
-  // CHECK: bb0([[OBJ:%[0-9]+]] : $AnyObject):
+  // CHECK: bb0([[OBJ:%[0-9]+]] : @guaranteed $AnyObject):
   // CHECK:   [[OBJBOX:%[0-9]+]] = alloc_box ${ var AnyObject }
   // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJBOX]]
   // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
@@ -138,7 +138,7 @@ func opt_to_static_method(_ obj: AnyObject) {
 // CHECK-LABEL: sil hidden @$S14dynamic_lookup15opt_to_property{{[_0-9a-zA-Z]*}}F
 func opt_to_property(_ obj: AnyObject) {
   var obj = obj
-  // CHECK: bb0([[OBJ:%[0-9]+]] : $AnyObject):
+  // CHECK: bb0([[OBJ:%[0-9]+]] : @guaranteed $AnyObject):
   // CHECK:   [[OBJ_BOX:%[0-9]+]] = alloc_box ${ var AnyObject }
   // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
   // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
@@ -151,7 +151,7 @@ func opt_to_property(_ obj: AnyObject) {
   // CHECK:   [[OPTTEMP:%.*]] = alloc_stack $Optional<Int>
   // CHECK:   dynamic_method_br [[RAWOBJ_SELF]] : $@opened({{.*}}) AnyObject, #X.value!getter.1.foreign, bb1, bb2
 
-  // CHECK: bb1([[METHOD:%[0-9]+]] : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> Int):
+  // CHECK: bb1([[METHOD:%[0-9]+]] : @trivial $@convention(objc_method) (@opened({{.*}}) AnyObject) -> Int):
   // CHECK:   [[RAWOBJ_SELF_COPY:%.*]] = copy_value [[RAWOBJ_SELF]]
   // CHECK:   [[BOUND_METHOD:%[0-9]+]] = partial_apply [callee_guaranteed] [[METHOD]]([[RAWOBJ_SELF_COPY]]) : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> Int
   // CHECK:   [[B:%.*]] = begin_borrow [[BOUND_METHOD]]
@@ -167,7 +167,7 @@ func opt_to_property(_ obj: AnyObject) {
 // CHECK: } // end sil function '$S14dynamic_lookup15opt_to_property{{[_0-9a-zA-Z]*}}F'
 
 // GUARANTEED-LABEL: sil hidden @$S14dynamic_lookup15opt_to_property{{[_0-9a-zA-Z]*}}F
-  // GUARANTEED: bb0([[OBJ:%[0-9]+]] : $AnyObject):
+  // GUARANTEED: bb0([[OBJ:%[0-9]+]] : @guaranteed $AnyObject):
   // GUARANTEED:   [[OBJ_BOX:%[0-9]+]] = alloc_box ${ var AnyObject }
   // GUARANTEED:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
   // GUARANTEED:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
@@ -180,7 +180,7 @@ func opt_to_property(_ obj: AnyObject) {
   // GUARANTEED:   [[OPTTEMP:%.*]] = alloc_stack $Optional<Int>
   // GUARANTEED:   dynamic_method_br [[RAWOBJ_SELF]] : $@opened({{.*}}) AnyObject, #X.value!getter.1.foreign, bb1, bb2
 
-  // GUARANTEED: bb1([[METHOD:%[0-9]+]] : $@convention(objc_method) (@opened({{.*}}) AnyObject) -> Int):
+  // GUARANTEED: bb1([[METHOD:%[0-9]+]] : @trivial $@convention(objc_method) (@opened({{.*}}) AnyObject) -> Int):
   // GUARANTEED:   [[RAWOBJ_SELF_COPY:%.*]] = copy_value [[RAWOBJ_SELF]]
   // GUARANTEED:   [[BOUND_METHOD:%[0-9]+]] = partial_apply [callee_guaranteed] [[METHOD]]([[RAWOBJ_SELF_COPY]])
   // GUARANTEED:   [[BEGIN_BORROW:%.*]] = begin_borrow [[BOUND_METHOD]]
@@ -196,7 +196,7 @@ func opt_to_property(_ obj: AnyObject) {
 func direct_to_subscript(_ obj: AnyObject, i: Int) {
   var obj = obj
   var i = i
-  // CHECK: bb0([[OBJ:%[0-9]+]] : $AnyObject, [[I:%[0-9]+]] : $Int):
+  // CHECK: bb0([[OBJ:%[0-9]+]] : @guaranteed $AnyObject, [[I:%[0-9]+]] : @trivial $Int):
   // CHECK:   [[OBJ_BOX:%[0-9]+]] = alloc_box ${ var AnyObject }
   // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
   // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
@@ -214,7 +214,7 @@ func direct_to_subscript(_ obj: AnyObject, i: Int) {
   // CHECK:   [[OPTTEMP:%.*]] = alloc_stack $Optional<Int>
   // CHECK:   dynamic_method_br [[OBJ_REF]] : $@opened({{.*}}) AnyObject, #X.subscript!getter.1.foreign, bb1, bb2
 
-  // CHECK: bb1([[GETTER:%[0-9]+]] : $@convention(objc_method) (Int, @opened({{.*}}) AnyObject) -> Int):
+  // CHECK: bb1([[GETTER:%[0-9]+]] : @trivial $@convention(objc_method) (Int, @opened({{.*}}) AnyObject) -> Int):
   // CHECK:   [[OBJ_REF_COPY:%.*]] = copy_value [[OBJ_REF]]
   // CHECK:   [[GETTER_WITH_SELF:%[0-9]+]] = partial_apply [callee_guaranteed] [[GETTER]]([[OBJ_REF_COPY]]) : $@convention(objc_method) (Int, @opened({{.*}}) AnyObject) -> Int
   // CHECK:   [[B:%.*]] = begin_borrow [[GETTER_WITH_SELF]]
@@ -230,7 +230,7 @@ func direct_to_subscript(_ obj: AnyObject, i: Int) {
 // CHECK: } // end sil function '$S14dynamic_lookup19direct_to_subscript{{[_0-9a-zA-Z]*}}F'
 
 // GUARANTEED-LABEL: sil hidden @$S14dynamic_lookup19direct_to_subscript{{[_0-9a-zA-Z]*}}F
-  // GUARANTEED: bb0([[OBJ:%[0-9]+]] : $AnyObject, [[I:%[0-9]+]] : $Int):
+  // GUARANTEED: bb0([[OBJ:%[0-9]+]] : @guaranteed $AnyObject, [[I:%[0-9]+]] : @trivial $Int):
   // GUARANTEED:   [[OBJ_BOX:%[0-9]+]] = alloc_box ${ var AnyObject }
   // GUARANTEED:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
   // GUARANTEED:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
@@ -248,7 +248,7 @@ func direct_to_subscript(_ obj: AnyObject, i: Int) {
   // GUARANTEED:   [[OPTTEMP:%.*]] = alloc_stack $Optional<Int>
   // GUARANTEED:   dynamic_method_br [[OBJ_REF]] : $@opened({{.*}}) AnyObject, #X.subscript!getter.1.foreign, bb1, bb2
 
-  // GUARANTEED: bb1([[GETTER:%[0-9]+]] : $@convention(objc_method) (Int, @opened({{.*}}) AnyObject) -> Int):
+  // GUARANTEED: bb1([[GETTER:%[0-9]+]] : @trivial $@convention(objc_method) (Int, @opened({{.*}}) AnyObject) -> Int):
   // GUARANTEED:   [[OBJ_REF_COPY:%.*]] = copy_value [[OBJ_REF]]
   // GUARANTEED:   [[GETTER_WITH_SELF:%[0-9]+]] = partial_apply [callee_guaranteed] [[GETTER]]([[OBJ_REF_COPY]])
   // GUARANTEED:   [[BORROW:%.*]] = begin_borrow [[GETTER_WITH_SELF]]
@@ -264,7 +264,7 @@ func direct_to_subscript(_ obj: AnyObject, i: Int) {
 func opt_to_subscript(_ obj: AnyObject, i: Int) {
   var obj = obj
   var i = i
-  // CHECK: bb0([[OBJ:%[0-9]+]] : $AnyObject, [[I:%[0-9]+]] : $Int):
+  // CHECK: bb0([[OBJ:%[0-9]+]] : @guaranteed $AnyObject, [[I:%[0-9]+]] : @trivial $Int):
   // CHECK:   [[OBJ_BOX:%[0-9]+]] = alloc_box ${ var AnyObject }
   // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
   // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
@@ -280,7 +280,7 @@ func opt_to_subscript(_ obj: AnyObject, i: Int) {
   // CHECK:   [[OPTTEMP:%.*]] = alloc_stack $Optional<Int>
   // CHECK:   dynamic_method_br [[OBJ_REF]] : $@opened({{.*}}) AnyObject, #X.subscript!getter.1.foreign, bb1, bb2
 
-  // CHECK: bb1([[GETTER:%[0-9]+]] : $@convention(objc_method) (Int, @opened({{.*}}) AnyObject) -> Int):
+  // CHECK: bb1([[GETTER:%[0-9]+]] : @trivial $@convention(objc_method) (Int, @opened({{.*}}) AnyObject) -> Int):
   // CHECK:   [[OBJ_REF_COPY:%.*]] = copy_value [[OBJ_REF]]
   // CHECK:   [[GETTER_WITH_SELF:%[0-9]+]] = partial_apply [callee_guaranteed] [[GETTER]]([[OBJ_REF_COPY]]) : $@convention(objc_method) (Int, @opened({{.*}}) AnyObject) -> Int
   // CHECK:   [[B:%.*]] = begin_borrow [[GETTER_WITH_SELF]]
@@ -297,7 +297,7 @@ func opt_to_subscript(_ obj: AnyObject, i: Int) {
 // CHECK-LABEL: sil hidden @$S14dynamic_lookup8downcast{{[_0-9a-zA-Z]*}}F
 func downcast(_ obj: AnyObject) -> X {
   var obj = obj
-  // CHECK: bb0([[OBJ:%[0-9]+]] : $AnyObject):
+  // CHECK: bb0([[OBJ:%[0-9]+]] : @guaranteed $AnyObject):
   // CHECK:   [[OBJ_BOX:%[0-9]+]] = alloc_box ${ var AnyObject }
   // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
   // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
@@ -317,11 +317,11 @@ func downcast(_ obj: AnyObject) -> X {
 }
 
 // CHECK-LABEL: sil hidden @$S14dynamic_lookup7consumeyyAA5Fruit_pF
-// CHECK: bb0(%0 : $Fruit):
+// CHECK: bb0(%0 : @guaranteed $Fruit):
 // CHECK:        [[BOX:%.*]] = alloc_stack $Optional<Juice>
 // CHECK:        dynamic_method_br [[SELF:%.*]] : $@opened("{{.*}}") Fruit, #Fruit.juice!getter.1.foreign, bb1, bb2
 
-// CHECK: bb1([[FN:%.*]] : $@convention(objc_method) (@opened("{{.*}}") Fruit) -> @autoreleased Juice):
+// CHECK: bb1([[FN:%.*]] : @trivial $@convention(objc_method) (@opened("{{.*}}") Fruit) -> @autoreleased Juice):
 // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
 // CHECK:   [[METHOD:%.*]] = partial_apply [callee_guaranteed] [[FN]]([[SELF_COPY]]) : $@convention(objc_method) (@opened("{{.*}}") Fruit) -> @autoreleased Juice
 // CHECK:   [[B:%.*]] = begin_borrow [[METHOD]]

--- a/test/SILGen/dynamic_lookup_throws.swift
+++ b/test/SILGen/dynamic_lookup_throws.swift
@@ -13,7 +13,7 @@ class Blub : NSObject {
 }
 
 // CHECK-LABEL: sil hidden @$S21dynamic_lookup_throws8testBlub1ayyXl_tKF : $@convention(thin) (@guaranteed AnyObject) -> @error Error
-// CHECK: bb0([[ARG:%.*]] : $AnyObject):
+// CHECK: bb0([[ARG:%.*]] : @guaranteed $AnyObject):
 func testBlub(a: AnyObject) throws {
   // CHECK:   [[ANYOBJECT_REF:%.*]] = open_existential_ref [[ARG]] : $AnyObject to $@opened("[[OPENED:.*]]") AnyObject
   // CHECK:   [[ANYOBJECT_REF_COPY:%.*]] = copy_value [[ANYOBJECT_REF]]

--- a/test/SILGen/foreign_errors.swift
+++ b/test/SILGen/foreign_errors.swift
@@ -66,9 +66,9 @@ extension NSObject {
 // CHECK:   [[VALUE:%.*]] = struct ${{Bool|UInt8}} ([[BITS]] : $Builtin.Int{{[18]}})
 // CHECK:   [[BOOL:%.*]] = struct $ObjCBool ([[VALUE]] : ${{Bool|UInt8}})
 // CHECK:   br bb6([[BOOL]] : $ObjCBool)
-// CHECK: bb2([[ERR:%.*]] : $Error):
+// CHECK: bb2([[ERR:%.*]] : @owned $Error):
 // CHECK:   switch_enum %0 : $Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, case #Optional.some!enumelt.1: bb3, case #Optional.none!enumelt: bb4
-// CHECK: bb3([[UNWRAPPED_OUT:%.+]] : $AutoreleasingUnsafeMutablePointer<Optional<NSError>>):
+// CHECK: bb3([[UNWRAPPED_OUT:%.+]] : @trivial $AutoreleasingUnsafeMutablePointer<Optional<NSError>>):
 // CHECK:   [[T0:%.*]] = function_ref @$S10Foundation22_convertErrorToNSErrorySo0E0Cs0C0_pF : $@convention(thin) (@guaranteed Error) -> @owned NSError
 // CHECK:   [[T1:%.*]] = apply [[T0]]([[ERR]])
 // CHECK:   [[OBJCERR:%.*]] = enum $Optional<NSError>, #Optional.some!enumelt.1, [[T1]] : $NSError
@@ -86,20 +86,20 @@ extension NSObject {
 // CHECK:   [[VALUE:%.*]] = struct ${{Bool|UInt8}} ([[BITS]] : $Builtin.Int{{[18]}})
 // CHECK:   [[BOOL:%.*]] = struct $ObjCBool ([[VALUE]] : ${{Bool|UInt8}})
 // CHECK:   br bb6([[BOOL]] : $ObjCBool)
-// CHECK: bb6([[BOOL:%.*]] : $ObjCBool):
+// CHECK: bb6([[BOOL:%.*]] : @trivial $ObjCBool):
 // CHECK:   return [[BOOL]] : $ObjCBool
 
   @objc func badDescription() throws -> String {
     throw NSError(domain: "", code: 1, userInfo: [:])
   }
 // CHECK-LABEL: sil hidden [thunk] @$SSo8NSObjectC14foreign_errorsE14badDescriptionSSyKFTo : $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, NSObject) -> @autoreleased Optional<NSString> {
-// CHECK: bb0([[UNOWNED_ARG0:%.*]] : $Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, [[UNOWNED_ARG1:%.*]] : $NSObject):
+// CHECK: bb0([[UNOWNED_ARG0:%.*]] : @trivial $Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, [[UNOWNED_ARG1:%.*]] : @unowned $NSObject):
 // CHECK: [[ARG1:%.*]] = copy_value [[UNOWNED_ARG1]]
 // CHECK: [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
 // CHECK: [[T0:%.*]] = function_ref @$SSo8NSObjectC14foreign_errorsE14badDescriptionSSyKF : $@convention(method) (@guaranteed NSObject) -> (@owned String, @error Error)
 // CHECK: try_apply [[T0]]([[BORROWED_ARG1]]) : $@convention(method) (@guaranteed NSObject) -> (@owned String, @error Error), normal [[NORMAL_BB:bb[0-9][0-9]*]], error [[ERROR_BB:bb[0-9][0-9]*]]
 //
-// CHECK: [[NORMAL_BB]]([[RESULT:%.*]] : $String):
+// CHECK: [[NORMAL_BB]]([[RESULT:%.*]] : @owned $String):
 // CHECK:   [[T0:%.*]] = function_ref @$SSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF : $@convention(method) (@guaranteed String) -> @owned NSString
 // CHECK:   [[BORROWED_RESULT:%.*]] = begin_borrow [[RESULT]]
 // CHECK:   [[T1:%.*]] = apply [[T0]]([[BORROWED_RESULT]])
@@ -108,10 +108,10 @@ extension NSObject {
 // CHECK:   destroy_value [[RESULT]]  
 // CHECK:   br bb6([[T2]] : $Optional<NSString>)
 //
-// CHECK: [[ERROR_BB]]([[ERR:%.*]] : $Error):
+// CHECK: [[ERROR_BB]]([[ERR:%.*]] : @owned $Error):
 // CHECK:   switch_enum [[UNOWNED_ARG0]] : $Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9][0-9]*]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9][0-9]*]]
 //
-// CHECK: [[SOME_BB]]([[UNWRAPPED_OUT:%.+]] : $AutoreleasingUnsafeMutablePointer<Optional<NSError>>):
+// CHECK: [[SOME_BB]]([[UNWRAPPED_OUT:%.+]] : @trivial $AutoreleasingUnsafeMutablePointer<Optional<NSError>>):
 // CHECK:   [[T0:%.*]] = function_ref @$S10Foundation22_convertErrorToNSErrorySo0E0Cs0C0_pF : $@convention(thin) (@guaranteed Error) -> @owned NSError
 // CHECK:   [[T1:%.*]] = apply [[T0]]([[ERR]])
 // CHECK:   [[OBJCERR:%.*]] = enum $Optional<NSError>, #Optional.some!enumelt.1, [[T1]] : $NSError
@@ -130,17 +130,17 @@ extension NSObject {
 // CHECK:   [[T0:%.*]] = enum $Optional<NSString>, #Optional.none!enumelt
 // CHECK:   br bb6([[T0]] : $Optional<NSString>)
 //
-// CHECK: bb6([[T0:%.*]] : $Optional<NSString>):
+// CHECK: bb6([[T0:%.*]] : @owned $Optional<NSString>):
 // CHECK:   end_borrow [[BORROWED_ARG1]] from [[ARG1]]
 // CHECK:   destroy_value [[ARG1]]
 // CHECK:   return [[T0]] : $Optional<NSString>
 
 // CHECK-LABEL: sil hidden [thunk] @$SSo8NSObjectC14foreign_errorsE7takeIntyySiKFTo : $@convention(objc_method) (Int, Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, NSObject) -> ObjCBool
-// CHECK: bb0([[I:%[0-9]+]] : $Int, [[ERROR:%[0-9]+]] : $Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, [[SELF:%[0-9]+]] : $NSObject)
+// CHECK: bb0([[I:%[0-9]+]] : @trivial $Int, [[ERROR:%[0-9]+]] : @trivial $Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, [[SELF:%[0-9]+]] : @unowned $NSObject)
   @objc func takeInt(_ i: Int) throws { }
 
 // CHECK-LABEL: sil hidden [thunk] @$SSo8NSObjectC14foreign_errorsE10takeDouble_3int7closureySd_S3iXEtKFTo : $@convention(objc_method) (Double, Int, Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @convention(block) @noescape (Int) -> Int, NSObject) -> ObjCBool
-// CHECK: bb0([[D:%[0-9]+]] : $Double, [[INT:%[0-9]+]] : $Int, [[ERROR:%[0-9]+]] : $Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, [[CLOSURE:%[0-9]+]] : $@convention(block) @noescape (Int) -> Int, [[SELF:%[0-9]+]] : $NSObject):
+// CHECK: bb0([[D:%[0-9]+]] : @trivial $Double, [[INT:%[0-9]+]] : @trivial $Int, [[ERROR:%[0-9]+]] : @trivial $Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, [[CLOSURE:%[0-9]+]] : @unowned $@convention(block) @noescape (Int) -> Int, [[SELF:%[0-9]+]] : @unowned $NSObject):
   @objc func takeDouble(_ d: Double, int: Int, closure: (Int) -> Int) throws {
     throw NSError(domain: "", code: 1, userInfo: [:])
   }
@@ -190,7 +190,7 @@ class VeryErrorProne : ErrorProne {
 // it.
 
 // CHECK-LABEL:    sil hidden @$S14foreign_errors14VeryErrorProneC7withTwoACyXlSg_tKcfc
-// CHECK:    bb0([[ARG1:%.*]] : $Optional<AnyObject>, [[ARG2:%.*]] : $VeryErrorProne):
+// CHECK:    bb0([[ARG1:%.*]] : @owned $Optional<AnyObject>, [[ARG2:%.*]] : @owned $VeryErrorProne):
 // CHECK:      [[BOX:%.*]] = alloc_box ${ var VeryErrorProne }
 // CHECK:      [[MARKED_BOX:%.*]] = mark_uninitialized [derivedself] [[BOX]]
 // CHECK:      [[PB:%.*]] = project_box [[MARKED_BOX]]
@@ -209,7 +209,7 @@ class VeryErrorProne : ErrorProne {
 
 // rdar://21051021
 // CHECK: sil hidden @$S14foreign_errors12testProtocolyySo010ErrorProneD0_pKF : $@convention(thin) (@guaranteed ErrorProneProtocol) -> @error Error
-// CHECK: bb0([[ARG0:%.*]] : $ErrorProneProtocol):
+// CHECK: bb0([[ARG0:%.*]] : @guaranteed $ErrorProneProtocol):
 func testProtocol(_ p: ErrorProneProtocol) throws {
   // CHECK:   [[T0:%.*]] = open_existential_ref [[ARG0]] : $ErrorProneProtocol to $[[OPENED:@opened(.*) ErrorProneProtocol]]
   // CHECK:   [[T1:%.*]] = objc_method [[T0]] : $[[OPENED]], #ErrorProneProtocol.obliterate!1.foreign : {{.*}}

--- a/test/SILGen/import_as_member.swift
+++ b/test/SILGen/import_as_member.swift
@@ -39,7 +39,7 @@ public func returnNullableStringGlobalVar() -> String? {
 // CHECK-NEXT: }
 
 // CHECK-LABEL: sil {{.*}}useClass{{.*}}
-// CHECK: bb0([[D:%[0-9]+]] : $Double, [[OPTS:%[0-9]+]] : $SomeClass.Options):
+// CHECK: bb0([[D:%[0-9]+]] : @trivial $Double, [[OPTS:%[0-9]+]] : @trivial $SomeClass.Options):
 public func useClass(d: Double, opts: SomeClass.Options) {
   // CHECK: [[CTOR:%[0-9]+]] = function_ref @MakeIAMSomeClass : $@convention(c) (Double) -> @autoreleased SomeClass
   // CHECK: [[OBJ:%[0-9]+]] = apply [[CTOR]]([[D]])
@@ -55,7 +55,7 @@ public func useClass(d: Double, opts: SomeClass.Options) {
 
 extension SomeClass {
   // CHECK-LABEL: sil hidden @$SSo12IAMSomeClassC16import_as_memberE6doubleABSd_tcfc
-  // CHECK: bb0([[DOUBLE:%[0-9]+]] : $Double
+  // CHECK: bb0([[DOUBLE:%[0-9]+]] : @trivial $Double
   // CHECK-NOT: value_metatype
   // CHECK: [[FNREF:%[0-9]+]] = function_ref @MakeIAMSomeClass
   // CHECK: apply [[FNREF]]([[DOUBLE]])

--- a/test/SILGen/indirect_enum.swift
+++ b/test/SILGen/indirect_enum.swift
@@ -9,7 +9,7 @@ indirect enum TreeA<T> {
 
 // CHECK-LABEL: sil hidden @$S13indirect_enum11TreeA_cases_1l1ryx_AA0C1AOyxGAGtlF : $@convention(thin) <T> (@in_guaranteed T, @guaranteed TreeA<T>, @guaranteed TreeA<T>) -> () {
 func TreeA_cases<T>(_ t: T, l: TreeA<T>, r: TreeA<T>) {
-// CHECK: bb0([[ARG1:%.*]] : $*T, [[ARG2:%.*]] : $TreeA<T>, [[ARG3:%.*]] : $TreeA<T>):
+// CHECK: bb0([[ARG1:%.*]] : @trivial $*T, [[ARG2:%.*]] : @guaranteed $TreeA<T>, [[ARG3:%.*]] : @guaranteed $TreeA<T>):
 // CHECK:         [[METATYPE:%.*]] = metatype $@thin TreeA<T>.Type
 // CHECK-NEXT:    [[NIL:%.*]] = enum $TreeA<T>, #TreeA.Nil!enumelt
 // CHECK-NOT:     destroy_value [[NIL]]
@@ -42,7 +42,7 @@ func TreeA_cases<T>(_ t: T, l: TreeA<T>, r: TreeA<T>) {
 
 // CHECK-LABEL: sil hidden @$S13indirect_enum16TreeA_reabstractyyS2icF : $@convention(thin) (@guaranteed @callee_guaranteed (Int) -> Int) -> () {
 func TreeA_reabstract(_ f: @escaping (Int) -> Int) {
-// CHECK: bb0([[ARG:%.*]] : $@callee_guaranteed (Int) -> Int):
+// CHECK: bb0([[ARG:%.*]] : @guaranteed $@callee_guaranteed (Int) -> Int):
 // CHECK:         [[METATYPE:%.*]] = metatype $@thin TreeA<(Int) -> Int>.Type
 // CHECK-NEXT:    [[BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <(Int) -> Int>
 // CHECK-NEXT:    [[PB:%.*]] = project_box [[BOX]]
@@ -103,7 +103,7 @@ func TreeB_cases<T>(_ t: T, l: TreeB<T>, r: TreeB<T>) {
 
 // CHECK-LABEL: sil hidden @$S13indirect_enum13TreeInt_cases_1l1rySi_AA0cD0OAFtF : $@convention(thin) (Int, @guaranteed TreeInt, @guaranteed TreeInt) -> ()
 func TreeInt_cases(_ t: Int, l: TreeInt, r: TreeInt) {
-// CHECK: bb0([[ARG1:%.*]] : $Int, [[ARG2:%.*]] : $TreeInt, [[ARG3:%.*]] : $TreeInt):
+// CHECK: bb0([[ARG1:%.*]] : @trivial $Int, [[ARG2:%.*]] : @guaranteed $TreeInt, [[ARG3:%.*]] : @guaranteed $TreeInt):
 // CHECK:         [[METATYPE:%.*]] = metatype $@thin TreeInt.Type
 // CHECK-NEXT:    [[NIL:%.*]] = enum $TreeInt, #TreeInt.Nil!enumelt
 // CHECK-NOT:     destroy_value [[NIL]]
@@ -148,7 +148,7 @@ func d() {}
 
 // CHECK-LABEL: sil hidden @$S13indirect_enum11switchTreeAyyAA0D1AOyxGlF : $@convention(thin) <T> (@guaranteed TreeA<T>) -> () {
 func switchTreeA<T>(_ x: TreeA<T>) {
-  // CHECK: bb0([[ARG:%.*]] : $TreeA<T>):
+  // CHECK: bb0([[ARG:%.*]] : @guaranteed $TreeA<T>):
   // --           x +2
   // CHECK:       [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK:       switch_enum [[ARG_COPY]] : $TreeA<T>,
@@ -161,7 +161,7 @@ func switchTreeA<T>(_ x: TreeA<T>) {
   // CHECK:       br [[OUTER_CONT:bb[0-9]+]]
   case .Nil:
     a()
-  // CHECK:     [[LEAF_CASE]]([[LEAF_BOX:%.*]] : $<τ_0_0> { var τ_0_0 } <T>):
+  // CHECK:     [[LEAF_CASE]]([[LEAF_BOX:%.*]] : @owned $<τ_0_0> { var τ_0_0 } <T>):
   // CHECK:       [[VALUE:%.*]] = project_box [[LEAF_BOX]]
   // CHECK:       copy_addr [[VALUE]] to [initialization] [[X:%.*]] : $*T
   // CHECK:       function_ref @$S13indirect_enum1b{{[_0-9a-zA-Z]*}}F
@@ -173,7 +173,7 @@ func switchTreeA<T>(_ x: TreeA<T>) {
   case .Leaf(let x):
     b(x)
 
-  // CHECK:     [[BRANCH_CASE]]([[NODE_BOX:%.*]] : $<τ_0_0> { var (left: TreeA<τ_0_0>, right: TreeA<τ_0_0>) } <T>):
+  // CHECK:     [[BRANCH_CASE]]([[NODE_BOX:%.*]] : @owned $<τ_0_0> { var (left: TreeA<τ_0_0>, right: TreeA<τ_0_0>) } <T>):
   // CHECK:       [[TUPLE_ADDR:%.*]] = project_box [[NODE_BOX]]
   // CHECK:       [[TUPLE:%.*]] = load_borrow [[TUPLE_ADDR]]
   // CHECK:       [[LEFT:%.*]] = tuple_extract [[TUPLE]] {{.*}}, 0
@@ -182,13 +182,13 @@ func switchTreeA<T>(_ x: TreeA<T>) {
   // CHECK:          case #TreeA.Leaf!enumelt.1: [[LEAF_CASE_LEFT:bb[0-9]+]],
   // CHECK:          default [[FAIL_LEFT:bb[0-9]+]]
 
-  // CHECK:     [[LEAF_CASE_LEFT]]([[LEFT_LEAF_BOX:%.*]] : $<τ_0_0> { var τ_0_0 } <T>):
+  // CHECK:     [[LEAF_CASE_LEFT]]([[LEFT_LEAF_BOX:%.*]] : @owned $<τ_0_0> { var τ_0_0 } <T>):
   // CHECK:       [[LEFT_LEAF_VALUE:%.*]] = project_box [[LEFT_LEAF_BOX]]
   // CHECK:       switch_enum [[RIGHT]] : $TreeA<T>,
   // CHECK:          case #TreeA.Leaf!enumelt.1: [[LEAF_CASE_RIGHT:bb[0-9]+]],
   // CHECK:          default [[FAIL_RIGHT:bb[0-9]+]]
 
-  // CHECK:     [[LEAF_CASE_RIGHT]]([[RIGHT_LEAF_BOX:%.*]] : $<τ_0_0> { var τ_0_0 } <T>):
+  // CHECK:     [[LEAF_CASE_RIGHT]]([[RIGHT_LEAF_BOX:%.*]] : @owned $<τ_0_0> { var τ_0_0 } <T>):
   // CHECK:       [[RIGHT_LEAF_VALUE:%.*]] = project_box [[RIGHT_LEAF_BOX]]
   // CHECK:       copy_addr [[LEFT_LEAF_VALUE]]
   // CHECK:       copy_addr [[RIGHT_LEAF_VALUE]]
@@ -313,11 +313,11 @@ func switchTreeB<T>(_ x: TreeB<T>) {
 
 // CHECK-LABEL: sil hidden @$S13indirect_enum10guardTreeA{{[_0-9a-zA-Z]*}}F
 func guardTreeA<T>(_ tree: TreeA<T>) {
-  // CHECK: bb0([[ARG:%.*]] : $TreeA<T>):
+  // CHECK: bb0([[ARG:%.*]] : @guaranteed $TreeA<T>):
   do {
     // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
     // CHECK:   switch_enum [[ARG_COPY]] : $TreeA<T>, case #TreeA.Nil!enumelt: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
-    // CHECK: [[NO]]([[ORIGINAL_VALUE:%.*]] : $TreeA<T>):
+    // CHECK: [[NO]]([[ORIGINAL_VALUE:%.*]] : @owned $TreeA<T>):
     // CHECK:   destroy_value [[ORIGINAL_VALUE]]
     // CHECK: [[YES]]:
     guard case .Nil = tree else { return }
@@ -325,9 +325,9 @@ func guardTreeA<T>(_ tree: TreeA<T>) {
     // CHECK:   [[X:%.*]] = alloc_stack $T
     // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
     // CHECK:   switch_enum [[ARG_COPY]] : $TreeA<T>, case #TreeA.Leaf!enumelt.1: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
-    // CHECK: [[NO]]([[ORIGINAL_VALUE:%.*]] : $TreeA<T>):
+    // CHECK: [[NO]]([[ORIGINAL_VALUE:%.*]] : @owned $TreeA<T>):
     // CHECK:   destroy_value [[ORIGINAL_VALUE]]
-    // CHECK: [[YES]]([[BOX:%.*]] : $<τ_0_0> { var τ_0_0 } <T>):
+    // CHECK: [[YES]]([[BOX:%.*]] : @owned $<τ_0_0> { var τ_0_0 } <T>):
     // CHECK:   [[VALUE_ADDR:%.*]] = project_box [[BOX]]
     // CHECK:   [[TMP:%.*]] = alloc_stack
     // CHECK:   copy_addr [[VALUE_ADDR]] to [initialization] [[TMP]]
@@ -337,9 +337,9 @@ func guardTreeA<T>(_ tree: TreeA<T>) {
 
     // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
     // CHECK:   switch_enum [[ARG_COPY]] : $TreeA<T>, case #TreeA.Branch!enumelt.1: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
-    // CHECK: [[NO]]([[ORIGINAL_VALUE:%.*]] : $TreeA<T>):
+    // CHECK: [[NO]]([[ORIGINAL_VALUE:%.*]] : @owned $TreeA<T>):
     // CHECK:   destroy_value [[ORIGINAL_VALUE]]
-    // CHECK: [[YES]]([[BOX:%.*]] : $<τ_0_0> { var (left: TreeA<τ_0_0>, right: TreeA<τ_0_0>) } <T>):
+    // CHECK: [[YES]]([[BOX:%.*]] : @owned $<τ_0_0> { var (left: TreeA<τ_0_0>, right: TreeA<τ_0_0>) } <T>):
     // CHECK:   [[VALUE_ADDR:%.*]] = project_box [[BOX]]
     // CHECK:   [[TUPLE:%.*]] = load [take] [[VALUE_ADDR]]
     // CHECK:   [[TUPLE_COPY:%.*]] = copy_value [[TUPLE]]
@@ -361,7 +361,7 @@ func guardTreeA<T>(_ tree: TreeA<T>) {
   do {
     // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
     // CHECK:   switch_enum [[ARG_COPY]] : $TreeA<T>, case #TreeA.Nil!enumelt: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
-    // CHECK: [[NO]]([[ORIGINAL_VALUE:%.*]] : $TreeA<T>):
+    // CHECK: [[NO]]([[ORIGINAL_VALUE:%.*]] : @owned $TreeA<T>):
     // CHECK:   destroy_value [[ORIGINAL_VALUE]]
     // CHECK: [[YES]]:
     // CHECK:   br
@@ -370,9 +370,9 @@ func guardTreeA<T>(_ tree: TreeA<T>) {
     // CHECK:   [[X:%.*]] = alloc_stack $T
     // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
     // CHECK:   switch_enum [[ARG_COPY]] : $TreeA<T>, case #TreeA.Leaf!enumelt.1: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
-    // CHECK: [[NO]]([[ORIGINAL_VALUE:%.*]] : $TreeA<T>):
+    // CHECK: [[NO]]([[ORIGINAL_VALUE:%.*]] : @owned $TreeA<T>):
     // CHECK:   destroy_value [[ORIGINAL_VALUE]]
-    // CHECK: [[YES]]([[BOX:%.*]] : $<τ_0_0> { var τ_0_0 } <T>):
+    // CHECK: [[YES]]([[BOX:%.*]] : @owned $<τ_0_0> { var τ_0_0 } <T>):
     // CHECK:   [[VALUE_ADDR:%.*]] = project_box [[BOX]]
     // CHECK:   [[TMP:%.*]] = alloc_stack
     // CHECK:   copy_addr [[VALUE_ADDR]] to [initialization] [[TMP]]
@@ -384,9 +384,9 @@ func guardTreeA<T>(_ tree: TreeA<T>) {
 
     // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
     // CHECK:   switch_enum [[ARG_COPY]] : $TreeA<T>, case #TreeA.Branch!enumelt.1: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
-    // CHECK: [[NO]]([[ORIGINAL_VALUE:%.*]] : $TreeA<T>):
+    // CHECK: [[NO]]([[ORIGINAL_VALUE:%.*]] : @owned $TreeA<T>):
     // CHECK:   destroy_value [[ORIGINAL_VALUE]]
-    // CHECK: [[YES]]([[BOX:%.*]] : $<τ_0_0> { var (left: TreeA<τ_0_0>, right: TreeA<τ_0_0>) } <T>):
+    // CHECK: [[YES]]([[BOX:%.*]] : @owned $<τ_0_0> { var (left: TreeA<τ_0_0>, right: TreeA<τ_0_0>) } <T>):
     // CHECK:   [[VALUE_ADDR:%.*]] = project_box [[BOX]]
     // CHECK:   [[TUPLE:%.*]] = load [take] [[VALUE_ADDR]]
     // CHECK:   [[TUPLE_COPY:%.*]] = copy_value [[TUPLE]]
@@ -495,22 +495,22 @@ func guardTreeB<T>(_ tree: TreeB<T>) {
 // SEMANTIC ARC TODO: This test needs to be made far more comprehensive.
 // CHECK-LABEL: sil hidden @$S13indirect_enum35dontDisableCleanupOfIndirectPayloadyyAA010TrivialButG0OF : $@convention(thin) (@guaranteed TrivialButIndirect) -> () {
 func dontDisableCleanupOfIndirectPayload(_ x: TrivialButIndirect) {
-  // CHECK: bb0([[ARG:%.*]] : $TrivialButIndirect):
+  // CHECK: bb0([[ARG:%.*]] : @guaranteed $TrivialButIndirect):
   // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK:   switch_enum [[ARG_COPY]] : $TrivialButIndirect, case #TrivialButIndirect.Direct!enumelt.1:  [[YES:bb[0-9]+]], case #TrivialButIndirect.Indirect!enumelt.1: [[NO:bb[0-9]+]]
   //
-  // CHECK: [[NO]]([[PAYLOAD:%.*]] : ${ var Int }):
+  // CHECK: [[NO]]([[PAYLOAD:%.*]] : @owned ${ var Int }):
   // CHECK:   destroy_value [[PAYLOAD]]
   guard case .Direct(let foo) = x else { return }
 
-  // CHECK: [[YES]]({{%.*}} : $Int):
+  // CHECK: [[YES]]({{%.*}} : @trivial $Int):
   // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK:   switch_enum [[ARG_COPY]] : $TrivialButIndirect, case #TrivialButIndirect.Indirect!enumelt.1:  [[YES:bb[0-9]+]], case #TrivialButIndirect.Direct!enumelt.1: [[NO:bb[0-9]+]]
 
-  // CHECK: [[NO]]({{%.*}} : $Int):
+  // CHECK: [[NO]]({{%.*}} : @trivial $Int):
   // CHECK-NOT: destroy_value
 
-  // CHECK: [[YES]]([[BOX:%.*]] : ${ var Int }):
+  // CHECK: [[YES]]([[BOX:%.*]] : @owned ${ var Int }):
   // CHECK:   destroy_value [[BOX]]
 
   guard case .Indirect(let bar) = x else { return }

--- a/test/SILGen/init_ref_delegation.swift
+++ b/test/SILGen/init_ref_delegation.swift
@@ -6,7 +6,7 @@ struct X { }
 struct S {
   // CHECK-LABEL: sil hidden @$S19init_ref_delegation1SV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@thin S.Type) -> S {
   init() {
-    // CHECK: bb0([[SELF_META:%[0-9]+]] : $@thin S.Type):
+    // CHECK: bb0([[SELF_META:%[0-9]+]] : @trivial $@thin S.Type):
     // CHECK-NEXT:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var S }
     // CHECK-NEXT:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
     // CHECK-NEXT:   [[PB:%.*]] = project_box [[MARKED_SELF_BOX]]
@@ -33,7 +33,7 @@ enum E {
 
   // CHECK-LABEL: sil hidden @$S19init_ref_delegation1EO{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@thin E.Type) -> E
   init() {
-    // CHECK: bb0([[E_META:%[0-9]+]] : $@thin E.Type):
+    // CHECK: bb0([[E_META:%[0-9]+]] : @trivial $@thin E.Type):
     // CHECK:   [[E_BOX:%[0-9]+]] = alloc_box ${ var E }
     // CHECK:   [[MARKED_E_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[E_BOX]]
     // CHECK:   [[PB:%.*]] = project_box [[MARKED_E_BOX]]
@@ -57,7 +57,7 @@ enum E {
 struct S2 {
   // CHECK-LABEL: sil hidden @$S19init_ref_delegation2S2V{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@thin S2.Type) -> S2
   init() {
-    // CHECK: bb0([[S2_META:%[0-9]+]] : $@thin S2.Type):
+    // CHECK: bb0([[S2_META:%[0-9]+]] : @trivial $@thin S2.Type):
     // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var S2 }
     // CHECK:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
     // CHECK:   [[PB:%.*]] = project_box [[MARKED_SELF_BOX]]
@@ -87,7 +87,7 @@ class C1 {
 
  // CHECK-LABEL: sil hidden @$S19init_ref_delegation2C1C{{[_0-9a-zA-Z]*}}fc : $@convention(method) (X, @owned C1) -> @owned C1
   convenience init(x: X) {
-    // CHECK: bb0([[X:%[0-9]+]] : $X, [[ORIG_SELF:%[0-9]+]] : $C1):
+    // CHECK: bb0([[X:%[0-9]+]] : @trivial $X, [[ORIG_SELF:%[0-9]+]] : @owned $C1):
     // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var C1 }
     // CHECK:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
     // CHECK:   [[PB:%.*]] = project_box [[MARKED_SELF_BOX]]
@@ -111,7 +111,7 @@ class C1 {
 
   // CHECK-LABEL: sil hidden @$S19init_ref_delegation2C2C{{[_0-9a-zA-Z]*}}fc : $@convention(method) (X, @owned C2) -> @owned C2
   convenience init(x: X) {
-    // CHECK: bb0([[X:%[0-9]+]] : $X, [[ORIG_SELF:%[0-9]+]] : $C2):
+    // CHECK: bb0([[X:%[0-9]+]] : @trivial $X, [[ORIG_SELF:%[0-9]+]] : @owned $C2):
     // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var C2 }
     // CHECK:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
     // CHECK:   [[PB_SELF:%.*]] = project_box [[MARKED_SELF_BOX]]

--- a/test/SILGen/lifetime.swift
+++ b/test/SILGen/lifetime.swift
@@ -131,7 +131,7 @@ func reftype_return() -> Ref {
 }
 
 // CHECK-LABEL: sil hidden @$S8lifetime11reftype_argyyAA3RefCF : $@convention(thin) (@guaranteed Ref) -> () {
-// CHECK: bb0([[A:%[0-9]+]] : $Ref):
+// CHECK: bb0([[A:%[0-9]+]] : @guaranteed $Ref):
 // CHECK:   [[AADDR:%[0-9]+]] = alloc_box ${ var Ref }
 // CHECK:   [[PA:%[0-9]+]] = project_box [[AADDR]]
 // CHECK:   [[A_COPY:%.*]] = copy_value [[A]]
@@ -180,7 +180,7 @@ func reftype_call_arg() {
 }
 
 // CHECK-LABEL: sil hidden @$S8lifetime21reftype_call_with_arg{{[_0-9a-zA-Z]*}}F
-// CHECK: bb0([[A1:%[0-9]+]] : $Ref):
+// CHECK: bb0([[A1:%[0-9]+]] : @guaranteed $Ref):
 // CHECK:   [[AADDR:%[0-9]+]] = alloc_box ${ var Ref }
 // CHECK:   [[PB:%.*]] = project_box [[AADDR]]
 // CHECK:   [[A1_COPY:%.*]] = copy_value [[A1]]
@@ -202,7 +202,7 @@ func reftype_call_with_arg(_ a: Ref) {
 // CHECK-LABEL: sil hidden @$S8lifetime16reftype_reassign{{[_0-9a-zA-Z]*}}F
 func reftype_reassign(_ a: inout Ref, b: Ref) {
     var b = b
-    // CHECK: bb0([[AADDR:%[0-9]+]] : $*Ref, [[B1:%[0-9]+]] : $Ref):
+    // CHECK: bb0([[AADDR:%[0-9]+]] : @trivial $*Ref, [[B1:%[0-9]+]] : @guaranteed $Ref):
     // CHECK: [[BADDR:%[0-9]+]] = alloc_box ${ var Ref }
     // CHECK: [[PBB:%.*]] = project_box [[BADDR]]
     a = b
@@ -238,7 +238,7 @@ struct Aleph {
 
   // -- loadable value constructor:
   // CHECK-LABEL: sil hidden @$S8lifetime5AlephV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@owned Ref, Val, @thin Aleph.Type) -> @owned Aleph
-  // CHECK: bb0([[A:%.*]] : $Ref, [[B:%.*]] : $Val, {{%.*}} : $@thin Aleph.Type):
+  // CHECK: bb0([[A:%.*]] : @owned $Ref, [[B:%.*]] : @trivial $Val, {{%.*}} : @trivial $@thin Aleph.Type):
   // CHECK-NEXT:   [[RET:%.*]] = struct $Aleph ([[A]] : {{.*}}, [[B]] : {{.*}})
   // CHECK-NEXT:   return [[RET]]
 }
@@ -260,7 +260,7 @@ struct Daleth {
 
   // -- address-only value constructor:
   // CHECK-LABEL: sil hidden @$S8lifetime6DalethV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@owned Aleph, @owned Beth, @in Unloadable, @thin Daleth.Type) -> @out Daleth {
-  // CHECK: bb0([[THIS:%.*]] : $*Daleth, [[A:%.*]] : $Aleph, [[B:%.*]] : $Beth, [[C:%.*]] : $*Unloadable, {{%.*}} : $@thin Daleth.Type):
+  // CHECK: bb0([[THIS:%.*]] : @trivial $*Daleth, [[A:%.*]] : @owned $Aleph, [[B:%.*]] : @owned $Beth, [[C:%.*]] : @trivial $*Unloadable, {{%.*}} : @trivial $@thin Daleth.Type):
   // CHECK-NEXT:   [[A_ADDR:%.*]] = struct_element_addr [[THIS]] : $*Daleth, #Daleth.a
   // CHECK-NEXT:   store [[A]] to [init] [[A_ADDR]]
   // CHECK-NEXT:   [[B_ADDR:%.*]] = struct_element_addr [[THIS]] : $*Daleth, #Daleth.b
@@ -275,7 +275,7 @@ class He {
   
   // -- default allocator:
   // CHECK-LABEL: sil hidden @$S8lifetime2HeC{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@thick He.Type) -> @owned He {
-  // CHECK: bb0({{%.*}} : $@thick He.Type):
+  // CHECK: bb0({{%.*}} : @trivial $@thick He.Type):
   // CHECK-NEXT:   [[THIS:%.*]] = alloc_ref $He
   // CHECK-NEXT:   // function_ref lifetime.He.init
   // CHECK-NEXT:   [[INIT:%.*]] = function_ref @$S8lifetime2HeC{{[_0-9a-zA-Z]*}}fc : $@convention(method) (@owned He) -> @owned He
@@ -285,7 +285,7 @@ class He {
 
   // -- default initializer:
   // CHECK-LABEL: sil hidden @$S8lifetime2HeC{{[_0-9a-zA-Z]*}}fc : $@convention(method) (@owned He) -> @owned He {
-  // CHECK: bb0([[SELF:%.*]] : $He):
+  // CHECK: bb0([[SELF:%.*]] : @owned $He):
   // CHECK-NEXT: debug_value
   // CHECK-NEXT: [[UNINITIALIZED_SELF:%.*]] = mark_uninitialized [rootself] [[SELF]]
   // CHECK-NEXT: [[UNINITIALIZED_SELF_COPY:%.*]] = copy_value [[UNINITIALIZED_SELF]]
@@ -302,7 +302,7 @@ struct Waw {
 
   // -- loadable value initializer with tuple destructuring:
   // CHECK-LABEL: sil hidden @$S8lifetime3WawV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@owned Ref, Val, Val, @thin Waw.Type) -> @owned Waw 
-  // CHECK: bb0([[A0:%.*]] : $Ref, [[A1:%.*]] : $Val, [[B:%.*]] : $Val, {{%.*}} : $@thin Waw.Type):
+  // CHECK: bb0([[A0:%.*]] : @owned $Ref, [[A1:%.*]] : @trivial $Val, [[B:%.*]] : @trivial $Val, {{%.*}} : @trivial $@thin Waw.Type):
   // CHECK-NEXT:   [[A:%.*]] = tuple ([[A0]] : {{.*}}, [[A1]] : {{.*}})
   // CHECK-NEXT:   [[RET:%.*]] = struct $Waw ([[A]] : {{.*}}, [[B]] : {{.*}})
   // CHECK-NEXT:   return [[RET]]
@@ -314,7 +314,7 @@ struct Zayin {
 
   // -- address-only value initializer with tuple destructuring:
   // CHECK-LABEL: sil hidden @$S8lifetime5ZayinV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@in Unloadable, Val, @in Unloadable, @thin Zayin.Type) -> @out Zayin
-  // CHECK: bb0([[THIS:%.*]] : $*Zayin, [[A0:%.*]] : $*Unloadable, [[A1:%.*]] : $Val, [[B:%.*]] : $*Unloadable, {{%.*}} : $@thin Zayin.Type):
+  // CHECK: bb0([[THIS:%.*]] : @trivial $*Zayin, [[A0:%.*]] : @trivial $*Unloadable, [[A1:%.*]] : @trivial $Val, [[B:%.*]] : @trivial $*Unloadable, {{%.*}} : @trivial $@thin Zayin.Type):
   // CHECK-NEXT:   [[THIS_A_ADDR:%.*]] = struct_element_addr [[THIS]] : $*Zayin, #Zayin.a
   // CHECK-NEXT:   [[THIS_A0_ADDR:%.*]] = tuple_element_addr [[THIS_A_ADDR]] : {{.*}}, 0
   // CHECK-NEXT:   [[THIS_A1_ADDR:%.*]] = tuple_element_addr [[THIS_A_ADDR]] : {{.*}}, 1
@@ -406,7 +406,7 @@ class Foo<T> {
   init() {
   // -- allocating entry point
   // CHECK-LABEL: sil hidden @$S8lifetime3FooC{{[_0-9a-zA-Z]*}}fC :
-    // CHECK: bb0([[METATYPE:%[0-9]+]] : $@thick Foo<T>.Type):
+    // CHECK: bb0([[METATYPE:%[0-9]+]] : @trivial $@thick Foo<T>.Type):
     // CHECK: [[THIS:%[0-9]+]] = alloc_ref $Foo<T>
     // CHECK: [[INIT_METHOD:%[0-9]+]] = function_ref @$S8lifetime3FooC{{[_0-9a-zA-Z]*}}fc
     // CHECK: [[INIT_THIS:%[0-9]+]] = apply [[INIT_METHOD]]<{{.*}}>([[THIS]])
@@ -414,7 +414,7 @@ class Foo<T> {
 
   // -- initializing entry point
   // CHECK-LABEL: sil hidden @$S8lifetime3FooC{{[_0-9a-zA-Z]*}}fc :
-    // CHECK: bb0([[THISIN:%[0-9]+]] : $Foo<T>):
+    // CHECK: bb0([[THISIN:%[0-9]+]] : @owned $Foo<T>):
     // CHECK: [[THIS:%[0-9]+]] = mark_uninitialized
 
     // -- initialization for y
@@ -473,7 +473,7 @@ class Foo<T> {
 
   // -- allocating entry point
   // CHECK-LABEL: sil hidden @$S8lifetime3FooC{{[_0-9a-zA-Z]*}}fC :
-    // CHECK: bb0([[CHI:%[0-9]+]] : $Int, [[METATYPE:%[0-9]+]] : $@thick Foo<T>.Type):
+    // CHECK: bb0([[CHI:%[0-9]+]] : @trivial $Int, [[METATYPE:%[0-9]+]] : @trivial $@thick Foo<T>.Type):
     // CHECK: [[THIS:%[0-9]+]] = alloc_ref $Foo<T>
     // CHECK: [[INIT_METHOD:%[0-9]+]] = function_ref @$S8lifetime3FooC{{[_0-9a-zA-Z]*}}fc
     // CHECK: [[INIT_THIS:%[0-9]+]] = apply [[INIT_METHOD]]<{{.*}}>([[CHI]], [[THIS]])
@@ -481,7 +481,7 @@ class Foo<T> {
 
   // -- initializing entry point
   // CHECK-LABEL: sil hidden @$S8lifetime3FooC3chiACyxGSi_tcfc : $@convention(method) <T> (Int, @owned Foo<T>) -> @owned Foo<T> {
-    // CHECK: bb0([[CHI:%[0-9]+]] : $Int, [[THISIN:%[0-9]+]] : $Foo<T>):
+    // CHECK: bb0([[CHI:%[0-9]+]] : @trivial $Int, [[THISIN:%[0-9]+]] : @owned $Foo<T>):
     // CHECK:   [[THIS:%[0-9]+]] = mark_uninitialized [rootself] [[THISIN]]
 
     // -- First we initialize #Foo.y.
@@ -542,7 +542,7 @@ class Foo<T> {
   // CHECK-LABEL: sil hidden @$S8lifetime3FooCfd : $@convention(method) <T> (@guaranteed Foo<T>) -> @owned Builtin.NativeObject
 
   deinit {
-    // CHECK: bb0([[THIS:%[0-9]+]] : $Foo<T>):
+    // CHECK: bb0([[THIS:%[0-9]+]] : @guaranteed $Foo<T>):
     bar()
     // CHECK: function_ref @$S8lifetime3barSiyF
     // CHECK: apply
@@ -567,7 +567,7 @@ class Foo<T> {
 
   // Deallocating destructor for Foo.
   // CHECK-LABEL: sil hidden @$S8lifetime3FooCfD : $@convention(method) <T> (@owned Foo<T>) -> ()
-  // CHECK: bb0([[SELF:%[0-9]+]] : $Foo<T>):
+  // CHECK: bb0([[SELF:%[0-9]+]] : @owned $Foo<T>):
   // CHECK:   [[DESTROYING_REF:%[0-9]+]] = function_ref @$S8lifetime3FooCfd : $@convention(method) <τ_0_0> (@guaranteed Foo<τ_0_0>) -> @owned Builtin.NativeObject
   // CHECK-NEXT:   [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
   // CHECK-NEXT:   [[RESULT_SELF:%[0-9]+]] = apply [[DESTROYING_REF]]<T>([[BORROWED_SELF]]) : $@convention(method) <τ_0_0> (@guaranteed Foo<τ_0_0>) -> @owned Builtin.NativeObject
@@ -584,7 +584,7 @@ class Foo<T> {
 class FooSubclass<T> : Foo<T> {
 
   // CHECK-LABEL: sil hidden @$S8lifetime11FooSubclassCfd : $@convention(method) <T> (@guaranteed FooSubclass<T>) -> @owned Builtin.NativeObject
-  // CHECK: bb0([[THIS:%[0-9]+]] : $FooSubclass<T>):
+  // CHECK: bb0([[THIS:%[0-9]+]] : @guaranteed $FooSubclass<T>):
   // -- base dtor
   // CHECK: [[BASE:%[0-9]+]] = upcast [[THIS]] : ${{.*}} to $Foo<T>
   // CHECK: [[BASE_DTOR:%[0-9]+]] = function_ref @$S8lifetime3FooCfd : $@convention(method) <τ_0_0> (@guaranteed Foo<τ_0_0>) -> @owned Builtin.NativeObject
@@ -606,7 +606,7 @@ class ImplicitDtor {
   init() { }
 
   // CHECK-LABEL: sil hidden @$S8lifetime12ImplicitDtorCfd
-  // CHECK: bb0([[THIS:%[0-9]+]] : $ImplicitDtor):
+  // CHECK: bb0([[THIS:%[0-9]+]] : @guaranteed $ImplicitDtor):
   // -- don't need to destroy_value x because it's trivial
   // CHECK-NOT: ref_element_addr [[THIS]] : {{.*}}, #ImplicitDtor.x
   // -- destroy_value y
@@ -627,7 +627,7 @@ class ImplicitDtorDerived<T> : ImplicitDtor {
   }
 
   // CHECK: sil hidden @$S8lifetime19ImplicitDtorDerivedCfd : $@convention(method) <T> (@guaranteed ImplicitDtorDerived<T>) -> @owned Builtin.NativeObject {
-  // CHECK: bb0([[THIS:%[0-9]+]] : $ImplicitDtorDerived<T>):
+  // CHECK: bb0([[THIS:%[0-9]+]] : @guaranteed $ImplicitDtorDerived<T>):
   // -- base dtor
   // CHECK: [[BASE:%[0-9]+]] = upcast [[THIS]] : ${{.*}} to $ImplicitDtor
   // CHECK: [[BASE_DTOR:%[0-9]+]] = function_ref @$S8lifetime12ImplicitDtorCfd
@@ -648,7 +648,7 @@ class ImplicitDtorDerivedFromGeneric<T> : ImplicitDtorDerived<Int> {
   init() { super.init(z: 5) }
 
   // CHECK-LABEL: sil hidden @$S8lifetime30ImplicitDtorDerivedFromGenericC{{[_0-9a-zA-Z]*}}fc
-  // CHECK: bb0([[THIS:%[0-9]+]] : $ImplicitDtorDerivedFromGeneric<T>):
+  // CHECK: bb0([[THIS:%[0-9]+]] : @guaranteed $ImplicitDtorDerivedFromGeneric<T>):
   // -- base dtor
   // CHECK: [[BASE:%[0-9]+]] = upcast [[THIS]] : ${{.*}} to $ImplicitDtorDerived<Int>
   // CHECK: [[BASE_DTOR:%[0-9]+]] = function_ref @$S8lifetime19ImplicitDtorDerivedCfd
@@ -666,7 +666,7 @@ struct Bar {
   // Loadable struct initializer
   // CHECK-LABEL: sil hidden @$S8lifetime3BarV{{[_0-9a-zA-Z]*}}fC
   init() {
-    // CHECK: bb0([[METATYPE:%[0-9]+]] : $@thin Bar.Type):
+    // CHECK: bb0([[METATYPE:%[0-9]+]] : @trivial $@thin Bar.Type):
     // CHECK: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var Bar }
     // CHECK: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [rootself] [[SELF_BOX]]
     // CHECK: [[PB_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
@@ -694,7 +694,7 @@ struct Bas<T> {
   // Address-only struct initializer
   // CHECK-LABEL: sil hidden @$S8lifetime3BasV{{[_0-9a-zA-Z]*}}fC
   init(yy:T) {
-    // CHECK: bb0([[THISADDRPTR:%[0-9]+]] : $*Bas<T>, [[YYADDR:%[0-9]+]] : $*T, [[META:%[0-9]+]] : $@thin Bas<T>.Type):
+    // CHECK: bb0([[THISADDRPTR:%[0-9]+]] : @trivial $*Bas<T>, [[YYADDR:%[0-9]+]] : @trivial $*T, [[META:%[0-9]+]] : @trivial $@thin Bas<T>.Type):
     // CHECK: [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var Bas<τ_0_0> } <T>
     // CHECK: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [rootself] [[SELF_BOX]]
     // CHECK: [[PB_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
@@ -723,7 +723,7 @@ struct Bas<T> {
 class B { init(y:Int) {} }
 class D : B {
   // CHECK-LABEL: sil hidden @$S8lifetime1DC1x1yACSi_Sitcfc
-  // CHECK: bb0([[X:%[0-9]+]] : $Int, [[Y:%[0-9]+]] : $Int, [[SELF:%[0-9]+]] : $D):
+  // CHECK: bb0([[X:%[0-9]+]] : @trivial $Int, [[Y:%[0-9]+]] : @trivial $Int, [[SELF:%[0-9]+]] : @owned $D):
   init(x: Int, y: Int) {
     var x = x
     var y = y

--- a/test/SILGen/materializeForSet.swift
+++ b/test/SILGen/materializeForSet.swift
@@ -6,7 +6,7 @@ class Base {
   var stored: Int = 0
 
 // CHECK-LABEL: sil hidden [transparent] @$S17materializeForSet4BaseC6storedSivm : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @guaranteed Base) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>) {
-// CHECK: bb0([[BUFFER:%.*]] : $Builtin.RawPointer, [[STORAGE:%.*]] : $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : $Base):
+// CHECK: bb0([[BUFFER:%.*]] : @trivial $Builtin.RawPointer, [[STORAGE:%.*]] : @trivial $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : @guaranteed $Base):
 // CHECK:   [[T0:%.*]] = ref_element_addr [[SELF]] : $Base, #Base.stored
 // CHECK:   [[T1:%.*]] = address_to_pointer [[T0]] : $*Int to $Builtin.RawPointer
 // CHECK:   [[T2:%.*]] = enum $Optional<Builtin.RawPointer>, #Optional.some
@@ -15,7 +15,7 @@ class Base {
 // CHECK: }
 
 // UNCHECKED-LABEL: sil hidden [transparent] @$S17materializeForSet4BaseC6storedSivm : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @guaranteed Base) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>) {
-// UNCHECKED: bb0([[BUFFER:%.*]] : $Builtin.RawPointer, [[STORAGE:%.*]] : $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : $Base):
+// UNCHECKED: bb0([[BUFFER:%.*]] : @trivial $Builtin.RawPointer, [[STORAGE:%.*]] : @trivial $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : @guaranteed $Base):
 // UNCHECKED:   [[T0:%.*]] = ref_element_addr [[SELF]] : $Base, #Base.stored
 // UNCHECKED:   [[T1:%.*]] = address_to_pointer [[T0]] : $*Int to $Builtin.RawPointer
 // UNCHECKED:   [[T2:%.*]] = enum $Optional<Builtin.RawPointer>, #Optional.none
@@ -24,7 +24,7 @@ class Base {
 // UNCHECKED: }
 
 // CHECK-LABEL: sil private [transparent] @$S17materializeForSet4BaseC8computedSivmytfU_ : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @in_guaranteed Base, @thick Base.Type) -> () {
-// CHECK: bb0([[BUFFER:%.*]] : $Builtin.RawPointer, [[STORAGE:%.*]] : $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : $*Base, [[SELFTYPE:%.*]] : $@thick Base.Type):
+// CHECK: bb0([[BUFFER:%.*]] : @trivial $Builtin.RawPointer, [[STORAGE:%.*]] : @trivial $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : @trivial $*Base, [[SELFTYPE:%.*]] : @trivial $@thick Base.Type):
 // CHECK:   [[T0:%.*]] = load_borrow [[SELF]]
 // CHECK:   [[T1:%.*]] = pointer_to_address [[BUFFER]] : $Builtin.RawPointer to [strict] $*Int
 // CHECK:   [[T2:%.*]] = load [trivial] [[T1]] : $*Int
@@ -32,7 +32,7 @@ class Base {
 // CHECK:   apply [[SETTER]]([[T2]], [[T0]])
 
 // CHECK-LABEL: sil hidden [transparent] @$S17materializeForSet4BaseC8computedSivm : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @guaranteed Base) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>) {
-// CHECK: bb0([[BUFFER:%.*]] : $Builtin.RawPointer, [[STORAGE:%.*]] : $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : $Base):
+// CHECK: bb0([[BUFFER:%.*]] : @trivial $Builtin.RawPointer, [[STORAGE:%.*]] : @trivial $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : @guaranteed $Base):
 // CHECK:   [[ADDR:%.*]] = pointer_to_address [[BUFFER]] : $Builtin.RawPointer to [strict] $*Int
 // CHECK:   [[T0:%.*]] = function_ref @$S17materializeForSet4BaseC8computedSivg
 // CHECK:   [[T1:%.*]] = apply [[T0]]([[SELF]])
@@ -78,7 +78,7 @@ protocol Abstractable {
 extension Derived : Abstractable {}
 
 // CHECK-LABEL: sil private [transparent] @$S17materializeForSet7DerivedCAA12AbstractableA2aDP14storedFunction6ResultQzycvmytfU_TW : $@convention(witness_method: Abstractable) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @in_guaranteed Derived, @thick Derived.Type) -> ()
-// CHECK: bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $*Derived, %3 : $@thick Derived.Type):
+// CHECK: bb0(%0 : @trivial $Builtin.RawPointer, %1 : @trivial $*Builtin.UnsafeValueBuffer, %2 : @trivial $*Derived, %3 : @trivial $@thick Derived.Type):
 // CHECK-NEXT: [[T0:%.*]] = load_borrow %2 : $*Derived
 // CHECK-NEXT: [[SELF:%.*]] = upcast [[T0]] : $Derived to $Base
 // CHECK-NEXT: [[RESULT_ADDR:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*@callee_guaranteed () -> @out Int
@@ -93,7 +93,7 @@ extension Derived : Abstractable {}
 // CHECK-NEXT: return
 
 // CHECK-LABEL: sil private [transparent] [thunk] @$S17materializeForSet7DerivedCAA12AbstractableA2aDP14storedFunction{{[_0-9a-zA-Z]*}}vmTW
-// CHECK: bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $*Derived):
+// CHECK: bb0(%0 : @trivial $Builtin.RawPointer, %1 : @trivial $*Builtin.UnsafeValueBuffer, %2 : @trivial $*Derived):
 // CHECK-NEXT: [[RESULT_ADDR:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*@callee_guaranteed () -> @out Int
 // CHECK-NEXT: [[T0:%.*]] = load_borrow %2 : $*Derived
 // CHECK-NEXT: [[SELF:%.*]] = upcast [[T0]] : $Derived to $Base
@@ -118,7 +118,7 @@ extension Derived : Abstractable {}
 // CHECK-NEXT: return [[T4]]
 
 // CHECK-LABEL: sil private [transparent] @$S17materializeForSet7DerivedCAA12AbstractableA2aDP19finalStoredFunction6ResultQzycvmytfU_TW :
-// CHECK: bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $*Derived, %3 : $@thick Derived.Type):
+// CHECK: bb0(%0 : @trivial $Builtin.RawPointer, %1 : @trivial $*Builtin.UnsafeValueBuffer, %2 : @trivial $*Derived, %3 : @trivial $@thick Derived.Type):
 // CHECK-NEXT: [[T0:%.*]] = load_borrow %2 : $*Derived
 // CHECK-NEXT: [[SELF:%.*]] = upcast [[T0]] : $Derived to $Base
 // CHECK-NEXT: [[RESULT_ADDR:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*@callee_guaranteed () -> @out Int
@@ -135,7 +135,7 @@ extension Derived : Abstractable {}
 // CHECK-NEXT: return
 
 // UNCHECKED-LABEL: sil private [transparent] @$S17materializeForSet7DerivedCAA12AbstractableA2aDP19finalStoredFunction6ResultQzycvmytfU_TW :
-// UNCHECKED: bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $*Derived, %3 : $@thick Derived.Type):
+// UNCHECKED: bb0(%0 : @trivial $Builtin.RawPointer, %1 : @trivial $*Builtin.UnsafeValueBuffer, %2 : @trivial $*Derived, %3 : @trivial $@thick Derived.Type):
 // UNCHECKED-NEXT: [[T0:%.*]] = load_borrow %2 : $*Derived
 // UNCHECKED-NEXT: [[SELF:%.*]] = upcast [[T0]] : $Derived to $Base
 // UNCHECKED-NEXT: [[RESULT_ADDR:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*@callee_guaranteed () -> @out Int
@@ -150,7 +150,7 @@ extension Derived : Abstractable {}
 // UNCHECKED-NEXT: return
 
 // CHECK-LABEL: sil private [transparent] [thunk] @$S17materializeForSet7DerivedCAA12AbstractableA2aDP19finalStoredFunction{{[_0-9a-zA-Z]*}}vmTW
-// CHECK: bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $*Derived):
+// CHECK: bb0(%0 : @trivial $Builtin.RawPointer, %1 : @trivial $*Builtin.UnsafeValueBuffer, %2 : @trivial $*Derived):
 // CHECK-NEXT: [[RESULT_ADDR:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*@callee_guaranteed () -> @out Int
 // CHECK-NEXT: [[T0:%.*]] = load_borrow %2 : $*Derived
 // CHECK-NEXT: [[SELF:%.*]] = upcast [[T0]] : $Derived to $Base
@@ -172,7 +172,7 @@ extension Derived : Abstractable {}
 // CHECK-NEXT: return [[T4]]
 
 // UNCHECKED-LABEL: sil private [transparent] [thunk] @$S17materializeForSet7DerivedCAA12AbstractableA2aDP19finalStoredFunction{{[_0-9a-zA-Z]*}}vmTW
-// UNCHECKED: bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $*Derived):
+// UNCHECKED: bb0(%0 : @trivial $Builtin.RawPointer, %1 : @trivial $*Builtin.UnsafeValueBuffer, %2 : @trivial $*Derived):
 // UNCHECKED-NEXT: [[RESULT_ADDR:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*@callee_guaranteed () -> @out Int
 // UNCHECKED-NEXT: [[T0:%.*]] = load_borrow %2 : $*Derived
 // UNCHECKED-NEXT: [[SELF:%.*]] = upcast [[T0]] : $Derived to $Base
@@ -192,7 +192,7 @@ extension Derived : Abstractable {}
 // UNCHECKED-NEXT: return [[T4]]
 
 // CHECK-LABEL: sil private [transparent] @$S17materializeForSet7DerivedCAA12AbstractableA2aDP14staticFunction6ResultQzycvmZytfU_TW
-// CHECK: bb0([[ARG1:%.*]] : $Builtin.RawPointer, [[ARG2:%.*]] : $*Builtin.UnsafeValueBuffer, [[ARG3:%.*]] : $*@thick Derived.Type, [[ARG4:%.*]] : $@thick Derived.Type.Type):
+// CHECK: bb0([[ARG1:%.*]] : @trivial $Builtin.RawPointer, [[ARG2:%.*]] : @trivial $*Builtin.UnsafeValueBuffer, [[ARG3:%.*]] : @trivial $*@thick Derived.Type, [[ARG4:%.*]] : @trivial $@thick Derived.Type.Type):
 // CHECK-NEXT: [[SELF:%.*]] = load [trivial] [[ARG3]] : $*@thick Derived.Type
 // CHECK-NEXT: [[BASE_SELF:%.*]] = upcast [[SELF]] : $@thick Derived.Type to $@thick Base.Type
 // CHECK-NEXT: [[BUFFER:%.*]] = pointer_to_address [[ARG1]] : $Builtin.RawPointer to [strict] $*@callee_guaranteed () -> @out Int
@@ -205,7 +205,7 @@ extension Derived : Abstractable {}
 // CHECK-NEXT: return [[RESULT]] : $()
 
 // CHECK-LABEL: sil private [transparent] [thunk] @$S17materializeForSet7DerivedCAA12AbstractableA2aDP14staticFunction6ResultQzycvmZTW
-// CHECK: bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $@thick Derived.Type):
+// CHECK: bb0(%0 : @trivial $Builtin.RawPointer, %1 : @trivial $*Builtin.UnsafeValueBuffer, %2 : @trivial $@thick Derived.Type):
 // CHECK-NEXT: [[RESULT_ADDR:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*@callee_guaranteed () -> @out Int
 // CHECK-NEXT: [[SELF:%.*]] = upcast %2 : $@thick Derived.Type to $@thick Base.Type
 // CHECK-NEXT: [[OUT:%.*]] = alloc_stack $@callee_guaranteed () -> Int
@@ -258,7 +258,7 @@ class HasDidSet : Base {
   }
 
 // CHECK-LABEL: sil hidden [transparent] @$S17materializeForSet06HasDidC0C6storedSivm : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @guaranteed HasDidSet) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>) {
-// CHECK: bb0([[BUFFER:%.*]] : $Builtin.RawPointer, [[STORAGE:%.*]] : $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : $HasDidSet):
+// CHECK: bb0([[BUFFER:%.*]] : @trivial $Builtin.RawPointer, [[STORAGE:%.*]] : @trivial $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : @guaranteed $HasDidSet):
 // CHECK:   [[T2:%.*]] = pointer_to_address [[BUFFER]] : $Builtin.RawPointer to [strict] $*Int
 // CHECK:   [[T0:%.*]] = function_ref @$S17materializeForSet06HasDidC0C6storedSivg
 // CHECK:   [[T1:%.*]] = apply [[T0]]([[SELF]])
@@ -277,7 +277,7 @@ class HasDidSet : Base {
   }
 
 // CHECK-LABEL: sil hidden [transparent] @$S17materializeForSet06HasDidC0C8computedSivm : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @guaranteed HasDidSet) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>) {
-// CHECK: bb0([[BUFFER:%.*]] : $Builtin.RawPointer, [[STORAGE:%.*]] : $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : $HasDidSet):
+// CHECK: bb0([[BUFFER:%.*]] : @trivial $Builtin.RawPointer, [[STORAGE:%.*]] : @trivial $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : @guaranteed $HasDidSet):
 // CHECK:   [[T2:%.*]] = pointer_to_address [[BUFFER]] : $Builtin.RawPointer to [strict] $*Int
 // CHECK:   [[T0:%.*]] = function_ref @$S17materializeForSet06HasDidC0C8computedSivg
 // CHECK:   [[T1:%.*]] = apply [[T0]]([[SELF]])
@@ -297,7 +297,7 @@ class HasStoredDidSet {
   }
 
 // CHECK-LABEL: sil private [transparent] @$S17materializeForSet012HasStoredDidC0C6storedSivmytfU_ : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @in_guaranteed HasStoredDidSet, @thick HasStoredDidSet.Type) -> () {
-// CHECK: bb0([[BUFFER:%.*]] : $Builtin.RawPointer, [[STORAGE:%.*]] : $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : $*HasStoredDidSet, [[METATYPE:%.*]] : $@thick HasStoredDidSet.Type):
+// CHECK: bb0([[BUFFER:%.*]] : @trivial $Builtin.RawPointer, [[STORAGE:%.*]] : @trivial $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : @trivial $*HasStoredDidSet, [[METATYPE:%.*]] : @trivial $@thick HasStoredDidSet.Type):
 // CHECK:   [[SELF_VALUE:%.*]] = load_borrow [[SELF]] : $*HasStoredDidSet
 // CHECK:   [[BUFFER_ADDR:%.*]] = pointer_to_address [[BUFFER]] : $Builtin.RawPointer to [strict] $*Int
 // CHECK:   [[VALUE:%.*]] = load [trivial] [[BUFFER_ADDR]] : $*Int
@@ -307,7 +307,7 @@ class HasStoredDidSet {
 // CHECK: }
 
 // CHECK-LABEL: sil hidden [transparent] @$S17materializeForSet012HasStoredDidC0C6storedSivm : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @guaranteed HasStoredDidSet) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>) {
-// CHECK: bb0([[BUFFER:%.*]] : $Builtin.RawPointer, [[STORAGE:%.*]] : $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : $HasStoredDidSet):
+// CHECK: bb0([[BUFFER:%.*]] : @trivial $Builtin.RawPointer, [[STORAGE:%.*]] : @trivial $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : @guaranteed $HasStoredDidSet):
 // CHECK:   [[T2:%.*]] = pointer_to_address [[BUFFER]] : $Builtin.RawPointer to [strict] $*Int
 // CHECK:   [[T0:%.*]] = ref_element_addr [[SELF]] : $HasStoredDidSet, #HasStoredDidSet.stored
 // CHECK:   [[T1:%.*]] = begin_access [read] [dynamic] [[T0]] : $*Int
@@ -327,7 +327,7 @@ class HasWeak {
   weak var weakvar: HasWeak?
 }
 // CHECK-LABEL: sil hidden [transparent] @$S17materializeForSet7HasWeakC7weakvarACSgXwvm : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @guaranteed HasWeak) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>) {
-// CHECK: bb0([[BUFFER:%.*]] : $Builtin.RawPointer, [[STORAGE:%.*]] : $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : $HasWeak):
+// CHECK: bb0([[BUFFER:%.*]] : @trivial $Builtin.RawPointer, [[STORAGE:%.*]] : @trivial $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : @guaranteed $HasWeak):
 // CHECK:   [[T2:%.*]] = pointer_to_address [[BUFFER]] : $Builtin.RawPointer to [strict] $*Optional<HasWeak>
 // CHECK:   [[T0:%.*]] = ref_element_addr [[SELF]] : $HasWeak, #HasWeak.weakvar
 // CHECK:   [[READ:%.*]] = begin_access [read] [dynamic] [[T0]] : $*@sil_weak Optional<HasWeak>
@@ -341,7 +341,7 @@ class HasWeak {
 // CHECK: }
 
 // UNCHECKED-LABEL: sil hidden [transparent] @$S17materializeForSet7HasWeakC7weakvarACSgXwvm : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @guaranteed HasWeak) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>) {
-// UNCHECKED: bb0([[BUFFER:%.*]] : $Builtin.RawPointer, [[STORAGE:%.*]] : $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : $HasWeak):
+// UNCHECKED: bb0([[BUFFER:%.*]] : @trivial $Builtin.RawPointer, [[STORAGE:%.*]] : @trivial $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : @guaranteed $HasWeak):
 // UNCHECKED:   [[T2:%.*]] = pointer_to_address [[BUFFER]] : $Builtin.RawPointer to [strict] $*Optional<HasWeak>
 // UNCHECKED:   [[T0:%.*]] = ref_element_addr [[SELF]] : $HasWeak, #HasWeak.weakvar
 // UNCHECKED:   [[T1:%.*]] = load_weak [[T0]] : $*@sil_weak Optional<HasWeak>
@@ -395,7 +395,7 @@ struct Bill : Totalled {
 }
 
 // CHECK-LABEL: sil hidden [transparent] @$S17materializeForSet4BillV5totalSivm : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout Bill) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>) {
-// CHECK: bb0([[BUFFER:%.*]] : $Builtin.RawPointer, [[STORAGE:%.*]] : $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : $*Bill):
+// CHECK: bb0([[BUFFER:%.*]] : @trivial $Builtin.RawPointer, [[STORAGE:%.*]] : @trivial $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : @trivial $*Bill):
 // CHECK:   [[T0:%.*]] = struct_element_addr [[SELF]] : $*Bill, #Bill.total
 // CHECK:   [[T1:%.*]] = address_to_pointer [[T0]] : $*Int to $Builtin.RawPointer
 // CHECK:   [[T3:%.*]] = enum $Optional<Builtin.RawPointer>, #Optional.none!enumelt
@@ -404,7 +404,7 @@ struct Bill : Totalled {
 // CHECK: }
 
 // CHECK-LABEL:  sil private [transparent] [thunk] @$S17materializeForSet4BillVAA8TotalledA2aDP5totalSivmTW : $@convention(witness_method: Totalled) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout Bill) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>) {
-// CHECK:        bb0([[BUFFER:%.*]] : $Builtin.RawPointer, [[STORAGE:%.*]] : $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : $*Bill):
+// CHECK:        bb0([[BUFFER:%.*]] : @trivial $Builtin.RawPointer, [[STORAGE:%.*]] : @trivial $*Builtin.UnsafeValueBuffer, [[SELF:%.*]] : @trivial $*Bill):
 // CHECK:          [[T0:%.*]] = function_ref @$S17materializeForSet4BillV5totalSivm
 // CHECK-NEXT:     [[T1:%.*]] = apply [[T0]]([[BUFFER]], [[STORAGE]], [[SELF]])
 // CHECK-NEXT:     [[LEFT:%.*]] = tuple_extract [[T1]]

--- a/test/SILGen/newtype.swift
+++ b/test/SILGen/newtype.swift
@@ -17,7 +17,7 @@ func createErrorDomain(str: String) -> ErrorDomain {
 }
 
 // CHECK-RAW-LABEL: sil shared [transparent] [serializable] @$SSo14SNTErrorDomaina8rawValueABSS_tcfC
-// CHECK-RAW: bb0([[STR:%[0-9]+]] : $String,
+// CHECK-RAW: bb0([[STR:%[0-9]+]] : @owned $String,
 // CHECK-RAW: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var ErrorDomain }, var, name "self"
 // CHECK-RAW: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [rootself] [[SELF_BOX]]
 // CHECK-RAW: [[PB_BOX:%[0-9]+]] = project_box [[MARKED_SELF_BOX]]
@@ -37,7 +37,7 @@ func getRawValue(ed: ErrorDomain) -> String {
 }
 
 // CHECK-RAW-LABEL: sil shared [serializable] @$SSo14SNTErrorDomaina8rawValueSSvg
-// CHECK-RAW: bb0([[SELF:%[0-9]+]] : $ErrorDomain):
+// CHECK-RAW: bb0([[SELF:%[0-9]+]] : @guaranteed $ErrorDomain):
 // CHECK-RAW: [[STORED_VALUE:%[0-9]+]] = struct_extract [[SELF]] : $ErrorDomain, #ErrorDomain._rawValue
 // CHECK-RAW: [[STORED_VALUE_COPY:%.*]] = copy_value [[STORED_VALUE]]
 // CHECK-RAW: [[BRIDGE_FN:%[0-9]+]] = function_ref @$SSS10FoundationE36_unconditionallyBridgeFromObjectiveCySSSo8NSStringCSgFZ

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -8,7 +8,7 @@ func use(_: Double) {}
 func getInt() -> Int { return zero }
 
 // CHECK-LABEL: sil hidden @{{.*}}physical_tuple_lvalue
-// CHECK: bb0(%0 : $Int):
+// CHECK: bb0(%0 : @trivial $Int):
 func physical_tuple_lvalue(_ c: Int) {
   var x : (Int, Int)
   // CHECK: [[BOX:%[0-9]+]] = alloc_box ${ var (Int, Int) }
@@ -33,7 +33,7 @@ func physical_tuple_rvalue() -> Int {
 
 // CHECK-LABEL: sil hidden @$S10properties16tuple_assignment{{[_0-9a-zA-Z]*}}F
 func tuple_assignment(_ a: inout Int, b: inout Int) {
-  // CHECK: bb0([[A_ADDR:%[0-9]+]] : $*Int, [[B_ADDR:%[0-9]+]] : $*Int):
+  // CHECK: bb0([[A_ADDR:%[0-9]+]] : @trivial $*Int, [[B_ADDR:%[0-9]+]] : @trivial $*Int):
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[B_ADDR]]
   // CHECK: [[B:%[0-9]+]] = load [trivial] [[READ]]
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[A_ADDR]]
@@ -47,7 +47,7 @@ func tuple_assignment(_ a: inout Int, b: inout Int) {
 
 // CHECK-LABEL: sil hidden @$S10properties18tuple_assignment_2{{[_0-9a-zA-Z]*}}F
 func tuple_assignment_2(_ a: inout Int, b: inout Int, xy: (Int, Int)) {
-  // CHECK: bb0([[A_ADDR:%[0-9]+]] : $*Int, [[B_ADDR:%[0-9]+]] : $*Int, [[X:%[0-9]+]] : $Int, [[Y:%[0-9]+]] : $Int):
+  // CHECK: bb0([[A_ADDR:%[0-9]+]] : @trivial $*Int, [[B_ADDR:%[0-9]+]] : @trivial $*Int, [[X:%[0-9]+]] : @trivial $Int, [[Y:%[0-9]+]] : @trivial $Int):
   (a, b) = xy
   // CHECK: [[XY2:%[0-9]+]] = tuple ([[X]] : $Int, [[Y]] : $Int)
   // CHECK: [[X:%[0-9]+]] = tuple_extract [[XY2]] : {{.*}}, 0
@@ -106,7 +106,7 @@ func physical_struct_lvalue(_ c: Int) {
 }
 
 // CHECK-LABEL: sil hidden @$S10properties21physical_class_lvalue{{[_0-9a-zA-Z]*}}F : $@convention(thin) (@guaranteed Ref, Int) -> ()
-// CHECK: bb0([[ARG0:%.*]] : $Ref,
+// CHECK: bb0([[ARG0:%.*]] : @guaranteed $Ref,
  func physical_class_lvalue(_ r: Ref, a: Int) {
     r.y = a
    // CHECK: [[FN:%[0-9]+]] = class_method [[ARG0]] : $Ref, #Ref.y!setter.1
@@ -116,7 +116,7 @@ func physical_struct_lvalue(_ c: Int) {
 
 // CHECK-LABEL: sil hidden @$S10properties24physical_subclass_lvalue{{[_0-9a-zA-Z]*}}F
 func physical_subclass_lvalue(_ r: RefSubclass, a: Int) {
-  // CHECK: bb0([[ARG1:%.*]] : $RefSubclass, [[ARG2:%.*]] : $Int):
+  // CHECK: bb0([[ARG1:%.*]] : @guaranteed $RefSubclass, [[ARG2:%.*]] : @trivial $Int):
   r.y = a
   // CHECK: [[ARG1_COPY:%.*]] = copy_value [[ARG1]] : $RefSubclass
   // CHECK: [[R_SUP:%[0-9]+]] = upcast [[ARG1_COPY]] : $RefSubclass to $Ref
@@ -171,7 +171,7 @@ func logical_struct_get() -> Int {
 
 // CHECK-LABEL: sil hidden @$S10properties18logical_struct_set{{[_0-9a-zA-Z]*}}F
 func logical_struct_set(_ value: inout Val, z: Int) {
-  // CHECK: bb0([[VAL:%[0-9]+]] : $*Val, [[Z:%[0-9]+]] : $Int):
+  // CHECK: bb0([[VAL:%[0-9]+]] : @trivial $*Val, [[Z:%[0-9]+]] : @trivial $Int):
   value.z = z
   // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[VAL]]
   // CHECK: [[Z_SET_METHOD:%[0-9]+]] = function_ref @$S10properties3ValV1z{{[_0-9a-zA-Z]*}}vs
@@ -181,7 +181,7 @@ func logical_struct_set(_ value: inout Val, z: Int) {
 
 // CHECK-LABEL: sil hidden @$S10properties27logical_struct_in_tuple_set{{[_0-9a-zA-Z]*}}F
 func logical_struct_in_tuple_set(_ value: inout (Int, Val), z: Int) {
-  // CHECK: bb0([[VAL:%[0-9]+]] : $*(Int, Val), [[Z:%[0-9]+]] : $Int):
+  // CHECK: bb0([[VAL:%[0-9]+]] : @trivial $*(Int, Val), [[Z:%[0-9]+]] : @trivial $Int):
   value.1.z = z
   // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[VAL]]
   // CHECK: [[VAL_1:%[0-9]+]] = tuple_element_addr [[WRITE]] : {{.*}}, 1
@@ -192,7 +192,7 @@ func logical_struct_in_tuple_set(_ value: inout (Int, Val), z: Int) {
 
 // CHECK-LABEL: sil hidden @$S10properties29logical_struct_in_reftype_set{{[_0-9a-zA-Z]*}}F
 func logical_struct_in_reftype_set(_ value: inout Val, z1: Int) {
-  // CHECK: bb0([[VAL:%[0-9]+]] : $*Val, [[Z1:%[0-9]+]] : $Int):
+  // CHECK: bb0([[VAL:%[0-9]+]] : @trivial $*Val, [[Z1:%[0-9]+]] : @trivial $Int):
   value.ref.val_prop.z_tuple.1 = z1
   // -- val.ref
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[VAL]]
@@ -233,7 +233,7 @@ func logical_struct_in_reftype_set(_ value: inout Val, z1: Int) {
   // CHECK: apply [[SET_Z_TUPLE_METHOD]]({{%[0-9]+, %[0-9]+}}, [[VAL_REF_VAL_PROP_MAT]])
   // -- writeback to val.ref.val_prop
   // CHECK: switch_enum [[OPT_CALLBACK]] : $Optional<Builtin.RawPointer>, case #Optional.some!enumelt.1: [[WRITEBACK:bb[0-9]+]], case #Optional.none!enumelt: [[CONT:bb[0-9]+]]
-  // CHECK: [[WRITEBACK]]([[CALLBACK_ADDR:%.*]] : $Builtin.RawPointer):
+  // CHECK: [[WRITEBACK]]([[CALLBACK_ADDR:%.*]] : @trivial $Builtin.RawPointer):
   // CHECK: [[CALLBACK:%.*]] = pointer_to_thin_function [[CALLBACK_ADDR]] : $Builtin.RawPointer to $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @in_guaranteed Ref, @thick Ref.Type) -> ()
   // CHECK: [[REF_MAT:%.*]] = alloc_stack $Ref
   // CHECK: store [[VAL_REF]] to [init] [[REF_MAT]]
@@ -257,7 +257,7 @@ func reftype_rvalue_set(_ value: Val) {
 
 // CHECK-LABEL: sil hidden @$S10properties27tuple_in_logical_struct_set{{[_0-9a-zA-Z]*}}F
 func tuple_in_logical_struct_set(_ value: inout Val, z1: Int) {
-  // CHECK: bb0([[VAL:%[0-9]+]] : $*Val, [[Z1:%[0-9]+]] : $Int):
+  // CHECK: bb0([[VAL:%[0-9]+]] : @trivial $*Val, [[Z1:%[0-9]+]] : @trivial $Int):
   value.z_tuple.1 = z1
   // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[VAL]]
   // CHECK: [[Z_TUPLE_MATERIALIZED:%[0-9]+]] = alloc_stack $(Int, Int)
@@ -318,7 +318,7 @@ func logical_local_get(_ x: Int) -> Int {
   return prop
 }
 // CHECK-: sil private [[PROP_GET_CLOSURE]]
-// CHECK: bb0(%{{[0-9]+}} : $Int):
+// CHECK: bb0(%{{[0-9]+}} : @trivial $Int):
 
 func logical_generic_local_get<T>(_ x: Int, _: T) {
   var prop1: Int {
@@ -355,7 +355,7 @@ func logical_local_captured_get(_ x: Int) -> Int {
   // CHECK: apply [[FUNC_REF]](%0)
 }
 // CHECK: sil private @$S10properties26logical_local_captured_get{{.*}}vg
-// CHECK: bb0(%{{[0-9]+}} : $Int):
+// CHECK: bb0(%{{[0-9]+}} : @trivial $Int):
 
 func inout_arg(_ x: inout Int) {}
 
@@ -375,7 +375,7 @@ func physical_inout(_ x: Int) {
  * reuses temporaries */
 
 // CHECK-LABEL: sil hidden @$S10properties17val_subscript_get{{[_0-9a-zA-Z]*}}F : $@convention(thin) (@guaranteed Val, Int) -> Float
-// CHECK: bb0([[VVAL:%[0-9]+]] : $Val, [[I:%[0-9]+]] : $Int):
+// CHECK: bb0([[VVAL:%[0-9]+]] : @guaranteed $Val, [[I:%[0-9]+]] : @trivial $Int):
 func val_subscript_get(_ v: Val, i: Int) -> Float {
   return v[i]
   // CHECK: [[SUBSCRIPT_GET_METHOD:%[0-9]+]] = function_ref @$S10properties3ValV{{[_0-9a-zA-Z]*}}ig
@@ -384,7 +384,7 @@ func val_subscript_get(_ v: Val, i: Int) -> Float {
 }
 
 // CHECK-LABEL: sil hidden @$S10properties17val_subscript_set{{[_0-9a-zA-Z]*}}F
-// CHECK: bb0(%0 : $Val, [[I:%[0-9]+]] : $Int, [[X:%[0-9]+]] : $Float):
+// CHECK: bb0(%0 : @guaranteed $Val, [[I:%[0-9]+]] : @trivial $Int, [[X:%[0-9]+]] : @trivial $Float):
 func val_subscript_set(_ v: Val, i: Int, x: Float) {
   var v = v
   v[i] = x
@@ -502,7 +502,7 @@ struct DidSetWillSetTests: ForceAccessors {
     a = x
     a = x
 
-    // CHECK: bb0(%0 : $Int, %1 : $@thin DidSetWillSetTests.Type):
+    // CHECK: bb0(%0 : @trivial $Int, %1 : @trivial $@thin DidSetWillSetTests.Type):
     // CHECK:        [[SELF:%.*]] = mark_uninitialized [rootself]
     // CHECK:        [[PB_SELF:%.*]] = project_box [[SELF]]
     // CHECK:        [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB_SELF]]
@@ -516,7 +516,7 @@ struct DidSetWillSetTests: ForceAccessors {
   var a: Int {
     // CHECK-LABEL: sil private @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vw
     willSet(newA) {
-      // CHECK: bb0(%0 : $Int, %1 : $*DidSetWillSetTests):
+      // CHECK: bb0(%0 : @trivial $Int, %1 : @trivial $*DidSetWillSetTests):
       // CHECK-NEXT: debug_value %0
       // CHECK-NEXT: debug_value_addr %1 : $*DidSetWillSetTests
 
@@ -551,7 +551,7 @@ struct DidSetWillSetTests: ForceAccessors {
 
     // CHECK-LABEL: sil private @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vW
     didSet {
-      // CHECK: bb0(%0 : $Int, %1 : $*DidSetWillSetTests):
+      // CHECK: bb0(%0 : @trivial $Int, %1 : @trivial $*DidSetWillSetTests):
       // CHECK-NEXT: debug
       // CHECK-NEXT: debug_value_addr %1 : $*DidSetWillSetTests
 
@@ -583,14 +583,14 @@ struct DidSetWillSetTests: ForceAccessors {
   // This is the synthesized getter and setter for the willset/didset variable.
 
   // CHECK-LABEL: sil hidden [transparent] @$S10properties010DidSetWillC5TestsV1aSivg
-  // CHECK: bb0(%0 : $DidSetWillSetTests):
+  // CHECK: bb0(%0 : @trivial $DidSetWillSetTests):
   // CHECK-NEXT:   debug_value %0
   // CHECK-NEXT:   %2 = struct_extract %0 : $DidSetWillSetTests, #DidSetWillSetTests.a
   // CHECK-NEXT:   return %2 : $Int{{.*}}                      // id: %3
 
 
   // CHECK-LABEL: sil hidden @$S10properties010DidSetWillC5TestsV1aSivs
-  // CHECK: bb0(%0 : $Int, %1 : $*DidSetWillSetTests):
+  // CHECK: bb0(%0 : @trivial $Int, %1 : @trivial $*DidSetWillSetTests):
   // CHECK-NEXT: debug_value %0
   // CHECK-NEXT: debug_value_addr %1
 
@@ -727,7 +727,7 @@ func local_observing_property(_ arg: Int) {
   localproperty = arg
 
   // Alloc and initialize the property to the argument value.
-  // CHECK: bb0([[ARG:%[0-9]+]] : $Int)
+  // CHECK: bb0([[ARG:%[0-9]+]] : @trivial $Int)
   // CHECK: [[BOX:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK: [[PB:%.*]] = project_box [[BOX]]
   // CHECK: store [[ARG]] to [trivial] [[PB]]
@@ -737,7 +737,7 @@ func local_observing_property(_ arg: Int) {
 // Ensure that setting the variable from within its own didSet doesn't recursively call didSet.
 
 // CHECK-LABEL: sil private @$S10properties24local_observing_property{{[_0-9a-zA-Z]*}}SiF13localproperty{{[_0-9a-zA-Z]*}}SivW
-// CHECK: bb0(%0 : $Int, %1 : ${ var Int })
+// CHECK: bb0(%0 : @trivial $Int, %1 : @guaranteed ${ var Int })
 // CHECK: [[POINTER:%.*]] = project_box %1 : ${ var Int }, 0
 // CHECK: // function_ref properties.zero.unsafeMutableAddressor : Swift.Int
 // CHECK-NEXT: [[ZEROFN:%.*]] = function_ref @$S10properties4zero{{[_0-9a-zA-Z]*}}vau
@@ -834,7 +834,7 @@ func propertyWithDidSetTakingOldValue() {
 
 // CHECK: // setter of p #1 : Swift.Int in properties.propertyWithDidSetTakingOldValue()
 // CHECK-NEXT: sil {{.*}} @$S10properties32propertyWithDidSetTakingOldValueyyF1pL_Sivs
-// CHECK: bb0([[ARG1:%.*]] : $Int, [[ARG2:%.*]] : ${ var Int }):
+// CHECK: bb0([[ARG1:%.*]] : @trivial $Int, [[ARG2:%.*]] : @guaranteed ${ var Int }):
 // CHECK-NEXT:  debug_value [[ARG1]] : $Int, let, name "newValue", argno 1
 // CHECK-NEXT:  [[ARG2_PB:%.*]] = project_box [[ARG2]]
 // CHECK-NEXT:  debug_value_addr [[ARG2_PB]] : $*Int, var, name "p", argno 2
@@ -870,7 +870,7 @@ class DerivedProperty : BaseProperty {
 // rdar://16381392 - Super property references in non-objc classes should be direct.
 
 // CHECK-LABEL: sil hidden @$S10properties15DerivedPropertyC24super_property_referenceSiyF : $@convention(method) (@guaranteed DerivedProperty) -> Int {
-// CHECK: bb0([[SELF:%.*]] : $DerivedProperty):
+// CHECK: bb0([[SELF:%.*]] : @guaranteed $DerivedProperty):
 // CHECK:   [[SELF_COPY:%[0-9]+]] = copy_value [[SELF]]
 // CHECK:   [[BASEPTR:%[0-9]+]] = upcast [[SELF_COPY]] : $DerivedProperty to $BaseProperty
 // CHECK:   [[FN:%[0-9]+]] = function_ref @$S10properties12BasePropertyC1xSivg : $@convention(method) (@guaranteed BaseProperty) -> Int 
@@ -888,7 +888,7 @@ struct ReferenceStorageTypeRValues {
     return p1
   }
 // CHECK: sil hidden @{{.*}}testRValueUnowned{{.*}} : $@convention(method) (@guaranteed ReferenceStorageTypeRValues) -> @owned Ref {
-// CHECK: bb0([[ARG:%.*]] : $ReferenceStorageTypeRValues):
+// CHECK: bb0([[ARG:%.*]] : @guaranteed $ReferenceStorageTypeRValues):
 // CHECK-NEXT:   debug_value [[ARG]] : $ReferenceStorageTypeRValues
 // CHECK-NEXT:   [[UNOWNED_ARG_FIELD:%.*]] = struct_extract [[ARG]] : $ReferenceStorageTypeRValues, #ReferenceStorageTypeRValues.p1
 // CHECK-NEXT:   [[COPIED_VALUE:%.*]] = copy_unowned_value [[UNOWNED_ARG_FIELD]]
@@ -1014,7 +1014,7 @@ class GenericClass<T> {
 
 // CHECK-LABEL: sil hidden @$S10properties12genericPropsyyAA12GenericClassCySSGF : $@convention(thin) (@guaranteed GenericClass<String>) -> () {
 func genericProps(_ x: GenericClass<String>) {
-  // CHECK: bb0([[ARG:%.*]] : $GenericClass<String>):
+  // CHECK: bb0([[ARG:%.*]] : @guaranteed $GenericClass<String>):
   // CHECK:   class_method [[ARG]] : $GenericClass<String>, #GenericClass.x!getter.1
   // CHECK:   apply {{.*}}<String>({{.*}}, [[ARG]]) : $@convention(method) <τ_0_0> (@guaranteed GenericClass<τ_0_0>) -> @out τ_0_0
   let _ = x.x
@@ -1030,7 +1030,7 @@ func genericProps(_ x: GenericClass<String>) {
 
 // CHECK-LABEL: sil hidden @$S10properties28genericPropsInGenericContext{{[_0-9a-zA-Z]*}}F
 func genericPropsInGenericContext<U>(_ x: GenericClass<U>) {
-  // CHECK: bb0([[ARG:%.*]] : $GenericClass<U>):
+  // CHECK: bb0([[ARG:%.*]] : @guaranteed $GenericClass<U>):
   // CHECK:   [[Z:%.*]] = ref_element_addr [[ARG]] : $GenericClass<U>, #GenericClass.z
   // CHECK:   copy_addr [[Z]] {{.*}} : $*U
   let _ = x.z
@@ -1045,7 +1045,7 @@ class ClassWithLetProperty {
   // We shouldn't have any dynamic dispatch within this method, just load p.
   func ReturnConstant() -> Int { return p }
 // CHECK-LABEL: sil hidden @$S10properties20ClassWithLetPropertyC14ReturnConstant{{[_0-9a-zA-Z]*}}F
-// CHECK:       bb0([[ARG:%.*]] : $ClassWithLetProperty):
+// CHECK:       bb0([[ARG:%.*]] : @guaranteed $ClassWithLetProperty):
 // CHECK-NEXT:    debug_value
 // CHECK-NEXT:    [[PTR:%[0-9]+]] = ref_element_addr [[ARG]] : $ClassWithLetProperty, #ClassWithLetProperty.p
 // CHECK-NEXT:    [[VAL:%[0-9]+]] = load [trivial] [[PTR]] : $*Int
@@ -1101,7 +1101,7 @@ class RedundantSelfRetains {
     f = RedundantSelfRetains()
   }
   // CHECK-LABEL: sil hidden @$S10properties20RedundantSelfRetainsC11testMethod1{{[_0-9a-zA-Z]*}}F
-  // CHECK: bb0(%0 : $RedundantSelfRetains):
+  // CHECK: bb0(%0 : @guaranteed $RedundantSelfRetains):
 
   // CHECK-NOT: copy_value
   
@@ -1216,7 +1216,7 @@ public class DerivedClassWithPublicProperty : BaseClassWithInternalProperty {
 // CHECK-LABEL: sil hidden [transparent] @$S10properties29BaseClassWithInternalPropertyC1xytvg
 
 // CHECK-LABEL: sil [transparent] [serialized] @$S10properties30DerivedClassWithPublicPropertyC1xytvg
-// CHECK:       bb0([[SELF:%.*]] : $DerivedClassWithPublicProperty):
+// CHECK:       bb0([[SELF:%.*]] : @guaranteed $DerivedClassWithPublicProperty):
 // CHECK:         [[SELF_COPY:%.*]] = copy_value [[SELF]] : $DerivedClassWithPublicProperty
 // CHECK-NEXT:    [[SUPER:%.*]] = upcast [[SELF_COPY]] : $DerivedClassWithPublicProperty to $BaseClassWithInternalProperty
 // CHECK-NEXT:    [[BORROWED_SUPER:%.*]] = begin_borrow [[SUPER]]

--- a/test/SILGen/properties_swift4.swift
+++ b/test/SILGen/properties_swift4.swift
@@ -15,7 +15,7 @@ struct DidSetWillSetTests: ForceAccessors {
   var a: Int {
     // CHECK-LABEL: sil private @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vw
     willSet(newA) {
-      // CHECK: bb0(%0 : $Int, %1 : $*DidSetWillSetTests):
+      // CHECK: bb0(%0 : @trivial $Int, %1 : @trivial $*DidSetWillSetTests):
 
       a = zero  // reassign, but don't infinite loop.
 

--- a/test/SILGen/properties_swift5.swift
+++ b/test/SILGen/properties_swift5.swift
@@ -15,7 +15,7 @@ struct DidSetWillSetTests: ForceAccessors {
   var a: Int {
     // CHECK-LABEL: sil private @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vw
     willSet(newA) {
-      // CHECK: bb0(%0 : $Int, %1 : $*DidSetWillSetTests):
+      // CHECK: bb0(%0 : @trivial $Int, %1 : @trivial $*DidSetWillSetTests):
 
       a = zero  // reassign, but don't infinite loop, as accessing on 'self'.
 

--- a/test/SILGen/protocol_extensions.swift
+++ b/test/SILGen/protocol_extensions.swift
@@ -12,7 +12,7 @@ struct Box {
 
 extension P1 {
   // CHECK-LABEL: sil hidden @$S19protocol_extensions2P1PAAE6extP1a{{[_0-9a-zA-Z]*}}F : $@convention(method) <Self where Self : P1> (@in_guaranteed Self) -> () {
-  // CHECK: bb0([[SELF:%[0-9]+]] : $*Self):
+  // CHECK: bb0([[SELF:%[0-9]+]] : @trivial $*Self):
   func extP1a() {
     // CHECK: [[WITNESS:%[0-9]+]] = witness_method $Self, #P1.reqP1a!1 : {{.*}} : $@convention(witness_method: P1) <τ_0_0 where τ_0_0 : P1> (@in_guaranteed τ_0_0) -> ()
     // CHECK-NEXT: apply [[WITNESS]]<Self>([[SELF]]) : $@convention(witness_method: P1) <τ_0_0 where τ_0_0 : P1> (@in_guaranteed τ_0_0) -> ()
@@ -21,7 +21,7 @@ extension P1 {
   }
 
   // CHECK-LABEL: sil @$S19protocol_extensions2P1PAAE6extP1b{{[_0-9a-zA-Z]*}}F : $@convention(method) <Self where Self : P1> (@in_guaranteed Self) -> () {
-  // CHECK: bb0([[SELF:%[0-9]+]] : $*Self):
+  // CHECK: bb0([[SELF:%[0-9]+]] : @trivial $*Self):
   public func extP1b() {
     // CHECK: [[FN:%[0-9]+]] = function_ref @$S19protocol_extensions2P1PAAE6extP1a{{[_0-9a-zA-Z]*}}F : $@convention(method) <τ_0_0 where τ_0_0 : P1> (@in_guaranteed τ_0_0) -> ()
     // CHECK-NEXT: apply [[FN]]<Self>([[SELF]]) : $@convention(method) <τ_0_0 where τ_0_0 : P1> (@in_guaranteed τ_0_0) -> ()
@@ -41,7 +41,7 @@ extension P1 {
     // But here we have to do a witness method call:
 
     // CHECK-LABEL: sil hidden @$S19protocol_extensions2P1PAAE13callSubscript{{[_0-9a-zA-Z]*}}F
-    // CHECK: bb0(%0 : $*Self):
+    // CHECK: bb0(%0 : @trivial $*Self):
     // CHECK: witness_method $Self, #P1.subscript!getter.1
     // CHECK: return
     return self[0]
@@ -71,7 +71,7 @@ class C : P1 {
 
 //   (materializeForSet test from above)
 // CHECK-LABEL: sil private [transparent] [thunk] @$S19protocol_extensions1CCAA2P1A2aDPyS2icimTW
-// CHECK: bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $Int, %3 : $*τ_0_0):
+// CHECK: bb0(%0 : @trivial $Builtin.RawPointer, %1 : @trivial $*Builtin.UnsafeValueBuffer, %2 : @trivial $Int, %3 : @trivial $*τ_0_0):
 // CHECK: function_ref @$S19protocol_extensions2P1PAAEyS2icig
 // CHECK: return
 
@@ -97,7 +97,7 @@ struct GenericMetaHolder<T> {
 func inout_func(_ n: inout Int) {}
 
 // CHECK-LABEL: sil hidden @$S19protocol_extensions5testD_2dd1dyAA10MetaHolderV_AA1DCmAHtF : $@convention(thin) (MetaHolder, @thick D.Type, @guaranteed D) -> ()
-// CHECK: bb0([[M:%[0-9]+]] : $MetaHolder, [[DD:%[0-9]+]] : $@thick D.Type, [[D:%[0-9]+]] : $D):
+// CHECK: bb0([[M:%[0-9]+]] : @trivial $MetaHolder, [[DD:%[0-9]+]] : @trivial $@thick D.Type, [[D:%[0-9]+]] : @guaranteed $D):
 func testD(_ m: MetaHolder, dd: D.Type, d: D) {
   // CHECK: [[D2:%[0-9]+]] = alloc_box ${ var D }
   // CHECK: [[RESULT:%.*]] = project_box [[D2]]
@@ -497,7 +497,7 @@ extension P1 {
 }
 
 // CHECK-LABEL: sil hidden @$S19protocol_extensions17testExistentials1{{[_0-9a-zA-Z]*}}F
-// CHECK: bb0([[P:%[0-9]+]] : $*P1, [[B:%[0-9]+]] : $Bool, [[I:%[0-9]+]] : $Int64):
+// CHECK: bb0([[P:%[0-9]+]] : @trivial $*P1, [[B:%[0-9]+]] : @trivial $Bool, [[I:%[0-9]+]] : @trivial $Int64):
 func testExistentials1(_ p1: P1, b: Bool, i: Int64) {
   // CHECK: [[POPENED:%[0-9]+]] = open_existential_addr immutable_access [[P]] : $*P1 to $*@opened([[UUID:".*"]])
   // CHECK: [[F1:%[0-9]+]] = function_ref @$S19protocol_extensions2P1PAAE2f1{{[_0-9a-zA-Z]*}}F
@@ -523,7 +523,7 @@ func testExistentials1(_ p1: P1, b: Bool, i: Int64) {
 }
 
 // CHECK-LABEL: sil hidden @$S19protocol_extensions17testExistentials2{{[_0-9a-zA-Z]*}}F
-// CHECK: bb0([[P:%[0-9]+]] : $*P1):
+// CHECK: bb0([[P:%[0-9]+]] : @trivial $*P1):
 func testExistentials2(_ p1: P1) {
   // CHECK: [[P1A:%[0-9]+]] = alloc_box ${ var P1 }
   // CHECK: [[PB:%.*]] = project_box [[P1A]]
@@ -535,7 +535,7 @@ func testExistentials2(_ p1: P1) {
 }
 
 // CHECK-LABEL: sil hidden @$S19protocol_extensions23testExistentialsGetters{{[_0-9a-zA-Z]*}}F
-// CHECK: bb0([[P:%[0-9]+]] : $*P1):
+// CHECK: bb0([[P:%[0-9]+]] : @trivial $*P1):
 func testExistentialsGetters(_ p1: P1) {
   // CHECK: [[POPENED:%[0-9]+]] = open_existential_addr immutable_access [[P]] : $*P1 to $*@opened([[UUID:".*"]]) P1
   // CHECK: copy_addr [[POPENED]] to [initialization] [[POPENED_COPY:%.*]] :
@@ -551,7 +551,7 @@ func testExistentialsGetters(_ p1: P1) {
 }
 
 // CHECK-LABEL: sil hidden @$S19protocol_extensions22testExistentialSetters{{[_0-9a-zA-Z]*}}F
-// CHECK: bb0([[P:%[0-9]+]] : $*P1, [[B:%[0-9]+]] : $Bool):
+// CHECK: bb0([[P:%[0-9]+]] : @trivial $*P1, [[B:%[0-9]+]] : @trivial $Bool):
 func testExistentialSetters(_ p1: P1, b: Bool) {
   var p1 = p1
   // CHECK: [[PBOX:%[0-9]+]] = alloc_box ${ var P1 }
@@ -584,7 +584,7 @@ struct HasAP1 {
 }
 
 // CHECK-LABEL: sil hidden @$S19protocol_extensions29testLogicalExistentialSetters{{[_0-9a-zA-Z]*}}F
-// CHECK: bb0([[HASP1:%[0-9]+]] : $*HasAP1, [[B:%[0-9]+]] : $Bool)
+// CHECK: bb0([[HASP1:%[0-9]+]] : @trivial $*HasAP1, [[B:%[0-9]+]] : @trivial $Bool)
 func testLogicalExistentialSetters(_ hasAP1: HasAP1, _ b: Bool) {
   var hasAP1 = hasAP1
   // CHECK: [[HASP1_BOX:%[0-9]+]] = alloc_box ${ var HasAP1 }
@@ -650,7 +650,7 @@ extension CP1 {
 func plusOneCP1() -> CP1 {}
 
 // CHECK-LABEL: sil hidden @$S19protocol_extensions37test_open_existential_semantics_class{{[_0-9a-zA-Z]*}}F
-// CHECK: bb0([[ARG0:%.*]] : $CP1, [[ARG1:%.*]] : $CP1):
+// CHECK: bb0([[ARG0:%.*]] : @guaranteed $CP1, [[ARG1:%.*]] : @guaranteed $CP1):
 func test_open_existential_semantics_class(_ guaranteed: CP1,
                                            immediate: CP1) {
   var immediate = immediate
@@ -691,7 +691,7 @@ protocol InitRequirement {
 
 extension InitRequirement {
   // CHECK-LABEL: sil hidden @$S19protocol_extensions15InitRequirementPAAE1dxAA1DC_tcfC : $@convention(method) <Self where Self : InitRequirement> (@owned D, @thick Self.Type) -> @out Self
-  // CHECK:       bb0([[OUT:%.*]] : $*Self, [[ARG:%.*]] : $D, [[SELF_TYPE:%.*]] : $@thick Self.Type):
+  // CHECK:       bb0([[OUT:%.*]] : @trivial $*Self, [[ARG:%.*]] : @owned $D, [[SELF_TYPE:%.*]] : @trivial $@thick Self.Type):
   init(d: D) {
     // CHECK:      [[SELF_BOX:%.*]] = alloc_box
     // CHECK-NEXT: [[UNINIT_SELF:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
@@ -713,7 +713,7 @@ extension InitRequirement {
   }
 
   // CHECK-LABEL: sil hidden @$S19protocol_extensions15InitRequirementPAAE2d2xAA1DC_tcfC : $@convention(method)
-  // CHECK:       bb0([[OUT:%.*]] : $*Self, [[ARG:%.*]] : $D, [[SELF_TYPE:%.*]] : $@thick Self.Type):
+  // CHECK:       bb0([[OUT:%.*]] : @trivial $*Self, [[ARG:%.*]] : @owned $D, [[SELF_TYPE:%.*]] : @trivial $@thick Self.Type):
   init(d2: D) {
     // CHECK:      [[SELF_BOX:%.*]] = alloc_box
     // CHECK-NEXT: [[UNINIT_SELF:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
@@ -734,7 +734,7 @@ extension InitRequirement {
   }
 
   // CHECK-LABEL: sil hidden @$S19protocol_extensions15InitRequirementPAAE2c2xAA1CC_tcfC  : $@convention(method)
-  // CHECK:       bb0([[OUT:%.*]] : $*Self, [[ARG:%.*]] : $C, [[SELF_TYPE:%.*]] : $@thick Self.Type):
+  // CHECK:       bb0([[OUT:%.*]] : @trivial $*Self, [[ARG:%.*]] : @owned $C, [[SELF_TYPE:%.*]] : @trivial $@thick Self.Type):
   init(c2: C) {
     // CHECK:      [[SELF_BOX:%.*]] = alloc_box
     // CHECK-NEXT: [[UNINIT_SELF:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
@@ -764,7 +764,7 @@ protocol ClassInitRequirement: class {
 
 extension ClassInitRequirement {
   // CHECK-LABEL: sil hidden @$S19protocol_extensions20ClassInitRequirementPAAE{{[_0-9a-zA-Z]*}}fC : $@convention(method) <Self where Self : ClassInitRequirement> (@owned D, @thick Self.Type) -> @owned Self
-  // CHECK:       bb0([[ARG:%.*]] : $D, [[SELF_TYPE:%.*]] : $@thick Self.Type):
+  // CHECK:       bb0([[ARG:%.*]] : @owned $D, [[SELF_TYPE:%.*]] : @trivial $@thick Self.Type):
   // CHECK:         [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
   // CHECK:         [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
   // CHECK:         [[ARG_COPY_CAST:%.*]] = upcast [[ARG_COPY]]
@@ -791,7 +791,7 @@ func foo(_ t: ObjCInitRequirement.Type, c: OC) -> ObjCInitRequirement {
 
 extension ObjCInitRequirement {
   // CHECK-LABEL: sil hidden @$S19protocol_extensions19ObjCInitRequirementPAAE{{[_0-9a-zA-Z]*}}fC : $@convention(method) <Self where Self : ObjCInitRequirement> (@owned OD, @thick Self.Type) -> @owned Self
-  // CHECK:       bb0([[ARG:%.*]] : $OD, [[SELF_TYPE:%.*]] : $@thick Self.Type):
+  // CHECK:       bb0([[ARG:%.*]] : @owned $OD, [[SELF_TYPE:%.*]] : @trivial $@thick Self.Type):
   // CHECK:         [[OBJC_SELF_TYPE:%.*]] = thick_to_objc_metatype [[SELF_TYPE]]
   // CHECK:         [[SELF:%.*]] = alloc_ref_dynamic [objc] [[OBJC_SELF_TYPE]] : $@objc_metatype Self.Type, $Self
   // CHECK:         [[BORROWED_ARG_1:%.*]] = begin_borrow [[ARG]]
@@ -818,7 +818,7 @@ protocol ProtoDelegatesToObjC { }
 
 extension ProtoDelegatesToObjC where Self : ObjCInitClass {
   // CHECK-LABEL: sil hidden @$S19protocol_extensions20ProtoDelegatesToObjCPA2A0F10CInitClassC{{[_0-9a-zA-Z]*}}fC
-  // CHECK: bb0([[STR:%[0-9]+]] : $String, [[SELF_META:%[0-9]+]] : $@thick Self.Type):
+  // CHECK: bb0([[STR:%[0-9]+]] : @owned $String, [[SELF_META:%[0-9]+]] : @trivial $@thick Self.Type):
   init(string: String) {
     // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0 where τ_0_0 : ObjCInitClass, τ_0_0 : ProtoDelegatesToObjC> { var τ_0_0 } <Self>
     // CHECK:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
@@ -844,7 +844,7 @@ protocol ProtoDelegatesToRequired { }
 
 extension ProtoDelegatesToRequired where Self : RequiredInitClass {
   // CHECK-LABEL: sil hidden @$S19protocol_extensions24ProtoDelegatesToRequiredPA2A0F9InitClassC{{[_0-9a-zA-Z]*}}fC 
-  // CHECK: bb0([[STR:%[0-9]+]] : $String, [[SELF_META:%[0-9]+]] : $@thick Self.Type):
+  // CHECK: bb0([[STR:%[0-9]+]] : @owned $String, [[SELF_META:%[0-9]+]] : @trivial $@thick Self.Type):
   init(string: String) {
   // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0 where τ_0_0 : RequiredInitClass, τ_0_0 : ProtoDelegatesToRequired> { var τ_0_0 } <Self>
   // CHECK:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]

--- a/test/SILGen/subclass_existentials.swift
+++ b/test/SILGen/subclass_existentials.swift
@@ -43,7 +43,7 @@ class Derived : Base<Int>, P {
 protocol R {}
 
 // CHECK-LABEL: sil hidden @$S21subclass_existentials11conversions8baseAndP7derived0fE1R0dE5PType0F4Type0fE5RTypeyAA1P_AA4BaseCySiGXc_AA7DerivedCAA1R_ANXcAaI_ALXcXpANmAaO_ANXcXptF : $@convention(thin) (@guaranteed Base<Int> & P, @guaranteed Derived, @guaranteed Derived & R, @thick (Base<Int> & P).Type, @thick Derived.Type, @thick (Derived & R).Type) -> () {
-// CHECK: bb0([[ARG0:%.*]] : $Base<Int> & P,
+// CHECK: bb0([[ARG0:%.*]] : @guaranteed $Base<Int> & P,
 
 func conversions(
   baseAndP: Base<Int> & P,
@@ -115,7 +115,7 @@ func conversions(
 func methodCalls(
   baseAndP: Base<Int> & P,
   baseAndPType: (Base<Int> & P).Type) {
-  // CHECK: bb0([[ARG0:%.*]] : $Base<Int> & P,
+  // CHECK: bb0([[ARG0:%.*]] : @guaranteed $Base<Int> & P,
   // CHECK: [[PAYLOAD:%.*]] = open_existential_ref [[ARG0]] : $Base<Int> & P to $@opened("{{.*}}") Base<Int> & P
   // CHECK: [[REF:%.*]] = copy_value [[PAYLOAD]] : $@opened("{{.*}}") Base<Int> & P
   // CHECK: [[CLASS_REF:%.*]] = upcast [[REF]] : $@opened("{{.*}}") Base<Int> & P to $Base<Int>
@@ -249,7 +249,7 @@ func downcasts(
   derived: Derived,
   baseAndPType: (Base<Int> & P).Type,
   derivedType: Derived.Type) {
-  // CHECK: bb0([[ARG0:%.*]] : $Base<Int> & P, [[ARG1:%.*]] : $Derived, [[ARG2:%.*]] : $@thick (Base<Int> & P).Type, [[ARG3:%.*]] : $@thick Derived.Type):
+  // CHECK: bb0([[ARG0:%.*]] : @guaranteed $Base<Int> & P, [[ARG1:%.*]] : @guaranteed $Derived, [[ARG2:%.*]] : @trivial $@thick (Base<Int> & P).Type, [[ARG3:%.*]] : @trivial $@thick Derived.Type):
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG0]] : $Base<Int> & P
   // CHECK-NEXT: checked_cast_br [[COPIED]] : $Base<Int> & P to $Derived
   let _ = baseAndP as? Derived
@@ -296,7 +296,7 @@ func archetypeUpcasts<T,
   baseTAndP: BaseTAndP,
   baseIntAndP : BaseIntAndP,
   derived : DerivedT) {
-  // CHECK: bb0([[ARG0:%.*]] : $BaseTAndP, [[ARG1:%.*]] : $BaseIntAndP, [[ARG2:%.*]] : $DerivedT)
+  // CHECK: bb0([[ARG0:%.*]] : @guaranteed $BaseTAndP, [[ARG1:%.*]] : @guaranteed $BaseIntAndP, [[ARG2:%.*]] : @guaranteed $DerivedT)
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG0]] : $BaseTAndP
   // CHECK-NEXT: init_existential_ref [[COPIED]] : $BaseTAndP : $BaseTAndP, $Base<T> & P
   let _: Base<T> & P = baseTAndP
@@ -336,7 +336,7 @@ func archetypeDowncasts<S,
   baseTAndP_concrete: Base<T> & P,
   baseIntAndP_concrete: Base<Int> & P) {
 
-  // CHECK: ([[ARG0:%.*]] : $*S, [[ARG1:%.*]] : $*T, [[ARG2:%.*]] : $*PT, [[ARG3:%.*]] : $BaseT, [[ARG4:%.*]] : $BaseInt, [[ARG5:%.*]] : $BaseTAndP, [[ARG6:%.*]] : $BaseIntAndP, [[ARG7:%.*]] : $DerivedT, [[ARG8:%.*]] : $Derived & R, [[ARG9:%.*]] : $Base<T> & P, [[ARG10:%.*]] : $Base<Int> & P)
+  // CHECK: ([[ARG0:%.*]] : @trivial $*S, [[ARG1:%.*]] : @trivial $*T, [[ARG2:%.*]] : @trivial $*PT, [[ARG3:%.*]] : @guaranteed $BaseT, [[ARG4:%.*]] : @guaranteed $BaseInt, [[ARG5:%.*]] : @guaranteed $BaseTAndP, [[ARG6:%.*]] : @guaranteed $BaseIntAndP, [[ARG7:%.*]] : @guaranteed $DerivedT, [[ARG8:%.*]] : @guaranteed $Derived & R, [[ARG9:%.*]] : @guaranteed $Base<T> & P, [[ARG10:%.*]] : @guaranteed $Base<Int> & P)
 
   // CHECK:      [[COPY:%.*]] = alloc_stack $S
   // CHECK-NEXT: copy_addr %0 to [initialization] [[COPY]] : $*S

--- a/test/SILGen/super.swift
+++ b/test/SILGen/super.swift
@@ -33,7 +33,7 @@ public class Parent {
 
 public class Child : Parent {
   // CHECK-LABEL: sil @$S5super5ChildC8propertySSvg : $@convention(method) (@guaranteed Child) -> @owned String {
-  // CHECK:       bb0([[SELF:%.*]] : $Child):
+  // CHECK:       bb0([[SELF:%.*]] : @guaranteed $Child):
   // CHECK:         [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:         [[CASTED_SELF_COPY:%[0-9]+]] = upcast [[SELF_COPY]] : $Child to $Parent
   // CHECK:         [[SUPER_METHOD:%[0-9]+]] = function_ref @$S5super6ParentC8propertySSvg : $@convention(method) (@guaranteed Parent) -> @owned String
@@ -45,7 +45,7 @@ public class Child : Parent {
   }
 
   // CHECK-LABEL: sil @$S5super5ChildC13otherPropertySSvg : $@convention(method) (@guaranteed Child) -> @owned String {
-  // CHECK:       bb0([[SELF:%.*]] : $Child):
+  // CHECK:       bb0([[SELF:%.*]] : @guaranteed $Child):
   // CHECK:         [[COPIED_SELF:%.*]] = copy_value [[SELF]]
   // CHECK:         [[CASTED_SELF_COPY:%[0-9]+]] = upcast [[COPIED_SELF]] : $Child to $Parent
   // CHECK:         [[SUPER_METHOD:%[0-9]+]] = function_ref @$S5super6ParentC13finalPropertySSvg
@@ -84,7 +84,7 @@ public class GreatGrandchild : Grandchild {
 public class ChildToResilientParent : ResilientOutsideParent {
   // CHECK-LABEL: sil @$S5super22ChildToResilientParentC6methodyyF : $@convention(method) (@guaranteed ChildToResilientParent) -> ()
   public override func method() {
-    // CHECK: bb0([[SELF:%.*]] : $ChildToResilientParent):
+    // CHECK: bb0([[SELF:%.*]] : @guaranteed $ChildToResilientParent):
     // CHECK:   [[COPY_SELF:%.*]] = copy_value [[SELF]]
     // CHECK:   [[UPCAST_SELF:%.*]] = upcast [[COPY_SELF]]
     // CHECK:   [[BORROW_UPCAST_SELF:%.*]] = begin_borrow [[UPCAST_SELF]]
@@ -98,7 +98,7 @@ public class ChildToResilientParent : ResilientOutsideParent {
 
   // CHECK-LABEL: sil @$S5super22ChildToResilientParentC11classMethodyyFZ : $@convention(method) (@thick ChildToResilientParent.Type) -> ()
   public override class func classMethod() {
-    // CHECK: bb0([[METASELF:%.*]] : $@thick ChildToResilientParent.Type):
+    // CHECK: bb0([[METASELF:%.*]] : @trivial $@thick ChildToResilientParent.Type):
     // CHECK:   [[UPCAST_METASELF:%.*]] = upcast [[METASELF]]
     // CHECK:   [[FUNC:%.*]] = super_method [[SELF]] : $@thick ChildToResilientParent.Type, #ResilientOutsideParent.classMethod!1 : (ResilientOutsideParent.Type) -> () -> (), $@convention(method) (@thick ResilientOutsideParent.Type) -> ()
     // CHECK:   apply [[FUNC]]([[UPCAST_METASELF]])
@@ -108,7 +108,7 @@ public class ChildToResilientParent : ResilientOutsideParent {
 
   // CHECK-LABEL: sil @$S5super22ChildToResilientParentC11returnsSelfACXDyFZ : $@convention(method) (@thick ChildToResilientParent.Type) -> @owned ChildToResilientParent
   public class func returnsSelf() -> Self {
-    // CHECK: bb0([[METASELF:%.*]] : $@thick ChildToResilientParent.Type):
+    // CHECK: bb0([[METASELF:%.*]] : @trivial $@thick ChildToResilientParent.Type):
     // CHECK:   [[CAST_METASELF:%.*]] = unchecked_trivial_bit_cast [[METASELF]] : $@thick ChildToResilientParent.Type to $@thick @dynamic_self ChildToResilientParent.Type
     // CHECK:   [[UPCAST_CAST_METASELF:%.*]] = upcast [[CAST_METASELF]] : $@thick @dynamic_self ChildToResilientParent.Type to $@thick ResilientOutsideParent.Type
     // CHECK:   [[FUNC:%.*]] = super_method [[METASELF]] : $@thick ChildToResilientParent.Type, #ResilientOutsideParent.classMethod!1 : (ResilientOutsideParent.Type) -> () -> ()
@@ -122,7 +122,7 @@ public class ChildToResilientParent : ResilientOutsideParent {
 public class ChildToFixedParent : OutsideParent {
   // CHECK-LABEL: sil @$S5super18ChildToFixedParentC6methodyyF : $@convention(method) (@guaranteed ChildToFixedParent) -> ()
   public override func method() {
-    // CHECK: bb0([[SELF:%.*]] : $ChildToFixedParent):
+    // CHECK: bb0([[SELF:%.*]] : @guaranteed $ChildToFixedParent):
     // CHECK:   [[COPY_SELF:%.*]] = copy_value [[SELF]]
     // CHECK:   [[UPCAST_COPY_SELF:%.*]] = upcast [[COPY_SELF]]
     // CHECK:   [[BORROWED_UPCAST_COPY_SELF:%.*]] = begin_borrow [[UPCAST_COPY_SELF]]
@@ -136,7 +136,7 @@ public class ChildToFixedParent : OutsideParent {
 
   // CHECK-LABEL: sil @$S5super18ChildToFixedParentC11classMethodyyFZ : $@convention(method) (@thick ChildToFixedParent.Type) -> ()
   public override class func classMethod() {
-    // CHECK: bb0([[SELF:%.*]] : $@thick ChildToFixedParent.Type):
+    // CHECK: bb0([[SELF:%.*]] : @trivial $@thick ChildToFixedParent.Type):
     // CHECK:   [[UPCAST_SELF:%.*]] = upcast [[SELF]]
     // CHECK:   [[FUNC:%.*]] = super_method [[SELF]] : $@thick ChildToFixedParent.Type, #OutsideParent.classMethod!1 : (OutsideParent.Type) -> () -> (), $@convention(method) (@thick OutsideParent.Type) -> ()
     // CHECK:   apply [[FUNC]]([[UPCAST_SELF]])
@@ -146,7 +146,7 @@ public class ChildToFixedParent : OutsideParent {
 
   // CHECK-LABEL: sil @$S5super18ChildToFixedParentC11returnsSelfACXDyFZ : $@convention(method) (@thick ChildToFixedParent.Type) -> @owned ChildToFixedParent
   public class func returnsSelf() -> Self {
-    // CHECK: bb0([[SELF:%.*]] : $@thick ChildToFixedParent.Type):
+    // CHECK: bb0([[SELF:%.*]] : @trivial $@thick ChildToFixedParent.Type):
     // CHECK:   [[FIRST_CAST:%.*]] = unchecked_trivial_bit_cast [[SELF]]
     // CHECK:   [[SECOND_CAST:%.*]] = upcast [[FIRST_CAST]]
     // CHECK:   [[FUNC:%.*]] = super_method [[SELF]] : $@thick ChildToFixedParent.Type, #OutsideParent.classMethod!1 : (OutsideParent.Type) -> () -> ()

--- a/test/SILGen/super_init_refcounting.swift
+++ b/test/SILGen/super_init_refcounting.swift
@@ -8,7 +8,7 @@ class Foo {
 
 class Bar: Foo {
   // CHECK-LABEL: sil hidden @$S22super_init_refcounting3BarC{{[_0-9a-zA-Z]*}}fc
-  // CHECK: bb0([[INPUT_SELF:%.*]] : $Bar):
+  // CHECK: bb0([[INPUT_SELF:%.*]] : @owned $Bar):
   // CHECK:         [[SELF_BOX:%.*]] = alloc_box ${ var Bar }
   // CHECK:         [[MARKED_SELF_BOX:%.*]] =  mark_uninitialized [derivedself] [[SELF_BOX]]
   // CHECK:         [[PB_SELF_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]

--- a/test/SILGen/switch.swift
+++ b/test/SILGen/switch.swift
@@ -433,12 +433,12 @@ class E : C {}
 
 // CHECK-LABEL: sil hidden @$S6switch16test_isa_class_11xyAA1BC_tF : $@convention(thin) (@guaranteed B) -> () {
 func test_isa_class_1(x: B) {
-  // CHECK: bb0([[X:%.*]] : $B):
+  // CHECK: bb0([[X:%.*]] : @guaranteed $B):
   // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
   // CHECK:   checked_cast_br [[X_COPY]] : $B to $D1, [[IS_D1:bb[0-9]+]], [[IS_NOT_D1:bb[0-9]+]]
   switch x {
 
-  // CHECK: [[IS_D1]]([[CAST_D1:%.*]]):
+  // CHECK: [[IS_D1]]([[CAST_D1:%.*]] : @owned $D1):
   // CHECK:   [[CAST_D1_COPY:%.*]] = copy_value [[CAST_D1]]
   // CHECK:   function_ref @$S6switch6runcedSbyF : $@convention(thin) () -> Bool
   // CHECK:   cond_br {{%.*}}, [[YES_CASE1:bb[0-9]+]], [[NO_CASE1:bb[0-9]+]]
@@ -461,7 +461,7 @@ func test_isa_class_1(x: B) {
   // CHECK: [[NEXT_CASE]]
   // CHECK:   checked_cast_br [[X_COPY]] : $B to $D2, [[IS_D2:bb[0-9]+]], [[IS_NOT_D2:bb[0-9]+]]
   case is D2:
-  // CHECK: [[IS_D2]]([[CAST_D2:%.*]]):
+  // CHECK: [[IS_D2]]([[CAST_D2:%.*]] : @owned $D2):
   // CHECK:   [[CAST_D2_COPY:%.*]] = copy_value [[CAST_D2]]
   // CHECK:   destroy_value [[CAST_D2_COPY]]
   // CHECK:   destroy_value [[X_COPY]]
@@ -475,7 +475,7 @@ func test_isa_class_1(x: B) {
   // CHECK: [[NEXT_CASE]]:
   // CHECK:   checked_cast_br [[X_COPY]] : $B to $E, [[IS_E:bb[0-9]+]], [[IS_NOT_E:bb[0-9]+]]
   case is E where funged():
-  // CHECK: [[IS_E]]([[CAST_E:%.*]]):
+  // CHECK: [[IS_E]]([[CAST_E:%.*]] : @owned $E):
   // CHECK:   [[CAST_E_COPY:%.*]] = copy_value [[CAST_E]]
   // CHECK:   function_ref @$S6switch6fungedSbyF
   // CHECK:   cond_br {{%.*}}, [[CASE3:bb[0-9]+]], [[NO_CASE3:bb[0-9]+]]
@@ -498,7 +498,7 @@ func test_isa_class_1(x: B) {
   // CHECK:   checked_cast_br [[X_COPY]] : $B to $C, [[IS_C:bb[0-9]+]], [[IS_NOT_C:bb[0-9]+]]
 
   case is C:
-  // CHECK: [[IS_C]]([[CAST_C:%.*]]):
+  // CHECK: [[IS_C]]([[CAST_C:%.*]] : @owned $C):
   // CHECK:   [[CAST_C_COPY:%.*]] = copy_value [[CAST_C]]
   // CHECK:   destroy_value [[CAST_C_COPY]]
   // CHECK:   destroy_value [[X_COPY]]
@@ -525,13 +525,13 @@ func test_isa_class_1(x: B) {
 
 // CHECK-LABEL: sil hidden @$S6switch16test_isa_class_21xyXlAA1BC_tF : $@convention(thin)
 func test_isa_class_2(x: B) -> AnyObject {
-  // CHECK: bb0([[X:%.*]] : $B):
+  // CHECK: bb0([[X:%.*]] : @guaranteed $B):
   // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
   switch x {
 
   // CHECK:   checked_cast_br [[X_COPY]] : $B to $D1, [[IS_D1:bb[0-9]+]], [[IS_NOT_D1:bb[0-9]+]]
   case let y as D1 where runced():
-  // CHECK: [[IS_D1]]([[CAST_D1:%.*]] : $D1):
+  // CHECK: [[IS_D1]]([[CAST_D1:%.*]] : @owned $D1):
   // CHECK:   [[CAST_D1_COPY:%.*]] = copy_value [[CAST_D1]]
   // CHECK:   function_ref @$S6switch6runcedSbyF
   // CHECK:   cond_br {{%.*}}, [[CASE1:bb[0-9]+]], [[NO_CASE1:bb[0-9]+]]
@@ -558,7 +558,7 @@ func test_isa_class_2(x: B) -> AnyObject {
   // CHECK: [[NEXT_CASE]]:
   // CHECK:   checked_cast_br [[X_COPY]] : $B to $D2, [[CASE2:bb[0-9]+]], [[IS_NOT_D2:bb[0-9]+]]
   case let y as D2:
-  // CHECK: [[CASE2]]([[CAST_D2:%.*]]):
+  // CHECK: [[CASE2]]([[CAST_D2:%.*]] : @owned $D2):
   // CHECK:   [[CAST_D2_COPY:%.*]] = copy_value [[CAST_D2]]
   // CHECK:   function_ref @$S6switch1byyF
   // CHECK:   [[BORROWED_CAST_D2_COPY:%.*]] = begin_borrow [[CAST_D2_COPY]]
@@ -577,7 +577,7 @@ func test_isa_class_2(x: B) -> AnyObject {
   // CHECK: [[NEXT_CASE]]:
   // CHECK:   checked_cast_br [[X_COPY]] : $B to $E, [[IS_E:bb[0-9]+]], [[IS_NOT_E:bb[0-9]+]]
   case let y as E where funged():
-  // CHECK: [[IS_E]]([[CAST_E:%.*]]):
+  // CHECK: [[IS_E]]([[CAST_E:%.*]] : @owned $E):
   // CHECK:   [[CAST_E_COPY:%.*]] = copy_value [[CAST_E]]
   // CHECK:   function_ref @$S6switch6fungedSbyF
   // CHECK:   cond_br {{%.*}}, [[CASE3:bb[0-9]+]], [[NO_CASE3:bb[0-9]+]]
@@ -604,7 +604,7 @@ func test_isa_class_2(x: B) -> AnyObject {
   // CHECK: [[NEXT_CASE]]
   // CHECK:   checked_cast_br [[X_COPY]] : $B to $C, [[CASE4:bb[0-9]+]], [[IS_NOT_C:bb[0-9]+]]
   case let y as C:
-  // CHECK: [[CASE4]]([[CAST_C:%.*]]):
+  // CHECK: [[CASE4]]([[CAST_C:%.*]] : @owned $C):
   // CHECK:   [[CAST_C_COPY:%.*]] = copy_value [[CAST_C]]
   // CHECK:   function_ref @$S6switch1dyyF
   // CHECK:   [[BORROWED_CAST_C_COPY:%.*]] = begin_borrow [[CAST_C_COPY]]
@@ -631,7 +631,7 @@ func test_isa_class_2(x: B) -> AnyObject {
     return x
   }
 
-  // CHECK: [[CONT]]([[T0:%.*]] : $AnyObject):
+  // CHECK: [[CONT]]([[T0:%.*]] : @owned $AnyObject):
   // CHECK:   return [[T0]]
 }
 // CHECK: } // end sil function '$S6switch16test_isa_class_21xyXlAA1BC_tF'
@@ -666,14 +666,14 @@ func test_union_1(u: MaybePair) {
   // CHECK:   br [[CONT]]
     b()
 
-  // CHECK: [[IS_RIGHT]]([[STR:%.*]] : $String):
+  // CHECK: [[IS_RIGHT]]([[STR:%.*]] : @owned $String):
   case var .Right:
   // CHECK:   destroy_value [[STR]] : $String
   // CHECK:   function_ref @$S6switch1cyyF
   // CHECK:   br [[CONT]]
     c()
 
-  // CHECK: [[IS_BOTH]]([[TUP:%.*]] : $(Int, String)):
+  // CHECK: [[IS_BOTH]]([[TUP:%.*]] : @owned $(Int, String)):
   case .Both:
   // CHECK:   tuple_extract [[TUP]] : $(Int, String), 0
   // CHECK:   [[TUP_STR:%.*]] = tuple_extract [[TUP]] : $(Int, String), 1
@@ -691,7 +691,7 @@ func test_union_1(u: MaybePair) {
 
 // CHECK-LABEL: sil hidden @$S6switch12test_union_31uyAA9MaybePairO_tF : $@convention(thin) (@guaranteed MaybePair) -> () {
 func test_union_3(u: MaybePair) {
-  // CHECK: bb0([[ARG:%.*]] : $MaybePair):
+  // CHECK: bb0([[ARG:%.*]] : @guaranteed $MaybePair):
   // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK:   switch_enum [[SUBJECT]] : $MaybePair,
   // CHECK:     case #MaybePair.Neither!enumelt: [[IS_NEITHER:bb[0-9]+]],
@@ -711,7 +711,7 @@ func test_union_3(u: MaybePair) {
   // CHECK:   br [[CONT]]
     b()
 
-  // CHECK: [[IS_RIGHT]]([[STR:%.*]] : $String):
+  // CHECK: [[IS_RIGHT]]([[STR:%.*]] : @owned $String):
   case .Right:
   // CHECK:   destroy_value [[STR]] : $String
   // CHECK:   function_ref @$S6switch1cyyF
@@ -991,7 +991,7 @@ enum LabeledScalarPayload {
 func testLabeledScalarPayload(_ lsp: LabeledScalarPayload) -> Any {
   // CHECK: switch_enum {{%.*}}, case #LabeledScalarPayload.Payload!enumelt.1: bb1
   switch lsp {
-  // CHECK: bb1([[TUPLE:%.*]] : $(name: Int)):
+  // CHECK: bb1([[TUPLE:%.*]] : @trivial $(name: Int)):
   // CHECK:   [[X:%.*]] = tuple_extract [[TUPLE]]
   // CHECK:   [[ANY_X_ADDR:%.*]] = init_existential_addr {{%.*}}, $Int
   // CHECK:   store [[X]] to [trivial] [[ANY_X_ADDR]]
@@ -1023,7 +1023,7 @@ func testOptionalEnumMix(_ a : Int?) -> Int {
   case let x?:
     return 0
 
-  // CHECK: [[SOMEBB]](%3 : $Int):
+  // CHECK: [[SOMEBB]](%3 : @trivial $Int):
   // CHECK-NEXT: debug_value %3 : $Int, let, name "x"
   // CHECK: integer_literal $Builtin.Int2048, 0
 
@@ -1045,7 +1045,7 @@ func testOptionalEnumMixWithNil(_ a : Int?) -> Int {
   case let x?:
     return 0
 
-  // CHECK: [[SOMEBB]](%3 : $Int):
+  // CHECK: [[SOMEBB]](%3 : @trivial $Int):
   // CHECK-NEXT: debug_value %3 : $Int, let, name "x"
   // CHECK: integer_literal $Builtin.Int2048, 0
 
@@ -1063,7 +1063,7 @@ func testMultiPatternsWithOuterScopeSameNamedVar(base: Int?, filter: Int?) {
   switch(base, filter) {
     
   case (.some(let base), .some(let filter)):
-    // CHECK: bb2(%10 : $Int):
+    // CHECK: bb2(%10 : @trivial $Int):
     // CHECK-NEXT: debug_value %8 : $Int, let, name "base"
     // CHECK-NEXT: debug_value %10 : $Int, let, name "filter"
     print("both: \(base), \(filter)")
@@ -1072,11 +1072,11 @@ func testMultiPatternsWithOuterScopeSameNamedVar(base: Int?, filter: Int?) {
     // CHECK-NEXT: debug_value %8 : $Int, let, name "base"
     // CHECK-NEXT: br bb6(%8 : $Int)
 
-    // CHECK: bb5([[OTHER_BASE:%.*]] : $Int)
+    // CHECK: bb5([[OTHER_BASE:%.*]] : @trivial $Int)
     // CHECK-NEXT: debug_value [[OTHER_BASE]] : $Int, let, name "base"
     // CHECK-NEXT: br bb6([[OTHER_BASE]] : $Int)
     
-    // CHECK: bb6([[ARG:%.*]] : $Int):
+    // CHECK: bb6([[ARG:%.*]] : @trivial $Int):
     print("single: \(base)")
   default:
     print("default")
@@ -1091,7 +1091,7 @@ func myFatalError() -> MyNever { fatalError("asdf") }
 
 func testUninhabitedSwitchScrutinee() {
   func test1(x : MyNever) {
-    // CHECK: bb0(%0 : $MyNever):
+    // CHECK: bb0(%0 : @trivial $MyNever):
     // CHECK-NEXT: debug_value %0 : $MyNever, let, name "x"
     // CHECK-NEXT: unreachable
     switch x {
@@ -1101,7 +1101,7 @@ func testUninhabitedSwitchScrutinee() {
     }
   }
   func test2(x : Never) {
-    // CHECK: bb0(%0 : $Never):
+    // CHECK: bb0(%0 : @trivial $Never):
     // CHECK-NEXT: debug_value %0 : $Never, let, name "x"
     // CHECK-NEXT: unreachable
     switch (x, x) {}

--- a/test/SILGen/switch_var.swift
+++ b/test/SILGen/switch_var.swift
@@ -561,7 +561,7 @@ func test_multiple_patterns1() {
     // CHECK:   [[SECOND_MATCH_CASE]]:
     // CHECK:     debug_value [[SECOND_X:%.*]] :
     // CHECK:     br [[CASE_BODY]]([[SECOND_X]] : $Int)
-    // CHECK:   [[CASE_BODY]]([[BODY_VAR:%.*]] : $Int):
+    // CHECK:   [[CASE_BODY]]([[BODY_VAR:%.*]] : @trivial $Int):
     // CHECK:     [[A:%.*]] = function_ref @$S10switch_var1a1xySi_tF
     // CHECK:     apply [[A]]([[BODY_VAR]])
     a(x: x)
@@ -618,23 +618,23 @@ func test_multiple_patterns3() {
   switch f {
     // CHECK:   switch_enum {{%.*}} : $Foo, case #Foo.A!enumelt.1: [[A:bb[0-9]+]], case #Foo.B!enumelt.1: [[B:bb[0-9]+]], case #Foo.C!enumelt.1: [[C:bb[0-9]+]]
   case .A(let x, let n), .B(let n, let x), .C(_, let x, let n):
-    // CHECK:   [[A]]({{%.*}} : $(Int, Double)):
+    // CHECK:   [[A]]({{%.*}} : @trivial $(Int, Double)):
     // CHECK:     [[A_X:%.*]] = tuple_extract
     // CHECK:     [[A_N:%.*]] = tuple_extract
     // CHECK:     br [[CASE_BODY:bb[0-9]+]]([[A_X]] : $Int, [[A_N]] : $Double)
     
-    // CHECK:   [[B]]({{%.*}} : $(Double, Int)):
+    // CHECK:   [[B]]({{%.*}} : @trivial $(Double, Int)):
     // CHECK:     [[B_N:%.*]] = tuple_extract
     // CHECK:     [[B_X:%.*]] = tuple_extract
     // CHECK:     br [[CASE_BODY]]([[B_X]] : $Int, [[B_N]] : $Double)
 
-    // CHECK:   [[C]]({{%.*}} : $(Int, Int, Double)):
+    // CHECK:   [[C]]({{%.*}} : @trivial $(Int, Int, Double)):
     // CHECK:     [[C__:%.*]] = tuple_extract
     // CHECK:     [[C_X:%.*]] = tuple_extract
     // CHECK:     [[C_N:%.*]] = tuple_extract
     // CHECK:     br [[CASE_BODY]]([[C_X]] : $Int, [[C_N]] : $Double)
 
-    // CHECK:   [[CASE_BODY]]([[BODY_X:%.*]] : $Int, [[BODY_N:%.*]] : $Double):
+    // CHECK:   [[CASE_BODY]]([[BODY_X:%.*]] : @trivial $Int, [[BODY_N:%.*]] : @trivial $Double):
     // CHECK:     [[FUNC_A:%.*]] = function_ref @$S10switch_var1a1xySi_tF
     // CHECK:     apply [[FUNC_A]]([[BODY_X]])
     a(x: x)
@@ -652,30 +652,30 @@ func test_multiple_patterns4() {
   switch b {
     // CHECK:   switch_enum {{%.*}} : $Bar, case #Bar.Y!enumelt.1: [[Y:bb[0-9]+]], case #Bar.Z!enumelt.1: [[Z:bb[0-9]+]]
   case .Y(.A(let x, _), _), .Y(.B(_, let x), _), .Y(.C, let x), .Z(let x, _):
-    // CHECK:   [[Y]]({{%.*}} : $(Foo, Int)):
+    // CHECK:   [[Y]]({{%.*}} : @trivial $(Foo, Int)):
     // CHECK:     [[Y_F:%.*]] = tuple_extract
     // CHECK:     [[Y_X:%.*]] = tuple_extract
     // CHECK:     switch_enum [[Y_F]] : $Foo, case #Foo.A!enumelt.1: [[A:bb[0-9]+]], case #Foo.B!enumelt.1: [[B:bb[0-9]+]], case #Foo.C!enumelt.1: [[C:bb[0-9]+]]
     
-    // CHECK:   [[A]]({{%.*}} : $(Int, Double)):
+    // CHECK:   [[A]]({{%.*}} : @trivial $(Int, Double)):
     // CHECK:     [[A_X:%.*]] = tuple_extract
     // CHECK:     [[A_N:%.*]] = tuple_extract
     // CHECK:     br [[CASE_BODY:bb[0-9]+]]([[A_X]] : $Int)
     
-    // CHECK:   [[B]]({{%.*}} : $(Double, Int)):
+    // CHECK:   [[B]]({{%.*}} : @trivial $(Double, Int)):
     // CHECK:     [[B_N:%.*]] = tuple_extract
     // CHECK:     [[B_X:%.*]] = tuple_extract
     // CHECK:     br [[CASE_BODY]]([[B_X]] : $Int)
     
-    // CHECK:   [[C]]({{%.*}} : $(Int, Int, Double)):
+    // CHECK:   [[C]]({{%.*}} : @trivial $(Int, Int, Double)):
     // CHECK:     br [[CASE_BODY]]([[Y_X]] : $Int)
 
-    // CHECK:   [[Z]]({{%.*}} : $(Int, Foo)):
+    // CHECK:   [[Z]]({{%.*}} : @trivial $(Int, Foo)):
     // CHECK:     [[Z_X:%.*]] = tuple_extract
     // CHECK:     [[Z_F:%.*]] = tuple_extract
     // CHECK:     br [[CASE_BODY]]([[Z_X]] : $Int)
 
-    // CHECK:   [[CASE_BODY]]([[BODY_X:%.*]] : $Int):
+    // CHECK:   [[CASE_BODY]]([[BODY_X:%.*]] : @trivial $Int):
     // CHECK:     [[FUNC_A:%.*]] = function_ref @$S10switch_var1a1xySi_tF
     // CHECK:     apply [[FUNC_A]]([[BODY_X]])
     a(x: x)
@@ -690,30 +690,30 @@ func test_multiple_patterns5() {
   switch b {
     // CHECK:   switch_enum {{%.*}} : $Bar, case #Bar.Y!enumelt.1: [[Y:bb[0-9]+]], case #Bar.Z!enumelt.1: [[Z:bb[0-9]+]]
   case .Y(.A(var x, _), _), .Y(.B(_, var x), _), .Y(.C, var x), .Z(var x, _):
-    // CHECK:   [[Y]]({{%.*}} : $(Foo, Int)):
+    // CHECK:   [[Y]]({{%.*}} : @trivial $(Foo, Int)):
     // CHECK:     [[Y_F:%.*]] = tuple_extract
     // CHECK:     [[Y_X:%.*]] = tuple_extract
     // CHECK:     switch_enum [[Y_F]] : $Foo, case #Foo.A!enumelt.1: [[A:bb[0-9]+]], case #Foo.B!enumelt.1: [[B:bb[0-9]+]], case #Foo.C!enumelt.1: [[C:bb[0-9]+]]
     
-    // CHECK:   [[A]]({{%.*}} : $(Int, Double)):
+    // CHECK:   [[A]]({{%.*}} : @trivial $(Int, Double)):
     // CHECK:     [[A_X:%.*]] = tuple_extract
     // CHECK:     [[A_N:%.*]] = tuple_extract
     // CHECK:     br [[CASE_BODY:bb[0-9]+]]([[A_X]] : $Int)
     
-    // CHECK:   [[B]]({{%.*}} : $(Double, Int)):
+    // CHECK:   [[B]]({{%.*}} : @trivial $(Double, Int)):
     // CHECK:     [[B_N:%.*]] = tuple_extract
     // CHECK:     [[B_X:%.*]] = tuple_extract
     // CHECK:     br [[CASE_BODY]]([[B_X]] : $Int)
     
-    // CHECK:   [[C]]({{%.*}} : $(Int, Int, Double)):
+    // CHECK:   [[C]]({{%.*}} : @trivial $(Int, Int, Double)):
     // CHECK:     br [[CASE_BODY]]([[Y_X]] : $Int)
     
-    // CHECK:   [[Z]]({{%.*}} : $(Int, Foo)):
+    // CHECK:   [[Z]]({{%.*}} : @trivial $(Int, Foo)):
     // CHECK:     [[Z_X:%.*]] = tuple_extract
     // CHECK:     [[Z_F:%.*]] = tuple_extract
     // CHECK:     br [[CASE_BODY]]([[Z_X]] : $Int)
     
-    // CHECK:   [[CASE_BODY]]([[BODY_X:%.*]] : $Int):
+    // CHECK:   [[CASE_BODY]]([[BODY_X:%.*]] : @trivial $Int):
     // CHECK:     store [[BODY_X]] to [trivial] [[BOX_X:%.*]] : $*Int
     // CHECK:     [[WRITE:%.*]] = begin_access [modify] [unknown] [[BOX_X]]
     // CHECK:     [[FUNC_AAA:%.*]] = function_ref @$S10switch_var3aaa1xySiz_tF

--- a/test/SILGen/toplevel_errors.swift
+++ b/test/SILGen/toplevel_errors.swift
@@ -14,10 +14,10 @@ throw MyError.A
 // CHECK: builtin "willThrow"([[ERR]] : $Error)
 // CHECK: br bb2([[ERR]] : $Error)
 
-// CHECK: bb1([[T0:%.*]] : $Int32):
+// CHECK: bb1([[T0:%.*]] : @trivial $Int32):
 // CHECK: return [[T0]] : $Int32
 
-// CHECK: bb2([[T0:%.*]] : $Error):
+// CHECK: bb2([[T0:%.*]] : @owned $Error):
 // CHECK: builtin "errorInMain"([[T0]] : $Error)
 // CHECK: [[T0:%.*]] = integer_literal $Builtin.Int32, 1
 // CHECK: [[T1:%.*]] = struct $Int32 ([[T0]] : $Builtin.Int32)

--- a/test/SILOptimizer/access_marker_elim.sil
+++ b/test/SILOptimizer/access_marker_elim.sil
@@ -67,7 +67,7 @@ bb0:
 // they are gone from the output.
 //
 // UNCHECKED-LABEL: sil hidden @f020_boxArg : $@convention(thin) (@owned { var Builtin.Int64 }) -> () {
-// UNCHECKED: bb0(%0 : ${ var Builtin.Int64 }):
+// UNCHECKED: bb0(%0 : @owned ${ var Builtin.Int64 }):
 // UNCHECKED:  [[ADR:%.*]] = project_box %0 : ${ var Builtin.Int64 }, 0
 // UNCHECKED:  [[VAL:%.*]] = integer_literal $Builtin.Int64, 42
 // UNCHECKED-NOT: begin_access
@@ -88,7 +88,7 @@ bb0:
 // CHECKED:  return %{{.*}} : $()
 // CHECKED-LABEL: } // end sil function 'f020_boxArg'
 sil hidden @f020_boxArg : $@convention(thin) (@owned { var Builtin.Int64 }) -> () {
-bb0(%0 : ${ var Builtin.Int64 }):
+bb0(%0 : @owned ${ var Builtin.Int64 }):
   %1 = project_box %0 : ${ var Builtin.Int64 }, 0
   %3 = integer_literal $Builtin.Int64, 42
   %5 = begin_access [modify] [unknown] %1 : $*Builtin.Int64

--- a/test/SILOptimizer/cast_folding_objc_bridging_conditional.sil
+++ b/test/SILOptimizer/cast_folding_objc_bridging_conditional.sil
@@ -10,7 +10,7 @@ struct MyError: Error {}
 
 // CHECK-LABEL: sil @cast_nserror_to_specific_error
 sil @cast_nserror_to_specific_error : $@convention(thin) (@in NSError, @in NSNumber, @in NSValue) -> () {
-entry(%0 : $*NSError, %1 : $*NSNumber, %2 : $*NSValue):
+entry(%0 : @trivial $*NSError, %1 : @trivial $*NSNumber, %2 : @trivial $*NSValue):
   %f = function_ref @use : $@convention(thin) <T> (@in T) -> ()
   %a = alloc_stack $MyError
   // CHECK: checked_cast_addr_br {{.*}} NSError {{.*}} to MyError

--- a/test/SILOptimizer/constant_propagation2.sil
+++ b/test/SILOptimizer/constant_propagation2.sil
@@ -4,7 +4,7 @@ import Builtin
 
 // fold_sadd_with_overflow_Overflow
 sil @fold_sadd_with_overflow_Overflow : $@convention(thin) (Builtin.RawPointer) -> Builtin.Int64 {
-bb0(%0 : $Builtin.RawPointer):
+bb0(%0 : @trivial $Builtin.RawPointer):
   %2 = integer_literal $Builtin.Int64, 9223372036854775807
   %3 = integer_literal $Builtin.Int64, 9223372036854775807
   %21 = integer_literal $Builtin.Int1, 1

--- a/test/SILOptimizer/exclusivity_static_diagnostics.sil
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.sil
@@ -18,7 +18,7 @@ sil @takesInoutAndNoEscapeOptionalBlockClosure : $@convention(thin) (@inout Int,
 
 // CHECK-LABEL: sil hidden @twoLocalInoutsDisaliased
 sil hidden @twoLocalInoutsDisaliased : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %2 = alloc_box ${ var Int }
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
@@ -39,7 +39,7 @@ bb0(%0 : $Int):
 
 // CHECK-LABEL: sil hidden @twoLocalInoutsSimpleAliasing
 sil hidden @twoLocalInoutsSimpleAliasing : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %2 = alloc_box ${ var Int }
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
@@ -56,7 +56,7 @@ bb0(%0 : $Int):
 
 // CHECK-LABEL: sil hidden @conflictingPriorAccess
 sil hidden @conflictingPriorAccess : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %2 = alloc_box ${ var Int }
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
@@ -75,7 +75,7 @@ bb0(%0 : $Int):
 
 // CHECK-LABEL: sil hidden @twoSequentialInouts
 sil hidden @twoSequentialInouts : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %2 = alloc_box ${ var Int }
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
@@ -94,7 +94,7 @@ bb0(%0 : $Int):
 
 // CHECK-LABEL: sil hidden @unconditionalBranch
 sil hidden @unconditionalBranch : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %2 = alloc_box ${ var Int }
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
@@ -109,7 +109,7 @@ finish:
 
 // CHECK-LABEL: sil hidden @diamondMergeStacks
 sil hidden @diamondMergeStacks : $@convention(thin) (Int, Builtin.Int1) -> () {
-bb0(%0 : $Int, %1 : $Builtin.Int1):
+bb0(%0 : @trivial $Int, %1 : @trivial $Builtin.Int1):
   %2 = alloc_box ${ var Int }
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
@@ -129,7 +129,7 @@ finish:
 
 // CHECK-LABEL: sil hidden @loopMergeStacks
 sil hidden @loopMergeStacks : $@convention(thin) (Int, Builtin.Int1) -> () {
-bb0(%0 : $Int, %1 : $Builtin.Int1):
+bb0(%0 : @trivial $Int, %1 : @trivial $Builtin.Int1):
   %2 = alloc_box ${ var Int }
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
@@ -146,7 +146,7 @@ bb2:
 
 // CHECK-LABEL: sil hidden @loopWithError
 sil hidden @loopWithError : $@convention(thin) (Int, Builtin.Int1) -> () {
-bb0(%0 : $Int, %1 : $Builtin.Int1):
+bb0(%0 : @trivial $Int, %1 : @trivial $Builtin.Int1):
   %2 = alloc_box ${ var Int }
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
@@ -166,7 +166,7 @@ bb2:
 
 // CHECK-LABEL: sil hidden @modifySubAccessesAreAllowed
 sil hidden @modifySubAccessesAreAllowed : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %2 = alloc_box ${ var Int }
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
@@ -185,7 +185,7 @@ bb0(%0 : $Int):
 
 // CHECK-LABEL: sil hidden @twoLocalReadsSimpleAliasing
 sil hidden @twoLocalReadsSimpleAliasing : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %1 = alloc_box ${ var Int }
   %2 = project_box %1 : ${ var Int }, 0
   store %0 to [trivial] %2 : $*Int
@@ -200,7 +200,7 @@ bb0(%0 : $Int):
 
 // CHECK-LABEL: sil hidden @localReadFollowedByModify
 sil hidden @localReadFollowedByModify : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %1 = alloc_box ${ var Int }
   %2 = project_box %1 : ${ var Int }, 0
   store %0 to [trivial] %2 : $*Int
@@ -215,7 +215,7 @@ bb0(%0 : $Int):
 
 // CHECK-LABEL: sil hidden @localModifyFollowedByRead
 sil hidden @localModifyFollowedByRead : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %1 = alloc_box ${ var Int }
   %2 = project_box %1 : ${ var Int }, 0
   store %0 to [trivial] %2 : $*Int
@@ -235,7 +235,7 @@ class ClassWithStoredProperty {
 }
 // CHECK-LABEL: sil hidden @classStoredProperty
 sil hidden @classStoredProperty : $@convention(thin) (ClassWithStoredProperty) -> () {
-bb0(%0 : $ClassWithStoredProperty):
+bb0(%0 : @unowned $ClassWithStoredProperty):
   %1 = ref_element_addr %0 : $ClassWithStoredProperty, #ClassWithStoredProperty.f
 
   // expected-error@+1{{overlapping accesses to 'f', but modification requires exclusive access; consider copying to a local variable}}
@@ -253,7 +253,7 @@ bb0(%0 : $ClassWithStoredProperty):
 
 // CHECK-LABEL: sil hidden @lookThroughBeginBorrow
 sil hidden @lookThroughBeginBorrow : $@convention(thin) (ClassWithStoredProperty) -> () {
-bb0(%0 : $ClassWithStoredProperty):
+bb0(%0 : @unowned $ClassWithStoredProperty):
   %1 = begin_borrow %0 : $ClassWithStoredProperty
   %2 = begin_borrow %0 : $ClassWithStoredProperty
   %3 = ref_element_addr %1 : $ClassWithStoredProperty, #ClassWithStoredProperty.f
@@ -279,7 +279,7 @@ bb0(%0 : $ClassWithStoredProperty):
 
 // CHECK-LABEL: sil hidden @twoAllocBoxProjections
 sil hidden @twoAllocBoxProjections : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %2 = alloc_box ${ var Int }
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
@@ -297,7 +297,7 @@ bb0(%0 : $Int):
 
 // CHECK-LABEL: sil hidden @lookThroughMarkUninitialized
 sil hidden @lookThroughMarkUninitialized : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %1 = alloc_box ${ var Int }
   %2 = mark_uninitialized [rootself] %1 : ${ var Int }
   %3 = project_box %2 : ${ var Int }, 0
@@ -318,7 +318,7 @@ sil_global hidden @global2 : $Int
 
 // CHECK-LABEL: sil hidden @modifySameGlobal
 sil hidden @modifySameGlobal : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %1 = global_addr @global1 :$*Int
   %2 = global_addr @global1 :$*Int
   %3 = begin_access [modify] [unknown] %1 : $*Int  // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
@@ -331,7 +331,7 @@ bb0(%0 : $Int):
 
 // CHECK-LABEL: sil hidden @modifyDifferentGlobal
 sil hidden @modifyDifferentGlobal : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %1 = global_addr @global1 :$*Int
   %2 = global_addr @global2 :$*Int
   %3 = begin_access [modify] [unknown] %1 : $*Int
@@ -348,7 +348,7 @@ bb0(%0 : $Int):
 // sure the second read doesn't report a confusing read-read conflict.
 // CHECK-LABEL: sil hidden @readWriteReadConflictingThirdAccess
 sil hidden @readWriteReadConflictingThirdAccess : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %2 = alloc_box ${ var Int }
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
@@ -369,7 +369,7 @@ bb0(%0 : $Int):
 // third write doesn't report a conflict.
 // CHECK-LABEL: sil hidden @writeWriteWriteConflictingThirdAccess
 sil hidden @writeWriteWriteConflictingThirdAccess : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %2 = alloc_box ${ var Int }
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
@@ -391,7 +391,7 @@ bb0(%0 : $Int):
 // about the conflict and not the first
 // CHECK-LABEL: sil hidden @resetFirstAccessForNote
 sil hidden @resetFirstAccessForNote : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %2 = alloc_box ${ var Int }
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
@@ -416,7 +416,7 @@ bb0(%0 : $Int):
 //  The unreachable block below must branch to bN where
 //    N = 3/4 * INITIAL_SIZE - 2
 sil @blockMapRehash : $@convention(method) (Builtin.Int1) -> () {
-bb0(%0: $Builtin.Int1):
+bb0(%0 : @trivial $Builtin.Int1):
  br bb1
 bb1:
   br bb2
@@ -473,7 +473,7 @@ bbUnreachable:
 //
 // CHECK-LABEL: sil hidden  @pointerToAddr
 sil hidden  @pointerToAddr : $@convention(thin) (Builtin.RawPointer) -> Int {
-bb0(%0: $Builtin.RawPointer):
+bb0(%0: @trivial $Builtin.RawPointer):
   %adr = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*Int
   %access = begin_access [read] [dynamic] %adr : $*Int
   %val = load [trivial] %access : $*Int
@@ -492,7 +492,7 @@ struct S {
 //
 // CHECK-LABEL: sil hidden @inlinedStructElement
 sil hidden @inlinedStructElement : $@convention(thin) (@inout S) -> Int {
-bb0(%0 : $*S):
+bb0(%0 : @trivial $*S):
   %2 = begin_access [modify] [static] %0 : $*S
   %3 = struct_element_addr %2 : $*S, #S.x
   %4 = begin_access [read] [static] %3 : $*Int
@@ -507,7 +507,7 @@ bb0(%0 : $*S):
 //
 // CHECK-LABEL: sil hidden @inlinedTupleElement
 sil hidden @inlinedTupleElement : $@convention(thin) (@inout (Int, Int)) -> Int {
-bb0(%0 : $*(Int, Int)):
+bb0(%0 : @trivial $*(Int, Int)):
   %2 = begin_access [modify] [static] %0 : $*(Int, Int)
   %3 = tuple_element_addr %2 : $*(Int, Int), 0
   %4 = begin_access [read] [static] %3 : $*Int
@@ -522,7 +522,7 @@ bb0(%0 : $*(Int, Int)):
 //
 // CHECK-LABEL: sil hidden @inlinedEnumValue
 sil hidden @inlinedEnumValue : $@convention(thin) (Int) -> (@out Optional<Int>, Int) {
-bb0(%0 : $*Optional<Int>, %1 : $Int):
+bb0(%0 : @trivial $*Optional<Int>, %1 : @trivial $Int):
   %6 = unchecked_take_enum_data_addr %0 : $*Optional<Int>, #Optional.some!enumelt.1
   %7 = begin_access [read] [static] %6 : $*Int
   %8 = load [trivial] %7 : $*Int
@@ -538,7 +538,7 @@ class Storage {}
 //
 // CHECK-LABEL: sil hidden @inlinedArrayProp
 sil hidden @inlinedArrayProp : $@convention(thin) (@guaranteed Storage, Builtin.Word) -> Int {
-bb0(%0 : $Storage, %1 : $Builtin.Word):
+bb0(%0 : @guaranteed $Storage, %1 : @trivial $Builtin.Word):
   %2 = ref_tail_addr %0 : $Storage, $UInt
   %3 = begin_access [read] [static] %2 : $*UInt
   %4 = tail_addr %3 : $*UInt, %1 : $Builtin.Word, $Int
@@ -555,7 +555,7 @@ bb0(%0 : $Storage, %1 : $Builtin.Word):
 // Conflicts involving noescape closures.
 
 sil hidden @closureThatModifiesCaptureAndTakesInout: $@convention(thin) (@inout Int, @inout_aliasable Int) -> () {
-bb0(%0 : $*Int, %1 : $*Int):
+bb0(%0 : @trivial $*Int, %1 : @trivial $*Int):
   %2 = begin_access [modify] [unknown] %1 : $*Int // expected-note {{conflicting access is here}}
   end_access %2 : $*Int
   %3 = tuple ()
@@ -571,7 +571,7 @@ bb0(%0 : $*Int, %1 : $*Int):
 //
 // CHECK-LABEL: sil hidden @inProgressModifyModifyConflictWithCallToClosure
 sil hidden @inProgressModifyModifyConflictWithCallToClosure : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %2 = alloc_box ${ var Int }
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
@@ -585,7 +585,7 @@ bb0(%0 : $Int):
 }
 
 sil hidden @closureWithArgument_1 : $@convention(thin) (Int, @inout_aliasable Int) -> () {
-bb0(%0 : $Int, %1 : $*Int):
+bb0(%0 : @trivial $Int, %1 : @trivial $*Int):
   %2 = begin_access [modify] [unknown] %1 : $*Int // expected-note 2 {{conflicting access is here}}
   end_access %2 : $*Int
   %3 = tuple ()
@@ -594,7 +594,7 @@ bb0(%0 : $Int, %1 : $*Int):
 
 // CHECK-LABEL: sil hidden @inProgressConflictWithNoEscapeClosureArgument
 sil hidden @inProgressConflictWithNoEscapeClosureArgument : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %2 = alloc_box ${ var Int }
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
@@ -612,7 +612,7 @@ bb0(%0 : $Int):
 
 // CHECK-LABEL: sil hidden @inProgressConflictWithNoEscapeGuaranteedClosureArgument : $@convention(thin) (Int) -> () {
 sil hidden @inProgressConflictWithNoEscapeGuaranteedClosureArgument : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %2 = alloc_box ${ var Int }
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
@@ -631,7 +631,7 @@ bb0(%0 : $Int):
 }
 
 sil hidden @closureThatModifiesCapture_2 : $@convention(thin) (@inout_aliasable Int) -> () {
-bb0(%0 : $*Int):
+bb0(%0 : @trivial $*Int):
   %1 = begin_access [modify] [unknown] %0 : $*Int // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   end_access %1 : $*Int
   %2 = tuple ()
@@ -640,7 +640,7 @@ bb0(%0 : $*Int):
 
 // CHECK-LABEL: sil hidden @inProgressReadModifyConflictWithNoEscapeClosureArgument
 sil hidden @inProgressReadModifyConflictWithNoEscapeClosureArgument : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %2 = alloc_box ${ var Int }
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
@@ -657,7 +657,7 @@ bb0(%0 : $Int):
 }
 
 sil hidden @closureWithConcreteReturn : $@convention(thin) (Int, @inout_aliasable Int) -> (Int) {
-bb0(%0 : $Int, %1 : $*Int):
+bb0(%0 : @trivial $Int, %1 : @trivial $*Int):
   %2 = begin_access [modify] [unknown] %1 : $*Int // expected-note {{conflicting access is here}}
   end_access %2 : $*Int
   return %0 : $Int
@@ -667,7 +667,7 @@ sil [reabstraction_thunk] @thunkForClosureWithConcreteReturn : $@convention(thin
 
 // CHECK-LABEL: sil hidden @inProgressConflictWithNoEscapeClosureWithReabstractionThunk
 sil hidden @inProgressConflictWithNoEscapeClosureWithReabstractionThunk : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %2 = alloc_box ${ var Int }
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
@@ -690,7 +690,7 @@ sil [reabstraction_thunk] @thunkForCalleeGuaranteed : $@convention(c) (@inout_al
 sil [reabstraction_thunk] @withoutActuallyEscapingThunk : $@convention(thin) (@noescape @callee_guaranteed () -> ()) -> ()
 
 sil hidden @closureThatModifiesCapture_1: $@convention(thin) (@inout_aliasable Int) -> () {
-bb0(%0 : $*Int):
+bb0(%0 : @trivial $*Int):
   %1 = begin_access [modify] [unknown] %0 : $*Int // expected-note 2{{conflicting access is here}}
   end_access %1 : $*Int
   %2 = tuple ()
@@ -699,7 +699,7 @@ bb0(%0 : $*Int):
 
 // CHECK-LABEL: sil hidden @inProgressConflictWithNoEscapeClosureWithBlockStorage
 sil hidden @inProgressConflictWithNoEscapeClosureWithBlockStorage : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %2 = alloc_box ${ var Int }
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
@@ -729,7 +729,7 @@ bb0(%0 : $Int):
 
 // CHECK-LABEL: sil hidden @inProgressConflictWithNoEscapeClosureWithOptionalBlockStorage
 sil hidden @inProgressConflictWithNoEscapeClosureWithOptionalBlockStorage : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %2 = alloc_box ${ var Int }
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
@@ -777,7 +777,7 @@ sil @takesInoutIntAndStructWithStoredProps : $@convention(thin) (@inout Int, @in
 
 // CHECK-LABEL: sil hidden @twoSeparateStoredProperties
 sil hidden @twoSeparateStoredProperties : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %2 = alloc_box ${ var StructWithStoredProps }
   %3 = project_box %2 : ${ var StructWithStoredProps }, 0
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
@@ -795,7 +795,7 @@ bb0(%0 : $Int):
 
 // CHECK-LABEL: sil hidden @twoSeparateNestedStoredProperties
 sil hidden @twoSeparateNestedStoredProperties : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %2 = alloc_box ${ var StructWithStoredProps }
   %3 = project_box %2 : ${ var StructWithStoredProps }, 0
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
@@ -815,7 +815,7 @@ bb0(%0 : $Int):
 
 // CHECK-LABEL: sil hidden @theSameStoredProperty
 sil hidden @theSameStoredProperty : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %2 = alloc_box ${ var StructWithStoredProps }
   %3 = project_box %2 : ${ var StructWithStoredProps }, 0
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
@@ -833,7 +833,7 @@ bb0(%0 : $Int):
 
 // CHECK-LABEL: sil hidden @storedPropertyAndAggregate
 sil hidden @storedPropertyAndAggregate : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %2 = alloc_box ${ var StructWithStoredProps }
   %3 = project_box %2 : ${ var StructWithStoredProps }, 0
   %4 = function_ref @takesInoutIntAndStructWithStoredProps : $@convention(thin) (@inout Int, @inout StructWithStoredProps) -> ()
@@ -850,7 +850,7 @@ bb0(%0 : $Int):
 
 // CHECK-LABEL: sil hidden @nestedStoredPropertyAndAggregate
 sil hidden @nestedStoredPropertyAndAggregate : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %2 = alloc_box ${ var StructWithStoredProps }
   %3 = project_box %2 : ${ var StructWithStoredProps }, 0
   %4 = function_ref @takesInoutIntAndStructWithStoredProps : $@convention(thin) (@inout Int, @inout StructWithStoredProps) -> ()
@@ -868,7 +868,7 @@ bb0(%0 : $Int):
 
 // CHECK-LABEL: sil hidden @twoSeparateTupleElements
 sil hidden @twoSeparateTupleElements : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %2 = alloc_box ${ var (Int, Int) }
   %3 = project_box %2 : ${ var (Int, Int) }, 0
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
@@ -886,7 +886,7 @@ bb0(%0 : $Int):
 
 // CHECK-LABEL: sil hidden @sameTupleElement
 sil hidden @sameTupleElement : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %2 = alloc_box ${ var (Int, Int) }
   %3 = project_box %2 : ${ var (Int, Int) }, 0
   %4 = function_ref @takesTwoInouts : $@convention(thin) (@inout Int, @inout Int) -> ()
@@ -903,7 +903,7 @@ bb0(%0 : $Int):
 }
 
 sil hidden @passNilToNoEscape : $@convention(thin) (Int) -> () {
-bb0( %0 : $Int):
+bb0(%0 : @trivial $Int):
   %2 = alloc_box ${ var Int }
   %3 = project_box %2 : ${ var Int }, 0
   %4 = enum $Optional<@convention(block) @noescape () -> ()>, #Optional.none!enumelt
@@ -914,7 +914,7 @@ bb0( %0 : $Int):
 }
 
 sil private @closureForDirectPartialApplyTakingInout : $@convention(thin) (@inout Int, @inout_aliasable Int) -> () {
-bb0(%0 : $*Int, %1 : $*Int):
+bb0(%0 : @trivial $*Int, %1 : @trivial $*Int):
   %access = begin_access [read] [unknown] %1 : $*Int // expected-note {{conflicting access is here}}
   %val = load [trivial] %access : $*Int
   end_access %access : $*Int
@@ -923,7 +923,7 @@ bb0(%0 : $*Int, %1 : $*Int):
 }
 
 sil hidden @directPartialApplyTakingInout : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %box = alloc_box ${ var Int }, var, name "i"
   %boxadr = project_box %box : ${ var Int }, 0
   store %0 to [trivial] %boxadr : $*Int
@@ -939,7 +939,7 @@ bb0(%0 : $Int):
 }
 
 sil private @closureForDirectPartialApplyChain : $@convention(thin) (@inout Int, Int, @inout_aliasable Int) -> () {
-bb0(%0 : $*Int, %1 : $Int, %2 : $*Int):
+bb0(%0 : @trivial $*Int, %1 : @trivial $Int, %2 : @trivial $*Int):
   %access = begin_access [read] [unknown] %2 : $*Int // expected-note {{conflicting access is here}}
   %val = load [trivial] %access : $*Int
   end_access %access : $*Int
@@ -948,7 +948,7 @@ bb0(%0 : $*Int, %1 : $Int, %2 : $*Int):
 }
 
 sil hidden @directPartialApplyChain : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %box = alloc_box ${ var Int }, var, name "i"
   %boxadr = project_box %box : ${ var Int }, 0
   store %0 to [trivial] %boxadr : $*Int
@@ -965,7 +965,7 @@ bb0(%0 : $Int):
 }
 
 sil private @closureForPartialApplyArgChain : $@convention(thin) (Int, @inout_aliasable Int) -> () {
-bb0(%0 : $Int, %1 : $*Int):
+bb0(%0 : @trivial $Int, %1 : @trivial $*Int):
   %access = begin_access [read] [unknown] %1 : $*Int // expected-note {{conflicting access is here}}
   %val = load [trivial] %access : $*Int
   end_access %access : $*Int
@@ -974,7 +974,7 @@ bb0(%0 : $Int, %1 : $*Int):
 }
 
 sil hidden @partialApplyArgChain : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %2 = alloc_box ${ var Int }
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int
@@ -1000,7 +1000,7 @@ class SomeClass {}
 // Check that this doesn't trigger the DiagnoseStaticExclusivity
 // assert that all accesses have a valid AccessedStorage source.
 sil @lldb_unsupported_markuninitialized_testcase : $@convention(thin) (UnsafeMutablePointer<Any>) -> () {
-bb0(%0 : $UnsafeMutablePointer<Any>):
+bb0(%0 : @trivial $UnsafeMutablePointer<Any>):
   %2 = struct_extract %0 : $UnsafeMutablePointer<Any>, #UnsafeMutablePointer._rawValue
   %3 = integer_literal $Builtin.Int64, 8
   %4 = index_raw_pointer %2 : $Builtin.RawPointer, %3 : $Builtin.Int64
@@ -1029,7 +1029,7 @@ sil @addressor : $@convention(thin) () -> UnsafeMutablePointer<Int32>
 // address to an inout can result in an enforced (unknown) access on
 // the unsafe address. We need to handle this case without asserting.
 sil @addressorAccess : $@convention(thin) (@guaranteed ClassWithStoredProperty, Int32) -> () {
-bb0(%0 : $ClassWithStoredProperty, %1 : $Int32):
+bb0(%0 : @guaranteed $ClassWithStoredProperty, %1 : @trivial $Int32):
   %f = function_ref @addressor : $@convention(thin) () -> UnsafeMutablePointer<Int32>
   %up = apply %f() : $@convention(thin) () -> UnsafeMutablePointer<Int32>
   %o = unchecked_ref_cast %0 : $ClassWithStoredProperty to $Builtin.NativeObject
@@ -1052,7 +1052,7 @@ bb0(%0 : $ClassWithStoredProperty, %1 : $Int32):
 // without the @noescape function-type argument convention.
 
 sil @mutatingNoescapeHelper : $@convention(thin) (Optional<UnsafePointer<Int32>>, @inout_aliasable Int32) -> () {
-bb0(%0 : $Optional<UnsafePointer<Int32>>, %1 : $*Int32):
+bb0(%0 : @trivial $Optional<UnsafePointer<Int32>>, %1 : @trivial $*Int32):
   %up = unchecked_enum_data %0 : $Optional<UnsafePointer<Int32>>, #Optional.some!enumelt.1
   %p = struct_extract %up : $UnsafePointer<Int32>, #UnsafePointer._rawValue
   %adr = pointer_to_address %p : $Builtin.RawPointer to [strict] $*Int32
@@ -1065,7 +1065,7 @@ bb0(%0 : $Optional<UnsafePointer<Int32>>, %1 : $*Int32):
 }
 
 sil shared [transparent] [serializable] [reabstraction_thunk] @mutatingNoescapeThunk : $@convention(thin) (UnsafePointer<Int32>, @guaranteed @callee_guaranteed (Optional<UnsafePointer<Int32>>) -> ()) -> () {
-bb0(%0 : $UnsafePointer<Int32>, %1 : $@callee_guaranteed (Optional<UnsafePointer<Int32>>) -> ()):
+bb0(%0 : @trivial $UnsafePointer<Int32>, %1 : @guaranteed $@callee_guaranteed (Optional<UnsafePointer<Int32>>) -> ()):
   %e = enum $Optional<UnsafePointer<Int32>>, #Optional.some!enumelt.1, %0 : $UnsafePointer<Int32>
   %c = apply %1(%e) : $@callee_guaranteed (Optional<UnsafePointer<Int32>>) -> ()
   %v = tuple ()
@@ -1078,7 +1078,7 @@ sil @takeMutatingNoescapeClosure : $@convention(thin) <τ_0_0> (UnsafePointer<τ
 // passed to a reabstraction_thunk as an escaping function type. This
 // is valid as long as the thunk is only used as a @nosecape type.
 sil @mutatingNoescapeWithThunk : $@convention(method) (UnsafePointer<Int32>, @inout Int32) -> () {
-bb0(%0 : $UnsafePointer<Int32>, %1 : $*Int32):
+bb0(%0 : @trivial $UnsafePointer<Int32>, %1 : @trivial $*Int32):
   %f1 = function_ref @mutatingNoescapeHelper : $@convention(thin) (Optional<UnsafePointer<Int32>>, @inout_aliasable Int32) -> ()
   %pa1 = partial_apply [callee_guaranteed] %f1(%1) : $@convention(thin) (Optional<UnsafePointer<Int32>>, @inout_aliasable Int32) -> ()
   %thunk = function_ref @mutatingNoescapeThunk : $@convention(thin) (UnsafePointer<Int32>, @guaranteed @callee_guaranteed (Optional<UnsafePointer<Int32>>) -> ()) -> ()
@@ -1093,7 +1093,7 @@ bb0(%0 : $UnsafePointer<Int32>, %1 : $*Int32):
 sil @takeInoutAndMutatingNoescapeClosure : $@convention(thin) <τ_0_0> (@inout Int32, UnsafePointer<τ_0_0>, @noescape @callee_guaranteed (UnsafePointer<Int32>) -> ()) -> ()
 
 sil @mutatingNoescapeConflictWithThunk : $@convention(method) (UnsafePointer<Int32>, @inout Int32) -> () {
-bb0(%0 : $UnsafePointer<Int32>, %1 : $*Int32):
+bb0(%0 : @trivial $UnsafePointer<Int32>, %1 : @trivial $*Int32):
   %f1 = function_ref @mutatingNoescapeHelper : $@convention(thin) (Optional<UnsafePointer<Int32>>, @inout_aliasable Int32) -> ()
   %pa1 = partial_apply [callee_guaranteed] %f1(%1) : $@convention(thin) (Optional<UnsafePointer<Int32>>, @inout_aliasable Int32) -> ()
   %thunk = function_ref @mutatingNoescapeThunk : $@convention(thin) (UnsafePointer<Int32>, @guaranteed @callee_guaranteed (Optional<UnsafePointer<Int32>>) -> ()) -> ()
@@ -1121,7 +1121,7 @@ sil @takeInoutInt : $@convention(thin) (@inout Int) -> ()
 // dynamic access within the addressor itself, before returning an
 // UnsafePointer.
 sil @testNestedKeypathAccess : $@convention(thin) (@guaranteed (UnsafeMutablePointer<Int>, Optional<AnyObject>)) -> () {
-bb0(%0 : $(UnsafeMutablePointer<Int>, Optional<AnyObject>)):
+bb0(%0 : @guaranteed $(UnsafeMutablePointer<Int>, Optional<AnyObject>)):
   %up = tuple_extract %0 : $(UnsafeMutablePointer<Int>, Optional<AnyObject>), 0
   %o = tuple_extract %0 : $(UnsafeMutablePointer<Int>, Optional<AnyObject>), 1
   %p = struct_extract %up : $UnsafeMutablePointer<Int>, #UnsafeMutablePointer._rawValue

--- a/test/SILOptimizer/guaranteed_arc_opts.sil
+++ b/test/SILOptimizer/guaranteed_arc_opts.sil
@@ -7,12 +7,12 @@ import Builtin
 sil @kraken : $@convention(thin) () -> ()
 
 // CHECK-LABEL: sil @copyvalue_test1 : $@convention(thin) (Builtin.NativeObject, Builtin.NativeObject) -> () {
-// CHECK: bb0([[ARG1:%.*]] : $Builtin.NativeObject, [[ARG2:%.*]] : $Builtin.NativeObject):
+// CHECK: bb0([[ARG1:%.*]] : @unowned $Builtin.NativeObject, [[ARG2:%.*]] : @unowned $Builtin.NativeObject):
 // CHECK-NOT: copy_value [[ARG1]]
 // CHECK: copy_value [[ARG2]]
 // CHECK-NOT: destroy_value [[ARG1]]
 sil @copyvalue_test1 : $@convention(thin) (Builtin.NativeObject, Builtin.NativeObject) -> () {
-bb0(%0 : $Builtin.NativeObject, %1 : $Builtin.NativeObject):
+bb0(%0 : @unowned $Builtin.NativeObject, %1 : @unowned $Builtin.NativeObject):
   %2 = copy_value %0 : $Builtin.NativeObject
   copy_value %1 : $Builtin.NativeObject
   destroy_value %2 : $Builtin.NativeObject
@@ -21,12 +21,12 @@ bb0(%0 : $Builtin.NativeObject, %1 : $Builtin.NativeObject):
 }
 
 // CHECK-LABEL: sil @copyvalue_test2 : $@convention(thin) (Builtin.NativeObject, @in Builtin.Int32) -> Builtin.NativeObject {
-// CHECK: bb0([[ARG1:%.*]] : $Builtin.NativeObject
+// CHECK: bb0([[ARG1:%.*]] : @unowned $Builtin.NativeObject
 // CHECK-NOT: copy_value
 // CHECK-NOT: destroy_value
 // CHECK: return [[ARG1]]
 sil @copyvalue_test2 : $@convention(thin) (Builtin.NativeObject, @in Builtin.Int32) -> Builtin.NativeObject {
-bb0(%0 : $Builtin.NativeObject, %1 : $*Builtin.Int32):
+bb0(%0 : @unowned $Builtin.NativeObject, %1 : @trivial $*Builtin.Int32):
   %2 = copy_value %0 : $Builtin.NativeObject
   %3 = integer_literal $Builtin.Int32, 0
   store %3 to [trivial] %1 : $*Builtin.Int32
@@ -38,7 +38,7 @@ bb0(%0 : $Builtin.NativeObject, %1 : $*Builtin.Int32):
 // CHECK: copy_value
 // CHECK: destroy_value
 sil @copyvalue_test3 : $@convention(thin) (Builtin.NativeObject) -> () {
-bb0(%0 : $Builtin.NativeObject):
+bb0(%0 : @unowned $Builtin.NativeObject):
   copy_value %0 : $Builtin.NativeObject
   %1 = function_ref @kraken : $@convention(thin) () -> ()
   apply %1() : $@convention(thin) () -> ()
@@ -50,7 +50,7 @@ bb0(%0 : $Builtin.NativeObject):
 // CHECK-LABEL: sil @copyvalue_test4 : $@convention(thin) (Builtin.NativeObject) -> () {
 // CHECK: destroy_value
 sil @copyvalue_test4 : $@convention(thin) (Builtin.NativeObject) -> () {
-bb0(%0 : $Builtin.NativeObject):
+bb0(%0 : @unowned $Builtin.NativeObject):
   destroy_value %0 : $Builtin.NativeObject
   %9999 = tuple()
   return %9999 : $()

--- a/test/SILOptimizer/inline_begin_apply.sil
+++ b/test/SILOptimizer/inline_begin_apply.sil
@@ -45,7 +45,7 @@ unwind:
 }
 
 // CHECK-LABEL: sil @test_simple_call
-// CHECK: bb0(%0 : $Builtin.Int1):
+// CHECK: bb0(%0 : @trivial $Builtin.Int1):
 // CHECK:  [[IND_RES:%.*]] = alloc_stack $Indirect<SomeSubclass>
 // CHECK:  [[MARKER:%.*]] = function_ref @marker
 // CHECK:  [[MARKER2:%.*]] = function_ref @marker
@@ -70,7 +70,7 @@ unwind:
 // CHECK:  dealloc_stack [[TEMP]] : $*Indirect<SomeSubclass>
 // CHECK:  br bb7
 
-// CHECK: bb3([[WHICH_YIELD:%.*]] : $Builtin.Int32):
+// CHECK: bb3([[WHICH_YIELD:%.*]] : @trivial $Builtin.Int32):
 // CHECK:  destroy_addr [[IND_RES]] : $*Indirect<SomeSubclass>
 // CHECK:  cond_br %0, bb4, bb6
 
@@ -102,7 +102,7 @@ unwind:
 // CHECK:}
 
 sil @test_simple_call : $(Builtin.Int1) -> () {
-entry(%flag : $Builtin.Int1):
+entry(%flag : @trivial $Builtin.Int1):
   %marker = function_ref @marker : $@convention(thin) (Builtin.Int32) -> ()
   %0 = function_ref @test_one_yield : $@convention(thin) @yield_once <T: SomeClass> () -> (@yields @in Indirect<T>)
   (%value, %token) = begin_apply %0<SomeSubclass>() : $@convention(thin) @yield_once <T: SomeClass> () -> (@yields @in Indirect<T>)
@@ -131,7 +131,7 @@ cont:
 }
 
 sil [transparent] @test_two_yield : $@yield_once <C: SomeClass> (Builtin.Int1) -> (@yields @in Indirect<C>, @yields Builtin.Int64) {
-entry(%0 : $Builtin.Int1):
+entry(%0 : @trivial $Builtin.Int1):
   %marker = function_ref @marker : $@convention(thin) (Builtin.Int32) -> ()
   %1000 = integer_literal $Builtin.Int32, 1000
   apply %marker(%1000) : $@convention(thin) (Builtin.Int32) -> ()
@@ -174,7 +174,7 @@ unwind:
 }
 
 // CHECK-LABEL: sil @test_simple_call_two_yields : $@convention(thin) (Builtin.Int1, Builtin.Int1) -> () {
-// CHECK: bb0(%0 : $Builtin.Int1, %1 : $Builtin.Int1):
+// CHECK: bb0(%0 : @trivial $Builtin.Int1, %1 : @trivial $Builtin.Int1):
 // CHECK:   %2 = alloc_stack $Indirect<SomeSubclass>
 // CHECK:   %3 = function_ref @marker : $@convention(thin) (Builtin.Int32) -> ()
 // CHECK:   %4 = function_ref @marker : $@convention(thin) (Builtin.Int32) -> ()
@@ -222,7 +222,7 @@ unwind:
 // CHECK: bb8:
 // CHECK:   br bb5
 
-// CHECK: bb9(%33 : $Builtin.Int64, %34 : $Builtin.Int32):
+// CHECK: bb9(%33 : @trivial $Builtin.Int64, %34 : @trivial $Builtin.Int32):
 // CHECK:   destroy_addr %2 : $*Indirect<SomeSubclass>
 // CHECK:   cond_br %1, bb10, bb12
 
@@ -248,7 +248,7 @@ unwind:
 // CHECK:   return %45 : $()
 
 sil @test_simple_call_two_yields : $(Builtin.Int1, Builtin.Int1) -> () {
-entry(%flag : $Builtin.Int1, %flag2: $Builtin.Int1):
+entry(%flag : @trivial $Builtin.Int1, %flag2 : @trivial $Builtin.Int1):
   %marker = function_ref @marker : $@convention(thin) (Builtin.Int32) -> ()
   %0 = function_ref @test_two_yield : $@convention(thin) @yield_once <T: SomeClass> (Builtin.Int1) -> (@yields @in Indirect<T>, @yields Builtin.Int64)
   (%value, %value2, %token) = begin_apply %0<SomeSubclass>(%flag) : $@convention(thin) @yield_once <T: SomeClass> (Builtin.Int1) -> (@yields @in Indirect<T>, @yields Builtin.Int64)
@@ -269,7 +269,7 @@ cont:
 }
 
 // CHECK: sil @test_simple_call_yield_owned : $@convention(thin) (Builtin.Int1, @owned SomeClass) -> () {
-// CHECK: bb0(%0 : $Builtin.Int1, %1 : $SomeClass):
+// CHECK: bb0(%0 : @trivial $Builtin.Int1, %1 : @owned $SomeClass):
 // CHECK:   %2 = function_ref @marker
 // CHECK:   %3 = integer_literal $Builtin.Int32, 1000
 // CHECK:   %4 = apply %2(%3)
@@ -288,7 +288,7 @@ cont:
 // CHECK:   destroy_value %1 : $SomeClass
 // CHECK:   br bb7
 
-// CHECK: bb3(%16 : $SomeClass, %17 : $Builtin.Int32):
+// CHECK: bb3(%16 : @owned $SomeClass, %17 : @trivial $Builtin.Int32):
 // CHECK:   cond_br %0, bb4, bb6
 
 // CHECK: bb4:
@@ -310,7 +310,7 @@ cont:
 // CHECK:   return %25 : $()
 
 sil [transparent] @yield_owned : $@yield_once(@owned SomeClass) -> (@yields @owned SomeClass) {
-entry(%0 : $SomeClass):
+entry(%0 : @owned $SomeClass):
   %marker = function_ref @marker : $@convention(thin) (Builtin.Int32) -> ()
   %1000 = integer_literal $Builtin.Int32, 1000
   apply %marker(%1000) : $@convention(thin) (Builtin.Int32) -> ()
@@ -331,7 +331,7 @@ unwind:
 }
 
 sil @test_simple_call_yield_owned : $(Builtin.Int1, @owned SomeClass) -> () {
-entry(%flag : $Builtin.Int1, %c: $SomeClass):
+entry(%flag : @trivial $Builtin.Int1, %c: @owned $SomeClass):
   %0 = function_ref @yield_owned : $@convention(thin) @yield_once(@owned SomeClass) -> (@yields @owned SomeClass)
   (%value, %token) = begin_apply %0(%c) : $@convention(thin) @yield_once(@owned SomeClass) -> (@yields @owned SomeClass)
   cond_br %flag, yes, no

--- a/test/SILOptimizer/mandatory_inlining_open_existential.sil
+++ b/test/SILOptimizer/mandatory_inlining_open_existential.sil
@@ -11,7 +11,7 @@ protocol P {
 }
 
 sil hidden @caller : $@convention(thin) (@in P) -> () {
-bb0(%0 : $*P):
+bb0(%0 : @trivial $*P):
   %2 = open_existential_addr immutable_access %0 : $*P to $*@opened("214EF566-CD33-11E6-A1F0-34363BD08DA0") P
   %3 = witness_method $@opened("214EF566-CD33-11E6-A1F0-34363BD08DA0") P, #P.f7!1, %2 : $*@opened("214EF566-CD33-11E6-A1F0-34363BD08DA0") P : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @owned @callee_owned () -> @out τ_0_0
   %4 = apply %3<@opened("214EF566-CD33-11E6-A1F0-34363BD08DA0") P>(%2) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @owned @callee_owned () -> @out τ_0_0
@@ -30,7 +30,7 @@ bb0(%0 : $*P):
 }
 
 sil hidden [transparent] @callee : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@owned @callee_owned () -> @out τ_0_0) -> @out P {
-bb0(%0 : $*P, %1 : $@callee_owned () -> @out τ_0_0):
+bb0(%0 : @trivial $*P, %1 : @owned $@callee_owned () -> @out τ_0_0):
   %2 = alloc_stack $τ_0_0
   %3 = apply %1(%2) : $@callee_owned () -> @out τ_0_0
   %4 = init_existential_addr %0 : $*P, $τ_0_0

--- a/test/SILOptimizer/opaque_values_mandatory.sil
+++ b/test/SILOptimizer/opaque_values_mandatory.sil
@@ -13,7 +13,7 @@ typealias Int = Builtin.Int64
 // CHECK: return %0 : $T
 // CHECK-LABEL: } // end sil function 'f010_diagnose_identity'
 sil hidden @f010_diagnose_identity : $@convention(thin) <T> (@in T) -> @out T {
-bb0(%0 : $T):
+bb0(%0 : @trivial $T):
   %c = copy_value %0 : $T
   destroy_value %0 : $T
   return %c : $T
@@ -31,7 +31,7 @@ bb0(%0 : $T):
 // CHECK: return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function 'f020_assign_inout'
 sil hidden @f020_assign_inout : $@convention(thin) <T> (@inout T, @in T) -> () {
-bb0(%0 : $*T, %1 : $T):
+bb0(%0 : @trivial $*T, %1 : @trivial $T):
   %2 = copy_value %1 : $T
   assign %2 to %0 : $*T
   destroy_value %1 : $T
@@ -52,7 +52,7 @@ bb0(%0 : $*T, %1 : $T):
 // CHECK:   return %6 : $(Builtin.Int64, Builtin.Int64, Builtin.Int64)
 // CHECK-LABEL: } // end sil function 'f030_callMultiResult'
 sil @f030_callMultiResult : $@convention(thin) (Int) -> (Int, Int, Int) {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %1 = function_ref @f040_multiResult : $@convention(thin) <τ_0_0> (@in τ_0_0) -> (@out τ_0_0, @out τ_0_0, @out τ_0_0)
   %2 = apply %1<Int>(%0) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> (@out τ_0_0, @out τ_0_0, @out τ_0_0)
   %3 = tuple_extract %2 : $(Int, Int, Int), 0
@@ -72,7 +72,7 @@ bb0(%0 : $Int):
 // CHECK:   return %3 : $(T, T, T)
 // CHECK-LABEL: } // end sil function 'f040_multiResult'
 sil hidden [noinline] @f040_multiResult : $@convention(thin) <T> (@in T) -> (@out T, @out T, @out T) {
-bb0(%0 : $T):
+bb0(%0 : @trivial $T):
   %2 = copy_value %0 : $T
   %3 = copy_value %0 : $T
   %4 = copy_value %0 : $T

--- a/test/SILOptimizer/peephole_trunc_and_ext.sil
+++ b/test/SILOptimizer/peephole_trunc_and_ext.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-sil -O -o - -verify | %FileCheck %s
+// RUN: %target-swift-frontend %s -assume-parsing-unqualified-ownership-sil -emit-sil -O -o - -sil-verify-all | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/prespecialization_with_definition.sil
+++ b/test/SILOptimizer/prespecialization_with_definition.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s -module-name main | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s -module-name main -assume-parsing-unqualified-ownership-sil | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/specialize_cg_update_crash.sil
+++ b/test/SILOptimizer/specialize_cg_update_crash.sil
@@ -1,6 +1,6 @@
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -parse-stdlib -parse-as-library  -module-name TestMod %S/Inputs/TestMod.sil -emit-module-path %t/TestMod.swiftmodule
+// RUN: %target-swift-frontend -parse-stdlib -assume-parsing-unqualified-ownership-sil -parse-as-library  -module-name TestMod %S/Inputs/TestMod.sil -emit-module-path %t/TestMod.swiftmodule
 // RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -inline -I %t %s | %FileCheck %s
 
 // Test if the CG is updated correctly during specialization and

--- a/test/SILOptimizer/static_report.sil
+++ b/test/SILOptimizer/static_report.sil
@@ -4,7 +4,7 @@ import Builtin
 
 // test_static_report
 sil @sil_test_static_report : $@convention(thin) (Builtin.RawPointer) -> Builtin.RawPointer {
-bb0(%0 : $Builtin.RawPointer):
+bb0(%0 : @trivial $Builtin.RawPointer):
   %1 = integer_literal $Builtin.Int1, 1
   %3 = builtin "staticReport"(%1 : $Builtin.Int1, %1 : $Builtin.Int1, %0 : $Builtin.RawPointer) : $() // expected-error {{static report error}}
   return %0 : $Builtin.RawPointer

--- a/test/SILOptimizer/verify_noescape_closure.sil
+++ b/test/SILOptimizer/verify_noescape_closure.sil
@@ -17,13 +17,13 @@ import Swift
 sil @takesEscapingClosure : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
 
 sil hidden @closureWithArgument : $@convention(thin) (@inout_aliasable Int) -> () {
-bb0(%1 : $*Int):
+bb0(%1 : @trivial $*Int):
   %3 = tuple ()
   return %3 : $()
 }
 
 sil @missingNoescape : $@convention(thin) (Int) ->() {
-bb0(%0 : $Int):
+bb0(%0 : @trivial $Int):
   %2 = alloc_box ${ var Int }
   %3 = project_box %2 : ${ var Int }, 0
   store %0 to [trivial] %3 : $*Int

--- a/test/Serialization/Inputs/def_basic_objc.sil
+++ b/test/Serialization/Inputs/def_basic_objc.sil
@@ -9,7 +9,7 @@ class SomeClass : SomeProtocol { }
 
 // CHECK-LABEL: @objc_classes : $@convention(thin) (@thick NSObject.Type) -> ()
 sil [transparent] [serialized] @objc_classes : $@convention(thin) (@thick NSObject.Type) -> () {
-bb0(%0 : $@thick NSObject.Type):
+bb0(%0 : @trivial $@thick NSObject.Type):
   %1 = thick_to_objc_metatype %0 : $@thick NSObject.Type to $@objc_metatype NSObject.Type
   // CHECK: %2 = alloc_ref_dynamic [objc] %1 : $@objc_metatype NSObject.Type, $NSObject
   %2 = alloc_ref_dynamic [objc] %1 : $@objc_metatype NSObject.Type, $NSObject
@@ -35,7 +35,7 @@ protocol SomeClassProtocol : class {}
 // CHECK:         {{%.*}} = objc_metatype_to_object {{%.*}} : $@objc_metatype SomeClass.Type to $AnyObject
 // CHECK:         {{%.*}} = objc_existential_metatype_to_object {{%.*}} : $@objc_metatype SomeClassProtocol.Type to $AnyObject
 sil [transparent] [serialized] @metatype_to_object : $@convention(thin) (@objc_metatype SomeClass.Type, @objc_metatype SomeClassProtocol.Type) -> @owned (AnyObject, AnyObject) {
-entry(%a : $@objc_metatype SomeClass.Type, %b : $@objc_metatype SomeClassProtocol.Type):
+entry(%a : @trivial $@objc_metatype SomeClass.Type, %b : @trivial $@objc_metatype SomeClassProtocol.Type):
   %x = objc_metatype_to_object %a : $@objc_metatype SomeClass.Type to $AnyObject
   %y = objc_existential_metatype_to_object %b : $@objc_metatype SomeClassProtocol.Type to $AnyObject
   %z = tuple (%x : $AnyObject, %y : $AnyObject)

--- a/test/Serialization/basic_sil.swift
+++ b/test/Serialization/basic_sil.swift
@@ -2,7 +2,7 @@
 // RUN: %target-build-swift -Xfrontend -assume-parsing-unqualified-ownership-sil -emit-module -Xfrontend -disable-diagnostic-passes -force-single-frontend-invocation -Xfrontend -enable-objc-interop -o %t/def_basic.swiftmodule %S/Inputs/def_basic.sil
 // RUN: llvm-bcanalyzer %t/def_basic.swiftmodule | %FileCheck %s
 // RUN: %target-build-swift -emit-sil -I %t %s -o %t/basic_sil.sil
-// RUN: %target-sil-opt -I %t %t/basic_sil.sil -performance-linker | %FileCheck %S/Inputs/def_basic.sil
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -I %t %t/basic_sil.sil -performance-linker | %FileCheck %S/Inputs/def_basic.sil
 
 // This test currently is written such that no optimizations are assumed.
 // REQUIRES: swift_test_mode_optimize_none

--- a/test/Serialization/basic_sil_objc.swift
+++ b/test/Serialization/basic_sil_objc.swift
@@ -3,7 +3,7 @@
 // RUN: llvm-bcanalyzer %t/def_basic_objc.swiftmodule | %FileCheck %s
 
 // RUN: %target-build-swift -Xfrontend %clang-importer-sdk -emit-sil -I %t %s -o %t/basic_sil_objc.sil
-// RUN: %target-sil-opt %t/basic_sil_objc.sil -performance-linker -I %t | %FileCheck %S/Inputs/def_basic_objc.sil
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil %t/basic_sil_objc.sil -performance-linker -I %t | %FileCheck %S/Inputs/def_basic_objc.sil
 
 // This test currently is written such that no optimizations are assumed.
 // REQUIRES: swift_test_mode_optimize_none

--- a/test/Serialization/sil_box_types.sil
+++ b/test/Serialization/sil_box_types.sil
@@ -13,14 +13,14 @@ protocol Q {
 // CHECK-LABEL: sil @boxes : $@convention(thin) (<τ_0_0> { var τ_0_0 } <Builtin.Int32>, <τ_0_0> { var τ_0_0 } <Builtin.Int32>) -> () {
 sil @boxes : $@convention(thin) (<τ_0_0> { var τ_0_0 } <Builtin.Int32>, <τ_0_0> { var τ_0_0 } <Builtin.Int32>) -> () {
 // CHECK: bb0(%0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>, %1 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>):
-entry(%0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>, %1 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>):
+entry(%0 : @unowned $<τ_0_0> { var τ_0_0 } <Builtin.Int32>, %1 : @unowned $<τ_0_0> { var τ_0_0 } <Builtin.Int32>):
   return undef : $()
 }
 
 // CHECK-LABEL: sil @boxes_extra_reqs : $@convention(thin) <T where T : Q, T.AT : P> (@owned <τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T>) -> () {
 sil @boxes_extra_reqs : $@convention(thin) <T where T : Q, T.AT : P> (@owned <τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T>) -> () {
 // CHECK: bb0(%0 : $<τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T>)
-bb0(%0 : $<τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T>):
+bb0(%0 : @owned $<τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T>):
   %1 = project_box %0 : $<τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T>, 0
   return undef : $()
 }

--- a/test/sil-opt/guaranteed-normal-args-negative.sil
+++ b/test/sil-opt/guaranteed-normal-args-negative.sil
@@ -9,7 +9,7 @@ sil_stage canonical
 import TestModule
 
 sil @callFoo : $@convention(thin) (@owned Foo) -> () {
-bb0(%0 : $Foo):
+bb0(%0 : @owned $Foo):
   %1 = class_method %0 : $Foo, #Foo.doSomething!1 : (Foo) -> (Foo) -> (), $@convention(method) (@guaranteed Foo, @owned Foo) -> ()
   destroy_value %0 : $Foo
   %9999 = tuple()

--- a/test/sil-opt/guaranteed-normal-args-positive.sil
+++ b/test/sil-opt/guaranteed-normal-args-positive.sil
@@ -9,7 +9,7 @@ sil_stage canonical
 import TestModule
 
 sil @callFoo : $@convention(thin) (@owned Foo) -> () {
-bb0(%0 : $Foo):
+bb0(%0 : @guaranteed $Foo):
   %1 = class_method %0 : $Foo, #Foo.doSomething!1 : (Foo) -> (Foo) -> (), $@convention(method) (@guaranteed Foo, @guaranteed Foo) -> ()
   destroy_value %0 : $Foo
   %9999 = tuple()

--- a/validation-test/Sema/wmo_verify_loaded.swift
+++ b/validation-test/Sema/wmo_verify_loaded.swift
@@ -21,6 +21,6 @@ extension Notification.Name {}
 // NSPasteboardType.init(rawValue:)
 // - just make sure it has a body.
 // CHECK-LABEL: sil shared [transparent] [serializable] @$SSo16NSPasteboardTypea8rawValueABSS_tcfC : $@convention(method) (@owned String, @thin NSPasteboard.PasteboardType.Type) -> @owned NSPasteboard.PasteboardType {
-// CHECK: bb0(%0 : $String, %1 : $@thin NSPasteboard.PasteboardType.Type):
+// CHECK: bb0(%0 : @owned $String, %1 : @trivial $@thin NSPasteboard.PasteboardType.Type):
 // CHECK: return %{{.*}} : $NSPasteboard.PasteboardType
 // CHECK-LABEL: } // end sil function '$SSo16NSPasteboardTypea8rawValueABSS_tcfC'


### PR DESCRIPTION
…r not -enable-sil-ownership is passed in.

This is how we originally controlled whether or not we printed out ownership
annotations when we printed SIL. Since then, I have changed (a few months ago I
believe) the ownership model eliminator to know how to eliminate these
annotations from the SIL itself. So this hack can be removed.

rdar://42509812
