### PR TITLE
Fix several incorrect uses of ApplySite::getArgumentConvention.

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1936,11 +1936,6 @@ public:
     return OperandValueArrayRef(opsWithoutSelf);
   }
 
-  /// Return the SILArgumentConvention for the given applied argument index.
-  SILArgumentConvention getArgumentConvention(unsigned index) const {
-    return getSubstCalleeConv().getSILArgumentConvention(index);
-  }
-
   Optional<SILResultInfo> getSingleResult() const {
     auto SubstCallee = getSubstCalleeType();
     if (SubstCallee->getNumAllResults() != 1)
@@ -7665,7 +7660,7 @@ public:
   }
 
   /// Return the applied argument index for the given operand.
-  unsigned getArgumentIndex(const Operand &oper) const {
+  unsigned getAppliedArgIndex(const Operand &oper) const {
     assert(oper.getUser() == Inst);
     assert(isArgumentOperand(oper));
 
@@ -7704,19 +7699,14 @@ public:
   /// Note: Passing an applied argument index into SILFunctionConvention, as
   /// opposed to a function argument index, is incorrect.
   unsigned getCalleeArgIndex(const Operand &oper) const {
-    return getCalleeArgIndexOfFirstAppliedArg() + getArgumentIndex(oper);
+    return getCalleeArgIndexOfFirstAppliedArg() + getAppliedArgIndex(oper);
   }
 
   /// Return the SILArgumentConvention for the given applied argument operand.
   SILArgumentConvention getArgumentConvention(Operand &oper) const {
     unsigned calleeArgIdx =
-      getCalleeArgIndexOfFirstAppliedArg() + getArgumentIndex(oper);
+        getCalleeArgIndexOfFirstAppliedArg() + getAppliedArgIndex(oper);
     return getSubstCalleeConv().getSILArgumentConvention(calleeArgIdx);
-  }
-
-  // FIXME: This is incorrect. It will be removed in the next commit.
-  SILArgumentConvention getArgumentConvention(unsigned index) const {
-    return getSubstCalleeConv().getSILArgumentConvention(index);
   }
 
   /// Return true if 'self' is an applied argument.

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -2713,7 +2713,7 @@ public:
     auto isConsumingOrMutatingApplyUse = [](Operand *use) -> bool {
       ApplySite apply(use->getUser());
       assert(apply && "Not an apply instruction kind");
-      auto conv = apply.getArgumentConvention(use->getOperandNumber() - 1);
+      auto conv = apply.getArgumentConvention(*use);
       switch (conv) {
       case SILArgumentConvention::Indirect_In_Guaranteed:
         return false;

--- a/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
+++ b/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
@@ -339,8 +339,7 @@ static SILInstruction *getOnlyDestroy(CopyBlockWithoutEscapingInst *CB) {
 
     // If this an apply use, only handle unowned parameters.
     if (auto Apply = FullApplySite::isa(Inst)) {
-      SILArgumentConvention Conv =
-          Apply.getArgumentConvention(Apply.getCalleeArgIndex(*Use));
+      SILArgumentConvention Conv = Apply.getArgumentConvention(*Use);
       if (Conv != SILArgumentConvention::Direct_Unowned)
         return nullptr;
       continue;

--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -877,13 +877,10 @@ static void checkForViolationsAtInstruction(SILInstruction &I,
   // SILVerifier to better pinpoint the offending pass.
   if (auto *PAI = dyn_cast<PartialApplyInst>(&I)) {
     ApplySite apply(PAI);
-    if (llvm::any_of(range(apply.getNumArguments()),
-                     [apply](unsigned argIdx) {
-                       unsigned calleeIdx =
-                         apply.getCalleeArgIndexOfFirstAppliedArg() + argIdx;
-                       return apply.getArgumentConvention(calleeIdx)
-                         == SILArgumentConvention::Indirect_InoutAliasable;
-                     })) {
+    if (llvm::any_of(apply.getArgumentOperands(), [apply](Operand &oper) {
+          return apply.getArgumentConvention(oper)
+                 == SILArgumentConvention::Indirect_InoutAliasable;
+        })) {
       checkNoEscapePartialApply(PAI);
     }
   }
@@ -1071,8 +1068,7 @@ static void checkAccessedAddress(Operand *memOper, StorageMap &Accesses) {
     return;
 
   if (auto apply = ApplySite::isa(memInst)) {
-    SILArgumentConvention conv =
-        apply.getArgumentConvention(apply.getCalleeArgIndex(*memOper));
+    SILArgumentConvention conv = apply.getArgumentConvention(*memOper);
     // Captured addresses currently use the @inout_aliasable convention. They
     // are considered an access at any call site that uses the closure. However,
     // those accesses are never explictly protected by access markers. Instead,

--- a/lib/SILOptimizer/Utils/Existential.cpp
+++ b/lib/SILOptimizer/Utils/Existential.cpp
@@ -152,9 +152,7 @@ SILValue swift::getAddressOfStackInit(AllocStackInst *ASI,
     }
     if (isa<ApplyInst>(User) || isa<TryApplyInst>(User)) {
       // Ignore function calls which do not write to the stack location.
-      auto Idx =
-          Use->getOperandNumber() - ApplyInst::getArgumentOperandNumber();
-      auto Conv = FullApplySite(User).getArgumentConvention(Idx);
+      auto Conv = FullApplySite(User).getArgumentConvention(*Use);
       if (Conv != SILArgumentConvention::Indirect_In &&
           Conv != SILArgumentConvention::Indirect_In_Guaranteed)
         return SILValue();


### PR DESCRIPTION
At least most of these were latent bugs since the code was
unreachable in the PartialApply case. But that's no excuse to misuse
the API.

Also, whenever referring to an integer index, be explicit about
whether it is an applied argument or callee argument.

