### PR TITLE
[WIP][AccessEnforcementOpts] Add mergeAccesses analysis + optimization

### DIFF
--- a/include/swift/SILOptimizer/Utils/LoopUtils.h
+++ b/include/swift/SILOptimizer/Utils/LoopUtils.h
@@ -27,6 +27,7 @@ class SILBasicBlock;
 class SILLoop;
 class DominanceInfo;
 class SILLoopInfo;
+class LoopRegion;
 
 /// Canonicalize the loop for rotation and downstream passes.
 ///
@@ -36,6 +37,13 @@ bool canonicalizeLoop(SILLoop *L, DominanceInfo *DT, SILLoopInfo *LI);
 /// Canonicalize all loops in the function F for which \p LI contains loop
 /// information. We update loop info and dominance info while we do this.
 bool canonicalizeAllLoops(DominanceInfo *DT, SILLoopInfo *LI);
+
+/// Returns true if it is defined to perform a bottom up from \p Succ to \p
+/// Pred.
+///
+/// This is interesting because in such cases, we must pessimistically assume
+/// that we are merging in the empty set from Succ into Pred or vis-a-versa.
+bool isDefinedMerge(const LoopRegion *Succ, const LoopRegion *Pred);
 
 /// A visitor that visits loops in a function in a bottom up order. It only
 /// performs the visit.

--- a/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.cpp
+++ b/lib/SILOptimizer/ARC/GlobalLoopARCSequenceDataflow.cpp
@@ -14,44 +14,20 @@
 #include "GlobalLoopARCSequenceDataflow.h"
 #include "ARCRegionState.h"
 #include "RCStateTransitionVisitors.h"
+#include "swift/SIL/CFG.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILModule.h"
+#include "swift/SIL/SILSuccessor.h"
 #include "swift/SILOptimizer/Analysis/ARCAnalysis.h"
 #include "swift/SILOptimizer/Analysis/PostOrderAnalysis.h"
 #include "swift/SILOptimizer/Analysis/RCIdentityAnalysis.h"
-#include "swift/SIL/SILInstruction.h"
-#include "swift/SIL/SILFunction.h"
-#include "swift/SIL/SILSuccessor.h"
-#include "swift/SIL/CFG.h"
-#include "swift/SIL/SILModule.h"
+#include "swift/SILOptimizer/Utils/LoopUtils.h"
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/Debug.h"
 
 using namespace swift;
-
-//===----------------------------------------------------------------------===//
-//                                  Utility
-//===----------------------------------------------------------------------===//
-
-/// Returns true if it is defined to perform a bottom up from \p Succ to \p
-/// Pred.
-///
-/// This is interesting because in such cases, we must pessimistically assume
-/// that we are merging in the empty set from Succ into Pred or vis-a-versa.
-static bool isDefinedMerge(const LoopRegion *Succ, const LoopRegion *Pred) {
-  // If the predecessor region is an unknown control flow edge tail, the
-  // dataflow that enters into the region bottom up is undefined in our model.
-  if (Pred->isUnknownControlFlowEdgeTail())
-    return false;
-
-  // If the successor region is an unknown control flow edge head, the dataflow
-  // that leaves the region bottom up is considered to be undefined in our
-  // model.
-  if (Succ->isUnknownControlFlowEdgeHead())
-    return false;
-
-  // Otherwise it is defined to perform the merge.
-  return true;
-}
 
 //===----------------------------------------------------------------------===//
 //                             Top Down Dataflow

--- a/lib/SILOptimizer/Utils/LoopUtils.cpp
+++ b/lib/SILOptimizer/Utils/LoopUtils.cpp
@@ -18,6 +18,7 @@
 #include "swift/SIL/SILBasicBlock.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILModule.h"
+#include "swift/SILOptimizer/Analysis/LoopRegionAnalysis.h"
 #include "swift/SILOptimizer/Utils/CFG.h"
 #include "llvm/Support/Debug.h"
 
@@ -269,6 +270,22 @@ bool swift::canonicalizeAllLoops(DominanceInfo *DT, SILLoopInfo *LI) {
   }
 
   return MadeChange;
