### PR TITLE
Enable key path resilience.

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -226,7 +226,7 @@ namespace swift {
     bool EnableSILOpaqueValues = false;
     
     /// Enables key path resilience.
-    bool EnableKeyPathResilience = false;
+    bool EnableKeyPathResilience = true;
 
     /// If set to true, the diagnosis engine can assume the emitted diagnostics
     /// will be used in editor. This usually leads to more aggressive fixit.

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1583,11 +1583,18 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
     return getSILLinkage(linkage, forDefinition);
   }
 
+  case Kind::PropertyDescriptor: {
+    // Return the linkage of the getter, which may be more permissive than the
+    // property itself (for instance, with a private/internal property whose
+    // accessor is @inlinable or @usableFromInline)
+    auto getterDecl = cast<AbstractStorageDecl>(getDecl())->getGetter();
+    return getSILLinkage(getDeclLinkage(getterDecl), forDefinition);
+  }
+
   case Kind::ObjCClass:
   case Kind::ObjCMetaclass:
   case Kind::SwiftMetaclassStub:
   case Kind::NominalTypeDescriptor:
-  case Kind::PropertyDescriptor:
   case Kind::ClassMetadataBaseOffset:
   case Kind::ProtocolDescriptor:
     return getSILLinkage(getDeclLinkage(getDecl()), forDefinition);

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -46,10 +46,15 @@
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/Types.h"
+#include "swift/Basic/Statistic.h"
 #include "swift/IRGen/Linking.h"
 
 using namespace swift;
 using namespace irgen;
