### PR TITLE
Remove a too-strict assertion concerning nested protocols

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2504,13 +2504,10 @@ static bool checkAccess(const DeclContext *useDC, const ValueDecl *VD,
       // marked 'public' if the protocol was '@_versioned' (now
       // '@usableFromInline'). Which works at the ABI level, so let's keep
       // supporting that here by explicitly checking for it.
-      if (access == AccessLevel::Public) {
-        assert(proto->getDeclContext()->isModuleScopeContext() &&
-               "if we get nested protocols, this should not apply to them");
-        if (proto->getFormalAccess() == AccessLevel::Internal &&
-            proto->isUsableFromInline()) {
-          return true;
-        }
+      if (access == AccessLevel::Public &&
+          proto->getFormalAccess() == AccessLevel::Internal &&
+          proto->isUsableFromInline()) {
+        return true;
       }
 
       // Skip the fast path below and just compare access scopes.

--- a/test/decl/nested/protocol.swift
+++ b/test/decl/nested/protocol.swift
@@ -89,3 +89,23 @@ struct Outer {
     }
   }
 }
+
+struct OuterForUFI {
+  @usableFromInline
+  protocol Inner { // expected-error {{protocol 'Inner' cannot be nested inside another declaration}}
+    func req()
+  }
+}
+
+extension OuterForUFI.Inner {
+  public func extMethod() {} // The 'public' puts this in a special path.
+}
+
+func testLookup(_ x: OuterForUFI.Inner) {
+  x.req()
+  x.extMethod()
+}
+func testLookup<T: OuterForUFI.Inner>(_ x: T) {
+  x.req()
+  x.extMethod()
+}


### PR DESCRIPTION
Follow-up for #18048. This isn't allowed in the language, but the compiler shouldn't crash!

Thanks for catching this, @slavapestov.