### PR TITLE
[master-next] Update a debug info test for LLVM r336847

### DIFF
--- a/test/DebugInfo/columns.swift
+++ b/test/DebugInfo/columns.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s --check-prefixes CHECK,DWARF-CHECK
 // RUN: %target-swift-frontend %s -emit-ir -g -debug-info-format=codeview -o - \
-// RUN:   | %FileCheck %s --check-prefixes CHECK,CV-CHECK
+// RUN:   | %FileCheck %s --check-prefixes CHECK,CV-CHECK --allow-deprecated-dag-overlap
 
 public func foo(_ a: Int64, _ b: Int64) -> Int64 {      // line 5
   // CHECK: sdiv i64 {{.*}}, !dbg ![[DIV:[0-9]+]]


### PR DESCRIPTION
LLVM r336847 changed FileCheck's CHECK-DAG feature to stop supporting
overlapping matches. That breaks the DebugInfo/columns.swift test.
This change works around the failure by invoking FileCheck with the
--allow-deprecated-dag-overlap option. I filed a bug report to track
fixing the test properly (https://bugs.swift.org/browse/SR-8359).