### PR TITLE
[Sema] Better key path failure diagnosis for unresolved roots

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -7098,6 +7098,19 @@ static bool diagnoseKeyPathComponents(ConstraintSystem &CS, KeyPathExpr *KPE,
                                       Type rootType) {
   auto &TC = CS.TC;
 
+  // The constraint system may have been unable to resolve the actual root
+  // type. The generic interface type of the root produces better
+  // diagnostics in this case.
+  if (rootType->hasUnresolvedType() && !KPE->isObjC()) {
+    if (auto ident = dyn_cast<ComponentIdentTypeRepr>(KPE->getRootType())) {
+      if (auto decl = ident->getBoundDecl()) {
+        if (auto metaType = decl->getInterfaceType()->castTo<MetatypeType>()) {
+          rootType = metaType->getInstanceType();
+        }
+      }
+    }
+  }
+
   // The key path string we're forming.
   SmallString<32> keyPathScratch;
   llvm::raw_svector_ostream keyPathOS(keyPathScratch);

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -7101,7 +7101,7 @@ static bool diagnoseKeyPathComponents(ConstraintSystem &CS, KeyPathExpr *KPE,
   // The constraint system may have been unable to resolve the actual root
   // type. The generic interface type of the root produces better
   // diagnostics in this case.
-  if (rootType->hasUnresolvedType() && !KPE->isObjC()) {
+  if (rootType->hasUnresolvedType() && !KPE->isObjC() && KPE->getRootType()) {
     if (auto ident = dyn_cast<ComponentIdentTypeRepr>(KPE->getRootType())) {
       if (auto decl = ident->getBoundDecl()) {
         if (auto metaType = decl->getInterfaceType()->castTo<MetatypeType>()) {

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -19,3 +19,18 @@ func test() {
 
   let _ = C()[keyPath: \.i] // no warning for a read
 }
+
+// SR-7339
+class Some<T, V> {
+  init(keyPath: KeyPath<T, ((V) -> Void)?>) {
+  }
+}
+
+class Demo {
+  var here: (() -> Void)?
+}
+
+// FIXME: This error is better than it was, but the diagnosis should break it down more specifically to 'here's type.
+let some = Some(keyPath: \Demo.here)
+// expected-error@-1 {{cannot convert value of type 'ReferenceWritableKeyPath<Demo, (() -> Void)?>' to expected argument type 'KeyPath<_, ((_) -> Void)?>'}}
+


### PR DESCRIPTION
When the root type of a keypath is unresolved by the constraint system, use the root interface type for diagnosis.

Resolves [SR-7339](https://bugs.swift.org/browse/SR-7339).