+}
+
+bool swift::isDefinedMerge(const LoopRegion *Succ, const LoopRegion *Pred) {
+  // If the predecessor region is an unknown control flow edge tail, the
+  // dataflow that enters into the region bottom up is undefined in our model.
+  if (Pred->isUnknownControlFlowEdgeTail())
+    return false;
+
+  // If the successor region is an unknown control flow edge head, the dataflow
+  // that leaves the region bottom up is considered to be undefined in our
+  // model.
+  if (Succ->isUnknownControlFlowEdgeHead())
+    return false;
+
+  // Otherwise it is defined to perform the merge.
+  return true;
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/SILOptimizer/merge_exclusivity.swift
+++ b/test/SILOptimizer/merge_exclusivity.swift
@@ -1,0 +1,277 @@
+// RUN: %target-swift-frontend -O -enforce-exclusivity=checked -emit-sil  -primary-file %s | %FileCheck %s --check-prefix=TESTSIL
+// REQUIRES: optimized_stdlib,asserts
+
+public var check: UInt64 = 0
+
+@inline(never)
+func sum(_ x: UInt64, _ y: UInt64) -> UInt64 {
+  return x &+ y
+}
+
+// TESTSIL-LABEL: sil [noinline] @$S17merge_exclusivity10MergeTest1yySiF : $@convention(thin)
+// TESTSIL: bb0
+// TESTSIL: [[GLOBALVAR:%.*]] = global_addr @$S17merge_exclusivity5checks6UInt64Vvp
+// TESTSIL: [[B1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL: end_access [[B1]]
+// TESTSIL: [[B2:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL-NEXT: br bb2
+// TESTSIL: bb1
+// TESTSIL: end_access [[B2]]
+// TESTSIL-NEXT: tuple
+// TESTSIL-NEXT: return
+// TESTSIL-NOT: begin_access
+// TESTSIL-LABEL: } // end sil function '$S17merge_exclusivity10MergeTest1yySiF'
+@inline(never)
+public func MergeTest1(_ N: Int) {
+  let range = 0..<10000
+  check = 0
+  for _ in 1...N {
+    for e in range {
+      check = sum(check, UInt64(e))
+      if (e == 0) {
+        check = sum(check, UInt64(1))
+      }
+      else {
+        check = sum(check, UInt64(2))
+      }
+    }
+  }
+}
+
+// TESTSIL-LABEL: sil [noinline] @$S17merge_exclusivity10MergeTest2yySiF : $@convention(thin)
+// TESTSIL: bb0
+// TESTSIL: [[GLOBALVAR:%.*]] = global_addr @$S17merge_exclusivity5checks6UInt64Vvp
+// TESTSIL: [[B1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL: end_access [[B1]]
+// TESTSIL: [[B2:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL-NEXT: br bb2
+// TESTSIL: bb1
+// TESTSIL: end_access [[B2]]
+// TESTSIL-NEXT: tuple
+// TESTSIL-NEXT: return
+// TESTSIL-NOT: begin_access
+// TESTSIL-LABEL: } // end sil function '$S17merge_exclusivity10MergeTest2yySiF'
+@inline(never)
+public func MergeTest2(_ N: Int) {
+  let range = 0..<10000
+  check = 0
+  for _ in 1...N {
+    for e in range {
+      if (e == 0) {
+        check = sum(check, UInt64(1))
+      }
+      else {
+        check = sum(check, UInt64(2))
+      }
+    }
+  }
+}
+
+// TESTSIL-LABEL: sil [noinline] @$S17merge_exclusivity10MergeTest3yySiF : $@convention(thin)
+// TESTSIL: bb0
+// TESTSIL: [[GLOBALVAR:%.*]] = global_addr @$S17merge_exclusivity5checks6UInt64Vvp
+// TESTSIL: [[B1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL: end_access [[B1]]
+// TESTSIL: [[B2:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL-NEXT: br bb2
+// TESTSIL: bb1
+// TESTSIL: end_access [[B2]]
+// TESTSIL-NEXT: tuple
+// TESTSIL-NEXT: return
+// TESTSIL-NOT: begin_access
+// TESTSIL-LABEL: } // end sil function '$S17merge_exclusivity10MergeTest3yySiF'
+@inline(never)
+public func MergeTest3(_ N: Int) {
+  let range = 0..<10000
+  check = 0
+  for _ in 1...N {
+    for e in range {
+      check = sum(check, UInt64(e))
+    }
+  }
+}
+
+// TESTSIL-LABEL: sil [noinline] @$S17merge_exclusivity10MergeTest4yySiF : $@convention(thin)
+// TESTSIL: bb0
+// TESTSIL: [[GLOBALVAR:%.*]] = global_addr @$S17merge_exclusivity5checks6UInt64Vvp
+// TESTSIL: [[B1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL: end_access [[B1]]
+// TESTSIL: [[B2:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL-NEXT: br bb2
+// TESTSIL: bb1
+// TESTSIL: end_access [[B2]]
+// TESTSIL-NEXT: tuple
+// TESTSIL-NEXT: return
+// TESTSIL-NOT: begin_access
+// TESTSIL-LABEL: } // end sil function '$S17merge_exclusivity10MergeTest4yySiF'
+@inline(never)
+public func MergeTest4(_ N: Int) {
+  let range = 0..<10000
+  check = 0
+  for _ in 1...N {
+    for e in range {
+      if (e == 0) {
+        check = sum(check, UInt64(1))
+      }
+    }
+  }
+}
+
+// TESTSIL-LABEL: sil [noinline] @$S17merge_exclusivity10MergeTest5yySiF : $@convention(thin)
+// TESTSIL: bb0
+// TESTSIL: [[GLOBALVAR:%.*]] = global_addr @$S17merge_exclusivity5checks6UInt64Vvp
+// TESTSIL: [[B1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL: end_access [[B1]]
+// TESTSIL: [[B2:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL-NEXT: br bb2
+// TESTSIL: bb1
+// TESTSIL: end_access [[B2]]
+// TESTSIL-NEXT: tuple
+// TESTSIL-NEXT: return
+// TESTSIL-NOT: begin_access
+// TESTSIL-LABEL: } // end sil function '$S17merge_exclusivity10MergeTest5yySiF'
+@inline(never)
+public func MergeTest5(_ N: Int) {
+  let range = 0..<10000
+  check = 0
+  for _ in 1...N {
+    for e in range {
+      if (e == 0) {
+        check = sum(check, UInt64(1))
+      }
+      check = sum(check, UInt64(e))
+    }
+  }
+}
+
+// TESTSIL-LABEL: sil [noinline] @$S17merge_exclusivity10MergeTest6yySiF : $@convention(thin)
+// TESTSIL: bb0
+// TESTSIL: [[GLOBALVAR:%.*]] = global_addr @$S17merge_exclusivity5checks6UInt64Vvp
+// TESTSIL: [[B1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL: end_access [[B1]]
+// TESTSIL: [[B2:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL-NEXT: br bb2
+// TESTSIL: bb1
+// TESTSIL: end_access [[B2]]
+// TESTSIL-NEXT: tuple
+// TESTSIL-NEXT: return
+// TESTSIL-NOT: begin_access
+// TESTSIL-LABEL: } // end sil function '$S17merge_exclusivity10MergeTest6yySiF'
+@inline(never)
+public func MergeTest6(_ N: Int) {
+  let range = 0..<10000
+  check = 0
+  for _ in 1...N {
+    for e in range {
+      if (e == 0) {
+        check = sum(check, UInt64(1))
+      }
+      else {
+        check = sum(check, UInt64(2))
+      }
+      check = sum(check, UInt64(e))
+    }
+  }
+}
+
+// TESTSIL-LABEL: sil [noinline] @$S17merge_exclusivity10MergeTest7yySiF : $@convention(thin)
+// TESTSIL: bb0
+// TESTSIL: [[GLOBALVAR:%.*]] = global_addr @$S17merge_exclusivity5checks6UInt64Vvp
+// TESTSIL: [[B1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL: end_access [[B1]]
+// TESTSIL: [[B2:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL-NEXT: br bb2
+// TESTSIL: bb1
+// TESTSIL: end_access [[B2]]
+// TESTSIL-NEXT: tuple
+// TESTSIL-NEXT: return
+// TESTSIL-NOT: begin_access
+// TESTSIL-LABEL: } // end sil function '$S17merge_exclusivity10MergeTest7yySiF'
+@inline(never)
+public func MergeTest7(_ N: Int) {
+  let range = 0..<10000
+  check = 0
+  for _ in 1...N {
+    for e in range {
+      check = sum(check, UInt64(e))
+      for _ in range {
+        check = sum(check, UInt64(e))
+      }
+      check = sum(check, UInt64(e))
+    }
+  }
+}
+
+@inline(never)
+public func foo() {
+}
+
+// TESTSIL-LABEL: sil [noinline] @$S17merge_exclusivity10MergeTest8yySiF : $@convention(thin)
+// TESTSIL: bb0
+// TESTSIL: [[GLOBALVAR:%.*]] = global_addr @$S17merge_exclusivity5checks6UInt64Vvp
+// TESTSIL: [[B1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL: end_access [[B1]]
+// TESTSIL: [[B2:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL-NEXT: br bb2
+// TESTSIL: bb1
+// TESTSIL: end_access [[B2]]
+// TESTSIL-NEXT: tuple
+// TESTSIL-NEXT: return
+// TESTSIL-NOT: begin_access
+// TESTSIL-LABEL: } // end sil function '$S17merge_exclusivity10MergeTest8yySiF'
+@inline(never)
+public func MergeTest8(_ N: Int) {
+  let range = 0..<10000
+  check = 0
+  for _ in 1...N {
+    for e in range {
+      check = sum(check, UInt64(e))
+      for _ in range {
+        foo()
+      }
+      check = sum(check, UInt64(e))
+    }
+  }
+}
+
+// TESTSIL-LABEL: sil [noinline] @$S17merge_exclusivity10MergeTest9yySiF : $@convention(thin)
+// TESTSIL: bb0
+// TESTSIL: [[GLOBALVAR:%.*]] = global_addr @$S17merge_exclusivity5checks6UInt64Vvp
+// TESTSIL: [[B1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL: end_access [[B1]]
+// TESTSIL: [[B2:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL-NEXT: br bb2
+// TESTSIL: bb1
+// TESTSIL: end_access [[B2]]
+// TESTSIL-NEXT: [[B3:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[GLOBALVAR]]
+// TESTSIL-NEXT: br bb8
+// TESTSIL-NOT: begin_access
+// TESTSIL: bb7
+// TESTSIL: end_access [[B3]]
+// TESTSIL-NEXT: tuple
+// TESTSIL-NEXT: return
+// TESTSIL-NOT: begin_access
+// TESTSIL-LABEL: } // end sil function '$S17merge_exclusivity10MergeTest9yySiF'
+@inline(never)
+public func MergeTest9(_ N: Int) {
+  let range = 0..<10000
+  check = 0
+  for _ in 1...N {
+    for e in range {
+      check = sum(check, UInt64(e))
+      for _ in range {
+        foo()
+      }
+      check = sum(check, UInt64(e))
+    }
+  }
+  for _ in 1...N {
+    for e in range {
+      check = sum(check, UInt64(e))
+      for _ in range {
+        foo()
+      }
+      check = sum(check, UInt64(e))
+    }
+  }
+}


### PR DESCRIPTION
We have the following code:
```
  %30 = begin_access [read] [dynamic] [no_nested_conflict] %1 : $*UInt64 // users: %31, %32
  %31 = load %30 : $*UInt64                       // user: %34
  end_access %30 : $*UInt64                       // id: %32
  %33 = struct $UInt64 (%27 : $Builtin.Int64)     // user: %34
  %34 = apply %14(%31, %33) : $@convention(thin) (UInt64, UInt64) -> UInt64 // user: %36
  %35 = begin_access [modify] [dynamic] [no_nested_conflict] %1 : $*UInt64 // users: %36, %37
  store %34 to %35 : $*UInt64                     // id: %36
  end_access %35 : $*UInt64                       // id: %37
 ```
If modify access fails then it is inclusive of the read access.

We can merge the two to a bigger “modify” block and reduce the amount of runtime overhead / calls.

We can also do the same for two merge accesses inside the same region, creating one larger scope access, as long as nothing conflicts in the larger scope / prevents us from doing so.

Now consider what happens when we couple what's described above with LICM: we can hoist the newly-merged large-scope access outside of loops! (see attached test case)

I have benchmarked this optimization on `RangeIteration`  from the benchmark suite: it improves performance by over 6X !!!

I will test it on more benchmarks later.

radar rdar://problem/40376124