### PR TITLE
[test] Provide an explicit TMPDIR for Driver/sdk-link.swift

### DIFF
--- a/test/Driver/sdk-link.swift
+++ b/test/Driver/sdk-link.swift
@@ -1,6 +1,6 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/test.swiftmodule %s
-// RUN: %target-build-swift -g -v -o %t/sdk-link %s
+// RUN: %empty-directory(%t/tmp)
+// RUN: env TMPDIR=%t/tmp/ %target-build-swift -emit-module -o %t/test.swiftmodule %s
+// RUN: env TMPDIR=%t/tmp/ %target-build-swift -g -v -o %t/sdk-link %s
 // RUN: %target-run %t/sdk-link | %FileCheck %s
 // REQUIRES: executable_test
 


### PR DESCRIPTION
And change a not-testing-anything-new frontend invocation into an only-slightly-more-useful driver invocation.

This shouldn't really affect anything, but we've seen this test fail spuriously for a long time. Maybe this fix'll stick.

rdar://problem/42247881