### PR TITLE
[Type checker] Request nominal layout for the result types of function calls.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7498,6 +7498,11 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
     cs.setType(apply, fnType->getResult());
     apply->setIsSuper(isSuper);
 
+    // We need the layout of nominal types returned from a function call.
+    if (auto nominalResult = fnType->getResult()->getAnyNominal()) {
+      tc.requestNominalLayout(nominalResult);
+    }
+
     cs.setExprTypes(apply);
     Expr *result = tc.substituteInputSugarTypeForResult(apply);
     cs.cacheExprTypes(result);

--- a/test/multifile/Inputs/require-layout-call-result-primary.swift
+++ b/test/multifile/Inputs/require-layout-call-result-primary.swift
@@ -1,0 +1,4 @@
+func foo<T, U: C<T>>(_ t: T, _ u: U) {
+  // Calling a function that returns a C<T> requests its layout
+  _ = bar(t, u)
+}

--- a/test/multifile/require-layout-call-result.swift
+++ b/test/multifile/require-layout-call-result.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift -module-name test -primary-file %S/Inputs/require-layout-call-result-primary.swift
+
+
+class C<T> {
+  dynamic func broken() { } // expected-error{{'dynamic'}}
+}
+
+func bar<T, U: C<T>>(_ t: T, _ u: U) -> C<T> { return u }


### PR DESCRIPTION
Once you’ve called a function and retrieved a result, IRGen will want
layout information for the result type. Make sure that the type checker
precomputes it.

This fixes the new crash in [SR-8179](https://bugs.swift.org/browse/SR-8179).