### PR TITLE
[AutoDiff] Make differential operators able to take a non-escaping function

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -720,7 +720,8 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
       // either as the callee or as an argument (in which case, the typechecker
       // validates that the noescape bit didn't get stripped off), or as
       // a special case, e.g. in the binding of a withoutActuallyEscaping block
-      // or the argument of a type(of: ...).
+      // or the argument of a type(of: ...) or a differential operator such as
+      // #gradient(...).
       if (parent) {
         if (auto apply = dyn_cast<ApplyExpr>(parent)) {
           if (isa<ParamDecl>(DRE->getDecl()) && useKind == OperandKind::Callee)
@@ -734,7 +735,8 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
           // SWIFT_ENABLE_TENSORFLOW
         } else if (auto *ole = dyn_cast<ObjectLiteralExpr>(parent)) {
           if (ole->isTFOp()) return;
-        } else if (isa<DynamicTypeExpr>(parent)) {
+        } else if (isa<DynamicTypeExpr>(parent) ||
+                   isa<ReverseAutoDiffExpr>(parent)) {
           return;
         }
 

--- a/test/AutoDiff/gradient_expr_type_checking.swift
+++ b/test/AutoDiff/gradient_expr_type_checking.swift
@@ -84,3 +84,11 @@ func daddFloatingPoint<T : FloatingPoint>(_ x: T, _ y: T) -> (T, T) {
 func daddFloatingPointWithValue<T : FloatingPoint>(_ x: T, _ y: T) -> (value: T, gradient: (T, T)) {
   return #valueAndGradient(addNumeric)(x, y) // ok
 }
+
+var gloablFn: (Float) -> Float
+
+func noescapeArgument(_ f: (Float) -> Float) {
+  let dfdx = #gradient(f) // okay
+  // expected-error @+1 {{invalid conversion from non-escaping function of type '(Float) -> Float' to potentially escaping function type '(Float) -> Float'}}
+  gloablFn = dfdx
+}


### PR DESCRIPTION
Passing a non-escaping function to a differential operator like `#gradient` should be allowed, just like `type(of:)`