### PR TITLE
IDE: Fix formatting of closing square brackets

### DIFF
--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -813,7 +813,9 @@ public:
                                            StringRef Text, TokenInfo ToInfo) {
 
     // If having sibling locs to align with, respect siblings.
-    if (FC.HasSibling()) {
+    auto isClosingSquare =
+      ToInfo && ToInfo.StartOfLineTarget->getKind() == tok::r_square;
+    if (!isClosingSquare && FC.HasSibling()) {
       StringRef Line = swift::ide::getTextForLine(LineIndex, Text, /*Trim*/true);
       StringBuilder Builder;
       FC.padToSiblingColumn(Builder, FmtOptions);

--- a/test/SourceKit/CodeFormat/indent-closing-array.swift
+++ b/test/SourceKit/CodeFormat/indent-closing-array.swift
@@ -1,0 +1,26 @@
+struct Foo {
+    let bar = [
+        1,
+        2,
+    ]
+
+    func baz() {
+        let qux = [
+            "a": 1,
+            "b": 2,
+        ]
+
+        let quxx = [
+            "a": 1,
+            "b": 2
+        ]
+    }
+}
+
+// RUN: %sourcekitd-test -req=format -line=5 -length=1 %s >%t.response
+// RUN: %sourcekitd-test -req=format -line=11 -length=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=16 -length=1 %s >>%t.response
+// RUN: %FileCheck --strict-whitespace %s <%t.response
+// CHECK: key.sourcetext: "    ]"
+// CHECK: key.sourcetext: "        ]"
+// CHECK: key.sourcetext: "        ]"


### PR DESCRIPTION
Previously closing square brackets would be caught in the logic for
elements in collections, indenting them to the same level. Now they are
indented with the normal non-sibling logic, which indents them
correctly.

Resolves [SR-7846](https://bugs.swift.org/browse/SR-7846).