### PR TITLE
-tf-dump-intermediates-to-tmp should default to false

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -42,17 +42,9 @@ static llvm::cl::opt<bool>
 TFDumpIntermediates("tf-dump-intermediates", llvm::cl::init(false),
               llvm::cl::desc("Dump intermediate results in TensorFlow passes"));
 
-// For Mac builds, default to saving logging files to /tmp since debugging in
-// Xcode and the REPL is so challenging.
-#if __APPLE__
-#define DEFAULT_TO_TMP_LOGGING true
-#else
-#define DEFAULT_TO_TMP_LOGGING false
-#endif
-
 static llvm::cl::opt<bool>
 TFDumpIntermediatesToTmp("tf-dump-intermediates-tmp",
-                         llvm::cl::init(DEFAULT_TO_TMP_LOGGING),
+                         llvm::cl::init(false),
                          llvm::cl::desc("Dump intermediate results in "
                                         "TensorFlow passes to files in /tmp"));
 


### PR DESCRIPTION
`-tf-dump-intermediates-tmp` defaulted to `true` for macOS, when we were debugging macOS playgrounds before the dev summit demo. Since we are no longer debugging playgrounds, I’m going to set -tf-dump-intermediates-tmp to false by default. Printing has been a huge overhead when running a debug `swiftc` on large programs.