### PR TITLE
 [Standard library] Ascribe types to some literals to improve typecheck time

### DIFF
--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -665,7 +665,9 @@ deriveEquatable_eq(DerivedConformance &derived, Identifier generatedIdentifier,
 
 bool DerivedConformance::canDeriveEquatable(TypeChecker &tc, DeclContext *DC,
                                             NominalTypeDecl *type) {
-  auto equatableProto = tc.Context.getProtocol(KnownProtocolKind::Equatable);
+  ASTContext &ctx = DC->getASTContext();
+  auto equatableProto = ctx.getProtocol(KnownProtocolKind::Equatable);
+  if (!equatableProto) return false;
   return canDeriveConformance(tc, DC, type, equatableProto);
 }
 
@@ -1135,8 +1137,7 @@ getHashableConformance(Decl *parentDecl) {
   return nullptr;
 }
 
-bool DerivedConformance::canDeriveHashable(TypeChecker &tc,
-                                           NominalTypeDecl *type) {
+bool DerivedConformance::canDeriveHashable(NominalTypeDecl *type) {
   if (!isa<EnumDecl>(type) && !isa<StructDecl>(type) && !isa<ClassDecl>(type))
     return false;
   // FIXME: This is not actually correct. We cannot promise to always

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -61,7 +61,7 @@ bool DerivedConformance::derivesProtocolConformance(TypeChecker &TC,
     // We can always complete a partial Hashable implementation, and we can
     // synthesize a full Hashable implementation for structs and enums with
     // Hashable components.
-    return canDeriveHashable(TC, Nominal);
+    return canDeriveHashable(Nominal);
   }
 
   if (auto *enumDecl = dyn_cast<EnumDecl>(Nominal)) {

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -137,7 +137,7 @@ public:
   /// associated values, and for structs with all-Hashable stored properties.
   ///
   /// \returns True if the requirement can be derived.
-  static bool canDeriveHashable(TypeChecker &tc, NominalTypeDecl *type);
+  static bool canDeriveHashable(NominalTypeDecl *type);
 
   /// Derive a Hashable requirement for a type.
   ///

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -1210,7 +1210,7 @@ RequirementCheckResult TypeChecker::checkGenericArguments(
   pendingReqs.push_back({requirements, {}});
 
   auto *env = dc->getGenericEnvironmentOfContext();
-
+  ASTContext &ctx = dc->getASTContext();
   while (!pendingReqs.empty()) {
     auto current = pendingReqs.pop_back_val();
 
@@ -1342,7 +1342,7 @@ RequirementCheckResult TypeChecker::checkGenericArguments(
 
       if (loc.isValid()) {
         // FIXME: Poor source-location information.
-        diagnose(loc, diagnostic, owner, firstType, secondType);
+        ctx.Diags.diagnose(loc, diagnostic, owner, firstType, secondType);
 
         std::string genericParamBindingsText;
         if (!genericParams.empty()) {
@@ -1350,11 +1350,11 @@ RequirementCheckResult TypeChecker::checkGenericArguments(
             gatherGenericParamBindingsText(
               {rawFirstType, rawSecondType}, genericParams, substitutions);
         }
-        diagnose(noteLoc, diagnosticNote, rawFirstType, rawSecondType,
-                 genericParamBindingsText);
+        ctx.Diags.diagnose(noteLoc, diagnosticNote, rawFirstType, rawSecondType,
+                           genericParamBindingsText);
 
-        ParentConditionalConformance::diagnoseConformanceStack(Diags, noteLoc,
-                                                               current.Parents);
+        ParentConditionalConformance::diagnoseConformanceStack(
+            ctx.Diags, noteLoc, current.Parents);
       }
 
       return RequirementCheckResult::Failure;

--- a/stdlib/public/core/Hasher.swift
+++ b/stdlib/public/core/Hasher.swift
@@ -90,7 +90,10 @@ internal struct _HasherTailBuffer {
   internal init(tail: UInt64, byteCount: UInt64) {
     // byteCount can be any value, but we only keep the lower 8 bits.  (The
     // lower three bits specify the count of bytes stored in this buffer.)
-    _sanityCheck(tail & ~(1 << ((byteCount & 7) << 3) - 1) == 0)
+    // FIXME: The "as UInt64" annotations here eliminate some exponential
+    // behavior in the expression type checker <rdar://problem/42672946>.
+    _sanityCheck(tail & ~((1 as UInt64) << ((byteCount & (7 as UInt64))
+          << (3 as UInt64)) - (1 as UInt64)) == (0 as UInt64))
     self.value = (byteCount &<< 56 | tail)
   }
 

--- a/stdlib/public/core/Hasher.swift
+++ b/stdlib/public/core/Hasher.swift
@@ -90,10 +90,11 @@ internal struct _HasherTailBuffer {
   internal init(tail: UInt64, byteCount: UInt64) {
     // byteCount can be any value, but we only keep the lower 8 bits.  (The
     // lower three bits specify the count of bytes stored in this buffer.)
-    // FIXME: The "as UInt64" annotations here eliminate some exponential
+    // FIXME: This should be a single expression, but it causes exponential
     // behavior in the expression type checker <rdar://problem/42672946>.
-    _sanityCheck(tail & ~((1 as UInt64) << ((byteCount & (7 as UInt64))
-          << (3 as UInt64)) - (1 as UInt64)) == (0 as UInt64))
+    let shiftedByteCount: UInt64 = ((byteCount & 7) << 3)
+    let mask: UInt64 = (1 << shiftedByteCount - 1)
+    _sanityCheck(tail & ~mask == 0)
     self.value = (byteCount &<< 56 | tail)
   }
 

--- a/stdlib/public/core/UTF16.swift
+++ b/stdlib/public/core/UTF16.swift
@@ -60,7 +60,9 @@ extension Unicode.UTF16 : Unicode.Encoding {
       return Unicode.Scalar(_unchecked: bits & 0xffff)
     }
     _sanityCheck(source._bitCount == 32)
-    let value = 0x10000 + (bits >> 16 & 0x03ff | (bits & 0x03ff) << 10)
+    let lower: UInt32 = bits >> 16 & 0x03ff
+    let upper: UInt32 = (bits & 0x03ff) << 10
+    let value = 0x10000 + (lower | upper)
     return Unicode.Scalar(_unchecked: value)
   }
 

--- a/validation-test/Sema/type_checker_perf/slow/rdar42672946.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar42672946.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+func f(tail: UInt64, byteCount: UInt64) {
+  if tail & ~(1 << ((byteCount & 7) << 3) - 1) == 0 { }
+  // expected-error@-1 {{reasonable time}}
+}


### PR DESCRIPTION
One expression in the new hashing implementation is going exponential,
accounting for a huge amount of type-checking type. Add (admittedly ugly)
“as UInt64” annotations to greatly reduce the time to type-check this
expression.

Do the same for some of the UnicodeScalar decoding code.

*Ahem* type-checking time for the standard library goes from 24s->12s with
this change. Added a type-checker “slow” performance test and captured
the problem in rdar://problem/42672946.