### PR TITLE
[4.2][Refactoring] Fix crasher in switch with non-nominal subject type

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -2394,7 +2394,8 @@ collectAvailableRefactoringsAtCursor(SourceFile *SF, unsigned Line,
 
 static EnumDecl* getEnumDeclFromSwitchStmt(SwitchStmt *SwitchS) {
   if (auto SubjectTy = SwitchS->getSubjectExpr()->getType()) {
-    return SubjectTy->getAnyNominal()->getAsEnumOrEnumExtensionContext();
+    // FIXME: Support more complex subject like '(Enum1, Enum2)'.
+    return dyn_cast_or_null<EnumDecl>(SubjectTy->getAnyNominal());
   }
   return nullptr;
 }

--- a/test/refactoring/RefactoringKind/crashers.swift
+++ b/test/refactoring/RefactoringKind/crashers.swift
@@ -20,3 +20,21 @@ func test() {
 
 // RUN: %refactor -source-filename %s -pos=17:3 -end-pos=18:15 | %FileCheck %s -check-prefix=CHECK2
 // CHECK2: Action begins
+
+// rdar://42098130
+enum E_42098130 { case foo, bar }
+func test_42098130<T>(e1: T, e2: E_42098130) {
+  switch e1 {
+  default:
+    break
+  }
+  switch (e2, e2) {
+  default:
+    break
+  }
+}
+// RUN: %refactor -source-filename %s -pos=27:3 | %FileCheck %s -check-prefix=CHECK3
+// RUN: %refactor -source-filename %s -pos=28:3 | %FileCheck %s -check-prefix=CHECK3
+// RUN: %refactor -source-filename %s -pos=31:3 | %FileCheck %s -check-prefix=CHECK3
+// RUN: %refactor -source-filename %s -pos=32:3 | %FileCheck %s -check-prefix=CHECK3
+// CHECK3: Action begins


### PR DESCRIPTION
Cherry-pick of #18177 reviewed by @nkcsgexi for swift-4.2-branch.

- **Explaination**: Getting list of applicable refactoring kind on `switch` or `default` checks if the subject type is "expandable" or not. Currently, this is limited to single `enum` type. Previously there was wrong assumption where subject type is always nominal type. But that is not true if the subject is, for example, tuple type.
- **Scope**: Affect getting list of applicable refactoring kind. 
- **Issue**: rdar://problem/42098130
- **Risk**: Very-low. Just added `nullptr` check where it should be.
- **Testing**: Added regression test cases.
- **Reviewed By**: Xi Ge (https://github.com/apple/swift/pull/18177)