### PR TITLE
Add a trailing closure version of GPU device placement API.

### DIFF
--- a/stdlib/public/TensorFlow/CMakeLists.txt
+++ b/stdlib/public/TensorFlow/CMakeLists.txt
@@ -38,6 +38,7 @@ set(SOURCES
   CompilerRuntime.swift
   CompositeMath.swift
   DataTypes.swift
+  DevicePlacement.swift
   Gradients.swift
   OpaqueHandles.swift
   Ops.swift

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -36,27 +36,6 @@ import Glibc
 #endif
 import CTensorFlow
 
-// If `serverAddress` is nil, use local session (good for forge testing).
-//
-// FIXME: We need transparent here because deabstraction isn't inlining this
-// function.  We need to inline if a callee contains tensor ops, not only if
-// it takes and returns a TensorFlow value.
-@_transparent
-public func enableTPU(serverAddress: String? = nil, infeed: Bool = true) {
-  _RuntimeConfig.executionMode = .tpu
-  if let serverAddress = serverAddress {
-    _RuntimeConfig.session = .remote(grpcAddress: serverAddress)
-  }
-  #tfop("tfc.configureTPU", enableInfeed: infeed) as Void
-}
-
-// FIXME: Extend the interface to support multiple GPU devices, and unify it
-// with enableTPU() above.
-@_transparent
-public func enableGPU() {
-  #tfop("tfc.configureGPU") as Void
-}
-
 @_frozen
 public enum _ExecutionMode : Equatable {
   /// CPU or GPU execution.

--- a/stdlib/public/TensorFlow/DevicePlacement.swift
+++ b/stdlib/public/TensorFlow/DevicePlacement.swift
@@ -1,0 +1,49 @@
+//===-- DevicePlacement.swift ---------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines APIs for device placement.
+//
+//===----------------------------------------------------------------------===//
+
+// If `serverAddress` is nil, use local session (good for forge testing).
+//
+// FIXME: We need transparent here because deabstraction isn't inlining this
+// function.  We need to inline if a callee contains tensor ops, not only if
+// it takes and returns a TensorFlow value.
+@_transparent
+public func enableTPU(serverAddress: String? = nil, infeed: Bool = true) {
+  _RuntimeConfig.executionMode = .tpu
+  if let serverAddress = serverAddress {
+    _RuntimeConfig.session = .remote(grpcAddress: serverAddress)
+  }
+  #tfop("tfc.configureTPU", enableInfeed: infeed) as Void
+}
+
+// FIXME: Extend the interface to support multiple GPU devices, and unify it
+// with enableTPU() above.
+@_transparent
+public func enableGPU() {
+  #tfop("tfc.configureGPU") as Void
+}
+
+// Executes a closure on GPU.
+//
+// - Parameter body: The closure to execute.
+// - Throws: The error that the body throws, if any.
+// - Returns: The value returned by the closure, if any.
+@inlinable @inline(__always)
+public func withGPU<Result>(
+  execute body: () throws -> Result
+) rethrows -> Result {
+  enableGPU()
+  return execute()
+}

--- a/stdlib/public/TensorFlow/DevicePlacement.swift
+++ b/stdlib/public/TensorFlow/DevicePlacement.swift
@@ -14,20 +14,25 @@
 //
 //===----------------------------------------------------------------------===//
 
-// If `serverAddress` is nil, use local session (good for forge testing).
-//
+/// Executes code in the current scope on GPU.
+///
+/// - Parameter serverAddress: The address to the TPU server where a remote
+///   session is alive. If `nil`, use a local session.
+///
 // FIXME: We need transparent here because deabstraction isn't inlining this
 // function.  We need to inline if a callee contains tensor ops, not only if
 // it takes and returns a TensorFlow value.
 @_transparent
-public func enableTPU(serverAddress: String? = nil, infeed: Bool = true) {
+public func enableTPU(serverAddress: String? = nil) {
   _RuntimeConfig.executionMode = .tpu
   if let serverAddress = serverAddress {
     _RuntimeConfig.session = .remote(grpcAddress: serverAddress)
   }
-  #tfop("tfc.configureTPU", enableInfeed: infeed) as Void
+  #tfop("tfc.configureTPU", enableInfeed: true) as Void
 }
 
+/// Executes code in the current scope on GPU.
+///
 // FIXME: Extend the interface to support multiple GPU devices, and unify it
 // with enableTPU() above.
 @_transparent
@@ -35,11 +40,12 @@ public func enableGPU() {
   #tfop("tfc.configureGPU") as Void
 }
 
-// Executes a closure on GPU.
-//
-// - Parameter body: The closure to execute.
-// - Throws: The error that the body throws, if any.
-// - Returns: The value returned by the closure, if any.
+/// Executes a closure on GPU.
+///
+/// - Parameter body: The closure to execute.
+/// - Throws: The error that the body throws, if any.
+/// - Returns: The value returned by the closure, if any.
+///
 @inlinable @inline(__always)
 public func withGPU<Result>(
   execute body: () throws -> Result

--- a/stdlib/public/TensorFlow/DevicePlacement.swift
+++ b/stdlib/public/TensorFlow/DevicePlacement.swift
@@ -14,6 +14,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+/// A TensorFlow device kind.
+public enum DeviceKind {
+  /// Default device.
+  case `default`
+  /// Graphics processing units.
+  case gpu
+  /// Tensor processing units.
+  case tpu
+}
+
 /// Executes code in the current scope on GPU.
 ///
 /// - Parameter serverAddress: The address to the TPU server where a remote
@@ -46,10 +56,9 @@ public func enableGPU() {
 /// - Throws: The error that the body throws, if any.
 /// - Returns: The value returned by the closure, if any.
 ///
-@inlinable @inline(__always)
-public func withGPU<Result>(
-  execute body: () throws -> Result
+@_semantics("tf.withDevice(_:execute:)") @_optimize(none) @inline(never)
+public func withDevice<Result>(
+  _ kind: DeviceKind, execute body: () throws -> Result
 ) rethrows -> Result {
-  enableGPU()
-  return execute()
+  return body()
 }

--- a/test/TensorFlow/device_placement.swift
+++ b/test/TensorFlow/device_placement.swift
@@ -27,6 +27,16 @@ public func explicitDeviceConfigGPU() {
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}explicitDeviceConfigGPU{{.*}}
 // CHECK: graph_op "Const"() {dtype$dtype: $Builtin.FPIEEE32, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"
 
+public func closureDeviceConfigGPU() {
+  withGPU {
+    let x = Tensor<Float>(1.0)
+    _hostOp(x)
+  }
+}
+
+// CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}closureDeviceConfigGPU{{.*}}
+// CHECK: graph_op "Const"() {dtype$dtype: $Builtin.FPIEEE32, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"
+
 // Check that in the TF graph, both the function node itself, and ops in the
 // function, are placed on GPU.
 //


### PR DESCRIPTION
Add `withGPU(execute:)`, which takes a closure and return the result that the closure returns (if any).

With this, users can do:
```swift
let x = readTensorFromFile().toAccelerator()
let y = withGPU {
  matmul(x, x).sum(alongAxes: 0, 1)
}
```

This is mechanically the same as declaring a `func` and throwing an `enableGPU()` in it.

Also: 
- Move device placement APIs to `TensorFlow/DevicePlacement.swift`.
- Remove the `infeed` argument from `enableTPU(serverAddress:infeed:)` and make TPU execution always use infeed, since we have standard infeed/outfeed support now.