### PR TITLE
Fix libsyntax doc

### DIFF
--- a/lib/Syntax/README.md
+++ b/lib/Syntax/README.md
@@ -523,7 +523,7 @@ declarations. The `Token` class has the following fields.
 
 libSyntax uses Swift's `gyb` tool to generate the `Syntax` subclasses,
 `SyntaxFactory` methods, `SyntaxKind` enum entry, and `SyntaxBuilder` class.
-These files rely on a support library located at `utils/gyb_syntax_support.py`
+These files rely on a support library located at `utils/gyb_syntax_support/`
 which holds some common logic used inside the `gyb` files. These `gyb` files
 will be re-generated whenever any Python files are changed.
 


### PR DESCRIPTION
`gyb_syntax_support.py` does not exist. It's a directory.