### PR TITLE
Simplify the logic for looking up runtime entry points. Resolve SR-8369.

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -97,7 +97,9 @@ static CanType getSingleElementDeclFieldType(NominalTypeDecl *decl) {
 static SubstitutionMap
 getSingleSubstitutionMapForFunction(SILFunction *f, Type ty,
                                     SILModule &userModule) {
-  auto *loadedFunc = lookupOrLoadFunction(f->getName(), userModule);
+  auto *loadedFunc = lookupOrLinkFunction(f->getName(), userModule);
+  if (loadedFunc->isExternalDeclaration())
+    userModule.loadFunction(loadedFunc);
   assert(loadedFunc->getGenericEnvironment());
   auto *genericSig = loadedFunc->getGenericEnvironment()->getGenericSignature();
   return getSingleSubstitutionMapForElementTypeAndSignature(ty, genericSig);

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -97,7 +97,7 @@ static CanType getSingleElementDeclFieldType(NominalTypeDecl *decl) {
 static SubstitutionMap
 getSingleSubstitutionMapForFunction(SILFunction *f, Type ty,
                                     SILModule &userModule) {
-  auto *loadedFunc = lookupOrLinkFunction(f->getName(), userModule);
+  auto *loadedFunc = lookupOrLoadFunction(f->getName(), userModule);
   assert(loadedFunc->getGenericEnvironment());
   auto *genericSig = loadedFunc->getGenericEnvironment()->getGenericSignature();
   return getSingleSubstitutionMapForElementTypeAndSignature(ty, genericSig);

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -91,20 +91,6 @@ static CanType getSingleElementDeclFieldType(NominalTypeDecl *decl) {
   return fieldType;
 }
 
-/// Given a generic function with a single generic parameter `<T>(...) -> ...`
-/// an a type for substitution, return a substitution map that's suitable for
-/// calling this func.
-static SubstitutionMap
-getSingleSubstitutionMapForFunction(SILFunction *f, Type ty,
-                                    SILModule &userModule) {
-  auto *loadedFunc = lookupOrLinkFunction(f->getName(), userModule);
-  if (loadedFunc->isExternalDeclaration())
-    userModule.loadFunction(loadedFunc);
-  assert(loadedFunc->getGenericEnvironment());
-  auto *genericSig = loadedFunc->getGenericEnvironment()->getGenericSignature();
-  return getSingleSubstitutionMapForElementTypeAndSignature(ty, genericSig);
-}
-
 /// Classification of instructions that are interesting to the partitioning
 /// pass for various reasons.
 enum class PartitioningClass {
@@ -2796,7 +2782,7 @@ static SILValue createHostReceive(SILBuilder &B, SILLocation loc,
   auto scalarType = getTensorHandleElementType(valueTy.getASTType());
   assert(scalarType && "valueTy is not TensorHandle<T>");
   auto subMap =
-      getSingleSubstitutionMapForFunction(receiveFn, scalarType, userModule);
+      getSingleSubstitutionMapForElementType(scalarType, B.getASTContext());
 
   // Generate an instruction like:
   // %3 = metatype $@thick TensorHandle<Float>.Type
@@ -2900,7 +2886,6 @@ getStdlibNumericTypeDeclFromBuiltinType(Type ty, ASTContext &ctx) {
 static SILValue createHostSend(SILBuilder &B, SILLocation loc, SILValue value,
                                SILValue tensorComputation, int idNumber,
                                ModuleDecl &tensorFlowModule,
-                               SILModule &userModule,
                                SILFunction *createScalarTensorFn,
                                SILFunction *sendFn) {
   assert(sendFn);
@@ -2968,8 +2953,8 @@ static SILValue createHostSend(SILBuilder &B, SILLocation loc, SILValue value,
 
     auto createScalarTensorFnRef =
         B.createFunctionRef(loc, createScalarTensorFn);
-    SubstitutionMap subMap = getSingleSubstitutionMapForFunction(
-        createScalarTensorFn, scalarValueTy, userModule);
+    SubstitutionMap subMap = getSingleSubstitutionMapForElementType(
+        scalarValueTy, B.getASTContext());
     value = B.createApply(loc, createScalarTensorFnRef, subMap,
                           /*args*/ {access, metaTypeInst},
                           /*isNonThrowing*/ false);
@@ -2983,7 +2968,7 @@ static SILValue createHostSend(SILBuilder &B, SILLocation loc, SILValue value,
   // Verify that tensorComputation is passed in as a guaranteed parameter below.
   verifyTensorComputationArgAsGuaranteedParam(sendFnRef);
   SubstitutionMap subMap =
-      getSingleSubstitutionMapForFunction(sendFn, scalarValueTy, userModule);
+      getSingleSubstitutionMapForElementType(scalarValueTy, B.getASTContext());
   // This is a member method of the class of `value`, so we add it as the last
   // parameter.
   return B.createApply(loc, sendFnRef, subMap,
@@ -3080,8 +3065,7 @@ void PartitionCloner::handleSendRecvForTerminator(TermInst *inst) {
         createSomeIntegerValue(caseId /*caseEntry.index()*/, BH, loc, int32Decl);
 
     createHostSend(BH, loc, caseIdInst, tensorComputation, nextSendID,
-                   tensorFlowModule, FP.hostFn.getModule(),
-                   createScalarTensorFn, sendFn);
+                   tensorFlowModule, createScalarTensorFn, sendFn);
     ++caseId;
   }
 
@@ -3228,8 +3212,7 @@ void PartitionCloner::insertSend(SILInstruction &inst) {
            "from Swift to TensorFlow.");
     // Create the send in the host code.
     createHostSend(BH, loc, result, tensorComputation, nextSendID,
-                   tensorFlowModule, FP.hostFn.getModule(),
-                   createScalarTensorFn, sendFn);
+                   tensorFlowModule, createScalarTensorFn, sendFn);
     nextSendID++;
   }
 }
@@ -3600,7 +3583,6 @@ bool PartitionCloner::finalizeOriginal() {
 /// function definition into `userModule` first, so that we can get the generic
 /// substitution map as needed to issue the call.
 static SILValue convertScalarToHostTensorHandle(SILValue value,
-                                                SILModule &userModule,
                                                 SILBuilder &B,
                                                 SILLocation loc) {
   // We need to create a dtype value.  It is an imported C enum value, so it is
@@ -3613,8 +3595,9 @@ static SILValue convertScalarToHostTensorHandle(SILValue value,
   // @_silgen_name("_swift_tfc_CreateCTensorHandle")
   // func _TFCCreateCTensorHandle<T>(_ value : T,
   //                                 _ dtype: TF_DataType) -> CTensorHandle
-  auto createFn = B.getModule().findFunction("_swift_tfc_CreateCTensorHandle",
-                                             SILLinkage::PublicExternal);
+  auto &userModule = B.getModule();
+  auto *createFn = userModule.findFunction("_swift_tfc_CreateCTensorHandle",
+                                           SILLinkage::PublicExternal);
   auto *fnRef = B.createFunctionRef(loc, createFn);
 
   auto dtypeType = fnRef->getFunctionType()->getParameters()[1].getType();
@@ -3642,8 +3625,8 @@ static SILValue convertScalarToHostTensorHandle(SILValue value,
                                     /*fromBuiltin=*/false);
   auto result =
       B.createApply(loc, fnRef,
-                    getSingleSubstitutionMapForFunction(
-                        createFn, value->getType().getASTType(), userModule),
+                    getSingleSubstitutionMapForElementType(
+                        value->getType().getASTType(), B.getASTContext()),
                     {access, dtype}, /*isNonThrowing*/ false);
   // Finish our read access and free the stack memory.
   B.createEndAccess(loc, access, /*aborted*/false);
@@ -3924,8 +3907,7 @@ void TFFunctionPartition::insertTensorComputationStartEndTerminate(
                                                  tensorHandleMember);
       tensorValue = B.createLoad(loc, fieldAddress, loadOwnership);
     } else {
-      tensorValue = convertScalarToHostTensorHandle(tensorValue,
-                                                    hostFn.getModule(), B, loc);
+      tensorValue = convertScalarToHostTensorHandle(tensorValue, B, loc);
     }
     SILValue eltAddr = stackAlloc;
     if (numArgs >= 2)

--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -226,16 +226,6 @@ SILType tf::convertElementTypeToTensorValueType(SILType ty) {
                                              ty.getASTContext());
 }
 
-/// Looks up a function in the current module. If it exists, returns it.
-/// Otherwise, attempt to link it from imported modules. Returns null if such
-/// function name does not exist.
-SILFunction *tf::lookupOrLinkFunction(StringRef name, SILModule &module) {
-  assert(!name.empty());
-  if (auto *localFn = module.lookUpFunction(name))
-    return localFn;
-  return module.findFunction(name, SILLinkage::PublicExternal);
-}
-
 /// Looks up members by `name` in the context of `typeDecl`, `proto` and
 /// `module`, and populates `results`.
 static void lookupProtocolRequiredMembers(
@@ -262,7 +252,7 @@ SILFunction *tf::findSILFunctionForRequiredProtocolMember(
   lookupProtocolRequiredMembers(typeDecl, proto, name, module, results);
   for (auto *result : results) {
     std::string name = SILDeclRef(result).mangle();
-    if (auto *fn = lookupOrLinkFunction(name, silModule))
+    if (auto *fn = silModule.findFunction(name, SILLinkage::PublicExternal))
       return fn;
   }
   return nullptr;

--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -206,7 +206,8 @@ unsigned tf::convertSwiftTypeToTF(Type ty) {
 
 /// `ty` must be a valid TensorFlow element type "T", like Builtin.Int32. Turn
 /// it into a TensorHandle<T> type.
-SILType tf::convertElementTypeToTensorValueType(Type ty, const ASTContext& ctx) {
+SILType tf::convertElementTypeToTensorValueType(Type ty,
+                                                const ASTContext& ctx) {
   assert(isValidTensorFlowElementType(ty));
   auto decl = ctx.getTensorHandleDecl();
   auto tensorType = BoundGenericClassType::get(decl, /*parent*/ Type(), ty);
@@ -221,27 +222,19 @@ SILType tf::convertElementTypeToTensorValueType(SILType ty) {
   if (isTensorFlowValue(ty))
     return ty;
 
-  return convertElementTypeToTensorValueType(ty.getASTType(), ty.getASTContext());
+  return convertElementTypeToTensorValueType(ty.getASTType(),
+                                             ty.getASTContext());
 }
 
 /// Looks up a function in the current module. If it exists, returns it.
 /// Otherwise, attempt to link it from imported modules. Returns null if such
 /// function name does not exist.
 SILFunction *tf::lookupOrLinkFunction(StringRef name, SILModule &module) {
-  auto *fn = module.lookUpFunction(name);
-  if (!fn)
-    fn = module.findFunction(name, SILLinkage::PublicExternal);
-  assert(fn);
-  if (fn->isExternalDeclaration()) {
-    bool loaded = module.loadFunction(fn);
-    assert(loaded);
-    (void)loaded;
-    // linkFunction() can return false if this function has already been
-    // deserialized and its body available in `module`.
-    module.linkFunction(fn);
-  }
-  assert(!fn->isExternalDeclaration());
-  assert(fn->isDefinition());
+  assert(!name.empty());
+  if (auto *localFn = module.lookUpFunction(name))
+    return localFn;
+  auto *fn = module.findFunction(name, SILLinkage::PublicExternal);
+  module.loadFunction(fn);
   return fn;
 }
 

--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -229,14 +229,11 @@ SILType tf::convertElementTypeToTensorValueType(SILType ty) {
 /// Looks up a function in the current module. If it exists, returns it.
 /// Otherwise, attempt to link it from imported modules. Returns null if such
 /// function name does not exist.
-SILFunction *tf::lookupOrLoadFunction(StringRef name, SILModule &module) {
+SILFunction *tf::lookupOrLinkFunction(StringRef name, SILModule &module) {
   assert(!name.empty());
   if (auto *localFn = module.lookUpFunction(name))
     return localFn;
-  auto *fn = module.findFunction(name, SILLinkage::PublicExternal);
-  module.loadFunction(fn);
-  assert(fn->isDefinition());
-  return fn;
+  return module.findFunction(name, SILLinkage::PublicExternal);
 }
 
 /// Looks up members by `name` in the context of `typeDecl`, `proto` and
@@ -265,7 +262,7 @@ SILFunction *tf::findSILFunctionForRequiredProtocolMember(
   lookupProtocolRequiredMembers(typeDecl, proto, name, module, results);
   for (auto *result : results) {
     std::string name = SILDeclRef(result).mangle();
-    if (auto *fn = lookupOrLoadFunction(name, silModule))
+    if (auto *fn = lookupOrLinkFunction(name, silModule))
       return fn;
   }
   return nullptr;

--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -229,12 +229,13 @@ SILType tf::convertElementTypeToTensorValueType(SILType ty) {
 /// Looks up a function in the current module. If it exists, returns it.
 /// Otherwise, attempt to link it from imported modules. Returns null if such
 /// function name does not exist.
-SILFunction *tf::lookupOrLinkFunction(StringRef name, SILModule &module) {
+SILFunction *tf::lookupOrLoadFunction(StringRef name, SILModule &module) {
   assert(!name.empty());
   if (auto *localFn = module.lookUpFunction(name))
     return localFn;
   auto *fn = module.findFunction(name, SILLinkage::PublicExternal);
   module.loadFunction(fn);
+  assert(fn->isDefinition());
   return fn;
 }
 
@@ -264,7 +265,7 @@ SILFunction *tf::findSILFunctionForRequiredProtocolMember(
   lookupProtocolRequiredMembers(typeDecl, proto, name, module, results);
   for (auto *result : results) {
     std::string name = SILDeclRef(result).mangle();
-    if (auto *fn = lookupOrLinkFunction(name, silModule))
+    if (auto *fn = lookupOrLoadFunction(name, silModule))
       return fn;
   }
   return nullptr;

--- a/lib/SILOptimizer/Mandatory/TFUtilities.h
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.h
@@ -73,7 +73,7 @@ namespace tf {
   /// Looks up a function in `module`, which must exist.
   /// If needed, load and link it, so that the function body is available to the
   /// caller.
-  SILFunction *lookupOrLoadFunction(StringRef name, SILModule &module);
+  SILFunction *lookupOrLinkFunction(StringRef name, SILModule &module);
 
   /// Looks up a function by `name` in the context of `typeDecl`, `proto` and
   /// `module`, and returns that function.

--- a/lib/SILOptimizer/Mandatory/TFUtilities.h
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.h
@@ -70,11 +70,6 @@ namespace tf {
     return convertSwiftTypeToTF(ty) != 0;
   }
 
-  /// Looks up a function in `module`, which must exist.
-  /// If needed, load and link it, so that the function body is available to the
-  /// caller.
-  SILFunction *lookupOrLinkFunction(StringRef name, SILModule &module);
-
   /// Looks up a function by `name` in the context of `typeDecl`, `proto` and
   /// `module`, and returns that function.
   SILFunction *findSILFunctionForRequiredProtocolMember(

--- a/lib/SILOptimizer/Mandatory/TFUtilities.h
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.h
@@ -73,7 +73,7 @@ namespace tf {
   /// Looks up a function in `module`, which must exist.
   /// If needed, load and link it, so that the function body is available to the
   /// caller.
-  SILFunction *lookupOrLinkFunction(StringRef name, SILModule &module);
+  SILFunction *lookupOrLoadFunction(StringRef name, SILModule &module);
 
   /// Looks up a function by `name` in the context of `typeDecl`, `proto` and
   /// `module`, and returns that function.

--- a/test/TensorFlow/deabstraction_crashers.swift
+++ b/test/TensorFlow/deabstraction_crashers.swift
@@ -1,7 +1,16 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -Xllvm -tf-strict-deabstraction -verify %s
+// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-strict-deabstraction -verify %s
 import TensorFlow
 
 public func SR8299(a: Tensor<Float>) {
    // expected-error @+1 {{attribute 'someAttr' requires a constant argument}}
    () = #tfop("foo", someAttr: a)
+}
+
+// @constExpr
+func one() -> Int {
+  return 1
+}
+
+public func SR8369(a: Tensor<Float>, idx: Tensor<Int32>) -> Tensor<Float> {
+  return Tensor<Float>(oneHotAtIndices: idx.toAccelerator(), depth: 0, axis: one())
 }


### PR DESCRIPTION
Simplify the logic for looking up runtime entry points. Remove `lookupOrLinkFunction` completely in favor of existing functions. Eliminating the need to deserialize any function for TFPartition.

Also: 
- Remove unnecessary passing of `userModule` in a few places in TFPartition where a builder is passed , because `B.getModule()` is always guaranteed to be the user module.
- Break some lines to fit within 80 cols.
- Remove unused run arguments in `deabstraction_crashers.swift`.

Resolves [SR-8369](https://bugs.swift.org/browse/SR-8369)