### PR TITLE
[Type checker] Don't substitute into unresolved types.

### DIFF
--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -677,7 +677,7 @@ void CalleeCandidateInfo::collectCalleeCandidates(Expr *fn,
           if (baseType->isAnyObject())
             baseType = Type();
 
-          if (baseType) {
+          if (baseType && !baseType->hasUnresolvedType()) {
             C.entityType = baseType->getTypeOfMember(CS.DC->getParentModule(),
                                                      C.getDecl(), nullptr);
             C.substituted = true;
@@ -883,7 +883,7 @@ CalleeCandidateInfo::CalleeCandidateInfo(Type baseType,
       if (substType->isAnyObject())
         substType = Type();
 
-      if (substType && selfAlreadyApplied)
+      if (substType && selfAlreadyApplied && !substType->hasUnresolvedType())
         substType =
           substType->getTypeOfMember(CS.DC->getParentModule(), decl, nullptr);
       if (substType) {

--- a/validation-test/compiler_crashers_2_fixed/0169-rdar42448618.swift
+++ b/validation-test/compiler_crashers_2_fixed/0169-rdar42448618.swift
@@ -1,0 +1,19 @@
+// RUN: not %target-swift-frontend -emit-ir %s
+
+protocol ObservableType {
+  associatedtype E
+}
+
+extension ObservableType where E == Any {
+  static func zip<O1>(_ source1: O1) { fatalError() }
+}
+
+extension ObservableType {
+  static func zip<O1, O2>(_ source1: O1, _ source2: O2) { fatalError() }
+}
+
+class Observable<Element> : ObservableType {
+  public typealias E = Element
+}
+
+Observable.zip(1, 2)


### PR DESCRIPTION
Unresolved types are formed in a few specific places within the type
checker's recovery path; don't let them bleed into the substitution
logic. Fixes rdar://problem/42448618.
