### PR TITLE
Fix dead instruction cleanup in deabstraction.

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -1735,7 +1735,7 @@ namespace {
 /// deleted if all references to them are removed.
 struct ArrayElementDecoder {
   SmallVector<SILValue, 4> elements;
-  SmallPtrSet<SILInstruction*, 8> arrayInsts;
+  SmallPtrSet<SILInstruction *, 8> arrayInsts;
 
   /// Given a SILValue that may be an array, attempt to decode it into the
   /// literal values that make up its elements.  This returns the element type
@@ -1776,14 +1776,9 @@ struct ArrayElementDecoder {
   }
 
   /// Try to remove the instructions that make up the array initialization.
-  void removeInstructionsIfPossible(SILBasicBlock::iterator &it) {
+  void removeInstructionsIfPossible() {
     if (arrayInsts.empty())
       return;
-
-    // If the iterator is pointing to an instruction we're about to remove,
-    // advance it to avoid invalidation.
-    while (arrayInsts.count(&*it))
-      ++it;
 
     // If we can remove it, drop all inter-dependent references.
     for (auto inst : arrayInsts)
@@ -1799,14 +1794,12 @@ struct ArrayElementDecoder {
 
 /// A reference to the specified array was just dropped.  If it was a literal
 /// array and this was the last use, clean up the instructions that fed it.
-///
-static void removeArrayValueIfPossible(ApplyInst *array,
-                                       SILBasicBlock::iterator &it) {
+static void removeArrayValueIfPossible(ApplyInst *array) {
   // If this array is a literal that we can decode, remove the instructions that
   // it came from.
   ArrayElementDecoder decoder;
   if (decoder.decodeApply(array))
-    decoder.removeInstructionsIfPossible(it);
+    decoder.removeInstructionsIfPossible();
 }
 
 /// Deabstraction can leave around lots of dead instructions from the attributes
@@ -1817,37 +1810,47 @@ void TFDeabstraction::cleanupDeadInstructions() {
   llvm::PrettyStackTraceFormat
   X("TFDeabstraction::cleanupDeadInstructions");
 
-  for (auto &block : fn) {
-    for (auto instIt = block.begin(), e = block.end(); instIt != e; ) {
-      // Manually move iterator to avoid invalidation if we remove 'inst'.
-      auto *inst = &*instIt++;
+  SmallVector<SILInstruction *, 16> deadInsts;
+  SmallVector<ApplyInst *, 8> arrayAllocUninitInsts;
 
-      // Do a quick job to remove obvious dead instructions.  Don't delete debug
-      // instructions.
-      if (isa<SingleValueInstruction>(inst) &&
-          isInstructionTriviallyDead(inst)) {
-        recursivelyDeleteTriviallyDeadInstructions(inst);
-        continue;
-      }
-
-      // The original call took the array at +0, so we don't need to destroy it.
-      // however, we want to clean up the mess to make the resultant IR simpler.
-      // Do so now if possible.
-      if (auto *apply = dyn_cast<ApplyInst>(inst)) {
-        removeArrayValueIfPossible(apply, instIt);
-        continue;
-      }
-
-      // TODO: Remove dead stack slots for tensors being passed as input lists.
-
-      // TODO: need to delete TensorShape.init and other methods that we
-      // shouldn't bake in special knowledge of.  Needs integration with
-      // ConstExpr.
-
-      // TODO: Handle String.init and other stuff.  Refactor this when ConstExpr
-      // handling subsumes ConstantPropagation.
+  auto markInstructionForRemoval = [&](SILInstruction *inst) {
+    // Mark trivially dead instructions.
+    if (isa<SingleValueInstruction>(inst) &&
+        isInstructionTriviallyDead(inst)) {
+      deadInsts.push_back(inst);
+      return;
     }
-  }
+
+    // Mark instructions applying the _allocateUninitialized function.
+    if (auto *apply = dyn_cast<ApplyInst>(inst)) {
+      SILValue tmp;
+      if (isArrayAllocUninit(apply, tmp)) {
+        arrayAllocUninitInsts.push_back(apply);
+        return;
+      }
+    }
+
+    // TODO: Mark dead stack slots for tensors being passed as input lists.
+
+    // TODO: Mark TensorShape.init and other methods that we shouldn't bake in
+    // special knowledge of. Needs integration with ConstExpr.
+
+    // TODO: Handle String.init and other stuff. Refactor this when ConstExpr
+    // handling subsumes ConstantPropagation.
+  };
+
+  // Mark instructions for removal.
+  for (auto &bb : fn)
+    for (auto &inst : bb)
+      markInstructionForRemoval(&inst);
+
+  // Remove dead instructions. Debug instructions are not deleted.
+  for (auto *inst : deadInsts)
+    recursivelyDeleteTriviallyDeadInstructions(inst);
+
+  // Clean up instructions related to array literal initialization, if possible.
+  for (auto *inst : arrayAllocUninitInsts)
+    removeArrayValueIfPossible(inst);
 }
 
 

--- a/test/TensorFlow/crashers.swift
+++ b/test/TensorFlow/crashers.swift
@@ -356,3 +356,16 @@ public func SR8222_cond_br_TensorHandle_Bool() {
   } while i != Tensor<Int32>(10)
   // expected-warning @-1{{implicitly copied to the host}}
 }
+
+// Previously, dead instruction cleanup during deabstraction crashed while
+// compiling the following code. (Instructions were deleted from a basic block
+// while traversing the basic block, causing iterator invalidation).
+func SR8316_helper() -> Tensor<Int32> {
+  return Tensor(1)
+}
+func SR8316_main() {
+  // It is important that `float` is let-bound so that a debug_value
+  // instruction is produced, which is what triggered the original crash.
+  let float: Float = 0.1 // expected-warning {{immutable value 'float' was never used}}
+  _ = SR8316_helper()
+}


### PR DESCRIPTION
Previously, `cleanupDeadInstructions` simultaneously traversed a basic block
while removing some of its instructions. This caused a segfault due to iterator
invalidation: for trivially dead instructions whose only uses were debug value
instructions, the debug value uses would be removed without incrementing the
iterator.

Now, instructions are marked for deletion, and marked instructions are deleted
in a separate pass. This is less efficient but avoids iterator invalidation
errors.

Addresses [SR-8316](https://bugs.swift.org/browse/SR-8316).