### PR TITLE
initial work on using new folder for constant propagation

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -342,6 +342,12 @@ ERROR(wrong_non_negative_assumption,none,
 ERROR(shifting_all_significant_bits,none,
       "shift amount is greater than or equal to type size in bits", ())
 
+// Arithmetic diagnostics from the new constant folder.
+// These are temporarily less detailed than the diagnostics from the old
+// constant folder, so that we can incrementally work on the new one.
+ERROR(new_folder_overflow,none,
+      "operation overflows", ())
+
 // FIXME: We won't need this as it will be replaced with user-generated strings.
 // staticReport diagnostics.
 ERROR(static_report_error, none,

--- a/lib/SILOptimizer/Mandatory/ConstantPropagation.cpp
+++ b/lib/SILOptimizer/Mandatory/ConstantPropagation.cpp
@@ -18,8 +18,7 @@
 
 using namespace swift;
 
-static llvm::cl::opt<bool>
-ConstantPropagationUseNewFolder(
+static llvm::cl::opt<bool> ConstantPropagationUseNewFolder(
     "constant-propagation-use-new-folder", llvm::cl::init(false),
     llvm::cl::desc("Use new folder in ConstantPropagation passes"));
 
@@ -43,8 +42,8 @@ private:
 
     if (ConstantPropagationUseNewFolder) {
       tf::ConstExprEvaluator evaluator(getFunction()->getModule());
-      Invalidation = evaluator.propagateConstants(*getFunction(),
-                                                  EnableDiagnostics);
+      Invalidation =
+          evaluator.propagateConstants(*getFunction(), EnableDiagnostics);
     } else {
       ConstantFolder Folder(getOptions().AssertConfig, EnableDiagnostics);
       Folder.initializeWorklist(*getFunction());

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
@@ -114,9 +114,7 @@ public:
       : evaluator(evaluator), fn(fn), substitutionMap(substitutionMap),
         numInstEvaluated(numInstEvaluated) {}
 
-  void eraseValue(SILValue value) {
-    calculatedValues.erase(value);
-  }
+  void eraseValue(SILValue value) { calculatedValues.erase(value); }
 
   void setValue(SILValue value, SymbolicValue symVal) {
     calculatedValues.insert({value, symVal});
@@ -1490,9 +1488,9 @@ void ConstExprEvaluator::computeConstantValues(
 ///
 /// Some constant values are not supported. Does nothing and returns nullptr for
 /// unsupported values.
-static SingleValueInstruction *
-emitConstantInst(SymbolicValue symVal, SILType type, SILLocation loc,
-                        SILBuilder &B) {
+static SingleValueInstruction *emitConstantInst(SymbolicValue symVal,
+                                                SILType type, SILLocation loc,
+                                                SILBuilder &B) {
   assert(symVal.isConstant() && "Not a constant value");
 
   switch (symVal.getKind()) {
@@ -1519,11 +1517,11 @@ emitConstantInst(SymbolicValue symVal, SILType type, SILLocation loc,
 
 /// If `value` is guaranteed to trap (e.g. overflow), then emit a diagnostic.
 /// TODO: More diagnostics, and more detailed diagnostics.
-static void
-emitConstantPropagationDiagnostic(SILValue value, SymbolicValue symVal,
-                                  DiagnosticEngine &diags,
-                                  ConstExprEvaluator &evaluator,
-                                  ConstExprFunctionState &state) {
+static void emitConstantPropagationDiagnostic(SILValue value,
+                                              SymbolicValue symVal,
+                                              DiagnosticEngine &diags,
+                                              ConstExprEvaluator &evaluator,
+                                              ConstExprFunctionState &state) {
   if (!symVal.isUnknown())
     return;
 
@@ -1564,9 +1562,8 @@ ConstExprEvaluator::propagateConstants(SILFunction &F, bool EnableDiagnostics) {
       auto symVal = state.getConstantValue(value);
 
       if (EnableDiagnostics) {
-        emitConstantPropagationDiagnostic(value, symVal,
-                                          M.getASTContext().Diags, *this,
-                                          state);
+        emitConstantPropagationDiagnostic(
+            value, symVal, M.getASTContext().Diags, *this, state);
       }
 
       // If it's possible and useful to replace the original instruction with
@@ -1599,7 +1596,8 @@ ConstExprEvaluator::propagateConstants(SILFunction &F, bool EnableDiagnostics) {
   using InvalidationKind = SILAnalysis::InvalidationKind;
 
   unsigned Inv = InvalidationKind::Nothing;
-  if (InvalidateInstructions) Inv |= (unsigned) InvalidationKind::Instructions;
+  if (InvalidateInstructions)
+    Inv |= (unsigned)InvalidationKind::Instructions;
 
   return InvalidationKind(Inv);
 }

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.h
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.h
@@ -88,10 +88,10 @@ public:
   /// Propagates constants through the passed-in function, mutating the function
   /// wherever it can replace instructions with constant instructions.
   ///
-  /// If EnableDiagnostics is true, then emits diagnostics on operations that are
-  /// guaranteed to trap (e.g. operations that cause overflows).
-  SILAnalysis::InvalidationKind
-  propagateConstants(SILFunction &F, bool EnableDiagnostics);
+  /// If EnableDiagnostics is true, then emits diagnostics on operations that
+  /// are guaranteed to trap (e.g. operations that cause overflows).
+  SILAnalysis::InvalidationKind propagateConstants(SILFunction &F,
+                                                   bool EnableDiagnostics);
 
   /// Try to decode the specified apply of the _allocateUninitializedArray
   /// function in the standard library.  This attempts to figure out what the

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.h
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.h
@@ -26,6 +26,7 @@
 
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/SourceLoc.h"
+#include "swift/SILOptimizer/Analysis/Analysis.h"
 #include "llvm/Support/Allocator.h"
 
 namespace swift {
@@ -48,6 +49,8 @@ class ConstExprEvaluator {
 
   /// The current call stack, used for providing accurate diagnostics.
   llvm::SmallVector<SourceLoc, 4> callStack;
+
+  SILModule &M;
 
   ConstExprEvaluator(const ConstExprEvaluator &) = delete;
   void operator=(const ConstExprEvaluator &) = delete;
@@ -81,6 +84,14 @@ public:
   /// that occur after after folding them.
   void computeConstantValues(ArrayRef<SILValue> values,
                              SmallVectorImpl<SymbolicValue> &results);
+
+  /// Propagates constants through the passed-in function, mutating the function
+  /// wherever it can replace instructions with constant instructions.
+  ///
+  /// If EnableDiagnostics is true, then emits diagnostics on operations that are
+  /// guaranteed to trap (e.g. operations that cause overflows).
+  SILAnalysis::InvalidationKind
+  propagateConstants(SILFunction &F, bool EnableDiagnostics);
 
   /// Try to decode the specified apply of the _allocateUninitializedArray
   /// function in the standard library.  This attempts to figure out what the

--- a/test/SILOptimizer/new_folder_constant_propagation.sil
+++ b/test/SILOptimizer/new_folder_constant_propagation.sil
@@ -1,0 +1,399 @@
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -diagnostic-constant-propagation -constant-propagation-use-new-folder | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -performance-constant-propagation -constant-propagation-use-new-folder | %FileCheck %s
+
+// This is a copy of ./constant_propagation.sil, modified to run with the new
+// folder.
+//
+// Comments marked FIXME(new_folder) describe problems with the new folder.
+
+import Swift
+import Builtin
+
+struct UInt {
+  var value: Builtin.Word
+}
+struct Int {
+  var value: Builtin.Word
+}
+struct Bool {
+  var value: Builtin.Int1
+}
+struct Int64 {
+  var value: Builtin.Int64
+}
+struct UInt64 {
+  var value: Builtin.Int64
+}
+
+// FIXME(new_folder): Deleted count_leading_zeros_corner_case
+// FIXME(new_folder): Deleted count_leading_zeros
+// FIXME(new_folder): Deleted fold_arithmetic_with_overflow
+
+// Fold casts. (This test assumes that DCE does not run, otherwise the unreachable blocks will get removed.)
+sil @fold_trunc : $@convention(thin) () -> Builtin.Int64 {
+bb0:
+ %0 = integer_literal $Builtin.Int128, 22
+ %2 = builtin "trunc_Int128_Int64"(%0 : $Builtin.Int128) : $Builtin.Int64
+ br bb4(%2 : $Builtin.Int64)
+
+bb1:
+ %3 = integer_literal $Builtin.Int8, 23
+ %5 = builtin "sext_Int8_Int64"(%3 : $Builtin.Int8) : $Builtin.Int64
+ br bb4(%5 : $Builtin.Int64)
+
+bb2:
+ %6 = integer_literal $Builtin.Int8, 24
+ %8 = builtin "zext_Int8_Int64"(%6 : $Builtin.Int8) : $Builtin.Int64
+ br bb4(%8 : $Builtin.Int64)
+
+bb4(%100 : $Builtin.Int64):
+ return %100 : $Builtin.Int64
+// CHECK-LABEL: sil @fold_trunc
+// CHECK-NOT: integer_literal $Builtin.Int128, 22
+// CHECK: integer_literal $Builtin.Int64, 22
+// CHECK-NOT: integer_literal $Builtin.Int8, 23
+// CHECK: integer_literal $Builtin.Int64, 23
+// CHECK-NOT: integer_literal $Builtin.Int8, 24
+// CHECK: integer_literal $Builtin.Int64, 24
+}
+
+sil @test_tuple_extract_folding : $@convention(thin) () -> Builtin.Int64 {
+bb0:
+  %0 = integer_literal $Builtin.Int64, 5
+  %1 = integer_literal $Builtin.Int1, 0
+  %2 = tuple (%0 : $Builtin.Int64, %1 : $Builtin.Int1)
+  %3 = tuple_extract %2 : $(Builtin.Int64, Builtin.Int1), 0
+  return %3 : $Builtin.Int64
+// CHECK-LABEL: sil @test_tuple_extract_folding
+// CHECK: bb0:
+// CHECK-NEXT: %0 = integer_literal $Builtin.Int64, 5
+// CHECK-NEXT: return %0 : $Builtin.Int64
+// CHECK-NEXT: }
+}
+
+sil @test_struct_extract_folding_first : $@convention(thin) () -> Builtin.Int64 {
+bb0:
+  %0 = integer_literal $Builtin.Int64, 2
+  %1 = struct $Int64 (%0 : $Builtin.Int64)
+  %2 = struct_extract %1 : $Int64, #Int64.value
+  return %2 : $Builtin.Int64
+// CHECK-LABEL: sil @test_struct_extract_folding_first
+// CHECK: bb0:
+// CHECK-NEXT: %0 = integer_literal $Builtin.Int64, 2
+// CHECK-NEXT: return %0 : $Builtin.Int64
+// CHECK-NEXT: }
+}
+
+struct TwoValueStruct {
+  var a : Builtin.Int64
+  var b : Builtin.Int64
+}
+
+sil @test_struct_extract_folding_second : $@convention(thin) () -> Builtin.Int64 {
+bb0:
+  %0 = integer_literal $Builtin.Int64, 2
+  %1 = integer_literal $Builtin.Int64, 20
+  %2 = struct $TwoValueStruct (%0 : $Builtin.Int64, %1 : $Builtin.Int64)
+  %3 = struct_extract %2 : $TwoValueStruct, #TwoValueStruct.b
+  return %3 : $Builtin.Int64
+// CHECK-LABEL: sil @test_struct_extract_folding_second
+// CHECK: bb0:
+// CHECK-NEXT: %0 = integer_literal $Builtin.Int64, 20
+// CHECK-NEXT: return %0 : $Builtin.Int64
+// CHECK-NEXT: }
+}
+
+// FIXME(new_folder): Deleted test_struct_extract_folding_third
+
+sil @testChainingCCP : $@convention(thin) () -> Builtin.Int1 {
+bb0:
+  %2 = integer_literal $Builtin.Int64, 0
+  %3 = struct $Int64 (%2 : $Builtin.Int64)
+  %4 = struct_extract %3 : $Int64, #Int64.value
+  %5 = builtin "trunc_Int64_Int1"(%4 : $Builtin.Int64) : $Builtin.Int1
+  return %5 : $Builtin.Int1
+
+// CHECK-LABEL: sil @testChainingCCP
+// CHECK: bb0:
+// CHECK-NEXT: %0 = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: return %0 : $Builtin.Int1
+// CHECK-NEXT: }
+}
+
+sil @testDivision : $@convention(thin) () -> Builtin.Int8 {
+bb0:
+  %1 = integer_literal $Builtin.Int8, 6
+  %2 = integer_literal $Builtin.Int8, 3
+  %3 = builtin "sdiv_Int8"(%1: $Builtin.Int8, %2: $Builtin.Int8) : $Builtin.Int8
+  return %3 : $Builtin.Int8
+
+// CHECK-LABEL: sil @testDivision
+// CHECK: bb0:
+// CHECK-NEXT: %0 = integer_literal $Builtin.Int8, 2
+// CHECK-NEXT: return %0 : $Builtin.Int8
+// CHECK-NEXT: }
+}
+
+sil @testRem : $@convention(thin) () -> Builtin.Int64 {
+bb0:
+  %1 = integer_literal $Builtin.Int64, 10
+  %2 = integer_literal $Builtin.Int64, 2
+  %3 = builtin "urem_Int64"(%1 : $Builtin.Int64, %2 : $Builtin.Int64) : $Builtin.Int64
+  return %3 : $Builtin.Int64
+
+// CHECK-LABEL: sil @testRem
+// CHECK: bb0:
+// CHECK-NEXT: %0 = integer_literal $Builtin.Int64, 0
+// CHECK-NEXT: return %0 : $Builtin.Int64
+// CHECK-NEXT: }
+}
+
+// FIXME(new_folder): Deleted testFoldingNonNegativeSignedInt
+
+sil @testFoldingIntBinaryPredicates : $@convention(thin) (Builtin.Int32) -> () {
+bb0(%0 : $Builtin.Int32):
+  %1 = integer_literal $Builtin.Int1, 1
+  %2 = integer_literal $Builtin.Int1, 0
+  // This is Int32.Max
+  %3 = integer_literal $Builtin.Int32, 2147483647 
+  %4 = builtin "cmp_eq_Int1"(%1 : $Builtin.Int1, %2 : $Builtin.Int1) : $Builtin.Int1
+  %11 = integer_literal $Builtin.Int32, 21
+  %12 = integer_literal $Builtin.Int32, 12
+  %14 = builtin "cmp_ne_Int32"(%11 : $Builtin.Int32, %12 : $Builtin.Int32) : $Builtin.Int1
+  %16 = builtin "cmp_sgt_Int32"(%12 : $Builtin.Int32, %11 : $Builtin.Int32) : $Builtin.Int1
+  %17 = builtin "cmp_ult_Int32"(%12 : $Builtin.Int32, %11 : $Builtin.Int32) : $Builtin.Int1
+  // Int32.Max < x
+  %18 = builtin "cmp_slt_Int32"(%3 : $Builtin.Int32, %0 : $Builtin.Int32) : $Builtin.Int1
+  // x > Int32.Max
+  %19 = builtin "cmp_sgt_Int32"(%0 : $Builtin.Int32, %3 : $Builtin.Int32) : $Builtin.Int1
+  // Int32.Max >= x
+  %20 = builtin "cmp_sge_Int32"(%3 : $Builtin.Int32, %0 : $Builtin.Int32) : $Builtin.Int1
+  // x <= Int32.Max
+  %21 = builtin "cmp_sle_Int32"(%0 : $Builtin.Int32, %3 : $Builtin.Int32) : $Builtin.Int1
+
+  %5 = tuple ()
+  return %5 : $()
+// CHECK-LABEL: sil @testFoldingIntBinaryPredicates
+// CHECK: bb
+//
+// FIXME(new_folder): The following inst should be deleted
+// CHECK-NEXT: integer_literal $Builtin.Int32, 2147483647
+//
+// CHECK-NEXT: integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: integer_literal $Builtin.Int1, -1
+// CHECK-NEXT: integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: integer_literal $Builtin.Int1, -1
+//
+// FIXME(new_folder): The following 4 insts should have gotten folded
+// CHECK-NEXT: builtin
+// CHECK-NEXT: builtin
+// CHECK-NEXT: builtin
+// CHECK-NEXT: builtin
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
+}
+
+// FIXME(new_folder): Deleted testFoldingUnsignedIntComparisons
+
+// fold_binary_bitwise
+sil @fold_binary_bitwise : $@convention(thin) () -> Builtin.Int64 {
+bb0:
+  %0 = integer_literal $Builtin.Int64, 1          // users: %7, %6, %5
+  %1 = integer_literal $Builtin.Int64, 0          // users: %7, %6, %5
+  %5 = builtin "and_Int64"(%0 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int64
+  %6 = builtin "or_Int64"(%0 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int64
+  %7 = builtin "xor_Int64"(%0 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int64 // user: %8
+  return %7 : $Builtin.Int64                      // id: %8
+
+// CHECK-LABEL: sil @fold_binary_bitwise
+// CHECK: bb0:
+// CHECK-NEXT: %0 = integer_literal $Builtin.Int64, 0
+// CHECK_NEXT: %1 = integer_literal $Builtin.Int64, 1
+// CHECK_NEXT: %2 = integer_literal $Builtin.Int64, 1
+// CHECK_NEXT: return %2 : $Builtin.Int64
+}
+
+// FIXME(new_folder): Deleted fold_cmp_lshr_with_IntMax
+
+// fold_shifts
+sil @fold_shifts : $@convention(thin) () -> Builtin.Int64 {
+bb0:
+  %0 = integer_literal $Builtin.Int64, -32        // users: %9, %8
+  %1 = integer_literal $Builtin.Int64, 32         // users: %11, %10
+  %2 = integer_literal $Builtin.Int64, 3          // users: %11, %10, %9, %8
+  %3 = integer_literal $Builtin.Int64, 1          // user: %12
+  %4 = integer_literal $Builtin.Int64, 5          // user: %12
+  %8 = builtin "ashr_Int64"(%0 : $Builtin.Int64, %2 : $Builtin.Int64) : $Builtin.Int64
+  %9 = builtin "lshr_Int64"(%0 : $Builtin.Int64, %2 : $Builtin.Int64) : $Builtin.Int64
+  %10 = builtin "ashr_Int64"(%1 : $Builtin.Int64, %2 : $Builtin.Int64) : $Builtin.Int64
+  %11 = builtin "lshr_Int64"(%1 : $Builtin.Int64, %2 : $Builtin.Int64) : $Builtin.Int64
+  %12 = builtin "shl_Int64"(%3 : $Builtin.Int64, %4 : $Builtin.Int64) : $Builtin.Int64 // user: %13
+  return %12 : $Builtin.Int64                     // id: %13
+
+// CHECK-LABEL: sil @fold_shifts
+// CHECK: bb0:
+// CHECK-NEXT: %0 = integer_literal $Builtin.Int64, -4
+// CHECK-NEXT: %1 = integer_literal $Builtin.Int64, 2305843009213693948
+// CHECK-NEXT: %2 = integer_literal $Builtin.Int64, 4
+// CHECK-NEXT: %3 = integer_literal $Builtin.Int64, 4
+// CHECK-NEXT: %4 = integer_literal $Builtin.Int64, 32
+// CHECK-NEXT: return %4 : $Builtin.Int64
+}
+
+// FIXME(new_folder): Deleted fold_unsigned_op_with_overflow_lt_zero
+
+// fold_float_operations
+sil @fold_float_operations : $@convention(thin) () -> Builtin.FPIEEE64 {
+bb0:
+  %4 = float_literal $Builtin.FPIEEE64, 0x402E4CCCCCCCCCCD // 15.15
+  %11 = float_literal $Builtin.FPIEEE64, 0x400A666666666666 // 3.2999999999999998 // user: %12
+  %8 = builtin "fadd_FPIEEE64"(%4 : $Builtin.FPIEEE64, %11 : $Builtin.FPIEEE64) : $Builtin.FPIEEE64
+  %9 = builtin "fdiv_FPIEEE64"(%4 : $Builtin.FPIEEE64, %11 : $Builtin.FPIEEE64) : $Builtin.FPIEEE64
+  %10 = builtin "fsub_FPIEEE64"(%4 : $Builtin.FPIEEE64, %11 : $Builtin.FPIEEE64) : $Builtin.FPIEEE64
+  %13 = builtin "fmul_FPIEEE64"(%4 : $Builtin.FPIEEE64, %11 : $Builtin.FPIEEE64) : $Builtin.FPIEEE64
+  return %13 : $Builtin.FPIEEE64
+
+// CHECK-LABEL: sil @fold_float_operations
+// CHECK: bb0:
+// CHECK-NEXT: %0 = float_literal $Builtin.FPIEEE64, 0x4032733333333333
+// CHECK-NEXT: %1 = float_literal $Builtin.FPIEEE64, 0x40125D1745D1745D
+// CHECK-NEXT: %2 = float_literal $Builtin.FPIEEE64, 0x4027B33333333334
+// CHECK-NEXT: %3 = float_literal $Builtin.FPIEEE64, 0x4048FF5C28F5C28F
+// CHECK-NEXT: return %3 : $Builtin.FPIEEE64
+}
+
+// rdar://15729207 - Verify that constant folding doesn't leave around obviously
+// dead cond_fail instructions.
+sil @fold_condfail_instructions : $@convention(thin) () -> Int64 {
+bb0:
+  %0 = integer_literal $Builtin.Int2048, 1        // user: %2
+  %2 = builtin "s_to_s_checked_trunc_Int2048_Int64"(%0 : $Builtin.Int2048) : $(Builtin.Int64, Builtin.Int1) // user: %3
+  %3 = tuple_extract %2 : $(Builtin.Int64, Builtin.Int1), 0 // user: %4
+  %4 = struct $Int64 (%3 : $Builtin.Int64)        // users: %14, %5
+  %6 = integer_literal $Builtin.Int2048, 2        // user: %8
+  %8 = builtin "s_to_s_checked_trunc_Int2048_Int64"(%6 : $Builtin.Int2048) : $(Builtin.Int64, Builtin.Int1) // user: %9
+  %9 = tuple_extract %8 : $(Builtin.Int64, Builtin.Int1), 0 // user: %10
+  %10 = struct $Int64 (%9 : $Builtin.Int64)       // users: %15, %11
+  %12 = integer_literal $Builtin.Int1, -1         // user: %16
+  %14 = struct_extract %4 : $Int64, #Int64.value  // user: %16
+  %15 = struct_extract %10 : $Int64, #Int64.value // user: %16
+  %16 = builtin "sadd_with_overflow_Int64"(%14 : $Builtin.Int64, %15 : $Builtin.Int64, %12 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1) // users: %18, %17
+  %17 = tuple_extract %16 : $(Builtin.Int64, Builtin.Int1), 0 // user: %19
+  %18 = tuple_extract %16 : $(Builtin.Int64, Builtin.Int1), 1 // user: %20
+  %19 = struct $Int64 (%17 : $Builtin.Int64)      // user: %21
+  cond_fail %18 : $Builtin.Int1                   // id: %20
+  return %19 : $Int64                             // id: %21
+
+
+// CHECK-LABEL: sil @fold_condfail_instructions
+// CHECK: bb0
+// CHECK-NEXT: integer_literal{{.*}}3
+//
+// FIXME(new_folder): The following inst should be deleted
+// CHECK-NEXT: integer_literal
+//
+// CHECK-NEXT: struct
+//
+// FIXME(new_folder): The following inst should be deleted
+// CHECK-NEXT: cond_fail
+//
+// CHECK-NEXT: return
+}
+
+// Make sure that we properly handle functions eliminated by CCP by removing
+// from the worklist. If we don't the following (reduced) test case will blow
+// up.
+
+// CHECK-LABEL: sil @properly_handle_eliminated_instructions_in_worklist : $@convention(method) (Bool, @inout UInt) -> () {
+sil @properly_handle_eliminated_instructions_in_worklist : $@convention(method) (Bool, @inout UInt) -> () {
+bb0(%0 : $Bool, %1 : $*UInt):
+  %2 = load %1 : $*UInt
+  %3 = integer_literal $Builtin.Int2048, 1
+  %5 = builtin "s_to_u_checked_trunc_Int2048_Word"(%3 : $Builtin.Int2048) : $(Builtin.Word, Builtin.Int1)
+  %6 = tuple_extract %5 : $(Builtin.Word, Builtin.Int1), 0
+  %7 = tuple_extract %5 : $(Builtin.Word, Builtin.Int1), 1
+  %8 = struct $UInt (%6 : $Builtin.Word)
+  %9 = integer_literal $Builtin.Int2048, 0
+  %11 = builtin "s_to_u_checked_trunc_Int2048_Word"(%9 : $Builtin.Int2048) : $(Builtin.Word, Builtin.Int1)
+  %12 = tuple_extract %11 : $(Builtin.Word, Builtin.Int1), 0
+  %13 = tuple_extract %11 : $(Builtin.Word, Builtin.Int1), 1
+  %14 = struct $UInt (%12 : $Builtin.Word)
+  %15 = integer_literal $Builtin.Int2048, 1
+  %17 = builtin "s_to_u_checked_trunc_Int2048_Word"(%15 : $Builtin.Int2048) : $(Builtin.Word, Builtin.Int1)
+  %18 = tuple_extract %17 : $(Builtin.Word, Builtin.Int1), 0
+  %19 = tuple_extract %17 : $(Builtin.Word, Builtin.Int1), 1
+  %20 = struct $UInt (%18 : $Builtin.Word)
+  %22 = struct_extract %14 : $UInt, #UInt.value
+  %23 = struct_extract %20 : $UInt, #UInt.value
+  %25 = integer_literal $Builtin.Int2048, 0
+  %27 = builtin "s_to_s_checked_trunc_Int2048_Word"(%25 : $Builtin.Int2048) : $(Builtin.Word, Builtin.Int1)
+  %28 = tuple_extract %27 : $(Builtin.Word, Builtin.Int1), 0
+  %29 = tuple_extract %27 : $(Builtin.Word, Builtin.Int1), 1
+  %30 = struct $Int (%28 : $Builtin.Word)
+  %31 = struct_extract %30 : $Int, #Int.value
+  %32 = builtin "trunc_Word_Int1"(%31 : $Builtin.Word) : $Builtin.Int1
+  %33 = struct $Bool (%32 : $Builtin.Int1)
+  %34 = struct_extract %33 : $Bool, #Bool.value
+  %35 = builtin "usub_with_overflow_Word"(%22 : $Builtin.Word, %23 : $Builtin.Word, %34 : $Builtin.Int1) : $(Builtin.Word, Builtin.Int1)
+  %36 = tuple_extract %35 : $(Builtin.Word, Builtin.Int1), 0
+  %37 = tuple_extract %35 : $(Builtin.Word, Builtin.Int1), 1
+  %38 = struct $UInt (%36 : $Builtin.Word)
+  %39 = struct $Bool (%37 : $Builtin.Int1)
+  %40 = tuple (%38 : $UInt, %39 : $Bool)
+  %41 = tuple_extract %40 : $(UInt, Bool), 0
+  %42 = tuple_extract %40 : $(UInt, Bool), 1
+  %44 = struct_extract %8 : $UInt, #UInt.value
+  %45 = struct_extract %41 : $UInt, #UInt.value
+  %46 = builtin "xor_Word"(%44 : $Builtin.Word, %45 : $Builtin.Word) : $Builtin.Word
+  %47 = struct $UInt (%46 : $Builtin.Word)
+  %49 = struct_extract %2 : $UInt, #UInt.value
+  %50 = struct_extract %47 : $UInt, #UInt.value
+  %51 = builtin "and_Word"(%49 : $Builtin.Word, %50 : $Builtin.Word) : $Builtin.Word
+  %52 = struct $UInt (%51 : $Builtin.Word)
+  %53 = tuple ()
+  return %53 : $()
+}
+
+// CHECK-LABEL: sil @constant_expect_hint
+// CHECK: bb0:
+// CHECK-NEXT: [[INT1:%[0-9]+]] = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT: [[INT2:%[0-9]+]] = integer_literal $Builtin.Int32, 5
+// CHECK-NEXT: [[INT3:%[0-9]+]] = integer_literal $Builtin.Int64, 32
+// CHECK-NEXT: [[TUPLE:%[0-9]+]] = tuple ([[INT1]] : $Builtin.Int1, [[INT2]] : $Builtin.Int32, [[INT3]] : $Builtin.Int64)
+// CHECK-NEXT: return [[TUPLE]]
+// CHECK-NEXT: }
+sil @constant_expect_hint : $@convention(thin) () -> (Builtin.Int1, Builtin.Int32, Builtin.Int64) {
+bb0:
+  %0 = integer_literal $Builtin.Int1, 0
+  %1 = integer_literal $Builtin.Int32, 5
+  %2 = integer_literal $Builtin.Int64, 32
+
+  %3 = integer_literal $Builtin.Int1, 1
+  %4 = integer_literal $Builtin.Int32, 400
+  %5 = integer_literal $Builtin.Int64, 5000
+
+  %9 = builtin "int_expect_Int1"(%0 : $Builtin.Int1, %3 : $Builtin.Int1) : $Builtin.Int1
+  %10 = builtin "int_expect_Int32"(%1 : $Builtin.Int32, %4 : $Builtin.Int32) : $Builtin.Int32
+  %11 = builtin "int_expect_Int64"(%2 : $Builtin.Int64, %5 : $Builtin.Int64) : $Builtin.Int64
+
+  %12 = tuple (%9 : $Builtin.Int1, %10 : $Builtin.Int32, %11 : $Builtin.Int64)
+  return %12 : $(Builtin.Int1, Builtin.Int32, Builtin.Int64)
+}
+
+// FIXME(new_folder): Deleted constant_fold_indexing_inst_of_0
+// FIXME(new_folder): Deleted constant_assume_non_negative
+// FIXME(new_folder): Deleted constant_fold_fptrunc
+// FIXME(new_folder): Deleted replace_unconditional_check_cast_failure
+// FIXME(new_folder): Deleted dont_replace_unconditional_check_cast_addr_for_type_to_unrelated_existential
+// FIXME(new_folder): Deleted dont_replace_unconditional_check_cast_addr_for_existential_to_existential
+// FIXME(new_folder): Deleted replace_unconditional_check_cast_addr_for_type_to_existential
+// FIXME(new_folder): Deleted replace_unconditional_check_cast_addr_for_class_to_existential
+// FIXME(new_folder): Deleted replace_unconditional_check_cast_addr_for_archetype_to_existential
+// FIXME(new_folder): Deleted replace_unconditional_check_cast_addr_for_generic_type_to_existential
+// FIXME(new_folder): Deleted replace_unconditional_check_cast_addr_for_type_to_class_existential
+// FIXME(new_folder): Deleted replace_unconditional_check_cast_addr_for_archetype_to_class_existential
+// FIXME(new_folder): Deleted replace_unconditional_check_cast_addr_to_class_existential
+// FIXME(new_folder): Deleted replace_unconditional_check_cast_addr_for_type_to_myerror_existential
+// FIXME(new_folder): Deleted replace_unconditional_check_cast_addr_for_archetype_to_myerror_existential
+// FIXME(new_folder): Deleted replace_unconditional_check_cast_addr_to_myerror_existential
+// FIXME(new_folder): Deleted replace_unconditional_check_cast_addr_for_type_to_error_existential


### PR DESCRIPTION
* Adds a flag that switches `ConstantPropagation.cpp` to use the new folder.
* Makes some existing constant propagation tests pass with the new flag.

The next step is to keep making more of the existing constant propagation tests pass with the new flag.

I also noticed that `SimplifyCFG.cpp` uses the old folder. This PR does not touch that. We'll have to do that at some point.

I certainly won't finish before I leave for my weeklong vacation tomorrow. I'll pick up where I left off when I get back, unless someone else goes ahead and finishes everything while I'm gone.