### PR TITLE
Update the ABI for uniquing foreign type metadata

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -1188,144 +1188,6 @@ using ObjCClassWrapperMetadata
 /// us to use.
 template <typename Runtime>
 struct TargetForeignTypeMetadata : public TargetMetadata<Runtime> {
-  using StoredPointer = typename Runtime::StoredPointer;
-  using StoredSize = typename Runtime::StoredSize;
-  using InitializationFunction_t =
-    void (TargetForeignTypeMetadata<Runtime> *selectedMetadata);
-  using RuntimeMetadataPointer =
-      ConstTargetMetadataPointer<Runtime, swift::TargetForeignTypeMetadata>;
-
-  /// An invasive cache for the runtime-uniqued lookup structure that is stored
-  /// in the header prefix of foreign metadata records.
-  ///
-  /// Prior to initialization, as emitted by the compiler, this contains the
-  /// initialization flags.
-  /// After initialization, it holds a pointer to the actual, runtime-uniqued
-  /// metadata for this type.
-  struct CacheValue {
-    StoredSize Value;
-    
-    /// Work around a bug in libstdc++'s std::atomic that requires the type to
-    /// be default-constructible.
-    CacheValue() = default;
-    
-    explicit CacheValue(RuntimeMetadataPointer p)
-      : Value(reinterpret_cast<StoredSize>(p))
-    {}
-
-    /// Various flags. The largest flag bit should be less than 4096 so that
-    /// a flag set is distinguishable from a valid pointer.
-    enum : StoredSize {
-      /// This metadata has an initialization callback function.  If
-      /// this flag is not set, the metadata object needn't actually
-      /// have a InitializationFunction field, and that field will be
-      /// undefined.
-      HasInitializationFunction = 0x1,
-      
-      LargestFlagMask = 0xFFF,
-    };    
-
-    /// True if the metadata record associated with this cache has not been
-    /// initialized, so contains a flag set describing parameters to the
-    /// initialization operation. isFlags() == !isInitialized()
-    bool isFlags() const {
-      return Value <= LargestFlagMask;
-    }
-    /// True if the metadata record associated with this cache has an
-    /// initialization function which must be run if it is picked as the
-    /// canonical metadata record for its key.
-    ///
-    /// Undefined if !isFlags().
-    bool hasInitializationFunction() const {
-      assert(isFlags());
-      return Value & HasInitializationFunction;
-    }
-    
-    /// True if the metadata record associated with this cache has been
-    /// initialized, so the cache contains an absolute pointer to the
-    /// canonical metadata record for its key. isInitialized() == !isFlags()
-    bool isInitialized() const {
-      return !isFlags();
-    }
-    
-    /// Gets the cached pointer to the unique canonical metadata record for
-    /// this metadata record's key.
-    ///
-    /// Undefined if !isInitialized().
-    RuntimeMetadataPointer getCachedUniqueMetadata() const {
-      assert(isInitialized());
-      return RuntimeMetadataPointer(Value);
-    }
-  };
-
-
-  /// Foreign type metadata may have extra header fields depending on
-  /// the flags.
-  struct HeaderPrefix {
-    /// An optional callback performed when a particular metadata object
-    /// is chosen as the unique structure.
-    ///
-    /// If there is no initialization function, this metadata record can be
-    /// assumed to be immutable (except for the \c Unique invasive cache
-    /// field). The field is not present unless the HasInitializationFunction
-    /// flag is set.
-    RelativeDirectPointer<InitializationFunction_t> InitializationFunction;
-    
-    mutable std::atomic<CacheValue> Cache;
-  };
-
-  struct HeaderType : HeaderPrefix, TargetTypeMetadataHeader<Runtime> {};
-
-  CacheValue getCacheValue() const {
-    /// NB: This can be a relaxed-order load if there is no initialization
-    /// function. On platforms Swift currently targets, consume is no more
-    /// expensive than relaxed, so there's no reason to branch here (and LLVM
-    /// isn't smart enough to eliminate it when it's not needed).
-    ///
-    /// A port to a platform where relaxed is significantly less expensive than
-    /// consume (historically, Alpha) would probably want to preserve the
-    /// 'hasInitializationFunction' bit in its own word to be able to avoid
-    /// the consuming load when not needed.
-    return asFullMetadata(this)->Cache
-      .load(SWIFT_MEMORY_ORDER_CONSUME);
-  }
-
-  void setCachedUniqueMetadata(RuntimeMetadataPointer unique) const {
-    auto cache = getCacheValue();
-
-    // If the cache was already set to a pointer, we're done. We ought to
-    // converge on a single unique pointer.
-    if (cache.isInitialized()) {
-      assert(cache.getCachedUniqueMetadata() == unique
-             && "already set unique metadata to something else");
-      return;
-    }
-    
-    auto newCache = CacheValue(unique);
-
-    // If there is no initialization function, this can be a relaxed store.
-    if (cache.hasInitializationFunction())
-      asFullMetadata(this)->Cache.store(newCache, std::memory_order_relaxed);
-    
-    // Otherwise, we need a release store to publish the result of
-    // initialization.
-    else
-      asFullMetadata(this)->Cache.store(newCache, std::memory_order_release);
-  }
-  
-  /// Return the initialization function for this metadata record.
-  ///
-  /// As a prerequisite, the metadata record must not have been initialized yet,
-  /// and must have an initialization function to begin with, otherwise the
-  /// result is undefined.
-  InitializationFunction_t *getInitializationFunction() const {
-#ifndef NDEBUG
-    auto cache = getCacheValue();
-    assert(cache.hasInitializationFunction());
-#endif
-
-    return asFullMetadata(this)->InitializationFunction;
-  }
 };
 using ForeignTypeMetadata = TargetForeignTypeMetadata<InProcess>;
 
@@ -1337,8 +1199,7 @@ using ForeignTypeMetadata = TargetForeignTypeMetadata<InProcess>;
 /// We assume for now that foreign classes are entirely opaque
 /// to Swift introspection.
 template <typename Runtime>
