### PR TITLE
Re-enable Lazy test on Linux.

### DIFF
--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -12,12 +12,6 @@
 // RUN: %target-run-simple-swiftgyb
 // REQUIRES: executable_test
 
-// <rdar://35797159> [Associated Type Inference]
-// heap-use-after-free ASTContext::getSpecializedConformance
-// llvm::FoldingSetBase::InsertNode
-// OR corrupted doubly linked list
-// REQUIRES: OS=macosx
-
 import StdlibUnittest
 import StdlibCollectionUnittest
 


### PR DESCRIPTION
Arnold fixed this by re-computing the insert position in
getSpecializedConformance(), with
https://github.com/apple/swift/pull/17904.

Fixes rdar://problem/35797159.
