### PR TITLE
Unify linker argument order across platforms

### DIFF
--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -475,9 +475,9 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
 
   Arguments.push_back("-no_objc_category_merging");
 
-  // These custom arguments should be right before the object file at the end
-  context.Args.AddAllArgValues(Arguments, options::OPT_Xlinker);
+  // These custom arguments should be right before the object file at the end.
   context.Args.AddAllArgs(Arguments, options::OPT_linker_option_Group);
+  context.Args.AddAllArgValues(Arguments, options::OPT_Xlinker);
 
   // This should be the last option, for convenience in checking output.
   Arguments.push_back("-o");

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -339,8 +339,6 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
     }
   }
 
-  context.Args.AddAllArgValues(Arguments, options::OPT_Xlinker);
-  context.Args.AddAllArgs(Arguments, options::OPT_linker_option_Group);
   for (const Arg *arg :
        context.Args.filtered(options::OPT_F, options::OPT_Fsystem)) {
     Arguments.push_back("-F");
@@ -476,6 +474,10 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
   }
 
   Arguments.push_back("-no_objc_category_merging");
+
+  // These custom arguments should be right before the object file at the end
+  context.Args.AddAllArgValues(Arguments, options::OPT_Xlinker);
+  context.Args.AddAllArgs(Arguments, options::OPT_linker_option_Group);
 
   // This should be the last option, for convenience in checking output.
   Arguments.push_back("-o");

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -210,9 +210,6 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
   SmallString<128> StaticRuntimeLibPath;
   getRuntimeLibraryPath(StaticRuntimeLibPath, context.Args, /*Shared=*/false);
 
