### PR TITLE
[4.2][CodeComplete] Strip out try and optional eval expr in operator completion

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -3468,10 +3468,13 @@ public:
       prepareForRetypechecking(SE);
 
       for (auto &element : sequence.drop_back(2)) {
-        // Unfold AssignExpr for re-typechecking sequence.
-        if (auto *AE = dyn_cast_or_null<AssignExpr>(element)) {
-          AE->setSrc(nullptr);
-          AE->setDest(nullptr);
+        // Unfold expressions for re-typechecking sequence.
+        if (auto *assignExpr = dyn_cast_or_null<AssignExpr>(element)) {
+          assignExpr->setSrc(nullptr);
+          assignExpr->setDest(nullptr);
+        } else if (auto *ifExpr = dyn_cast_or_null<IfExpr>(element)) {
+          ifExpr->setCondExpr(nullptr);
+          ifExpr->setElseExpr(nullptr);
         }
 
         // Reset any references to operators in types, so they are properly
@@ -3522,6 +3525,12 @@ public:
       flattenBinaryExpr(assignExpr->getSrc(), sequence);
       assignExpr->setDest(nullptr);
       assignExpr->setSrc(nullptr);
+    } else if (auto ifExpr = dyn_cast<IfExpr>(expr)) {
+      flattenBinaryExpr(ifExpr->getCondExpr(), sequence);
+      sequence.push_back(ifExpr);
+      flattenBinaryExpr(ifExpr->getElseExpr(), sequence);
+      ifExpr->setCondExpr(nullptr);
+      ifExpr->setElseExpr(nullptr);
     } else if (auto tryExpr = dyn_cast<AnyTryExpr>(expr)) {
       // Strip out try expression. It doesn't affect completion.
       flattenBinaryExpr(tryExpr->getSubExpr(), sequence);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2106,11 +2106,20 @@ bool TypeChecker::typeCheckCompletionSequence(Expr *&expr, DeclContext *DC) {
   expr = foldSequence(SE, DC);
 
   // Find the code-completion expression and operator again.
-  BinaryExpr *exprAsBinOp = nullptr;
-  while (auto *binExpr = dyn_cast<BinaryExpr>(expr)) {
-    auto *RHS = binExpr->getArg()->getElement(1);
+  Expr *exprAsBinOp = nullptr;
+  while (true) {
+    Expr *RHS;
+    if (auto *binExpr = dyn_cast<BinaryExpr>(expr))
+      RHS = binExpr->getArg()->getElement(1);
+    else if (auto *assignExpr = dyn_cast<AssignExpr>(expr))
+      RHS = assignExpr->getSrc();
+    else if (auto *ifExpr = dyn_cast<IfExpr>(expr))
+      RHS = ifExpr->getElseExpr();
+    else
+      break;
+
     if (RHS == CCE) {
-      exprAsBinOp = binExpr;
+      exprAsBinOp = expr;
       break;
     }
     expr = RHS;
@@ -2119,7 +2128,7 @@ bool TypeChecker::typeCheckCompletionSequence(Expr *&expr, DeclContext *DC) {
     return true;
 
   // Ensure the output expression is up to date.
-  assert(exprAsBinOp == expr && "found wrong expr?");
+  assert(exprAsBinOp == expr && isa<BinaryExpr>(expr) && "found wrong expr?");
 
   // Add type variable for the code-completion expression.
   auto tvRHS =

--- a/test/IDE/complete_crashes.swift
+++ b/test/IDE/complete_crashes.swift
@@ -220,9 +220,10 @@ protocol Bar_38149042 {
 func foo_38149042(bar: Bar_38149042) {
   _ = bar.foo? #^RDAR_38149042^# .x
 }
-
 // RDAR_38149042: Begin completions
 // RDAR_38149042-DAG: Decl[InstanceVar]/CurrNominal:                  .x[#Int#]; name=x
+// RDAR_38149042-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]: [' ']=== {#AnyObject?#}[#Bool#]; name==== AnyObject?
+// RDAR_38149042-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]: [' ']!== {#AnyObject?#}[#Bool#]; name=!== AnyObject?
 // RDAR_38149042: End completions
 
 // rdar://problem/38272904
@@ -274,7 +275,8 @@ func foo(x: RDAR41159258_MyResult1) {
 
 
 // rdar://problem/41232519
-// RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=RDAR41232519 | %FileCheck %s -check-prefix=RDAR_41232519
+// RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=RDAR41232519_1 | %FileCheck %s -check-prefix=RDAR_41232519
+// RUN: %target-swift-ide-test -code-completion -source-filename=%s -code-completion-token=RDAR41232519_2 | %FileCheck %s -check-prefix=RDAR_41232519
 public protocol IntProvider {
   func nextInt() -> Int
 }
@@ -282,10 +284,13 @@ public protocol IntProvider {
 public final class IntStore {
   public var myInt: Int = 0
   func readNextInt(from provider: IntProvider) {
-      myInt = provider.nextInt() #^RDAR41232519^#
+      myInt = provider.nextInt() #^RDAR41232519_1^#
+      _ = true ? 1 : provider.nextInt() #^RDAR41232519_2^#
   }
 }
 // RDAR_41232519: Begin completions
+// RDAR_41232519: Decl[InfixOperatorFunction]/OtherModule[Swift]: [' ']+ {#Int#}[#Int#]; name=+ Int
+// RDAR_41232519: End completions
 
 // rdar://problem/28188259
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=RDAR_28188259 -source-filename=%s | %FileCheck %s -check-prefix=RDAR_28188259

--- a/test/IDE/complete_crashes.swift
+++ b/test/IDE/complete_crashes.swift
@@ -312,3 +312,19 @@ func test_40956846(
 // RDAR_40956846-DAG: Decl[LocalVar]/Local:               arg_40956846_3[#(() -> Int)!#]; name=arg_40956846_3
 // RDAR_40956846-DAG: Decl[LocalVar]/Local:               arg_40956846_4[#inout ((Int) -> Int)!#]; name=arg_40956846_4
 // RDAR_40956846: End completions
+
+// rdar://problem/42452085
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=RDAR_42452085_1 -source-filename=%s | %FileCheck %s -check-prefix=RDAR_42452085
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=RDAR_42452085_2 -source-filename=%s | %FileCheck %s -check-prefix=RDAR_42452085
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=RDAR_42452085_3 -source-filename=%s | %FileCheck %s -check-prefix=RDAR_42452085
+class cls_42452085 {
+  var value: Any
+  func canThrow() throws -> Int { return 1 }
+}
+func test_42452085(any: Any, obj: cls_42452085?) throws {
+  var object: Any? = nil
+  object = (any as? String) #^RDAR_42452085_1^#
+  obj?.value = any #^RDAR_42452085_2^#
+  _ = try obj?.canThrow() #^RDAR_42452085_3^#
+}
+// RDAR_42452085: found code completion token


### PR DESCRIPTION
Cherry-pick of #18209 reviewed by @benlangmuir 

- **Explaination**: `foldSequence()` may hoist up try expression and optional-evaluation-expression by mutating their sub expression. When completing operators, this behavior ruins reusability of operand, and used to cause excessively nested expression which leads to stack overflow. Since these expression doesn't affect completion, strip them out beforehand so we can reuse operands. Also, this change contains fix for a regression introduced in earlier change where infix operator were disappeared from completion results when leading sequence contains AssignExpr.
- **Scope**: Affect code-completion regarding optional evaluation expression.
- **Issue**: rdar://problem/42452085
- **Risk**: Low.
- **Testing**: Added regression test cases.
- **Reviewed By**: Ben Langmuir (https://github.com/apple/swift/pull/18209)