### PR TITLE
[Type checker] Don't finalize decls from other source files after an error

### DIFF
--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -572,6 +572,12 @@ static void typeCheckFunctionsAndExternalDecls(SourceFile &SF, TypeChecker &TC) 
       if (decl->isInvalid())
         continue;
 
+      // If we've already encountered an error, don't finalize declarations
+      // from other source files.
+      if (TC.Context.hadError() &&
+          decl->getDeclContext()->getParentSourceFile() != &SF)
+        continue;
+
       TC.finalizeDecl(decl);
     }
 

--- a/test/Sema/Inputs/availability_multi_other.swift
+++ b/test/Sema/Inputs/availability_multi_other.swift
@@ -32,18 +32,17 @@ class OtherIntroduced10_51 {
     return OtherIntroduced10_52()
   }
 
-  func takes10_52(o: OtherIntroduced10_52) {
+  func takes10_52(o: OtherIntroduced10_52) { 
   }
-  // expected-error@-2{{'OtherIntroduced10_52' is only available on OS X 10.52 or newer}}
-  // expected-note@-3{{add @available attribute to enclosing instance method}}
-  
+
   @available(OSX, introduced: 10.52)
   func takes10_52Introduced10_52(o: OtherIntroduced10_52) {
   }
 
-  // expected-error@+1{{'OtherIntroduced10_52' is only available on OS X 10.52 or newer}}
   var propOf10_52: OtherIntroduced10_52 = 
-      OtherIntroduced10_52()
+
+
+      OtherIntroduced10_52() // We don't expect an error here because the initializer is not type checked (by design).
 
   @available(OSX, introduced: 10.52)
   var propOf10_52Introduced10_52: OtherIntroduced10_52 = OtherIntroduced10_52()

--- a/test/Sema/Inputs/circularity_multifile_error_helper.swift
+++ b/test/Sema/Inputs/circularity_multifile_error_helper.swift
@@ -1,5 +1,5 @@
 struct External {
-  var member: Something // expected-error{{use of undeclared type 'Something'}}
+  var member: Something
 }
 
 struct OtherExternal {}


### PR DESCRIPTION
Per feedback from Jordan, this avoids extra work without missing
additional diagnostics from the current source file.
