### PR TITLE
When undef node creation fails, make sure an error diagnostic is emited

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -1752,16 +1752,6 @@ GLStatus TFGraphLowering::visitTFDataset(Inst *inst) {
   return GLStatus::Success;
 }
 
-/// Check whether the specified TensorFlow status object is valid or not.  If
-/// valid return false.  If invalid, emit a diagnostic and return true.
-static bool checkStatus(SILFunction &fn, SILLocation loc, TF_Status *status,
-                        Diag<StringRef> id = diag::tf_lowering_error) {
-  if (TF_GetCode(status) == TF_OK)
-    return false;
-  diagnose(fn, loc, id, TF_Message(status));
-  return true;
-}
-
 /// Copy the graphs functions in `srcGraph` to `resultGraph`, and verify that
 /// `graphFuncName` must be one of the graph functions to copy over. Return true
 /// on error, with error already emitted on `fn` and `loc`.

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -840,6 +840,8 @@ public func _TFCStartTensorComputation(
     \(helperFunctionCount) helper functions, and \(resultCount) output tensors.
     """)
 
+  internalConsistencyCheck(programByteCount > 0, "Cannot run an empty graph!")
+  
   return _TensorComputation(programByteAddress: programByteAddress,
                             programByteCount: programByteCount,
                             entryFunctionBaseNameAddress: entryFunctionBaseNameAddress,


### PR DESCRIPTION
This is so that optimizer pipeline / pass manager infra can later reject the program properly.

Otherwise, we are generating a binary where the serialized graph def has 0
bytes, and that triggers a runtime failure when running that graph. [SR-8387](https://bugs.swift.org/browse/SR-8387) has more context.


With this patch, we get a compiler error diagnostic as expected:

```
$ ../build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swiftc  -Xllvm -tf-strict-deabstraction -Xllvm -tf-ensure-single-loop-exit=true -O  /usr/local/google/home/hongm/ssd_part/git/swift-models/MNIST/MNIST_s.swift
<unknown>:0: error: internal error generating TensorFlow graph:
Duplicate node name in graph: 'UndefConstDTensorHandleLFloatG'
```

Fixing the undef creation logic to avoid duplicate names (or even better,
removing the undef creation code) will be left for @bgogul to tackle.
