### PR TITLE
[No Merge] Draft implementation of divide/remainder proposal

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -107,6 +107,7 @@ set(SWIFTLIB_ESSENTIAL
   Repeat.swift
   REPL.swift
   Reverse.swift
+  RoundingRule.swift
   Runtime.swift.gyb
   RuntimeFunctionCounters.swift
   SipHash.swift

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -936,16 +936,16 @@ public protocol FloatingPoint : SignedNumeric, Strideable, Hashable
   ///     // Prints "6.0"
   ///
   /// For more information about the available rounding rules, see the
-  /// `FloatingPointRoundingRule` enumeration. To round a value using the
-  /// default "schoolbook rounding", you can use the shorter `rounded()`
-  /// method instead.
+  /// `RoundingRule` enumeration. To round a value using the default
+  /// "schoolbook rounding", you can use the shorter `rounded()` method
+  /// instead.
   ///
   ///     print(x.rounded())
   ///     // Prints "7.0"
   ///
   /// - Parameter rule: The rounding rule to use.
   /// - Returns: The integral value found by rounding using `rule`.
-  func rounded(_ rule: FloatingPointRoundingRule) -> Self
+  func rounded(_ rule: RoundingRule) -> Self
 
   /// Rounds the value to an integral value using the specified rounding rule.
   ///
@@ -972,8 +972,8 @@ public protocol FloatingPoint : SignedNumeric, Strideable, Hashable
   ///     // z == 6.0
   ///
   /// For more information about the available rounding rules, see the
-  /// `FloatingPointRoundingRule` enumeration. To round a value using the
-  /// default "schoolbook rounding", you can use the shorter `round()` method
+  /// `RoundingRule` enumeration. To round a value using the default
+  /// "schoolbook rounding", you can use the shorter `round()` method
   /// instead.
   ///
   ///     var w1 = 6.5
@@ -981,7 +981,7 @@ public protocol FloatingPoint : SignedNumeric, Strideable, Hashable
   ///     // w1 == 7.0
   ///
   /// - Parameter rule: The rounding rule to use.
-  mutating func round(_ rule: FloatingPointRoundingRule)
+  mutating func round(_ rule: RoundingRule)
 
   /// The least representable value that compares greater than this value.
   ///
@@ -1287,133 +1287,6 @@ public enum FloatingPointClassification {
   case positiveInfinity
 }
 
-/// A rule for rounding a floating-point number.
-public enum FloatingPointRoundingRule {
-  /// Round to the closest allowed value; if two values are equally close, the
-  /// one with greater magnitude is chosen.
-  ///
-  /// This rounding rule is also known as "schoolbook rounding." The following
-  /// example shows the results of rounding numbers using this rule:
-  ///
-  ///     (5.2).rounded(.toNearestOrAwayFromZero)
-  ///     // 5.0
-  ///     (5.5).rounded(.toNearestOrAwayFromZero)
-  ///     // 6.0
-  ///     (-5.2).rounded(.toNearestOrAwayFromZero)
-  ///     // -5.0
-  ///     (-5.5).rounded(.toNearestOrAwayFromZero)
-  ///     // -6.0
-  ///
-  /// This rule is equivalent to the C `round` function and implements the
-  /// `roundToIntegralTiesToAway` operation defined by the [IEEE 754
-  /// specification][spec].
-  ///
-  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
-  case toNearestOrAwayFromZero
-
-  /// Round to the closest allowed value; if two values are equally close, the
-  /// even one is chosen.
-  ///
-  /// This rounding rule is also known as "bankers rounding," and is the
-  /// default IEEE 754 rounding mode for arithmetic. The following example
-  /// shows the results of rounding numbers using this rule:
-  ///
-  ///     (5.2).rounded(.toNearestOrEven)
-  ///     // 5.0
-  ///     (5.5).rounded(.toNearestOrEven)
-  ///     // 6.0
-  ///     (4.5).rounded(.toNearestOrEven)
-  ///     // 4.0
-  ///
-  /// This rule implements the `roundToIntegralTiesToEven` operation defined by
-  /// the [IEEE 754 specification][spec].
-  ///
-  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
-  case toNearestOrEven
-
-  /// Round to the closest allowed value that is greater than or equal to the
-  /// source.
-  ///
-  /// The following example shows the results of rounding numbers using this
-  /// rule:
-  ///
-  ///     (5.2).rounded(.up)
-  ///     // 6.0
-  ///     (5.5).rounded(.up)
-  ///     // 6.0
-  ///     (-5.2).rounded(.up)
-  ///     // -5.0
-  ///     (-5.5).rounded(.up)
-  ///     // -5.0
-  ///
-  /// This rule is equivalent to the C `ceil` function and implements the
-  /// `roundToIntegralTowardPositive` operation defined by the [IEEE 754
-  /// specification][spec].
-  ///
-  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
-  case up
-
-  /// Round to the closest allowed value that is less than or equal to the
-  /// source.
-  ///
-  /// The following example shows the results of rounding numbers using this
-  /// rule:
-  ///
-  ///     (5.2).rounded(.down)
-  ///     // 5.0
-  ///     (5.5).rounded(.down)
-  ///     // 5.0
-  ///     (-5.2).rounded(.down)
-  ///     // -6.0
-  ///     (-5.5).rounded(.down)
-  ///     // -6.0
-  ///
-  /// This rule is equivalent to the C `floor` function and implements the
-  /// `roundToIntegralTowardNegative` operation defined by the [IEEE 754
-  /// specification][spec].
-  ///
-  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
-  case down
-
-  /// Round to the closest allowed value whose magnitude is less than or equal
-  /// to that of the source.
-  ///
-  /// The following example shows the results of rounding numbers using this
-  /// rule:
-  ///
-  ///     (5.2).rounded(.towardZero)
-  ///     // 5.0
-  ///     (5.5).rounded(.towardZero)
-  ///     // 5.0
-  ///     (-5.2).rounded(.towardZero)
-  ///     // -5.0
-  ///     (-5.5).rounded(.towardZero)
-  ///     // -5.0
-  ///
-  /// This rule is equivalent to the C `trunc` function and implements the
-  /// `roundToIntegralTowardZero` operation defined by the [IEEE 754
-  /// specification][spec].
-  ///
-  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
-  case towardZero
-
-  /// Round to the closest allowed value whose magnitude is greater than or
-  /// equal to that of the source.
-  ///
-  /// The following example shows the results of rounding numbers using this
-  /// rule:
-  ///
-  ///     (5.2).rounded(.awayFromZero)
-  ///     // 6.0
-  ///     (5.5).rounded(.awayFromZero)
-  ///     // 6.0
-  ///     (-5.2).rounded(.awayFromZero)
-  ///     // -6.0
-  ///     (-5.5).rounded(.awayFromZero)
-  ///     // -6.0
-  case awayFromZero
-}
-
 extension FloatingPoint {
   @_transparent
   public static func == (lhs: Self, rhs: Self) -> Bool {
@@ -1654,9 +1527,9 @@ extension FloatingPoint {
   ///     // Prints "6.0"
   ///
   /// For more information about the available rounding rules, see the
-  /// `FloatingPointRoundingRule` enumeration. To round a value using the
-  /// default "schoolbook rounding", you can use the shorter `rounded()`
-  /// method instead.
+  /// `RoundingRule` enumeration. To round a value using the default
+  /// "schoolbook rounding", you can use the shorter `rounded()` method
+  /// instead.
   ///
   ///     print(x.rounded())
   ///     // Prints "7.0"
@@ -1664,7 +1537,7 @@ extension FloatingPoint {
   /// - Parameter rule: The rounding rule to use.
   /// - Returns: The integral value found by rounding using `rule`.
   @_transparent
-  public func rounded(_ rule: FloatingPointRoundingRule) -> Self {
+  public func rounded(_ rule: RoundingRule) -> Self {
     var lhs = self
     lhs.round(rule)
     return lhs

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -986,7 +986,7 @@ extension ${Self}: BinaryFloatingPoint {
   ///     // z == 6.0
   ///
   /// For more information about the available rounding rules, see the
-  /// `FloatingPointRoundingRule` enumeration. To round a value using the
+  /// `RoundingRule` enumeration. To round a value using the
   /// default "schoolbook rounding", you can use the shorter `round()` method
   /// instead.
   ///
@@ -996,7 +996,7 @@ extension ${Self}: BinaryFloatingPoint {
   ///
   /// - Parameter rule: The rounding rule to use.
   @_transparent
-  public mutating func round(_ rule: FloatingPointRoundingRule) {
+  public mutating func round(_ rule: RoundingRule) {
     switch rule {
     case .toNearestOrAwayFromZero:
       _value = Builtin.int_round_FPIEEE${bits}(_value)
@@ -1025,7 +1025,7 @@ extension ${Self}: BinaryFloatingPoint {
   // the case, this non-inlinable function will call into the _newer_ version
   // which _will_ support this rounding rule.
   @usableFromInline
-  internal mutating func _roundSlowPath(_ rule: FloatingPointRoundingRule) {
+  internal mutating func _roundSlowPath(_ rule: RoundingRule) {
     self.round(rule)
   }
 

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -138,6 +138,7 @@
   "Math": [
     "SetAlgebra.swift",
     "BuiltinMath.swift",
+    "RoundingRule.swift",
     {
     "Integers": [
       "Integers.swift",

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1732,6 +1732,13 @@ ${assignmentOperatorComment(x.nonMaskingOperator, False)}
     _ lhs: inout Self, _ rhs: RHS)
 % end
 
+  /// Returns `-1` if this value is negative and `1` if it's positive;
+  /// otherwise, `0`.
+  ///
+  /// - Returns: The sign of this number, expressed as an integer of the same
+  ///   type.
+  func signum() -> Self
+
   /// Divides this value by `divisor`, rounding the result according to `rule`
   /// to produce a `quotient` and `remainder`.
   ///
@@ -1775,88 +1782,23 @@ ${assignmentOperatorComment(x.nonMaskingOperator, False)}
   ///
   /// - Returns: the quotient and remainder.
   ///
-  /// See also `divided(by:,rounding:)`,
-  /// `remainder(dividingBy:, roundingQuotient:)`, `mod(_:)`, and `isDivisible(by:)`.
-  func quotientAndRemainder(
-    dividingBy rhs: Self,
-    roundingQuotient rule: RoundingRule
-  ) -> (quotient: Self, remainder: Self)
-
-  /// This value divided by `divisor`, rounded to an integer value.
-  ///
-  /// Division is unique among the basic arithmetic operations on integers in
-  /// that the result if we interpret the arguments as real numbers is
-  /// generally not an integer. For example, as real numbers, 3/2 is 1.5.
-  /// Thus, we need to choose a rounding rule that describes how to round
-  /// the quotient when it is not an exact integer. This function provides
-  /// the ability to control the rounding.
-  ///
-  /// A few of the available rounding rules are worth calling out in particular:
-  ///
-  /// - `.towardZero` matches the behavior of the `/` operator.
-  ///
-  /// - `.down` is frequently called "floored" or "flooring" division.
-  ///
-  /// - `.up` and `.awayFromZero` are useful when working with sizes and counts.
-  ///   If you want to put `n` objects into buckets, each of which can hold `k`
-  ///   objects, you will use `n.divided(by: k, rounding: .up)` buckets.
-  ///
-  /// - `.toNearestOrEven` and `.toNearestOrAwayFromZero` are useful if you
-  ///   need to emulate or implement floating-point rounding with integer
-  ///   arithmetic.
-  ///
-  /// - Parameters:
-  ///   - divisor: the number to divide by.
-  ///   - rule: the rounding rule to use.
-  ///
-  /// See also `remainder(dividingBy:, roundingQuotient:)` and
-  /// `quotientAndRemainder(dividingBy:, roundingQuotient:)`.
-  func divided(by divisor: Self, rounding rule: RoundingRule) -> Self
-
-  /// The remainder of dividing this value by `divisor`, using the specified
-  /// rounding `rule`.
-  ///
-  /// Equivalent to
-  /// ~~~~
-  /// let quotient = self.divided(by: divisor, rounding: rule)
-  /// return self - q*quotient
-  /// ~~~~
-  ///
-  /// A few of the available rounding rules are worth calling out in particular:
-  ///
-  /// - `.towardZero` matches the behavior of the `%` operator.
-  ///
-  /// - `.down` has the property the sign of the result always matches the
-  ///   sign of the divisor, and so when the divisor is positive, the result
-  ///   is always in `0 ..< divisor`.
-  ///
-  /// - `.toNearestOrEven` and `.toNearestOrAwayFromZero` are sometimes used
-  ///   because they produce the smallest magnitude remainder.
-  ///
-  /// - Parameters:
-  ///   - divisor: the number to divide by to get the remainder.
-  ///   - rule: the rounding rule to apply to the quotient.
-  ///
-  /// See also `mod(_:)`, `divided(by:,rounding:)`,
-  /// `quotientAndRemainder(dividingBy:, roundingQuotient:)`, and `isDivisible(by:)`.
-  func remainder(
-    dividingBy divisor: Self,
-    roundingQuotient rule: RoundingRule
-  ) -> Self
+  /// See also `mod(_:)`.
+  func divided(by rhs: Self, rounding rule: RoundingRule)
+    -> (quotient: Self, remainder: Self)
 
   /// The mathematical modulo operation.
   ///
-  /// This operation is similar to the `%` operator or `.remainder`, but
-  /// differs importantly in how it handles negative numbers. The `modulus`
-  /// must be positive, and the result is always non-negative, even if `self`
-  /// is negative.
+  /// This operation is similar to the `%` operator and the `remainder` result
+  /// of the `.divided(by:, rounding:)` function, but differs importantly in
+  /// how it handles negative numbers. The `modulus` must be positive, and the
+  /// result is always non-negative, even if `self` is negative.
   ///
   /// - Parameters:
   ///   - modulus: must be positive.
   /// - Returns: the unique integer in `0 ..< modulus` that satisfies
   ///   `self = n*modulus + result` for some integer `n`.
   ///
-  /// See also `remainder(dividingBy:, roundingQuotient:)` and `isDivisible(by:)`.
+  /// See also `divided(by:, rounding:)`.
   func mod(_ modulus: Self) -> Self
 
   /// Shifts this value right by n, rounding according to the specified
@@ -1865,19 +1807,14 @@ ${assignmentOperatorComment(x.nonMaskingOperator, False)}
   /// - Parameters:
   ///   - n: The number of bits to shift by. Must be non-negative.
   ///   - rule: The direction in which to round the result if it is not exact.
-  /// - Returns: the pair `(rounded: Self, exact: Bool)`, where `rounded`
-  ///   is `self*2**(-n)` rounded to the nearest integer, and `exact` is
+  /// - Returns: the pair `(rounded: Self, isExact: Bool)`, where `rounded`
+  ///   is `self*2**(-n)` rounded to the nearest integer, and `isExact` is
   ///   true if and only if the result of the shift was an integer before
   ///   rounding.
+  ///
+  /// See also `divided(by:, rounding:)`.
   func shiftedRight<Count>(by n: Count, rounding rule: RoundingRule)
     -> (result: Self, isExact: Bool) where Count : BinaryInteger
-
-  /// Returns `-1` if this value is negative and `1` if it's positive;
-  /// otherwise, `0`.
-  ///
-  /// - Returns: The sign of this number, expressed as an integer of the same
-  ///   type.
-  func signum() -> Self
 }
 
 public extension BinaryInteger {
@@ -1906,9 +1843,7 @@ public extension BinaryInteger {
   @inlinable // FIXME(sil-serialize-all)
   func _binaryLogarithm() -> Int {
     _precondition(self > (0 as Self))
-    var (quotient, remainder) =
-      (bitWidth &- 1).quotientAndRemainder(dividingBy: UInt.bitWidth)
-    remainder = remainder &+ 1
+    var (quotient, remainder) = bitWidth.divided(by: UInt.bitWidth, rounding: .up)
     var word = UInt(truncatingIfNeeded: self >> (bitWidth &- remainder))
     // If, internally, a variable-width binary integer uses digits of greater
     // bit width than that of Magnitude.Words.Element (i.e., UInt), then it is
@@ -1954,16 +1889,13 @@ ${operatorComment(x.nonMaskingOperator, False)}
 % end
 
   @_transparent
-  func quotientAndRemainder(
-    dividingBy divisor: Self
-  ) -> (quotient: Self, remainder: Self) {
-    return quotientAndRemainder(dividingBy: divisor, roundingQuotient: .down)
+  func divided(by divisor: Self) -> (quotient: Self, remainder: Self) {
+    return divided(by: divisor, rounding: .down)
   }
 
-  func quotientAndRemainder(
-    dividingBy divisor: Self,
-    roundingQuotient rule: RoundingRule
-  ) -> (quotient: Self, remainder: Self) {
+  @inlinable
+  func divided(by divisor: Self, rounding rule: RoundingRule)
+  -> (quotient: Self, remainder: Self) {
     //  Figure out the sign of the real-number ratio self/divisor; this informs
     //  how we actually implement the rounding.
     let negativeQuotient = Self.isSigned && (self < 0) != (divisor < 0)
@@ -2005,39 +1937,22 @@ ${operatorComment(x.nonMaskingOperator, False)}
       }
       //  Otherwise, round away from zero.
       roundAway()
+    @unknown default:
+      return self.dividedNoInline(by: divisor, rounding: rule)
     }
     return (quotient, remainder)
   }
 
-  @_transparent
-  func divided(by divisor: Self) -> Self {
-    return self.divided(by: divisor, rounding: .down)
+  @usableFromInline
+  internal func dividedNoInline(by divisor: Self, rounding rule: RoundingRule)
+  -> (quotient: Self, remainder: Self) {
+    return self.divided(by: divisor, rounding: rule)
   }
 
-  @_transparent
-  func divided(by divisor: Self, rounding rule: RoundingRule) -> Self {
-    let (result, _) = quotientAndRemainder(dividingBy: divisor, roundingQuotient: rule)
-    return result
-  }
-
-  @_transparent
-  func remainder(dividingBy divisor: Self) -> Self {
-    return self.remainder(dividingBy: divisor, roundingQuotient: .down)
-  }
-
-  @_transparent
-  func remainder(
-    dividingBy divisor: Self,
-    roundingQuotient rule: RoundingRule
-  ) -> Self {
-    let (_, result) = quotientAndRemainder(dividingBy: divisor, roundingQuotient: rule)
-    return result
-  }
-
-  @_transparent
+  @inlinable
   func mod(_ modulus: Self) -> Self {
     _precondition(modulus > 0, "mod(_:) requires a positive modulus.")
-    return remainder(dividingBy: modulus, roundingQuotient: .down)
+    return divided(by: modulus, rounding: .down).remainder
   }
 
   @_transparent
@@ -2046,6 +1961,7 @@ ${operatorComment(x.nonMaskingOperator, False)}
     return shiftedRight(by: n, rounding: .down)
   }
 
+  @inlinable
   func shiftedRight<Count>(
     by n: Count,
     rounding rule: RoundingRule
@@ -2080,6 +1996,8 @@ ${operatorComment(x.nonMaskingOperator, False)}
       case .toNearestOrEven:
         if fraction > halfway { rounded += 1 }
         else if fraction == halfway { rounded += rounded & 1 }
+      @unknown default:
+        return self.shiftedRightNoInline(by: n, rounding: rule)
       }
     } else {
       switch rule {
@@ -2098,46 +2016,20 @@ ${operatorComment(x.nonMaskingOperator, False)}
       case .toNearestOrEven:
         if fraction > halfway { rounded += 1 }
         else if fraction == halfway { rounded += rounded & 1 }
+      @unknown default:
+        return self.shiftedRightNoInline(by: n, rounding: rule)
       }
     }
     return (rounded, !sticky)
   }
 
-  /// Test if this value is exactly divisible by `testDivisor`.
-  ///
-  /// For example:
-  ///
-  /// ~~~~
-  /// 5.isDivisible(by: 2)  // false, because 5 is not twice any integer.
-  /// 21.isDivisible(by: 7) // true, because 21 = 3*7.
-  /// ~~~~
-  ///
-  /// Two edge cases warrant special attention:
-  /// - `x.isDivisible(by: 0)` is `false` for all `x`, even `x == 0`. This is
-  ///   because zero times anything is zero, so there is no *unique* `k`
-  ///   satisfying `0 = k*0`.
-  /// - For signed fixed-width integer types `T`, `T.min.isDivisible(by: -1)`
-  ///   is `true`, even though `T.min / -1` overflows, because the integer
-  ///   `k` exists and is unique; it simply isn't representable as a `T`.
-  ///
-  /// - Parameter testDivisor: the number by which to test for divisibility.
-  /// - Returns: true if a unique integer `k` exists such that `self == k * testDivisor`.
-  ///
-  /// - See also: isEven, isOdd.
-  @_transparent
-  func isDivisible(by testDivisor: Self) -> Bool {
-    return testDivisor != 0 && self % testDivisor == 0
+  @usableFromInline
+  internal func shiftedRightNoInline<Count>(
+    by n: Count,
+    rounding rule: RoundingRule
+  ) -> (result: Self, isExact: Bool) where Count : BinaryInteger {
+    return self.shiftedRight(by: n, rounding: rule)
   }
-
-  /// True if this value is evenly divisible by two, false otherwise.
-  /// - See also: isDivisible(by:), isOdd
-  @_transparent
-  var isEven: Bool { return _lowWord % 2 == 0 }
-
-  /// True if this value is not evenly divisible by two, false otherwise.
-  /// - See also: isDivisible(by:), isEven
-  @_transparent
-  var isOdd: Bool { return !isEven }
 }
 
 //===----------------------------------------------------------------------===//
@@ -2164,10 +2056,10 @@ extension BinaryInteger {
     // (although not necessarily the case for builtin types).
     let isRadixPowerOfTwo = radix.nonzeroBitCount == 1
     let radix_ = Magnitude(radix)
-    func _quotientAndRemainder(_ value: Magnitude) -> (Magnitude, Magnitude) {
+    func _divided(_ value: Magnitude) -> (Magnitude, Magnitude) {
       return isRadixPowerOfTwo
         ? (value >> radix.trailingZeroBitCount, value & (radix_ - 1))
-        : value.quotientAndRemainder(dividingBy: radix_)
+        : value.divided(by: radix_)
     }
 
     let hasLetters = radix > 10
@@ -2191,7 +2083,7 @@ extension BinaryInteger {
 
     var result: [UInt8] = []
     while value != 0 {
-      let (quotient, remainder) = _quotientAndRemainder(value)
+      let (quotient, remainder) = _divided(value)
       result.append(_ascii(UInt8(truncatingIfNeeded: remainder)))
       value = quotient
     }
@@ -2694,12 +2586,17 @@ ${overflowOperationComment(x.operator)}
   ///     // quotient == 186319822866995413
   ///     // remainder == 0
   ///
-  /// - Parameter dividend: A tuple containing the high and low parts of a
-  ///   double-width integer.
+  /// - Parameters
+  ///   - dividend: A tuple containing the high and low parts of a double-width
+  ///     integer.
+  ///   - rule: The rule to use to round the quotient if the division is not
+  ///     exact.
   /// - Returns: A tuple containing the quotient and remainder obtained by
   ///   dividing `dividend` by this value.
-  func dividingFullWidth(_ dividend: (high: Self, low: Self.Magnitude))
-    -> (quotient: Self, remainder: Self)
+  func dividingFullWidth(
+    _ dividend: (high: Self, low: Self.Magnitude),
+    rounding rule: RoundingRule
+  ) -> (quotient: Self, remainder: Self)
 
   init(_truncatingBits bits: UInt)
 
@@ -3297,11 +3194,9 @@ extension FixedWidthInteger {
       return Self(truncatingIfNeeded: generator.next() as UInt64)
     }
 
-    let (quotient, remainder) = bitWidth.quotientAndRemainder(
-      dividingBy: UInt64.bitWidth
-    )
+    let quotient = bitWidth.divided(by: UInt64.bitWidth, rounding: .up).quotient
     var tmp: Self = 0
-    for i in 0 ..< quotient + remainder.signum() {
+    for i in 0 ..< quotient {
       let next: UInt64 = generator.next()
       tmp += Self(truncatingIfNeeded: next) &<< (UInt64.bitWidth * i)
     }
@@ -4006,6 +3901,13 @@ ${assignmentOperatorComment(x.operator, True)}
 %   end
   }
 
+  @_transparent
+  public func dividingFullWidth(
+    _ dividend: (high: ${Self}, low: ${Self}.Magnitude)
+  ) -> (quotient: ${Self}, remainder: ${Self}) {
+    return self.dividingFullWidth(dividend, rounding: .down)
+  }
+
   /// Returns a tuple containing the quotient and remainder of dividing the
   /// given value by this value.
   ///
@@ -4018,9 +3920,9 @@ ${assignmentOperatorComment(x.operator, True)}
   ///   sign, if the type is signed.
   /// - Returns: A tuple containing the quotient and remainder of `dividend`
   ///   divided by this value.
-  @inlinable // FIXME(sil-serialize-all)
   public func dividingFullWidth(
-    _ dividend: (high: ${Self}, low: ${Self}.Magnitude)
+    _ dividend: (high: ${Self}, low: ${Self}.Magnitude),
+    rounding rule: RoundingRule
   ) -> (quotient: ${Self}, remainder: ${Self}) {
     // FIXME(integers): tests
 %   # 128-bit types are not provided by the 32-bit LLVM

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1732,22 +1732,145 @@ ${assignmentOperatorComment(x.nonMaskingOperator, False)}
     _ lhs: inout Self, _ rhs: RHS)
 % end
 
-  /// Returns the quotient and remainder of this value divided by the given
-  /// value.
+  /// Divides this value by `divisor`, rounding the result according to `rule`
+  /// to produce a `quotient` and `remainder`.
   ///
-  /// Use this method to calculate the quotient and remainder of a division at
-  /// the same time.
+  /// For every value of `self`, and `divisor`, the following constraints are
+  /// satisfied by the results.
   ///
-  ///     let x = 1_000_000
-  ///     let (q, r) = x.quotientAndRemainder(dividingBy: 933)
-  ///     // q == 1071
-  ///     // r == 757
+  /// - self == quotient*divisor + remainder
+  /// - 0 <= remainder.magnitude && remainder.magnitude < divisor.magnitude
   ///
-  /// - Parameter rhs: The value to divide this value by.
-  /// - Returns: A tuple containing the quotient and remainder of this value
-  ///   divided by `rhs`. The remainder has the same sign as `rhs`.
-  func quotientAndRemainder(dividingBy rhs: Self)
-    -> (quotient: Self, remainder: Self)
+  /// If these constraints cannot be satisfied, a trap occurs. These
+  /// constraints do not fully specify the behavior of the function; for
+  /// most values of `self` and `divisor`, there are two possible result
+  /// pairs that we must select between.
+  ///
+  /// Let ratio be the real number self/divisor. This real number is rounded
+  /// to the integer quotient following the specified rounding rule, and the
+  /// remainder is determined by self - quotient*divisor.
+  ///
+  /// A few rounding rules are worth calling out specifically:
+  ///
+  /// - `.towardZero` matches the behavior of the `/` and
+  ///   `%` operators. This is sometimes called "truncating division".
+  ///
+  /// - `.down` is sometimes called "floored" or "flooring" division. It has
+  ///   the nice property that the sign of the remainder always matches the
+  ///   sign of the divisor (in particular, in the common case of a positive
+  ///   divisor, the remainder is always contained in `0..<divisor`.
+  ///
+  /// - `.up` and `.awayFromZero` are used with sizes and counts, where you
+  ///   want to round the quotient to a larger value if the remainder is
+  ///   nonzero.
+  ///
+  /// - .towardNearestOrEven and .towardNearestOrAwayFromZero are used with
+  ///   integers when you want to select the result with the smallest-magnitude
+  ///   remainder, but are also useful for implementing and emulating floating-
+  ///   point arithmetic in integer.
+  ///
+  /// - Parameters:
+  ///   - divisor: the value by which to divide.
+  ///   - rule: the `RoundingRule` describing how to select the result.
+  ///
+  /// - Returns: the quotient and remainder.
+  ///
+  /// See also `divided(by:,rounding:)`,
+  /// `remainder(dividingBy:, roundingQuotient:)`, `mod(_:)`, and `isDivisible(by:)`.
+  func quotientAndRemainder(
+    dividingBy rhs: Self,
+    roundingQuotient rule: RoundingRule
+  ) -> (quotient: Self, remainder: Self)
+
+  /// This value divided by `divisor`, rounded to an integer value.
+  ///
+  /// Division is unique among the basic arithmetic operations on integers in
+  /// that the result if we interpret the arguments as real numbers is
+  /// generally not an integer. For example, as real numbers, 3/2 is 1.5.
+  /// Thus, we need to choose a rounding rule that describes how to round
+  /// the quotient when it is not an exact integer. This function provides
+  /// the ability to control the rounding.
+  ///
+  /// A few of the available rounding rules are worth calling out in particular:
+  ///
+  /// - `.towardZero` matches the behavior of the `/` operator.
+  ///
+  /// - `.down` is frequently called "floored" or "flooring" division.
+  ///
+  /// - `.up` and `.awayFromZero` are useful when working with sizes and counts.
+  ///   If you want to put `n` objects into buckets, each of which can hold `k`
+  ///   objects, you will use `n.divided(by: k, rounding: .up)` buckets.
+  ///
+  /// - `.toNearestOrEven` and `.toNearestOrAwayFromZero` are useful if you
+  ///   need to emulate or implement floating-point rounding with integer
+  ///   arithmetic.
+  ///
+  /// - Parameters:
+  ///   - divisor: the number to divide by.
+  ///   - rule: the rounding rule to use.
+  ///
+  /// See also `remainder(dividingBy:, roundingQuotient:)` and
+  /// `quotientAndRemainder(dividingBy:, roundingQuotient:)`.
+  func divided(by divisor: Self, rounding rule: RoundingRule) -> Self
+
+  /// The remainder of dividing this value by `divisor`, using the specified
+  /// rounding `rule`.
+  ///
+  /// Equivalent to
+  /// ~~~~
+  /// let quotient = self.divided(by: divisor, rounding: rule)
+  /// return self - q*quotient
+  /// ~~~~
+  ///
+  /// A few of the available rounding rules are worth calling out in particular:
+  ///
+  /// - `.towardZero` matches the behavior of the `%` operator.
+  ///
+  /// - `.down` has the property the sign of the result always matches the
+  ///   sign of the divisor, and so when the divisor is positive, the result
+  ///   is always in `0 ..< divisor`.
+  ///
+  /// - `.toNearestOrEven` and `.toNearestOrAwayFromZero` are sometimes used
+  ///   because they produce the smallest magnitude remainder.
+  ///
+  /// - Parameters:
+  ///   - divisor: the number to divide by to get the remainder.
+  ///   - rule: the rounding rule to apply to the quotient.
+  ///
+  /// See also `mod(_:)`, `divided(by:,rounding:)`,
+  /// `quotientAndRemainder(dividingBy:, roundingQuotient:)`, and `isDivisible(by:)`.
+  func remainder(
+    dividingBy divisor: Self,
+    roundingQuotient rule: RoundingRule
+  ) -> Self
+
+  /// The mathematical modulo operation.
+  ///
+  /// This operation is similar to the `%` operator or `.remainder`, but
+  /// differs importantly in how it handles negative numbers. The `modulus`
+  /// must be positive, and the result is always non-negative, even if `self`
+  /// is negative.
+  ///
+  /// - Parameters:
+  ///   - modulus: must be positive.
+  /// - Returns: the unique integer in `0 ..< modulus` that satisfies
+  ///   `self = n*modulus + result` for some integer `n`.
+  ///
+  /// See also `remainder(dividingBy:, roundingQuotient:)` and `isDivisible(by:)`.
+  func mod(_ modulus: Self) -> Self
+
+  /// Shifts this value right by n, rounding according to the specified
+  /// rounding rule.
+  ///
+  /// - Parameters:
+  ///   - n: The number of bits to shift by. Must be non-negative.
+  ///   - rule: The direction in which to round the result if it is not exact.
+  /// - Returns: the pair `(rounded: Self, exact: Bool)`, where `rounded`
+  ///   is `self*2**(-n)` rounded to the nearest integer, and `exact` is
+  ///   true if and only if the result of the shift was an integer before
+  ///   rounding.
+  func shiftedRight<Count>(by n: Count, rounding rule: RoundingRule)
+    -> (result: Self, isExact: Bool) where Count : BinaryInteger
 
   /// Returns `-1` if this value is negative and `1` if it's positive;
   /// otherwise, `0`.
@@ -1757,10 +1880,10 @@ ${assignmentOperatorComment(x.nonMaskingOperator, False)}
   func signum() -> Self
 }
 
-extension BinaryInteger {
+public extension BinaryInteger {
   /// Creates a new value equal to zero.
   @_transparent
-  public init() {
+  init() {
     self = 0
   }
 
@@ -1770,18 +1893,18 @@ extension BinaryInteger {
   /// - Returns: The sign of this number, expressed as an integer of the same
   ///   type.
   @_transparent
-  public func signum() -> Self {
+  func signum() -> Self {
     return (self > (0 as Self) ? 1 : 0) - (self < (0 as Self) ? 1 : 0)
   }
 
   @_transparent
-  public var _lowWord: UInt {
+  var _lowWord: UInt {
     var it = words.makeIterator()
     return it.next() ?? 0
   }
 
   @inlinable // FIXME(sil-serialize-all)
-  public func _binaryLogarithm() -> Int {
+  func _binaryLogarithm() -> Int {
     _precondition(self > (0 as Self))
     var (quotient, remainder) =
       (bitWidth &- 1).quotientAndRemainder(dividingBy: UInt.bitWidth)
@@ -1803,32 +1926,12 @@ extension BinaryInteger {
         (UInt.bitWidth &- (word.leadingZeroBitCount &+ 1))
   }
 
-  /// Returns the quotient and remainder of this value divided by the given
-  /// value.
-  ///
-  /// Use this method to calculate the quotient and remainder of a division at
-  /// the same time.
-  ///
-  ///     let x = 1_000_000
-  ///     let (q, r) = x.quotientAndRemainder(dividingBy: 933)
-  ///     // q == 1071
-  ///     // r == 757
-  ///
-  /// - Parameter rhs: The value to divide this value by.
-  /// - Returns: A tuple containing the quotient and remainder of this value
-  ///   divided by `rhs`.
-  @inlinable // FIXME(sil-serialize-all)
-  public func quotientAndRemainder(dividingBy rhs: Self)
-    -> (quotient: Self, remainder: Self) {
-    return (self / rhs, self % rhs)
-  }
-
   % for x in binaryBitwise:
 
   // Homogeneous
 ${operatorComment(x.operator, False)}
   @_transparent
-  public static func ${x.operator} (lhs: Self, rhs: Self) -> Self {
+  static func ${x.operator} (lhs: Self, rhs: Self) -> Self {
     var lhs = lhs
     lhs ${x.operator}= rhs
     return lhs
@@ -1841,7 +1944,7 @@ ${operatorComment(x.operator, False)}
 ${operatorComment(x.nonMaskingOperator, False)}
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @inlinable
-  public static func ${x.nonMaskingOperator}<RHS: BinaryInteger>(
+  static func ${x.nonMaskingOperator}<RHS: BinaryInteger>(
     _ lhs: Self, _ rhs: RHS
   ) -> Self {
     var r = lhs
@@ -1850,6 +1953,164 @@ ${operatorComment(x.nonMaskingOperator, False)}
   }
 % end
 
+  @_transparent
+  func quotientAndRemainder(
+    dividingBy divisor: Self
+  ) -> (quotient: Self, remainder: Self) {
+    return quotientAndRemainder(dividingBy: divisor, roundingQuotient: .down)
+  }
+
+  func quotientAndRemainder(
+    dividingBy divisor: Self,
+    roundingQuotient rule: RoundingRule
+  ) -> (quotient: Self, remainder: Self) {
+    //  Figure out the sign of the real-number ratio self/divisor; this informs
+    //  how we actually implement the rounding.
+    let negativeQuotient = Self.isSigned && (self < 0) != (divisor < 0)
+    //  Get the "usual" quotient and remainder (computed by rounding the
+    //  quotient towards zero).
+    var (quotient, remainder) = (self/divisor, self%divisor)
+    //  If the remainder is zero, the quotient is exact, and so rounding
+    //  direction does not matter. Just return the result we have.
+    if remainder == 0 { return (quotient, remainder) }
+    //  Small nested helper functions to actually perform rounding:
+    func roundDown( ) { if negativeQuotient { quotient -= 1; remainder += divisor } }
+    func roundUp( ) { if !negativeQuotient { quotient += 1; remainder -= divisor } }
+    func roundAway( ) { roundDown(); roundUp(); }
+    //  Otherwise, we may need to adjust the result to account for the
+    //  requested rounding direction.
+    switch rule {
+    case .towardZero: break
+    case .down: roundDown()
+    case .up: roundUp()
+    case .awayFromZero: roundAway()
+    case .toNearestOrAwayFromZero:
+      //  Determine if we already have the nearest candidate quotient by
+      //  comparing |remainder| to |divisor|/2.
+      let (halfway, _) = divisor.magnitude.shiftedRight(by: 1, rounding: .up)
+      //  If we already have the nearest canidate, we're done. If not,
+      //  fallthrough into the round-away-from-zero path.
+      if remainder.magnitude < halfway { break }
+      roundAway()
+    case .toNearestOrEven:
+      //  Determine if we already have the nearest candidate quotient by
+      //  comparing |remainder| to |divisor|/2.
+      let (halfway, isExact) = divisor.magnitude.shiftedRight(by: 1, rounding: .up)
+      //  If we already have the nearest canidate, we're done.
+      if remainder.magnitude < halfway { break }
+      //  If we're in an exact halfway case, and the existing quotient is
+      //  even, we're done.
+      if isExact && remainder.magnitude == halfway && (quotient & 1) == 0 {
+        break
+      }
+      //  Otherwise, round away from zero.
+      roundAway()
+    }
+    return (quotient, remainder)
+  }
+
+  @_transparent
+  func divided(by divisor: Self) -> Self {
+    return self.divided(by: divisor, rounding: .down)
+  }
+
+  @_transparent
+  func divided(by divisor: Self, rounding rule: RoundingRule) -> Self {
+    let (result, _) = quotientAndRemainder(dividingBy: divisor, roundingQuotient: rule)
+    return result
+  }
+
+  @_transparent
+  func remainder(dividingBy divisor: Self) -> Self {
+    return self.remainder(dividingBy: divisor, roundingQuotient: .down)
+  }
+
+  @_transparent
+  func remainder(
+    dividingBy divisor: Self,
+    roundingQuotient rule: RoundingRule
+  ) -> Self {
+    let (_, result) = quotientAndRemainder(dividingBy: divisor, roundingQuotient: rule)
+    return result
+  }
+
+  @_transparent
+  func mod(_ modulus: Self) -> Self {
+    _precondition(modulus > 0, "mod(_:) requires a positive modulus.")
+    return remainder(dividingBy: modulus, roundingQuotient: .down)
+  }
+
+  @_transparent
+  func shiftedRight<Count>(by n: Count) -> (result: Self, isExact: Bool)
+  where Count : BinaryInteger {
+    return shiftedRight(by: n, rounding: .down)
+  }
+
+  func shiftedRight<Count>(
+    by n: Count,
+    rounding rule: RoundingRule
+  ) -> (result: Self, isExact: Bool) where Count : BinaryInteger {
+    _precondition(n >= 0)
+    //  Separate self into two parts: the "fraction" -- the piece that we're
+    //  rounding away when we right shift and the provisional shift result,
+    //  which is just a normal (truncating) shift. Also generate the halfway
+    //  point for use in rounding.
+    let lowestKeptBit = (1 as Self) << n
+    let halfway = lowestKeptBit >> 1
+    let fraction = self & (lowestKeptBit - 1)
+    var rounded = self >> n
+    let sticky = fraction != 0
+    //  For simplicity, we separate the positive-or-unsigned path out from
+    //  the negative path for rounding, since many rounding rules are
+    //  implemented differently for negative and positive numbers.
+    if Self.isSigned && self < 0 {
+      switch rule {
+      // .down and .awayFromZero are the same for negative numbers, and are
+      // the natural rounding mode of right shifts, so we need not adjust the
+      // result.
+      case .down, .awayFromZero: break
+      // .up and .towardZero are the same for negative numbers; we need to
+      // increment the result if *any* bit is set in the fraction.
+      case .up, .towardZero: rounded += sticky ? 1 : 0
+      // Since we have a negative number, .toNearestOrAway needs to break ties
+      // (halfway) rounding down; anything bigger rounds up.
+      case .toNearestOrAwayFromZero: if fraction > halfway { rounded += 1 }
+      // .toNearestOrEven doesn't depend on sign at all. Exact halfway cases
+      // round up if and only the provisional result is odd.
+      case .toNearestOrEven:
+        if fraction > halfway { rounded += 1 }
+        else if fraction == halfway { rounded += rounded & 1 }
+      }
+    } else {
+      switch rule {
+      // .down and .towardZero are the same for positive numbers, and are
+      // the natural rounding mode of right shifts, so we need not adjust the
+      // result.
+      case .down, .towardZero: break
+      // .up and .awayFromZero are the same for positive numbers; we need to
+      // increment the result if *any* bit is set in the fraction.
+      case .up, .awayFromZero: rounded += sticky ? 1 : 0
+      // Since we have a positive number, .toNearestOrAway needs to break ties
+      // (halfway) rounding up; anything smaller rounds down.
+      case .toNearestOrAwayFromZero: if fraction >= halfway { rounded += 1 }
+      // .toNearestOrEven doesn't depend on sign at all. Exact halfway cases
+      // round up if and only the provisional result is odd.
+      case .toNearestOrEven:
+        if fraction > halfway { rounded += 1 }
+        else if fraction == halfway { rounded += rounded & 1 }
+      }
+    }
+    return (rounded, !sticky)
+  }
+
+  @_transparent
+  func isDivisible(by divisor: Self) -> Bool { return self % divisor == 0 }
+
+  @_transparent
+  var isEven: Bool { return _lowWord % 2 == 0 }
+
+  @_transparent
+  var isOdd: Bool { return !isEven }
 }
 
 

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2103,16 +2103,42 @@ ${operatorComment(x.nonMaskingOperator, False)}
     return (rounded, !sticky)
   }
 
+  /// Test if this value is exactly divisible by `testDivisor`.
+  ///
+  /// For example:
+  ///
+  /// ~~~~
+  /// 5.isDivisible(by: 2)  // false, because 5 is not twice any integer.
+  /// 21.isDivisible(by: 7) // true, because 21 = 3*7.
+  /// ~~~~
+  ///
+  /// Two edge cases warrant special attention:
+  /// - `x.isDivisible(by: 0)` is `false` for all `x`, even `x == 0`. This is
+  ///   because zero times anything is zero, so there is no *unique* `k`
+  ///   satisfying `0 = k*0`.
+  /// - For signed fixed-width integer types `T`, `T.min.isDivisible(by: -1)`
+  ///   is `true`, even though `T.min / -1` overflows, because the integer
+  ///   `k` exists and is unique; it simply isn't representable as a `T`.
+  ///
+  /// - Parameter testDivisor: the number by which to test for divisibility.
+  /// - Returns: true if a unique integer `k` exists such that `self == k * testDivisor`.
+  ///
+  /// - See also: isEven, isOdd.
   @_transparent
-  func isDivisible(by divisor: Self) -> Bool { return self % divisor == 0 }
+  func isDivisible(by testDivisor: Self) -> Bool {
+    return testDivisor != 0 && self % testDivisor == 0
+  }
 
+  /// True if this value is evenly divisible by two, false otherwise.
+  /// - See also: isDivisible(by:), isOdd
   @_transparent
   var isEven: Bool { return _lowWord % 2 == 0 }
 
+  /// True if this value is not evenly divisible by two, false otherwise.
+  /// - See also: isDivisible(by:), isEven
   @_transparent
   var isOdd: Bool { return !isEven }
 }
-
 
 //===----------------------------------------------------------------------===//
 //===--- CustomStringConvertible conformance ------------------------------===//

--- a/stdlib/public/core/MigrationSupport.swift
+++ b/stdlib/public/core/MigrationSupport.swift
@@ -265,6 +265,9 @@ extension BinaryFloatingPoint {
 @available(*, unavailable, renamed: "FloatingPoint")
 public typealias FloatingPointType = FloatingPoint
 
+@available(swift, deprecated: 5, renamed: "RoundingRule")
+public typealias FloatingPointRoundingRule = RoundingRule
+
 // Swift 3 compatibility APIs
 @available(swift, obsoleted: 4, renamed: "BinaryInteger")
 public typealias Integer = BinaryInteger

--- a/stdlib/public/core/RoundingRule.swift
+++ b/stdlib/public/core/RoundingRule.swift
@@ -1,0 +1,138 @@
+//===--- RoundingRule.swift -----------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A rule for rounding a number to the closest allowed value.
+public enum RoundingRule {
+  /// Round to the closest allowed value; if two values are equally close, the
+  /// one with greater magnitude is chosen.
+  ///
+  /// This rounding rule is also known as "schoolbook rounding." The following
+  /// example shows the results of rounding numbers using this rule:
+  ///
+  ///     (5.2).rounded(.toNearestOrAwayFromZero)
+  ///     // 5.0
+  ///     (5.5).rounded(.toNearestOrAwayFromZero)
+  ///     // 6.0
+  ///     (-5.2).rounded(.toNearestOrAwayFromZero)
+  ///     // -5.0
+  ///     (-5.5).rounded(.toNearestOrAwayFromZero)
+  ///     // -6.0
+  ///
+  /// This rule is equivalent to the C `round` function and implements the
+  /// `roundToIntegralTiesToAway` operation defined by the [IEEE 754
+  /// specification][spec].
+  ///
+  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
+  case toNearestOrAwayFromZero
+  
+  /// Round to the closest allowed value; if two values are equally close, the
+  /// even one is chosen.
+  ///
+  /// This rounding rule is also known as "bankers rounding," and is the
+  /// default IEEE 754 rounding mode for arithmetic. The following example
+  /// shows the results of rounding numbers using this rule:
+  ///
+  ///     (5.2).rounded(.toNearestOrEven)
+  ///     // 5.0
+  ///     (5.5).rounded(.toNearestOrEven)
+  ///     // 6.0
+  ///     (4.5).rounded(.toNearestOrEven)
+  ///     // 4.0
+  ///
+  /// This rule implements the `roundToIntegralTiesToEven` operation defined by
+  /// the [IEEE 754 specification][spec].
+  ///
+  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
+  case toNearestOrEven
+  
+  /// Round to the closest allowed value that is greater than or equal to the
+  /// source.
+  ///
+  /// The following example shows the results of rounding numbers using this
+  /// rule:
+  ///
+  ///     (5.2).rounded(.up)
+  ///     // 6.0
+  ///     (5.5).rounded(.up)
+  ///     // 6.0
+  ///     (-5.2).rounded(.up)
+  ///     // -5.0
+  ///     (-5.5).rounded(.up)
+  ///     // -5.0
+  ///
+  /// This rule is equivalent to the C `ceil` function and implements the
+  /// `roundToIntegralTowardPositive` operation defined by the [IEEE 754
+  /// specification][spec].
+  ///
+  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
+  case up
+  
+  /// Round to the closest allowed value that is less than or equal to the
+  /// source.
+  ///
+  /// The following example shows the results of rounding numbers using this
+  /// rule:
+  ///
+  ///     (5.2).rounded(.down)
+  ///     // 5.0
+  ///     (5.5).rounded(.down)
+  ///     // 5.0
+  ///     (-5.2).rounded(.down)
+  ///     // -6.0
+  ///     (-5.5).rounded(.down)
+  ///     // -6.0
+  ///
+  /// This rule is equivalent to the C `floor` function and implements the
+  /// `roundToIntegralTowardNegative` operation defined by the [IEEE 754
+  /// specification][spec].
+  ///
+  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
+  case down
+  
+  /// Round to the closest allowed value whose magnitude is less than or equal
+  /// to that of the source.
+  ///
+  /// The following example shows the results of rounding numbers using this
+  /// rule:
+  ///
+  ///     (5.2).rounded(.towardZero)
+  ///     // 5.0
+  ///     (5.5).rounded(.towardZero)
+  ///     // 5.0
+  ///     (-5.2).rounded(.towardZero)
+  ///     // -5.0
+  ///     (-5.5).rounded(.towardZero)
+  ///     // -5.0
+  ///
+  /// This rule is equivalent to the C `trunc` function and implements the
+  /// `roundToIntegralTowardZero` operation defined by the [IEEE 754
+  /// specification][spec].
+  ///
+  /// [spec]: http://ieeexplore.ieee.org/servlet/opac?punumber=4610933
+  case towardZero
+  
+  /// Round to the closest allowed value whose magnitude is greater than or
+  /// equal to that of the source.
+  ///
+  /// The following example shows the results of rounding numbers using this
+  /// rule:
+  ///
+  ///     (5.2).rounded(.awayFromZero)
+  ///     // 6.0
+  ///     (5.5).rounded(.awayFromZero)
+  ///     // 6.0
+  ///     (-5.2).rounded(.awayFromZero)
+  ///     // -6.0
+  ///     (-5.5).rounded(.awayFromZero)
+  ///     // -6.0
+  case awayFromZero
+}


### PR DESCRIPTION
This is a first draft of changes to be proposed for adding support for explicit rounding control in integer division, plus some additional functionality that's closely related: rounded right shifts, `.mod(_:)`, `.isEven` and `.isOdd`.

This will require an Evolution proposal, so it should not be merged. This branch exists to let people experiment with the proposed interfaces.