### PR TITLE
[Constraint solver] Reduce timer overhead associated with "expression too complex"

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -484,9 +484,6 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numDefaultedConstraints = cs.DefaultedConstraints.size();
   numCheckedConformances = cs.CheckedConformances.size();
   PreviousScore = cs.CurrentScore;
-  if (cs.Timer) {
-    startTime = cs.Timer->getElapsedProcessTimeInFractionalSeconds();
-  }
 
   cs.solverState->registerScope(this);
   assert(!cs.failedConstraint && "Unexpected failed constraint!");

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1453,9 +1453,6 @@ public:
     /// The scope number of this scope. Set when the scope is registered.
     unsigned scopeNumber = 0;
 
-    /// Time in fractional seconds at which we entered this scope.
-    double startTime;
-
     /// Constraint graph scope associated with this solver scope.
     ConstraintGraphScope CGScope;
 
@@ -1467,13 +1464,6 @@ public:
   public:
     explicit SolverScope(ConstraintSystem &cs);
     ~SolverScope();
-
-    Optional<double> getElapsedTimeInFractionalSeconds() {
-      if (!cs.Timer)
-        return None;
-
-      return cs.Timer->getElapsedProcessTimeInFractionalSeconds() - startTime;
-    }
   };
 
   ConstraintSystem(TypeChecker &tc, DeclContext *dc,

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -665,7 +665,9 @@ deriveEquatable_eq(DerivedConformance &derived, Identifier generatedIdentifier,
 
 bool DerivedConformance::canDeriveEquatable(TypeChecker &tc, DeclContext *DC,
                                             NominalTypeDecl *type) {
-  auto equatableProto = tc.Context.getProtocol(KnownProtocolKind::Equatable);
+  ASTContext &ctx = DC->getASTContext();
+  auto equatableProto = ctx.getProtocol(KnownProtocolKind::Equatable);
+  if (!equatableProto) return false;
   return canDeriveConformance(tc, DC, type, equatableProto);
 }
 
@@ -1135,8 +1137,7 @@ getHashableConformance(Decl *parentDecl) {
   return nullptr;
 }
 
-bool DerivedConformance::canDeriveHashable(TypeChecker &tc,
-                                           NominalTypeDecl *type) {
+bool DerivedConformance::canDeriveHashable(NominalTypeDecl *type) {
   if (!isa<EnumDecl>(type) && !isa<StructDecl>(type) && !isa<ClassDecl>(type))
     return false;
   // FIXME: This is not actually correct. We cannot promise to always

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -61,7 +61,7 @@ bool DerivedConformance::derivesProtocolConformance(TypeChecker &TC,
     // We can always complete a partial Hashable implementation, and we can
     // synthesize a full Hashable implementation for structs and enums with
     // Hashable components.
-    return canDeriveHashable(TC, Nominal);
+    return canDeriveHashable(Nominal);
   }
 
   if (auto *enumDecl = dyn_cast<EnumDecl>(Nominal)) {

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -137,7 +137,7 @@ public:
   /// associated values, and for structs with all-Hashable stored properties.
   ///
   /// \returns True if the requirement can be derived.
-  static bool canDeriveHashable(TypeChecker &tc, NominalTypeDecl *type);
+  static bool canDeriveHashable(NominalTypeDecl *type);
 
   /// Derive a Hashable requirement for a type.
   ///

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -1210,7 +1210,7 @@ RequirementCheckResult TypeChecker::checkGenericArguments(
   pendingReqs.push_back({requirements, {}});
 
   auto *env = dc->getGenericEnvironmentOfContext();
-
+  ASTContext &ctx = dc->getASTContext();
   while (!pendingReqs.empty()) {
     auto current = pendingReqs.pop_back_val();
 
@@ -1342,7 +1342,7 @@ RequirementCheckResult TypeChecker::checkGenericArguments(
 
       if (loc.isValid()) {
         // FIXME: Poor source-location information.
-        diagnose(loc, diagnostic, owner, firstType, secondType);
+        ctx.Diags.diagnose(loc, diagnostic, owner, firstType, secondType);
 
         std::string genericParamBindingsText;
         if (!genericParams.empty()) {
@@ -1350,11 +1350,11 @@ RequirementCheckResult TypeChecker::checkGenericArguments(
             gatherGenericParamBindingsText(
               {rawFirstType, rawSecondType}, genericParams, substitutions);
         }
-        diagnose(noteLoc, diagnosticNote, rawFirstType, rawSecondType,
-                 genericParamBindingsText);
+        ctx.Diags.diagnose(noteLoc, diagnosticNote, rawFirstType, rawSecondType,
+                           genericParamBindingsText);
 
-        ParentConditionalConformance::diagnoseConformanceStack(Diags, noteLoc,
-                                                               current.Parents);
+        ParentConditionalConformance::diagnoseConformanceStack(
+            ctx.Diags, noteLoc, current.Parents);
       }
 
       return RequirementCheckResult::Failure;

--- a/stdlib/public/core/Hasher.swift
+++ b/stdlib/public/core/Hasher.swift
@@ -90,7 +90,10 @@ internal struct _HasherTailBuffer {
   internal init(tail: UInt64, byteCount: UInt64) {
     // byteCount can be any value, but we only keep the lower 8 bits.  (The
     // lower three bits specify the count of bytes stored in this buffer.)
-    _sanityCheck(tail & ~(1 << ((byteCount & 7) << 3) - 1) == 0)
+    // FIXME: The "as UInt64" annotations here eliminate some exponential
+    // behavior in the expression type checker <rdar://problem/42672946>.
+    _sanityCheck(tail & ~((1 as UInt64) << ((byteCount & (7 as UInt64))
+          << (3 as UInt64)) - (1 as UInt64)) == (0 as UInt64))
     self.value = (byteCount &<< 56 | tail)
   }
 

--- a/validation-test/Sema/type_checker_perf/slow/rdar42672946.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar42672946.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+func f(tail: UInt64, byteCount: UInt64) {
+  if tail & ~(1 << ((byteCount & 7) << 3) - 1) == 0 { }
+  // expected-error@-1 {{reasonable time}}
+}


### PR DESCRIPTION
This pull request reduces the overhead associated with polling timers to determine whether a given expression is "too complex" to be solved in a reasonable amount of time. Before this pull request, the timing overhead for type-checking the standard library is ~5.7%; afterward, it's a more-acceptable ~1.7%. There were two changes:

* Remove debugging-only API that allowed us to see how long a specific solver state was alive; if we need it, we can bring it back behind a debugging flag.
* Limit the places where we poll the timer. Now we check at decision points (before we try type variable bindings or visit a disjunction) and at the end (to make sure we fail consistently when the expression is "too complex") 