### PR TITLE
[Frontend] Track SwiftOnoneSupport as a system dependency

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -141,8 +141,6 @@ public:
     EmitObject,   ///< Emit object file
   };
 
-  bool isCreatingSIL() { return RequestedAction >= ActionType::EmitSILGen; }
-
   /// Indicates the action the user requested that the frontend perform.
   ActionType RequestedAction = ActionType::NoneAction;
 
@@ -310,6 +308,7 @@ private:
   static bool canActionEmitInterface(ActionType);
 
 public:
+  static bool doesActionRunSILPasses(ActionType);
   static bool doesActionProduceOutput(ActionType);
   static bool doesActionProduceTextualOutput(ActionType);
   static bool needsProperModuleName(ActionType);

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -454,6 +454,39 @@ bool FrontendOptions::doesActionProduceTextualOutput(ActionType action) {
   }
 }
 
+bool FrontendOptions::doesActionRunSILPasses(ActionType action) {
+  switch (action) {
+  case ActionType::NoneAction:
+  case ActionType::Parse:
+  case ActionType::ResolveImports:
+  case ActionType::Typecheck:
+  case ActionType::DumpParse:
+  case ActionType::DumpInterfaceHash:
+  case ActionType::EmitSyntax:
+  case ActionType::DumpAST:
+  case ActionType::PrintAST:
+  case ActionType::DumpScopeMaps:
+  case ActionType::DumpTypeRefinementContexts:
+  case ActionType::EmitImportedModules:
+  case ActionType::EmitPCH:
+  case ActionType::EmitSILGen:
+    return false;
+  case ActionType::EmitSIL:
+  case ActionType::EmitModuleOnly:
+  case ActionType::MergeModules:
+  case ActionType::EmitSIBGen:
+  case ActionType::EmitSIB:
+  case ActionType::Immediate:
+  case ActionType::REPL:
+  case ActionType::EmitAssembly:
+  case ActionType::EmitIR:
+  case ActionType::EmitBC:
+  case ActionType::EmitObject:
+    return true;
+  }
+}
+
+
 const PrimarySpecificPaths &
 FrontendOptions::getPrimarySpecificPathsForAtMostOnePrimary() const {
   return InputsAndOutputs.getPrimarySpecificPathsForAtMostOnePrimary();

--- a/test/Frontend/dependencies.swift
+++ b/test/Frontend/dependencies.swift
@@ -59,6 +59,8 @@
 
 // CHECK-IMPORT-TRACK-SYSTEM-LABEL: - :
 // CHECK-IMPORT-TRACK-SYSTEM: dependencies.swift
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: Swift.swiftmodule
+// CHECK-IMPORT-TRACK-SYSTEM-DAG: SwiftOnoneSupport.swiftmodule
 // CHECK-IMPORT-TRACK-SYSTEM-DAG: CoreFoundation.swift
 // CHECK-IMPORT-TRACK-SYSTEM-DAG: CoreGraphics.swift
 // CHECK-IMPORT-TRACK-SYSTEM-DAG: Foundation.swift


### PR DESCRIPTION
SwiftOnoneSupport is an implicit dependency of no-opt builds that is usually only loaded when frontend actions that emit optimization-sensitive outputs are run.

Force the implicit dependency to be explicit when -track-system-dependencies is used.