### PR TITLE
Make BinaryInteger._binaryLogarithm() return Int instead of Self

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -2069,7 +2069,7 @@ extension BinaryFloatingPoint {
 
     let magnitude = source.magnitude
 
-    let exponent = Int(magnitude._binaryLogarithm())
+    let exponent = magnitude._binaryLogarithm()
     let exemplar = Self.greatestFiniteMagnitude
     guard _fastPath(exponent <= exemplar.exponent) else {
       return Source.isSigned && source < 0

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -750,8 +750,7 @@ extension ${Self}: BinaryFloatingPoint {
     let provisional = Int(exponentBitPattern) - Int(${Self}._exponentBias)
     if isNormal { return provisional }
     let shift =
-      ${Self}.significandBitCount -
-        Int(significandBitPattern._binaryLogarithm())
+      ${Self}.significandBitCount - significandBitPattern._binaryLogarithm()
     return provisional + 1 - shift
   }
 
@@ -793,8 +792,7 @@ extension ${Self}: BinaryFloatingPoint {
     }
     if isSubnormal {
       let shift =
-        ${RawSignificand}(${Self}.significandBitCount) -
-          significandBitPattern._binaryLogarithm()
+        ${Self}.significandBitCount - significandBitPattern._binaryLogarithm()
       return ${Self}(sign: .plus,
         exponentBitPattern: ${Self}._exponentBias,
         significandBitPattern: significandBitPattern &<< shift)

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1599,8 +1599,8 @@ public protocol BinaryInteger :
 
   /// Returns the integer binary logarithm of this value.
   ///
-  /// If the value is negative, a runtime error will occur.
-  func _binaryLogarithm() -> Self
+  /// If the value is negative or zero, a runtime error will occur.
+  func _binaryLogarithm() -> Int
 
   /// The number of trailing zeros in this value's binary representation.
   ///
@@ -1710,7 +1710,7 @@ extension BinaryInteger {
   }
 
   @inlinable // FIXME(sil-serialize-all)
-  public func _binaryLogarithm() -> Self {
+  public func _binaryLogarithm() -> Int {
     _precondition(self > (0 as Self))
     var (quotient, remainder) =
       (bitWidth &- 1).quotientAndRemainder(dividingBy: UInt.bitWidth)
@@ -1728,9 +1728,8 @@ extension BinaryInteger {
     }
     // Note that the order of operations below is important to guarantee that
     // we won't overflow.
-    return Self(
-      UInt.bitWidth &* quotient &+
-        (UInt.bitWidth &- (word.leadingZeroBitCount &+ 1)))
+    return UInt.bitWidth &* quotient &+
+        (UInt.bitWidth &- (word.leadingZeroBitCount &+ 1))
   }
 
   /// Returns the quotient and remainder of this value divided by the given
@@ -2412,7 +2411,7 @@ extension FixedWidthInteger {
   public var bitWidth: Int { return Self.bitWidth }
 
   @inlinable // FIXME(sil-serialize-all)
-  public func _binaryLogarithm() -> Self {
+  public func _binaryLogarithm() -> Int {
     _precondition(self > (0 as Self))
     return Self(Self.bitWidth &- (leadingZeroBitCount &+ 1))
   }

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2413,7 +2413,7 @@ extension FixedWidthInteger {
   @inlinable // FIXME(sil-serialize-all)
   public func _binaryLogarithm() -> Int {
     _precondition(self > (0 as Self))
-    return Self(Self.bitWidth &- (leadingZeroBitCount &+ 1))
+    return Self.bitWidth &- (leadingZeroBitCount &+ 1)
   }
 
   /// Creates an integer from its little-endian representation, changing the

--- a/test/stdlib/Integers.swift.gyb
+++ b/test/stdlib/Integers.swift.gyb
@@ -861,47 +861,46 @@ tests.test("signum/concrete") {
 
 tests.test("binaryLogarithm/generic") {
   expectEqual(
-    Int((42 as MockBinaryInteger<Int8>)._binaryLogarithm()),
-    Int((42 as Int8)._binaryLogarithm()))
+    (42 as MockBinaryInteger<Int8>)._binaryLogarithm(),
+    (42 as Int8)._binaryLogarithm())
   expectEqual(
-    Int((42 as MockBinaryInteger<UInt8>)._binaryLogarithm()),
-    Int((42 as UInt8)._binaryLogarithm()))
+    (42 as MockBinaryInteger<UInt8>)._binaryLogarithm(),
+    (42 as UInt8)._binaryLogarithm())
   expectEqual(
-    Int((42 as MockBinaryInteger<Int16>)._binaryLogarithm()),
-    Int((42 as Int16)._binaryLogarithm()))
+    (42 as MockBinaryInteger<Int16>)._binaryLogarithm(),
+    (42 as Int16)._binaryLogarithm())
   expectEqual(
-    Int((42 as MockBinaryInteger<UInt16>)._binaryLogarithm()),
-    Int((42 as UInt16)._binaryLogarithm()))
+    (42 as MockBinaryInteger<UInt16>)._binaryLogarithm(),
+    (42 as UInt16)._binaryLogarithm())
   expectEqual(
-    Int((42 as MockBinaryInteger<Int32>)._binaryLogarithm()),
-    Int((42 as Int32)._binaryLogarithm()))
+    (42 as MockBinaryInteger<Int32>)._binaryLogarithm(),
+    (42 as Int32)._binaryLogarithm())
   expectEqual(
-    Int((42 as MockBinaryInteger<UInt32>)._binaryLogarithm()),
-    Int((42 as UInt32)._binaryLogarithm()))
+    (42 as MockBinaryInteger<UInt32>)._binaryLogarithm(),
+    (42 as UInt32)._binaryLogarithm())
   expectEqual(
-    Int((42 as MockBinaryInteger<Int64>)._binaryLogarithm()),
-    Int((42 as Int64)._binaryLogarithm()))
+    (42 as MockBinaryInteger<Int64>)._binaryLogarithm(),
+    (42 as Int64)._binaryLogarithm())
   expectEqual(
-    Int((42 as MockBinaryInteger<UInt64>)._binaryLogarithm()),
-    Int((42 as UInt64)._binaryLogarithm()))
+    (42 as MockBinaryInteger<UInt64>)._binaryLogarithm(),
+    (42 as UInt64)._binaryLogarithm())
   expectEqual(
-    Int((42 as MockBinaryInteger<Int>)._binaryLogarithm()),
+    (42 as MockBinaryInteger<Int>)._binaryLogarithm(),
     (42 as Int)._binaryLogarithm())
   expectEqual(
-    Int((42 as MockBinaryInteger<UInt>)._binaryLogarithm()),
-    Int((42 as UInt)._binaryLogarithm()))
+    (42 as MockBinaryInteger<UInt>)._binaryLogarithm(),
+    (42 as UInt)._binaryLogarithm())
 // FIXME: DoubleWidth is no longer part of the standard library
 #if false
   expectEqual(
-    Int((42 as MockBinaryInteger<DoubleWidth<Int>>)._binaryLogarithm()),
-    Int((42 as DoubleWidth<Int>)._binaryLogarithm()))
+    (42 as MockBinaryInteger<DoubleWidth<Int>>)._binaryLogarithm(),
+    (42 as DoubleWidth<Int>)._binaryLogarithm())
   expectEqual(
-    Int((42 as MockBinaryInteger<DoubleWidth<UInt>>)._binaryLogarithm()),
-    Int((42 as DoubleWidth<UInt>)._binaryLogarithm()))
+    (42 as MockBinaryInteger<DoubleWidth<UInt>>)._binaryLogarithm(),
+    (42 as DoubleWidth<UInt>)._binaryLogarithm())
   expectEqual(
-    Int((42 as MockBinaryInteger<DoubleWidth<DoubleWidth<Int>>>)
-      ._binaryLogarithm()),
-    Int((42 as DoubleWidth<DoubleWidth<Int>>)._binaryLogarithm()))
+    (42 as MockBinaryInteger<DoubleWidth<DoubleWidth<Int>>>)._binaryLogarithm(),
+    (42 as DoubleWidth<DoubleWidth<Int>>)._binaryLogarithm())
 #endif
 }
 


### PR DESCRIPTION
Returning `Self` was probably a hack from when shifts were required to be homogeneous and we didn't have good generic inits between integer types. Returning Int is more natural, because:

1. Dimensional analysis says that we shouldn't expect the logarithm to have the same type.
2. Int is guaranteed to be able to represent any object size, and BinaryInteger does not admit sparse representations, so the logarithm of the value cannot exceed allocated storage size.
3. Every single use case in the stdlib and tests is either unchanged or simplified by this change.

Still to be resolved question: should binaryLogarithm be a property instead of a method? I *think* that's it was originally implemented as a function because it traps for negative and zero values, but it would feel more natural at use sites as a property. One way we might address this would be to define it on UnsignedInteger instead of BinaryInteger; then zero is the only exceptional value.

I would also like to drop the `_` prefix and make this part of the API surface, because it's useful, but let's resolve these issues before we propose that.