### PR TITLE
enable strict deabstraction in diagnostics.swift (SR-8392)

### DIFF
--- a/test/TensorFlow/diagnostics.swift
+++ b/test/TensorFlow/diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s
+// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-strict-deabstraction -O -emit-sil -verify %s
 
 import TensorFlow
 
@@ -14,20 +14,9 @@ func testInferredElementResult() -> TensorHandle<Int32> {
   _ = #tfop("bar") as TensorHandle<Int32>
 }
 
-// This shows passing a non-constant value into an attribute.
-// TODO: Improve the diagnostic to display the Swift parameter name instead of
-// the internal TensorFlow attribute name. (In this example, it's hard to tell
-// because both Swift/TensorFlow use the same name "padding".)
-public func nonConstantAttribute(x: Tensor<Float>, padding: Padding) {
-  // expected-error @+1 {{attribute 'padding' requires a constant argument}}
-  print(x.convolved2D(withFilter: Tensor<Float>(ones: [1, 3, 3, 1]),
-                      strides: (1, 1, 1, 1),
-                      padding: padding))
-}
-
 class ClassTest {
   var w = Tensor<Float>(zeros: [1, 2])  // expected-warning {{value implicitly copied to the host}}
-  let b = Tensor<Float>(zeros: [1, 2])
+  let b = Tensor<Float>(zeros: [1, 2])  // expected-warning {{value implicitly copied to the host}}
 
   var c : Tensor<Float> { return w } // expected-warning {{properties in classes always cause a copy to the accelerator}}
 
@@ -43,20 +32,6 @@ public func f() {
   // expected-note @+1 {{value used here}}
   _ = x.c+x.b+x.w  // expected-warning 2 {{properties in classes always cause a copy to the accelerator}}
 
-}
-
-public enum X {
-  case A, B
-}
-
-public func invalidAttributeArg() -> TensorHandle<Int32> {
-  // expected-error@+1 {{attribute 'someAttr' requires a constant argument}}
-  return #tfop("bar", someAttr: X.A)
-}
-
-public func invalidAttrTensor(a: Tensor<Float>) {
-   // expected-error @+1 {{attribute 'someAttr' requires a constant argument}}
-   () = #tfop("foo", someAttr: a)
 }
 
 // b/76387659 - Verify that there is a way to configure the TPU.

--- a/test/TensorFlow/diagnostics_with_deabstraction_error.swift
+++ b/test/TensorFlow/diagnostics_with_deabstraction_error.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-strict-deabstraction -O -emit-sil -verify %s
+
+// This file contains tests that used to be in ./diagnostics.swift that produced
+// expected errors in the deabstraction pass, which prevented partitioning from
+// running.
+//
+// Once we move partitioning into the mandatory pipeline, we should be able to
+// move these tests back into ./diagnostics.swift.
+
+import TensorFlow
+
+// This shows passing a non-constant value into an attribute.
+// TODO: Improve the diagnostic to display the Swift parameter name instead of
+// the internal TensorFlow attribute name. (In this example, it's hard to tell
+// because both Swift/TensorFlow use the same name "padding".)
+public func nonConstantAttribute(x: Tensor<Float>, padding: Padding) {
+  // expected-error @+1 {{attribute 'padding' requires a constant argument}}
+  print(x.convolved2D(withFilter: Tensor<Float>(ones: [1, 3, 3, 1]),
+                      strides: (1, 1, 1, 1),
+                      padding: padding))
+}
+
+public enum X {
+  case A, B
+}
+
+public func invalidAttributeArg() -> TensorHandle<Int32> {
+  // expected-error@+1 {{attribute 'someAttr' cannot be an enum, struct, or tuple}}
+  return #tfop("bar", someAttr: X.A)
+}
+
+public func invalidAttrTensor(a: Tensor<Float>) {
+   // expected-error @+1 {{attribute 'someAttr' requires a constant argument}}
+   () = #tfop("foo", someAttr: a)
+}
+
+


### PR DESCRIPTION
This was mostly the same thing as (1) from https://github.com/apple/swift/pull/18273.

I also had to add a new expected warning to `let b = Tensor<Float>(zeros: [1, 2])` in `class ClassTest`. Is that okay? Does it need further investigation?