### PR TITLE
[GPE] Split critical edges before marking blocks

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -32,8 +32,8 @@
 #include "swift/SILOptimizer/Analysis/LoopAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
-#include "swift/SILOptimizer/Utils/Local.h"
 #include "swift/SILOptimizer/Utils/CFG.h"
+#include "swift/SILOptimizer/Utils/Local.h"
 #include "llvm/ADT/BitVector.h"
 #ifdef SWIFT_ENABLE_TENSORFLOW
 #include "tensorflow/c/c_api.h"

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -1116,7 +1116,7 @@ bool TFFunctionPartition::markBlock(SILBasicBlock *BB) {
           ++numTensorSuccs;
         else {
           assert(succ->getSinglePredecessorBlock() &&
-                 "Need to split critical edges??");
+                 "Critical edges should've been split");
           tensorKillBlocks.insert(succ);
         }
       }
@@ -1968,7 +1968,7 @@ bool TFFunctionPartition::markFunction(bool &hasTensorOps) {
     }
   };
   
-  // Split all critical edges for partitioning.
+  // Split all critical edges for block marking.
   splitAllCondBrCriticalEdgesWithNonTrivialArgs(hostFn, &DI, &LI);
 
   // We walk the function in depth first order so that we only visit reachable

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -29,9 +29,11 @@
 #include "swift/SIL/SILCloner.h"
 #include "swift/SIL/SILConstants.h"
 #include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
+#include "swift/SILOptimizer/Analysis/LoopAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/Local.h"
+#include "swift/SILOptimizer/Utils/CFG.h"
 #include "llvm/ADT/BitVector.h"
 #ifdef SWIFT_ENABLE_TENSORFLOW
 #include "tensorflow/c/c_api.h"
@@ -622,6 +624,7 @@ public:
   DenseMap<StringRef, std::unique_ptr<LoweredGraphFunction>> &graphFunctions;
   GraphFunctionDeviceInfo deviceInfo; // Device placement info.
   DominanceInfo &DI;
+  SILLoopInfo &LI;
   BlocksReachingTensorCode tensorCodeBlocks;
 
   /// These are all the tensor ops found in the initial scan over the function.
@@ -729,6 +732,7 @@ public:
             GraphFunctionDeviceInfo::getForFunction(hostFn,
                                                     /*removeConfigInst*/ true)),
         DI(*PM->getAnalysis<DominanceAnalysis>()->get(&Fn)),
+        LI(*PM->getAnalysis<SILLoopAnalysis>()->get(&Fn)),
         tensorCodeBlocks(Fn) {}
 
   ~TFFunctionPartition() {
@@ -1963,6 +1967,9 @@ bool TFFunctionPartition::markFunction(bool &hasTensorOps) {
       loggedInput = true;
     }
   };
+  
+  // Split all critical edges for partitioning.
+  splitAllCondBrCriticalEdgesWithNonTrivialArgs(hostFn, &DI, &LI);
 
   // We walk the function in depth first order so that we only visit reachable
   // blocks and to slightly improve compile time performance of the 'marking'

--- a/test/TensorFlow/control_flow.swift
+++ b/test/TensorFlow/control_flow.swift
@@ -330,3 +330,12 @@ public func infLoop2(maxCount: Int32) {
 //     i += 1
 //   }
 // }
+
+
+// SR-8373: Critical edges should be split.
+public func testCriticalEdges() {
+  _ = Tensor(1).scalars[0..<5 * Int(2)]
+  for _ in 1...5 {
+    Tensor(1).scalars.forEach { _ in }
+  }
+}

--- a/test/TensorFlow/control_flow.swift
+++ b/test/TensorFlow/control_flow.swift
@@ -293,30 +293,6 @@ public func infLoop1() {
   _hostOp(a)
 }
 
-// Another infinite loop that we reject in partitioning.
-// simplified from https://bugs.swift.org/browse/SR-8236
-// expected-error @+1 {{Functions containing infinite loops are not supported by TensorFlow yet}}
-public func infLoop2(maxCount: Int32) {
-  var a = Tensor<Int32>(0)
-  var count: Int32 = 0
-  // expected-warning @+1 {{implicitly copied to the accelerator}}
-  while count < maxCount {
-    a += a
-    count += 1
-    if count == 50 {
-      let i: Int32 = 0
-      // this causes trouble: infinite loop
-      while i < maxCount {
-        count += i
-      }
-      a = Tensor<Int32>(count)
-      break
-    }
-  }
-  a -= a
-  _hostOp(a)
-}
-
 // TODO: Enable this test when we fix
 // SESE FIXME: Imperfect loop exits not handled yet!
 // public func SR8256(_ cond: Int?) {


### PR DESCRIPTION
Bug [SR-8373](https://bugs.swift.org/browse/SR-8373) originates from the [Autoencoder](https://github.com/tensorflow/swift-models/tree/master/Autoencoder) model.

This patch fixes it by splitting `cond_br` critical edges before marking blocks.

After splitting critical edges, the compiler no longer sees `infLoop2` as a self loop, so it can be correctly lowered.