### PR TITLE
Temporarily change to build master-next against swift-5.0-branch of LLVM

### DIFF
--- a/utils/update-checkout-config.json
+++ b/utils/update-checkout-config.json
@@ -57,9 +57,9 @@
                         "stable-next", "upstream",
                         "next-upstream", "upstream-with-swift"],
             "repos": {
-                "llvm": "upstream-with-swift",
-                "clang": "upstream-with-swift",
-                "compiler-rt": "upstream-with-swift",
+                "llvm": "swift-5.0-branch",
+                "clang": "swift-5.0-branch",
+                "compiler-rt": "swift-5.0-branch",
                 "swift": "master-next",
                 "lldb": "upstream-with-swift",
                 "cmark": "master",


### PR DESCRIPTION
As Swift 4.2 winds down, we're due to move to a newer version of LLVM.
The swift-5.0-branch in swift-llvm, swift-clang, and swift-compiler-rt
has been updated with content from upstream-with-swift as of last week,
and we're planning to adopt this as our next "stable" branch of LLVM
(forum announcement should be going out soon). There are still some
issues that we need to work through, so to help test that, we're going
to temporarily use the master-next bots to build with those branches.
We'll switch back to testing against upstream-with-swift after we're
done with the transition.