### PR TITLE
[GSB] Use resolved type when looking for a representative constraint.

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -7062,7 +7062,7 @@ void GenericSignatureBuilder::checkSuperclassConstraints(
                               EquivalenceClass *equivClass) {
   assert(equivClass->superclass && "No superclass constraint?");
 
-  // Resolve any this-far-unresolved dependent types.
+  // Resolve any thus-far-unresolved dependent types.
   Type resolvedSuperclass =
     resolveDependentMemberTypes(*this, equivClass->superclass);
 
@@ -7075,13 +7075,13 @@ void GenericSignatureBuilder::checkSuperclassConstraints(
 
         Type resolvedType =
           resolveDependentMemberTypes(*this, constraint.value);
-        return resolvedType->isEqual(equivClass->superclass);
+        return resolvedType->isEqual(resolvedSuperclass);
       },
       [&](const Constraint<Type> &constraint) {
         Type superclass = constraint.value;
 
         // If this class is a superclass of the "best"
-        if (superclass->isExactSuperclassOf(equivClass->superclass))
+        if (superclass->isExactSuperclassOf(resolvedSuperclass))
           return ConstraintRelation::Redundant;
 
         // Otherwise, it conflicts.
@@ -7091,7 +7091,7 @@ void GenericSignatureBuilder::checkSuperclassConstraints(
       diag::redundant_superclass_constraint,
       diag::superclass_redundancy_here);
 
-  // Resolve any this-far-unresolved dependent types.
+  // Record the resolved superclass type.
   equivClass->superclass = resolvedSuperclass;
 
   // If we have a concrete type, check it.

--- a/validation-test/compiler_crashers_2_fixed/0169-sr8179.swift
+++ b/validation-test/compiler_crashers_2_fixed/0169-sr8179.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -emit-sil %s
+
+protocol SignalInterface {
+	associatedtype OutputValue
+}
+
+class Signal<OV>: SignalInterface {
+  typealias OutputValue = OV
+}
+
+extension Signal {
+  func foo<U>(_: U) -> SignalChannel<[U], Signal<Array<U>>>
+    where OutputValue == Optional<U> { return SignalChannel() }
+}
+
+struct SignalChannel<OutputValue, Output: Signal<OutputValue>> { }
+


### PR DESCRIPTION
When looking for a representative superclass constraint, take into
account other same-type constraints by comparing against the resolved
superclass constraint type rather than the type as spelled.

Fixes SR-8179 / rdar://problem/41851224.