### PR TITLE
[TF] Fix SR-8358: parameter aggregate updater not being GPE'd 

### DIFF
--- a/stdlib/public/TensorFlow/Parameterized.swift
+++ b/stdlib/public/TensorFlow/Parameterized.swift
@@ -26,7 +26,8 @@ public protocol ParameterAggregate {
   /// Update parameters with their gradient values, using an updater function.
   mutating func update(
     withGradients gradients: Self,
-    _ updater: (inout Parameter, Parameter) -> Void)
+    _ updater: (inout Parameter, Parameter) -> Void
+  )
 }
 
 //===----------------------------------------------------------------------===//
@@ -56,6 +57,7 @@ public protocol Parameterized {
 
 public extension Parameterized where Parameters : ParameterAggregate {
   /// Update parameters with their gradient values, using an updater function.
+  @inlinable
   mutating func updateParameters(
     withGradients gradients: Parameters,
     _ updater: (inout Parameters.Parameter, Parameters.Parameter) -> Void

--- a/test/TensorFlowRuntime/parameter_update.swift
+++ b/test/TensorFlowRuntime/parameter_update.swift
@@ -6,11 +6,6 @@
 // TensorFlow aggregate parameter update tests.
 
 import TensorFlow
-#if TPU
-import TensorFlowUnittestTPU
-#else
-import TensorFlowUnittest
-#endif
 import StdlibUnittest
 
 var ParameterUpdateTests = TestSuite("ParameterUpdate")

--- a/test/TensorFlowRuntime/parameter_update.swift
+++ b/test/TensorFlowRuntime/parameter_update.swift
@@ -23,7 +23,7 @@ struct Foo : Parameterized {
 ParameterUpdateTests.test("UpdateParameters") {
   var f = Foo()
   f.foo()
-  expectEqual(Tensor<Float>(2), f.w)
+  expectEqual(2, f.w.scalar!)
 }
 
 runAllTests()

--- a/test/TensorFlowRuntime/parameter_update.swift
+++ b/test/TensorFlowRuntime/parameter_update.swift
@@ -10,7 +10,7 @@ import StdlibUnittest
 
 var ParameterUpdateTests = TestSuite("ParameterUpdate")
 
-RawOpTests.test("UpdateParameters") {
+ParameterUpdateTests.test("UpdateParameters") {
   struct Foo : Parameterized {
     @TFParameter var w = Tensor<Float>(1)
     mutating func foo() {

--- a/test/TensorFlowRuntime/parameter_update.swift
+++ b/test/TensorFlowRuntime/parameter_update.swift
@@ -9,15 +9,18 @@ import StdlibUnittest
 
 var ParameterUpdateTests = TestSuite("ParameterUpdate")
 
-ParameterUpdateTests.test("UpdateParameters") {
-  struct Foo : Parameterized {
-    @TFParameter var w = Tensor<Float>(1)
-    mutating func foo() {
-      updateParameters(withGradients: Parameters(w: Tensor(1))) {
-        $0 += $1
-      }
+// TODO: When SR-8360 is fixed, move this to the body of the 'UpdateParameters'
+// test.
+struct Foo : Parameterized {
+  @TFParameter var w = Tensor<Float>(1)
+  mutating func foo() {
+    updateParameters(withGradients: Parameters(w: Tensor(1))) {
+      $0 += $1
     }
   }
+}
+
+ParameterUpdateTests.test("UpdateParameters") {
   var f = Foo()
   f.foo()
   expectEqual(Tensor<Float>(2), f.w)

--- a/test/TensorFlowRuntime/parameter_update.swift
+++ b/test/TensorFlowRuntime/parameter_update.swift
@@ -1,7 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
-// REQUIRES: tensorflow_swift_bindings
 //
 // TensorFlow aggregate parameter update tests.
 

--- a/test/TensorFlowRuntime/parameter_update.swift
+++ b/test/TensorFlowRuntime/parameter_update.swift
@@ -1,0 +1,32 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize
+// REQUIRES: tensorflow_swift_bindings
+//
+// TensorFlow aggregate parameter update tests.
+
+import TensorFlow
+#if TPU
+import TensorFlowUnittestTPU
+#else
+import TensorFlowUnittest
+#endif
+import StdlibUnittest
+
+var ParameterUpdateTests = TestSuite("ParameterUpdate")
+
+RawOpTests.test("UpdateParameters") {
+  struct Foo : Parameterized {
+    @TFParameter var w = Tensor<Float>(1)
+    mutating func foo() {
+      updateParameters(withGradients: Parameters(w: Tensor(1))) {
+        $0 += $1
+      }
+    }
+  }
+  var f = Foo()
+  f.foo()
+  expectEqual(Tensor<Float>(2), f.w)
+}
+
+runAllTests()

--- a/test/TensorFlowRuntime/parameter_update.swift
+++ b/test/TensorFlowRuntime/parameter_update.swift
@@ -9,18 +9,15 @@ import StdlibUnittest
 
 var ParameterUpdateTests = TestSuite("ParameterUpdate")
 
-// TODO: When SR-8360 is fixed, move this to the body of the 'UpdateParameters'
-// test.
-struct Foo : Parameterized {
-  @TFParameter var w = Tensor<Float>(1)
-  mutating func foo() {
-    updateParameters(withGradients: Parameters(w: Tensor(1))) {
-      $0 += $1
+ParameterUpdateTests.test("UpdateParameters") {
+  struct Foo : Parameterized {
+    @TFParameter var w = Tensor<Float>(1)
+    mutating func foo() {
+      updateParameters(withGradients: Parameters(w: Tensor(1))) {
+        $0 += $1
+      }
     }
   }
-}
-
-ParameterUpdateTests.test("UpdateParameters") {
   var f = Foo()
   f.foo()
   expectEqual(2, f.w.scalar!)


### PR DESCRIPTION
Public functions containing tensor code in the `TensorFlow` module **must be inlinable**.

https://bugs.swift.org/browse/SR-8358