### PR TITLE
[Sema] Quick conditional conformance associated type inference fix

### DIFF
--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -176,6 +176,13 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
   InferredAssociatedTypesByWitnesses result;
 
   auto isExtensionUsableForInference = [&](ExtensionDecl *extension) -> bool {
+
+    // The extension where the conformance being checked is declared.
+    auto conformanceExtension = checker.Conformance->
+      getDeclContext()->getAsDeclOrDeclExtensionContext();
+    if (extension == conformanceExtension)
+      return true;
+
     // Assume unconstrained concrete extensions we found witnesses in are
     // always viable.
     if (!extension->getExtendedType()->isAnyExistentialType()) {

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -413,3 +413,15 @@ extension Array: NestedArrayProtocol where Element: ElementProtocol, Element: Ar
   // with the typealias uncommented you do not get a crash.
   // typealias BaseElement = Element.BaseElement
 }
+
+// SR-8337
+struct Foo<Bar> {}
+
+protocol P {
+  associatedtype A
+  var foo: Foo<A> { get }
+}
+
+extension Foo: P where Bar: P {
+  var foo: Foo { return self }
+}


### PR DESCRIPTION
Always allow the extension where a conformance is declared to be checked for witnesses to that conformance.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-8337](https://bugs.swift.org/browse/SR-8337).

(Previously the code in that bug failed because `isExtensionUsableForInference()` returned false just after the added check since it is constrained. Presumably when the TODO for 'is as specialized as'  gets implemented it would be equally specialized and this identity test could be reverted, if desired.)