### PR TITLE
[ParameterUpdate] Fix `Parameterized` synthesis for types nested in functions.

### DIFF
--- a/lib/Sema/DerivedConformanceParameterized.cpp
+++ b/lib/Sema/DerivedConformanceParameterized.cpp
@@ -306,7 +306,6 @@ deriveParameterized_allParameters(DerivedConformance &derived) {
   auto *setterDecl =
       derived.declareDerivedPropertySetter(derived.TC, allParamsDecl, returnTy);
   setterDecl->setBodySynthesizer(&derivedBody_allParametersSetter);
-  allParamsDecl->setSetterAccess(nominal->getFormalAccess());
   allParamsDecl->setAccessors(StorageImplInfo::getMutableComputed(),
                               SourceLoc(), {getterDecl, setterDecl},
                               SourceLoc());

--- a/test/Sema/parameterized.swift
+++ b/test/Sema/parameterized.swift
@@ -61,6 +61,13 @@ struct A<T> {
   }
 }
 
+func foo() {
+  struct NestedInFunction : Parameterized {
+    @TFParameter var layer: DenseLayer
+    @TFParameter var float: Float
+  }
+}
+
 // Test heterogenous parameter types.
 struct MixedParameterized : Parameterized {
   @TFParameter var int: Int


### PR DESCRIPTION
Addresses [SR-8360](https://bugs.swift.org/browse/SR-8360).