### PR TITLE
Added a new code path to create a TF graph for each module, instead of one for each partitionable function. 

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFDevicePartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDevicePartition.cpp
@@ -615,22 +615,24 @@ class DevicePartitionerImpl
 
   /// This is a counter we use to give each cross-device send/receive operation
   /// a unique ID.
-  int nextTensorTransferId = 0;
+  int &nextTensorTransferId;
 
- public:
+public:
   /// Impl note: Although we can short-circuit
   /// markFunctionAndInsertTensorTransfers() and extractFunctionForDevice() when
   /// there is a single device, we choose to exercise them for test
   /// coverage. This can be optimized for compiler performance later if it turns
   /// out to matter.
-   DevicePartitionerImpl(SILFunction &srcFn,
-                         const GraphFunctionDeviceInfo &deviceInfo)
-       : srcFn(srcFn), deviceInfo(deviceInfo) {
-     static_assert(
-         NUM_DEVICE_TYPES <= 8,
-         "3 bits are allocated in KeyByInstDestDevice to encode device types");
-     markFunctionAndInsertTensorTransfers();
-   }
+  DevicePartitionerImpl(SILFunction &srcFn,
+                        const GraphFunctionDeviceInfo &deviceInfo,
+                        int &nextTensorTransferId)
+      : srcFn(srcFn), deviceInfo(deviceInfo),
+        nextTensorTransferId(nextTensorTransferId) {
+    static_assert(
+        NUM_DEVICE_TYPES <= 8,
+        "3 bits are allocated in KeyByInstDestDevice to encode device types");
+    markFunctionAndInsertTensorTransfers();
+  }
 
   /// Returns a function extracted from `srcFn`, specialized on `deviceType`.
   ///
@@ -960,8 +962,10 @@ class DevicePartitionerImpl
 };
 
 DevicePartitioner::DevicePartitioner(SILFunction &srcFn,
-                                     const GraphFunctionDeviceInfo &deviceInfo)
-    : impl(new DevicePartitionerImpl(srcFn, deviceInfo)) {}
+                                     const GraphFunctionDeviceInfo &deviceInfo,
+                                     int &nextTensorTransferId)
+    : impl(new DevicePartitionerImpl(srcFn, deviceInfo, nextTensorTransferId)) {
+}
 
 DevicePartitioner::~DevicePartitioner() { delete impl; }
 

