### PR TITLE
[IDE] Handle OpenExistentialExpr in SemaAnnotator

### DIFF
--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -33,6 +33,7 @@ class SemaAnnotator : public ASTWalker {
   SourceEntityWalker &SEWalker;
   SmallVector<ConstructorRefCallExpr *, 2> CtorRefs;
   SmallVector<ExtensionDecl *, 2> ExtDecls;
+  llvm::SmallDenseMap<OpaqueValueExpr *, Expr *, 4> OpaqueValueMap;
   bool Cancelled = false;
   Optional<AccessKind> OpAccess;
 
@@ -260,6 +261,9 @@ std::pair<bool, Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
 
   if (!isa<InOutExpr>(E) &&
       !isa<LoadExpr>(E) &&
+      !isa<OpenExistentialExpr>(E) &&
+      !isa<CollectionUpcastConversionExpr>(E) &&
+      !isa<OpaqueValueExpr>(E) &&
       E->isImplicit())
     return { true, E };
 
@@ -422,6 +426,37 @@ std::pair<bool, Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
     if (!walkToExprPost(E))
       return { false, nullptr };
     return { false, E };
+  } else if (auto OEE = dyn_cast<OpenExistentialExpr>(E)) {
+    // Record opaque value.
+    OpaqueValueMap[OEE->getOpaqueValue()] = OEE->getExistentialValue();
+    SWIFT_DEFER {
+      OpaqueValueMap.erase(OEE->getOpaqueValue());
+    };
+
+    if (!OEE->getSubExpr()->walk(*this))
+      return { false, nullptr };
+    if (!walkToExprPost(E))
+      return { false, nullptr };
+    return { false, E };
+  } else if (auto CUCE = dyn_cast<CollectionUpcastConversionExpr>(E)) {
+    // Ignore conversion expressions. We don't handle OpaqueValueExpr here
+    // because it's only in conversion expressions. Instead, just walk into
+    // sub expression.
+    if (!CUCE->getSubExpr()->walk(*this))
+      return { false, nullptr };
+    if (!walkToExprPost(E))
+      return { false, nullptr };
+    return { false, E };
+  } else if (auto OVE = dyn_cast<OpaqueValueExpr>(E)) {
+    // Walk into mapped value.
+    auto value = OpaqueValueMap.find(OVE);
+    if (value != OpaqueValueMap.end()) {
+      if (!value->second->walk(*this))
+        return { false, nullptr };
+      if (!walkToExprPost(E))
+        return { false, nullptr };
+      return { false, E };
+    }
   }
 
   return { true, E };

--- a/test/IDE/range_info_expr.swift
+++ b/test/IDE/range_info_expr.swift
@@ -31,6 +31,12 @@ func foo(x: Foo) {
   _ = x.bar
 }
 
+func testWithoutActuallyEscaping(closure: (Int) -> Void) {
+  withoutActuallyEscaping(closure) { escapable in
+    _ = escapable
+  }
+}
+
 // RUN: %target-swift-ide-test -range -pos=7:8 -end-pos=7:19 -source-filename %s | %FileCheck %s -check-prefix=CHECK-BOOL
 // CHECK-BOOL: <Type>Bool</Type>
 
