### PR TITLE
[test] Provide a dummy AVFoundation overlay for the mock SDK

### DIFF
--- a/test/Inputs/clang-importer-sdk/swift-modules/AVFoundation.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/AVFoundation.swift
@@ -1,0 +1,1 @@
+@_exported import AVFoundation // Clang module


### PR DESCRIPTION
We were getting away with using the real one, but we shouldn't.