### PR TITLE
Fixed a bug in const folding, where an inst that's not of type SingleValueInstruction gets added to the worklist

### DIFF
--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -1667,8 +1667,10 @@ ConstantFolder::processWorkList() {
       UserV->replaceAllUsesWith(C);
 
       // The new constant could be further folded now, add it to the worklist.
+      // SWIFT_ENABLE_TENSORFLOW
       if (auto *Inst = C->getDefiningInstruction())
-        WorkList.insert(Inst);
+        if (isa<SingleValueInstruction>(Inst))
+          WorkList.insert(Inst);
     }
 
     // Eagerly DCE. We do this after visiting all users to ensure we don't


### PR DESCRIPTION
This causes cast assert at https://github.com/apple/swift/blame/master/lib/SILOptimizer/Utils/ConstantFolding.cpp#L1585.

One such example inst is the following, which produces a SILValue of type
MultipleValueInstructionResult, so ValueBase::getDefiningInstruction() still
returns a valid inst for it, even though that graph_op inst is not a SingleValueInstruction.

```
%94 = graph_op "Fill,i,i"(%73 : $TensorHandle<Int32>, %85 : $TensorHandle<Float>) {T: $Float, index_type: $Int32, __device: "/device:CPU:0"} : $TensorHandle<Float> // users: %1581, %100, %98, %97, %99, %103, %106, %111, %113, %118, %755
```
