### PR TITLE
Merge pull request #17665 from allevato/debug-prefix-map-wip

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -235,6 +235,10 @@ WARNING(cannot_assign_value_to_conditional_compilation_flag,none,
 ERROR(error_optimization_remark_pattern, none, "%0 in '%1'",
       (StringRef, StringRef))
 
+ERROR(error_invalid_debug_prefix_map, none,
+      "invalid argument '%0' to -debug-prefix-map; it must be of the form "
+      "'original=remapped'", (StringRef))
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -19,6 +19,7 @@
 #define SWIFT_AST_IRGENOPTIONS_H
 
 #include "swift/AST/LinkLibrary.h"
+#include "swift/Basic/PathRemapper.h"
 #include "swift/Basic/Sanitizers.h"
 #include "swift/Basic/OptionSet.h"
 #include "swift/Basic/OptimizationMode.h"
@@ -99,6 +100,9 @@ public:
 
   /// Whether we should emit debug info.
   IRGenDebugInfoKind DebugInfoKind : 2;
+
+  /// Path prefixes that should be rewritten in debug info.
+  PathRemapper DebugPrefixMap;
 
   /// \brief Whether we're generating IR for the JIT.
   unsigned UseJIT : 1;

--- a/include/swift/Basic/PathRemapper.h
+++ b/include/swift/Basic/PathRemapper.h
@@ -1,0 +1,63 @@
+//===--- PathRemapper.h - Transforms path prefixes --------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines a data structure that stores a string-to-string
+//  mapping used to transform file paths based on a prefix mapping. It
+//  is optimized for the common case, which is that there will be
+//  extremely few mappings (i.e., one or two).
+//
+//  Remappings are stored such that they are applied in the order they
+//  are passed on the command line. This would only matter if one
+//  source mapping was a prefix of another.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_PATHREMAPPER_H
+#define SWIFT_BASIC_PATHREMAPPER_H
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/Twine.h"
+
+#include <string>
+#include <utility>
+
+namespace swift {
+
+class PathRemapper {
+  SmallVector<std::pair<std::string, std::string>, 2> PathMappings;
+
+public:
+  /// Adds a mapping such that any paths starting with `FromPrefix` have that
+  /// portion replaced with `ToPrefix`.
+  void addMapping(StringRef FromPrefix, StringRef ToPrefix) {
+    PathMappings.emplace_back(FromPrefix, ToPrefix);
+  }
+
+  /// Returns a remapped `Path` if it starts with a prefix in the map; otherwise
+  /// the original path is returned.
+  std::string remapPath(StringRef Path) const {
+    // Clang's implementation of this feature also compares the path string
+    // directly instead of treating path segments as indivisible units. The
+    // latter would arguably be more accurate, but we choose to preserve
+    // compatibility with Clang (especially because we propagate the flag to
+    // ClangImporter as well).
+    for (const auto &Mapping : PathMappings)
+      if (Path.startswith(Mapping.first))
+        return (Twine(Mapping.second) +
+                Path.substr(Mapping.first.size())).str();
+    return Path.str();
+  }
+};
+
+} // end namespace swift
+
+#endif // SWIFT_BASIC_PATHREMAPPER_H

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -465,6 +465,9 @@ def gline_tables_only : Flag<["-"], "gline-tables-only">,
 def gdwarf_types : Flag<["-"], "gdwarf-types">,
   Group<g_Group>, Flags<[FrontendOption]>,
   HelpText<"Emit full DWARF type info.">;
+def debug_prefix_map : Separate<["-"], "debug-prefix-map">,
+    Flags<[FrontendOption]>,
+    HelpText<"Remap source paths in debug info">;
 
 // Verify debug info
 def verify_debug_info : Flag<["-"], "verify-debug-info">,

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -198,6 +198,12 @@ static void validateDebugInfoArgs(DiagnosticEngine &diags,
                      diag::verify_debug_info_requires_debug_option);
     }
   }
