### PR TITLE
[WIP][ConstraintSystem] Don't try to open generic requirements of context

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2181,11 +2181,10 @@ public:
                    ConstraintLocatorBuilder locator,
                    OpenedTypeMap &replacements);
 
-  /// Given generic signature open its generic requirements,
-  /// using substitution function, and record them in the
-  /// constraint system for further processing.
+  /// Open given generic requirements using substitution function,
+  /// and record them in the constraint system for further processing.
   void openGenericRequirements(DeclContext *outerDC,
-                               GenericSignature *signature,
+                               ArrayRef<Requirement> requirements,
                                bool skipProtocolSelfConstraint,
                                ConstraintLocatorBuilder locator,
                                llvm::function_ref<Type(Type)> subst);

--- a/test/decl/nested/type_in_type.swift
+++ b/test/decl/nested/type_in_type.swift
@@ -377,8 +377,8 @@ protocol ExpressibleByDogLiteral {}
 struct Kitten : ExpressibleByCatLiteral {}
 struct Puppy : ExpressibleByDogLiteral {}
 
-struct Claws<A: ExpressibleByCatLiteral> {
-  struct Fangs<B: ExpressibleByDogLiteral> { }
+struct Claws<A: ExpressibleByCatLiteral> { // expected-note 2 {{'A' declared as parameter to type 'Claws'}}
+  struct Fangs<B: ExpressibleByDogLiteral> { } // expected-note {{'B' declared as parameter to type 'Claws.Fangs'}}
 }
 
 struct NotADog {}
@@ -402,6 +402,15 @@ func test() {
   let _: Claws.Fangs<NotADog> = something()
   // expected-error@-1 {{generic parameter 'T' could not be inferred}} // FIXME: bad diagnostic
   _ = Claws.Fangs<NotADog>()
+  // expected-error@-1 {{generic parameter 'A' could not be inferred}}
+  // expected-note@-2 {{explicitly specify the generic arguments to fix this issue}}
+  _ = Claws.Fangs<Puppy>()
+  // expected-error@-1 {{generic parameter 'A' could not be inferred}}
+  // expected-note@-2 {{explicitly specify the generic arguments to fix this issue}}
+  _ = Claws<Kitten>.Fangs()
+  // expected-error@-1 {{generic parameter 'B' could not be inferred}}
+  // expected-note@-2 {{explicitly specify the generic arguments to fix this issue}}
+  _ = Claws<Kitten>.Fangs<NotADog>()
   // expected-error@-1 {{type 'NotADog' does not conform to protocol 'ExpressibleByDogLiteral'}}
 }
 


### PR DESCRIPTION
If the base type has already opened some generic requirements
don't re-introduce them while opening member type, because `self`
is bound to `base` while forming type of member reference it
just leads to solving the same constraints multiple times, e.g.

```swift
class A<T: Hashable> {
  init(_: [T]) {}
}

_ = A([0, 42])
```

Since call has reference to a type `A<T>.Type` by the time we
attempt to open reference to initializer `(A<T>) -> ([T]) -> A<T>`
`T` would already be opened and all of its generic requirements
would be registered in the constraint system.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
