### PR TITLE
[ParameterUpdate] Improve @TFParameter diagnostics.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2683,7 +2683,7 @@ ERROR(tf_graph_attr_no_generic_functions,none,
 
 // @TFParameter attribute
 ERROR(tfparameter_attr_tensorflow_not_imported,none,
-      "@%0 is enabled only when the 'TensorFlow' module is imported", (StringRef))
+      "@%0 is available only when 'TensorFlow' is imported", (StringRef))
 ERROR(tfparameter_attr_instance_stored_property_only,none,
       "only instance stored properties can be declared @%0", (StringRef))
 ERROR(tfparameter_attr_not_in_parameterized,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2682,8 +2682,12 @@ ERROR(tf_graph_attr_no_generic_functions,none,
       "@TensorFlowGraph cannot be applied to generic functions", ())
 
 // @TFParameter attribute
+ERROR(tfparameter_attr_tensorflow_not_imported,none,
+      "@%0 is enabled only when the 'TensorFlow' module is imported", (StringRef))
 ERROR(tfparameter_attr_instance_stored_property_only,none,
       "only instance stored properties can be declared @%0", (StringRef))
+ERROR(tfparameter_attr_not_in_parameterized,none,
+      "@%0 is allowed only in types that conform to 'Parameterized'", (StringRef))
 
 //------------------------------------------------------------------------------
 // MARK: Type Check Expressions

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2664,12 +2664,31 @@ void AttributeChecker::visitTensorFlowGraphAttr(TensorFlowGraphAttr *attr) {
 
 // SWIFT_ENABLE_TENSORFLOW
 void AttributeChecker::visitTFParameterAttr(TFParameterAttr *attr) {
-  VarDecl *VD = dyn_cast<VarDecl>(D);
-  if (!VD->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext() ||
-      !VD->hasStorage() || VD->isStatic())
+  // The `TensorFlow` module must be imported.
+  auto parameterizedProto =
+    TC.Context.getProtocol(KnownProtocolKind::Parameterized);
+  if (!parameterizedProto) {
+    diagnoseAndRemoveAttr(attr, diag::tfparameter_attr_tensorflow_not_imported,
+                          attr->getAttrName());
+    return;
+  }
+  // Declaration must be an instance stored property of a nominal type.
+  auto *VD = dyn_cast<VarDecl>(D);
+  auto *nominal =
+    VD->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
+  if (!nominal || !VD->hasStorage() || VD->isStatic()) {
     diagnoseAndRemoveAttr(attr,
                           diag::tfparameter_attr_instance_stored_property_only,
                           attr->getAttrName());
+    return;
+  }
+  // The nominal type must conform to `Parameterized`.
+  if (!TC.conformsToProtocol(nominal->getDeclaredInterfaceType(),
+                             parameterizedProto, nominal->getDeclContext(),
+                             ConformanceCheckFlags::InExpression)) {
+    diagnoseAndRemoveAttr(attr, diag::tfparameter_attr_not_in_parameterized,
+                          attr->getAttrName());
+  }
 }
 
 void TypeChecker::checkDeclAttributes(Decl *D) {

--- a/test/Sema/parameter_aggregate.swift
+++ b/test/Sema/parameter_aggregate.swift
@@ -30,7 +30,6 @@ tensorParams.update(withGradients: tensorParams) { p, g in p -= g }
 tensorParams.update(withGradients: tensorParams) { $0 -= 0.1 * $1 }
 
 // Test types with ParameterAggregate members.
-
 struct NestedParameters : ParameterAggregate {
   var params1: Parameters
   var params2: Parameters
@@ -52,7 +51,6 @@ veryNested.update(withGradients: veryNested) { p, g in p -= g }
 veryNested.update(withGradients: veryNested) { $0 -= 0.1 * $1 }
 
 // Test type in generic context.
-
 struct A<T> {
   struct B<U, V> {
     struct GenericContextParams : ParameterAggregate {
@@ -63,7 +61,6 @@ struct A<T> {
 }
 
 // Test manual conformances to ParameterAggregate.
-
 struct HeterogeneousParameters : ParameterAggregate {
   var float: Float
   var double: Double

--- a/test/Sema/parameterized.swift
+++ b/test/Sema/parameterized.swift
@@ -32,7 +32,6 @@ struct TensorLayer : Parameterized {
 _ = TensorLayer.Parameters(w: [1], b: [2])
 
 // Test types with `Parameterized` members.
-
 struct Model : Parameterized {
   @TFParameter var layer1: DenseLayer
   @TFParameter var layer2: DenseLayer
@@ -48,13 +47,11 @@ model.updateParameters(withGradients: modelGradients) { p, g in p -= g }
 model.updateParameters(withGradients: modelGradients) { $0 -= 0.1 * $1 }
 
 // Test extension of synthesized `Parameters` struct.
-
 extension Model.Parameters {
   func foo() {}
 }
 
 // Test type in generic context.
-
 struct A<T> {
   struct B<U, V> {
     struct GenericContextModel : Parameterized {
@@ -65,7 +62,6 @@ struct A<T> {
 }
 
 // Test heterogenous parameter types.
-
 struct MixedParameterized : Parameterized {
   @TFParameter var int: Int
   @TFParameter var float: Float
@@ -85,16 +81,7 @@ extension MixedParameterized.Parameters : ParameterAggregate {
 }
 mixed.updateParameters(withGradients: mixed.allParameters, -=)
 
-// Test invalid `Parameters` struct.
-
-struct ModelWithInvalidParameters : Parameterized {
-  @TFParameter var layer: DenseLayer
-  @TFParameter var float: Float
-  struct Parameters {} // expected-error {{'Parameters' struct is invalid}}
-}
-
 // Test user-specified `Parameters` struct with reordered parameters.
-
 struct ModelWithReorderedParameters : Parameterized {
   @TFParameter var layer: DenseLayer
   @TFParameter var float: Float
@@ -106,3 +93,15 @@ struct ModelWithReorderedParameters : Parameterized {
 var reorderedModel = ModelWithReorderedParameters(layer: layer, float: 1)
 _ = reorderedModel.allParameters
 reorderedModel.updateParameters(withGradients: reorderedModel.allParameters, -=)
+
+// Test invalid `Parameters` struct.
+struct ModelWithInvalidParameters : Parameterized {
+  @TFParameter var layer: DenseLayer
+  @TFParameter var float: Float
+  struct Parameters {} // expected-error {{'Parameters' struct is invalid}}
+}
+
+// Test invalid `@TFParameter` usage outside of `Parameterized` type.
+struct NonParameterized {
+  @TFParameter var float: Float // expected-error {{@TFParameter is allowed only in types that conform to 'Parameterized'}}
+}


### PR DESCRIPTION
Diagnose when:
- `@TFParameter` is used when `TensorFlow` module is not imported.
- `@TFParameter` is used in a nominal type that doesn't conform to `Parameterized`.