### PR TITLE
[stdlib] More documentation revisions

### DIFF
--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -375,7 +375,7 @@ extension ClosedRange: Equatable {
   ///
   /// Two ranges are equal when they have the same lower and upper bounds.
   ///
-  ///     let x: ClosedRange = 5...15
+  ///     let x = 5...15
   ///     print(x == 5...15)
   ///     // Prints "true"
   ///     print(x == 10...20)

--- a/stdlib/public/core/Codable.swift.gyb
+++ b/stdlib/public/core/Codable.swift.gyb
@@ -1237,7 +1237,7 @@ public enum DecodingError : Error {
   /// for debugging.
   case typeMismatch(Any.Type, Context)
 
-  /// An indication that a non-optional value of the given type was expected,
+  /// An indication that a nonoptional value of the given type was expected,
   /// but a null value was found.
   ///
   /// As associated values, this case contains the attempted type and context

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -634,7 +634,7 @@ public protocol Collection: Sequence where SubSequence: Collection {
 
   // FIXME(move-only types): `first` might not be implementable by collections
   // with move-only elements, since they would need to be able to somehow form
-  // a temporary `Optional<Element>` value from a non-optional Element without
+  // a temporary `Optional<Element>` value from a nonoptional Element without
   // modifying the collection.
 
   /// The first element of the collection.

--- a/stdlib/public/core/CollectionAlgorithms.swift
+++ b/stdlib/public/core/CollectionAlgorithms.swift
@@ -141,7 +141,7 @@ extension BidirectionalCollection {
   ///
   ///     let numbers = [3, 7, 4, -2, 9, -6, 10, 1]
   ///     if let lastNegative = numbers.last(where: { $0 < 0 }) {
-  ///         print("The last negative number is \(firstNegative).")
+  ///         print("The last negative number is \(lastNegative).")
   ///     }
   ///     // Prints "The last negative number is -6."
   ///
@@ -165,7 +165,7 @@ extension BidirectionalCollection {
   /// You can use the predicate to find an element of a type that doesn't
   /// conform to the `Equatable` protocol or to find an element that matches
   /// particular criteria. This example finds the index of the last name that
-  /// begins with the letter "A":
+  /// begins with the letter *A:*
   ///
   ///     let students = ["Kofi", "Abena", "Peter", "Kweku", "Akosua"]
   ///     if let i = students.lastIndex(where: { $0.hasPrefix("A") }) {
@@ -213,7 +213,7 @@ extension BidirectionalCollection where Element : Equatable {
   ///
   /// - Parameter element: An element to search for in the collection.
   /// - Returns: The last index where `element` is found. If `element` is not
-  ///   found in the collection, returns `nil`.
+  ///   found in the collection, this method returns `nil`.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   @inlinable

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -342,7 +342,7 @@ import SwiftShims
 ///
 /// Note that in this example, `imagePaths` is subscripted using a dictionary
 /// index. Unlike the key-based subscript, the index-based subscript returns
-/// the corresponding key-value pair as a non-optional tuple.
+/// the corresponding key-value pair as a nonoptional tuple.
 ///
 ///     print(imagePaths[glyphIndex!])
 ///     // Prints "("star", "/glyphs/star.png")"

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -123,8 +123,8 @@ def operatorComment(operator, fixedWidth):
   ///
   /// - Note: Overflow checking is not performed in `-Ounchecked` builds.
   ///
-  /// If you want to opt out of overflow checking and ignore any overflow, use
-  /// the overflow addition operator (`&+`).
+  /// If you want to opt out of overflow checking and wrap the result in case
+  /// of any overflow, use the overflow addition operator (`&+`).
   ///
   ///     x &+ 120                // -115
   ///
@@ -160,8 +160,8 @@ def operatorComment(operator, fixedWidth):
   ///
   /// - Note: Overflow checking is not performed in `-Ounchecked` builds.
   ///
-  /// If you want to opt out of overflow checking and ignore any overflow, use
-  /// the overflow subtraction operator (`&-`).
+  /// If you want to opt out of overflow checking and wrap the result in case
+  /// of any overflow, use the overflow subtraction operator (`&-`).
   ///
   ///     x &- 50                // 227
   ///
@@ -197,8 +197,8 @@ def operatorComment(operator, fixedWidth):
   ///
   /// - Note: Overflow checking is not performed in `-Ounchecked` builds.
   ///
-  /// If you want to opt out of overflow checking and ignore any overflow, use
-  /// the overflow multiplication operator (`&*`).
+  /// If you want to opt out of overflow checking and wrap the result in case
+  /// of any overflow, use the overflow multiplication operator (`&*`).
   ///
   ///     x &* 21                // -115
   ///
@@ -223,7 +223,7 @@ def operatorComment(operator, fixedWidth):
   /// Returns the remainder of dividing the first value by the second.
   ///
   /// The result of the remainder operator (`%`) has the same sign as `lhs` and
-  /// is less than `rhs.magnitude`.
+  /// has a magnitude less than `rhs.magnitude`.
   ///
   ///     let x = 22 % 5
   ///     // x == 2
@@ -240,7 +240,8 @@ def operatorComment(operator, fixedWidth):
   ///   - rhs: The value to divide `lhs` by. `rhs` must not be zero.
 """,
         '&+': """\
-  /// Returns the sum of the two given values, wrapping any overflow.
+  /// Returns the sum of the two given values, wrapping the result in case of
+  /// any overflow.
   ///
   /// The overflow addition operator (`&+`) discards any bits that overflow the
   /// fixed width of the integer type. In the following example, the sum of
@@ -254,7 +255,7 @@ def operatorComment(operator, fixedWidth):
   ///     // y == -35 (after overflow)
   ///
   /// For more about arithmetic with overflow operators, see [Overflow
-  /// Operators][overflow] in [The Swift Programming Language][tspl].
+  /// Operators][overflow] in *[The Swift Programming Language][tspl]*.
   ///
   /// [overflow]: https://docs.swift.org/swift-book/LanguageGuide/AdvancedOperators.html#ID37
   /// [tspl]: https://docs.swift.org/swift-book/
@@ -264,7 +265,8 @@ def operatorComment(operator, fixedWidth):
   ///   - rhs: The second value to add.
 """,
         '&-': """\
-  /// Returns the difference of the two given values, wrapping any overflow.
+  /// Returns the difference of the two given values, wrapping the result in
+  /// case of any overflow.
   ///
   /// The overflow subtraction operator (`&-`) discards any bits that overflow
   /// the fixed width of the integer type. In the following example, the
@@ -278,7 +280,7 @@ def operatorComment(operator, fixedWidth):
   ///     // y == 245 (after overflow)
   ///
   /// For more about arithmetic with overflow operators, see [Overflow
-  /// Operators][overflow] in [The Swift Programming Language][tspl].
+  /// Operators][overflow] in *[The Swift Programming Language][tspl]*.
   ///
   /// [overflow]: https://docs.swift.org/swift-book/LanguageGuide/AdvancedOperators.html#ID37
   /// [tspl]: https://docs.swift.org/swift-book/
@@ -288,7 +290,8 @@ def operatorComment(operator, fixedWidth):
   ///   - rhs: The value to subtract from `lhs`.
 """,
         '&*': """\
-  /// Returns the product of the two given values, wrapping any overflow.
+  /// Returns the product of the two given values, wrapping the result in case
+  /// of any overflow.
   ///
   /// The overflow multiplication operator (`&*`) discards any bits that
   /// overflow the fixed width of the integer type. In the following example,
@@ -302,7 +305,7 @@ def operatorComment(operator, fixedWidth):
   ///     // y == -12 (after overflow)
   ///
   /// For more about arithmetic with overflow operators, see [Overflow
-  /// Operators][overflow] in [The Swift Programming Language][tspl].
+  /// Operators][overflow] in *[The Swift Programming Language][tspl]*.
   ///
   /// [overflow]: https://docs.swift.org/swift-book/LanguageGuide/AdvancedOperators.html#ID37
   /// [tspl]: https://docs.swift.org/swift-book/
@@ -607,7 +610,8 @@ def assignmentOperatorComment(operator, fixedWidth):
   /// Divides the first value by the second and stores the remainder in the
   /// left-hand-side variable.
   ///
-  /// The result has the same sign as `lhs` and is less than `rhs.magnitude`.
+  /// The result has the same sign as `lhs` and has a magnitude less than
+  /// `rhs.magnitude`.
   ///
   ///     var x = 22
   ///     x %= 5
@@ -632,7 +636,8 @@ def assignmentOperatorComment(operator, fixedWidth):
   /// The masking addition assignment operator (`&+=`) silently wraps any
   /// overflow that occurs during the operation. In the following example, the
   /// sum of `100` and `121` is greater than the maximum representable `Int8`
-  /// value, so the result is the wrapped overflow value:
+  /// value, so the result is the partial value after discarding the
+  /// overflowing bits.
   ///
   ///     var x: Int8 = 10
   ///     x &+= 21
@@ -640,6 +645,12 @@ def assignmentOperatorComment(operator, fixedWidth):
   ///     var y: Int8 = 100
   ///     y &+= 121
   ///     // y == -35 (after overflow)
+  ///
+  /// For more about arithmetic with overflow operators, see [Overflow
+  /// Operators][overflow] in *[The Swift Programming Language][tspl]*.
+  ///
+  /// [overflow]: https://docs.swift.org/swift-book/LanguageGuide/AdvancedOperators.html#ID37
+  /// [tspl]: https://docs.swift.org/swift-book/
   ///
   /// - Parameters:
   ///   - lhs: The first value to add.
@@ -652,7 +663,8 @@ def assignmentOperatorComment(operator, fixedWidth):
   /// The masking subtraction assignment operator (`&-=`) silently wraps any
   /// overflow that occurs during the operation. In the following example, the
   /// difference of `10` and `21` is less than zero, the minimum representable
-  /// `UInt` value, so the result is the wrapped overflow value:
+  /// `UInt` value, so the result is the result is the partial value after
+  /// discarding the overflowing bits.
   ///
   ///     var x: Int8 = 21
   ///     x &-= 10
@@ -660,6 +672,12 @@ def assignmentOperatorComment(operator, fixedWidth):
   ///     var y: UInt8 = 10
   ///     y &-= 21
   ///     // y == 245 (after overflow)
+  ///
+  /// For more about arithmetic with overflow operators, see [Overflow
+  /// Operators][overflow] in *[The Swift Programming Language][tspl]*.
+  ///
+  /// [overflow]: https://docs.swift.org/swift-book/LanguageGuide/AdvancedOperators.html#ID37
+  /// [tspl]: https://docs.swift.org/swift-book/
   ///
   /// - Parameters:
   ///   - lhs: A numeric value.
@@ -672,7 +690,8 @@ def assignmentOperatorComment(operator, fixedWidth):
   /// The masking multiplication assignment operator (`&*=`) silently wraps
   /// any overflow that occurs during the operation. In the following example,
   /// the product of `10` and `50` is greater than the maximum representable
-  /// `Int8` value, so the result is the wrapped overflow value:
+  /// `Int8` value, so the result is the partial value after discarding the
+  /// overflowing bits.
   ///
   ///     var x: Int8 = 10
   ///     x &*= 5
@@ -680,6 +699,12 @@ def assignmentOperatorComment(operator, fixedWidth):
   ///     var y: Int8 = 10
   ///     y &*= 50
   ///     // y == -12 (after overflow)
+  ///
+  /// For more about arithmetic with overflow operators, see [Overflow
+  /// Operators][overflow] in *[The Swift Programming Language][tspl]*.
+  ///
+  /// [overflow]: https://docs.swift.org/swift-book/LanguageGuide/AdvancedOperators.html#ID37
+  /// [tspl]: https://docs.swift.org/swift-book/
   ///
   /// - Parameters:
   ///   - lhs: The first value to multiply.
@@ -1194,8 +1219,13 @@ ${operatorComment(x.operator, False)}
 /// your own mutating `negate()` method.
 ///
 /// When the additive inverse of a value is unrepresentable in a conforming
-/// type, the operation should return a sentinel value, such as NaN, or
-/// result in a runtime error.
+/// type, the operation should either trap or return an exceptional value. For
+/// example, using the negation operator (prefix `-`) with `Int.min` results in
+/// a runtime error.
+///
+///     let x = Int.min
+///     let y = -x
+///     // Overflow error
 public protocol SignedNumeric : Numeric {
   /// Returns the additive inverse of the specified value.
   ///
@@ -2631,7 +2661,7 @@ extension FixedWidthInteger {
   ///     // Prints "64"
   ///     // Prints "5"
   ///
-  /// This method is equivalent to calling the version that takes a generator, 
+  /// This method is equivalent to calling the version that takes a generator,
   /// passing in the system's default random generator.
   ///
   /// - Parameter range: The range in which to create a random value.

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -240,12 +240,12 @@ def operatorComment(operator, fixedWidth):
   ///   - rhs: The value to divide `lhs` by. `rhs` must not be zero.
 """,
         '&+': """\
-  /// Returns the sum of the two given values, discarding any overflow.
+  /// Returns the sum of the two given values, wrapping any overflow.
   ///
-  /// The masking addition operator (`&+`) silently discards any overflow that
+  /// The masking addition operator (`&+`) silently wraps any overflow that
   /// occurs during the operation. In the following example, the sum of `100`
   /// and `121` is greater than the maximum representable `Int8` value, so the
-  /// result is the overflowed value:
+  /// result is the wrapped overflow value:
   ///
   ///     let x: Int8 = 10 &+ 21
   ///     // x == 31
@@ -257,12 +257,12 @@ def operatorComment(operator, fixedWidth):
   ///   - rhs: The second value to add.
 """,
         '&-': """\
-  /// Returns the difference of the two given values, discarding any overflow.
+  /// Returns the difference of the two given values, wrapping any overflow.
   ///
-  /// The masking subtraction operator (`&-`) silently discards any overflow
+  /// The masking subtraction operator (`&-`) silently wraps any overflow
   /// that occurs during the operation. In the following example, the
   /// difference of `10` and `21` is less than zero, the minimum representable
-  /// `UInt` value, so the result is the overflowed value:
+  /// `UInt` value, so the result is the wrapped overflow value:
   ///
   ///     let x: UInt8 = 21 &- 10
   ///     // x == 11
@@ -274,12 +274,12 @@ def operatorComment(operator, fixedWidth):
   ///   - rhs: The value to subtract from `lhs`.
 """,
         '&*': """\
-  /// Returns the product of the two given values, discarding any overflow.
+  /// Returns the product of the two given values, wrapping any overflow.
   ///
-  /// The masking multiplication operator (`&*`) silently discards any overflow
+  /// The masking multiplication operator (`&*`) silently wraps any overflow
   /// that occurs during the operation. In the following example, the product
   /// of `10` and `50` is greater than the maximum representable `Int8` value,
-  /// so the result is the overflowed value:
+  /// so the result is the wrapped overflow value:
   ///
   ///     let x: Int8 = 10 &* 5
   ///     // x == 50
@@ -605,13 +605,13 @@ def assignmentOperatorComment(operator, fixedWidth):
   ///   - rhs: The value to divide `lhs` by. `rhs` must not be zero.
 """,
         '&+': """\
-  /// Adds two values and stores the result in the left-hand-side variable, 
-  /// discarding any overflow.
+  /// Adds two values and stores the result in the left-hand-side variable,
+  /// wrapping any overflow.
   ///
-  /// The masking addition assignment operator (`&+=`) silently discards any 
-  /// overflow that occurs during the operation. In the following example, the 
-  /// sum of `100` and `121` is greater than the maximum representable `Int8` 
-  /// value, so the result is the overflowed value:
+  /// The masking addition assignment operator (`&+=`) silently wraps any
+  /// overflow that occurs during the operation. In the following example, the
+  /// sum of `100` and `121` is greater than the maximum representable `Int8`
+  /// value, so the result is the wrapped overflow value:
   ///
   ///     var x: Int8 = 10
   ///     x &+= 21
@@ -626,12 +626,12 @@ def assignmentOperatorComment(operator, fixedWidth):
 """,
         '&-': """\
   /// Subtracts the second value from the first and stores the difference in the
-  /// left-hand-side variable, discarding any overflow.
+  /// left-hand-side variable, wrapping any overflow.
   ///
-  /// The masking subtraction assignment operator (`&-=`) silently discards any
+  /// The masking subtraction assignment operator (`&-=`) silently wraps any
   /// overflow that occurs during the operation. In the following example, the
   /// difference of `10` and `21` is less than zero, the minimum representable
-  /// `UInt` value, so the result is the overflowed value:
+  /// `UInt` value, so the result is the wrapped overflow value:
   ///
   ///     var x: Int8 = 21
   ///     x &-= 10
@@ -646,12 +646,12 @@ def assignmentOperatorComment(operator, fixedWidth):
 """,
         '&*': """\
   /// Multiplies two values and stores the result in the left-hand-side
-  /// variable, discarding any overflow.
+  /// variable, wrapping any overflow.
   ///
-  /// The masking multiplication assignment operator (`&*=`) silently discards 
-  /// any overflow that occurs during the operation. In the following example, 
-  /// the product of `10` and `50` is greater than the maximum representable 
-  /// `Int8` value, so the result is the overflowed value:
+  /// The masking multiplication assignment operator (`&*=`) silently wraps
+  /// any overflow that occurs during the operation. In the following example,
+  /// the product of `10` and `50` is greater than the maximum representable
+  /// `Int8` value, so the result is the wrapped overflow value:
   ///
   ///     var x: Int8 = 10
   ///     x &*= 5
@@ -1199,6 +1199,14 @@ public protocol SignedNumeric : Numeric {
   ///     var x = 21
   ///     x.negate()
   ///     // x == -21
+  ///
+  /// The resulting value must be representable within the value's type. In
+  /// particular, negating a signed, fixed-width integer type's minimum
+  /// results in a value that cannot be represented.
+  ///
+  ///     var y = Int8.min
+  ///     y.negate()
+  ///     // Overflow error
   mutating func negate()
 }
 
@@ -1235,6 +1243,14 @@ extension SignedNumeric {
   ///     var x = 21
   ///     x.negate()
   ///     // x == -21
+  ///
+  /// The resulting value must be representable within the value's type. In
+  /// particular, negating a signed, fixed-width integer type's minimum
+  /// results in a value that cannot be represented.
+  ///
+  ///     var y = Int8.min
+  ///     y.negate()
+  ///     // Overflow error
   @_transparent
   public mutating func negate() {
     self = 0 - self

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -223,7 +223,7 @@ def operatorComment(operator, fixedWidth):
   /// Returns the remainder of dividing the first value by the second.
   ///
   /// The result of the remainder operator (`%`) has the same sign as `lhs` and
-  /// is less than `abs(rhs)`.
+  /// is less than `rhs.magnitude`.
   ///
   ///     let x = 22 % 5
   ///     // x == 2

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -223,7 +223,7 @@ def operatorComment(operator, fixedWidth):
   /// Returns the remainder of dividing the first value by the second.
   ///
   /// The result of the remainder operator (`%`) has the same sign as `lhs` and
-  /// is less than `rhs.magnitude`.
+  /// is less than `abs(rhs)`.
   ///
   ///     let x = 22 % 5
   ///     // x == 2
@@ -242,15 +242,22 @@ def operatorComment(operator, fixedWidth):
         '&+': """\
   /// Returns the sum of the two given values, wrapping any overflow.
   ///
-  /// The masking addition operator (`&+`) silently wraps any overflow that
-  /// occurs during the operation. In the following example, the sum of `100`
-  /// and `121` is greater than the maximum representable `Int8` value, so the
-  /// result is the wrapped overflow value:
+  /// The overflow addition operator (`&+`) discards any bits that overflow the
+  /// fixed width of the integer type. In the following example, the sum of
+  /// `100` and `121` is greater than the maximum representable `Int8` value,
+  /// so the result is the partial value after discarding the overflowing
+  /// bits.
   ///
   ///     let x: Int8 = 10 &+ 21
   ///     // x == 31
   ///     let y: Int8 = 100 &+ 121
   ///     // y == -35 (after overflow)
+  ///
+  /// For more about arithmetic with overflow operators, see [Overflow
+  /// Operators][overflow] in [The Swift Programming Language][tspl].
+  ///
+  /// [overflow]: https://docs.swift.org/swift-book/LanguageGuide/AdvancedOperators.html#ID37
+  /// [tspl]: https://docs.swift.org/swift-book/
   ///
   /// - Parameters:
   ///   - lhs: The first value to add.
@@ -259,15 +266,22 @@ def operatorComment(operator, fixedWidth):
         '&-': """\
   /// Returns the difference of the two given values, wrapping any overflow.
   ///
-  /// The masking subtraction operator (`&-`) silently wraps any overflow
-  /// that occurs during the operation. In the following example, the
+  /// The overflow subtraction operator (`&-`) discards any bits that overflow
+  /// the fixed width of the integer type. In the following example, the
   /// difference of `10` and `21` is less than zero, the minimum representable
-  /// `UInt` value, so the result is the wrapped overflow value:
+  /// `UInt` value, so the result is the partial value after discarding the
+  /// overflowing bits.
   ///
   ///     let x: UInt8 = 21 &- 10
   ///     // x == 11
   ///     let y: UInt8 = 10 &- 21
   ///     // y == 245 (after overflow)
+  ///
+  /// For more about arithmetic with overflow operators, see [Overflow
+  /// Operators][overflow] in [The Swift Programming Language][tspl].
+  ///
+  /// [overflow]: https://docs.swift.org/swift-book/LanguageGuide/AdvancedOperators.html#ID37
+  /// [tspl]: https://docs.swift.org/swift-book/
   ///
   /// - Parameters:
   ///   - lhs: A numeric value.
@@ -276,15 +290,22 @@ def operatorComment(operator, fixedWidth):
         '&*': """\
   /// Returns the product of the two given values, wrapping any overflow.
   ///
-  /// The masking multiplication operator (`&*`) silently wraps any overflow
-  /// that occurs during the operation. In the following example, the product
-  /// of `10` and `50` is greater than the maximum representable `Int8` value,
-  /// so the result is the wrapped overflow value:
+  /// The overflow multiplication operator (`&*`) discards any bits that
+  /// overflow the fixed width of the integer type. In the following example,
+  /// the product of `10` and `50` is greater than the maximum representable
+  /// `Int8` value, so the result is the partial value after discarding the
+  /// overflowing bits.
   ///
   ///     let x: Int8 = 10 &* 5
   ///     // x == 50
   ///     let y: Int8 = 10 &* 50
   ///     // y == -12 (after overflow)
+  ///
+  /// For more about arithmetic with overflow operators, see [Overflow
+  /// Operators][overflow] in [The Swift Programming Language][tspl].
+  ///
+  /// [overflow]: https://docs.swift.org/swift-book/LanguageGuide/AdvancedOperators.html#ID37
+  /// [tspl]: https://docs.swift.org/swift-book/
   ///
   /// - Parameters:
   ///   - lhs: The first value to multiply.
@@ -1171,6 +1192,10 @@ ${operatorComment(x.operator, False)}
 /// declaring conformance to the protocol and ensuring that the values of your
 /// type support negation. To customize your type's implementation, provide
 /// your own mutating `negate()` method.
+///
+/// When the additive inverse of a value is unrepresentable in a conforming
+/// type, the operation should return a sentinel value, such as NaN, or
+/// result in a runtime error.
 public protocol SignedNumeric : Numeric {
   /// Returns the additive inverse of the specified value.
   ///
@@ -1690,7 +1715,7 @@ ${assignmentOperatorComment(x.nonMaskingOperator, False)}
   ///
   /// - Parameter rhs: The value to divide this value by.
   /// - Returns: A tuple containing the quotient and remainder of this value
-  ///   divided by `rhs`.
+  ///   divided by `rhs`. The remainder has the same sign as `rhs`.
   func quotientAndRemainder(dividingBy rhs: Self)
     -> (quotient: Self, remainder: Self)
 

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -328,8 +328,8 @@ extension Optional : Equatable where Wrapped : Equatable {
   ///     }
   ///     // Prints "The two groups start the same."
   ///
-  /// You can also use this operator to compare a non-optional value to an
-  /// optional that wraps the same type. The non-optional value is wrapped as an
+  /// You can also use this operator to compare a nonoptional value to an
+  /// optional that wraps the same type. The nonoptional value is wrapped as an
   /// optional before the comparison is made. In the following example, the
   /// `numberToMatch` constant is wrapped as an optional before comparing to the
   /// optional `numberFromString`:
@@ -384,8 +384,8 @@ extension Optional : Equatable where Wrapped : Equatable {
   ///     }
   ///     // Prints "The two groups start differently."
   ///
-  /// You can also use this operator to compare a non-optional value to an
-  /// optional that wraps the same type. The non-optional value is wrapped as an
+  /// You can also use this operator to compare a nonoptional value to an
+  /// optional that wraps the same type. The nonoptional value is wrapped as an
   /// optional before the comparison is made. In this example, the
   /// `numberToMatch` constant is wrapped as an optional before comparing to the
   /// optional `numberFromString`:
@@ -681,7 +681,7 @@ public func ?? <T>(optional: T?, defaultValue: @autoclosure () throws -> T)
 ///
 /// If `userPrefs[greetingKey]` has a value, that value is assigned to
 /// `greeting`. If not, any value in `defaults[greetingKey]` will succeed, and
-/// if not that, `greeting` will be set to the non-optional default value,
+/// if not that, `greeting` will be set to the nonoptional default value,
 /// `"Greetings!"`.
 ///
 /// - Parameters:

--- a/stdlib/public/core/Random.swift
+++ b/stdlib/public/core/Random.swift
@@ -41,8 +41,9 @@ import SwiftShims
 /// ================================================
 ///
 /// A custom `RandomNumberGenerator` type can have different characteristics
-/// than the default `Random` type. For example, a seedable generator can be
-/// used to generate the same sequence of random values for testing purposes.
+/// than the default `SystemRandomNumberGenerator` type. For example, a
+/// seedable generator can be used to generate a repeatable sequence of random
+/// values for testing purposes.
 ///
 /// To make a custom type conform to the `RandomNumberGenerator` protocol,
 /// implement the required `next()` method. Each call to `next()` must produce

--- a/stdlib/public/core/Random.swift
+++ b/stdlib/public/core/Random.swift
@@ -17,7 +17,7 @@ import SwiftShims
 /// When you call methods that use random data, such as creating new random
 /// values or shuffling a collection, you can pass a `RandomNumberGenerator`
 /// type to be used as the source for randomness. When you don't pass a
-/// generator, the default `Random` type is used.
+/// generator, the default `SystemRandomNumberGenerator` type is used.
 ///
 /// When providing new APIs that use randomness, provide a version that accepts
 /// a generator conforming to the `RandomNumberGenerator` protocol as well as a
@@ -32,7 +32,7 @@ import SwiftShims
 ///         }
 ///
 ///         static func random() -> Weekday {
-///             var g = SystemRandomGenerator()
+///             var g = SystemRandomNumberGenerator()
 ///             return Weekday.random(using: &g)
 ///         }
 ///     }
@@ -52,6 +52,11 @@ import SwiftShims
 /// the thread safety and quality of the generator.
 public protocol RandomNumberGenerator {
   /// Returns a value from a uniform, independent distribution of binary data.
+  ///
+  /// Use this method when you need random binary data to generate another
+  /// value. If you need an integer value within a specific range, use the
+  /// static `random(in:using:)` method on that integer type instead of this
+  /// method.
   ///
   /// - Returns: An unsigned 64-bit random value.
   mutating func next() -> UInt64
@@ -81,6 +86,11 @@ extension RandomNumberGenerator {
 extension RandomNumberGenerator {
   /// Returns a value from a uniform, independent distribution of binary data.
   ///
+  /// Use this method when you need random binary data to generate another
+  /// value. If you need an integer value within a specific range, use the
+  /// static `random(in:using:)` method on that integer type instead of this
+  /// method.
+  ///
   /// - Returns: A random value of `T`. Bits are randomly distributed so that
   ///   every value of `T` is equally likely to be returned.
   @inlinable
@@ -89,6 +99,11 @@ extension RandomNumberGenerator {
   }
 
   /// Returns a random value that is less than the given upper bound.
+  ///
+  /// Use this method when you need random binary data to generate another
+  /// value. If you need an integer value within a specific range, use the
+  /// static `random(in:using:)` method on that integer type instead of this
+  /// method.
   ///
   /// - Parameter upperBound: The upper bound for the randomly generated value.
   ///   Must be non-zero.
@@ -138,6 +153,7 @@ extension RandomNumberGenerator {
 ///   from `/dev/urandom`.
 @_fixed_layout
 public struct SystemRandomNumberGenerator : RandomNumberGenerator {
+  /// Creates a new instance of the system's default random number generator.
   @inlinable
   public init() { }
 

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -373,11 +373,11 @@ extension Range: Equatable {
   /// Two ranges are equal when they have the same lower and upper bounds.
   /// That requirement holds even for empty ranges.
   ///
-  ///     let x: Range = 5..<15
+  ///     let x = 5..<15
   ///     print(x == 5..<15)
   ///     // Prints "true"
   ///
-  ///     let y: Range = 5..<5
+  ///     let y = 5..<5
   ///     print(y == 15..<15)
   ///     // Prints "false"
   ///

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -244,7 +244,7 @@ public struct UnsafePointer<Pointee>: _Pointer {
   ///
   /// Use this method when you have a pointer to memory bound to one type and
   /// you need to access that memory as instances of another type. Accessing
-  /// memory as type `T` requires that the memory be bound to that type. A
+  /// memory as a type `T` requires that the memory be bound to that type. A
   /// memory location may only be bound to one type at a time, so accessing
   /// the same memory as an unrelated type without first rebinding the memory
   /// is undefined.
@@ -279,7 +279,7 @@ public struct UnsafePointer<Pointee>: _Pointer {
   ///   - type: The type to temporarily bind the memory referenced by this
   ///     pointer. The type `T` must be the same size and be layout compatible
   ///     with the pointer's `Pointee` type.
-  ///   - count: The number of instances of `T` to bind to `type`.
+  ///   - count: The number of instances of `Pointee` to bind to `type`.
   ///   - body: A closure that takes a  typed pointer to the
   ///     same memory as this pointer, only bound to type `T`. The closure's
   ///     pointer argument is valid only for the duration of the closure's
@@ -852,7 +852,7 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer {
   ///
   /// Use this method when you have a pointer to memory bound to one type and
   /// you need to access that memory as instances of another type. Accessing
-  /// memory as type `T` requires that the memory be bound to that type. A
+  /// memory as a type `T` requires that the memory be bound to that type. A
   /// memory location may only be bound to one type at a time, so accessing
   /// the same memory as an unrelated type without first rebinding the memory
   /// is undefined.
@@ -887,7 +887,7 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer {
   ///   - type: The type to temporarily bind the memory referenced by this
   ///     pointer. The type `T` must be the same size and be layout compatible
   ///     with the pointer's `Pointee` type.
-  ///   - count: The number of instances of `T` to bind to `type`.
+  ///   - count: The number of instances of `Pointee` to bind to `type`.
   ///   - body: A closure that takes a mutable typed pointer to the
   ///     same memory as this pointer, only bound to type `T`. The closure's
   ///     pointer argument is valid only for the duration of the closure's


### PR DESCRIPTION
- Fix error in `last(where:)` example
- Improve MemoryLayout, UnsafePointer, and integer operator discussions
