### PR TITLE
Revert "[lit] Add a new feature DARWIN_SIMULATOR so we can use requires lines…"

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -638,15 +638,12 @@ if run_vendor == 'apple':
     elif run_os == 'ios' or run_os == 'tvos' or run_os == 'watchos':
         # iOS/tvOS/watchOS simulator
         if run_os == 'ios':
-            config.available_features('DARWIN_SIMULATOR=ios')
             lit_config.note("Testing iOS simulator " + config.variant_triple)
             xcrun_sdk_name = "iphonesimulator"
         elif run_os == 'watchos':
-            config.available_features('DARWIN_SIMULATOR=watchos')
             lit_config.note("Testing watchOS simulator " + config.variant_triple)
             xcrun_sdk_name = "watchsimulator"
         else:
-            config.available_features('DARWIN_SIMULATOR=tvos')
             lit_config.note("Testing AppleTV simulator " + config.variant_triple)
             xcrun_sdk_name = "appletvsimulator"
 


### PR DESCRIPTION
Reverts apple/swift#18294. It appears to be breaking PR testing for the simulators.

Resolves: rdar://problem/42684385