### PR TITLE
[Type checker] Finalize referenced members of class extensions.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -480,17 +480,13 @@ protected:
     IsDebuggerAlias : 1
   );
 
-  SWIFT_INLINE_BITFIELD(NominalTypeDecl, GenericTypeDecl, 1+1+1,
+  SWIFT_INLINE_BITFIELD(NominalTypeDecl, GenericTypeDecl, 1+1,
     /// Whether we have already added implicitly-defined initializers
     /// to this declaration.
     AddedImplicitInitializers : 1,
 
     /// Whether there is are lazily-loaded conformances for this nominal type.
-    HasLazyConformances : 1,
-
-    /// Whether we have already validated all members of the type that
-    /// affect layout.
-    HasValidatedLayout : 1
+    HasLazyConformances : 1
   );
 
   SWIFT_INLINE_BITFIELD_FULL(ProtocolDecl, NominalTypeDecl, 1+1+1+1+1+1+1+1+2+8+16,
@@ -3036,7 +3032,6 @@ protected:
     Bits.NominalTypeDecl.AddedImplicitInitializers = false;
     ExtensionGeneration = 0;
     Bits.NominalTypeDecl.HasLazyConformances = false;
-    Bits.NominalTypeDecl.HasValidatedLayout = false;
   }
 
   friend class ProtocolType;
@@ -3072,18 +3067,6 @@ public:
   /// Note that we have attempted to add implicit initializers.
   void setAddedImplicitInitializers() {
     Bits.NominalTypeDecl.AddedImplicitInitializers = true;
-  }
-
-  /// Determine whether we have already validated any members
-  /// which affect layout.
-  bool hasValidatedLayout() const {
-    return Bits.NominalTypeDecl.HasValidatedLayout;
-  }
-
-  /// Note that we have attempted to validate any members
-  /// which affect layout.
-  void setHasValidatedLayout() {
-    Bits.NominalTypeDecl.HasValidatedLayout = true;
   }
 
   /// Set the interface type of this nominal type to the metatype of the

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2723,7 +2723,6 @@ public:
 
     checkUnsupportedNestedType(ED);
     TC.validateDecl(ED);
-    ED->setHasValidatedLayout();
 
     {
       // Check for circular inheritance of the raw type.
@@ -2761,7 +2760,6 @@ public:
     checkUnsupportedNestedType(SD);
 
     TC.validateDecl(SD);
-    SD->setHasValidatedLayout();
 
     TC.addImplicitConstructors(SD);
 
@@ -2891,7 +2889,6 @@ public:
 
     TC.validateDecl(CD);
     TC.requestSuperclassLayout(CD);
-    CD->setHasValidatedLayout();
 
     {
       // Check for circular inheritance.
@@ -4649,11 +4646,6 @@ void TypeChecker::requestMemberLayout(ValueDecl *member) {
 }
 
 void TypeChecker::requestNominalLayout(NominalTypeDecl *nominalDecl) {
-  if (nominalDecl->hasValidatedLayout())
-    return;
-
-  nominalDecl->setHasValidatedLayout();
-
   if (isa<SourceFile>(nominalDecl->getModuleScopeContext()))
     DeclsToFinalize.insert(nominalDecl);
 }

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -567,8 +567,8 @@ static void typeCheckFunctionsAndExternalDecls(SourceFile &SF, TypeChecker &TC) 
     // Note: if we ever start putting extension members in vtables, we'll need
     // to validate those members too.
     // FIXME: If we're not planning to run SILGen, this is wasted effort.
-    while (!TC.DeclsToFinalize.empty()) {
-      auto decl = TC.DeclsToFinalize.pop_back_val();
+    while (TC.NextDeclToFinalize < TC.DeclsToFinalize.size()) {
+      auto decl = TC.DeclsToFinalize[TC.NextDeclToFinalize++];
       if (decl->isInvalid() || TC.Context.hadError())
         continue;
 
@@ -603,7 +603,7 @@ static void typeCheckFunctionsAndExternalDecls(SourceFile &SF, TypeChecker &TC) 
            currentExternalDef < TC.Context.ExternalDefinitions.size() ||
            currentSynthesizedDecl < SF.SynthesizedDecls.size() ||
            !TC.FunctionsToSynthesize.empty() ||
-           !TC.DeclsToFinalize.empty() ||
+           TC.NextDeclToFinalize < TC.DeclsToFinalize.size() ||
            !TC.ConformanceContexts.empty() ||
            !TC.DelayedRequirementSignatures.empty() ||
            !TC.UsedConformances.empty() ||

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -569,7 +569,7 @@ static void typeCheckFunctionsAndExternalDecls(SourceFile &SF, TypeChecker &TC) 
     // FIXME: If we're not planning to run SILGen, this is wasted effort.
     while (TC.NextDeclToFinalize < TC.DeclsToFinalize.size()) {
       auto decl = TC.DeclsToFinalize[TC.NextDeclToFinalize++];
-      if (decl->isInvalid() || TC.Context.hadError())
+      if (decl->isInvalid())
         continue;
 
       TC.finalizeDecl(decl);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -652,6 +652,10 @@ public:
   /// we can hand them off to SILGen etc.
   llvm::SetVector<ValueDecl *> DeclsToFinalize;
 
+  /// Track the index of the next declaration that needs to be finalized,
+  /// from the \c DeclsToFinalize set.
+  unsigned NextDeclToFinalize = 0;
+
   /// The list of functions that need to have their bodies synthesized.
   llvm::MapVector<FuncDecl*, SynthesizedFunction> FunctionsToSynthesize;
 

--- a/test/FixCode/fixits-apply-objc.swift
+++ b/test/FixCode/fixits-apply-objc.swift
@@ -4,15 +4,6 @@ import ObjectiveC
 
 // REQUIRES: objc_interop
 
-@objc class Selectors {
-  func takeSel(_: Selector) {}
-  func mySel() {}
-  func test() {
-    takeSel("mySel")
-    takeSel(Selector("mySel"))
-  }
-}
-
 func foo(an : Any) {
   let a1 : AnyObject
   a1 = an

--- a/test/FixCode/fixits-apply-objc.swift.result
+++ b/test/FixCode/fixits-apply-objc.swift.result
@@ -4,15 +4,6 @@ import ObjectiveC
 
 // REQUIRES: objc_interop
 
-@objc class Selectors {
-  func takeSel(_: Selector) {}
-  func mySel() {}
-  func test() {
-    takeSel(#selector(Selectors.mySel))
-    takeSel(#selector(Selectors.mySel))
-  }
-}
-
 func foo(an : Any) {
   let a1 : AnyObject
   a1 = an as AnyObject

--- a/test/IDE/complete_pound_keypath.swift
+++ b/test/IDE/complete_pound_keypath.swift
@@ -41,6 +41,5 @@ func completeInKeyPath2() {
 // CHECK-IN_KEYPATH: Decl[InstanceVar]/CurrNominal:      prop1[#String#]; name=prop1
 // CHECK-IN_KEYPATH: Decl[InstanceVar]/CurrNominal:      prop2[#ObjCClass?#]; name=prop2
 // CHECK-IN_KEYPATH: Decl[InstanceVar]/Super:            hashValue[#Int#]; name=hashValue
-// CHECK-IN_KEYPATH: Decl[InstanceVar]/Super:            hash[#Int#]; name=hash
 
 

--- a/test/Sema/Inputs/availability_multi_other.swift
+++ b/test/Sema/Inputs/availability_multi_other.swift
@@ -32,17 +32,18 @@ class OtherIntroduced10_51 {
     return OtherIntroduced10_52()
   }
 
-  func takes10_52(o: OtherIntroduced10_52) { 
+  func takes10_52(o: OtherIntroduced10_52) {
   }
-
+  // expected-error@-2{{'OtherIntroduced10_52' is only available on OS X 10.52 or newer}}
+  // expected-note@-3{{add @available attribute to enclosing instance method}}
+  
   @available(OSX, introduced: 10.52)
   func takes10_52Introduced10_52(o: OtherIntroduced10_52) {
   }
 
+  // expected-error@+1{{'OtherIntroduced10_52' is only available on OS X 10.52 or newer}}
   var propOf10_52: OtherIntroduced10_52 = 
-
-
-      OtherIntroduced10_52() // We don't expect an error here because the initializer is not type checked (by design).
+      OtherIntroduced10_52()
 
   @available(OSX, introduced: 10.52)
   var propOf10_52Introduced10_52: OtherIntroduced10_52 = OtherIntroduced10_52()

--- a/test/Sema/Inputs/circularity_multifile_error_helper.swift
+++ b/test/Sema/Inputs/circularity_multifile_error_helper.swift
@@ -1,5 +1,5 @@
 struct External {
-  var member: Something
+  var member: Something // expected-error{{use of undeclared type 'Something'}}
 }
 
 struct OtherExternal {}

--- a/test/decl/protocol/conforms/near_miss_objc.swift
+++ b/test/decl/protocol/conforms/near_miss_objc.swift
@@ -10,7 +10,7 @@
 class C1a : P1 {
   @objc func doSomething(a: Int, c: Double) { }
   // expected-warning@-1{{instance method 'doSomething(a:c:)' nearly matches optional requirement 'doSomething(a:b:)' of protocol 'P1'}}
-  // expected-note@-2{{rename to 'doSomething(a:b:)' to satisfy this requirement}}{{34-34=b }}{{none}}
+  // expected-note@-2{{rename to 'doSomething(a:b:)' to satisfy this requirement}}{{34-34=b }}{{8-8=(doSomethingWithA:b:)}} {{34-34=b }}
   // expected-note@-3{{move 'doSomething(a:c:)' to an extension to silence this warning}}
   // expected-note@-4{{make 'doSomething(a:c:)' private to silence this warning}}{{9-9=private }}
 }

--- a/test/expr/primary/selector/Inputs/fixits_helper.swift
+++ b/test/expr/primary/selector/Inputs/fixits_helper.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public class Bar : Foo {
+  @objc(method2WithValue:) public override func method2(_ value: Int) { }
+
+  @objc(overloadedWithInt:) public func overloaded(_ x: Int) { }
+  @objc(overloadedWithString:) public func overloaded(_ x: String) { }
+
+  @objc(staticOverloadedWithInt:) public static func staticOverloaded(_ x: Int) { }
+  @objc(staticOverloadedWithString:) public static func staticOverloaded(_ x: String) { }
+
+  @objc(staticOrNonStatic:) public func staticOrNonStatic(_ x: Int) { }
+  @objc(staticOrNonStatic:) public static func staticOrNonStatic(_ x: Int) { }
+
+  @objc(theInstanceOne:) public func staticOrNonStatic2(_ x: Int) { }
+  @objc(theStaticOne:) public static func staticOrNonStatic2(_ x: Int) { }
+}
+
+public class Foo {
+  @objc(methodWithValue:label:) public func method(_ value: Int, label: String) { }
+
+  @objc(method2WithValue:) public func method2(_ value: Int) { }
+
+  @objc public func method3() { }
+
+  @objc public var property: String = ""
+}

--- a/test/expr/primary/selector/fixits.swift
+++ b/test/expr/primary/selector/fixits.swift
@@ -9,6 +9,8 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t.overlays %clang-importer-sdk-path/swift-modules/Foundation.swift
 // FIXME: END -enable-source-import hackaround
 
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t.overlays %S/Inputs/fixits_helper.swift -module-name Helper
+
 // Make sure we get the right diagnostics.
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t.overlays) -typecheck %s -verify
 
@@ -29,33 +31,7 @@
 // CHECK: warning: string literal is not a valid Objective-C selector
 
 import Foundation
-
-class Bar : Foo {
-  @objc(method2WithValue:) override func method2(_ value: Int) { }
-
-  @objc(overloadedWithInt:) func overloaded(_ x: Int) { }
-  @objc(overloadedWithString:) func overloaded(_ x: String) { }
-
-  @objc(staticOverloadedWithInt:) static func staticOverloaded(_ x: Int) { }
-  @objc(staticOverloadedWithString:) static func staticOverloaded(_ x: String) { }
-
-  @objc(staticOrNonStatic:) func staticOrNonStatic(_ x: Int) { }
-  @objc(staticOrNonStatic:) static func staticOrNonStatic(_ x: Int) { }
-
-  @objc(theInstanceOne:) func staticOrNonStatic2(_ x: Int) { }
-  @objc(theStaticOne:) static func staticOrNonStatic2(_ x: Int) { }
-}
-
-class Foo {
-  @objc(methodWithValue:label:) func method(_ value: Int, label: String) { }
-
-  @objc(method2WithValue:) func method2(_ value: Int) { }
-
-  @objc func method3() { }
-
-  @objc var property: String = ""
-}
-
+import Helper
 
 func testDeprecatedStringLiteralSelector() {
   let sel1: Selector = "methodWithValue:label:" // expected-warning{{use of string literal for Objective-C selectors is deprecated; use '#selector' instead}}{{24-48=#selector(Foo.method(_:label:))}}

--- a/test/multifile/Inputs/require-member-layout-dynamic-bridging.h
+++ b/test/multifile/Inputs/require-member-layout-dynamic-bridging.h
@@ -1,0 +1,5 @@
+@import Foundation;
+
+@interface NSObject(Testing)
+-(void)bar:(nonnull NSString *)param;
+@end

--- a/test/multifile/Inputs/require-member-layout-dynamic-other.swift
+++ b/test/multifile/Inputs/require-member-layout-dynamic-other.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+extension Foo {
+  open override func bar(_: String) { }
+}

--- a/test/multifile/require-member-layout-dynamic.swift
+++ b/test/multifile/require-member-layout-dynamic.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -module-name test -emit-ir -primary-file %s %S/Inputs/require-member-layout-dynamic-other.swift -import-objc-header %S/Inputs/require-member-layout-dynamic-bridging.h -sdk %sdk -o %t.o
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+public class Foo: NSObject {
+  func foo() {
+    bar("hello")
+  }
+}


### PR DESCRIPTION
When we reference a member of a class extension, we need to
compute its overrides, @objc bit, and ‘dynamic’ status because SILGen
may rely on them. Do that consistently by adding such members to the
list of declarations to “finalize”.

Rework the finalization logic to handle the computation of each of those
bits, and never remove a finalized declaration from the set: rather,
process new declarations as they enter the set, to avoid looping or
extra state bits.

Fixes rdar://problem/42440686.