--- a/lib/SILOptimizer/Mandatory/TFDeviceSupport.h
+++ b/lib/SILOptimizer/Mandatory/TFDeviceSupport.h
@@ -114,9 +114,8 @@ static inline std::string getDeviceShortName(DeviceType deviceType) {
 /// TensorShape-typed elements.
 bool isShapeArrayPseudoAttr(llvm::StringRef name, SymbolicValue attrValue);
 
-/// This struct holds information about the global configuration of the graph
-/// we are generating.  This can be different between distinct graphs in the
-/// same program though.
+/// This struct holds information about the deviceInfo of the graph we are
+/// generating.
 struct GraphFunctionDeviceInfo {
   const DeviceType primaryDeviceType;
   const bool isTPUInfeedEnabled;
@@ -187,7 +186,7 @@ struct GraphFunctionDeviceInfo {
     return DeviceTypeMgr(usedDeviceTypes);
   }
 
-  /// Return the configuration for the specified function.
+  /// Return the deviceInfo for the specified function.
   static GraphFunctionDeviceInfo getForFunction(SILFunction &fn,
                                                 bool removeConfigInst);
 
@@ -204,7 +203,7 @@ struct GraphFunctionDeviceInfo {
   // `usedDeviceTypes`.
   //
   // If `opDevice` is already set, respects that device choice. Otherwise,
-  // chooses a device based on this configuration and op kernel device
+  // chooses a device based on this deviceInfo and op kernel device
   // availability.
   //
   // For some tfops (e.g. "tfc.scalarToTensor"), device placement is handled
@@ -255,7 +254,7 @@ struct GraphFunctionDeviceInfo {
   // `usedDeviceTypes`.
   //
   // If `opDevice` is already set, respects that device choice. Otherwise,
-  // chooses a device based on this configuration and op kernel device
+  // chooses a device based on this deviceInfo and op kernel device
   // availability.
   //
   // Caller should avoid adding duplicate device attributes (e.g. calling
@@ -280,7 +279,7 @@ private:
     if (opType == "tfc.RecvFromHost" || opType == "tfc.SendToHost")
       return DeviceType::CPU;
 
-    // Place this inst on the device given by this configuration.
+    // Place this inst on the device given by this deviceInfo.
     // FIXME: Use the op kernel device availability info to select a device for
     // `opType` -- if that op has no available kernel on `primaryDeviceType`, a
     // different device should be returned.
@@ -299,7 +298,8 @@ class DevicePartitioner {
 
 public:
   DevicePartitioner(SILFunction &srcFn,
-                    const GraphFunctionDeviceInfo &configuration);
+                    const GraphFunctionDeviceInfo &deviceInfo,
+                    int &nextTensorTransferId);
 
   ~DevicePartitioner();
 

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -44,11 +44,17 @@ TFDumpGraph("tf-dump-graph", llvm::cl::init(false),
             llvm::cl::desc("Dump generated tensorflow graphs to /tmp"));
 
 #ifdef SWIFT_ENABLE_TENSORFLOW
-template<typename...T, typename...U>
-static InFlightDiagnostic
-diagnose(SILFunction &fn, SILLocation loc, Diag<T...> diag, U &&...args) {
-  auto &diags = fn.getASTContext().Diags;
+template <typename... T, typename... U>
+static InFlightDiagnostic diagnose(ASTContext &ctx, SILLocation loc,
+                                   Diag<T...> diag, U &&... args) {
+  auto &diags = ctx.Diags;
   return diags.diagnose(loc.getSourceLoc(), diag, std::forward<U>(args)...);
+}
+
+template <typename... T, typename... U>
+static InFlightDiagnostic diagnose(SILFunction &fn, SILLocation loc,
+                                   Diag<T...> diag, U &&... args) {
+  return diagnose(fn.getASTContext(), loc, diag, std::forward<U>(args)...);
 }
 
 static const char DEVICE_TPU_REPLICATED_CORE[] = "TPU_REPLICATED_CORE";
@@ -210,12 +216,14 @@ enum class GLStatus {
   Error,
 };
 
-struct TFGraphLowering : public SILInstructionVisitor<TFGraphLowering, GLStatus> {
+struct TFGraphFunctionLowering
+    : public SILInstructionVisitor<TFGraphFunctionLowering, GLStatus> {
   SILFunction &SILFn;
   // The TF device to which the generated graph is targeting.
   const DeviceType thisDeviceType;
   const std::string thisDeviceTypeStr;
   const GraphFunctionDeviceInfo &deviceInfo;
+  const std::string &funcNodeBaseName;
   llvm::DenseMap<StringRef, std::unique_ptr<LoweredGraphFunction>>
       &graphFunctions;
   TF_Graph *resultGraph;
@@ -250,9 +258,10 @@ struct TFGraphLowering : public SILInstructionVisitor<TFGraphLowering, GLStatus>
 public:
   /// Generate one or more TF graph functions from `fn` targeting
   /// `thisDeviceType`, and add them to `resultGraph`.
-  TFGraphLowering(
+  TFGraphFunctionLowering(
       SILFunction &fn, DeviceType thisDeviceType,
       const GraphFunctionDeviceInfo &deviceInfo,
+      const std::string &funcNodeBaseName,
       llvm::DenseMap<StringRef, std::unique_ptr<LoweredGraphFunction>>
           &graphFunctions,
       TF_Graph *resultGraph,
@@ -260,14 +269,14 @@ public:
       TF_Status *status)
       : SILFn(fn), thisDeviceType(thisDeviceType),
         thisDeviceTypeStr(getDeviceString(thisDeviceType)),
-        deviceInfo(deviceInfo), graphFunctions(graphFunctions),
-        resultGraph(resultGraph), status(status),
-        pendingGraphFnNames(pendingGraphFnNames) {}
+        deviceInfo(deviceInfo), funcNodeBaseName(funcNodeBaseName),
+        graphFunctions(graphFunctions), resultGraph(resultGraph),
+        status(status), pendingGraphFnNames(pendingGraphFnNames) {}
 
   /// Return the current graph function that is being set up.
   GraphFunctionBody &getCurrentGraphFunction() { return functionStack.back(); }
 
-  ~TFGraphLowering() {}
+  ~TFGraphFunctionLowering() {}
 
   /// Check whether the specified TensorFlow status object is valid or not.  If
   /// valid return false.  If invalid, emit a diagnostic and return true.
@@ -309,7 +318,10 @@ public:
   /// Builds TF graph nodes for the top level TF function call, where
   /// `funcOpType` is the TF graph function name, and `funcNodeBaseName` is the
   /// node base name for calling that function. `inputs` and `outputs`
-  /// respectively specify the inputs and outputs to the function.
+  /// respectively specify the inputs and outputs to the
+  /// function. `metadataNodeForTPU` is a graph node needed when we target TPU
+  /// -- if it's NULL, it'll be set to one such node that's created in the call;
+  /// otherwise no such node is created.
   ///
   /// Context of `isPrimaryFn`: An accelerator SIL function produced by
   /// TFPartition is to be partitioned into a set of N SIL functions, one per
@@ -336,10 +348,10 @@ public:
   ///
   /// This emits an error and returns true on error.
   bool buildGraphNodesForTopLevelFunctionCall(
-      StringRef funcOpType, StringRef funcNodeBaseName, bool isPrimaryFn,
-      ArrayRef<TF_DataType> inputTypes, ArrayRef<TF_DataType> outputTypes);
+      StringRef funcOpType, bool isPrimaryFn, ArrayRef<TF_DataType> inputTypes,
+      ArrayRef<TF_DataType> outputTypes, TF_Operation *&metadataNodeForTPU);
 
- private:  // Helpers to create TensorFlow graph nodes.
+private: // Helpers to create TensorFlow graph nodes.
   unsigned OpID = 0;
   llvm::StringSet<> usedOpNames;
 
@@ -564,7 +576,7 @@ public:
   GLStatus visitSILInstruction(SILInstruction *inst) {
     internalError(inst->getLoc(),
                   "GraphGen cannot lower this instruction yet");
-    llvm::errs() << "Unhandled SIL instruction in TFGraphLowering:\n";
+    llvm::errs() << "Unhandled SIL instruction in TFGraphFunctionLowering:\n";
     inst->dump();
     return GLStatus::Error;
   }
@@ -591,6 +603,8 @@ public:
     Inst *inst, std::vector<SILOpResult>& results);
   template <typename Inst>
   GLStatus visitTFDataset(Inst *inst);
+
+  // TODO: remove this after we complete proper dataset/iterator support.
   bool createDatasetIteratorNodesWithInfeedEnqueue();
 
   GLStatus visitTFOpInst(BuiltinInst *inst);
@@ -618,10 +632,7 @@ public:
   // For `op` with `opName` under construction, set a function-typed attribute
   // with a graph function name derived from `silFuncName` under the following
   // naming convention: Let `silFuncName` be "$foo", then the corresponding
-  // graph function name is "foo.tf_only". If that graph function's definition
-  // is available in `graphFunctions`, copy it over to `resultGraph`. Otherwise
-  // add an entry to `pendingGraphFnNames`, so that the graph function
-  // definition can be copied over later when it becomes available.
+  // graph function name is "foo.tf_only".
   bool handleFunctionAttribute(TF_OperationDescription *op,
                                const std::string &opName, SILLocation loc,
                                StringRef silFuncName);
@@ -659,8 +670,8 @@ static std::string escapeDeclName(DeclName name) {
 
 /// Produce a "stack trace" for the specified location, producing it in a form
 /// that we can use as a unique op name.
-std::string TFGraphLowering::getUniqueName(SILDebugLocation loc,
-                                           const char *baseName) {
+std::string TFGraphFunctionLowering::getUniqueName(SILDebugLocation loc,
+                                                   const char *baseName) {
   std::string name = baseName;
 
   // Skip over internal implementation details of the Tensor library.
@@ -738,8 +749,8 @@ std::string TFGraphLowering::getUniqueName(SILDebugLocation loc,
   return name;
 }
 
-TF_DataType TFGraphLowering::getTensorFlowDataType(SILType type,
-                                                   SILLocation loc) {
+TF_DataType TFGraphFunctionLowering::getTensorFlowDataType(SILType type,
+                                                           SILLocation loc) {
   // Handle things like TensorHandle<Float>.
   switch (classifyTensorFlowValue(type)) {
   case TFValueKind::TensorHandle: {
@@ -843,7 +854,7 @@ static bool checkStatus(SILFunction &fn, SILLocation loc, TF_Status *status,
 }
 
 /// On error, return a "NULL" value, and emit an error diagnostic.
-TF_Output TFGraphLowering::createUndefNode(SILType type) {
+TF_Output TFGraphFunctionLowering::createUndefNode(SILType type) {
   // Create some magic constant. Actual value does not matter as it will
   // not be used in any calculations.
   // FIXME: Is there a better way to model undefs in TF Graph if we
@@ -932,7 +943,7 @@ TF_Output TFGraphLowering::createUndefNode(SILType type) {
 // Helpers to create TensorFlow graph nodes.
 //===----------------------------------------------------------------------===//
 
-GLStatus TFGraphLowering::visitBuiltinInst(BuiltinInst *inst) {
+GLStatus TFGraphFunctionLowering::visitBuiltinInst(BuiltinInst *inst) {
   // If this is the magic tf_tensor_to_i1 builtin, then we completely ignore it.
   // the only user of it are things that take conditional branches, and they
   // handle it directly.
@@ -947,7 +958,7 @@ GLStatus TFGraphLowering::visitBuiltinInst(BuiltinInst *inst) {
   llvm_unreachable("Unhandled builtin instruction");
 }
 
-bool TFGraphLowering::createDatasetIteratorNodesWithInfeedEnqueue() {
+bool TFGraphFunctionLowering::createDatasetIteratorNodesWithInfeedEnqueue() {
   assert(datasetCreationContext);
   TF_Operation *getnextOp =
       datasetCreationContext->makeIteratorGetNextWithDatasets(resultGraph,
@@ -964,8 +975,9 @@ bool TFGraphLowering::createDatasetIteratorNodesWithInfeedEnqueue() {
 
   // Add infeed enqueue to consume the output of the iterator.
   {
+    auto infeedOpName = funcNodeBaseName + "/InfeedEnqueueTuple";
     auto *desc = TF_NewOperation(resultGraph, "InfeedEnqueueTuple",
-                                 "InfeedEnqueueTuple");
+                                 infeedOpName.c_str());
     int numInputs = datasetCreationContext->getNumTensors();
     std::vector<TF_Output> infeedInputs;
     infeedInputs.reserve(numInputs);
@@ -1095,8 +1107,8 @@ static void decodeShapeArrayAtAttr(const GraphOperationInfo &graphOpInfo,
   decodeShapeArray(attr.value, dims, numDims, dimPtrs);
 }
 
-GLStatus
-TFGraphLowering::visitGraphOpSendToHostInst(GraphOperationInfo &graphOpInfo) {
+GLStatus TFGraphFunctionLowering::visitGraphOpSendToHostInst(
+    GraphOperationInfo &graphOpInfo) {
   auto &graphFn = getCurrentGraphFunction();
   // TODO(b/78472806): Add a more thorough and proper fix for effectful ops in
   // the while cond function.
@@ -1193,8 +1205,8 @@ TFGraphLowering::visitGraphOpSendToHostInst(GraphOperationInfo &graphOpInfo) {
   return GLStatus::Success;
 }
 
-GLStatus
-TFGraphLowering::visitGraphOpRecvFromHostInst(GraphOperationInfo &graphOpInfo) {
+GLStatus TFGraphFunctionLowering::visitGraphOpRecvFromHostInst(
+    GraphOperationInfo &graphOpInfo) {
   auto &graphFn = getCurrentGraphFunction();
   // TODO(b/78472806): Add a more thorough and proper fix for effectful ops in
   // the while cond function.
@@ -1307,8 +1319,9 @@ TFGraphLowering::visitGraphOpRecvFromHostInst(GraphOperationInfo &graphOpInfo) {
   return GLStatus::Success;
 }
 
-GLStatus TFGraphLowering::addTFRecvOp(SILInstruction *inst, int transferId,
-                                      StringRef srcDevice) {
+GLStatus TFGraphFunctionLowering::addTFRecvOp(SILInstruction *inst,
+                                              int transferId,
+                                              StringRef srcDevice) {
   auto opName = "tf_recv_" + llvm::itostr(transferId);
   auto &graphFn = getCurrentGraphFunction();
   auto *desc = TF_NewOperation(graphFn.getGraph(), "_Recv", opName.c_str());
@@ -1334,11 +1347,11 @@ GLStatus TFGraphLowering::addTFRecvOp(SILInstruction *inst, int transferId,
   return GLStatus::Success;
 }
 
-GLStatus TFGraphLowering::addTPUDequeueOp(SILInstruction *inst, bool isInfeed,
-                                          int transferId,
-                                          ArrayRef<int64_t> dims,
-                                          ArrayRef<int> numDims,
-                                          ArrayRef<int64_t *> dimPtrs) {
+GLStatus TFGraphFunctionLowering::addTPUDequeueOp(SILInstruction *inst,
+                                                  bool isInfeed, int transferId,
+                                                  ArrayRef<int64_t> dims,
+                                                  ArrayRef<int> numDims,
+                                                  ArrayRef<int64_t *> dimPtrs) {
   // Infeed dequeue runs on TPU, while outfeed dequeue runs on CPU.
   // Otherwise they have the same op signature.
   if (numDims.size() != 1) {
@@ -1400,7 +1413,7 @@ GLStatus TFGraphLowering::addTPUDequeueOp(SILInstruction *inst, bool isInfeed,
   return GLStatus::Success;
 }
 
-GLStatus TFGraphLowering::visitGraphOpD2DTensorRecvInst(
+GLStatus TFGraphFunctionLowering::visitGraphOpD2DTensorRecvInst(
     GraphOperationInfo &graphOpInfo) {
   // Signature: "tfc.D2DTensorRecv {transferId,srcDevice,device}"
   // Can also carry an optional shape array.
@@ -1434,8 +1447,9 @@ GLStatus TFGraphLowering::visitGraphOpD2DTensorRecvInst(
   }
 }
 
-GLStatus TFGraphLowering::addTFSendOp(SILInstruction *inst, int transferId,
-                                      StringRef destDevice) {
+GLStatus TFGraphFunctionLowering::addTFSendOp(SILInstruction *inst,
+                                              int transferId,
+                                              StringRef destDevice) {
   auto opName = "tf_send_" + llvm::itostr(transferId);
   auto &graphFn = getCurrentGraphFunction();
   auto *desc = TF_NewOperation(graphFn.getGraph(), "_Send", opName.c_str());
@@ -1462,11 +1476,11 @@ GLStatus TFGraphLowering::addTFSendOp(SILInstruction *inst, int transferId,
   return GLStatus::Success;
 }
 
-GLStatus TFGraphLowering::addTPUEnqueueOp(SILInstruction *inst, bool isInfeed,
-                                          int transferId,
-                                          ArrayRef<int64_t> dims,
-                                          ArrayRef<int> numDims,
-                                          ArrayRef<int64_t *> dimPtrs) {
+GLStatus TFGraphFunctionLowering::addTPUEnqueueOp(SILInstruction *inst,
+                                                  bool isInfeed, int transferId,
+                                                  ArrayRef<int64_t> dims,
+                                                  ArrayRef<int> numDims,
+                                                  ArrayRef<int64_t *> dimPtrs) {
   // Infeed enqueue runs on CPU, while outfeed enqueue runs on TPU.
   if (isInfeed) {
     if (thisDeviceType != DeviceType::CPU) {
@@ -1524,7 +1538,7 @@ GLStatus TFGraphLowering::addTPUEnqueueOp(SILInstruction *inst, bool isInfeed,
   return GLStatus::Success;
 }
 
-GLStatus TFGraphLowering::visitGraphOpD2DTensorSendInst(
+GLStatus TFGraphFunctionLowering::visitGraphOpD2DTensorSendInst(
     GraphOperationInfo &graphOpInfo) {
   // Signature: "tfc.D2DTensorSend,$in {transferId,destDevice,device}"
   // Can also carry an optional shape array.
@@ -1558,8 +1572,8 @@ GLStatus TFGraphLowering::visitGraphOpD2DTensorSendInst(
 }
 
 template <>
-GLStatus TFGraphLowering::createDatasetCreationContext(
-  GraphOperationInst *inst, std::vector<SILOpResult> &outputResults) {
+GLStatus TFGraphFunctionLowering::createDatasetCreationContext(
+    GraphOperationInst *inst, std::vector<SILOpResult> &outputResults) {
   GraphOperationInfo graphOpInfo(inst);
   // Type check and process the first attribute: dataSource.
   auto dataSource =
@@ -1621,8 +1635,8 @@ GLStatus TFGraphLowering::createDatasetCreationContext(
 
 // TODO: Remove this version when graph op takes over completely.
 template <>
-GLStatus TFGraphLowering::createDatasetCreationContext(
-  BuiltinInst *inst, std::vector<SILOpResult> &outputResults) {
+GLStatus TFGraphFunctionLowering::createDatasetCreationContext(
+    BuiltinInst *inst, std::vector<SILOpResult> &outputResults) {
   SILTensorOpInfo tfopInfo = SILTensorOpInfo::decode(inst).getValue();
   // Type check and process the first attribute: dataSource.
   DatasetCreationContext::DataSource dataSource;
@@ -1718,7 +1732,7 @@ GLStatus TFGraphLowering::createDatasetCreationContext(
 }
 
 template <typename Inst>
-GLStatus TFGraphLowering::visitTFDataset(Inst *inst) {
+GLStatus TFGraphFunctionLowering::visitTFDataset(Inst *inst) {
   // FIXME: Also support dataset/iterator outside of TPU context.
   if (thisDeviceType != DeviceType::TPU || !deviceInfo.isTPUInfeedEnabled) {
     internalError(
@@ -1752,85 +1766,25 @@ GLStatus TFGraphLowering::visitTFDataset(Inst *inst) {
   return GLStatus::Success;
 }
 
-/// Copy the graphs functions in `srcGraph` to `resultGraph`, and verify that
-/// `graphFuncName` must be one of the graph functions to copy over. Return true
-/// on error, with error already emitted on `fn` and `loc`.
-static bool copyGraphFunctions(SILFunction &fn, SILLocation loc,
-                               StringRef graphFuncName, TF_Graph *srcGraph,
-                               TF_Graph *resultGraph, TF_Status *status) {
-  DEBUG(llvm::dbgs() << "Copying graph functions including " << graphFuncName
-                     << " to a caller graph.\n");
-  assert(srcGraph);
-  // Now get the functions and copy them cover to `resultGraph`.
-  auto funcCount = TF_GraphNumFunctions(srcGraph);
-  std::vector<TF_Function *> funcs(funcCount);
-  int numImportedFuncs =
-      TF_GraphGetFunctions(srcGraph, funcs.data(), funcCount, status);
-  if (checkStatus(fn, loc, status))
-    return true;
-  assert(numImportedFuncs == funcCount);
-
-  SWIFT_DEFER {
-    for (auto *func : funcs) {
-      TF_DeleteFunction(func);
-    }
-  };
-
-  // TODO: Add sanity-check code that `funcs` include a function named
-  // `graphFuncName`.
-  for (auto *func : funcs) {
-    TF_GraphCopyFunction(resultGraph, func, /*gradient*/ nullptr, status);
-    if (checkStatus(fn, loc, status))
-      return true;
-  }
-
-  // All done!
-  return false;
-}
-
-bool tf::copyGraphFunctions(SILFunction &fn, SILLocation loc,
-                            StringRef graphFuncName, TF_Graph *srcGraph,
-                            TF_Graph *resultGraph) {
-  TF_Status *status = TF_NewStatus();
-  SWIFT_DEFER { TF_DeleteStatus(status); };
-  return copyGraphFunctions(fn, loc, graphFuncName, srcGraph, resultGraph,
-                            status);
-}
-
 static std::string getGraphFuncNameForFuncAttr(StringRef fnName) {
   if (fnName.startswith("$"))
     fnName = fnName.substr(1);
   return std::string(fnName) + ".tf_only";
 }
 
-bool TFGraphLowering::handleFunctionAttribute(TF_OperationDescription *op,
-                                              const std::string &opName,
-                                              SILLocation loc,
-                                              StringRef silFuncName) {
+bool TFGraphFunctionLowering::handleFunctionAttribute(
+    TF_OperationDescription *op, const std::string &opName, SILLocation loc,
+    StringRef silFuncName) {
   auto graphFnName = getGraphFuncNameForFuncAttr(silFuncName);
   TF_SetAttrFuncName(op, opName.c_str(), graphFnName.data(),
                      graphFnName.size());
-  auto findIt = graphFunctions.find(silFuncName);
-  if (findIt == graphFunctions.end()) {
-    DEBUG(llvm::dbgs() << "Cannot find function " << silFuncName
-                       << " to use as attr.\n");
-    pendingGraphFnNames.push_back(std::make_pair(silFuncName, loc));
-    return false;
-  } else {
-    DEBUG(llvm::dbgs() << "Found function " << silFuncName
-                       << " to use as attr.\n");
-    auto &graphFunc = *findIt->second;
-    assert(graphFnName == graphFunc.graphFnName);
-    // Now that we are using 'graphFunc' as an attribute, copy over that
-    // function along with any helper functions called by it.
-    return copyGraphFunctions(SILFn, loc, graphFunc.graphFnName,
-                              graphFunc.graph.get(), resultGraph, status);
-  }
+  return false;
 }
 
 /// Lower a graph_op into the TensorFlow op node.
 ///
-GLStatus TFGraphLowering::visitGraphOperationInst(GraphOperationInst *inst) {
+GLStatus
+TFGraphFunctionLowering::visitGraphOperationInst(GraphOperationInst *inst) {
   // If this is the magic tf_tensor_to_i1 builtin, then we completely ignore it.
   // the only user of it are things that take conditional branches, and they
   // handle it directly.
@@ -2247,7 +2201,7 @@ GLStatus TFGraphLowering::visitGraphOperationInst(GraphOperationInst *inst) {
 
 /// Lower a builtin for a TFOp instruction into a TensorFlow op node.
 ///
-GLStatus TFGraphLowering::visitTFOpInst(BuiltinInst *inst) {
+GLStatus TFGraphFunctionLowering::visitTFOpInst(BuiltinInst *inst) {
   SILTensorOpInfo tfopInfo = SILTensorOpInfo::decode(inst).getValue();
 
   // Swift host <-> TF device sends/recvs.
@@ -2575,7 +2529,7 @@ GLStatus TFGraphLowering::visitTFOpInst(BuiltinInst *inst) {
   return GLStatus::Success;
 }
 
-GLStatus TFGraphLowering::visitTupleInst(TupleInst *inst) {
+GLStatus TFGraphFunctionLowering::visitTupleInst(TupleInst *inst) {
   // Tuples never exist in the graph except when they are the argument to
   // the return instruction.
   assert(inst->hasOneUse() && isa<ReturnInst>(inst->getSingleUse()->getUser())&&
@@ -2583,15 +2537,16 @@ GLStatus TFGraphLowering::visitTupleInst(TupleInst *inst) {
   return GLStatus::Success;
 }
 
-GLStatus TFGraphLowering::visitTupleExtractInst(TupleExtractInst *inst) {
+GLStatus
+TFGraphFunctionLowering::visitTupleExtractInst(TupleExtractInst *inst) {
   // tuple_extracts only exist as part of the handling for multi-result
   // tensor operations.  This is handled as part of the 'getOperandValue'
   // implementation.
   return GLStatus::Success;
 }
 
-GLStatus TFGraphLowering::
-visitUncheckedRefCastInst(UncheckedRefCastInst *inst) {
+GLStatus
+TFGraphFunctionLowering::visitUncheckedRefCastInst(UncheckedRefCastInst *inst) {
   // UncheckedBitwiseCast's get generated between two identical TensorHandle's
   // when one is using a Swift type like Int32 and one is using Builtin.Int32.
   // None of this matters for graph lowering.
@@ -2602,8 +2557,7 @@ visitUncheckedRefCastInst(UncheckedRefCastInst *inst) {
   return GLStatus::Success;
 }
 
-
-GLStatus TFGraphLowering::visitReturnInst(ReturnInst *inst) {
+GLStatus TFGraphFunctionLowering::visitReturnInst(ReturnInst *inst) {
   auto &graphFn = getCurrentGraphFunction();
   assert(graphFn.outputs.empty() &&
          "Should only have one return per graph function");
@@ -2628,7 +2582,7 @@ GLStatus TFGraphLowering::visitReturnInst(ReturnInst *inst) {
   return GLStatus::Success;
 }
 
-GLStatus TFGraphLowering::visitBranchInst(BranchInst *inst) {
+GLStatus TFGraphFunctionLowering::visitBranchInst(BranchInst *inst) {
   auto &graphFn = getCurrentGraphFunction();
   assert(graphFn.outputs.empty() &&
          "Should only have one exit branch per graph function");
@@ -2650,12 +2604,11 @@ GLStatus TFGraphLowering::visitBranchInst(BranchInst *inst) {
   return GLStatus::Success;
 }
 
-
 /// Lower all of the instructions in the specified basic block.  If
 /// skipTerminator is set to true, then the terminator instruction isn't
 /// lowered.
-GLStatus TFGraphLowering::lowerBasicBlock(SILBasicBlock *bb,
-                                          bool skipTerminator) {
+GLStatus TFGraphFunctionLowering::lowerBasicBlock(SILBasicBlock *bb,
+                                                  bool skipTerminator) {
   // Visit all of the instructions other than the terminator.
   auto I = bb->begin(), E = bb->end();
 
@@ -2673,7 +2626,7 @@ GLStatus TFGraphLowering::lowerBasicBlock(SILBasicBlock *bb,
   return GLStatus::Success;
 }
 
-GLStatus TFGraphLowering::lowerSequenceRegion(SequenceSESERegion *r) {
+GLStatus TFGraphFunctionLowering::lowerSequenceRegion(SequenceSESERegion *r) {
   for (auto &child : r->getNodes()) {
     // The outputs for a sequence corresponds to the outputs of the last region
     // in the sequence. Hence, clear outputs for the current function if any.
@@ -2686,7 +2639,7 @@ GLStatus TFGraphLowering::lowerSequenceRegion(SequenceSESERegion *r) {
 
 /// Given a conditional branch, produce the TF_Output for its branch condition.
 static TF_Output getCondition(CondBranchInst *condBr,
-                              TFGraphLowering &lowering) {
+                              TFGraphFunctionLowering &lowering) {
   auto cond = condBr->getCondition();
   SILInstruction *tensorToI1 = nullptr;
   // TODO: remove the case of BuiltinInst.
@@ -2711,7 +2664,7 @@ static TF_Output getCondition(CondBranchInst *condBr,
 // Given a boolean value, create a 'not' operation to invert it, returning the
 // inverted result.
 static TF_Output createNotOp(TF_Output input, SILDebugLocation loc,
-                             TFGraphLowering &lowering) {
+                             TFGraphFunctionLowering &lowering) {
   auto opLocString = lowering.getUniqueName(loc, "not");
   auto &graphFn = lowering.getCurrentGraphFunction();
   auto *op = TF_NewOperation(graphFn.getGraph(), "LogicalNot",
@@ -2729,7 +2682,7 @@ static TF_Output createNotOp(TF_Output input, SILDebugLocation loc,
 
 /// Given a boolean value, create a 'cast' operation to convert it to int32.
 static TF_Output castBoolToInt32(TF_Output input, SILDebugLocation loc,
-                                 TFGraphLowering &lowering) {
+                                 TFGraphFunctionLowering &lowering) {
   auto opLocString = lowering.getUniqueName(loc, "cast");
   auto &graphFn = lowering.getCurrentGraphFunction();
   auto *op = TF_NewOperation(graphFn.getGraph(), "Cast",
@@ -2761,7 +2714,7 @@ static SILType getOpResultType(SILOpResult r) {
 //
 // This means that we can turn the computation that produces the bool for the
 // termination condition into the loop exit check.
-GLStatus TFGraphLowering::lowerWhileLoopRegion(WhileLoopSESERegion *r) {
+GLStatus TFGraphFunctionLowering::lowerWhileLoopRegion(WhileLoopSESERegion *r) {
   // Emit the preheader block.  The preheader ends with a branch that sets BB
   // arguments, which we will handle specially later.  They provide the passed
   // values to the loop function that we will create.
@@ -2972,7 +2925,8 @@ GLStatus TFGraphLowering::lowerWhileLoopRegion(WhileLoopSESERegion *r) {
   return lowerBasicBlock(r->getHeader(), /*skipTerminator:*/ true);
 }
 
-GLStatus TFGraphLowering::lowerConditionalRegion(ConditionalSESERegion *r) {
+GLStatus
+TFGraphFunctionLowering::lowerConditionalRegion(ConditionalSESERegion *r) {
   // Start by lowering any code that exists in the block that leads up to the
   // conditional branch.  This ensures that the condition bool is available.
   GLStatus S = lowerBasicBlock(r->getBranchBB(), /*skipTerminator:*/ true);
@@ -3156,7 +3110,7 @@ GLStatus TFGraphLowering::lowerConditionalRegion(ConditionalSESERegion *r) {
   return GLStatus::Success;
 }
 
-GLStatus TFGraphLowering::lowerRegion(SESERegionTree *region) {
+GLStatus TFGraphFunctionLowering::lowerRegion(SESERegionTree *region) {
   switch (region->getKind()) {
   case SESERegionTree::SingleBlock:
     return lowerBasicBlock(cast<SingleBlockSESERegion>(region)->getBB());
@@ -3180,9 +3134,9 @@ GLStatus TFGraphLowering::lowerRegion(SESERegionTree *region) {
 /// next outer scope.  For the top-level parameters to the SIL function, the
 /// passedValue can be null.
 /// On error, return a "NULL" value, and emit an error diagnostic.
-TF_Output TFGraphLowering::
-createParameter(SILOpResult value, TF_Output passedValue,
-                GraphFunctionBody &fn) {
+TF_Output TFGraphFunctionLowering::createParameter(SILOpResult value,
+                                                   TF_Output passedValue,
+                                                   GraphFunctionBody &fn) {
   auto opName = "arg_" + llvm::utostr(OpID++);
   auto *desc = TF_NewOperation(fn.getGraph(), "Placeholder", opName.c_str());
   auto loc = value.first.getLoc();
@@ -3218,9 +3172,9 @@ createParameter(SILOpResult value, TF_Output passedValue,
 /// Lower the specified list of SIL arguments to a bunch of parameters, filling
 /// the inputs list for the current function.  If the passedValues array is
 /// non-empty, it specifies the passed values to add to the input.
-GLStatus TFGraphLowering::lowerArgumentsToParams(ArrayRef<SILArgument *> args,
-                                             ArrayRef<TF_Output> passedValues,
-                                             SILLocation loc) {
+GLStatus TFGraphFunctionLowering::lowerArgumentsToParams(
+    ArrayRef<SILArgument *> args, ArrayRef<TF_Output> passedValues,
+    SILLocation loc) {
   auto &graphFn = getCurrentGraphFunction();
   unsigned idx = 0;
   for (auto arg : args) {
@@ -3236,10 +3190,9 @@ GLStatus TFGraphLowering::lowerArgumentsToParams(ArrayRef<SILArgument *> args,
   return GLStatus::Success;
 }
 
-
 /// Build a function around the code produced by the specified std::function.
-GraphFunctionBody TFGraphLowering::
-lowerToFunction(const std::function<void()> &body) {
+GraphFunctionBody
+TFGraphFunctionLowering::lowerToFunction(const std::function<void()> &body) {
   // Push a scope, allowing us to keep track of any live-in values in the
   // true code.  These will need to become tuple elements live across the
   // loop.
@@ -3256,7 +3209,8 @@ lowerToFunction(const std::function<void()> &body) {
   return result;
 }
 
-bool TFGraphLowering::addTopLevelTPUConfigLogic(TF_Operation **metadataNode) {
+bool TFGraphFunctionLowering::addTopLevelTPUConfigLogic(
+    TF_Operation **metadataNode) {
   {
     auto *desc = TF_NewOperation(resultGraph, "TPUReplicateMetadata",
                                  "TPUReplicate/TPUReplicateMetadata");
@@ -3292,15 +3246,15 @@ bool TFGraphLowering::addTopLevelTPUConfigLogic(TF_Operation **metadataNode) {
   return false;
 }
 
-bool TFGraphLowering::buildGraphNodesForTopLevelFunctionCall(
-    StringRef funcOpType, StringRef funcNodeBaseName, bool isPrimaryFn,
-    ArrayRef<TF_DataType> inputTypes, ArrayRef<TF_DataType> outputTypes) {
-  TF_Operation *metadataNode = nullptr;
-  if (isPrimaryFn && thisDeviceType == DeviceType::TPU) {
-    if (addTopLevelTPUConfigLogic(&metadataNode)) {
+bool TFGraphFunctionLowering::buildGraphNodesForTopLevelFunctionCall(
+    StringRef funcOpType, bool isPrimaryFn, ArrayRef<TF_DataType> inputTypes,
+    ArrayRef<TF_DataType> outputTypes, TF_Operation *&metadataNodeForTPU) {
+  if (isPrimaryFn && thisDeviceType == DeviceType::TPU && !metadataNodeForTPU) {
+    if (addTopLevelTPUConfigLogic(&metadataNodeForTPU)) {
       // An error has occurred. Abort graph generation.
       return true;
     }
+    assert(metadataNodeForTPU);
   }
 
   // Now we create top level graph nodes to invoke the function.
@@ -3327,7 +3281,7 @@ bool TFGraphLowering::buildGraphNodesForTopLevelFunctionCall(
   // The above discussion generalizes to multiple inputs and/or outputs.
   // FIXME: Lift the current restriction that the # TPU replicas is always 1.
   std::string funcOpTypeStr = funcOpType.str();
-  std::string funcNodeName = "tfc_func_" + funcNodeBaseName.str();
+  std::string funcNodeName = "tfc_func_" + funcNodeBaseName;
   TF_OperationDescription *funcDesc =
       TF_NewOperation(resultGraph, /*op_type*/ funcOpTypeStr.c_str(),
                       /*op_name*/ funcNodeName.c_str());
@@ -3340,7 +3294,7 @@ bool TFGraphLowering::buildGraphNodesForTopLevelFunctionCall(
   // Handle inputs.
   for (unsigned i = 0, e = inputTypes.size(); i != e; ++i) {
     std::string inputNodeName =
-      "tfc_input_" + std::to_string(i) + "_" + funcNodeBaseName.str();
+        "tfc_input_" + std::to_string(i) + "_" + funcNodeBaseName;
     TF_OperationDescription *inputDesc =
         TF_NewOperation(resultGraph, "Placeholder", inputNodeName.c_str());
     TF_SetAttrType(inputDesc, "dtype", inputTypes[i]);
@@ -3354,7 +3308,8 @@ bool TFGraphLowering::buildGraphNodesForTopLevelFunctionCall(
       // Add some intermediate nodes between I and F.
       TF_Operation *replicatedInput;
       {
-        std::string nodeName = "TPUReplicate/input" + std::to_string(i);
+        std::string nodeName =
+            funcNodeBaseName + "/TPUReplicate/input" + std::to_string(i);
         auto *desc = TF_NewOperation(resultGraph, "TPUReplicatedInput",
                                      nodeName.c_str());
         SmallVector<TF_Output, 1> input;
@@ -3365,10 +3320,11 @@ bool TFGraphLowering::buildGraphNodesForTopLevelFunctionCall(
         if (checkStatus(SILFn.getLocation())) return true;
       }
       {
-        std::string nodeName =
-          "TPUReplicate/replicated_input_" + std::to_string(i);
+        std::string nodeName = funcNodeBaseName +
+                               "/TPUReplicate/replicated_input_" +
+                               std::to_string(i);
         auto *desc = TF_NewOperation(resultGraph, "Identity", nodeName.c_str());
-        TF_AddControlInput(desc, metadataNode);
+        TF_AddControlInput(desc, metadataNodeForTPU);
         TF_AddInput(desc, {replicatedInput, 0});
         markNodeAsTPUReplicated(desc);
         TF_Operation *idInput = TF_FinishOperation(desc, status);
@@ -3385,7 +3341,7 @@ bool TFGraphLowering::buildGraphNodesForTopLevelFunctionCall(
   // Now handle outputs.
   for (unsigned i = 0, e = outputTypes.size(); i != e; ++i) {
     std::string outputNodeName =
-        "tfc_output_" + std::to_string(i) + "_" + funcNodeBaseName.str();
+        "tfc_output_" + std::to_string(i) + "_" + funcNodeBaseName;
     TF_OperationDescription *outputDesc =
         TF_NewOperation(resultGraph, "Identity", outputNodeName.c_str());
     TF_Output funcOutputNode{funcNode, static_cast<int>(i)};
@@ -3397,7 +3353,7 @@ bool TFGraphLowering::buildGraphNodesForTopLevelFunctionCall(
       TF_Operation *outputIdNode;
       {
         const std::string nodeName =
-            "TPUReplicate/Identity_" + std::to_string(i);
+            funcNodeBaseName + "/TPUReplicate/Identity_" + std::to_string(i);
         auto *desc = TF_NewOperation(resultGraph, "Identity", nodeName.c_str());
         TF_AddInput(desc, funcOutputNode);
         const auto deviceName =
@@ -3408,7 +3364,8 @@ bool TFGraphLowering::buildGraphNodesForTopLevelFunctionCall(
         if (checkStatus(SILFn.getLocation())) return true;
       }
       {
-        const std::string nodeName = "TPUReplicate/output" + std::to_string(i);
+        const std::string nodeName =
+            funcNodeBaseName + "/TPUReplicate/output" + std::to_string(i);
         auto *desc = TF_NewOperation(resultGraph, "TPUReplicatedOutput",
                                      nodeName.c_str());
         TF_AddInput(desc, {outputIdNode, 0});
@@ -3423,14 +3380,15 @@ bool TFGraphLowering::buildGraphNodesForTopLevelFunctionCall(
   }
 
   if (datasetCreationContext) {
-    if (createDatasetIteratorNodesWithInfeedEnqueue()) return true;
+    if (createDatasetIteratorNodesWithInfeedEnqueue())
+      return true;
   }
 
   // Everything is good!
   return false;
 }
 
-bool TFGraphLowering::buildGraphFunction(
+bool TFGraphFunctionLowering::buildGraphFunction(
     const GraphFunctionBody &graphBody, StringRef funcName,
     bool &hasSideEffects, SmallVectorImpl<TF_DataType> *inputTypes,
     SmallVectorImpl<TF_DataType> *outputTypes) {
@@ -3486,8 +3444,9 @@ bool TFGraphLowering::buildGraphFunction(
   return false;
 }
 
-bool tf::serializeGraphProtoBuf(SILFunction &SILFn, TF_Graph *resultGraph,
-                                std::vector<char> &bytes) {
+bool TFGraphLowering::serializeGraphProtoBuf(ASTContext &ctx,
+                                             SILLocation errorLoc,
+                                             std::vector<char> &bytes) {
   TF_Status *status = TF_NewStatus();
   // Create a buffer to hold the result.
   auto buffer = TF_NewBuffer();
@@ -3497,10 +3456,9 @@ bool tf::serializeGraphProtoBuf(SILFunction &SILFn, TF_Graph *resultGraph,
   };
 
   // Serialize the graph into the buffer.
-  TF_GraphToGraphDef(resultGraph, buffer, status);
+  TF_GraphToGraphDef(graph.get(), buffer, status);
   if (TF_GetCode(status) != TF_OK)  {
-    diagnose(SILFn, SILFn.getLocation(), diag::tf_lowering_error,
-             TF_Message(status));
+    diagnose(ctx, errorLoc, diag::tf_lowering_error, TF_Message(status));
     return true;
   }
 
@@ -3508,8 +3466,8 @@ bool tf::serializeGraphProtoBuf(SILFunction &SILFn, TF_Graph *resultGraph,
   if (TFDumpGraph) {
     int resultFD = -1;
     SmallString<64> resultPath;
-    auto error = llvm::sys::fs::createTemporaryFile(
-        "tf-dump-graph-" + SILFn.getName().str(), "pb", resultFD, resultPath);
+    auto error = llvm::sys::fs::createTemporaryFile("tf-dump-graph", "pb",
+                                                    resultFD, resultPath);
     if (error) {
       llvm::errs() << "error opening '" << resultPath.str()
                    << "' for -tf-dump-graph emission!\n";
@@ -3518,32 +3476,30 @@ bool tf::serializeGraphProtoBuf(SILFunction &SILFn, TF_Graph *resultGraph,
                    << " bytes to '" << resultPath.str() << "'\n";
       llvm::raw_fd_ostream file(resultFD, /*shouldClose*/ true,
                                 /*unbuffered*/ false);
-      file.write((const char*)buffer->data, buffer->length);
+      file.write((const char *)buffer->data, buffer->length);
     }
 
     // Also write in a textual format.
-    error = llvm::sys::fs::createTemporaryFile(
-        "tf-dump-graph-" + SILFn.getName().str(), "pbtxt", resultFD,
-        resultPath);
+    error = llvm::sys::fs::createTemporaryFile("tf-dump-graph", "pbtxt",
+                                               resultFD, resultPath);
     if (error) {
       llvm::errs() << "error opening '" << resultPath.str()
                    << "' for -tf-dump-graph emission!\n";
     } else {
       size_t len;
-      const char *content = TF_GraphDebugString(resultGraph, &len);
+      const char *content = TF_GraphDebugString(graph.get(), &len);
       llvm::outs() << "wrote textual graph of " << len << " bytes to '"
                    << resultPath.str() << "'\n";
       llvm::raw_fd_ostream file(resultFD, /*shouldClose*/ true,
                                 /*unbuffered*/ false);
       file.write(content, len);
 
-      llvm::outs() << "--- TFPartition GraphDef Proto: " << SILFn.getName()
-                   << "\n";
+      llvm::outs() << "--- TFPartition GraphDef Proto: \n";
       llvm::outs() << content << "\n";
       llvm::outs() << "----\n";
       llvm::outs().flush();
 
-      free((void*)content);
+      free((void *)content);
     }
   }
 
@@ -3561,21 +3517,10 @@ StringRef getTFCompatibleFuncName(SILFunction *fn) {
   return fnName;
 }
 
-/// This is a helper function to unify the implementation of
-/// tf::lowerTFFunction() and tf::lowerTFGraph(). Where the former calls this
-/// method with `isAcceleratorOnly` set to true, and the latter false. See their
-/// doc comments on the high-level semantics.
-///
-///  `graphFnNameForCaller` provides for the caller with a name to call this
-/// lowered graph function. If `isAcceleratorOnly` is true, it is the
-/// graph function name for a TF graph node to call; otherwise, it is a function
-/// name for the host runtime to call.
-static bool lowerTFGraphOrFunction(
+bool TFGraphLowering::lowerTFGraphOrFunction(
     StringRef hostFnName, SILFunction *fn,
     const std::string &graphFnNameForCaller, bool isAcceleratorOnly,
-    const GraphFunctionDeviceInfo &deviceInfo,
-    llvm::DenseMap<StringRef, std::unique_ptr<LoweredGraphFunction>>
-        &graphFunctions) {
+    const GraphFunctionDeviceInfo &deviceInfo) {
 #ifndef SWIFT_ENABLE_TENSORFLOW
   // This should never be called if TensorFlow support isn't enabled, but just
   // in case, emit an error message so a misconfiguration is diagnosable.
@@ -3602,15 +3547,13 @@ static bool lowerTFGraphOrFunction(
   // the file descriptor mapping...
   setenv("TF_CPP_MIN_LOG_LEVEL", "2", 1);
 
-  std::unique_ptr<TF_Graph, decltype(&TF_DeleteGraph)> resultGraph(
-      TF_NewGraph(), &TF_DeleteGraph);
   TF_Status *status = TF_NewStatus();
 
   SWIFT_DEFER {
     TF_DeleteStatus(status);
   };
 
-  DevicePartitioner partitioner(*fn, deviceInfo);
+  DevicePartitioner partitioner(*fn, deviceInfo, nextTensorTransferId);
   auto entryFnBaseName = graphFnNameForCaller;
   unsigned helperFuncId = 0;
   SmallVector<std::pair<StringRef, SILLocation>, 1> pendingGraphFnNames;
@@ -3623,21 +3566,30 @@ static bool lowerTFGraphOrFunction(
     };
     bool isPrimaryFn = deviceType == deviceInfo.primaryDeviceType;
 
-    TFGraphLowering graphGen(*perDeviceFn, deviceType, deviceInfo,
-                             graphFunctions, resultGraph.get(),
-                             pendingGraphFnNames, status);
+    // The func op type is `graphFnName`, with the caller node name being
+    // based on `funcNodeBaseName`.
+    std::string funcNodeBaseName = entryFnBaseName;
+    if (!isPrimaryFn) {
+      funcNodeBaseName += "_helper_" + llvm::utostr(helperFuncId);
+      ++helperFuncId;
+    }
+    TFGraphFunctionLowering graphFuncGen(
+        *perDeviceFn, deviceType, deviceInfo, funcNodeBaseName, graphFunctions,
+        graph.get(), pendingGraphFnNames, status);
     GLStatus S = GLStatus::Success;
-    auto graphFnBody = graphGen.lowerToFunction([&graphGen, perDeviceFn, &S]() {
-      // This is the top level of the function, add its formal arguments.
-      S = graphGen.lowerArgumentsToParams(perDeviceFn->getArguments(), {},
-                                      perDeviceFn->getLocation());
-      if (S != GLStatus::Success) return;
+    auto graphFnBody =
+        graphFuncGen.lowerToFunction([&graphFuncGen, perDeviceFn, &S]() {
+          // This is the top level of the function, add its formal arguments.
+          S = graphFuncGen.lowerArgumentsToParams(
+              perDeviceFn->getArguments(), {}, perDeviceFn->getLocation());
+          if (S != GLStatus::Success)
+            return;
 
-      // Lower all of the code inside the function body (which can of course
-      // recursively creates functions and call them as ops.
-      auto structure = canonicalizeCFGForXLA(perDeviceFn);
-      S = graphGen.lowerRegion(structure.get());
-    });
+          // Lower all of the code inside the function body (which can of course
+          // recursively creates functions and call them as ops.
+          auto structure = canonicalizeCFGForXLA(perDeviceFn);
+          S = graphFuncGen.lowerRegion(structure.get());
+        });
     if (S != GLStatus::Success)
       return true;
 
@@ -3648,25 +3600,22 @@ static bool lowerTFGraphOrFunction(
 
     bool hasSideEffects = false;
     SmallVector<TF_DataType, 4> inputTypes, outputTypes;
-    if (graphGen.buildGraphFunction(graphFnBody, graphFnName, hasSideEffects,
-                                    &inputTypes, &outputTypes))
+    if (graphFuncGen.buildGraphFunction(graphFnBody, graphFnName,
+                                        hasSideEffects, &inputTypes,
+                                        &outputTypes))
       return true;
 
-    // The func op type is `graphFnName`, with the caller node name being
-    // based on `funcNodeBaseName`.
-    std::string funcNodeBaseName = entryFnBaseName;
     if (!isPrimaryFn) {
-      funcNodeBaseName += "_helper_" + llvm::utostr(helperFuncId);
-      ++helperFuncId;
       assert(inputTypes.empty());
       assert(outputTypes.empty());
     }
 
     // Create the top level graph nodes, only when we are lowering to a graph
     // for host-side invocation.
-    if (!isAcceleratorOnly && graphGen.buildGraphNodesForTopLevelFunctionCall(
-                                  graphFnName, funcNodeBaseName, isPrimaryFn,
-                                  inputTypes, outputTypes))
+    if (!isAcceleratorOnly &&
+        graphFuncGen.buildGraphNodesForTopLevelFunctionCall(
+            graphFnName, isPrimaryFn, inputTypes, outputTypes,
+            metadataNodeForTPU))
       return true;
   }
 
@@ -3674,9 +3623,8 @@ static bool lowerTFGraphOrFunction(
   DEBUG(llvm::dbgs() << "Inserting a graph functions entry with host fn "
                      << hostFnName << "\n");
   assert(!graphFunctions.count(hostFnName));
-  auto graphFn = llvm::make_unique<LoweredGraphFunction>(
-      hostFnName, entryFnBaseName, std::move(resultGraph),
-      std::move(pendingGraphFnNames));
+  auto graphFn =
+      llvm::make_unique<LoweredGraphFunction>(hostFnName, entryFnBaseName);
   graphFunctions[graphFn->silHostFnName] = std::move(graphFn);
   // This confirms that the StringRef-typed map key has a proper backing buffer.
   assert(graphFunctions.count(hostFnName));
@@ -3685,30 +3633,27 @@ static bool lowerTFGraphOrFunction(
 #endif
 }
 
-bool tf::lowerTFFunction(
-    StringRef hostFnName, SILFunction *fn,
-    const GraphFunctionDeviceInfo &deviceInfo,
+TFGraphLowering::TFGraphLowering(
     llvm::DenseMap<StringRef, std::unique_ptr<LoweredGraphFunction>>
-        &graphFunctions) {
+        &graphFunctions)
+    : graphFunctions(graphFunctions), graph(TF_NewGraph(), &TF_DeleteGraph) {}
+
+bool TFGraphLowering::lowerTFFunction(
+    StringRef hostFnName, SILFunction *fn,
+    const GraphFunctionDeviceInfo &deviceInfo) {
   std::string graphFnName = getGraphFuncNameForFuncAttr(hostFnName);
   DEBUG(llvm::dbgs() << "Lowering accelerator-only host fn " << hostFnName
                      << " to graph function " << graphFnName << "\n");
   return lowerTFGraphOrFunction(hostFnName, fn, graphFnName,
-                                /*isAcceleratorOnly*/ true, deviceInfo,
-                                graphFunctions);
+                                /*isAcceleratorOnly*/ true, deviceInfo);
 }
 
-bool tf::lowerTFGraph(
-    StringRef hostFnName, SILFunction *fn,
-    const GraphFunctionDeviceInfo &deviceInfo,
-    llvm::DenseMap<StringRef, std::unique_ptr<LoweredGraphFunction>>
-        &graphFunctions) {
+bool TFGraphLowering::lowerTFGraph(StringRef hostFnName, SILFunction *fn,
+                                   const GraphFunctionDeviceInfo &deviceInfo) {
   std::string entryFnBaseName = getTFCompatibleFuncName(fn);
   return lowerTFGraphOrFunction(hostFnName, fn, entryFnBaseName,
-                                /*isAcceleratorOnly*/ false, deviceInfo,
-                                graphFunctions);
+                                /*isAcceleratorOnly*/ false, deviceInfo);
 }
-
 
 //===----------------------------------------------------------------------===//
 // TFLowerGraphTestPass
@@ -3727,22 +3672,20 @@ struct TFLowerGraphTestPass : public SILFunctionTransform {
         *fn, /*removeConfigInst*/ true);
     llvm::DenseMap<StringRef, std::unique_ptr<LoweredGraphFunction>>
         graphFunctions;
-    if (lowerTFGraph(fn->getName(), fn, deviceInfo, graphFunctions)) {
+    TFGraphLowering graphLowering(graphFunctions);
+    if (graphLowering.lowerTFGraph(fn->getName(), fn, deviceInfo)) {
       llvm::errs() << "Failed to generate TFGraph for " << fn->getName()
                    << "\n";
       return;
     }
-    for (const auto &kv : graphFunctions) {
-      const LoweredGraphFunction* resultGraph = kv.second.get();
-      size_t len;
-      const char *content = TF_GraphDebugString(resultGraph->graph.get(), &len);
-      llvm::outs() << "--- TFPartition GraphDef Proto: " << fn->getName()
-                   << "\n";
-      llvm::outs() << content << "\n";
-      llvm::outs() << "----\n";
-      llvm::outs().flush();
-      free((void*)content);
-    }
+    size_t len;
+    const char *content =
+        TF_GraphDebugString(graphLowering.getGraphDebug(), &len);
+    llvm::outs() << "--- TFPartition GraphDef Proto: " << fn->getName() << "\n";
+    llvm::outs() << content << "\n";
+    llvm::outs() << "----\n";
+    llvm::outs().flush();
+    free((void *)content);
   }
 };
 

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -4394,11 +4394,6 @@ void TFFunctionPartition::finalizeHostFunction(const std::vector<char> &bytes,
   // the placeholder instructions for the data + length with the actual bits
   // we want to use.
   // This effectively emits the encoded graph as a global symbol.
-  //
-  // TODO: Currently the byte buffer is local to the host function, so multiple
-  // partitionable functions that share the same graphDef could have replicated
-  // byte buffers. Can move to a global byte buffer if this helps with
-  // performance.
   SILBuilder B(tensorProgram.programPlaceholder);
   auto data = B.createStringLiteral(hostFn.getLocation(),
                                     StringRef(bytes.data(), bytes.size()),
@@ -4546,6 +4541,10 @@ void TFPartition::run() {
     assert(graphFunctions.count(hostFn->getName()));
     auto &thisGraphFunc = *graphFunctions[hostFn->getName()];
 
+    // TODO: Currently the byte buffer is local to the host function, so
+    // multiple partitionable functions that share the same graphDef could have
+    // replicated byte buffers. Can move to a global byte buffer if this helps
+    // with performance.
     partitioner->finalizeHostFunction(bytes, thisGraphFunc.graphFnName);
   }
 }

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -46,6 +46,17 @@ using namespace swift;
 using namespace tf;
 using llvm::DenseMap;
 
+/// This is a counter we use to give each send/receive operation a unique ID.
+static int nextSendID = 0;
+
+static llvm::cl::opt<bool> TFModuleLevelGraph(
+    "tf-module-level-graph", llvm::cl::init(true),
+    llvm::cl::desc(
+        "When true, generate 1 TF graph per module. Otherwise generate 1 TF "
+        "graph per partitionable function, for ease of writing tests and "
+        "verifying test outputs. Only set to false in unit tests,"
+        "and when the unit tests do not involve function-typed attributes."));
+
 template<typename...T, typename...U>
 static InFlightDiagnostic
 diagnose(ASTContext &Context, SourceLoc loc, Diag<T...> diag, U &&...args) {
@@ -628,6 +639,7 @@ class TFFunctionPartition {
 public:
   SILFunction &hostFn;
   ModuleDecl &tensorFlowModule;  // TensorFlow standard library.
+  TFGraphLowering *const graphLowering;
   /// For partitionable functions, map the SIL host function names to the
   /// lowered TF graph artifacts.
   DenseMap<StringRef, std::unique_ptr<LoweredGraphFunction>> &graphFunctions;
@@ -731,10 +743,11 @@ public:
 public:
   TFFunctionPartition(SILFunction &Fn, SILPassManager *PM,
                       ModuleDecl &tensorFlowModule,
+                      TFGraphLowering *graphLowering,
                       DenseMap<StringRef, std::unique_ptr<LoweredGraphFunction>>
                           &graphFunctions)
       : hostFn(Fn), tensorFlowModule(tensorFlowModule),
-        graphFunctions(graphFunctions),
+        graphLowering(graphLowering), graphFunctions(graphFunctions),
         // TODO: remote this call once partition pass is folded into
         // deabstraction.
         deviceInfo(
@@ -754,16 +767,18 @@ public:
   /// Run the marking/analysis phase on this function. Return true on error.
   bool markFunction(bool &hasTensorOps);
 
+  TFGraphLowering *getGraphLoweringTest() { return graphLowering; }
+
   /// Partition and lower this function to a graph, and add an entry to
   /// `graphFunctions`.  Return true on error.
   ///
   /// Should only be called when markFunction() succeeds.
   bool partitionAndLowerGraph(bool isTest);
 
-  // Complete graph lowering by serializing it into a protobuf. For a
-  // non-accelerator-only function, also complete the host function rewrite, by
-  // "installing" the serialized protobuf bytes into that function.
-  void finalizeGraphLowering(StringRef entryFnBaseName, TF_Graph *graph);
+  /// For a non-accelerator-only function, complete the host function
+  /// rewrite, by "installing" the serialized protobuf bytes into that function.
+  void finalizeHostFunction(const std::vector<char> &bytes,
+                            StringRef entryFnBaseName);
 
   void diagnoseCopyToAccelerator(SILValue value, SILInstruction *user,
                                  bool isTensorProgramArgument);
@@ -2208,9 +2223,6 @@ class PartitionCloner : public SILClonerWithScopes<PartitionCloner> {
   /// This is a basic block on the newly created function which represents the
   /// exit node of the function.
   SILBasicBlock *exitBB;
-
-  /// This is a counter we use to give each send/receive operation a unique ID.
-  int nextSendID = 0;
 
   /// This is the set of instructions that should be removed from the host code
   /// after the cloning operation is complete.
@@ -4355,28 +4367,25 @@ bool TFFunctionPartition::lowerGraph(bool isTest) {
     assert(deviceInfo.numUsedDeviceTypes == 1 &&
            "An accelerator-only SIL function must be lowered to a single TF "
            "device.");
-    if (lowerTFFunction(hostFn.getName(), acceleratorFn, deviceInfo,
-                        graphFunctions))
+    if (graphLowering->lowerTFFunction(hostFn.getName(), acceleratorFn,
+                                       deviceInfo))
       return true;
 
     // Remove the host function so it doesn't go through the normal
     // compiler flow.
     hostFn.getModule().eraseFunction(&hostFn);
   } else {
-    if (lowerTFGraph(hostFn.getName(), acceleratorFn, deviceInfo, graphFunctions
-                     /*entryFnBaseName, pendingGraphFnNames*/))
+    if (graphLowering->lowerTFGraph(hostFn.getName(), acceleratorFn,
+                                    deviceInfo))
       return true;
   }
 
   return false;
 }
 
-void TFFunctionPartition::finalizeGraphLowering(StringRef entryFnBaseName,
-                                                TF_Graph *graph) {
+void TFFunctionPartition::finalizeHostFunction(const std::vector<char> &bytes,
+                                               StringRef entryFnBaseName) {
   assert(!entryFnBaseName.startswith("$"));
-  std::vector<char> bytes;
-  if (serializeGraphProtoBuf(hostFn, graph, bytes))
-    return; // error already emitted
 
   if (isAcceleratorOnly(hostFn))
     return;
@@ -4385,6 +4394,11 @@ void TFFunctionPartition::finalizeGraphLowering(StringRef entryFnBaseName,
   // the placeholder instructions for the data + length with the actual bits
   // we want to use.
   // This effectively emits the encoded graph as a global symbol.
+  //
+  // TODO: Currently the byte buffer is local to the host function, so multiple
+  // partitionable functions that share the same graphDef could have replicated
+  // byte buffers. Can move to a global byte buffer if this helps with
+  // performance.
   SILBuilder B(tensorProgram.programPlaceholder);
   auto data = B.createStringLiteral(hostFn.getLocation(),
                                     StringRef(bytes.data(), bytes.size()),
@@ -4439,11 +4453,16 @@ class TFPartition : public SILModuleTransform {
   /// `LoweredGraphFunction::silHostFnName` in that object.
   DenseMap<StringRef, std::unique_ptr<LoweredGraphFunction>> graphFunctions;
 
+  // Mutually exclusive, based on flag value TFModuleLevelGraph.
+  TFGraphLowering moduleGraphLowering; // Used when the flag is true.
+  SmallVector<TFGraphLowering, 16> testGraphLowerings; // Used when false.
+
   using HostPartitionContext =
       std::pair<SILFunction *, std::unique_ptr<TFFunctionPartition>>;
 
 public:
-  TFPartition(bool isTest) : isTest(isTest) {}
+  TFPartition(bool isTest)
+      : isTest(isTest), moduleGraphLowering(TFGraphLowering(graphFunctions)) {}
 
   /// The entry point to the transformation.
   void run() override;
@@ -4506,30 +4525,28 @@ void TFPartition::run() {
       continue; // error already emitted, but continue processing other
                 // functions.
 
+  if (hostPartitionContexts.empty() || !TFModuleLevelGraph)
+    return;
+
   // In the second pass, we know all partitionable functions have had their
   // graph function bodies generated. When a function foo() references another
   // function bar() as a function-typed attribute, but bar()'s graph function
   // body is not avilable during the first pass, we will be copying the graph
   // function body of bar() into the graph function body of foo() in this pass.
+
+  std::vector<char> bytes;
+  auto errorLoc = hostPartitionContexts.front().first->getLocation();
+  if (TFModuleLevelGraph &&
+      moduleGraphLowering.serializeGraphProtoBuf(ctx, errorLoc, bytes))
+    return; // error already emitted
+
   for (auto &context : hostPartitionContexts) {
     auto *hostFn = context.first;
     auto *partitioner = context.second.get();
     assert(graphFunctions.count(hostFn->getName()));
     auto &thisGraphFunc = *graphFunctions[hostFn->getName()];
-    auto *resultGraph = thisGraphFunc.graph.get();
-    for (auto pair : thisGraphFunc.pendingGraphFnNames) {
-      auto silHostFnName = pair.first;
-      auto loc = pair.second;
-      // TODO: Support the case where `silHostFnName` is defined in another
-      // module if that's important.
-      assert(graphFunctions.count(silHostFnName));
-      auto &srcGraphFunc = graphFunctions[silHostFnName];
-      auto *srcGraph = srcGraphFunc->graph.get();
-      if (copyGraphFunctions(*hostFn, loc, srcGraphFunc->graphFnName, srcGraph,
-                             resultGraph))
-        return; // error already emitted.
-    }
-    partitioner->finalizeGraphLowering(thisGraphFunc.graphFnName, resultGraph);
+
+    partitioner->finalizeHostFunction(bytes, thisGraphFunc.graphFnName);
   }
 }
 
@@ -4540,14 +4557,24 @@ bool TFPartition::processFunction(
   if (partitionFunction(hostFn, partitioner)) {
     return true; // error already emitted.
   } else if (partitioner) {
-    assert(graphFunctions.count(hostFn->getName()));
-    auto &thisGraphFunc = *graphFunctions[hostFn->getName()];
-    if (thisGraphFunc.pendingGraphFnNames.empty()) {
-      // The lowered graph is self-contained, so we can serialize it and
-      // complete the host function rewrite here.
-      auto *resultGraph = thisGraphFunc.graph.get();
-      partitioner->finalizeGraphLowering(thisGraphFunc.graphFnName,
-                                         resultGraph);
+    if (!TFModuleLevelGraph) {
+      // In this test mode, for code simplicity we eagerly serialize the graph
+      // def, without first copying over any graph functions that this graph
+      // function depends on (in its function-typed attributes), so this test
+      // mode is only robust when there are no function-typed attributes.
+      assert(graphFunctions.count(hostFn->getName()));
+      auto &thisGraphFunc = *graphFunctions[hostFn->getName()];
+
+      std::vector<char> bytes;
+      auto errorLoc = hostFn->getLocation();
+      if (partitioner->getGraphLoweringTest()->serializeGraphProtoBuf(
+              getModule()->getASTContext(), errorLoc, bytes))
+        return true; // error already emitted
+      partitioner->finalizeHostFunction(bytes, thisGraphFunc.graphFnName);
+
+      // Reset the tensor id counter for host-TF sends/recvs, so that each test
+      // starts with a nice 0 as the id.
+      nextSendID = 0;
     } else {
       // The lowered graph references some other graph functions whose
       // bodies are not yet available -- track it for continued processing
@@ -4588,8 +4615,13 @@ bool TFPartition::partitionFunction(
 
   DEBUG(llvm::dbgs() << "  " << hostFn->getName()
                      << " should be partitioned.\n");
-  partitioner = llvm::make_unique<TFFunctionPartition>(*hostFn, PM, *tfModule,
-                                                       graphFunctions);
+  TFGraphLowering *graphLowering = &moduleGraphLowering;
+  if (!TFModuleLevelGraph) {
+    testGraphLowerings.emplace_back(TFGraphLowering(graphFunctions));
+    graphLowering = &testGraphLowerings.back();
+  }
+  partitioner = llvm::make_unique<TFFunctionPartition>(
+      *hostFn, PM, *tfModule, graphLowering, graphFunctions);
   bool hasTensorOps = false;
   if (partitioner->markFunction(hasTensorOps))
     return true; // We've encountered an error.

--- a/stdlib/public/TensorFlow/TensorHandle.swift
+++ b/stdlib/public/TensorFlow/TensorHandle.swift
@@ -97,12 +97,15 @@ extension TensorHandle : TensorSendableReceivable {
   ) -> TensorHandle<Scalar> {
     debugLog("Receiving tensor of id \(tensorId) and type \(Scalar.self).")
     let status = TF_NewStatus()
-    let cTensor: CTensor = TF_DequeueNamedTensor(
+    let cTensor: CTensor? = TF_DequeueNamedTensor(
       computation.cSession, Int32(tensorId), status)
     checkOk(status)
+    internalConsistencyCheck(
+      cTensor != nil,
+      "TF_DequeueNamedTensor() cannot return nil when the status is OK.")
     TF_DeleteStatus(status)
-    let tensorHandle = TensorHandle<Scalar>(copyingFromCTensor: cTensor)
-    TF_DeleteTensor(cTensor)
+    let tensorHandle = TensorHandle<Scalar>(copyingFromCTensor: cTensor!)
+    TF_DeleteTensor(cTensor!)
     if _RuntimeConfig.printsDebugLog {
       debugLog("The received tensor of id \(tensorId) has content:")
       dumpTensorContent(tensorHandle.cTensorHandle, Scalar.self)

--- a/test/TensorFlow/dataset.swift
+++ b/test/TensorFlow/dataset.swift
@@ -1,67 +1,5 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -O -emit-sil -verify %s | %FileCheck %s
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -Xllvm -tf-strict-deabstraction -O -emit-sil -verify %s | %FileCheck %s --check-prefix=STRICTDA
+// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -Xllvm -tf-strict-deabstraction -O -emit-sil -verify %s | %FileCheck %s
 import TensorFlow
-
-public func testDatasetWithFakeData() {
-  TensorFlow.enableTPU(infeed: true)
-  let x: TensorHandle<Float> = #tfop(
-    "tfc.makeIteratorGetNextWithDatasets",
-    dataSource: "fake",
-    filePath: "dummy_path",
-    batchSize: 1,
-    outputShapes: [TensorShape()])
-  let y = Tensor<Float>(handle: x) + 1
-  print(y.array.scalars[0])
-}
-
-// CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testDatasetWithFakeData{{.*}}
-// CHECK: bb0:
-// CHECK:        [[GETNEXT:%[0-9]+]] = builtin "__tfop_tfc.makeIteratorGetNextWithDatasets{{.*}} : $TensorHandle<Float>
-// CHECK:        [[RESULT:%[0-9]+]] = builtin "__tfop_Add,$in,$in,T,__device"([[GETNEXT]] : $TensorHandle<Float>, {{.*}} : $TensorHandle<Float>
-// CHECK-NEXT:   return [[RESULT]] : $TensorHandle<Float>
-
-// STRICTDA-LABEL: --- TFPartition Accelerator Result: {{.*}}testDatasetWithFakeData{{.*}}
-// STRICTDA: bb0:
-// STRICTDA:        [[GETNEXT:%[0-9]+]] = graph_op "tfc.makeIteratorGetNextWithDatasets{{.*}} : $TensorHandle<Float>
-// STRICTDA:        [[RESULT:%[0-9]+]] = graph_op "Add,i,i"([[GETNEXT]] : $TensorHandle<Float>, {{.*}} : $TensorHandle<Float>
-// STRICTDA-NEXT:   return [[RESULT]] : $TensorHandle<Float>
-
-public func testDatasetWithMNIST() {
-  TensorFlow.enableTPU(infeed: true)
-  let (images1, labels1): (TensorHandle<Float>, TensorHandle<Int32>) = #tfop(
-    "tfc.makeIteratorGetNextWithDatasets",
-    dataSource: "mnist",
-    filePath: "some_path",
-    batchSize: 64,
-    output_shapes: [TensorShape(64,224,224,3), TensorShape(64)])
-  let images : TensorHandle<Float> = #tfop("Identity", images1)
-  let labels : TensorHandle<Int32> = #tfop("Identity", labels1)
-  // Confirm we can add more nodes to the graph.
-  let imagesMod = Tensor<Float>(handle: images) + 1
-  let labelsMod = Tensor<Int32>(handle: labels) + 2
-  print(imagesMod.array.scalars[0])
-  print(labelsMod.array.scalars[0])
-}
-
-// CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testDatasetWithMNIST{{.*}}
-// CHECK: bb0:
-// CHECK:  builtin "__tfop_tfc.makeIteratorGetNextWithDatasets{{.*}} : $(TensorHandle<Float>, TensorHandle<Int32>)
-// CHECK-NEXT:  tuple_extract {{.*}} : $(TensorHandle<Float>, TensorHandle<Int32>), 0
-// CHECK-NEXT:  tuple_extract {{.*}} : $(TensorHandle<Float>, TensorHandle<Int32>), 1
-// CHECK: builtin "__tfop_Add,$in,$in,T,__device"(
-// CHECK: builtin "__tfop_Add,$in,$in,T,__device"(
-// The operands can appear in arbitrary order here.
-// CHECK:  [[RESULT:%.*]] = tuple ({{.*}} : $TensorHandle<{{.*}}>, {{.*}} : $TensorHandle<{{.*}}>)
-// CHECK-NEXT:  return [[RESULT]] : $(TensorHandle<{{.*}}>, TensorHandle<{{.*}}>)
-
-// STRICTDA-LABEL: --- TFPartition Accelerator Result: {{.*}}testDatasetWithMNIST{{.*}}
-// STRICTDA: bb0:
-// STRICTDA:  (%0, %1) = graph_op "tfc.makeIteratorGetNextWithDatasets{{.*}} : $TensorHandle<Float>, $TensorHandle<Int32>
-// STRICTDA: graph_op "Add,i,i"(
-// STRICTDA: graph_op "Add,i,i"(
-// The operands can appear in arbitrary order here.
-// STRICTDA:  [[RESULT:%.*]] = tuple ({{.*}} : $TensorHandle<{{.*}}>, {{.*}} : $TensorHandle<{{.*}}>)
-// STRICTDA-NEXT:  return [[RESULT]] : $(TensorHandle<{{.*}}>, TensorHandle<{{.*}}>)
 
 // Creates a dataset, which produces one float scalar value in each get next
 // call.
@@ -81,29 +19,6 @@ public func createMockDataSet() -> VariantHandle {
                                       output_shapes: [TensorShape()])
   return dataset
 }
-
-// The lowered graph should only contain the graph function, and not any
-// top-level nodes.
-//
-// CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}createMockDataSet{{.*}}
-// CHECK-NOT:   node {
-// CHECK:       function {
-// CHECK-NEXT:    signature {
-// CHECK-NEXT:      name: "{{.*}}createMockDataSet{{.*}}.tf_only"
-// CHECK:           output_arg {
-// CHECK-NEXT:        name: "op_createmockdataset{{.*}}"
-// CHECK-NEXT:        type: DT_VARIANT
-// CHECK-NEXT:      }
-
-// STRICTDA-LABEL: --- TFPartition Accelerator Result: {{.*}}createMockDataSet{{.*}}
-// STRICTDA-NOT:   node {
-// STRICTDA:       function {
-// STRICTDA-NEXT:    signature {
-// STRICTDA-NEXT:      name: "{{.*}}createMockDataSet{{.*}}.tf_only"
-// STRICTDA:           output_arg {
-// STRICTDA-NEXT:        name: "op_createmockdataset{{.*}}"
-// STRICTDA-NEXT:        type: DT_VARIANT
-// STRICTDA-NEXT:      }
 
 // TODO: support taking the following function typed parameter.
 // _ datasetCreator : @convention(tensorflow) () -> VariantHandle
@@ -137,10 +52,11 @@ public func model() {
   _hostOp(one)
 }
 
+// CHECK-LABEL: --- TFPartition GraphDef Proto
+
 // The lowered graph should only contain two graph functions, plus the
 // top-level nodes for calling the grah function lowered from model().
 
-// CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}model{{.*}}
 // CHECK:      node {
 // CHECK-NEXT:   name: "{{.*}}model{{.*}}"
 // CHECK-NEXT:   op: "{{.*}}model{{.*}}.tf_CPU.device_partition"
@@ -151,13 +67,13 @@ public func model() {
 // CHECK:       function {
 // CHECK-NOT:   function {
 
-// STRICTDA-LABEL: --- TFPartition Accelerator Result: {{.*}}model{{.*}}
-// STRICTDA:      node {
-// STRICTDA-NEXT:   name: "{{.*}}model{{.*}}"
-// STRICTDA-NEXT:   op: "{{.*}}model{{.*}}.tf_CPU.device_partition"
-// STRICTDA:      node {
-// STRICTDA-NEXT:  name: "tfc_output_0_{{.*}}model{{.*}}"
+// Ideally we want to check the following as well, but the two graph functions
+// above do not have a deterministic ordering in the GraphDef proto, which will
+// cause the test to be flakey.
 
-// STRICTDA:       function {
-// STRICTDA:       function {
-// STRICTDA-NOT:   function {
+// HECK-NEXT:    signature {
+// HECK-NEXT:      name: "{{.*}}createMockDataSet{{.*}}.tf_only"
+// HECK:           output_arg {
+// HECK-NEXT:        name: "op_createmockdataset{{.*}}"
+// HECK-NEXT:        type: DT_VARIANT
+// HECK-NEXT:      }

--- a/test/TensorFlow/dataset_legacy.swift
+++ b/test/TensorFlow/dataset_legacy.swift
@@ -1,0 +1,64 @@
+// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -O -emit-sil -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -Xllvm -tf-strict-deabstraction -O -emit-sil -verify %s | %FileCheck %s --check-prefix=STRICTDA
+import TensorFlow
+
+public func testDatasetWithFakeData() {
+  TensorFlow.enableTPU(infeed: true)
+  let x: TensorHandle<Float> = #tfop(
+    "tfc.makeIteratorGetNextWithDatasets",
+    dataSource: "fake",
+    filePath: "dummy_path",
+    batchSize: 1,
+    outputShapes: [TensorShape()])
+  let y = Tensor<Float>(handle: x) + 1
+  print(y.array.scalars[0])
+}
+
+// CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testDatasetWithFakeData{{.*}}
+// CHECK: bb0:
+// CHECK:        [[GETNEXT:%[0-9]+]] = builtin "__tfop_tfc.makeIteratorGetNextWithDatasets{{.*}} : $TensorHandle<Float>
+// CHECK:        [[RESULT:%[0-9]+]] = builtin "__tfop_Add,$in,$in,T,__device"([[GETNEXT]] : $TensorHandle<Float>, {{.*}} : $TensorHandle<Float>
+// CHECK-NEXT:   return [[RESULT]] : $TensorHandle<Float>
+
+// STRICTDA-LABEL: --- TFPartition Accelerator Result: {{.*}}testDatasetWithFakeData{{.*}}
+// STRICTDA: bb0:
+// STRICTDA:        [[GETNEXT:%[0-9]+]] = graph_op "tfc.makeIteratorGetNextWithDatasets{{.*}} : $TensorHandle<Float>
+// STRICTDA:        [[RESULT:%[0-9]+]] = graph_op "Add,i,i"([[GETNEXT]] : $TensorHandle<Float>, {{.*}} : $TensorHandle<Float>
+// STRICTDA-NEXT:   return [[RESULT]] : $TensorHandle<Float>
+
+public func testDatasetWithMNIST() {
+  TensorFlow.enableTPU(infeed: true)
+  let (images1, labels1): (TensorHandle<Float>, TensorHandle<Int32>) = #tfop(
+    "tfc.makeIteratorGetNextWithDatasets",
+    dataSource: "mnist",
+    filePath: "some_path",
+    batchSize: 64,
+    output_shapes: [TensorShape(64,224,224,3), TensorShape(64)])
+  let images : TensorHandle<Float> = #tfop("Identity", images1)
+  let labels : TensorHandle<Int32> = #tfop("Identity", labels1)
+  // Confirm we can add more nodes to the graph.
+  let imagesMod = Tensor<Float>(handle: images) + 1
+  let labelsMod = Tensor<Int32>(handle: labels) + 2
+  print(imagesMod.array.scalars[0])
+  print(labelsMod.array.scalars[0])
+}
+
+// CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testDatasetWithMNIST{{.*}}
+// CHECK: bb0:
+// CHECK:  builtin "__tfop_tfc.makeIteratorGetNextWithDatasets{{.*}} : $(TensorHandle<Float>, TensorHandle<Int32>)
+// CHECK-NEXT:  tuple_extract {{.*}} : $(TensorHandle<Float>, TensorHandle<Int32>), 0
+// CHECK-NEXT:  tuple_extract {{.*}} : $(TensorHandle<Float>, TensorHandle<Int32>), 1
+// CHECK: builtin "__tfop_Add,$in,$in,T,__device"(
+// CHECK: builtin "__tfop_Add,$in,$in,T,__device"(
+// The operands can appear in arbitrary order here.
+// CHECK:  [[RESULT:%.*]] = tuple ({{.*}} : $TensorHandle<{{.*}}>, {{.*}} : $TensorHandle<{{.*}}>)
+// CHECK-NEXT:  return [[RESULT]] : $(TensorHandle<{{.*}}>, TensorHandle<{{.*}}>)
+
+// STRICTDA-LABEL: --- TFPartition Accelerator Result: {{.*}}testDatasetWithMNIST{{.*}}
+// STRICTDA: bb0:
+// STRICTDA:  (%0, %1) = graph_op "tfc.makeIteratorGetNextWithDatasets{{.*}} : $TensorHandle<Float>, $TensorHandle<Int32>
+// STRICTDA: graph_op "Add,i,i"(
+// STRICTDA: graph_op "Add,i,i"(
+// The operands can appear in arbitrary order here.
+// STRICTDA:  [[RESULT:%.*]] = tuple ({{.*}} : $TensorHandle<{{.*}}>, {{.*}} : $TensorHandle<{{.*}}>)
+// STRICTDA-NEXT:  return [[RESULT]] : $(TensorHandle<{{.*}}>, TensorHandle<{{.*}}>)

--- a/test/TensorFlow/deabstraction_finished.swift
+++ b/test/TensorFlow/deabstraction_finished.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -Xllvm -tf-strict-deabstraction -verify %s
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -Xllvm -tf-strict-deabstraction -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -Xllvm -tf-strict-deabstraction -Xllvm -tf-module-level-graph=false -verify %s | %FileCheck %s
 import TensorFlow
 
 // FIXME: This should not build with -O.

--- a/test/TensorFlow/device_placement.swift
+++ b/test/TensorFlow/device_placement.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph  -Xllvm -tf-strict-deabstraction -O -emit-sil -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph  -Xllvm -tf-strict-deabstraction -Xllvm -tf-module-level-graph=false -O -emit-sil -verify %s | %FileCheck %s
 
 import TensorFlow
 

--- a/test/TensorFlow/integration.swift
+++ b/test/TensorFlow/integration.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -verify -Xllvm -tf-strict-deabstraction %s | %FileCheck %s 
+// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -verify -Xllvm -tf-strict-deabstraction -Xllvm -tf-module-level-graph=false %s | %FileCheck %s 
 
 import TensorFlow
 

--- a/test/TensorFlow/sends_recvs.swift
+++ b/test/TensorFlow/sends_recvs.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -Xllvm -tf-strict-deabstraction -Xllvm -tf-ensure-single-loop-exit=false -O -emit-sil %s -verify | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -Xllvm -tf-strict-deabstraction -Xllvm -tf-ensure-single-loop-exit=false -Xllvm -tf-module-level-graph=false -O -emit-sil %s -verify | %FileCheck %s
 
 // In this file, send means accelerator->host, and recv means the opposite.
 


### PR DESCRIPTION
The new code path is exercised by default, but can
be turned off via a new flag `tf-module-level-graph`. Turning it off is useful
for some unit test files, where we check the GraphDef on a per test base basis,
so we don't want all test cases in the file to end up in a single GraphDef for
us to CHECK against.

Overall this PR simplifies the code base, because in the two-pass lowering design, 
we no longer need to track the graph function dependency in the first pass, and copy 
over the dependent graph functions in the second pass. 

Say `foo()` references `bar()` as a function-typed attribute. Previously,
when we lower foo(), if bar() has not been lowered, we need to track such
dependency, and come back later to copy the lowered graph function of `bar()`
into the graph of `foo()`. Now that `foo()` and `bar()` are lowered into the
same graph, the dependency tracking and graph function copying is no longer
needed.

One concern is that the module level graph can be large, thus incurring a non-trivial cost when deserializing and running the graph in TF, especially if we are only running a small portion of that graph. This overhead can be measured later.