### PR TITLE
[master-next] Update more tests for LLVM r336847

### DIFF
--- a/test/DebugInfo/columns.swift
+++ b/test/DebugInfo/columns.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s --check-prefixes CHECK,DWARF-CHECK
 // RUN: %target-swift-frontend %s -emit-ir -g -debug-info-format=codeview -o - \
-// RUN:   | %FileCheck %s --check-prefixes CHECK,CV-CHECK --allow-deprecated-dag-overlap
+// RUN:   | %FileCheck %s --check-prefixes CHECK,CV-CHECK -allow-deprecated-dag-overlap
 
 public func foo(_ a: Int64, _ b: Int64) -> Int64 {      // line 5
   // CHECK: sdiv i64 {{.*}}, !dbg ![[DIV:[0-9]+]]

--- a/test/DebugInfo/fnptr.swift
+++ b/test/DebugInfo/fnptr.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-ir -gdwarf-types -o - | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -gdwarf-types -o - | %FileCheck %s -allow-deprecated-dag-overlap
 // RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s --check-prefix=AST
 
 // CHECK-DAG: ![[SINODE:.*]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Int64",{{.*}} identifier: [[SI:.*]])

--- a/test/DebugInfo/generic_args.swift
+++ b/test/DebugInfo/generic_args.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-frontend -module-name generic_args -primary-file %s -emit-ir -verify -g -o - | %FileCheck %s
+// RUN: %target-swift-frontend -module-name generic_args -primary-file %s -emit-ir -verify -g -o - | %FileCheck %s -allow-deprecated-dag-overlap
 
 func markUsed<T>(_ t: T) {}
 

--- a/test/DebugInfo/generic_enum.swift
+++ b/test/DebugInfo/generic_enum.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s -allow-deprecated-dag-overlap
 
 func markUsed<T>(_ t: T) {}
 

--- a/test/IDE/complete_associated_types.swift
+++ b/test/IDE/complete_associated_types.swift
@@ -12,10 +12,10 @@
 // RUN: %FileCheck %s -check-prefix=STRUCT_INSTANCE < %t.types.txt
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ASSOCIATED_TYPES_UNQUAL_1 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=ASSOCIATED_TYPES_UNQUAL < %t.types.txt
+// RUN: %FileCheck %s -allow-deprecated-dag-overlap -check-prefix=ASSOCIATED_TYPES_UNQUAL < %t.types.txt
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ASSOCIATED_TYPES_UNQUAL_2 > %t.types.txt
-// RUN: %FileCheck %s -check-prefix=ASSOCIATED_TYPES_UNQUAL < %t.types.txt
+// RUN: %FileCheck %s -allow-deprecated-dag-overlap -check-prefix=ASSOCIATED_TYPES_UNQUAL < %t.types.txt
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=BROKEN_CONFORMANCE_1 > %t.types.txt
 // RUN: %FileCheck %s -check-prefix=BROKEN_CONFORMANCE_1 < %t.types.txt

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -28,7 +28,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=FARG4 | %FileCheck %s -check-prefix=MEMBER4
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=FARG5 | %FileCheck %s -check-prefix=MEMBER2
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=FARG6 | %FileCheck %s -check-prefix=FARG6
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=FARG7 | %FileCheck %s -check-prefix=EXPECT_OINT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=FARG7 | %FileCheck %s -allow-deprecated-dag-overlap -check-prefix=EXPECT_OINT
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=FIRST_ARG_NAME_1 | %FileCheck %s -check-prefix=FIRST_ARG_NAME_PATTERN
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=FIRST_ARG_NAME_2 | %FileCheck %s -check-prefix=FIRST_ARG_NAME_PATTERN

--- a/test/IDE/complete_member_decls_from_parent_decl_context.swift
+++ b/test/IDE/complete_member_decls_from_parent_decl_context.swift
@@ -27,7 +27,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NESTED_NOMINAL_DECL_C_4 | %FileCheck %s -check-prefix=NESTED_NOMINAL_DECL_C_4
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NESTED_NOMINAL_DECL_C_5 | %FileCheck %s -check-prefix=NESTED_NOMINAL_DECL_C_5
 
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NESTED_NOMINAL_DECL_D_1 | %FileCheck %s -check-prefix=NESTED_NOMINAL_DECL_D_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NESTED_NOMINAL_DECL_D_1 | %FileCheck %s -allow-deprecated-dag-overlap -check-prefix=NESTED_NOMINAL_DECL_D_1
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NESTED_NOMINAL_DECL_E_1 | %FileCheck %s -check-prefix=NESTED_NOMINAL_DECL_E_1
 

--- a/test/IDE/merge_local_types.swift
+++ b/test/IDE/merge_local_types.swift
@@ -5,7 +5,7 @@
 // Create separate modules and merge them together
 // RUN: %target-swiftc_driver -v -emit-module -module-name LocalTypesMerged -o %t/LocalTypesMerged.swiftmodule %s %S/local_types.swift
 
-// RUN: %target-swift-ide-test -print-local-types -I %t -module-to-print LocalTypesMerged -source-filename %s | %FileCheck %s
+// RUN: %target-swift-ide-test -print-local-types -I %t -module-to-print LocalTypesMerged -source-filename %s | %FileCheck %s -allow-deprecated-dag-overlap
 
 public func toMerge() {
   // CHECK-DAG: 16LocalTypesMerged7toMergeyyF16SingleFuncStructL_V

--- a/test/NameBinding/reference-dependencies-dynamic-lookup.swift
+++ b/test/NameBinding/reference-dependencies-dynamic-lookup.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -primary-file %t/main.swift -emit-reference-dependencies-path - > %t.swiftdeps
-// RUN: %FileCheck %s < %t.swiftdeps
+// RUN: %FileCheck %s -allow-deprecated-dag-overlap < %t.swiftdeps
 // RUN: %FileCheck -check-prefix=NEGATIVE %s < %t.swiftdeps
 
 // Check that the output is deterministic.

--- a/test/SILGen/witness_tables_multifile.swift
+++ b/test/SILGen/witness_tables_multifile.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership -primary-file %s %S/Inputs/witness_tables_multifile_2.swift | %FileCheck %s -check-prefix=CHECK-FIRST-FILE
+// RUN: %target-swift-emit-silgen -enable-sil-ownership -primary-file %s %S/Inputs/witness_tables_multifile_2.swift | %FileCheck %s -allow-deprecated-dag-overlap -check-prefix=CHECK-FIRST-FILE
 // RUN: %target-swift-emit-silgen -enable-sil-ownership %s -primary-file %S/Inputs/witness_tables_multifile_2.swift | %FileCheck %S/Inputs/witness_tables_multifile_2.swift -check-prefix=CHECK-SECOND-FILE
 
 

--- a/test/SourceKit/CodeComplete/complete_underscores.swift
+++ b/test/SourceKit/CodeComplete/complete_underscores.swift
@@ -33,7 +33,7 @@ func test001() {
   #^TOP_LEVEL_0,,_^#
 }
 // REQUIRES: objc_interop
-// RUN: %complete-test %s -hide-none -tok=TOP_LEVEL_0  -- -F %S/../Inputs/libIDE-mock-sdk | %FileCheck %s -check-prefix=TOP_LEVEL_0
+// RUN: %complete-test %s -hide-none -tok=TOP_LEVEL_0  -- -F %S/../Inputs/libIDE-mock-sdk | %FileCheck %s -allow-deprecated-dag-overlap -check-prefix=TOP_LEVEL_0
 // TOP_LEVEL_0-LABEL: Results for filterText: [
 // TOP_LEVEL_0-DAG: Foo
 // TOP_LEVEL_0-DAG: FooStruct
@@ -57,7 +57,7 @@ func test001() {
 func test002(x: Foo) {
   x.#^FOO_QUALIFIED_0,,^#
 }
-// RUN: %complete-test %s -tok=FOO_QUALIFIED_0  -- -F %S/../Inputs/libIDE-mock-sdk | %FileCheck %s -check-prefix=FOO_QUALIFIED_0
+// RUN: %complete-test %s -tok=FOO_QUALIFIED_0  -- -F %S/../Inputs/libIDE-mock-sdk | %FileCheck %s -allow-deprecated-dag-overlap -check-prefix=FOO_QUALIFIED_0
 // FOO_QUALIFIED_0: Results for filterText: [
 // FOO_QUALIFIED_0-DAG:   foo()
 // FOO_QUALIFIED_0-DAG:   extFoo()
@@ -68,7 +68,7 @@ func test002(x: Foo) {
 func test003(x: _Bar) {
   x.#^BAR_QUALIFIED_0,,_^#
 }
-// RUN: %complete-test %s -tok=BAR_QUALIFIED_0  -- -F %S/../Inputs/libIDE-mock-sdk | %FileCheck %s -check-prefix=BAR_QUALIFIED_0
+// RUN: %complete-test %s -tok=BAR_QUALIFIED_0  -- -F %S/../Inputs/libIDE-mock-sdk | %FileCheck %s -allow-deprecated-dag-overlap -check-prefix=BAR_QUALIFIED_0
 // BAR_QUALIFIED_0: Results for filterText: [
 // BAR_QUALIFIED_0-DAG:   bar()
 // BAR_QUALIFIED_0-DAG:   _bar()
@@ -89,7 +89,7 @@ func test003(x: _Bar) {
 func test004(x: Baz) {
   x.#^BAZ_QUALIFIED_0,,^#
 }
-// RUN: %complete-test %s -tok=BAZ_QUALIFIED_0  -- -F %S/../Inputs/libIDE-mock-sdk | %FileCheck %s -check-prefix=BAZ_QUALIFIED_0
+// RUN: %complete-test %s -tok=BAZ_QUALIFIED_0  -- -F %S/../Inputs/libIDE-mock-sdk | %FileCheck %s -allow-deprecated-dag-overlap -check-prefix=BAZ_QUALIFIED_0
 // BAZ_QUALIFIED_0: Results for filterText: [
 // BAZ_QUALIFIED_0-DAG:   baz()
 // BAZ_QUALIFIED_0-DAG:   _baz()


### PR DESCRIPTION
LLVM r336847 changed FileCheck's CHECK-DAG feature to stop supporting
overlapping matches. I already fixed one test by invoking FileCheck with the
-allow-deprecated-dag-overlap option, but it turns out there are a bunch
more of them. This change applies the same workaround to all of them.