### PR TITLE
[libSyntax] JSON serialization improvements

### DIFF
--- a/include/swift/Basic/JSONSerialization.h
+++ b/include/swift/Basic/JSONSerialization.h
@@ -420,7 +420,7 @@ public:
 
   void beginObject();
   void endObject();
-  bool preflightKey(const char*, bool, bool, bool &, void *&);
+  bool preflightKey(StringRef, bool, bool, bool &, void *&);
   void postflightKey(void*);
 
   void beginEnumScalar();
@@ -462,13 +462,13 @@ public:
   }
 
   template <typename T>
-  void mapRequired(const char* Key, T& Val) {
+  void mapRequired(StringRef Key, T& Val) {
     this->processKey(Key, Val, true);
   }
 
   template <typename T>
   typename std::enable_if<has_ArrayTraits<T>::value,void>::type
-  mapOptional(const char* Key, T& Val) {
+  mapOptional(StringRef Key, T& Val) {
     // omit key/value instead of outputting empty array
     if (this->canElideEmptyArray() && !(Val.begin() != Val.end()))
       return;
@@ -476,24 +476,24 @@ public:
   }
 
   template <typename T>
-  void mapOptional(const char* Key, Optional<T> &Val) {
+  void mapOptional(StringRef Key, Optional<T> &Val) {
     processKeyWithDefault(Key, Val, Optional<T>(), /*Required=*/false);
   }
 
   template <typename T>
   typename std::enable_if<!has_ArrayTraits<T>::value,void>::type
-  mapOptional(const char* Key, T& Val) {
+  mapOptional(StringRef Key, T& Val) {
     this->processKey(Key, Val, false);
   }
 
   template <typename T>
-  void mapOptional(const char* Key, T& Val, const T& Default) {
+  void mapOptional(StringRef Key, T& Val, const T& Default) {
     this->processKeyWithDefault(Key, Val, Default, false);
   }
 
 private:
   template <typename T>
-  void processKeyWithDefault(const char *Key, Optional<T> &Val,
+  void processKeyWithDefault(StringRef Key, Optional<T> &Val,
                              const Optional<T> &DefaultValue, bool Required) {
     assert(!DefaultValue.hasValue() &&
            "Optional<T> shouldn't have a value!");
@@ -513,7 +513,7 @@ private:
   }
 
   template <typename T>
-  void processKeyWithDefault(const char *Key, T &Val, const T& DefaultValue,
+  void processKeyWithDefault(StringRef Key, T &Val, const T &DefaultValue,
                              bool Required) {
     void *SaveInfo;
     bool UseDefault;
@@ -529,7 +529,7 @@ private:
   }
 
   template <typename T>
-  void processKey(const char *Key, T &Val, bool Required) {
+  void processKey(StringRef Key, T &Val, bool Required) {
     void *SaveInfo;
     bool UseDefault;
     if (this->preflightKey(Key, Required, false, UseDefault, SaveInfo)) {

--- a/include/swift/Basic/JSONSerialization.h
+++ b/include/swift/Basic/JSONSerialization.h
@@ -21,6 +21,7 @@
 #define SWIFT_BASIC_JSONSERIALIZATION_H
 
 #include "swift/Basic/LLVM.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -110,6 +111,27 @@ struct ScalarTraits {
   //static bool mustQuote(StringRef);
 };
 
+/// This is an optimized form of ScalarTraits in case the scalar value is
+/// already present in a memory buffer.  For example:
+///
+///    template<>
+///    struct ScalarReferenceTraits<MyType> {
+///      static StringRef stringRef(const MyType &val) {
+///        // Retrieve scalar value from memory
+///        return value.stringValue;
+///      }
+///      static bool mustQuote(StringRef) { return true; }
+///    };
+template<typename T>
+struct ScalarReferenceTraits {
+  // Must provide:
+  //
+  // Function to return a string representation of the value.
+  // static StringRef stringRef(const T &value);
+  //
+  // Function to determine if the value should be quoted.
+  // static bool mustQuote(StringRef);
+};
 
 /// This class should be specialized by any type that can be 'null' in JSON.
 /// For example:
@@ -218,6 +240,24 @@ public:
   (sizeof(test<ScalarTraits<T>>(nullptr, nullptr)) == 1);
 };
 
+// Test if ScalarReferenceTraits<T> is defined on type T.
+template <class T>
+struct has_ScalarReferenceTraits
+{
+  using Signature_stringRef = StringRef (*)(const T &);
+  using Signature_mustQuote = bool (*)(StringRef);
+
+  template <typename U>
+  static char test(SameType<Signature_stringRef, &U::stringRef> *,
+                   SameType<Signature_mustQuote, &U::mustQuote> *);
+
+  template <typename U>
+  static double test(...);
+
+public:
+  static bool const value =
+  (sizeof(test<ScalarReferenceTraits<T>>(nullptr, nullptr)) == 1);
+};
 
 // Test if ObjectTraits<T> is defined on type T.
 template <class T>
@@ -327,6 +367,7 @@ struct missingTraits : public std::integral_constant<bool,
     !has_ScalarEnumerationTraits<T>::value
  && !has_ScalarBitSetTraits<T>::value
  && !has_ScalarTraits<T>::value
+ && !has_ScalarReferenceTraits<T>::value
  && !has_NullableTraits<T>::value
  && !has_ObjectTraits<T>::value
  && !has_ArrayTraits<T>::value> {};
@@ -512,20 +553,20 @@ template <typename T> struct ArrayTraits<std::vector<T>> {
 };
 
 template<>
-struct ScalarTraits<bool> {
-  static void output(const bool &, llvm::raw_ostream &);
+struct ScalarReferenceTraits<bool> {
+  static StringRef stringRef(const bool &);
   static bool mustQuote(StringRef) { return false; }
 };
 
 template<>
-struct ScalarTraits<StringRef> {
-  static void output(const StringRef &, llvm::raw_ostream &);
+struct ScalarReferenceTraits<StringRef> {
+  static StringRef stringRef(const StringRef &);
   static bool mustQuote(StringRef S) { return true; }
 };
 
 template<>
-struct ScalarTraits<std::string> {
-  static void output(const std::string &, llvm::raw_ostream &);
+struct ScalarReferenceTraits<std::string> {
+  static StringRef stringRef(const std::string &);
   static bool mustQuote(StringRef S) { return true; }
 };
 
@@ -624,14 +665,21 @@ template<typename T>
 typename std::enable_if<has_ScalarTraits<T>::value,void>::type
 jsonize(Output &out, T &Val, bool) {
   {
-    std::string Storage;
-    llvm::raw_string_ostream Buffer(Storage);
+    SmallString<64> Storage;
+    llvm::raw_svector_ostream Buffer(Storage);
+    Buffer.SetUnbuffered();
     ScalarTraits<T>::output(Val, Buffer);
     StringRef Str = Buffer.str();
     out.scalarString(Str, ScalarTraits<T>::mustQuote(Str));
   }
 }
 
+template <typename T>
+typename std::enable_if<has_ScalarReferenceTraits<T>::value, void>::type
+jsonize(Output &out, T &Val, bool) {
+  StringRef Str = ScalarReferenceTraits<T>::stringRef(Val);
+  out.scalarString(Str, ScalarReferenceTraits<T>::mustQuote(Str));
+}
 
 template<typename T>
 typename std::enable_if<has_NullableTraits<T>::value,void>::type

--- a/include/swift/Syntax/Serialization/SyntaxSerialization.h
+++ b/include/swift/Syntax/Serialization/SyntaxSerialization.h
@@ -33,20 +33,39 @@ static void *DontSerializeNodeIdsUserInfoKey = &DontSerializeNodeIdsUserInfoKey;
 
 /// Serialization traits for SourcePresence.
 template <>
-struct ScalarEnumerationTraits<syntax::SourcePresence> {
-  static void enumeration(json::Output &out, syntax::SourcePresence &value) {
-    out.enumCase(value, "Present", syntax::SourcePresence::Present);
-    out.enumCase(value, "Missing", syntax::SourcePresence::Missing);
+struct ScalarReferenceTraits<syntax::SourcePresence> {
+  static StringRef stringRef(const syntax::SourcePresence &value) {
+    switch (value) {
+    case syntax::SourcePresence::Present:
+      return "\"Present\"";
+    case syntax::SourcePresence::Missing:
+      return "\"Missing\"";
+    }
+  }
+
+  static bool mustQuote(StringRef) {
+    // The string is already quoted. This is more efficient since it does not
+    // check for characters that need to be escaped
+    return false;
   }
 };
 
 /// Serialization traits for swift::tok.
 template <>
-struct ScalarEnumerationTraits<tok> {
-  static void enumeration(Output &out, tok &value) {
+struct ScalarReferenceTraits<tok> {
+  static StringRef stringRef(const tok &value) {
+    switch (value) {
 #define TOKEN(name) \
-    out.enumCase(value, #name, tok::name);
+    case tok::name: return "\"" #name "\"";
 #include "swift/Syntax/TokenKinds.def"
+    default: llvm_unreachable("Unknown token kind");
+    }
+  }
+
+  static bool mustQuote(StringRef) {
+    // The string is already quoted. This is more efficient since it does not
+    // check for characters that need to be escaped
+    return false;
   }
 };
 

--- a/include/swift/Syntax/SyntaxKind.h.gyb
+++ b/include/swift/Syntax/SyntaxKind.h.gyb
@@ -80,13 +80,24 @@ namespace json {
 
 /// Serialization traits for SyntaxKind.
 template <>
-struct ScalarEnumerationTraits<syntax::SyntaxKind> {
-  static void enumeration(Output &out, syntax::SyntaxKind &value) {
-    out.enumCase(value, "Token", syntax::SyntaxKind::Token);
-    out.enumCase(value, "Unknown", syntax::SyntaxKind::Unknown);
+struct ScalarReferenceTraits<syntax::SyntaxKind> {
+  static StringRef stringRef(const syntax::SyntaxKind &value) {
+    switch (value) {
+      case syntax::SyntaxKind::Token:
+        return "\"Token\"";
+      case syntax::SyntaxKind::Unknown:
+        return "\"Unknown\"";
 % for node in SYNTAX_NODES:
-    out.enumCase(value, "${node.syntax_kind}", syntax::SyntaxKind::${node.syntax_kind});
+      case syntax::SyntaxKind::${node.syntax_kind}:
+        return "\"${node.syntax_kind}\"";
 % end
+    }
+  }
+
+  static bool mustQuote(StringRef) {
+    // The string is already quoted. This is more efficient since it does not
+    // check for characters that need to be escaped
+    return false;
   }
 };
 

--- a/include/swift/Syntax/Trivia.h.gyb
+++ b/include/swift/Syntax/Trivia.h.gyb
@@ -405,11 +405,20 @@ struct ObjectTraits<syntax::TriviaPiece> {
 
 /// Serialization traits for TriviaKind.
 template <>
-struct ScalarEnumerationTraits<syntax::TriviaKind> {
-  static void enumeration(Output &out, syntax::TriviaKind &value) {
+struct ScalarReferenceTraits<syntax::TriviaKind> {
+  static StringRef stringRef(const syntax::TriviaKind &value) {
+    switch (value) {
 % for trivia in TRIVIAS:
-    out.enumCase(value, "${trivia.name}", syntax::TriviaKind::${trivia.name});
+    case syntax::TriviaKind::${trivia.name}:
+      return "\"${trivia.name}\"";
 % end
+    }
+  }
+
+  static bool mustQuote(StringRef) {
+    // The string is already quoted. This is more efficient since it does not
+    // check for characters that need to be escaped
+    return false;
   }
 };
 } // namespace json

--- a/lib/Basic/JSONSerialization.cpp
+++ b/lib/Basic/JSONSerialization.cpp
@@ -231,18 +231,17 @@ void Output::indent() {
 //  traits for built-in types
 //===----------------------------------------------------------------------===//
 
-void ScalarTraits<bool>::output(const bool &Val, raw_ostream &Out) {
-  Out << (Val ? "true" : "false");
+StringRef ScalarReferenceTraits<bool>::stringRef(const bool &Val) {
+  return (Val ? "true" : "false");
 }
 
-void ScalarTraits<StringRef>::output(const StringRef &Val,
-                                     raw_ostream &Out) {
-  Out << Val;
+StringRef ScalarReferenceTraits<StringRef>::stringRef(const StringRef &Val) {
+  return Val;
 }
 
-void ScalarTraits<std::string>::output(const std::string &Val,
-                                       raw_ostream &Out) {
-  Out << Val;
+StringRef
+ScalarReferenceTraits<std::string>::stringRef(const std::string &Val) {
+  return Val;
 }
 
 void ScalarTraits<uint8_t>::output(const uint8_t &Val,

--- a/lib/Basic/JSONSerialization.cpp
+++ b/lib/Basic/JSONSerialization.cpp
@@ -76,7 +76,7 @@ void Output::endObject() {
   Stream << "}";
 }
 
-bool Output::preflightKey(const char *Key, bool Required, bool SameAsDefault,
+bool Output::preflightKey(StringRef Key, bool Required, bool SameAsDefault,
                           bool &UseDefault, void *&) {
   UseDefault = false;
   if (Required || !SameAsDefault) {


### PR DESCRIPTION
This PR adds incorporates two changes that significantly speed up the serialization time of JSON from C++:
- Make `key` a `StringRef`
  - Most keys are string literals and if they are converted directly to StringRef, the string length can be computed at compile time, increasing
performance.
- Introduce `ScalarReferenceTraits`
  - For ScalarTraits, a buffer was always created on the heap to which the scalar string value was written just to be copied to the output buffer again. In case the value already exists in a memory buffer it is way cheaper to avoid the heap allocation and copy the string straight to the output buffer.
- Minimise String escapes
  - For several enums we know that they never contain characters that need to be escaped, thus we can just skip the escaping which needs to walk the entire string and just add the quotes around the string statically.