### PR TITLE
Add fix-it for incorrectly cased module name

### DIFF
--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -417,11 +417,12 @@ FileUnit *SerializedModuleLoader::loadAST(
   case serialization::Status::NameMismatch: {
     // FIXME: This doesn't handle a non-debugger REPL, which should also treat
     // this as a non-fatal error.
-    auto diagKind = diag::serialization_name_mismatch;
     if (Ctx.LangOpts.DebuggerSupport)
-      diagKind = diag::serialization_name_mismatch_repl;
-    Ctx.Diags.diagnose(*diagLoc, diagKind,
-                       loadInfo.name, M.getName());
+      Ctx.Diags.diagnose(*diagLoc, diag::serialization_name_mismatch_repl,
+          loadInfo.name, M.getName());
+    else
+      Ctx.Diags.diagnose(*diagLoc, diag::serialization_name_mismatch,
+          loadInfo.name, M.getName()).fixItReplace(*diagLoc, loadInfo.name);
     break;
   }
 

--- a/test/FixCode/load-wrong-name.swift
+++ b/test/FixCode/load-wrong-name.swift
@@ -1,0 +1,4 @@
+// RUN: not %swift -emit-sil -target %target-triple %s -emit-fixits-path %t.remap -I %S/Inputs -diagnostics-editor-mode
+// RUN: c-arcmt-test %t.remap | arcmt-test -verify-transformed-files %s.result
+
+import swift

--- a/test/FixCode/load-wrong-name.swift.result
+++ b/test/FixCode/load-wrong-name.swift.result
@@ -1,0 +1,4 @@
+// RUN: not %swift -emit-sil -target %target-triple %s -emit-fixits-path %t.remap -I %S/Inputs -diagnostics-editor-mode
+// RUN: c-arcmt-test %t.remap | arcmt-test -verify-transformed-files %s.result
+
+import Swift


### PR DESCRIPTION
This offers a fix-it for the case where you do:

```swift
import foundation
```

But you mean:

```swift
import Foundation
```

Resolves [SR-4259](https://bugs.swift.org/browse/SR-4259).