### PR TITLE
[tensorflow] [Deabstraction] Fix an assertion failure when it comes to non-constant attribute operands.

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -1642,14 +1642,17 @@ void TFDeabstraction::checkAttributesAndFormGraphOps() {
   SmallVector<SILValue, 32> valuesToCheck;
 
   for (auto *op : tensorOps) {
-    for (auto &operand : op->getAllOperands()) {
+    auto opInfo = SILTensorOpInfo::decode(op);
+    for (unsigned i = 0; i < op->getNumOperands(); ++i) {
       // Dump anything that might be an attribute into the list without too much
-      // filtering.  We take out TensorFlow values since they are the most
-      // obvious ones we don't care about later, but there may be other minor
-      // things we over-query on.
-      auto value = operand.get();
-      if (!isTensorFlowValue(value->getType()))
+      // filtering.  We take out TensorFlow values that are known as $in, since
+      // they are the most obvious ones we don't care about later, but there may
+      // be other minor things we over-query on.
+      const SILValue &value = op->getOperand(i);
+      bool isInput = opInfo && opInfo->isInput(i);
+      if (!isInput || !isTensorFlowValue(value->getType())) {
         valuesToCheck.push_back(value);
+      }
     }
   }
 

--- a/test/TensorFlow/deabstraction_crashers.swift
+++ b/test/TensorFlow/deabstraction_crashers.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -Xllvm -tf-strict-deabstraction -verify %s
+import TensorFlow
+
+public func SR8299(a: Tensor<Float>) {
+   // expected-error @+1 {{attribute 'someAttr' requires a constant argument}}
+   () = #tfop("foo", someAttr: a)
+}


### PR DESCRIPTION
~~When collecting `constants` from operands of tensorOps, all TensowFlow Values are skipped. Such strategy is not conservative and may skip the operands which appear as TensorFlowValue but are indeed used as attributes. Consequently, assertion failures ([SR-8299](https://bugs.swift.org/browse/SR-8299))  may occur.~~

~~This patch adds considerations of `OperandClass`, making the constant collection more conservative.~~

When performing constant scanning for operands of tensorOps, all TensowFlow Values are not collected. In this case, we should not assert such operands always appear in `constants`. This patch fixes such assertion.

Resolves [SR-8299](https://bugs.swift.org/browse/SR-8299).
