### PR TITLE
[CodeComplete] Strip out try and optional eval expo in operator completion

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -3440,24 +3440,38 @@ public:
       flattenBinaryExpr(assignExpr->getSrc(), sequence);
       assignExpr->setDest(nullptr);
       assignExpr->setSrc(nullptr);
+    } else if (auto tryExpr = dyn_cast<AnyTryExpr>(expr)) {
+      // Strip out try expression. It doesn't affect completion.
+      flattenBinaryExpr(tryExpr->getSubExpr(), sequence);
+    } else if (auto optEval = dyn_cast<OptionalEvaluationExpr>(expr)){
+      // Strip out optional evaluation expression. It doesn't affect completion.
+      flattenBinaryExpr(optEval->getSubExpr(), sequence);
     } else {
       sequence.push_back(expr);
     }
   }
 
   void typeCheckLeadingSequence(SmallVectorImpl<Expr *> &sequence) {
+
+    // Strip out try and optional evaluation expr because foldSequence() mutates
+    // hierarchy of these expressions. They don't affect completion anyway.
+    for (auto &element : sequence) {
+      if (auto *tryExpr = dyn_cast<AnyTryExpr>(element))
+        element = tryExpr->getSubExpr();
+      if (auto *optEval = dyn_cast<OptionalEvaluationExpr>(element))
+        element = optEval->getSubExpr();
+    }
+
     Expr *expr =
         SequenceExpr::create(CurrDeclContext->getASTContext(), sequence);
     prepareForRetypechecking(expr);
     // Take advantage of the fact the type-checker leaves the types on the AST.
     if (!typeCheckExpression(const_cast<DeclContext *>(CurrDeclContext),
                              expr)) {
-      if (isa<BinaryExpr>(expr) || isa<AssignExpr>(expr)) {
-        // Rebuild the sequence from the type-checked version.
-        sequence.clear();
-        flattenBinaryExpr(expr, sequence);
-        return;
-      }
+      // Rebuild the sequence from the type-checked version.
+      sequence.clear();
+      flattenBinaryExpr(expr, sequence);
+      return;
     }
 
     // Fall back to just using the immediate LHS.

--- a/test/IDE/complete_crashes.swift
+++ b/test/IDE/complete_crashes.swift
@@ -313,3 +313,19 @@ func test_40956846(
 // RDAR_40956846-DAG: Decl[LocalVar]/Local:               arg_40956846_3[#(() -> Int)!#]; name=arg_40956846_3
 // RDAR_40956846-DAG: Decl[LocalVar]/Local:               arg_40956846_4[#inout ((Int) -> Int)!#]; name=arg_40956846_4
 // RDAR_40956846: End completions
+
+// rdar://problem/42452085
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=RDAR_42452085_1 -source-filename=%s | %FileCheck %s -check-prefix=RDAR_42452085
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=RDAR_42452085_2 -source-filename=%s | %FileCheck %s -check-prefix=RDAR_42452085
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=RDAR_42452085_3 -source-filename=%s | %FileCheck %s -check-prefix=RDAR_42452085
+class cls_42452085 {
+  var value: Any
+  func canThrow() throws -> Int { return 1 }
+}
+func test_42452085(any: Any, obj: cls_42452085?) throws {
+  var object: Any? = nil
+  object = (any as? String) #^RDAR_42452085_1^#
+  obj?.value = any #^RDAR_42452085_2^#
+  _ = try obj?.canThrow() #^RDAR_42452085_3^#
+}
+// RDAR_42452085: Begin completions

--- a/test/IDE/complete_crashes.swift
+++ b/test/IDE/complete_crashes.swift
@@ -220,9 +220,11 @@ protocol Bar_38149042 {
 func foo_38149042(bar: Bar_38149042) {
   _ = bar.foo? #^RDAR_38149042^# .x
 }
-// RDAR_38149042: Begin completions, 2 items
+// RDAR_38149042: Begin completions
 // RDAR_38149042-DAG: Decl[InstanceVar]/CurrNominal:                  .x[#Int#]; name=x
 // RDAR_38149042-DAG: Keyword[self]/CurrNominal: .self[#Baz_38149042#]; name=self
+// RDAR_38149042-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]: [' ']=== {#AnyObject?#}[#Bool#]; name==== AnyObject?
+// RDAR_38149042-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]: [' ']!== {#AnyObject?#}[#Bool#]; name=!== AnyObject?
 // RDAR_38149042: End completions
 
 // rdar://problem/38272904
@@ -274,7 +276,8 @@ func foo(x: RDAR41159258_MyResult1) {
 
 
 // rdar://problem/41232519
-// RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=RDAR41232519 | %FileCheck %s -check-prefix=RDAR_41232519
+// RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=RDAR41232519_1 | %FileCheck %s -check-prefix=RDAR_41232519
+// RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=RDAR41232519_2 | %FileCheck %s -check-prefix=RDAR_41232519
 public protocol IntProvider {
   func nextInt() -> Int
 }
@@ -282,10 +285,13 @@ public protocol IntProvider {
 public final class IntStore {
   public var myInt: Int = 0
   func readNextInt(from provider: IntProvider) {
-      myInt = provider.nextInt() #^RDAR41232519^#
+      myInt = provider.nextInt() #^RDAR41232519_1^#
+      _ = true ? 1 : provider.nextInt() #^RDAR41232519_2^#
   }
 }
 // RDAR_41232519: Begin completions
+// RDAR_41232519: Decl[InfixOperatorFunction]/OtherModule[Swift]: [' ']+ {#Int#}[#Int#]; name=+ Int
+// RDAR_41232519: End completions
 
 // rdar://problem/28188259
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=RDAR_28188259 -source-filename=%s | %FileCheck %s -check-prefix=RDAR_28188259


### PR DESCRIPTION
`foldSequence()` may hoist these expression up by mutating their sub expression. When completing operators, this behavior ruins reusability of operand. Since these expression doesn't affect completion, we can strip them out.

rdar://problem/42452085

Also, this PR contains follow-up fix for f577578. The same treatment for ternary expression (IfExpr). Plus, fix a regression where infix operator were disappeared from results when leading sequence contains `AssignExpr`.