### PR TITLE
[Associated type inference] Eliminate unnecessary recursion on error.

### DIFF
--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -564,7 +564,7 @@ class ConformanceChecker : public WitnessChecker {
   ///
   /// \param typeDecl The decl the witness type came from; can be null.
   void recordTypeWitness(AssociatedTypeDecl *assocType, Type type,
-                         TypeDecl *typeDecl, bool performRedeclarationCheck);
+                         TypeDecl *typeDecl);
 
   /// Enforce restrictions on non-final classes witnessing requirements
   /// involving the protocol 'Self' type.

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1979,8 +1979,7 @@ void ConformanceChecker::resolveTypeWitnesses() {
   if (auto inferred = inference.solve(*this)) {
     for (const auto &inferredWitness : *inferred) {
       recordTypeWitness(inferredWitness.first, inferredWitness.second,
-                        /*typeDecl=*/nullptr,
-                        /*performRedeclarationCheck=*/true);
+                        /*typeDecl=*/nullptr);
     }
 
     ensureRequirementsAreSatisfied(/*failUnsubstituted=*/false);
@@ -1997,7 +1996,7 @@ void ConformanceChecker::resolveTypeWitnesses() {
     if (Conformance->hasTypeWitness(assocType))
       continue;
 
-    recordTypeWitness(assocType, ErrorType::get(TC.Context), nullptr, true);
+    recordTypeWitness(assocType, ErrorType::get(TC.Context), nullptr);
   }
 }
 


### PR DESCRIPTION
The original motivation for this change, which came in with a big refactor/rewrite in early 2015, is long gone, and it's causing extraneous recursion on ill-formed code.

Fixes rdar://problem/42312632.