### PR TITLE
Reapply "Revert "[lit] Add a new feature DARWIN_SIMULATOR so we can u…

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -638,12 +638,15 @@ if run_vendor == 'apple':
     elif run_os == 'ios' or run_os == 'tvos' or run_os == 'watchos':
         # iOS/tvOS/watchOS simulator
         if run_os == 'ios':
+            config.available_features.add('DARWIN_SIMULATOR=ios')
             lit_config.note("Testing iOS simulator " + config.variant_triple)
             xcrun_sdk_name = "iphonesimulator"
         elif run_os == 'watchos':
+            config.available_features.add('DARWIN_SIMULATOR=watchos')
             lit_config.note("Testing watchOS simulator " + config.variant_triple)
             xcrun_sdk_name = "watchsimulator"
         else:
+            config.available_features.add('DARWIN_SIMULATOR=tvos')
             lit_config.note("Testing AppleTV simulator " + config.variant_triple)
             xcrun_sdk_name = "appletvsimulator"
 


### PR DESCRIPTION
…se requires lines…""

This reverts commit 47dbac0aae3471f28b91585a026e31596d3b96fc. But this time do
it the right way. I wonder if it would be possible to pylint lit.cfg to prevent
problems like this.
