### PR TITLE
Adapted the test in debug_scope.swift into a new one, which generates sends/recvs when -Onone is turned on.

### DIFF
--- a/test/TensorFlow/no_copy.swift
+++ b/test/TensorFlow/no_copy.swift
@@ -258,3 +258,8 @@ public func testMultiOutputs() {
   _hostOp(y)
 }
 
+// TODO: Eliminate the sends/recvs when -Onone is enabled.
+public func SR8395() {
+  let x: Tensor<Float> = [[1, 2], [3, 4]]
+  print(matmul(x, x) + x)
+}


### PR DESCRIPTION
Filed https://bugs.swift.org/browse/SR-8395 for it.
