### PR TITLE
[4.2][AST] Fix a crash in UnqualifiedLookup

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -816,7 +816,7 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
             return;
         }
 
-        if (BaseDC && !ExtendedType->hasError()) {
+        if (BaseDC && ExtendedType && !ExtendedType->hasError()) {
           NLOptions options = baseNLOptions;
           if (isCascadingUse.getValue())
             options |= NL_KnownCascadingDependency;

--- a/test/IDE/complete_crashes.swift
+++ b/test/IDE/complete_crashes.swift
@@ -343,3 +343,15 @@ func test_42452085(any: Any, obj: cls_42452085?) throws {
   _ = try obj?.canThrow() #^RDAR_42452085_3^#
 }
 // RDAR_42452085: found code completion token
+
+// rdar://problem/41234606
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=RDAR_41234606 -source-filename=%s | %FileCheck %s -check-prefix=RDAR_41234606
+#if false
+extension Foo {
+  func foo<T: Collection #^RDAR_41234606^#>(x: T) {}
+}
+#endif
+// RDAR_41234606: Begin completion
+// RDAR_41234606-DAG: Decl[AssociatedType]/Super:         .Element; name=Element
+// RDAR_41234606-DAG: Decl[AssociatedType]/Super:         .Iterator; name=Iterator
+// RDAR_41234606: End completions


### PR DESCRIPTION
**Explanation**: Add null type check for Self type in UnqualifiedLookup. It seems this doesn't happen in normal compilation. But when code-completion happens in inactive conditional compilation block, since surrounding context hasn't been typechecked, Self type can be null.
**Scope**: Code-completion regarding completion inside conditional compilation blocks
**Issue**: rdar://problem/41234606
**Risk**: Low. This is just a null check to avoid crash for code-completion functionality
**Testing**: Added regression test case.
**Reviewed By**: Doug Gregor (https://github.com/apple/swift/pull/18279)
