### PR TITLE
[benchmark] Alphabetic sorting of tests and warning about incorrect use of memory option

### DIFF
--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -174,8 +174,9 @@ struct TestConfig {
     tags: Set<BenchmarkCategory>,
     skipTags: Set<BenchmarkCategory>
   ) -> [(index: String, info: BenchmarkInfo)] {
+    let allTests = registeredBenchmarks.sorted()
     let indices = Dictionary(uniqueKeysWithValues:
-      zip(registeredBenchmarks.sorted().map { $0.name },
+      zip(allTests.map { $0.name },
           (1...).lazy.map { String($0) } ))
 
     func byTags(b: BenchmarkInfo) -> Bool {
@@ -186,7 +187,7 @@ struct TestConfig {
       return specifiedTests.contains(b.name) ||
         specifiedTests.contains(indices[b.name]!)
     } // !! "All registeredBenchmarks have been assigned an index"
-    return registeredBenchmarks
+    return allTests
       .filter(specifiedTests.isEmpty ? byTags : byNamesOrIndices)
       .map { (index: indices[$0.name]!, info: $0) }
   }

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -141,6 +141,16 @@ struct TestConfig {
                                     tags: c.tags ?? [],
                                     skipTags: c.skipTags ?? [.unstable, .skip])
 
+    if logMemory && tests.count > 1 {
+      print(
+      """
+      warning: The memory usage of a test, reported as the change in MAX_RSS,
+               is based on measuring the peak memory used by the whole process.
+               These results are meaningful only when running a single test,
+               not in the batch mode!
+      """)
+    }
+
     if verbose {
       let testList = tests.map({ $0.1.name }).joined(separator: ", ")
       print("""
@@ -186,7 +196,7 @@ struct TestConfig {
     func byNamesOrIndices(b: BenchmarkInfo) -> Bool {
       return specifiedTests.contains(b.name) ||
         specifiedTests.contains(indices[b.name]!)
-    } // !! "All registeredBenchmarks have been assigned an index"
+    } // !! "`allTests` have been assigned an index"
     return allTests
       .filter(specifiedTests.isEmpty ? byTags : byNamesOrIndices)
       .map { (index: indices[$0.name]!, info: $0) }

--- a/test/benchmark/Benchmark_O.test.md
+++ b/test/benchmark/Benchmark_O.test.md
@@ -188,6 +188,14 @@ BADSKIPTAG: error: 'bogus' is not a valid 'BenchmarkCategory'
 
 ````
 
+Measuring memory use of a test with our method is valid only for single test.
+
+````
+RUN: %Benchmark_O 1 2 --memory --list \
+RUN:         2>&1 | %FileCheck %s --check-prefix WARNMEMORY
+WARNMEMORY: warning:
+````
+
 ## Usage
 
 ````

--- a/test/benchmark/Benchmark_O.test.md
+++ b/test/benchmark/Benchmark_O.test.md
@@ -86,6 +86,19 @@ ORSKIPTAGS: Fibonacci
 ORSKIPTAGS-NOT: RomanNumbers
 ````
 
+Alphabetic sorting of tests
+
+````
+RUN: %Benchmark_O --list \
+RUN:             | %FileCheck %s --check-prefix ALPHASORT
+ALPHASORT: COWArrayGuaranteedParameterOverhead
+ALPHASORT: COWTree
+ALPHASORT: ChainedFilterMap
+ALPHASORT: Chars
+ALPHASORT: FatCompactMap
+
+````
+
 ## Running Benchmarks
 Each real benchmark execution takes about a second per sample. If possible,
 multiple checks are combined into one run to minimize the test time.


### PR DESCRIPTION
This is a trivial follow-up to #18124 that ties a few loose ends:
* Fix: alphabetic sorting of tests
* Warn about incorrect `--memory` use