### PR TITLE
[Sema] Avoid merging type variables that can have different results in CS.

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -317,6 +317,13 @@ namespace {
         return { false, expr };
       }
       
+      // Don't walk into unresolved member expressions - we avoid merging type
+      // variables inside UnresolvedMemberExpr and those outside, since they
+      // should be allowed to behave independently in CS.
+      if (isa<UnresolvedMemberExpr>(expr)) {
+        return {false, expr };
+      }
+
       return { true, expr };
     }
     

--- a/test/Constraints/array_literal.swift
+++ b/test/Constraints/array_literal.swift
@@ -340,3 +340,19 @@ func testConditional(i: Int, s: String) {
   let _: PArray<Int> = [i, i, i]
   let _: PArray<String> = [s, s, s] // expected-error{{cannot convert value of type '[String]' to specified type 'PArray<String>'}}
 }
+
+
+// SR-8385
+enum SR8385: ExpressibleByStringLiteral {
+  case text(String)
+  init(stringLiteral value: String) {
+    self = .text(value)
+  }
+}
+
+func testSR8385() {
+  let _: [SR8385] = [SR8385("hello")]
+  let _: [SR8385] = [.text("hello")]
+  let _: [SR8385] = ["hello", SR8385.text("world")]
+  let _: [SR8385] = ["hello", .text("world")]
+}


### PR DESCRIPTION
This patch avoids merging type variables inside `UnresolvedMemberExpr` and those outside, because they may not always be equivalent in ConstraintSystem. Otherwise, it may fail to resolve constraints for code like [SR-8385](https://bugs.swift.org/browse/SR-8385).

Resolves [SR-8385](https://bugs.swift.org/browse/SR-8385).