### PR TITLE
Revert "Create one undef node per type to avoid failures in graph creation."

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -226,7 +226,6 @@ struct TFGraphFunctionLowering
   const std::string &funcNodeBaseName;
   llvm::DenseMap<StringRef, std::unique_ptr<LoweredGraphFunction>>
       &graphFunctions;
-  llvm::DenseMap<SILType, TF_Output> undefGraphNodes;
   TF_Graph *resultGraph;
   TF_Status *status;
 
@@ -859,10 +858,6 @@ static bool checkStatus(SILFunction &fn, SILLocation loc, TF_Status *status,
 
 /// On error, return a "NULL" value, and emit an error diagnostic.
 TF_Output TFGraphFunctionLowering::createUndefNode(SILType type) {
-  auto iter = undefGraphNodes.find(type);
-  if (iter != undefGraphNodes.end()) {
-    return iter->second;
-  }
   // Create some magic constant. Actual value does not matter as it will
   // not be used in any calculations.
   // FIXME: Is there a better way to model undefs in TF Graph if we
@@ -944,8 +939,6 @@ TF_Output TFGraphFunctionLowering::createUndefNode(SILType type) {
                        /*isEligibleForTPU*/ true, status);
   if (::checkStatus(SILFn, SILFn.getLocation(), status))
     return {nullptr, 0};
-  // Update cache
-  undefGraphNodes[type] = {finalResult, 0};
   return {finalResult, 0};
 }
 

--- a/test/TensorFlow/undef_lowering.sil
+++ b/test/TensorFlow/undef_lowering.sil
@@ -4,38 +4,10 @@ import Builtin
 import Swift
 import TensorFlow
 
-sil @$undefDuplicates : $@convention(thin) () -> TensorHandle<Bool>  {
-bb0:
-  br bb1(undef : $TensorHandle<Bool>)
-bb1(%0 : $TensorHandle<Bool>):
-  return undef : $TensorHandle<Bool>
-}
-// CHECK-LABEL: --- TFPartition GraphDef Proto: $undefDuplicates
-// CHECK: library {
-// CHECK:  function {
-// CHECK:  node_def {
-// CHECK:      name: "UndefConstDTensorHandleLBoolG"
-// CHECK:      op: "Const"
-// CHECK:      attr {
-// CHECK:        key: "dtype"
-// CHECK:        value {
-// CHECK:          type: DT_BOOL
-// CHECK:        }
-// CHECK:      }
-// CHECK:      attr {
-// CHECK:        key: "value"
-// CHECK:        value {
-// CHECK:          tensor {
-// CHECK:            dtype: DT_BOOL
-// CHECK:            tensor_shape {
-// CHECK:            }
-// CHECK:            bool_val: false
-// CHECK:          }
-// CHECK:        }
-// CHECK:      }
-// CHECK:    }
-// CHECK:  }
-// CHECK:}
+// sil @$undefInt32 : $@convention(thin) () -> Builtin.Int32  {
+// bb0:
+//  return undef : $Builtin.Int32
+// }
 
 sil @$undefTFBool : $@convention(thin) () -> TensorHandle<Bool>  {
 bb0:


### PR DESCRIPTION
Reverts apple/swift#18288

It looks like cached undef nodes become stale somehow.  