### PR TITLE
Temporarily disable SIL debug scope verification for deabstraction.

### DIFF
--- a/test/TensorFlow/debug_scope.swift
+++ b/test/TensorFlow/debug_scope.swift
@@ -6,5 +6,6 @@
 
 import TensorFlow
 func test() {
-  _ = Tensor(1)
+  let x: Tensor<Float> = [1, 2, 3, 4] // expected-error {{array input is not a constant array of tensors}}
+  print(matmul(x, x) + x) // expected-error {{attribute 'transpose_a' requires a constant argument}}
 }


### PR DESCRIPTION
Debug scope verification was enabled by default in https://github.com/apple/swift/commit/f917c9355764dc6d9308ccf2801776c62e032612.
This caused verification errors as a result of performance inlining during deabstraction.

Eventually, the verifier should be enhanced to handle inline call sites.
Until then, debug scope verification will be disabled.

Addresses [SR-8114](https://bugs.swift.org/browse/SR-8114). Undoes incomplete workaround in https://github.com/apple/swift/pull/17797.

Currently, since debug scope verification is enabled, any `Tensor` program compiled with `-Onone` fails verification.