-  context.Args.AddAllArgs(Arguments, options::OPT_Xlinker);
-  context.Args.AddAllArgs(Arguments, options::OPT_linker_option_Group);
-
   // Add the runtime library link path, which is platform-specific and found
   // relative to the compiler.
   if (!(staticExecutable || staticStdlib) && shouldProvideRPathToLinker()) {
@@ -324,6 +321,10 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
   if (context.Args.hasArg(options::OPT_v)) {
     Arguments.push_back("-v");
   }
+
+  // These custom arguments should be right before the object file at the end
+  context.Args.AddAllArgs(Arguments, options::OPT_Xlinker);
+  context.Args.AddAllArgs(Arguments, options::OPT_linker_option_Group);
 
   // This should be the last option, for convenience in checking output.
   Arguments.push_back("-o");

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -210,6 +210,9 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
   SmallString<128> StaticRuntimeLibPath;
   getRuntimeLibraryPath(StaticRuntimeLibPath, context.Args, /*Shared=*/false);
 
+  context.Args.AddAllArgs(Arguments, options::OPT_Xlinker);
+  context.Args.AddAllArgs(Arguments, options::OPT_linker_option_Group);
+
   // Add the runtime library link path, which is platform-specific and found
   // relative to the compiler.
   if (!(staticExecutable || staticStdlib) && shouldProvideRPathToLinker()) {
@@ -316,9 +319,6 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
     Arguments.push_back(context.Args.MakeArgString(
         Twine("-u", llvm::getInstrProfRuntimeHookVarName())));
   }
-
-  context.Args.AddAllArgs(Arguments, options::OPT_Xlinker);
-  context.Args.AddAllArgs(Arguments, options::OPT_linker_option_Group);
 
   // Run clang++ in verbose mode if "-v" is set
   if (context.Args.hasArg(options::OPT_v)) {

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -322,9 +322,9 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
     Arguments.push_back("-v");
   }
 
-  // These custom arguments should be right before the object file at the end
-  context.Args.AddAllArgs(Arguments, options::OPT_Xlinker);
+  // These custom arguments should be right before the object file at the end.
   context.Args.AddAllArgs(Arguments, options::OPT_linker_option_Group);
+  context.Args.AddAllArgs(Arguments, options::OPT_Xlinker);
 
   // This should be the last option, for convenience in checking output.
   Arguments.push_back("-o");

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -43,6 +43,12 @@
 // RUN: %FileCheck %s < %t.complex.txt
 // RUN: %FileCheck -check-prefix COMPLEX %s < %t.complex.txt
 
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-ios7.1 -Xlinker -rpath -Xlinker customrpath %s 2>&1 > %t.simple.txt
+// RUN: %FileCheck -check-prefix IOS-custom-rpath %s < %t.simple.txt
+
+// RUN: %swiftc_driver -driver-print-jobs -target armv7-unknown-linux-gnueabihf -Xlinker -rpath -Xlinker customrpath %s 2>&1 > %t.linux.txt
+// RUN: %FileCheck -check-prefix LINUX-custom-rpath %s < %t.linux.txt
+
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 -g %s | %FileCheck -check-prefix DEBUG %s
 
 // RUN: %empty-directory(%t)
@@ -276,6 +282,7 @@
 // LINUX_DYNLIB-x86_64: clang++{{"? }}
 // LINUX_DYNLIB-x86_64-DAG: -shared
 // LINUX_DYNLIB-x86_64-DAG: -fuse-ld=gold
+// LINUX_DYNLIB-x86_64-DAG: -L bar
 // LINUX_DYNLIB-x86_64-NOT: -pie
 // LINUX_DYNLIB-x86_64-DAG: -Xlinker -rpath -Xlinker [[STDLIB_PATH:[^ ]+/lib/swift/linux]]
 // LINUX_DYNLIB-x86_64: [[STDLIB_PATH]]/x86_64/swiftrt.o
@@ -283,8 +290,21 @@
 // LINUX_DYNLIB-x86_64-DAG: @[[AUTOLINKFILE]]
 // LINUX_DYNLIB-x86_64-DAG: [[STDLIB_PATH]]
 // LINUX_DYNLIB-x86_64-DAG: -lswiftCore
-// LINUX_DYNLIB-x86_64-DAG: -L bar
 // LINUX_DYNLIB-x86_64: -o dynlib.out
+
+// IOS-custom-rpath: swift
+// IOS-custom-rpath: -o [[OBJECTFILE:.*]]
+
+// IOS-custom-rpath: bin/ld{{"? }}
+// IOS-custom-rpath: -rpath customrpath
+// IOS-custom-rpath: -rpath [[STDLIB_PATH:[^ ]+/lib/swift/iphonesimulator]]
+
+// LINUX-custom-rpath: swift
+// LINUX-custom-rpath: -o [[OBJECTFILE:.*]]
+
+// LINUX-custom-rpath: clang++{{"? }}
+// LINUX-custom-rpath: -Xlinker -rpath -Xlinker customrpath
+// LINUX-custom-rpath: -Xlinker -rpath -Xlinker [[STDLIB_PATH:[^ ]+/lib/swift/linux]]
 
 // DEBUG: bin/swift
 // DEBUG-NEXT: bin/swift

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -282,7 +282,6 @@
 // LINUX_DYNLIB-x86_64: clang++{{"? }}
 // LINUX_DYNLIB-x86_64-DAG: -shared
 // LINUX_DYNLIB-x86_64-DAG: -fuse-ld=gold
-// LINUX_DYNLIB-x86_64-DAG: -L bar
 // LINUX_DYNLIB-x86_64-NOT: -pie
 // LINUX_DYNLIB-x86_64-DAG: -Xlinker -rpath -Xlinker [[STDLIB_PATH:[^ ]+/lib/swift/linux]]
 // LINUX_DYNLIB-x86_64: [[STDLIB_PATH]]/x86_64/swiftrt.o
@@ -290,21 +289,24 @@
 // LINUX_DYNLIB-x86_64-DAG: @[[AUTOLINKFILE]]
 // LINUX_DYNLIB-x86_64-DAG: [[STDLIB_PATH]]
 // LINUX_DYNLIB-x86_64-DAG: -lswiftCore
+// LINUX_DYNLIB-x86_64-DAG: -L bar
 // LINUX_DYNLIB-x86_64: -o dynlib.out
 
 // IOS-custom-rpath: swift
 // IOS-custom-rpath: -o [[OBJECTFILE:.*]]
 
 // IOS-custom-rpath: bin/ld{{"? }}
-// IOS-custom-rpath: -rpath customrpath
 // IOS-custom-rpath: -rpath [[STDLIB_PATH:[^ ]+/lib/swift/iphonesimulator]]
+// IOS-custom-rpath: -rpath customrpath
+// IOS-custom-rpath: -o {{.*}}
 
 // LINUX-custom-rpath: swift
 // LINUX-custom-rpath: -o [[OBJECTFILE:.*]]
 
 // LINUX-custom-rpath: clang++{{"? }}
+// LINUX-custom-rpath: -Xlinker -rpath -Xlinker {{[^ ]+/lib/swift/linux}}
 // LINUX-custom-rpath: -Xlinker -rpath -Xlinker customrpath
-// LINUX-custom-rpath: -Xlinker -rpath -Xlinker [[STDLIB_PATH:[^ ]+/lib/swift/linux]]
+// LINUX-custom-rpath: -o {{.*}}
 
 // DEBUG: bin/swift
 // DEBUG-NEXT: bin/swift

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -43,11 +43,11 @@
 // RUN: %FileCheck %s < %t.complex.txt
 // RUN: %FileCheck -check-prefix COMPLEX %s < %t.complex.txt
 
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-ios7.1 -Xlinker -rpath -Xlinker customrpath %s 2>&1 > %t.simple.txt
-// RUN: %FileCheck -check-prefix IOS-custom-rpath %s < %t.simple.txt
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-ios7.1 -Xlinker -rpath -Xlinker customrpath -L foo %s 2>&1 > %t.simple.txt
+// RUN: %FileCheck -check-prefix IOS-linker-order %s < %t.simple.txt
 
-// RUN: %swiftc_driver -driver-print-jobs -target armv7-unknown-linux-gnueabihf -Xlinker -rpath -Xlinker customrpath %s 2>&1 > %t.linux.txt
-// RUN: %FileCheck -check-prefix LINUX-custom-rpath %s < %t.linux.txt
+// RUN: %swiftc_driver -driver-print-jobs -target armv7-unknown-linux-gnueabihf -Xlinker -rpath -Xlinker customrpath -L foo %s 2>&1 > %t.linux.txt
+// RUN: %FileCheck -check-prefix LINUX-linker-order %s < %t.linux.txt
 
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 -g %s | %FileCheck -check-prefix DEBUG %s
 
@@ -292,21 +292,23 @@
 // LINUX_DYNLIB-x86_64-DAG: -L bar
 // LINUX_DYNLIB-x86_64: -o dynlib.out
 
-// IOS-custom-rpath: swift
-// IOS-custom-rpath: -o [[OBJECTFILE:.*]]
+// IOS-linker-order: swift
+// IOS-linker-order: -o [[OBJECTFILE:.*]]
 
-// IOS-custom-rpath: bin/ld{{"? }}
-// IOS-custom-rpath: -rpath [[STDLIB_PATH:[^ ]+/lib/swift/iphonesimulator]]
-// IOS-custom-rpath: -rpath customrpath
-// IOS-custom-rpath: -o {{.*}}
+// IOS-linker-order: bin/ld{{"? }}
+// IOS-linker-order: -rpath [[STDLIB_PATH:[^ ]+/lib/swift/iphonesimulator]]
+// IOS-linker-order: -L foo
+// IOS-linker-order: -rpath customrpath
+// IOS-linker-order: -o {{.*}}
 
-// LINUX-custom-rpath: swift
-// LINUX-custom-rpath: -o [[OBJECTFILE:.*]]
+// LINUX-linker-order: swift
+// LINUX-linker-order: -o [[OBJECTFILE:.*]]
 
-// LINUX-custom-rpath: clang++{{"? }}
-// LINUX-custom-rpath: -Xlinker -rpath -Xlinker {{[^ ]+/lib/swift/linux}}
-// LINUX-custom-rpath: -Xlinker -rpath -Xlinker customrpath
-// LINUX-custom-rpath: -o {{.*}}
+// LINUX-linker-order: clang++{{"? }}
+// LINUX-linker-order: -Xlinker -rpath -Xlinker {{[^ ]+/lib/swift/linux}}
+// LINUX-linker-order: -L foo
+// LINUX-linker-order: -Xlinker -rpath -Xlinker customrpath
+// LINUX-linker-order: -o {{.*}}
 
 // DEBUG: bin/swift
 // DEBUG-NEXT: bin/swift


### PR DESCRIPTION
Previously extra linker arguments had different behavior on darwin vs
other unix platforms. On darwin the arguments passed with -Xlinker would
be passed to the linker before the default arguments, where as with the
default unix toolchain they would be passed afterwards.

There isn't really a great option for which order these should be in.
If you want to have a custom rpath that takes precedence over the
default rpaths, you want them to be passed before, but if you want to
negate a default argument you want them to come after.

This change unifies the behavior so at least you always get the same
behavior across platforms.

Resolves [SR-6508](https://bugs.swift.org/browse/SR-6508).