+
+#define DEBUG_TYPE "IRGen key paths"
+STATISTIC(NumTrivialPropertyDescriptors, "# of trivial property descriptors");
+STATISTIC(NumNonTrivialPropertyDescriptors, "# of nontrivial property descriptors");
 
 enum KeyPathAccessor {
   Getter,
@@ -1207,6 +1212,7 @@ IRGenModule::getAddrOfKeyPathPattern(KeyPathPattern *pattern,
 
 void IRGenModule::emitSILProperty(SILProperty *prop) {
   if (prop->isTrivial()) {
+    ++NumTrivialPropertyDescriptors;
     // All trivial property descriptors can share a single definition in the
     // translation unit.
     if (!TheTrivialPropertyDescriptor) {
@@ -1232,6 +1238,8 @@ void IRGenModule::emitSILProperty(SILProperty *prop) {
     }
     return;
   }
+
+  ++NumNonTrivialPropertyDescriptors;
 
   ConstantInitBuilder builder(*this);
   ConstantStructBuilder fields = builder.beginStruct();

--- a/lib/IRGen/MetadataLayout.cpp
+++ b/lib/IRGen/MetadataLayout.cpp
@@ -400,12 +400,9 @@ ClassMetadataLayout::getMethodInfo(IRGenFunction &IGF, SILDeclRef method) const{
   return MethodInfo(offset);
 }
 
-Size ClassMetadataLayout::getStaticMethodOffset(SILDeclRef method) const{
-  auto &stored = getStoredMethodInfo(method);
-
-  assert(stored.TheOffset.isStatic() &&
-         "resilient class metadata layout unsupported!");
-  return stored.TheOffset.getStaticOffset();
+MetadataLayout::StoredOffset
+ClassMetadataLayout::getMethodOffsetInfo(SILDeclRef method) const {
+  return getStoredMethodInfo(method).TheOffset;
 }
 
 Offset

--- a/lib/IRGen/MetadataLayout.h
+++ b/lib/IRGen/MetadataLayout.h
@@ -249,12 +249,9 @@ public:
 
   MethodInfo getMethodInfo(IRGenFunction &IGF, SILDeclRef method) const;
 
-  /// Assuming that the given method is at a static offset in the metadata,
-  /// return that static offset.
-  ///
-  /// DEPRECATED: callers should be updated to handle this in a
-  /// more arbitrary fashion.
-  Size getStaticMethodOffset(SILDeclRef method) const;
+  /// Return the information necessary to compute the offset of a method's
+  /// vtable entry in the class object.
+  StoredOffset getMethodOffsetInfo(SILDeclRef method) const;
 
   Offset getFieldOffset(IRGenFunction &IGF, VarDecl *field) const;
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3653,7 +3653,10 @@ SILGenModule::emitKeyPathComponentForDecl(SILLocation loc,
     [&]() -> bool {
       return getASTContext().LangOpts.EnableKeyPathResilience
         && !forPropertyDescriptor
-        && storage->getModuleContext() != SwiftModule;
+        && storage->getModuleContext() != SwiftModule
+        // Properties that only dispatch via ObjC lookup do not have nor need
+        // property descriptors, since the selector identifies the storage.
+        && !getGetterDeclRef(storage).isForeign;
     };
   
   auto strategy = storage->getAccessStrategy(AccessSemantics::Ordinary,

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3654,6 +3654,8 @@ SILGenModule::emitKeyPathComponentForDecl(SILLocation loc,
       return getASTContext().LangOpts.EnableKeyPathResilience
         && !forPropertyDescriptor
         && storage->getModuleContext() != SwiftModule
+        // Protocol requirements don't have nor need property descriptors.
+        && !isa<ProtocolDecl>(storage->getDeclContext())
         // Properties that only dispatch via ObjC lookup do not have nor need
         // property descriptors, since the selector identifies the storage.
         && !getGetterDeclRef(storage).isForeign;

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3658,7 +3658,8 @@ SILGenModule::emitKeyPathComponentForDecl(SILLocation loc,
         && !isa<ProtocolDecl>(storage->getDeclContext())
         // Properties that only dispatch via ObjC lookup do not have nor need
         // property descriptors, since the selector identifies the storage.
-        && !getGetterDeclRef(storage).isForeign;
+        && (!storage->hasAnyAccessors()
+            || !getGetterDeclRef(storage).isForeign);
     };
   
   auto strategy = storage->getAccessStrategy(AccessSemantics::Ordinary,

--- a/stdlib/public/core/MemoryLayout.swift
+++ b/stdlib/public/core/MemoryLayout.swift
@@ -227,3 +227,64 @@ extension MemoryLayout {
     return key._storedInlineOffset
   }
 }
+
+// Not-yet-public alignment conveniences
+extension MemoryLayout {
+  internal static var _alignmentMask: Int { return alignment - 1 }
+
+  internal static func _roundingUpToAlignment(_ value: Int) -> Int {
+    return (value + _alignmentMask) & ~_alignmentMask
+  }
+  internal static func _roundingDownToAlignment(_ value: Int) -> Int {
+    return value & ~_alignmentMask
+  }
+
+  internal static func _roundingUpToAlignment(_ value: UInt) -> UInt {
+    return (value + UInt(bitPattern: _alignmentMask)) & ~UInt(bitPattern: _alignmentMask)
+  }
+  internal static func _roundingDownToAlignment(_ value: UInt) -> UInt {
+    return value & ~UInt(bitPattern: _alignmentMask)
+  }
+
+  internal static func _roundingUpToAlignment(_ value: UnsafeRawPointer) -> UnsafeRawPointer {
+    return UnsafeRawPointer(bitPattern:
+     _roundingUpToAlignment(UInt(bitPattern: value))).unsafelyUnwrapped
+  }
+  internal static func _roundingDownToAlignment(_ value: UnsafeRawPointer) -> UnsafeRawPointer {
+    return UnsafeRawPointer(bitPattern:
+     _roundingDownToAlignment(UInt(bitPattern: value))).unsafelyUnwrapped
+  }
+
+  internal static func _roundingUpToAlignment(_ value: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+    return UnsafeMutableRawPointer(bitPattern:
+     _roundingUpToAlignment(UInt(bitPattern: value))).unsafelyUnwrapped
+  }
+  internal static func _roundingDownToAlignment(_ value: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+    return UnsafeMutableRawPointer(bitPattern:
+     _roundingDownToAlignment(UInt(bitPattern: value))).unsafelyUnwrapped
+  }
+
+  internal static func _roundingUpBaseToAlignment(_ value: UnsafeRawBufferPointer) -> UnsafeRawBufferPointer {
+    let baseAddressBits = Int(bitPattern: value.baseAddress)
+    var misalignment = baseAddressBits & _alignmentMask
+    if misalignment != 0 {
+      misalignment = _alignmentMask & -misalignment
+      return UnsafeRawBufferPointer(
+        start: UnsafeRawPointer(bitPattern: baseAddressBits + misalignment),
+        count: value.count - misalignment)
+    }
+    return value
+  }
+
+  internal static func _roundingUpBaseToAlignment(_ value: UnsafeMutableRawBufferPointer) -> UnsafeMutableRawBufferPointer {
+    let baseAddressBits = Int(bitPattern: value.baseAddress)
+    var misalignment = baseAddressBits & _alignmentMask
+    if misalignment != 0 {
+      misalignment = _alignmentMask & -misalignment
+      return UnsafeMutableRawBufferPointer(
+        start: UnsafeMutableRawPointer(bitPattern: baseAddressBits + misalignment),
+        count: value.count - misalignment)
+    }
+    return value
+  }
+}

--- a/test/IRGen/class_resilience.swift
+++ b/test/IRGen/class_resilience.swift
@@ -316,6 +316,19 @@ extension ResilientGenericOutsideParent {
 // CHECK-NEXT: [[GENERIC_PARAM:%.*]] = load %swift.type*, %swift.type** [[GENERIC_PARAM_ADDR]]
 // CHECK:       ret %swift.type* [[GENERIC_PARAM]]
 
+// ResilientChild.field getter dispatch thunk
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @"$S16class_resilience14ResilientChildC5fields5Int32VvgTj"(%T16class_resilience14ResilientChildC* swiftself)
+// CHECK:      [[ISA_ADDR:%.*]] = getelementptr inbounds %T16class_resilience14ResilientChildC, %T16class_resilience14ResilientChildC* %0, i32 0, i32 0, i32 0
+// CHECK-NEXT: [[ISA:%.*]] = load %swift.type*, %swift.type** [[ISA_ADDR]]
+// CHECK-NEXT: [[BASE:%.*]] = load [[INT]], [[INT]]* getelementptr inbounds ([[BOUNDS]], [[BOUNDS]]* @"$S16class_resilience14ResilientChildCMo", i32 0, i32 0)
+// CHECK-NEXT: [[METADATA_BYTES:%.*]] = bitcast %swift.type* [[ISA]] to i8*
+// CHECK-NEXT: [[VTABLE_OFFSET_TMP:%.*]] = getelementptr inbounds i8, i8* [[METADATA_BYTES]], [[INT]] [[BASE]]
+// CHECK-NEXT: [[VTABLE_OFFSET_ADDR:%.*]] = bitcast i8* [[VTABLE_OFFSET_TMP]] to i32 (%T16class_resilience14ResilientChildC*)**
+// CHECK-NEXT: [[METHOD:%.*]] = load i32 (%T16class_resilience14ResilientChildC*)*, i32 (%T16class_resilience14ResilientChildC*)** [[VTABLE_OFFSET_ADDR]]
+// CHECK-NEXT: [[RESULT:%.*]] = call swiftcc i32 [[METHOD]](%T16class_resilience14ResilientChildC* swiftself %0)
+// CHECK-NEXT: ret i32 [[RESULT]]
+
 // ClassWithResilientProperty metadata initialization function
 
 
@@ -392,19 +405,6 @@ extension ResilientGenericOutsideParent {
 
 // CHECK:              ret void
 
-
-// ResilientChild.field getter dispatch thunk
-
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @"$S16class_resilience14ResilientChildC5fields5Int32VvgTj"(%T16class_resilience14ResilientChildC* swiftself)
-// CHECK:      [[ISA_ADDR:%.*]] = getelementptr inbounds %T16class_resilience14ResilientChildC, %T16class_resilience14ResilientChildC* %0, i32 0, i32 0, i32 0
-// CHECK-NEXT: [[ISA:%.*]] = load %swift.type*, %swift.type** [[ISA_ADDR]]
-// CHECK-NEXT: [[BASE:%.*]] = load [[INT]], [[INT]]* getelementptr inbounds ([[BOUNDS]], [[BOUNDS]]* @"$S16class_resilience14ResilientChildCMo", i32 0, i32 0)
-// CHECK-NEXT: [[METADATA_BYTES:%.*]] = bitcast %swift.type* [[ISA]] to i8*
-// CHECK-NEXT: [[VTABLE_OFFSET_TMP:%.*]] = getelementptr inbounds i8, i8* [[METADATA_BYTES]], [[INT]] [[BASE]]
-// CHECK-NEXT: [[VTABLE_OFFSET_ADDR:%.*]] = bitcast i8* [[VTABLE_OFFSET_TMP]] to i32 (%T16class_resilience14ResilientChildC*)**
-// CHECK-NEXT: [[METHOD:%.*]] = load i32 (%T16class_resilience14ResilientChildC*)*, i32 (%T16class_resilience14ResilientChildC*)** [[VTABLE_OFFSET_ADDR]]
-// CHECK-NEXT: [[RESULT:%.*]] = call swiftcc i32 [[METHOD]](%T16class_resilience14ResilientChildC* swiftself %0)
-// CHECK-NEXT: ret i32 [[RESULT]]
 
 // ResilientChild.field setter dispatch thunk
 

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -29,7 +29,7 @@ class C: Hashable {
 }
 
 struct G<T> {
-  var x: T
+  var x: T { get set }
   subscript<U: Hashable>(x: U) -> T { get set }
 }
 

--- a/test/IRGen/property_descriptor.sil
+++ b/test/IRGen/property_descriptor.sil
@@ -7,8 +7,8 @@ sil_stage canonical
 import Swift
 
 public struct ExternalGeneric<T: Comparable> {
-  public let ro: T
-  public var rw: T
+  @sil_stored public var ro: T { get }
+  @sil_stored public var rw: T { get set }
 
   public var computedRO: T { get }
   public var computedRW: T { get set }
@@ -21,8 +21,8 @@ public struct ExternalGeneric<T: Comparable> {
 }
 
 public struct External {
-  public let ro: Int
-  public var rw: Int
+  @sil_stored public var ro: Int { get }
+  @sil_stored public var rw: Int { get set }
 
   public var computedRO: Int { get }
   public var computedRW: Int { get set }
@@ -35,8 +35,8 @@ public struct External {
 }
 
 public struct ExternalReabstractions<T> {
-  public var ro: T
-  public var reabstracted: () -> ()
+  @sil_stored public var ro: T { get }
+  @sil_stored public var reabstracted: () -> () { get set }
 }
 
 // -- 0xff_fffe - struct property, offset resolved from field offset vector in metadata

--- a/test/SILGen/Inputs/ExternalKeyPaths.swift
+++ b/test/SILGen/Inputs/ExternalKeyPaths.swift
@@ -13,3 +13,7 @@ public struct External<A> {
 public struct ExternalEmptySubscript {
   public subscript() -> Int { return 0 }
 }
+
+public protocol ExternalProto {
+  var protoReqt: Int { get set }
+}

--- a/test/SILGen/external-keypath.swift
+++ b/test/SILGen/external-keypath.swift
@@ -67,3 +67,10 @@ func externalKeyPaths<T: Hashable, U>(_ x: T, _ y: U, _ z: Int) {
   // CHECK-SAME: external #External.subscript
   _ = \External<Int>.[privateSet: 0]
 }
+
+// CHECK-LABEL: sil hidden @{{.*}}testProtocolRequirement
+func testProtocolRequirement<T: ExternalProto>(_: T.Type) {
+  // CHECK: keypath $WritableKeyPath<T, Int>,
+  // CHECK-NOT: external #ExternalProto.protoReqt
+  _ = \T.protoReqt
+}

--- a/test/SILGen/keypaths_objc.swift
+++ b/test/SILGen/keypaths_objc.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/keypaths_objc.h %s | %FileCheck %s
-// RUN: %target-swift-emit-ir(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/keypaths_objc.h %s
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -enable-key-path-resilience -import-objc-header %S/Inputs/keypaths_objc.h %s | %FileCheck %s
+// RUN: %target-swift-emit-ir(mock-sdk: %clang-importer-sdk) -enable-key-path-resilience -import-objc-header %S/Inputs/keypaths_objc.h %s
 // REQUIRES: objc_interop
 
 import Foundation
@@ -87,4 +87,12 @@ func objcProtocolRequirement<T: ObjCProto>(_: T) {
   _ = \T.objcRequirement
   // CHECK: keypath {{.*}} id #ObjCProto.objcRequirement!getter.1.foreign
   _ = \ObjCProto.objcRequirement
+}
+
+// CHECK-LABEL: sil hidden @{{.*}}externalObjCProperty
+func externalObjCProperty() {
+  // Pure ObjC-dispatched properties do not have external descriptors.
+  // CHECK: keypath $KeyPath<NSObject, String>, 
+  // CHECK-NOT: external #NSObject.description
+  _ = \NSObject.description
 }

--- a/test/stdlib/Inputs/KeyPathMultiModule_b.swift
+++ b/test/stdlib/Inputs/KeyPathMultiModule_b.swift
@@ -193,6 +193,104 @@ public func B_Int_storedB_keypath() -> KeyPath<B<Int>, Int> {
   return \B<Int>.storedB
 }
 
+open class ResilientRoot {
+  open var storedA = "a"
+  open var storedB = "b"
+
+  open var virtual: String {
+    get { return "foo" }
+    set { }
+  }
+
+  open var virtualRO: String {
+    get { return "foo" }
+  }
+
+  final public var final: String {
+    get { return "foo" }
+    set { }
+  }
+}
+
+open class ResilientSub: ResilientRoot {
+  open var storedC = "c"
+
+  override open var virtual: String {
+    get { return "bar" }
+    set { }
+  }
+
+  open var sub: String {
+    get { return "bar" }
+    set { }
+  }
+
+  open var subRO: String {
+    get { return "foo" }
+  }
+
+}
+
+public func ResilientRoot_storedA_keypath() -> KeyPath<ResilientRoot, String> {
+  return \ResilientRoot.storedA
+}
+public func ResilientRoot_storedB_keypath() -> KeyPath<ResilientRoot, String> {
+  return \ResilientRoot.storedB
+}
+public func ResilientRoot_virtual_keypath() -> KeyPath<ResilientRoot, String> {
+  return \ResilientRoot.virtual
+}
+public func ResilientRoot_virtualRO_keypath() -> KeyPath<ResilientRoot, String> {
+  return \ResilientRoot.virtualRO
+}
+public func ResilientRoot_final_keypath() -> KeyPath<ResilientRoot, String> {
+  return \ResilientRoot.final
+}
+public func ResilientSub_storedA_keypath() -> KeyPath<ResilientSub, String> {
+  return \ResilientSub.storedA
+}
+public func ResilientSub_storedB_keypath() -> KeyPath<ResilientSub, String> {
+  return \ResilientSub.storedB
+}
+public func ResilientSub_storedC_keypath() -> KeyPath<ResilientSub, String> {
+  return \ResilientSub.storedC
+}
+public func ResilientSub_virtual_keypath() -> KeyPath<ResilientSub, String> {
+  return \ResilientSub.virtual
+}
+public func ResilientSub_virtualRO_keypath() -> KeyPath<ResilientSub, String> {
+  return \ResilientSub.virtualRO
+}
+public func ResilientSub_final_keypath() -> KeyPath<ResilientSub, String> {
+  return \ResilientSub.final
+}
+public func ResilientSub_sub_keypath() -> KeyPath<ResilientSub, String> {
+  return \ResilientSub.sub
+}
+public func ResilientSub_subRO_keypath() -> KeyPath<ResilientSub, String> {
+  return \ResilientSub.subRO
+}
+
+public protocol ResilientRootProto {
+  var root: String { get }
+}
+
+public protocol ResilientSubProto: ResilientRootProto {
+  var sub: String { get }
+}
+
+extension Int: ResilientSubProto {
+  public var root: String { return "root" }
+  public var sub: String { return "sub" }
+}
+
+public func ResilientRootProto_root_keypath<T: ResilientRootProto>(_: T.Type) -> KeyPath<T, String> {
+  return \T.root
+}
+public func ResilientSubProto_sub_keypath<T: ResilientSubProto>(_: T.Type) -> KeyPath<T, String> {
+  return \T.sub
+}
+
 extension Int {
   public var appendTest: Int { return self }
 }
@@ -202,3 +300,4 @@ extension String {
 extension LifetimeTracked {
   public var appendTest: LifetimeTracked { return self }
 }
+

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -o %t/a.out
+// RUN: %target-build-swift -g %s -o %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
 

--- a/test/stdlib/KeyPathMultiModule.swift
+++ b/test/stdlib/KeyPathMultiModule.swift
@@ -23,6 +23,22 @@ func expectEqualWithHashes<T: Hashable>(_ x: T, _ y: T,
   expectEqual(x.hashValue, y.hashValue, file: file, line: line)
 }
 
+class LocalSub: ResilientSub {
+  override var virtual: String {
+    get {
+      return "bas"
+    }
+    set {
+    }
+  }
+
+  final var storedD: String = "zim"
+
+  var localSub: String {
+    get { return "zang" }
+  }
+}
+
 keyPathMultiModule.test("identity across multiple modules") {
   // Do this twice, to ensure that fully constant key paths remain stable
   // after one-time instantiation of the object
@@ -45,7 +61,6 @@ keyPathMultiModule.test("identity across multiple modules") {
                 \A.[withGenericPrivateSet: 0])
     expectEqualWithHashes(A_subscript_withGenericPrivateSet_keypath(index: "butt"),
                 \A.[withGenericPrivateSet: "butt"])
-
 
     do {
       let lifetimeTracker = LifetimeTracked(679)
@@ -130,6 +145,51 @@ keyPathMultiModule.test("identity across multiple modules") {
                          appending: \String.appendTest)
     testInGenericContext(x: LifetimeTracked(17), y: LifetimeTracked(38),
                          appending: \LifetimeTracked.appendTest)
+
+    expectEqualWithHashes(ResilientRoot_storedA_keypath(),
+                          \ResilientRoot.storedA)
+    expectEqualWithHashes(ResilientRoot_storedB_keypath(),
+                          \ResilientRoot.storedB)
+    expectEqualWithHashes(ResilientRoot_virtual_keypath(),
+                          \ResilientRoot.virtual)
+    expectEqualWithHashes(ResilientRoot_virtualRO_keypath(),
+                          \ResilientRoot.virtualRO)
+    expectEqualWithHashes(ResilientRoot_final_keypath(),
+                          \ResilientRoot.final)
+    expectEqualWithHashes(ResilientSub_storedA_keypath(),
+                          \ResilientSub.storedA)
+    expectEqualWithHashes(ResilientSub_storedB_keypath(),
+                          \ResilientSub.storedB)
+    expectEqualWithHashes(ResilientSub_storedC_keypath(),
+                          \ResilientSub.storedC)
+    expectEqualWithHashes(ResilientSub_virtual_keypath(),
+                          \ResilientSub.virtual)
+    expectEqualWithHashes(ResilientSub_virtualRO_keypath(),
+                          \ResilientSub.virtualRO)
+    expectEqualWithHashes(ResilientSub_final_keypath(),
+                          \ResilientSub.final)
+    expectEqualWithHashes(ResilientSub_sub_keypath(),
+                          \ResilientSub.sub)
+    expectEqualWithHashes(ResilientSub_subRO_keypath(),
+                          \ResilientSub.subRO)
+
+    // Ensure that we can instantiate key paths on a local subclass of a
+    // resilient class.
+    expectEqual(\LocalSub.storedA, \LocalSub.storedA)
+    expectEqual(\LocalSub.storedB, \LocalSub.storedB)
+    expectEqual(\LocalSub.storedC, \LocalSub.storedC)
+    //TODO expectEqual(\LocalSub.storedD, \LocalSub.storedD)
+    expectEqual(\LocalSub.virtual, \LocalSub.virtual)
+    //TODO expectEqual(\LocalSub.localSub, \LocalSub.localSub)
+
+    func testInGenericContext2<W: ResilientSubProto>(_: W.Type) {
+      expectEqualWithHashes(ResilientRootProto_root_keypath(W.self),
+                            \W.root)
+      expectEqualWithHashes(ResilientSubProto_sub_keypath(W.self),
+                            \W.sub)
+    }
+
+    testInGenericContext2(Int.self)
   }
 }
 

--- a/test/stdlib/KeyPathMultiModule.swift
+++ b/test/stdlib/KeyPathMultiModule.swift
@@ -33,9 +33,13 @@ class LocalSub: ResilientSub {
   }
 
   final var storedD: String = "zim"
+  final var storedE: String = "zang"
 
-  var localSub: String {
-    get { return "zang" }
+  var localSubA: String {
+    get { return "zung" }
+  }
+  var localSubB: String {
+    get { return "zipiti" }
   }
 }
 
@@ -174,13 +178,25 @@ keyPathMultiModule.test("identity across multiple modules") {
                           \ResilientSub.subRO)
 
     // Ensure that we can instantiate key paths on a local subclass of a
-    // resilient class.
-    expectEqual(\LocalSub.storedA, \LocalSub.storedA)
-    expectEqual(\LocalSub.storedB, \LocalSub.storedB)
-    expectEqual(\LocalSub.storedC, \LocalSub.storedC)
-    //TODO expectEqual(\LocalSub.storedD, \LocalSub.storedD)
-    expectEqual(\LocalSub.virtual, \LocalSub.virtual)
-    //TODO expectEqual(\LocalSub.localSub, \LocalSub.localSub)
+    // resilient class, and that they have distinct values.
+    let kps: [PartialKeyPath<LocalSub>] = [
+      \LocalSub.storedA,
+      \LocalSub.storedB,
+      \LocalSub.storedC,
+      \LocalSub.storedD,
+      \LocalSub.storedE,
+      \LocalSub.virtual,
+      \LocalSub.sub,
+      \LocalSub.localSubA,
+      \LocalSub.localSubB,
+    ]
+
+    for i in kps.indices {
+      for j in kps.indices {
+        if i == j { continue }
+        expectNotEqual(kps[i], kps[j])
+      }
+    }
 
     func testInGenericContext2<W: ResilientSubProto>(_: W.Type) {
       expectEqualWithHashes(ResilientRootProto_root_keypath(W.self),

--- a/validation-test/Evolution/Inputs/keypaths.swift.gyb
+++ b/validation-test/Evolution/Inputs/keypaths.swift.gyb
@@ -25,7 +25,7 @@ public enum AnEnum {
     }
   }
 
-% for (name, kind, before, after) in testCases:
+% for (name, kind, before, after, addsAPI) in testCases:
 
 %   if kind == "mutating" or kind == "nonmutating":
 
@@ -51,7 +51,7 @@ public struct AStruct {
 
   public var sink: Int = 0
 
-% for (name, kind, before, after) in testCases:
+% for (name, kind, before, after, addsAPI) in testCases:
 
 %   if kind == "mutating" or kind == "nonmutating" or kind == "stored":
 
@@ -75,7 +75,7 @@ public class AClass {
 
   public var sink: Int = 0
 
-% for (name, kind, before, after) in testCases:
+% for (name, kind, before, after, addsAPI) in testCases:
 
 %   if kind == "nonmutating" or kind == "stored":
 
@@ -86,6 +86,32 @@ public class AClass {
     #endif
 
     public static var keyPath_${name}: PartialKeyPath<AClass> { return \AClass.${name} }
+
+%   elif kind == "mutating":
+
+%   else:
+      %{ raise ValueError("improper test case kind") }%
+%   end
+
+% end
+
+}
+
+public final class AFinalClass {
+
+  public var sink: Int = 0
+
+% for (name, kind, before, after, addsAPI) in testCases:
+
+%   if kind == "nonmutating" or kind == "stored":
+
+    #if BEFORE
+      ${before.format(name=name, nonmutating="")}
+    #else
+      ${after.format(name=name, nonmutating="")}
+    #endif
+
+    public static var keyPath_${name}: PartialKeyPath<AFinalClass> { return \AFinalClass.${name} }
 
 %   elif kind == "mutating":
 

--- a/validation-test/Evolution/test_keypaths.swift.gyb
+++ b/validation-test/Evolution/test_keypaths.swift.gyb
@@ -3,8 +3,7 @@
 // RUN: %empty-directory(%t/rth)
 // RUN: env PYTHONPATH=%S/Inputs %gyb < %s > %t/test_keypaths.swift
 // RUN: env PYTHONPATH=%S/Inputs %gyb < %S/Inputs/keypaths.swift.gyb > %t/Inputs/keypaths.swift
-// FIXME implement key path resilience
-// RUN: not %rth --target-build-swift "%target-build-swift" --target-run "%target-run" --t "%t/rth" --S "%t" --s "%t/test_keypaths.swift" --lib-prefix "lib" --lib-suffix ".%target-dylib-extension" --target-codesign "%target-codesign"
+// RUN: %rth --target-build-swift "%target-build-swift" --target-run "%target-run" --t "%t/rth" --S "%t" --s "%t/test_keypaths.swift" --lib-prefix "lib" --lib-suffix ".%target-dylib-extension" --target-codesign "%target-codesign"
 
 // REQUIRES: executable_test
 
@@ -17,7 +16,11 @@ from keypaths_gyb import testCases
 
 var tests = TestSuite("key path resilience")
 
-% for (name, kind, before, after) in testCases:
+% for (name, kind, before, after, addsAPI) in testCases:
+
+%  if addsAPI:
+#if BEFORE
+%  end
 
 %  if kind == "mutating" or kind == "nonmutating":
 
@@ -33,9 +36,18 @@ tests.test("AnEnum.${name}") {
 %  else:
      %{ raise ValueError("improper test case kind") }%
 %  end
+
+%  if addsAPI:
+#endif // BEFORE
+%  end
+
 % end
 
-% for (name, kind, before, after) in testCases:
+% for (name, kind, before, after, addsAPI) in testCases:
+
+%  if addsAPI:
+#if BEFORE
+%  end
 
 %  if kind == "mutating" or kind == "nonmutating" or kind == "stored":
 
@@ -49,9 +61,18 @@ tests.test("AStruct.${name}") {
 %  else:
      %{ raise ValueError("improper test case kind") }%
 %  end
+
+%  if addsAPI:
+#endif // BEFORE
+%  end
+
 % end
 
-% for (name, kind, before, after) in testCases:
+% for (name, kind, before, after, addsAPI) in testCases:
+
+%  if addsAPI:
+#if BEFORE
+%  end
 
 %  if kind == "nonmutating" or kind == "stored":
 
@@ -62,11 +83,23 @@ tests.test("AClass.${name}") {
   expectEqual(fromModule, formedLocally)
 }
 
+tests.test("AFinalClass.${name}") {
+  let fromModule = AFinalClass.keyPath_${name}
+  let formedLocally = \AFinalClass.${name}
+
+  expectEqual(fromModule, formedLocally)
+}
+
 %  elif kind == "mutating":
 
 %  else:
      %{ raise ValueError("improper test case kind") }%
 %  end
+
+%  if addsAPI:
+#endif
+%  end
+
 % end
 
 runAllTests()


### PR DESCRIPTION
Along with other fixes uncovered during integration:

- Properly identify resilient methods by their dispatch thunk
- Fix some size computation bugs in the KeyPath runtime
- Fix some TBD and SILGen issues trying to refer to unnecessary, nonexistent property descriptors

rdar://problem/33946557