### PR TITLE
LoopRegionAnalysis: fix a bug in the reverse_iterator

### DIFF
--- a/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
@@ -479,10 +479,10 @@ private:
       return subregion_iterator(Subregions.end(), &Subloops);
     }
     subregion_reverse_iterator rbegin() const {
-      return subregion_reverse_iterator(begin());
+      return subregion_reverse_iterator(end());
     }
     subregion_reverse_iterator rend() const {
-      return subregion_reverse_iterator(end());
+      return subregion_reverse_iterator(begin());
     }
 
     unsigned size() const { return Subregions.size(); }


### PR DESCRIPTION
The reverse iterator initialization got the initializations of its rbegin() and rend() reversed (pun intended)

part of the work on  rdar://problem/40376124