### PR TITLE
Sema: Prefer class properties to protocol properties when ranking overloads

### DIFF
--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -939,6 +939,26 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
       }
     }
 
+    // If both are properties and one is in a protocol, prefer the one not in
+    // a protocol.
+    //
+    // This is a Swift 4.1 compatibility hack. Changes elsewhere in the compiler
+    // made this case ambiguous. Perhaps it was never meant to be unambiguous in
+    // the first place, because it only seemed to work for properties, and not
+    // methods, so I'm going to keep this intentionally narrow.
+    if (isa<VarDecl>(decl1) && isa<VarDecl>(decl2)) {
+      auto *nominal1 = dc1->getAsNominalTypeOrNominalTypeExtensionContext();
+      auto *nominal2 = dc2->getAsNominalTypeOrNominalTypeExtensionContext();
+
+      if (nominal1 && nominal2 && nominal1 != nominal2) {
+        if (isa<ProtocolDecl>(nominal1))
+          score2 += weight;
+
+        if (isa<ProtocolDecl>(nominal2))
+          score1 += weight;
+      }
+    }
+
     // If we haven't found a refinement, record whether one overload is in
     // any way more constrained than another. We'll only utilize this
     // information in the case of a potential ambiguity.

--- a/test/Constraints/ranking.swift
+++ b/test/Constraints/ranking.swift
@@ -155,3 +155,23 @@ func testDerived(b: B) {
   f0(f1(b))
   // CHECK: end sil function '$S7ranking11testDerived1byAA1BC_tF'
 }
+
+protocol X {
+  var z: Int { get }
+}
+
+class Y {
+  var z: Int = 0
+}
+
+// CHECK-LABEL: sil hidden @$S7ranking32testGenericPropertyProtocolClassyyxAA1YCRbzAA1XRzlF
+func testGenericPropertyProtocolClass<T : X & Y>(_ t: T) {
+  // CHECK: class_method {{%.*}} : $Y, #Y.z!getter.1
+  _ = t.z
+}
+
+// CHECK-LABEL: sil hidden @$S7ranking36testExistentialPropertyProtocolClassyyAA1X_AA1YCXcF
+func testExistentialPropertyProtocolClass(_ t: X & Y) {
+  // CHECK: class_method {{%.*}} : $Y, #Y.z!getter.1
+  _ = t.z
+}


### PR DESCRIPTION
This was the old behavior in Swift 4.1, but it broke after some changes
to redeclaration checking and shadowing.

Fixes <rdar://problem/42201583>.