### PR TITLE
"if `is RandomAccessCollection`" is unnecessary

### DIFF
--- a/stdlib/public/core/RandomAccessCollection.swift
+++ b/stdlib/public/core/RandomAccessCollection.swift
@@ -152,9 +152,7 @@ where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection
   ///   is the same value as the result of `abs(distance)` calls to
   ///   `index(before:)`.
   ///
-  /// - Complexity: O(1) if the collection conforms to
-  ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is the absolute
-  ///   value of `distance`.
+  /// - Complexity: O(1)
   func index(_ i: Index, offsetBy distance: Int) -> Index
 
   /// Returns an index that is the specified distance from the given index,
@@ -196,9 +194,7 @@ where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection
   ///   index would be beyond `limit` in the direction of movement. In that
   ///   case, the method returns `nil`.
   ///
-  /// - Complexity: O(1) if the collection conforms to
-  ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is the absolute
-  ///   value of `distance`.
+  /// - Complexity: O(1)
   func index(
     _ i: Index, offsetBy distance: Int, limitedBy limit: Index
   ) -> Index?
@@ -216,9 +212,7 @@ where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection
   ///   negative only if the collection conforms to the
   ///   `BidirectionalCollection` protocol.
   ///
-  /// - Complexity: O(1) if the collection conforms to
-  ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is the
-  ///   resulting distance.
+  /// - Complexity: O(1)
   func distance(from start: Index, to end: Index) -> Int
 }
 


### PR DESCRIPTION
<!-- What's in this pull request?
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate. -->
* remove the performance qualifiers on API redeclared from `Collection`, because they are necessarily satisfied.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link:
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN). -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->