-struct TargetForeignClassMetadata
-  : public TargetForeignTypeMetadata<Runtime> {
+struct TargetForeignClassMetadata : public TargetForeignTypeMetadata<Runtime> {
   using StoredPointer = typename Runtime::StoredPointer;
 
   /// An out-of-line description of the type.
@@ -1348,8 +1209,15 @@ struct TargetForeignClassMetadata
   ConstTargetMetadataPointer<Runtime, swift::TargetForeignClassMetadata>
     Superclass;
 
-  /// Reserved space.  For now, these should be zero-initialized.
-  StoredPointer Reserved[3];
+  /// Reserved space.  For now, this should be zero-initialized.
+  /// If this is used for anything in the future, at least some of these
+  /// first bits should be flags.
+  StoredPointer Reserved[1];
+
+  ConstTargetMetadataPointer<Runtime, TargetClassDescriptor>
+  getDescription() const {
+    return Description;
+  }
 
   static bool classof(const TargetMetadata<Runtime> *metadata) {
     return metadata->getKind() == MetadataKind::ForeignClass;
@@ -3384,6 +3252,15 @@ private:
   }
 };
 
+/// The control structure for performing non-trivial initialization of
+/// singleton foreign metadata.
+template <typename Runtime>
+struct TargetForeignMetadataInitialization {
+  /// The completion function.  The pattern will always be null.
+  TargetRelativeDirectPointer<Runtime, MetadataCompleter, /*nullable*/ true>
+    CompletionFunction;
+};
+
 template <typename Runtime>
 class TargetTypeContextDescriptor
     : public TargetContextDescriptor<Runtime> {
@@ -3407,6 +3284,13 @@ public:
     return TypeContextDescriptorFlags(this->Flags.getKindSpecificFlags());
   }
 
+  /// Return the kind of metadata initialization required by this type.
+  /// Note that this is only meaningful for non-generic types.
+  TypeContextDescriptorFlags::MetadataInitializationKind
+  getMetadataInitialization() const {
+    return getTypeContextDescriptorFlags().getMetadataInitialization();
+  }
+
   /// Does this type have non-trivial "in place" metadata initialization?
   ///
   /// The type of the initialization-control structure differs by subclass,
@@ -3414,6 +3298,16 @@ public:
   bool hasInPlaceMetadataInitialization() const {
     return getTypeContextDescriptorFlags().hasInPlaceMetadataInitialization();
   }
+
+  /// Does this type have "foreign" metadata initialiation?
+  bool hasForeignMetadataInitialization() const {
+    return getTypeContextDescriptorFlags().hasForeignMetadataInitialization();
+  }
+
+  /// Given that this type has foreign metadata initialization, return the
+  /// control structure for it.
+  const TargetForeignMetadataInitialization<Runtime> &
+  getForeignMetadataInitialization() const;
 
   const TargetTypeGenericContextDescriptorHeader<Runtime> &
     getFullGenericContextHeader() const;
@@ -3553,12 +3447,14 @@ class TargetClassDescriptor final
       public TrailingGenericContextObjects<TargetClassDescriptor<Runtime>,
                               TargetTypeGenericContextDescriptorHeader,
                               /*additional trailing objects:*/
+                              TargetForeignMetadataInitialization<Runtime>,
                               TargetVTableDescriptorHeader<Runtime>,
                               TargetMethodDescriptor<Runtime>> {
 private:
   using TrailingGenericContextObjects =
     TrailingGenericContextObjects<TargetClassDescriptor<Runtime>,
                                   TargetTypeGenericContextDescriptorHeader,
+                                  TargetForeignMetadataInitialization<Runtime>,
                                   TargetVTableDescriptorHeader<Runtime>,
                                   TargetMethodDescriptor<Runtime>>;
 
@@ -3569,6 +3465,8 @@ private:
 public:
   using MethodDescriptor = TargetMethodDescriptor<Runtime>;
   using VTableDescriptorHeader = TargetVTableDescriptorHeader<Runtime>;
+  using ForeignMetadataInitialization =
+    TargetForeignMetadataInitialization<Runtime>;
 
   using StoredPointer = typename Runtime::StoredPointer;
   using StoredPointerDifference = typename Runtime::StoredPointerDifference;
@@ -3656,6 +3554,10 @@ private:
   
   using TrailingGenericContextObjects::numTrailingObjects;
 
+  size_t numTrailingObjects(OverloadToken<ForeignMetadataInitialization>) const{
+    return this->hasForeignMetadataInitialization() ? 1 : 0;
+  }
+
   size_t numTrailingObjects(OverloadToken<VTableDescriptorHeader>) const {
     return hasVTable() ? 1 : 0;
   }
@@ -3668,6 +3570,11 @@ private:
   }
 
 public:
+  const ForeignMetadataInitialization &getForeignMetadataInitialization() const{
+    assert(this->hasForeignMetadataInitialization());
+    return *this->template getTrailingObjects<ForeignMetadataInitialization>();
+  }
+
   /// True if metadata records for this type have a field offset vector for
   /// its stored properties.
   bool hasFieldOffsetVector() const { return FieldOffsetVectorOffset != 0; }
@@ -3815,8 +3722,12 @@ class TargetStructDescriptor final
     : public TargetValueTypeDescriptor<Runtime>,
       public TrailingGenericContextObjects<TargetStructDescriptor<Runtime>,
                             TargetTypeGenericContextDescriptorHeader,
+                            /*additional trailing objects*/
+                            TargetForeignMetadataInitialization<Runtime>,
                             TargetInPlaceValueMetadataInitialization<Runtime>> {
 public:
+  using ForeignMetadataInitialization =
+    TargetForeignMetadataInitialization<Runtime>;
   using InPlaceMetadataInitialization =
     TargetInPlaceValueMetadataInitialization<Runtime>;
 
@@ -3824,6 +3735,7 @@ private:
   using TrailingGenericContextObjects =
     TrailingGenericContextObjects<TargetStructDescriptor<Runtime>,
                                   TargetTypeGenericContextDescriptorHeader,
+                                  ForeignMetadataInitialization,
                                   InPlaceMetadataInitialization>;
 
   using TrailingObjects =
@@ -3832,8 +3744,12 @@ private:
 
   template<typename T>
   using OverloadToken = typename TrailingObjects::template OverloadToken<T>;
-
   using TrailingGenericContextObjects::numTrailingObjects;
+
+  size_t numTrailingObjects(OverloadToken<ForeignMetadataInitialization>) const{
+    return this->hasForeignMetadataInitialization() ? 1 : 0;
+  }
+
   size_t numTrailingObjects(OverloadToken<InPlaceMetadataInitialization>) const{
     return this->hasInPlaceMetadataInitialization() ? 1 : 0;
   }
@@ -3856,6 +3772,11 @@ public:
   /// its stored properties.
   bool hasFieldOffsetVector() const { return FieldOffsetVectorOffset != 0; }
 
+  const ForeignMetadataInitialization &getForeignMetadataInitialization() const{
+    assert(this->hasForeignMetadataInitialization());
+    return *this->template getTrailingObjects<ForeignMetadataInitialization>();
+  }
+
   const InPlaceMetadataInitialization &getInPlaceMetadataInitialization() const{
     assert(this->hasInPlaceMetadataInitialization());
     return *this->template getTrailingObjects<InPlaceMetadataInitialization>();
@@ -3877,15 +3798,20 @@ class TargetEnumDescriptor final
     : public TargetValueTypeDescriptor<Runtime>,
       public TrailingGenericContextObjects<TargetEnumDescriptor<Runtime>,
                             TargetTypeGenericContextDescriptorHeader,
+                            /*additional trailing objects*/
+                            TargetForeignMetadataInitialization<Runtime>,
                             TargetInPlaceValueMetadataInitialization<Runtime>> {
 public:
   using InPlaceMetadataInitialization =
     TargetInPlaceValueMetadataInitialization<Runtime>;
+  using ForeignMetadataInitialization =
+    TargetForeignMetadataInitialization<Runtime>;
 
 private:
   using TrailingGenericContextObjects =
     TrailingGenericContextObjects<TargetEnumDescriptor<Runtime>,
                                   TargetTypeGenericContextDescriptorHeader,
+                                  ForeignMetadataInitialization,
                                   InPlaceMetadataInitialization>;
 
   using TrailingObjects =
@@ -3894,8 +3820,12 @@ private:
 
   template<typename T>
   using OverloadToken = typename TrailingObjects::template OverloadToken<T>;
-
   using TrailingGenericContextObjects::numTrailingObjects;
+
+  size_t numTrailingObjects(OverloadToken<ForeignMetadataInitialization>) const{
+    return this->hasForeignMetadataInitialization() ? 1 : 0;
+  }
+
   size_t numTrailingObjects(OverloadToken<InPlaceMetadataInitialization>) const{
     return this->hasInPlaceMetadataInitialization() ? 1 : 0;
   }
@@ -3934,6 +3864,11 @@ public:
 
   static constexpr int32_t getGenericArgumentOffset() {
     return TargetEnumMetadata<Runtime>::getGenericArgumentOffset();
+  }
+
+  const ForeignMetadataInitialization &getForeignMetadataInitialization() const{
+    assert(this->hasForeignMetadataInitialization());
+    return *this->template getTrailingObjects<ForeignMetadataInitialization>();
   }
 
   const InPlaceMetadataInitialization &getInPlaceMetadataInitialization() const{
@@ -4024,6 +3959,24 @@ TargetTypeContextDescriptor<Runtime>::getGenericParams() const {
     return llvm::cast<TargetEnumDescriptor<Runtime>>(this)->getGenericParams();
   case ContextDescriptorKind::Struct:
     return llvm::cast<TargetStructDescriptor<Runtime>>(this)->getGenericParams();
+  default:
+    swift_runtime_unreachable("Not a type context descriptor.");
+  }
+}
+
+template <typename Runtime>
+const TargetForeignMetadataInitialization<Runtime> &
+TargetTypeContextDescriptor<Runtime>::getForeignMetadataInitialization() const {
+  switch (this->getKind()) {
+  case ContextDescriptorKind::Class:
+    return llvm::cast<TargetClassDescriptor<Runtime>>(this)
+        ->getForeignMetadataInitialization();
+  case ContextDescriptorKind::Enum:
+    return llvm::cast<TargetEnumDescriptor<Runtime>>(this)
+        ->getForeignMetadataInitialization();
+  case ContextDescriptorKind::Struct:
+    return llvm::cast<TargetStructDescriptor<Runtime>>(this)
+        ->getForeignMetadataInitialization();
   default:
     swift_runtime_unreachable("Not a type context descriptor.");
   }

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -1268,6 +1268,10 @@ public:
     /// "in-place" code pattern.
     InPlaceMetadataInitialization = 1,
 
+    /// The type requires non-trivial singleton initialization using the
+    /// "foreign" code pattern.
+    ForeignMetadataInitialization = 2,
+
     // We only have two bits here, so if you add a third special kind,
     // include more flag bits in its out-of-line storage.
   };
@@ -1280,6 +1284,10 @@ public:
 
   bool hasInPlaceMetadataInitialization() const {
     return getMetadataInitialization() == InPlaceMetadataInitialization;
+  }
+
+  bool hasForeignMetadataInitialization() const {
+    return getMetadataInitialization() == ForeignMetadataInitialization;
   }
 
   enum ImportNamespaceKind {

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -469,9 +469,10 @@ swift_getObjCClassFromObject(HeapObject *object);
 #endif
 
 /// \brief Fetch a unique type metadata object for a foreign type.
-SWIFT_RUNTIME_EXPORT
-const ForeignTypeMetadata *
-swift_getForeignTypeMetadata(ForeignTypeMetadata *nonUnique);
+SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
+MetadataResponse
+swift_getForeignTypeMetadata(MetadataRequest request,
+                             ForeignTypeMetadata *nonUnique);
 
 /// \brief Fetch a unique witness table for a foreign witness table.
 SWIFT_RUNTIME_EXPORT

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -638,9 +638,9 @@ FUNCTION(GetFunctionMetadata3, swift_getFunctionTypeMetadata3,
         ATTRS(NoUnwind, ReadNone))
 
 // Metadata *swift_getForeignTypeMetadata(Metadata *nonUnique);
-FUNCTION(GetForeignTypeMetadata, swift_getForeignTypeMetadata, C_CC,
-         RETURNS(TypeMetadataPtrTy),
-         ARGS(TypeMetadataPtrTy),
+FUNCTION(GetForeignTypeMetadata, swift_getForeignTypeMetadata, SwiftCC,
+         RETURNS(TypeMetadataResponseTy),
+         ARGS(SizeTy, TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone)) // only writes to runtime-private fields
 
 // WitnessTable *swift_getForeignWitnessTable(

--- a/lib/IRGen/ForeignClassMetadataVisitor.h
+++ b/lib/IRGen/ForeignClassMetadataVisitor.h
@@ -37,16 +37,8 @@ public:
   void layout() {
     super::layout();
     asImpl().addNominalTypeDescriptor();
-    asImpl().noteStartOfSuperClass();
     asImpl().addSuperclass();
     asImpl().addReservedWord();
-    asImpl().addReservedWord();
-    asImpl().addReservedWord();
-  }
-
-  bool requiresInitializationFunction() {
-    return Target->getSuperclassDecl() &&
-           Target->getSuperclassDecl()->isForeign();
   }
 
   CanType getTargetType() const {

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1488,8 +1488,7 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
       return getSILLinkage(FormalLinkage::PublicUnique, forDefinition);
 
     // Imported types.
-    if (getTypeMetadataAccessStrategy(type) ==
-          MetadataAccessStrategy::NonUniqueAccessor)
+    if (isAccessorLazilyGenerated(getTypeMetadataAccessStrategy(type)))
       return SILLinkage::Shared;
 
     // Everything else is only referenced inside its module.
@@ -1507,8 +1506,7 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
     auto type = getType();
 
     // Imported types, non-primitive structural types.
-    if (getTypeMetadataAccessStrategy(type) ==
-          MetadataAccessStrategy::NonUniqueAccessor)
+    if (isAccessorLazilyGenerated(getTypeMetadataAccessStrategy(type)))
       return SILLinkage::Shared;
 
     // Everything else is only referenced inside its module.
@@ -1548,6 +1546,7 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
       return getSILLinkage(FormalLinkage::HiddenUnique, forDefinition);
     case MetadataAccessStrategy::PrivateAccessor:
       return getSILLinkage(FormalLinkage::Private, forDefinition);
+    case MetadataAccessStrategy::ForeignAccessor:
     case MetadataAccessStrategy::NonUniqueAccessor:
       return SILLinkage::Shared;
     }

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -188,6 +188,20 @@ static void emitMetadataCompletionFunction(IRGenModule &IGM,
   IGF.Builder.CreateRet(returnValue);
 }
 
+static bool needsForeignMetadataCompletionFunction(StructDecl *decl) {
+  // Currently, foreign structs never need a completion function.
+  return false;
+}
+
+static bool needsForeignMetadataCompletionFunction(EnumDecl *decl) {
+  // Currently, foreign enums never need a completion function.
+  return false;
+}
+
+static bool needsForeignMetadataCompletionFunction(ClassDecl *decl) {
+  return decl->hasSuperclass();
+}
+
 /*****************************************************************************/
 /** Nominal Type Descriptor Emission *****************************************/
 /*****************************************************************************/
@@ -695,16 +709,17 @@ namespace {
     }
   };
 
-  template<class Impl>
+  template<class Impl, class DeclType>
   class TypeContextDescriptorBuilderBase
     : public ContextDescriptorBuilderBase<Impl> {
   
     using super = ContextDescriptorBuilderBase<Impl>;
   
   protected:
-    NominalTypeDecl *Type;
+    DeclType *Type;
     RequireMetadata_t HasMetadata;
-    bool HasInPlaceMetadataInitialization;
+    TypeContextDescriptorFlags::MetadataInitializationKind
+      MetadataInitialization;
     
     using super::IGM;
     using super::B;
@@ -713,12 +728,11 @@ namespace {
   public:
     using super::addGenericSignature;
   
-    TypeContextDescriptorBuilderBase(IRGenModule &IGM, NominalTypeDecl *Type,
+    TypeContextDescriptorBuilderBase(IRGenModule &IGM, DeclType *Type,
                                      RequireMetadata_t requireMetadata)
       : super(IGM), Type(Type),
         HasMetadata(requireMetadata),
-        HasInPlaceMetadataInitialization(
-                                    computeHasInPlaceMetadataInitialization()) {
+        MetadataInitialization(computeMetadataInitialization()) {
     }
     
     void layout() {
@@ -728,7 +742,7 @@ namespace {
       // ABI TODO: layout info should be superseded by remote mirror metadata
       asImpl().addLayoutInfo();
       asImpl().addGenericSignature();
-      asImpl().maybeAddInPlaceMetadataInitialization();
+      asImpl().maybeAddMetadataInitialization();
     }
     
     void addName() {
@@ -738,7 +752,8 @@ namespace {
       // Use the original name with tag for synthesized decls. The tag comes
       // after the null terminator for the name.
       if (auto *synthesizedTypeAttr =
-            Type->getAttrs().getAttribute<ClangImporterSynthesizedTypeAttr>()) {
+            Type->getAttrs()
+                 .template getAttribute<ClangImporterSynthesizedTypeAttr>()) {
         nameBuf.append(synthesizedTypeAttr->originalTypeName);
         nameBuf.push_back('\0');
         nameBuf.append(synthesizedTypeAttr->getManglingName());
@@ -758,16 +773,28 @@ namespace {
     }
       
     void addAccessFunction() {
-      // Don't emit the access function if we're only lazily emitting the
-      // context descriptor.
+      llvm::Constant *accessor;
+
+      // Don't include an access function if we're emitting the context
+      // descriptor without metadata.
       if (!HasMetadata) {
-        B.addInt32(0);
-        return;
+        accessor = nullptr;
+
+      // If it's a generic type, use the generic access function.
+      // This has a different prototype from an ordinary function, but
+      // the runtime knows to check for that.
+      } else if (Type->isGenericContext()) {
+        accessor = getGenericTypeMetadataAccessFunction(IGM, Type,
+                                                        NotForDefinition);
+
+      // Otherwise, use the ordinary access function, which we'll define
+      // when we emit the metadata.
+      } else {
+        CanType type = Type->getDeclaredType()->getCanonicalType();
+        accessor = getOtherwiseDefinedTypeMetadataAccessFunction(IGM, type);
       }
     
-      llvm::Constant *accessFn =
-        getRequiredTypeMetadataAccessFunction(IGM, Type, NotForDefinition);
-      B.addRelativeAddressOrNull(accessFn);
+      B.addRelativeAddressOrNull(accessor);
     }
     
     ConstantReference getParent() {
@@ -831,7 +858,8 @@ namespace {
     /// Flags to indicate Clang-imported declarations so we mangle them
     /// consistently at runtime.
     void setClangImportedFlags(TypeContextDescriptorFlags &flags) {
-      if (Type->getAttrs().getAttribute<ClangImporterSynthesizedTypeAttr>()) {
+      if (Type->getAttrs()
+               .template getAttribute<ClangImporterSynthesizedTypeAttr>()) {
         flags.setIsSynthesizedRelatedEntity(true);
       }
       
@@ -845,41 +873,75 @@ namespace {
       }
     }
 
-    bool computeHasInPlaceMetadataInitialization() {
+    TypeContextDescriptorFlags::MetadataInitializationKind
+    computeMetadataInitialization() {
       // Not if we don't have metadata.
       if (!HasMetadata)
-        return false;
+        return TypeContextDescriptorFlags::NoMetadataInitialization;
+
+      // Generic types use their own system.
+      if (Type->isGenericContext())
+        return TypeContextDescriptorFlags::NoMetadataInitialization;
+
+      // Check for foreign metadata.
+      if (requiresForeignTypeMetadata(Type))
+        return TypeContextDescriptorFlags::ForeignMetadataInitialization;
+
+      // The only other option is in-place initialization.
 
       // Only struct and enums for now.  Classes currently use an eager
       // mechanism that doesn't properly support recursive dependencies, so
       // their equivalent of in-place initialization does not yet use this
       // infrastructure.
       if (!isa<StructDecl>(Type) && !isa<EnumDecl>(Type))
-        return false;
+        return TypeContextDescriptorFlags::NoMetadataInitialization;
 
-      return needsInPlaceMetadataInitialization(IGM, Type);
-    }
+      if (needsInPlaceMetadataInitialization(IGM, Type))
+        return TypeContextDescriptorFlags::InPlaceMetadataInitialization;
 
-    bool hasInPlaceMetadataInitialization() {
-      return HasInPlaceMetadataInitialization;
+      return TypeContextDescriptorFlags::NoMetadataInitialization;
     }
 
     void setMetadataInitializationKind(TypeContextDescriptorFlags &flags) {
-      if (HasInPlaceMetadataInitialization) {
-        flags.setMetadataInitialization(
-                     TypeContextDescriptorFlags::InPlaceMetadataInitialization);
-      }
+      flags.setMetadataInitialization(MetadataInitialization);
     }
 
-    void maybeAddInPlaceMetadataInitialization() {
-      if (!HasInPlaceMetadataInitialization)
+    void maybeAddMetadataInitialization() {
+      switch (MetadataInitialization) {
+      case TypeContextDescriptorFlags::NoMetadataInitialization:
         return;
 
+      case TypeContextDescriptorFlags::ForeignMetadataInitialization:
+        asImpl().addForeignMetadataInitialization();
+        return;
+
+      case TypeContextDescriptorFlags::InPlaceMetadataInitialization:
+        asImpl().addInPlaceMetadataInitialization();
+        return;
+      }
+      llvm_unreachable("bad kind");
+    }
+
+    void addInPlaceMetadataInitialization() {
       if (isa<StructDecl>(Type) || isa<EnumDecl>(Type)) {
         asImpl().addInPlaceValueMetadataInitialization();
       } else {
         llvm_unreachable("unexpected type allowing in-place initialization");
       }
+    }
+
+    /// Add a ForeignMetadataInitialization structure to the descriptor.
+    void addForeignMetadataInitialization() {
+      llvm::Constant *completionFunction = nullptr;
+      if (asImpl().needsForeignMetadataCompletionFunction()) {
+        completionFunction =
+          IGM.getAddrOfTypeMetadataCompletionFunction(Type, NotForDefinition);
+      }
+      B.addRelativeAddressOrNull(completionFunction);
+    }
+
+    bool needsForeignMetadataCompletionFunction() {
+      return ::needsForeignMetadataCompletionFunction(Type);
     }
 
     /// Add an InPlaceValueMetadataInitialization structure to the descriptor.
@@ -975,7 +1037,8 @@ namespace {
 
 
   class StructContextDescriptorBuilder
-    : public TypeContextDescriptorBuilderBase<StructContextDescriptorBuilder>
+    : public TypeContextDescriptorBuilderBase<StructContextDescriptorBuilder,
+                                              StructDecl>
   {
     using super = TypeContextDescriptorBuilderBase;
   
@@ -1024,7 +1087,8 @@ namespace {
   };
   
   class EnumContextDescriptorBuilder
-    : public TypeContextDescriptorBuilderBase<EnumContextDescriptorBuilder>
+    : public TypeContextDescriptorBuilderBase<EnumContextDescriptorBuilder,
+                                              EnumDecl>
   {
     using super = TypeContextDescriptorBuilderBase;
   
@@ -1082,7 +1146,8 @@ namespace {
   };
   
   class ClassContextDescriptorBuilder
-    : public TypeContextDescriptorBuilderBase<ClassContextDescriptorBuilder>,
+    : public TypeContextDescriptorBuilderBase<ClassContextDescriptorBuilder,
+                                              ClassDecl>,
       public SILVTableVisitor<ClassContextDescriptorBuilder>
   {
     using super = TypeContextDescriptorBuilderBase;
@@ -2365,8 +2430,7 @@ namespace {
       assert(!Target->isGenericContext());
       auto type =cast<ClassType>(Target->getDeclaredType()->getCanonicalType());
 
-      (void) getTypeMetadataAccessFunction(IGM, type, ForDefinition,
-                                           CacheStrategy::Lazy,
+      (void) createTypeMetadataAccessFunction(IGM, type, CacheStrategy::Lazy,
       [&](IRGenFunction &IGF, DynamicMetadataRequest request,
           llvm::Constant *cacheVar) -> MetadataResponse {
         // There's an interesting special case where we can do the
@@ -2842,32 +2906,6 @@ namespace {
   };
 }
 
-static llvm::Value *
-emitOnceValueTypeMetadataInitialization(IRGenFunction &IGF,
-                                        CanNominalType type,
-                                        llvm::Value *metadata,
-                                   MetadataDependencyCollector *collector) {
-  // All the value types are basically similar, as are foreign types.
-  assert(isa<StructType>(type) || isa<EnumType>(type) ||
-         IGF.IGM.requiresForeignTypeMetadata(type));
-
-  // Set up the value witness table if it's dependent.
-  SILType loweredType = IGF.IGM.getLoweredType(AbstractionPattern(type), type);
-  auto &ti = IGF.IGM.getTypeInfo(loweredType);
-  if (!ti.isFixedSize()) {
-    loweredType = loweredType.getAddressType();
-    if (isa<StructType>(type)) {
-      emitInitializeFieldOffsetVector(IGF, loweredType, metadata, true,
-                                      collector);
-    } else if (isa<EnumType>(type)) {
-      auto &strategy = getEnumImplStrategy(IGF.IGM, loweredType);
-      strategy.initializeMetadata(IGF, metadata, true, loweredType, collector);
-    }
-  }
-
-  return metadata;
-}
-
 /// Create an access function for the given type which triggers the
 /// in-place initialization path.
 static void
@@ -2876,11 +2914,11 @@ createInPlaceInitializationMetadataAccessFunction(IRGenModule &IGM,
                                                   CanType type) {
   assert(!typeDecl->isGenericContext());
 
-  (void) getTypeMetadataAccessFunction(IGM, type, ForDefinition,
-                                       CacheStrategy::InPlaceInitialization,
-                                       [&](IRGenFunction &IGF,
-                                           DynamicMetadataRequest request,
-                                           llvm::Constant *cacheVariable) {
+  (void) createTypeMetadataAccessFunction(IGM, type,
+                                          CacheStrategy::InPlaceInitialization,
+                                          [&](IRGenFunction &IGF,
+                                              DynamicMetadataRequest request,
+                                              llvm::Constant *cacheVariable) {
     llvm::Value *descriptor =
       IGF.IGM.getAddrOfTypeContextDescriptor(typeDecl, RequireMetadata);
     auto responsePair =
@@ -2904,7 +2942,7 @@ static void createNonGenericMetadataAccessFunction(IRGenModule &IGM,
 
   // Otherwise, use the lazy pattern, which should be emitted using a
   // direct reference to the metadata.
-  (void) getTypeMetadataAccessFunction(IGM, type, ForDefinition);
+  createDirectTypeMetadataAccessFunction(IGM, type, /*allow existing*/ false);
 }
 
 
@@ -3423,6 +3461,7 @@ namespace {
 
   protected:
     using super::IGM;
+    using super::Target;
     using super::asImpl;
     using super::B;
 
@@ -3430,90 +3469,53 @@ namespace {
     ForeignMetadataBuilderBase(T &&...args) : super(std::forward<T>(args)...) {}
 
     Size AddressPoint = Size::invalid();
+    bool CanBeConstant = true;
 
   public:
-    void layout() {
-      if (asImpl().requiresInitializationFunction())
-        asImpl().addInitializationFunction();
-      asImpl().addForeignFlags();
-      super::layout();
-    }
-    
-    void addForeignFlags() {
-      int64_t flags = 0;
-      if (asImpl().requiresInitializationFunction()) flags |= 1;
-      B.addInt(IGM.IntPtrTy, flags);
-    }
-
-    void addForeignName() {
-      CanType targetType = asImpl().getTargetType();
-      IRGenMangler mangler;
-      std::string Name =
-        mangler.mangleTypeForForeignMetadataUniquing(targetType);
-      llvm::Constant *nameStr = IGM.getAddrOfGlobalString(Name,
-                                                 /*relatively addressed*/ true);
-      B.addRelativeAddress(nameStr);
-    }
-
-    void addInitializationFunction() {
-      auto type = cast<NominalType>(asImpl().getTargetType());
-
-      auto fnTy = llvm::FunctionType::get(IGM.VoidTy, {IGM.TypeMetadataPtrTy},
-                                          /*variadic*/ false);
-      llvm::Function *fn = llvm::Function::Create(fnTy,
-                                           llvm::GlobalValue::PrivateLinkage,
-                                           Twine("initialize_metadata_")
-                                             + type->getDecl()->getName().str(),
-                                           &IGM.Module);
-      fn->setAttributes(IGM.constructInitialAttributes());
-      
-      // Set up the function.
-      IRGenFunction IGF(IGM, fn);
-      if (IGM.DebugInfo)
-        IGM.DebugInfo->emitArtificialFunction(IGF, fn);
-
-      // Emit the initialization.
-      llvm::Value *metadata = IGF.collectParameters().claimNext();
-      asImpl().emitInitialization(IGF, metadata);
-
-      IGF.Builder.CreateRetVoid();
-
-      B.addRelativeAddress(fn);
-      
-      // Keep pointer alignment on 64-bit platforms for further fields.
-      switch (IGM.getPointerSize().getValue()) {
-      case 4:
-        break;
-      case 8:
-        B.addInt32(0);
-        break;
-      default:
-        llvm_unreachable("unsupported word size");
-      }
-    }
-    
     void noteAddressPoint() {
       AddressPoint = B.getNextOffsetFromGlobal();
+    }
+
+    bool canBeConstant() {
+      return CanBeConstant;
     }
 
     Size getOffsetOfAddressPoint() const { return AddressPoint; }
 
     void createMetadataAccessFunction() {
+      if (asImpl().needsMetadataCompletionFunction())
+        asImpl().createMetadataCompletionFunction();
+
       auto type = cast<NominalType>(asImpl().getTargetType());
 
-      (void) getTypeMetadataAccessFunction(IGM, type, ForDefinition,
-                                           CacheStrategy::Lazy,
-                                           [&](IRGenFunction &IGF,
-                                               DynamicMetadataRequest request,
-                                               llvm::Constant *cacheVariable) {
-        return emitOnceTypeMetadataAccessFunctionBody(IGF, type, cacheVariable,
-          [&](IRGenFunction &IGF, llvm::Value *candidate) {
-            MetadataDependencyCollector *collector = nullptr;
-            auto metadata = uniqueForeignTypeMetadataRef(IGF, candidate);
-            return emitOnceValueTypeMetadataInitialization(IGF, type,
-                                                              metadata,
-                                                              collector);
-          });
+      (void) createTypeMetadataAccessFunction(IGM, type, CacheStrategy::Lazy,
+                                              [&](IRGenFunction &IGF,
+                                                  DynamicMetadataRequest request,
+                                                llvm::Constant *cacheVariable) {
+        auto candidate = IGF.IGM.getAddrOfForeignTypeMetadataCandidate(type);
+        auto call = IGF.Builder.CreateCall(IGF.IGM.getGetForeignTypeMetadataFn(),
+                                           {request.get(IGF), candidate});
+        call->addAttribute(llvm::AttributeList::FunctionIndex,
+                           llvm::Attribute::NoUnwind);
+        call->addAttribute(llvm::AttributeList::FunctionIndex,
+                           llvm::Attribute::ReadNone);
+
+        return MetadataResponse::handle(IGF, request, call);
+      });
+    }
+
+    bool needsMetadataCompletionFunction() {
+      return needsForeignMetadataCompletionFunction(Target);
+    }
+
+    void createMetadataCompletionFunction() {
+      // Note that we can't call this until we've finished laying out the
+      // metadata because otherwise we'll try to reenter when we ask for
+      // the metadata candidate.
+      emitMetadataCompletionFunction(IGM, Target,
+        [&](IRGenFunction &IGF, llvm::Value *metadata,
+            MetadataDependencyCollector *collector) {
+        asImpl().emitInitializeMetadata(IGF, metadata, collector);
       });
     }
   };
@@ -3538,24 +3540,20 @@ namespace {
                                 ConstantStructBuilder &B)
       : ForeignMetadataBuilderBase(IGM, target, B) {}
 
-    void emitInitialization(IRGenFunction &IGF, llvm::Value *metadata) {
-      // Dig out the address of the superclass field.
-      auto &layout = IGF.IGM.getForeignMetadataLayout(Target);
-      Address metadataWords(IGF.Builder.CreateBitCast(metadata,
-                                                      IGM.Int8PtrPtrTy),
-                            IGM.getPointerAlignment());
-      auto superclassField =
-        createPointerSizedGEP(IGF, metadataWords,
-                              layout.getSuperClassOffset().getStaticOffset());
-      superclassField =
-        IGF.Builder.CreateBitCast(
-                          superclassField,
-                          llvm::PointerType::get(IGM.TypeMetadataPtrTy, 0));
+    void emitInitializeMetadata(IRGenFunction &IGF, llvm::Value *metadata,
+                                MetadataDependencyCollector *collector) {
+      // Emit a reference to the superclass.
+      auto superclass = IGF.emitAbstractTypeMetadataRef(
+                                   Target->getSuperclass()->getCanonicalType());
 
-      // Unique the superclass field and write it back.
-      auto superclass = IGF.Builder.CreateLoad(superclassField);
-      auto uniquedSuperclass = uniqueForeignTypeMetadataRef(IGF, superclass);
-      IGF.Builder.CreateStore(uniquedSuperclass, superclassField);
+      // Dig out the address of the superclass field and store.
+      auto &layout = IGF.IGM.getForeignMetadataLayout(Target);
+      Address addr(metadata, IGM.getPointerAlignment());
+      addr = IGF.Builder.CreateElementBitCast(addr, IGM.TypeMetadataPtrTy);
+      auto superclassField =
+        createPointerSizedGEP(IGF, addr,
+                              layout.getSuperClassOffset().getStaticOffset());
+      IGF.Builder.CreateStore(superclass, superclassField);
     }
 
     // Visitor methods.
@@ -3580,21 +3578,15 @@ namespace {
       B.add(descriptor);
     }
 
-    void noteStartOfSuperClass() { }
-
     void addSuperclass() {
-      auto superclassDecl = Target->getSuperclassDecl();
-      if (!superclassDecl || !superclassDecl->isForeign()) {
-        B.addNullPointer(IGM.TypeMetadataPtrTy);
-        return;
-      }
+      // Always leave the superclass pointer unfilled.  We'll have to
+      // unique it during initialization anyway, so we might as well spare
+      // ourselves the load-time work.
+      B.addNullPointer(IGM.TypeMetadataPtrTy);
 
-      auto superclassType =
-        superclassDecl->swift::TypeDecl::getDeclaredInterfaceType()
-          ->getCanonicalType();
-      auto superclass =
-        IGM.getAddrOfForeignTypeMetadataCandidate(superclassType);
-      B.add(superclass);
+      // But remember if we might need to change it.
+      if (Target->hasSuperclass())
+        CanBeConstant = false;
     }
 
     void addReservedWord() {
@@ -3616,10 +3608,9 @@ namespace {
       return Target->getDeclaredType()->getCanonicalType();
     }
 
-    bool requiresInitializationFunction() const {
-      return false;
+    void createMetadataCompletionFunction() {
+      llvm_unreachable("foreign structs never require completion");
     }
-    void emitInitialization(IRGenFunction &IGF, llvm::Value *metadata) {}
 
     void addValueWitnessTable() {
       B.add(emitValueWitnessTable());
@@ -3644,10 +3635,9 @@ namespace {
       return Target->getDeclaredType()->getCanonicalType();
     }
 
-    bool requiresInitializationFunction() const {
-      return false;
+    void createMetadataCompletionFunction() {
+      llvm_unreachable("foreign enums never require completion");
     }
-    void emitInitialization(IRGenFunction &IGF, llvm::Value *metadata) {}
 
     void addValueWitnessTable() {
       B.add(emitValueWitnessTable());
@@ -3659,23 +3649,27 @@ namespace {
   };
 } // end anonymous namespace
 
-bool IRGenModule::requiresForeignTypeMetadata(CanType type) {
+bool irgen::requiresForeignTypeMetadata(CanType type) {
   if (NominalTypeDecl *nominal = type->getAnyNominal()) {
-    if (auto *clas = dyn_cast<ClassDecl>(nominal)) {
-      switch (clas->getForeignClassKind()) {
-      case ClassDecl::ForeignKind::Normal:
-      case ClassDecl::ForeignKind::RuntimeOnly:
-        return false;
-      case ClassDecl::ForeignKind::CFType:
-        return true;
-      }
-      llvm_unreachable("bad foreign class kind");
-    }
-
-    return isa<ClangModuleUnit>(nominal->getModuleScopeContext());
+    return requiresForeignTypeMetadata(nominal);
   }
 
   return false;
+}
+
+bool irgen::requiresForeignTypeMetadata(NominalTypeDecl *decl) {
+  if (auto *clas = dyn_cast<ClassDecl>(decl)) {
+    switch (clas->getForeignClassKind()) {
+    case ClassDecl::ForeignKind::Normal:
+    case ClassDecl::ForeignKind::RuntimeOnly:
+      return false;
+    case ClassDecl::ForeignKind::CFType:
+      return true;
+    }
+    llvm_unreachable("bad foreign class kind");
+  }
+
+  return isa<ClangModuleUnit>(decl->getModuleScopeContext());
 }
 
 llvm::Constant *
@@ -3692,6 +3686,7 @@ IRGenModule::getAddrOfForeignTypeMetadataCandidate(CanType type) {
 
   // Local function to create the global variable for the foreign type
   // metadata candidate.
+  bool canBeConstant;
   Size addressPoint;
   llvm::Constant *result = nullptr;
   auto createCandidateVariable = [&] {
@@ -3703,6 +3698,7 @@ IRGenModule::getAddrOfForeignTypeMetadataCandidate(CanType type) {
         createVariable(*this, link, definition.getType(),
                        getPointerAlignment());
     definition.installInGlobal(var);
+    var->setConstant(canBeConstant);
 
     // Apply the offset.
     result = llvm::ConstantExpr::getBitCast(var, Int8PtrTy);
@@ -3724,6 +3720,7 @@ IRGenModule::getAddrOfForeignTypeMetadataCandidate(CanType type) {
     ForeignClassMetadataBuilder builder(*this, classDecl, init);
     builder.layout();
     addressPoint = builder.getOffsetOfAddressPoint();
+    canBeConstant = builder.canBeConstant();
 
     createCandidateVariable();
     builder.createMetadataAccessFunction();
@@ -3736,6 +3733,7 @@ IRGenModule::getAddrOfForeignTypeMetadataCandidate(CanType type) {
     ForeignStructMetadataBuilder builder(*this, structDecl, init);
     builder.layout();
     addressPoint = builder.getOffsetOfAddressPoint();
+    canBeConstant = builder.canBeConstant();
 
     createCandidateVariable();
     builder.createMetadataAccessFunction();
@@ -3746,6 +3744,7 @@ IRGenModule::getAddrOfForeignTypeMetadataCandidate(CanType type) {
     ForeignEnumMetadataBuilder builder(*this, enumDecl, init);
     builder.layout();
     addressPoint = builder.getOffsetOfAddressPoint();
+    canBeConstant = builder.canBeConstant();
 
     createCandidateVariable();
     builder.createMetadataAccessFunction();
@@ -3760,8 +3759,7 @@ IRGenModule::getAddrOfForeignTypeMetadataCandidate(CanType type) {
   if (auto enclosing = type->getNominalParent()) {
     auto canonicalEnclosing = enclosing->getCanonicalType();
     if (requiresForeignTypeMetadata(canonicalEnclosing)) {
-      (void)getTypeMetadataAccessFunction(*this, canonicalEnclosing,
-                                          ForDefinition);
+      (void)getAddrOfForeignTypeMetadataCandidate(canonicalEnclosing);
     }
   }
 

--- a/lib/IRGen/GenMeta.h
+++ b/lib/IRGen/GenMeta.h
@@ -47,6 +47,9 @@ namespace irgen {
   class StructLayout;
   struct ClassLayout;
 
+  bool requiresForeignTypeMetadata(CanType type);
+  bool requiresForeignTypeMetadata(NominalTypeDecl *decl);
+
   /// Emit the metadata associated with the given class declaration.
   void emitClassMetadata(IRGenModule &IGM, ClassDecl *theClass,
                          const StructLayout &layout,

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2226,19 +2226,7 @@ void IRGenModule::emitSILWitnessTable(SILWitnessTable *wt) {
   // Trigger the lazy emission of the foreign type metadata.
   CanType conformingType = conf->getType()->getCanonicalType();
   if (requiresForeignTypeMetadata(conformingType)) {
-    // Make sure we emit the metadata access function.
-    (void)getTypeMetadataAccessFunction(*this, conformingType,
-                                        ForDefinition);
-
-    // Make sure we emit the nominal type descriptor.
-    auto *nominal = conformingType->getAnyNominal();
-    auto entity = LinkEntity::forNominalTypeDescriptor(nominal);
-    if (auto entry = GlobalVars[entity]) {
-      if (!cast<llvm::GlobalValue>(entry)->isDeclaration())
-        return;
-    }
-
-    emitLazyTypeContextDescriptor(*this, nominal, RequireMetadata);
+    (void)getAddrOfForeignTypeMetadataCandidate(conformingType);
   }
 }
 

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1170,9 +1170,6 @@ public:
                                                ForDefinition_t forDefinition);
   llvm::Constant *getAddrOfForeignTypeMetadataCandidate(CanType concreteType);
 
-  /// Determine whether the given type requires foreign type metadata.
-  bool requiresForeignTypeMetadata(CanType type);
-
   llvm::Constant *getAddrOfClassMetadataBounds(ClassDecl *D,
                                                ForDefinition_t forDefinition);
   llvm::Constant *getAddrOfTypeContextDescriptor(NominalTypeDecl *D,

--- a/lib/IRGen/MetadataLayout.cpp
+++ b/lib/IRGen/MetadataLayout.cpp
@@ -613,8 +613,9 @@ ForeignClassMetadataLayout::ForeignClassMetadataLayout(IRGenModule &IGM,
             ForeignClassMetadataLayout &layout)
       : super(IGM, decl), Layout(layout) {}
 
-    void noteStartOfSuperClass() {
+    void addSuperclass() {
       Layout.SuperClassOffset = getNextOffset();
+      super::addSuperclass();
     }
 
     void layout() {

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -231,13 +231,6 @@ namespace {
       return { metadata, state };
     }
 
-    static const TypeContextDescriptor *getDescription(Metadata *type) {
-      if (auto classType = dyn_cast<ClassMetadata>(type))
-        return classType->getDescription();
-      else
-        return cast<ValueMetadata>(type)->getDescription();
-    }
-
     TryInitializeResult tryInitialize(Metadata *metadata,
                                       PrivateMetadataState state,
                                PrivateMetadataCompletionContext *context) {
@@ -246,7 +239,8 @@ namespace {
       // Finish the completion function.
       if (state < PrivateMetadataState::NonTransitiveComplete) {
         // Find a pattern.  Currently we always use the default pattern.
-        auto &generics = getDescription(metadata)->getFullGenericContextHeader();
+        auto &generics = metadata->getTypeContextDescriptor()
+                                 ->getFullGenericContextHeader();
         auto pattern = generics.DefaultInstantiationPattern.get();
 
         // Complete the metadata's instantiation.
@@ -580,10 +574,6 @@ namespace {
 
       auto state = inferStateForMetadata(metadata);
       return { metadata, state };
-    }
-
-    static const TypeContextDescriptor *getDescription(Metadata *type) {
-      return cast<ValueMetadata>(type)->getDescription();
     }
 
     TryInitializeResult tryInitialize(Metadata *metadata,
@@ -1611,6 +1601,37 @@ swift::swift_getTupleTypeMetadata3(MetadataRequest request,
 /***************************************************************************/
 /*** Nominal type descriptors **********************************************/
 /***************************************************************************/
+
+namespace {
+  /// A class encapsulating everything interesting about the identity of
+  /// a type context *except* the identity of the parent context.
+  class TypeContextIdentity {
+    StringRef Name;
+  public:
+    explicit TypeContextIdentity(const TypeContextDescriptor *type) {
+      // Use the name of the type context.
+      Name = type->Name.get();
+
+      // If this is a synthesized entity, include the related entity tag.
+      if (type->isSynthesizedRelatedEntity()) {
+        auto tag = type->getSynthesizedDeclRelatedEntityTag();
+        assert(Name.end() + 1 == tag.begin());
+
+        // The length computation needs to include the \0 at the
+        // end of the name.
+        Name = StringRef(Name.begin(), Name.size() + tag.size() + 1);
+      }
+    }
+
+    bool operator==(const TypeContextIdentity &other) const {
+      return Name == other.Name;
+    }
+    int compare(const TypeContextIdentity &other) const {
+      return Name.compare(other.Name);
+    }
+  };
+}
+
 bool swift::equalContexts(const ContextDescriptor *a,
                           const ContextDescriptor *b)
 {
@@ -1651,20 +1672,7 @@ bool swift::equalContexts(const ContextDescriptor *a,
         && kind <= ContextDescriptorKind::Type_Last) {
       auto typeA = cast<TypeContextDescriptor>(a);
       auto typeB = cast<TypeContextDescriptor>(b);
-      if (strcmp(typeA->Name.get(), typeB->Name.get()) != 0)
-        return false;
-      
-      // A synthesized entity has to match the related entity tag too.
-      if (typeA->isSynthesizedRelatedEntity()) {
-        if (!typeB->isSynthesizedRelatedEntity())
-          return false;
-        
-        if (typeA->getSynthesizedDeclRelatedEntityTag()
-            != typeB->getSynthesizedDeclRelatedEntityTag())
-          return false;
-      }
-      
-      return true;
+      return TypeContextIdentity(typeA) == TypeContextIdentity(typeB);
     }
     
     // Otherwise, this runtime doesn't know anything about this context kind.
@@ -3108,147 +3116,122 @@ OpaqueValue *swift::swift_assignExistentialWithCopy(OpaqueValue *dest,
 /*** Foreign types *********************************************************/
 /***************************************************************************/
 
-namespace {
-  /// A reference to a context descriptor, used as a uniquing key.
-  struct ContextDescriptorKey {
-    const TypeContextDescriptor *Data;
-  };
-} // end anonymous namespace
-
-template <>
-struct llvm::DenseMapInfo<ContextDescriptorKey> {
-  static ContextDescriptorKey getEmptyKey() {
-    return ContextDescriptorKey{(const TypeContextDescriptor*) 0};
-  }
-  static ContextDescriptorKey getTombstoneKey() {
-    return ContextDescriptorKey{(const TypeContextDescriptor*) 1};
-  }
-  static unsigned getHashValue(ContextDescriptorKey val) {
-    if ((uintptr_t)val.Data <= 1) {
-      return llvm::hash_value(val.Data);
-    }
-
-    // Hash by name.
-    // In full generality, we'd get a better hash by walking up the entire
-    // descriptor tree and hashing names all along the way, and we'd be faster
-    // if we special cased unique keys by hashing pointers. In practice, this
-    // is only used to unique foreign metadata records, which only ever appear
-    // in the "C" or "ObjC" special context, and are never unique.
-    
-    // llvm::hash_value(StringRef) is, unfortunately, defined out of
-    // line in a library we otherwise would not need to link against.
-    StringRef name(val.Data->Name.get());
-    return llvm::hash_combine_range(name.begin(), name.end());
-  }
-  static bool isEqual(ContextDescriptorKey lhs, ContextDescriptorKey rhs) {
-    if ((uintptr_t)lhs.Data <= 1 || (uintptr_t)rhs.Data <= 1) {
-      return lhs.Data == rhs.Data;
-    }
-    return equalContexts(lhs.Data, rhs.Data);
-  }
-};
-
 // We use a DenseMap over what are essentially StringRefs instead of a
 // StringMap because we don't need to actually copy the string.
 namespace {
-struct ForeignTypeState {
-  Mutex Lock;
-  ConditionVariable InitializationWaiters;
-  llvm::DenseMap<ContextDescriptorKey, const ForeignTypeMetadata *> Types;
-};
-} // end anonymous namespace
 
-static Lazy<ForeignTypeState> ForeignTypes;
+static const TypeContextDescriptor *
+getForeignTypeDescription(Metadata *metadata) {
+  if (auto foreignClass = dyn_cast<ForeignClassMetadata>(metadata))
+    return foreignClass->getDescription();
+  return cast<ValueMetadata>(metadata)->getDescription();
+}
 
-const ForeignTypeMetadata *
-swift::swift_getForeignTypeMetadata(ForeignTypeMetadata *nonUnique) {
-  // Fast path: check the invasive cache.
-  auto cache = nonUnique->getCacheValue();
-  if (cache.isInitialized()) {
-    return cache.getCachedUniqueMetadata();
+class ForeignMetadataCacheEntry
+  : public MetadataCacheEntryBase<ForeignMetadataCacheEntry, /*spurious*/ int> {
+
+  Metadata *Value;
+
+  friend MetadataCacheEntryBase;
+  ValueType getValue() {
+    return Value;
+  }
+  void setValue(ValueType value) {
+    swift_runtime_unreachable("should never be called");
   }
 
-  // Okay, check the global map.
-  auto &foreignTypes = ForeignTypes.get();
-  ContextDescriptorKey key{nonUnique->getTypeContextDescriptor()};
-  assert(key.Data
-         && "all foreign metadata should have a type context descriptor");
-  bool hasInit = cache.hasInitializationFunction();
+public:
+  static const char *getName() { return "ForeignMetadataCache"; }
 
-  const ForeignTypeMetadata *uniqueMetadata;
-  bool inserted;
+  template <class... Args>
+  ForeignMetadataCacheEntry(const TypeContextDescriptor *description,
+                            MetadataRequest request, Metadata *candidate)
+      : Value(candidate) {
+    // Remember that the metadata is still just a candidate until this
+    // is actually successfully installed in the concurrent map.
 
-  // A helper function to find the current entry for the key using the
-  // saved iterator if it's still valid.  This should only be called
-  // while the lock is held.
-  decltype(foreignTypes.Types.begin()) savedIterator;
-  size_t savedSize = 0;
-  auto getCurrentEntry = [&]() -> const ForeignTypeMetadata *& {
-    // The iterator may have been invalidated if the size of the map
-    // has changed since the last lookup.
-    if (foreignTypes.Types.size() != savedSize) {
-      savedSize = foreignTypes.Types.size();
-      savedIterator = foreignTypes.Types.find(key);
-      assert(savedIterator != foreignTypes.Types.end() &&
-             "entries cannot be removed from foreign types metadata map");
-    }
-    return savedIterator->second;
-  };
+    auto &init = description->getForeignMetadataInitialization();
 
-  {
-    ScopedLock guard(foreignTypes.Lock);
-
-    // Try to create an entry in the map.  The initial value of the entry
-    // is our copy of the metadata unless it has an initialization function,
-    // in which case we have to insert null as a placeholder to tell others
-    // to wait while we call the initializer.
-    auto valueToInsert = (hasInit ? nullptr : nonUnique);
-    auto insertResult = foreignTypes.Types.insert({key, valueToInsert});
-    inserted = insertResult.second;
-    savedIterator = insertResult.first;
-    savedSize = foreignTypes.Types.size();
-    uniqueMetadata = savedIterator->second;
-
-    // If we created the entry, then the unique metadata is our copy.
-    if (inserted) {
-      uniqueMetadata = nonUnique;
-
-    // If we didn't create the entry, but it's null, then we have to wait
-    // until it becomes non-null.
+    PrivateMetadataState state;
+    if (!init.CompletionFunction) {
+      if (areAllTransitiveMetadataComplete_cheap(candidate)) {
+        state = PrivateMetadataState::Complete;
+      } else {
+        state = PrivateMetadataState::NonTransitiveComplete;
+      }
     } else {
-      while (uniqueMetadata == nullptr) {
-        foreignTypes.Lock.wait(foreignTypes.InitializationWaiters);
-        uniqueMetadata = getCurrentEntry();
+      state = inferStateForMetadata(candidate);
+    }
+
+    flagAllocatedDuringConstruction(state);
+  }
+
+  enum : bool { MayFlagAllocatedDuringConstruction = true };
+
+  const TypeContextDescriptor *getDescription() const {
+    return getForeignTypeDescription(Value);
+  }
+
+  template <class... Args>
+  static size_t numTrailingObjects(OverloadToken<int>, Args &&...) {
+    return 0;
+  }
+
+  intptr_t getKeyIntValueForDump() const {
+    return reinterpret_cast<intptr_t>(getDescription()->Name.get());
+  }
+
+  int compareWithKey(const TypeContextDescriptor *key) const {
+    // We can just compare unparented type-context identities because
+    // we assume that foreign types don't have interesting parenting
+    // structure.
+    return TypeContextIdentity(key)
+             .compare(TypeContextIdentity(getDescription()));
+  }
+
+  AllocationResult allocate(Metadata *candidate) {
+    swift_runtime_unreachable(
+                        "always flags allocation complete during construction");
+  }
+
+  TryInitializeResult tryInitialize(Metadata *metadata,
+                                    PrivateMetadataState state,
+                                    PrivateMetadataCompletionContext *ctxt) {
+    assert(state != PrivateMetadataState::Complete);
+
+    // Finish the completion function.
+    auto &init = getDescription()->getForeignMetadataInitialization();
+    if (init.CompletionFunction) {
+      // Try to complete the metadata's instantiation.
+      auto dependency =
+        init.CompletionFunction(metadata, &ctxt->Public, nullptr);
+
+      // If this failed with a dependency, infer the current metadata state
+      // and return.
+      if (dependency) {
+        return { inferStateForMetadata(metadata), dependency };
       }
     }
+
+    // Check for transitive completeness.
+    if (auto dependency = checkTransitiveCompleteness(metadata)) {
+      return { PrivateMetadataState::NonTransitiveComplete, dependency };
+    }
+
+    // We're done.
+    return { PrivateMetadataState::Complete, MetadataDependency() };
   }
+};
 
-  // If we inserted the entry and there's an initialization function,
-  // call it.  This has to be done with the lock dropped.
-  if (inserted && hasInit) {
-    nonUnique->getInitializationFunction()(nonUnique);
+} // end anonymous namespace
 
-    // Update the cache entry:
+static Lazy<MetadataCache<ForeignMetadataCacheEntry, false>> ForeignMetadata;
 
-    //   - Reacquire the lock.
-    ScopedLock guard(foreignTypes.Lock);
-
-    //   - Change the entry.
-    auto &entry = getCurrentEntry();
-    assert(entry == nullptr);
-    entry = nonUnique;
-
-    //   - Notify waiters.
-    foreignTypes.InitializationWaiters.notifyAll();
-  }
-
-  // Remember the unique result in the invasive cache.  We don't want
-  // to do this until after the initialization completes; otherwise,
-  // it will be possible for code to fast-path through this function
-  // too soon.
-  nonUnique->setCachedUniqueMetadata(uniqueMetadata);
-
-  return uniqueMetadata;
+MetadataResponse
+swift::swift_getForeignTypeMetadata(MetadataRequest request,
+                                    ForeignTypeMetadata *candidate) {
+  auto description = getForeignTypeDescription(candidate);
+  return ForeignMetadata->getOrInsert(description, request, candidate).second;
 }
 
 /// Unique-ing of foreign types' witness tables.
@@ -3639,16 +3622,25 @@ static Result performOnMetadataCache(const Metadata *metadata,
     if (tupleMetadata->NumElements == 0)
       return std::move(callbacks).forOtherMetadata(tupleMetadata);
     return std::move(callbacks).forTupleMetadata(tupleMetadata);
+  } else if (auto foreignClass = dyn_cast<ForeignClassMetadata>(metadata)) {
+    return std::move(callbacks).forForeignMetadata(foreignClass,
+                                                foreignClass->getDescription());
   } else {
     return std::move(callbacks).forOtherMetadata(metadata);
   }
 
   if (!description->isGeneric()) {
-    if (description->hasInPlaceMetadataInitialization()) {
+    switch (description->getMetadataInitialization()) {
+    case TypeContextDescriptorFlags::NoMetadataInitialization:
+      return std::move(callbacks).forOtherMetadata(metadata);
+
+    case TypeContextDescriptorFlags::ForeignMetadataInitialization:
+      return std::move(callbacks).forForeignMetadata(metadata, description);
+
+    case TypeContextDescriptorFlags::InPlaceMetadataInitialization:
       return std::move(callbacks).forInPlaceMetadata(description);
     }
-
-    return std::move(callbacks).forOtherMetadata(metadata);
+    swift_runtime_unreachable("bad metadata initialization kind");
   }
 
   auto &generics = description->getFullGenericContextHeader();
@@ -3676,6 +3668,11 @@ bool swift::addToMetadataQueue(MetadataCompletionQueueEntry *queueEntry,
       return cache.enqueue(key, QueueEntry, Dependency);
     }
 
+    bool forForeignMetadata(const Metadata *metadata,
+                            const TypeContextDescriptor *description) {
+      return ForeignMetadata.get().enqueue(description, QueueEntry, Dependency);
+    }
+
     bool forInPlaceMetadata(const TypeContextDescriptor *description) && {
       return InPlaceMetadata.get().enqueue(description, QueueEntry, Dependency);
     }
@@ -3701,6 +3698,11 @@ void swift::resumeMetadataCompletion(MetadataCompletionQueueEntry *queueEntry) {
                             GenericMetadataCache &cache,
                             MetadataCacheKey key) && {
       cache.resumeInitialization(key, QueueEntry);
+    }
+
+    void forForeignMetadata(const Metadata *metadata,
+                            const TypeContextDescriptor *description) {
+      ForeignMetadata.get().resumeInitialization(description, QueueEntry);
     }
 
     void forInPlaceMetadata(const TypeContextDescriptor *description) && {
@@ -3731,6 +3733,11 @@ MetadataResponse swift::swift_checkMetadataState(MetadataRequest request,
                                       GenericMetadataCache &cache,
                                       MetadataCacheKey key) && {
       return cache.await(key, Request);
+    }
+
+    MetadataResponse forForeignMetadata(const Metadata *metadata,
+                            const TypeContextDescriptor *description) {
+      return ForeignMetadata.get().await(description, Request);
     }
 
     MetadataResponse forInPlaceMetadata(
@@ -3778,6 +3785,14 @@ static bool findAnyTransitiveMetadata(const Metadata *type, T &&predicate) {
 
     return false;
 
+  // Foreign classes require their superclass to be transitively complete.
+  } else if (auto foreignClassType = dyn_cast<ForeignClassMetadata>(type)) {
+    if (auto super = foreignClassType->Superclass) {
+      if (predicate(super))
+        return true;
+    }
+    return false;
+
   // Other types do not have transitive completeness requirements.
   } else {
     return false;
@@ -3809,7 +3824,7 @@ static bool findAnyTransitiveMetadata(const Metadata *type, T &&predicate) {
 /// Do a quick check to see if all the transitive type metadata are complete.
 static bool
 areAllTransitiveMetadataComplete_cheap(const Metadata *type) {
-  // Look for any transitive metadata that's incomplete.
+  // Look for any transitive metadata that's *incomplete*.
   return !findAnyTransitiveMetadata(type, [](const Metadata *type) {
     struct IsIncompleteCallbacks {
       bool forGenericMetadata(const Metadata *type,
@@ -3819,6 +3834,17 @@ areAllTransitiveMetadataComplete_cheap(const Metadata *type) {
         // Metadata cache lookups aren't really cheap enough for this
         // optimization.
         return true;
+      }
+
+      bool forForeignMetadata(const Metadata *metadata,
+                              const TypeContextDescriptor *description) {
+        // If the type doesn't have a completion function, we can assume
+        // it's transitively complete by construction.
+        if (!description->getForeignMetadataInitialization().CompletionFunction)
+          return false;
+
+        // TODO: it might be worth doing a quick check against the cache here.
+        return false;
       }
 
       bool forInPlaceMetadata(const TypeContextDescriptor *description) && {
@@ -3981,6 +4007,11 @@ checkMetadataDependency(MetadataDependency dependency) {
                                           GenericMetadataCache &cache,
                                           MetadataCacheKey key) && {
       return cache.checkDependency(key, Requirement);
+    }
+
+    MetadataDependency forForeignMetadata(const Metadata *metadata,
+                                    const TypeContextDescriptor *description) {
+      return ForeignMetadata.get().checkDependency(description, Requirement);
     }
 
     MetadataDependency forInPlaceMetadata(

--- a/test/IRGen/cf.sil
+++ b/test/IRGen/cf.sil
@@ -9,26 +9,19 @@
 // CHECK: [[MUTABLE_REFRIGERATOR:%TSo24CCMutableRefrigeratorRefa]] = type
 // CHECK: [[OBJC:%objc_object]] = type
 
-// CHECK-32: @"$SSo17CCRefrigeratorRefaN" = linkonce_odr hidden global <{ {{.*}} }> <{
-// CHECK-32-SAME: i32 0,
-// CHECK-32-SAME: i8** @"$SBOWV", i32 16, {{.*}}"$SSo17CCRefrigeratorRefaMn", [[TYPE]]* null, i8* null, i8* null, i8* null }>
-
-// CHECK-64: @"$SSo17CCRefrigeratorRefaN" = linkonce_odr hidden global <{ {{.*}} }> <{
-// CHECK-64-SAME: i64 0,
-// CHECK-64-SAME: i8** @"$SBOWV", i64 16, {{.*}}"$SSo17CCRefrigeratorRefaMn", [[TYPE]]* null, i8* null, i8* null, i8* null }>
+// CHECK: @"$SSo17CCRefrigeratorRefaN" = linkonce_odr hidden constant <{ {{.*}} }> <{ i8** @"$SBOWV", [[INT]] 16, {{.*}}"$SSo17CCRefrigeratorRefaMn", [[TYPE]]* null, i8* null }>
 
 // CHECK: [[MUTABLE_REFRIGERATOR_NAME:@.*]] = private constant [25 x i8] c"CCMutableRefrigeratorRef\00"
 
 // CHECK-64: @"$SSo24CCMutableRefrigeratorRefaMn" = linkonce_odr hidden constant
-// -- is imported C typedef, is class, is nonunique
-// CHECK-64-SAME: <i32 0x0011_0010>
+// -- is imported C typedef, foreign init, reflectable, is class, is nonunique
+// CHECK-64-SAME: <i32 0x0015_0010>
 // CHECK-64-SAME: [[MUTABLE_REFRIGERATOR_NAME]]
+// CHECK-64-SAME: @"$SSo24CCMutableRefrigeratorRefaMa"
+// CHECK-64-SAME: @"$SSo24CCMutableRefrigeratorRefaMr"
 
 // CHECK-64: @"$SSo24CCMutableRefrigeratorRefaN" = linkonce_odr hidden global <{ {{.*}} }> <{
-// CHECK-64-SAME: @initialize_metadata_CCMutableRefrigerator
-// CHECK-64-SAME: i32 0,
-// CHECK-64-SAME: i64 1,
-// CHECK-64-SAME: i8** @"$SBOWV", i64 16, {{.*}}"$SSo24CCMutableRefrigeratorRefaMn", [[TYPE]]* bitcast{{.*}}@"$SSo17CCRefrigeratorRefaN{{.*}} to %swift.type*), i8* null, i8* null, i8* null }>
+// CHECK-64-SAME: i8** @"$SBOWV", i64 16, {{.*}}"$SSo24CCMutableRefrigeratorRefaMn", %swift.type* null, i8* null }>
 
 sil_stage canonical
 
@@ -46,7 +39,8 @@ bb0(%0 : $CCRefrigerator, %1: $CCMutableRefrigerator):
   return %5 : $()
 }
 
-// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @call_generic([[REFRIGERATOR]]*, [[MUTABLE_REFRIGERATOR]]*) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @call_generic
+// CHECK-SAME:    ([[REFRIGERATOR]]*, [[MUTABLE_REFRIGERATOR]]*) {{.*}} {
 // CHECK:      [[T0:%.*]] = bitcast [[REFRIGERATOR]]* %0 to [[OBJC]]*
 // CHECK-NEXT: [[T1:%.*]] = call swiftcc %swift.metadata_response @"$SSo17CCRefrigeratorRefaMa"([[INT]] 0)
 // CHECK-NEXT: [[T2:%.*]] = extractvalue %swift.metadata_response [[T1]], 0
@@ -57,14 +51,15 @@ bb0(%0 : $CCRefrigerator, %1: $CCMutableRefrigerator):
 // CHECK-NEXT: call swiftcc void @generic_function([[OBJC]]* [[T0]], [[TYPE]]* [[T2]])
 // CHECK-NEXT: ret void
 
-// CHECK:    define linkonce_odr hidden swiftcc %swift.metadata_response @"$SSo17CCRefrigeratorRefaMa"(
-// CHECK-32:    call [[TYPE]]* @swift_getForeignTypeMetadata([[TYPE]]* bitcast (i8* getelementptr inbounds (i8, i8* bitcast ({{.*}}* @"$SSo17CCRefrigeratorRefaN" to i8*), i32 8) to [[TYPE]]*))
-// CHECK-64:    call [[TYPE]]* @swift_getForeignTypeMetadata([[TYPE]]* bitcast (i8* getelementptr inbounds (i8, i8* bitcast ({{.*}}* @"$SSo17CCRefrigeratorRefaN" to i8*), i64 16) to [[TYPE]]*))
+// CHECK-LABEL:    define linkonce_odr hidden swiftcc %swift.metadata_response @"$SSo17CCRefrigeratorRefaMa"(
+// CHECK-32:      call swiftcc %swift.metadata_response @swift_getForeignTypeMetadata([[INT]] %0, [[TYPE]]* bitcast (i8* getelementptr inbounds (i8, i8* bitcast ({{.*}}* @"$SSo17CCRefrigeratorRefaN" to i8*), [[INT]] 4) to [[TYPE]]*))
+// CHECK-64:      call swiftcc %swift.metadata_response @swift_getForeignTypeMetadata([[INT]] %0, [[TYPE]]* bitcast (i8* getelementptr inbounds (i8, i8* bitcast ({{.*}}* @"$SSo17CCRefrigeratorRefaN" to i8*), [[INT]] 8) to [[TYPE]]*))
 
-// CHECK:    define private void @initialize_metadata_CCMutableRefrigerator(%swift.type*)
-// CHECK-64:   [[T0:%.*]] = bitcast %swift.type* %0 to i8**
-// CHECK-64:   [[T1:%.*]] = getelementptr inbounds i8*, i8** [[T0]], i32 2
-// CHECK-64:   [[T2:%.*]] = bitcast i8** [[T1]] to %swift.type**
-// CHECK-64:   [[T3:%.*]] = load %swift.type*, %swift.type** [[T2]]
-// CHECK-64:   [[T4:%.*]] = call %swift.type* @swift_getForeignTypeMetadata(%swift.type* [[T3]])
-// CHECK-64:  store %swift.type* [[T4]], %swift.type** [[T2]]
+// CHECK-LABEL:    define internal swiftcc %swift.metadata_response @"$SSo24CCMutableRefrigeratorRefaMr"(%swift.type*, i8*, i8**)
+// CHECK:      [[T0:%.*]] = call swiftcc %swift.metadata_response @"$SSo17CCRefrigeratorRefaMa"([[INT]] 255)
+// CHECK-NEXT: [[T1:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
+// CHECK-NEXT: extractvalue %swift.metadata_response [[T0]], 1
+// CHECK-NEXT: [[T2:%.*]] = bitcast %swift.type* %0 to %swift.type**
+// CHECK-NEXT: [[T3:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T2]], i32 2
+// CHECK-NEXT: store %swift.type* [[T1]], %swift.type** [[T3]], align
+// CHECK-NEXT: ret %swift.metadata_response zeroinitializer

--- a/test/IRGen/foreign_types.sil
+++ b/test/IRGen/foreign_types.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -I %S/Inputs/abi %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -I %S/Inputs/abi %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize
 
 sil_stage canonical
 import c_layout
@@ -15,8 +15,7 @@ import c_layout
 // CHECK-SAME: [[AMAZING_COLOR_NAME]]
 // CHECK-SAME: @"$SSo12AmazingColorVMa"
 
-// CHECK-LABEL: @"$SSo14HasNestedUnionV18__Unnamed_struct_sVN" = linkonce_odr hidden global
-// CHECK-SAME:  [[INT:i[0-9]+]] 0,
+// CHECK-LABEL: @"$SSo14HasNestedUnionV18__Unnamed_struct_sVN" = linkonce_odr hidden constant
 // CHECK-SAME:  @"$SSo14HasNestedUnionV18__Unnamed_struct_sVWV"
 // CHECK-SAME:  [[INT]] 1,
 // CHECK-SAME:  @"$SSo14HasNestedUnionV18__Unnamed_struct_sVMn"
@@ -38,7 +37,7 @@ bb0:
 }
 
 // CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$SSo14HasNestedUnionVMa"(
-// CHECK: call %swift.type* @swift_getForeignTypeMetadata{{.*}}$SSo14HasNestedUnionVN
+// CHECK: call swiftcc %swift.metadata_response @swift_getForeignTypeMetadata([[INT]] %0, {{.*}}$SSo14HasNestedUnionVN
 
 // CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$SSo12AmazingColorVMa"(
-// CHECK: call %swift.type* @swift_getForeignTypeMetadata{{.*}}@"$SSo12AmazingColorVN"
+// CHECK: call swiftcc %swift.metadata_response @swift_getForeignTypeMetadata([[INT]] %0, {{.*}}@"$SSo12AmazingColorVN"

--- a/test/IRGen/objc.swift
+++ b/test/IRGen/objc.swift
@@ -23,7 +23,7 @@ import gizmo
 // CHECK: @"\01L_selector(bar)" = private externally_initialized global i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"\01L_selector_data(bar)", i64 0, i64 0), section "__DATA,__objc_selrefs,literal_pointers,no_dead_strip", align 8
 
 // CHECK: @"$SSo4RectVMn" = linkonce_odr hidden constant
-// CHECK: @"$SSo4RectVN" = linkonce_odr hidden global
+// CHECK: @"$SSo4RectVN" = linkonce_odr hidden constant
 
 // CHECK: @"\01L_selector_data(acquiesce)"
 // CHECK-NOT: @"\01L_selector_data(disharmonize)"
@@ -130,7 +130,7 @@ func test10(_ g: Gizmo, r: Rect) {
 func test11_helper<T>(_ t: T) {}
 // NSRect's metadata needs to be uniqued at runtime using getForeignTypeMetadata.
 // CHECK-LABEL: define hidden swiftcc void @"$S4objc6test11yySo4RectVF"
-// CHECK:         call %swift.type* @swift_getForeignTypeMetadata({{.*}} @"$SSo4RectVN"
+// CHECK:         call swiftcc %swift.metadata_response @swift_getForeignTypeMetadata(i64 %0, {{.*}} @"$SSo4RectVN"
 func test11(_ r: Rect) { test11_helper(r) }
 
 class WeakObjC {

--- a/test/IRGen/objc_ns_enum.swift
+++ b/test/IRGen/objc_ns_enum.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop
@@ -10,7 +10,7 @@ import gizmo
 
 // CHECK: @"$SSo16NSRuncingOptionsVWV" = linkonce_odr hidden constant
 // CHECK: @"$SSo16NSRuncingOptionsVMn" = linkonce_odr hidden constant
-// CHECK: @"$SSo16NSRuncingOptionsVN" = linkonce_odr hidden global
+// CHECK: @"$SSo16NSRuncingOptionsVN" = linkonce_odr hidden constant
 // CHECK: @"$SSo16NSRuncingOptionsVSQSCMc" = linkonce_odr hidden constant %swift.protocol_conformance_descriptor { {{.*}}@"$SSo16NSRuncingOptionsVSQSCWa
 // CHECK: @"$SSo28NeverActuallyMentionedByNameVSQSCWp" = linkonce_odr hidden constant
 
@@ -87,11 +87,11 @@ func use_metadata<T: Equatable>(_ t:T){}
 use_metadata(NSRuncingOptions.mince)
 
 // CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$SSo16NSRuncingOptionsVMa"(i64)
-// CHECK:         call %swift.type* @swift_getForeignTypeMetadata({{.*}} @"$SSo16NSRuncingOptionsVN" {{.*}}) [[NOUNWIND_READNONE:#[0-9]+]]
+// CHECK:         call swiftcc %swift.metadata_response @swift_getForeignTypeMetadata([[INT]] %0, {{.*}} @"$SSo16NSRuncingOptionsVN" {{.*}}) [[NOUNWIND_READNONE:#[0-9]+]]
 
 // CHECK-LABEL: define linkonce_odr hidden i8** @"$SSo16NSRuncingOptionsVSQSCWa"()
 // CHECK:  [[NONUNIQUE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$SSo16NSRuncingOptionsVSQSCWG", %swift.type* null, i8*** null)
-// CHECK:  [[UNIQUE:%.*]] = call i8** @swift_getForeignWitnessTable(i8** [[NONUNIQUE]], %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32 }>* @"$SSo16NSRuncingOptionsVMn" to %swift.type_descriptor*), %swift.protocol* @"$SSQMp")
+// CHECK:  [[UNIQUE:%.*]] = call i8** @swift_getForeignWitnessTable(i8** [[NONUNIQUE]], %swift.type_descriptor* bitcast (<{ i32, i32, i32, i32, i32, i32, i32 }>* @"$SSo16NSRuncingOptionsVMn" to %swift.type_descriptor*), %swift.protocol* @"$SSQMp")
 // CHECK:  ret i8** [[UNIQUE]]
 
 @objc enum ExportedToObjC: Int {


### PR DESCRIPTION
- `swift_getForeignTypeMetadata` is now a request/response function.

- The initialization function is now a completion function, and the pointer to it has moved into the type descriptor.

- The cache variable is no longer part of the ABI; it's an implementation detail of the access function.

- The two points above mean that there is no special header on foreign type metadata and therefore that they can be marked constant when there isn't something about them that needs to be initialized.

The only foreign-metadata initialization we actually do right now is of the superclass field of a foreign class, and since that relationship is a proper DAG, it's not actually possible to have recursive initialization problems.  But this is the right long-term thing to do, and it removes one of the last two clients of once-based initialization.

I'm calling this part of SR-7876 despite it not actually resolving any real problems because it *is* part of the finishing-recursive-metadata project.