### PR TITLE
Support `swift -e` for immediate execution

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -677,6 +677,12 @@ def deprecated_integrated_repl : Flag<["-"], "deprecated-integrated-repl">,
   Flags<[FrontendOption, NoBatchOption]>, ModeOpt;
 def i : Flag<["-"], "i">, ModeOpt; // only used to provide diagnostics.
 
+def execute : Separate<["-"], "execute">,
+  HelpText<"Execute the passed Swift code immediately">,
+  Flags<[NoBatchOption]>;
+def e : Separate<["-"], "e">, Alias<execute>,
+  Flags<[NoBatchOption]>, ModeOpt;
+
 def whole_module_optimization : Flag<["-"], "whole-module-optimization">,
   HelpText<"Optimize input files together instead of individually">,
   Flags<[FrontendOption, NoInteractiveOption]>;

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1815,12 +1815,11 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
     if (Args.hasArg(options::OPT_execute)) {
       SmallString<128> Buffer;
       std::error_code EC =
-        llvm::sys::fs::createTemporaryFile("execute", "swift", Buffer);
+          llvm::sys::fs::createTemporaryFile("execute", "swift", Buffer);
 
       if (EC) {
-        Diags.diagnose(SourceLoc(),
-            diag::error_unable_to_make_temporary_file,
-            EC.message());
+        Diags.diagnose(SourceLoc(), diag::error_unable_to_make_temporary_file,
+                       EC.message());
         return;
       }
 
@@ -1834,9 +1833,9 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
       OS.flush();
 
       const Arg *A = Args.getLastArg(options::OPT_execute);
-      const Arg *InputArg = new Arg(
-          Opts->getOption(options::OPT_INPUT), A->getValue(),
-          A->getIndex(), Args.MakeArgString(Buffer.str()));
+      const Arg *InputArg =
+          new Arg(Opts->getOption(options::OPT_INPUT), A->getValue(),
+                  A->getIndex(), Args.MakeArgString(Buffer.str()));
       InputArg->claim();
       CA->addInput(
           C.createAction<InputAction>(*InputArg, file_types::TY_Swift));

--- a/test/Driver/options-interpreter.swift
+++ b/test/Driver/options-interpreter.swift
@@ -13,6 +13,9 @@
 // RUN: %swift_driver -### -parse-stdlib | %FileCheck -check-prefix PARSE_STDLIB %s
 // PARSE_STDLIB: -parse-stdlib
 
+// RUN: %swift_driver -### -e "foo bar" -e "baz" | %FileCheck -check-prefix EXECUTE_IMMEDIATELY %s
+// EXECUTE_IMMEDIATELY: -frontend -interpret
+// EXECUTE_IMMEDIATELY: {{[^ ]+.swift}}
 
 // RUN: %swift_driver -### -target x86_64-apple-macosx10.9 -resource-dir /RSRC/ %s | %FileCheck -check-prefix=CHECK-RESOURCE-DIR-ONLY %s
 // CHECK-RESOURCE-DIR-ONLY: # DYLD_LIBRARY_PATH=/RSRC/macosx{{$}}

--- a/test/Interpreter/execute-immediately.swift
+++ b/test/Interpreter/execute-immediately.swift
@@ -1,0 +1,6 @@
+// RUN: %swift_driver -e 'print("first")' -e 'print("second")' | %FileCheck %s
+
+// REQUIRES: swift_interpreter
+
+// CHECK: first
+// CHECK: second


### PR DESCRIPTION
This adds the ability to pass code directly to the Swift interpreter
using `-e`. Usage:

```sh
swift -e 'print("Hello World!")'
```

You can also pass `-e` multiple times:

```sh
swift -e 'print("Hello World!")' -e 'print("Hello again :)")'
```

Resolves [SR-5860](https://bugs.swift.org/browse/SR-5860).