### PR TITLE
[migrator] Fix offset in no_duplicate_aarch64_use_tbi test

### DIFF
--- a/test/Migrator/no_duplicate_aarch64_use_tbi.swift
+++ b/test/Migrator/no_duplicate_aarch64_use_tbi.swift
@@ -9,7 +9,7 @@
 
 public func foo(_ f: (Void) -> ()) {}
 
-// CHECK-REMAP: "offset": 632,
+// CHECK-REMAP: "offset": 581,
 // CHECK-REMAP: "remove": 5,
 // CHECK-REMAP: "text": "("
 


### PR DESCRIPTION
A recent commit caused an offset drift.

rdar://problem/42631862
