### PR TITLE
WIP [Sema] Allow for pruning arbitrary subexpressions from the constraint system

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7814,6 +7814,9 @@ namespace {
     }
 
     std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
+      if (Rewriter.cs.prunedSubexpressions.count(expr))
+        return { false, expr };
+
       // For closures, update the parameter types and check the body.
       if (auto closure = dyn_cast<ClosureExpr>(expr)) {
         Rewriter.simplifyExprType(expr);

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -919,6 +919,8 @@ public:
   //         was created in.
   llvm::DenseMap<Constraint *, unsigned> DisjunctionNumber;
 
+  llvm::SmallPtrSet<Expr *, 4> prunedSubexpressions;
+
 private:
 
   /// \brief Allocator used for all of the related constraint systems.


### PR DESCRIPTION
A bit of infrastructure so that the constraint generation walker and solution application walker can be told not to descend into arbitrary subexpressions.

Then for array literals, if the type is specified up front, and individually type checking an element matches that expected element type, then prune that element subexpression from the constraint system. 

Resolves [SR-8314](https://bugs.swift.org/browse/SR-8314).

Could use some clean up and needs tests, but makes a huge difference for large statically typed arrays. On my machine (w/ debug swift):

before:
./swiftc slow_swift_compilation.swift  364.33s user 4.24s system 99% cpu 6:09.02 total
after:
./swiftc slow_swift_compilation.swift  16.48s user 0.15s system 99% cpu 16.648 total

Does this seem like a reasonable approach? Are there issues with this direction that I'm not thinking of?