@@ -45,6 +51,10 @@ func foo(x: Foo) {
 // RUN: %target-swift-ide-test -range -pos=23:9 -end-pos=23:19 -source-filename %s | %FileCheck %s -check-prefix=CHECK-PART-EXPR1
 
 // RUN: %target-swift-ide-test -range -pos=31:7 -end-pos=31:12 -source-filename %s | %FileCheck %s -check-prefix=CHECK-OEE-EXPR
+
+// RUN: %target-swift-ide-test -range -pos=35:1 -end-pos=38:1 -source-filename %s | %FileCheck %s -check-prefix=CHECK-MTEE-EXPR-1
+// RUN: %target-swift-ide-test -range -pos=35:27 -end-pos=35:34 -source-filename %s | %FileCheck %s -check-prefix=CHECK-MTEE-EXPR-2
+// RUN: %target-swift-ide-test -range -pos=35:36 -end-pos=37:4 -source-filename %s | %FileCheck %s -check-prefix=CHECK-MTEE-EXPR-3
 
 // CHECK-PART-EXPR: <Kind>PartOfExpression</Kind>
 // CHECK-PART-EXPR-NEXT: <Content>getSelf()</Content>
@@ -66,3 +76,34 @@ func foo(x: Foo) {
 // CHECK-OEE-EXPR-NEXT: <Context>swift_ide_test.(file).foo(x:)</Context>
 // CHECK-OEE-EXPR-NEXT: <ASTNodes>1</ASTNodes>
 // CHECK-OEE-EXPR-NEXT: <end>
+
+// CHECK-MTEE-EXPR-1: <Kind>SingleExpression</Kind>
+// CHECK-MTEE-EXPR-1-NEXT: <Content>withoutActuallyEscaping(closure) { escapable in
+// CHECK-MTEE-EXPR-1-NEXT:     _ = escapable
+// CHECK-MTEE-EXPR-1-NEXT:   }</Content>
+// CHECK-MTEE-EXPR-1-NEXT: <Type>()</Type><Exit>false</Exit>
+// CHECK-MTEE-EXPR-1-NEXT: <Context>swift_ide_test.(file).testWithoutActuallyEscaping(closure:)</Context>
+// CHECK-MTEE-EXPR-1-NEXT: <Declared>escapable</Declared><OutscopeReference>false</OutscopeReference>
+// CHECK-MTEE-EXPR-1-NEXT: <Referenced>closure</Referenced><Type>(Int) -> Void</Type>
+// CHECK-MTEE-EXPR-1-NEXT: <Referenced>escapable</Referenced><Type>(Int) -> Void</Type>
+// CHECK-MTEE-EXPR-1-NEXT: <ASTNodes>1</ASTNodes>
+// CHECK-MTEE-EXPR-1-NEXT: <end>
+
+// CHECK-MTEE-EXPR-2: <Kind>SingleExpression</Kind>
+// CHECK-MTEE-EXPR-2-NEXT: <Content>closure</Content>
+// CHECK-MTEE-EXPR-2-NEXT: <Type>(Int) -> Void</Type><Exit>false</Exit>
+// CHECK-MTEE-EXPR-2-NEXT: <Context>swift_ide_test.(file).testWithoutActuallyEscaping(closure:)</Context>
+// CHECK-MTEE-EXPR-2-NEXT: <Referenced>closure</Referenced><Type>(Int) -> Void</Type>
+// CHECK-MTEE-EXPR-2-NEXT: <ASTNodes>1</ASTNodes>
+// CHECK-MTEE-EXPR-2-NEXT: <end>
+
+// CHECK-MTEE-EXPR-3: <Kind>SingleExpression</Kind>
+// CHECK-MTEE-EXPR-3-NEXT: <Content>{ escapable in
+// CHECK-MTEE-EXPR-3-NEXT:     _ = escapable
+// CHECK-MTEE-EXPR-3-NEXT:   }</Content>
+// CHECK-MTEE-EXPR-3-NEXT: <Type>((Int) -> Void) -> ()</Type><Exit>false</Exit>
+// CHECK-MTEE-EXPR-3-NEXT: <Context>swift_ide_test.(file).testWithoutActuallyEscaping(closure:)</Context>
+// CHECK-MTEE-EXPR-3-NEXT: <Declared>escapable</Declared><OutscopeReference>false</OutscopeReference>
+// CHECK-MTEE-EXPR-3-NEXT: <Referenced>escapable</Referenced><Type>(Int) -> Void</Type>
+// CHECK-MTEE-EXPR-3-NEXT: <ASTNodes>1</ASTNodes>
+// CHECK-MTEE-EXPR-3-NEXT: <end>

--- a/test/IDE/range_info_expr.swift
+++ b/test/IDE/range_info_expr.swift
@@ -24,6 +24,13 @@ func foo1(_ c : CC) -> CC{
   return c.getSelf()
 }
 
+protocol Foo {
+  var bar: String { get }
+}
+func foo(x: Foo) {
+  _ = x.bar
+}
+
 // RUN: %target-swift-ide-test -range -pos=7:8 -end-pos=7:19 -source-filename %s | %FileCheck %s -check-prefix=CHECK-BOOL
 // CHECK-BOOL: <Type>Bool</Type>
 
@@ -36,6 +43,8 @@ func foo1(_ c : CC) -> CC{
 // RUN: %target-swift-ide-test -range -pos=23:31 -end-pos=23:41 -source-filename %s | %FileCheck %s -check-prefix=CHECK-PART-EXPR1
 // RUN: %target-swift-ide-test -range -pos=23:20 -end-pos=23:30 -source-filename %s | %FileCheck %s -check-prefix=CHECK-PART-EXPR1
 // RUN: %target-swift-ide-test -range -pos=23:9 -end-pos=23:19 -source-filename %s | %FileCheck %s -check-prefix=CHECK-PART-EXPR1
+
+// RUN: %target-swift-ide-test -range -pos=31:7 -end-pos=31:12 -source-filename %s | %FileCheck %s -check-prefix=CHECK-OEE-EXPR
 
 // CHECK-PART-EXPR: <Kind>PartOfExpression</Kind>
 // CHECK-PART-EXPR-NEXT: <Content>getSelf()</Content>
@@ -50,3 +59,10 @@ func foo1(_ c : CC) -> CC{
 // CHECK-PART-EXPR2: <Parent>Call</Parent>
 // CHECK-PART-EXPR2: <ASTNodes>2</ASTNodes>
 // CHECK-PART-EXPR2: <end>
+
+// CHECK-OEE-EXPR: <Kind>SingleExpression</Kind>
+// CHECK-OEE-EXPR-NEXT: <Content>x.bar</Content>
+// CHECK-OEE-EXPR-NEXT: <Type>String</Type><Exit>false</Exit>
+// CHECK-OEE-EXPR-NEXT: <Context>swift_ide_test.(file).foo(x:)</Context>
+// CHECK-OEE-EXPR-NEXT: <ASTNodes>1</ASTNodes>
+// CHECK-OEE-EXPR-NEXT: <end>


### PR DESCRIPTION
For `OpenExistentialExpr`, normal `ASTWalker` walks into the existential expression first, then walks into sub expression. However, `SourceEntitiyWalker` must walk AST tree by source order. Handle `OpenExistentialExpr` and its `OpaqueValueExpr` so that `SourceEntityWalker` walks to them in "outer to inner" manner.

rdar://problem/41147733