### PR TITLE
[Runtime] Targetize the layout of ValueWitnessTable.

### DIFF
--- a/include/swift/ABI/ValueWitness.def
+++ b/include/swift/ABI/ValueWitness.def
@@ -72,7 +72,7 @@
 ///     MUTABLE_BUFFER_TYPE - a pointer to a fixed-size value buffer
 ///     IMMUTABLE_BUFFER_TYPE - a pointer to an immutable fixed-size buffer
 ///     TYPE_TYPE - a pointer to type metadata
-///     SIZE_TYPE - size_t
+///     SIZE_TYPE - StoredSize
 ///     INT_TYPE - int
 ///     UINT_TYPE - unsigned int
 ///     VOID_TYPE - void
@@ -193,7 +193,7 @@ FUNCTION_VALUE_WITNESS(storeEnumTagSinglePayload,
 END_VALUE_WITNESS_RANGE(RequiredValueWitnessFunction,
                         StoreEnumTagSinglePayload)
 
-///   size_t size;
+///   SIZE_TYPE size;
 ///
 /// The required storage size of a single object of this type.
 DATA_VALUE_WITNESS(size,
@@ -206,7 +206,7 @@ BEGIN_VALUE_WITNESS_RANGE(TypeLayoutWitness,
 BEGIN_VALUE_WITNESS_RANGE(RequiredTypeLayoutWitness,
                           Size)
 
-///   size_t flags;
+///   SIZE_TYPE flags;
 ///
 /// The ValueWitnessAlignmentMask bits represent the required
 /// alignment of the first byte of an object of this type, expressed
@@ -235,7 +235,7 @@ DATA_VALUE_WITNESS(flags,
                    Flags,
                    SIZE_TYPE)
 
-///   size_t stride;
+///   SIZE_TYPE stride;
 ///
 /// The required size per element of an array of this type. It is at least
 /// one, even for zero-sized types, like the empty tuple.
@@ -256,7 +256,7 @@ END_VALUE_WITNESS_RANGE(RequiredValueWitness,
 // The following value witnesses are conditionally present based on
 // the Enum_HasExtraInhabitants bit of the flags.
 
-///   size_t extraInhabitantFlags;
+///   SIZE_TYPE extraInhabitantFlags;
 ///
 /// These bits are always present if the extra inhabitants witnesses are:
 ///

--- a/include/swift/Runtime/Enum.h
+++ b/include/swift/Runtime/Enum.h
@@ -22,9 +22,10 @@
 namespace swift {
   
 struct OpaqueValue;
-struct ValueWitnessTable;
-  
 struct InProcess;
+
+template <typename Runtime> struct TargetValueWitnessTable;
+using ValueWitnessTable = TargetValueWitnessTable<InProcess>;
 
 template <typename Runtime> struct TargetMetadata;
 using Metadata = TargetMetadata<InProcess>;

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -65,7 +65,7 @@ OpaqueValue *swift_copyPOD(OpaqueValue *dest,
 struct ExtraInhabitantsValueWitnessTable : ValueWitnessTable {
 #define WANT_ONLY_EXTRA_INHABITANT_VALUE_WITNESSES
 #define VALUE_WITNESS(LOWER_ID, UPPER_ID) \
-  value_witness_types::LOWER_ID LOWER_ID;
+  ValueWitnessTypes::LOWER_ID LOWER_ID;
 #include "swift/ABI/ValueWitness.def"
 
 #define SET_WITNESS(NAME) base.NAME,
@@ -76,9 +76,9 @@ struct ExtraInhabitantsValueWitnessTable : ValueWitnessTable {
       getExtraInhabitantIndex(nullptr) {}
   constexpr ExtraInhabitantsValueWitnessTable(
                             const ValueWitnessTable &base,
-                            value_witness_types::extraInhabitantFlags eif,
-                            value_witness_types::storeExtraInhabitant sei,
-                            value_witness_types::getExtraInhabitantIndex geii)
+                            ValueWitnessTypes::extraInhabitantFlags eif,
+                            ValueWitnessTypes::storeExtraInhabitant sei,
+                            ValueWitnessTypes::getExtraInhabitantIndex geii)
     : ValueWitnessTable(base),
       extraInhabitantFlags(eif),
       storeExtraInhabitant(sei),
@@ -95,7 +95,7 @@ struct ExtraInhabitantsValueWitnessTable : ValueWitnessTable {
 struct EnumValueWitnessTable : ExtraInhabitantsValueWitnessTable {
 #define WANT_ONLY_ENUM_VALUE_WITNESSES
 #define VALUE_WITNESS(LOWER_ID, UPPER_ID) \
-  value_witness_types::LOWER_ID LOWER_ID;
+  ValueWitnessTypes::LOWER_ID LOWER_ID;
 #include "swift/ABI/ValueWitness.def"
 
   constexpr EnumValueWitnessTable()
@@ -105,9 +105,9 @@ struct EnumValueWitnessTable : ExtraInhabitantsValueWitnessTable {
       destructiveInjectEnumTag(nullptr) {}
   constexpr EnumValueWitnessTable(
           const ExtraInhabitantsValueWitnessTable &base,
-          value_witness_types::getEnumTag getEnumTag,
-          value_witness_types::destructiveProjectEnumData destructiveProjectEnumData,
-          value_witness_types::destructiveInjectEnumTag destructiveInjectEnumTag)
+          ValueWitnessTypes::getEnumTag getEnumTag,
+          ValueWitnessTypes::destructiveProjectEnumData destructiveProjectEnumData,
+          ValueWitnessTypes::destructiveInjectEnumTag destructiveInjectEnumTag)
     : ExtraInhabitantsValueWitnessTable(base),
       getEnumTag(getEnumTag),
       destructiveProjectEnumData(destructiveProjectEnumData),
@@ -123,26 +123,26 @@ struct EnumValueWitnessTable : ExtraInhabitantsValueWitnessTable {
 /// the value witness functions and includes only the size, alignment,
 /// extra inhabitants, and miscellaneous flags about the type.
 struct TypeLayout {
-  value_witness_types::size size;
-  value_witness_types::flags flags;
-  value_witness_types::stride stride;
+  ValueWitnessTypes::size size;
+  ValueWitnessTypes::flags flags;
+  ValueWitnessTypes::stride stride;
 
 private:
   // Only available if the "hasExtraInhabitants" flag is set.
-  value_witness_types::extraInhabitantFlags extraInhabitantFlags;
+  ValueWitnessTypes::extraInhabitantFlags extraInhabitantFlags;
 
   void _static_assert_layout();
 public:
   TypeLayout() = default;
-  constexpr TypeLayout(value_witness_types::size size,
-                       value_witness_types::flags flags,
-                       value_witness_types::stride stride,
-                       value_witness_types::extraInhabitantFlags eiFlags =
-                         value_witness_types::extraInhabitantFlags())
+  constexpr TypeLayout(ValueWitnessTypes::size size,
+                       ValueWitnessTypes::flags flags,
+                       ValueWitnessTypes::stride stride,
+                       ValueWitnessTypes::extraInhabitantFlags eiFlags =
+                         ValueWitnessTypes::extraInhabitantFlags())
     : size(size), flags(flags), stride(stride),
       extraInhabitantFlags(eiFlags) {}
 
-  value_witness_types::extraInhabitantFlags getExtraInhabitantFlags() const {
+  ValueWitnessTypes::extraInhabitantFlags getExtraInhabitantFlags() const {
     assert(flags.hasExtraInhabitants());
     return extraInhabitantFlags;
   }
@@ -169,6 +169,7 @@ inline void TypeLayout::_static_assert_layout() {
   #undef CHECK_TYPE_LAYOUT_OFFSET
 }
 
+template <>
 inline void ValueWitnessTable::publishLayout(const TypeLayout &layout) {
   size = layout.size;
   stride = layout.stride;
@@ -184,23 +185,24 @@ inline void ValueWitnessTable::publishLayout(const TypeLayout &layout) {
   flags = layout.flags;
 }
 
-inline bool ValueWitnessTable::checkIsComplete() const {
+template <> inline bool ValueWitnessTable::checkIsComplete() const {
   return !flags.isIncomplete();
 }
 
+template <>
 inline const ExtraInhabitantsValueWitnessTable *
 ValueWitnessTable::_asXIVWT() const {
   assert(ExtraInhabitantsValueWitnessTable::classof(this));
   return static_cast<const ExtraInhabitantsValueWitnessTable *>(this);
 }
-  
-inline const EnumValueWitnessTable *
-ValueWitnessTable::_asEVWT() const {
+
+template <>
+inline const EnumValueWitnessTable *ValueWitnessTable::_asEVWT() const {
   assert(EnumValueWitnessTable::classof(this));
   return static_cast<const EnumValueWitnessTable *>(this);
 }
 
-inline unsigned ValueWitnessTable::getNumExtraInhabitants() const {
+template <> inline unsigned ValueWitnessTable::getNumExtraInhabitants() const {
   // If the table does not have extra inhabitant witnesses, then there are zero.
   if (!flags.hasExtraInhabitants())
     return 0;

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -955,7 +955,7 @@ static void tuple_destroy(OpaqueValue *tuple, const Metadata *_metadata) {
 
 // The operation doesn't have to be initializeWithCopy, but they all
 // have basically the same type.
-typedef value_witness_types::initializeWithCopy forEachOperation;
+typedef ValueWitnessTypes::initializeWithCopy forEachOperation;
 
 /// Perform an operation for each field of two tuples.
 static OpaqueValue *tuple_forEachField(OpaqueValue *destTuple,
@@ -1558,7 +1558,7 @@ static OpaqueValue *pod_indirect_initializeBufferWithCopyOfBuffer(
 static void pod_noop(void *object, const Metadata *self) {
 }
 #define pod_direct_destroy \
-  pointer_function_cast<value_witness_types::destroy>(pod_noop)
+  pointer_function_cast<ValueWitnessTypes::destroy>(pod_noop)
 #define pod_indirect_destroy pod_direct_destroy
 
 static OpaqueValue *pod_direct_initializeWithCopy(OpaqueValue *dest,
@@ -1569,7 +1569,7 @@ static OpaqueValue *pod_direct_initializeWithCopy(OpaqueValue *dest,
 }
 #define pod_indirect_initializeWithCopy pod_direct_initializeWithCopy
 #define pod_direct_initializeBufferWithCopyOfBuffer \
-  pointer_function_cast<value_witness_types::initializeBufferWithCopyOfBuffer> \
+  pointer_function_cast<ValueWitnessTypes::initializeBufferWithCopyOfBuffer> \
     (pod_direct_initializeWithCopy)
 #define pod_direct_assignWithCopy pod_direct_initializeWithCopy
 #define pod_indirect_assignWithCopy pod_direct_initializeWithCopy


### PR DESCRIPTION
From what I see the only fields are DATA_VALUE_WITNESS which
all have type size_t. I converted them to use the target-dependent
`StoredSize`. While I was around I fixed also isValueInline()
to do the right thing (it was using ValueBuffer instead of
TargetValueBuffer) and all the getters for the data value witnesses.

<rdar://problem/41546568>