+
+  // Check for any -debug-prefix-map options that aren't of the form
+  // 'original=remapped' (either side can be empty, however).
+  for (auto A : args.getAllArgValues(options::OPT_debug_prefix_map))
+    if (A.find('=') == StringRef::npos)
+      diags.diagnose(SourceLoc(), diag::error_invalid_debug_prefix_map, A);
 }
 
 static void validateCompilationConditionArgs(DiagnosticEngine &diags,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -220,6 +220,9 @@ static void addCommonFrontendArgs(const ToolChain &TC,
   // Pass on any build config options
   inputArgs.AddAllArgs(arguments, options::OPT_D);
 
+  // Pass on file paths that should be remapped in debug info.
+  inputArgs.AddAllArgs(arguments, options::OPT_debug_prefix_map);
+
   // Pass through the values passed to -Xfrontend.
   inputArgs.AddAllArgValues(arguments, options::OPT_Xfrontend);
 

--- a/test/DebugInfo/debug_prefix_map.swift
+++ b/test/DebugInfo/debug_prefix_map.swift
@@ -1,0 +1,7 @@
+// RUN: %swiftc_driver -g -debug-prefix-map %S=/var/empty %s -emit-ir -o - | %FileCheck %s
+
+func square(_ n: Int) -> Int {
+  return n * n
+}
+
+// CHECK: !DIFile(filename: "/var/empty/debug_prefix_map.swift"

--- a/test/Driver/debug-prefix-map.swift
+++ b/test/Driver/debug-prefix-map.swift
@@ -1,0 +1,9 @@
+// RUN: not %target-swiftc_driver -debug-prefix-map old %s 2>&1 | %FileCheck %s -check-prefix CHECK-INVALID
+// RUN: %target-swiftc_driver -### -debug-prefix-map old=new %s 2>&1 | %FileCheck %s -check-prefix CHECK-SIMPLE
+// RUN: %target-swiftc_driver -### -debug-prefix-map old=n=ew %s 2>&1 | %FileCheck %s -check-prefix CHECK-COMPLEX
+// RUN: %target-swiftc_driver -### -debug-prefix-map old= %s 2>&1 | %FileCheck %s -check-prefix CHECK-EMPTY
+
+// CHECK-INVALID: error: invalid argument 'old' to -debug-prefix-map
+// CHECK-SIMPLE: debug-prefix-map old=new
+// CHECK-COMPLEX: debug-prefix-map old=n=ew
+// CHECK-EMPTY: debug-prefix-map old=


### PR DESCRIPTION
_[Note: This is my first release branch cherry-pick PR, so I hope I've done this correctly. As with the response file PRs that were previously merged into 4.2, this would unblock and greatly improve the user experience for many of our Swift developers if it's not too late to get into this release. Thanks!]_

* **Explanation:** Add the `-debug-prefix-map` flag to remap paths in debug info.

* **Scope:** This is the Swift implementation of the corresponding Clang `-fdebug-prefix-map`, which allows users to remap absolute paths in debug info to different (perhaps relative) paths that can be used verbatim or reverse-mapped by LLDB. This makes such builds reproducible and, more importantly, makes it possible for users to debug Swift binaries that have been built remotely on machines whose directory layout does not match that on their local machine.

* **SR Issue:** [SR-5694](https://bugs.swift.org/browse/SR-5694)

* **Risk:** I believe it to be low. There is a minor behavioral change w.r.t. debug info generation even when the flag is not in use ([details](https://github.com/apple/swift/pull/17665#issuecomment-407536202)) but I do not anticipate any regressions (see Testing below).

* **Testing:** The existing LLDB tests run during the PR cycle verify that the change did not cause regressions for existing debugging scenarios (i.e., where the `-debug-prefix-map` flag is not used). I have manually tested some scenarios debugging an executable built using the flag and am working on a follow-up PR to swift-lldb to add a test to cover this.

* **Reviewers:** @jrose-apple and @dcci (#17665).