### PR TITLE
[IDE] Fix asstion failure when querying cursor info in defer statement body

### DIFF
--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -217,8 +217,9 @@ std::pair<bool, Stmt *> SemaAnnotator::walkToStmtPre(Stmt *S) {
       // walk into the body.
       if (auto *FD = DeferS->getTempDecl()) {
         auto *RetS = FD->getBody()->walk(*this);
+        if (!RetS)
+          return { false, nullptr };
         assert(RetS == FD->getBody());
-        (void)RetS;
       }
       bool Continue = SEWalker.walkToStmtPost(DeferS);
       if (!Continue)

--- a/test/SourceKit/CursorInfo/rdar_41100570.swift
+++ b/test/SourceKit/CursorInfo/rdar_41100570.swift
@@ -1,0 +1,6 @@
+func foo(x: String) {
+  defer { _ = x.count }
+}
+
+// RUN: %sourcekitd-test -req=cursor -cursor-action -pos=2:15 %s -- %s | %FileCheck %s
+// CHECK: source.lang.swift.ref.var.local (1:10-1:11)


### PR DESCRIPTION
In `SemaAnnotator`, when walking into body of defer statement returns nullptr, it indicates *cutting-off* walking. Previously there was wrong assertion where it must be unmodified, non-nullptr return.

(This bug is introduced in #16440)

rdar://problem/41100570