### PR TITLE
Add warning for bitcode marker without object

### DIFF
--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -136,6 +136,8 @@ ERROR(error_option_not_supported, none,
 
 WARNING(warn_ignore_embed_bitcode, none,
         "ignoring -embed-bitcode since no object file is being generated", ())
+WARNING(warn_ignore_embed_bitcode_marker, none,
+        "ignoring -embed-bitcode-marker since no object file is being generated", ())
 
 WARNING(verify_debug_info_requires_debug_option,none,
         "ignoring '-verify-debug-info'; no debug info is being generated", ())

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -612,6 +612,12 @@ static void validateEmbedBitcode(DerivedArgList &Args, const OutputInfo &OI,
     Diags.diagnose(SourceLoc(), diag::warn_ignore_embed_bitcode);
     Args.eraseArg(options::OPT_embed_bitcode);
   }
+
+  if (Args.hasArg(options::OPT_embed_bitcode_marker) &&
+      OI.CompilerOutputType != file_types::TY_Object) {
+    Diags.diagnose(SourceLoc(), diag::warn_ignore_embed_bitcode_marker);
+    Args.eraseArg(options::OPT_embed_bitcode_marker);
+  }
 }
 
 /// Gets the filelist threshold to use. Diagnoses and returns true on error.

--- a/test/Driver/embed-bitcode.swift
+++ b/test/Driver/embed-bitcode.swift
@@ -119,3 +119,15 @@
 // RUN: %target-swiftc_driver -embed-bitcode -emit-assembly %s 2>&1 -### | %FileCheck %s -check-prefix=WARN-EMBED-BITCODE
 // WARN-EMBED-BITCODE: warning: ignoring -embed-bitcode since no object file is being generated
 // WARN-EMBED-BITCODE-NOT: -embed-bitcode
+
+// RUN: %target-swiftc_driver -embed-bitcode-marker -emit-module %s 2>&1 -### | %FileCheck %s -check-prefix=WARN-EMBED-BITCODE-MARKER
+// RUN: %target-swiftc_driver -embed-bitcode-marker -emit-module-path a.swiftmodule %s 2>&1 -### | %FileCheck %s -check-prefix=WARN-EMBED-BITCODE-MARKER
+// RUN: %target-swiftc_driver -embed-bitcode-marker -emit-sib %s 2>&1 -### | %FileCheck %s -check-prefix=WARN-EMBED-BITCODE-MARKER
+// RUN: %target-swiftc_driver -embed-bitcode-marker -emit-sibgen %s 2>&1 -### | %FileCheck %s -check-prefix=WARN-EMBED-BITCODE-MARKER
+// RUN: %target-swiftc_driver -embed-bitcode-marker -emit-sil %s 2>&1 -### | %FileCheck %s -check-prefix=WARN-EMBED-BITCODE-MARKER
+// RUN: %target-swiftc_driver -embed-bitcode-marker -emit-silgen %s 2>&1 -### | %FileCheck %s -check-prefix=WARN-EMBED-BITCODE-MARKER
+// RUN: %target-swiftc_driver -embed-bitcode-marker -emit-ir %s 2>&1 -### | %FileCheck %s -check-prefix=WARN-EMBED-BITCODE-MARKER
+// RUN: %target-swiftc_driver -embed-bitcode-marker -emit-bc %s 2>&1 -### | %FileCheck %s -check-prefix=WARN-EMBED-BITCODE-MARKER
+// RUN: %target-swiftc_driver -embed-bitcode-marker -emit-assembly %s 2>&1 -### | %FileCheck %s -check-prefix=WARN-EMBED-BITCODE-MARKER
+// WARN-EMBED-BITCODE-MARKER: warning: ignoring -embed-bitcode-marker since no object file is being generated
+// WARN-EMBED-BITCODE-MARKER-NOT: -embed-bitcode-marker


### PR DESCRIPTION
Previously if you passed `-embed-bitcode-marker` to a command that
wasn't producing an object file, it would silently be ignored. This
change puts it inline with `-embed-bitcode` in this same case, which
generates a warning.

Resolves [SR-3352](https://bugs.swift.org/browse/SR-3352).