### PR TITLE
IRGen, benchmarks: add an option -align-module-to-page-size for benchmarking

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -272,6 +272,7 @@ message("--   SWIFT_LIBRARY_PATH = ${SWIFT_LIBRARY_PATH}")
 message("--   CLANG_EXEC = ${CLANG_EXEC}")
 message("--   SWIFT_OPTIMIZATION_LEVELS = ${SWIFT_OPTIMIZATION_LEVELS}")
 message("--   ONLY_PLATFORMS = ${ONLY_PLATFORMS}")
+message("--   PAGE_ALIGNMENT_OPTION = ${PAGE_ALIGNMENT_OPTION}")
 
 message("--   found platforms: ${platforms}")
 message("--   found sdks:")

--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -40,6 +40,19 @@ macro(configure_build)
     message(FATAL_ERROR "Unsupported platform?!")
   endif()
 
+  set(PAGE_ALIGNMENT_OPTION "-Xllvm" "-align-module-to-page-size")
+  execute_process(
+      COMMAND "touch" "empty.swift"
+      RESULT_VARIABLE result
+      ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+  execute_process(
+      COMMAND "${SWIFT_EXEC}" ${PAGE_ALIGNMENT_OPTION} "empty.swift"
+      RESULT_VARIABLE result
+      ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(NOT "${result}" MATCHES "0")
+    set(PAGE_ALIGNMENT_OPTION "")
+  endif()
+
   # We always infer the SWIFT_LIBRARY_PATH from SWIFT_EXEC unless
   # SWIFT_LIBRARY_PATH is specified explicitly.
   if(NOT SWIFT_LIBRARY_PATH)
@@ -293,7 +306,7 @@ function (swift_benchmark_compile_archopts)
   set(common_options
       "-c"
       "-target" "${target}"
-      "-${BENCH_COMPILE_ARCHOPTS_OPT}")
+      "-${BENCH_COMPILE_ARCHOPTS_OPT}" ${PAGE_ALIGNMENT_OPTION})
 
   if (is_darwin)
     list(APPEND common_options


### PR DESCRIPTION
The option aligns all modules to the page size. This help giving more consistent results when doing performance testing with the swift benchmark suite.
It solves the problem that benchmarks which compile down to identical code give different runtime data because of different alignment of the code within a page.
Also compile the benchmarks with the new option, if supported by the compiler
