### PR TITLE
fix SILLocation in test/sends_recvs.swift (SR-8309)

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -2180,11 +2180,10 @@ void TFDeabstraction::formGraphOp(SILTensorOpInfo &opInfo,
     resultTypes.push_back(inst->getType());
   }
 
-  auto op = B.createGraphOperation(inst->getLoc(),
+  auto op = B.createGraphOperation(getUserSourceLocation(inst),
                                    context.getIdentifier(opName), inputs,
                                    attributes, resultTypes);
-  op->setDebugLocation(inst->getDebugLocation());
-  
+
   if (auto tuple = inst->getType().getAs<TupleType>()) {
     SmallVector<SILValue, 4> elts;
     for (unsigned i = 0, e = tuple->getNumElements(); i != e; ++i)

--- a/test/TensorFlow/sends_recvs.swift
+++ b/test/TensorFlow/sends_recvs.swift
@@ -227,7 +227,7 @@ public func test1RecvScalarCPU() {
 // CHECK-LABEL: --- TFPartition Host Result: {{.*}}test1RecvScalarCPU{{.*}}
 // CHECK:      function_ref @_swift_tfc_StartTensorComputation
 // CHECK:      // function_ref static TensorHandle.receiveFromAccelerator
-// CHECK-NEXT: function_ref 
+// CHECK-NEXT: function_ref
 // CHECK-NEXT: [[X_HANDLE:%.*]] = apply
 // CHECK:      // function_ref static TensorHandle.scalar(_:)
 // CHECK-NEXT: [[MAKE_SCALAR_TENSOR_FN:%.*]] = function_ref
@@ -308,7 +308,7 @@ public func test1RecvTensorCPU() {
 // CHECK-LABEL: --- TFPartition Host Result: {{.*}}test1RecvTensor{{.*}}
 // CHECK:      function_ref @_swift_tfc_StartTensorComputation
 // CHECK:      // function_ref static TensorHandle.receiveFromAccelerator
-// CHECK-NEXT: function_ref 
+// CHECK-NEXT: function_ref
 // CHECK-NEXT: [[A_HANDLE:%.*]] = apply
 // CHECK-NEXT: [[A_TENSOR:%.*]] = struct $Tensor<Float> ([[A_HANDLE]]
 // CHECK:      // function_ref {{.*}} atariSim(_:)
@@ -345,9 +345,6 @@ public func test1RecvTensorTPU_ToHostNoShape_Error() {
   _hostOp(b)
 }
 
-// TODO: fix the wrong diagnostic location, due to an invalid SILLocation value
-// in a graph op
-// expected-error @+1 {{TPU infeed enqueue supports enqueuing a single tensor -- did you specify shape?}}
 public func test1RecvTensorTPU_ToAcceleratorNoShape_Error() {
   TensorFlow.enableTPU()
   let a_tpu_h: TensorHandle<Float> = #tfop("Const", dtype: Float.self, value$tensor: 1.0, __device: "TPU_SYSTEM")
@@ -357,7 +354,7 @@ public func test1RecvTensorTPU_ToAcceleratorNoShape_Error() {
   // For the result of atariSim(): host -> CPU, and then CPU->TPU.
   var b = atariSim(a_host).toAccelerator()
   // This is the correct location
-  // xpected-error @+1 {{TPU infeed dequeue supports dequeuing a single tensor -- did you specify shape?}}
+  // expected-error @+1 {{TPU infeed enqueue supports enqueuing a single tensor -- did you specify shape?}}
   b += a_tpu
   _hostOp(b)
 }


### PR DESCRIPTION
In non-strict deabstraction, this line sets the `loc` of the `tfop` to `getUserSourceLocation(...)`: https://github.com/apple/swift/blob/dea2d52c849c519316f7f416b527d13abba4babb/lib/SILOptimizer/Mandatory/TFPartition.cpp#L2464

In strict deabstraction, the tfop has been turned into a graph op before it gets to that point, so its `loc` never gets set to `getUserSourceLocation(...)`.

I think there's actually a deeper problem -- we shouldn't need to set the instruction's `loc` to `getUserSourceLocation(...)` because the diagnostic also calls `getUserSourceLocation` (https://github.com/apple/swift/blob/dea2d52c849c519316f7f416b527d13abba4babb/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp#L1500). I think that the instruction's `SILDebugScope` is getting clobbered somewhere, which is making the diagnostic's call to `getUserSourceLocation` in `TFLowerGraph` not work. I didn't have time to trace through and figure out why it's getting clobbered. I could create a ticket, and pick it up in a week when I get back from vacation, if you think it's important to get to the bottom of this.