### PR TITLE
[libSyntax] Fix compiler error

### DIFF
--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -701,7 +701,7 @@ int doSerializeRawTree(const char *MainExecutablePath,
     [](SourceFile *SF, SyntaxParsingCache *SyntaxCache) -> int {
     auto SerializeTree = [](llvm::raw_ostream &os, RC<RawSyntax> Root,
                             SyntaxParsingCache *SyntaxCache) {
-      std::unordered_set<unsigned> ReusedNodeIds = {};
+      std::unordered_set<unsigned> ReusedNodeIds;
       if (options::IncrementalSerialization && SyntaxCache) {
         ReusedNodeIds = SyntaxCache->getReusedNodeIds();
       }


### PR DESCRIPTION
Another instance of 7ad81a88b9803a9b82dc5b0b7e63c2d426bc8228.
cc @ahoppen 