### PR TITLE
Fix the code that inserts TensorTransfer instructions to respect dominance

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFDevicePartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDevicePartition.cpp
@@ -881,7 +881,8 @@ class DevicePartitionerImpl
           GraphOperationInfo::getInputMarker(GraphOperationInfo::IM_Normal);
 
       auto loc = inst->getLoc();
-      SILBuilder B(inst);
+      // Insert the transfer right after the operandInst.
+      SILBuilder B(std::next(operandInst->getIterator()));
       auto &ctx = B.getASTContext();
 
       auto &allocator = ctx.getAllocator();

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -682,12 +682,6 @@ std::string TFGraphLowering::getUniqueName(SILDebugLocation loc,
         break;
 
       auto lineCol = SM.getLineAndColumn(ds->Loc.getSourceLoc());
-      auto fnName = F->getName();
-
-      // Drop ".device_partition" suffix off function names.
-      if (fnName.endswith(".device_partition"))
-        fnName = fnName.drop_back(strlen(".device_partition"));
-
       // Separate functions using '/' so that TensorBoard can treat it as a
       // hierarchical separator.
       name += '/';
@@ -705,6 +699,11 @@ std::string TFGraphLowering::getUniqueName(SILDebugLocation loc,
         else
           uniqueNames.insert({afd, 1});
       } else {
+        auto fnName = F->getName();
+        // Drop ".device_partition" suffix off function names.
+        if (fnName.endswith(".device_partition")) {
+          fnName = fnName.drop_back(strlen(".device_partition"));
+        }
         funcName = fnName.str();
       }
 
@@ -724,6 +723,10 @@ std::string TFGraphLowering::getUniqueName(SILDebugLocation loc,
       name += "." + llvm::utostr(lineCol.second);
     }
   }
+
+  // Append device type to ensure the name is unique across all devices.
+  name += ':';
+  name += thisDeviceTypeStr;
 
   // Escape op name.
   escapeOpName(name);

--- a/test/TensorFlow/sends_recvs.swift
+++ b/test/TensorFlow/sends_recvs.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -Xllvm -tf-strict-deabstraction -Xllvm -tf-ensure-single-loop-exit=false -O -emit-sil %s -verify | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -Xllvm -tf-strict-deabstraction -O -emit-sil %s -verify | %FileCheck %s
 
 // In this file, send means accelerator->host, and recv means the opposite.
 
@@ -165,7 +165,6 @@ public func testSendsInALoopTPU() {
 // CHECK-LABEL: --- TFDevicePartition Per-Device Function Extraction Result: {{.*}}testSendsInALoopTPU{{.*}}TPU{{.*}}
 // CHECK: bb1
 // CHECK:   graph_op "tfc.D2DTensorSend
-// CHECK: bb2
 // CHECK:   graph_op "tfc.D2DTensorSend
 
 public func testSendsInALoopWithNoResultTensor() {
@@ -384,7 +383,6 @@ public func testRecvsInALoop() {
   var a = Tensor<Float>(1.0)
   while count < maxCount {
     // One recv.
-    // expected-error @+1 {{tfop invalid: FIXME: cannot lower a Host->TF tensor transfer in a loop header}}
     let b = atariSim(a.toHost()).toAccelerator()
     a += b
     count += 1

--- a/test/TensorFlowRuntime/sends_recvs_1.swift
+++ b/test/TensorFlowRuntime/sends_recvs_1.swift
@@ -3,7 +3,7 @@
 // REQUIRES: swift_test_mode_optimize
 //
 // Compiler-only testing for TPU graph lowering (e.g. shape requirements by XLA).
-// RUN: %target-swift-frontend -Xllvm -tf-strict-deabstraction -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -Xllvm -tf-target-tpu -Xllvm -tf-ensure-single-loop-exit=false -O -emit-sil %s >/dev/null
+// RUN: %target-swift-frontend -Xllvm -tf-strict-deabstraction -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -Xllvm -tf-target-tpu -O -emit-sil %s >/dev/null
 
 // Swift <-> TF sends/recvs tests.
 


### PR DESCRIPTION
- Adds the TensorTransfer instruction in the same block as the corresponding graph_op instruction. 
- Also updates the naming logic to make sure names are unique across all devices. In the send_recvs.swift example, the name for the while block in the CPU and TPU turned out to be the same causing a runtime error in tensorflow. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-8372](https://bugs.swift.org/browse/SR-8372).

