### PR TITLE
[4.2][CodeComplete] Use PrintOptionalAsImplicitlyUnwrapped to print IUO

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2559,16 +2559,17 @@ public:
         // What's left is the result type.
         if (ResultType->isVoid()) {
           OS << "Void";
-        } else if (!IsImplicitlyCurriedInstanceMethod
-                   && FD->getAttrs().hasAttribute<ImplicitlyUnwrappedOptionalAttr>()) {
+        } else {
           // As we did with parameters in addParamPatternFromFunction,
           // for regular methods we'll print '!' after implicitly
           // unwrapped optional results.
-          auto ObjectType = ResultType->getOptionalObjectType();
-          OS << ObjectType->getStringAsComponent();
-          OS << "!";
-        } else {
-          ResultType.print(OS);
+          bool IsIUO =
+              !IsImplicitlyCurriedInstanceMethod &&
+              FD->getAttrs().hasAttribute<ImplicitlyUnwrappedOptionalAttr>();
+
+          PrintOptions PO;
+          PO.PrintOptionalAsImplicitlyUnwrapped = IsIUO;
+          ResultType.print(OS, PO);
         }
       }
       Builder.addTypeAnnotation(TypeStr);

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -372,13 +372,8 @@ public:
 
     PrintOptions PO;
     PO.SkipAttributes = true;
-    std::string TypeName;
-    if (IsIUO) {
-      assert(Ty->getOptionalObjectType());
-      TypeName = Ty->getOptionalObjectType()->getStringAsComponent(PO) + "!";
-    } else {
-      TypeName = Ty->getString(PO);
-    }
+    PO.PrintOptionalAsImplicitlyUnwrapped = IsIUO;
+    std::string TypeName = Ty->getString(PO);
     addChunkWithText(CodeCompletionString::Chunk::ChunkKind::CallParameterType,
                      TypeName);
 

--- a/test/IDE/complete_crashes.swift
+++ b/test/IDE/complete_crashes.swift
@@ -306,7 +306,7 @@ func test_28188259(x: ((Int) -> Void) -> Void) {
 func test_40956846(
   arg_40956846_1: inout Int!,
   arg_40956846_2: Void!,
-  arg_40956846_3: (() -> Int)!,
+  arg_40956846_3: (() -> Int?)!,
   arg_40956846_4: inout ((Int) -> Int)!
 ) {
   let y = #^RDAR_40956846^#
@@ -314,9 +314,19 @@ func test_40956846(
 // RDAR_40956846: Begin completions
 // RDAR_40956846-DAG: Decl[LocalVar]/Local:               arg_40956846_1[#inout Int!#]; name=arg_40956846_1
 // RDAR_40956846-DAG: Decl[LocalVar]/Local:               arg_40956846_2[#Void!#]; name=arg_40956846_2
-// RDAR_40956846-DAG: Decl[LocalVar]/Local:               arg_40956846_3[#(() -> Int)!#]; name=arg_40956846_3
+// RDAR_40956846-DAG: Decl[LocalVar]/Local:               arg_40956846_3[#(() -> Int?)!#]; name=arg_40956846_3
 // RDAR_40956846-DAG: Decl[LocalVar]/Local:               arg_40956846_4[#inout ((Int) -> Int)!#]; name=arg_40956846_4
 // RDAR_40956846: End completions
+
+// rdar://problem/42443512
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=RDAR_42443512 -source-filename=%s | %FileCheck %s -check-prefix=RDAR_42443512
+class test_42443512 {
+  func foo(x: Int!) { }
+  static func test() {
+    self.foo#^RDAR_42443512^#
+  }
+}
+// RDAR_42443512: Begin completions
 
 // rdar://problem/42452085
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=RDAR_42452085_1 -source-filename=%s | %FileCheck %s -check-prefix=RDAR_42452085


### PR DESCRIPTION
Cherry-pick of #18217 reviewed by @rudkx 

- **Explaination**: Use `PrintOptions.PrintOptionalAsImplicitlyUnwrapped` to print `Optional` type annotations in code-completion. Previously, it used to manually print `!` after object type of the optional with an assumption where the type is `Optional`. Because of various reasons, there are several circumstances that the type is *not* optional, thus caused SourceKit crashes. Use ASTPrinter with the option which can handle them.
- **Scope**: Code-completion regarding implicitly unwrapped optional.
- **Issue**: rdar://problem/41046225, rdar://problem/42443512
- **Risk**: Low. This is just a migration to well-tested ASTPrinter functionality from hand-crafted logic.
- **Testing**: Added regression test cases.
- **Reviewed By**: Mark Lacey (https://github.com/apple/swift/pull/18217)

