### PR TITLE
[AutoDiff] Significantly improve differentiation diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -354,6 +354,8 @@ ERROR(pound_assert_failure,none,
        "%0", (StringRef))
 
 // Automatic differentiation diagnostics
+ERROR(autodiff_internal_swift_not_imported,none,
+      "AD internal error: the Swift module is not imported", ())
 ERROR(autodiff_opaque_function_unsupported,none,
       "differentiating an opaque function is not supported yet", ())
 ERROR(autodiff_cannot_synthesize_primal_yet,none,
@@ -363,16 +365,11 @@ ERROR(autodiff_unsupported_type,none,
       "differentiating '%0' is not supported yet", (Type))
 ERROR(autodiff_function_not_differentiable,none,
       "function is not differentiable", ())
-ERROR(autodiff_differential_operator_applied_to_nondifferentiable,none,
-      "applying differential operator on a non-differentiable function", ())
-ERROR(autodiff_differentiable_attr_applied_to_nondifferentiable,none,
-      "This function is not differentiable but marked "
-      "'@differentiable(reverse)', would you like to make it differentiable by "
-      "defining a custom adjoint using '@differentiable(reverse, adjoint:)'?",
-      ())
-NOTE(autodiff_when_differentiating_function_call, none,
+NOTE(autodiff_value_defined_here,none,
+     "value defined here", ())
+NOTE(autodiff_when_differentiating_function_call,none,
      "when differentiating this function call", ())
-NOTE(autodiff_expression_is_not_differentiable, none,
+NOTE(autodiff_expression_is_not_differentiable,none,
      "expression is not differentiable", ())
 NOTE(autodiff_nested_function_call_multiple_return_active,none,
      "function call is being differentiated from multiple return values", ())

--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -260,16 +260,20 @@ static FuncDecl *findAssociativeOperatorDeclInProtocol(
 
 /// Assuming the buffer is for indirect passing, returns the store ownership
 /// qualifier for creating a `store` instruction into the buffer.
-static StoreOwnershipQualifier getBufferSOQ(Type type, SILModule &module) {
-  return module.Types.getTypeLowering(type).isTrivial()
-    ? StoreOwnershipQualifier::Trivial : StoreOwnershipQualifier::Init;
+static StoreOwnershipQualifier getBufferSOQ(Type type, SILFunction &fn) {
+  if (fn.hasQualifiedOwnership())
+    return fn.getModule().Types.getTypeLowering(type).isTrivial()
+        ? StoreOwnershipQualifier::Trivial : StoreOwnershipQualifier::Init;
+  return StoreOwnershipQualifier::Unqualified;
 }
 
 /// Assuming the buffer is for indirect passing, returns the load ownership
 /// qualified for creating a `load` instruction from the buffer.
-static LoadOwnershipQualifier getBufferLOQ(Type type, SILModule &module) {
-  return module.Types.getTypeLowering(type).isTrivial()
-    ? LoadOwnershipQualifier::Trivial : LoadOwnershipQualifier::Take;
+static LoadOwnershipQualifier getBufferLOQ(Type type, SILFunction &fn) {
+  if (fn.hasQualifiedOwnership())
+    return fn.getModule().Types.getTypeLowering(type).isTrivial()
+        ? LoadOwnershipQualifier::Trivial : LoadOwnershipQualifier::Take;
+  return LoadOwnershipQualifier::Unqualified;
 }
 
 //===----------------------------------------------------------------------===//
@@ -317,7 +321,7 @@ private:
     std::pair<ApplyInst *,
               DifferentiationTask *> indirectDifferentiation;
     Value(ApplyInst *applyInst, DifferentiationTask *parentTask)
-      : indirectDifferentiation({applyInst, parentTask}) {}
+        : indirectDifferentiation({applyInst, parentTask}) {}
 
     /// The differential operator associated with the `DifferentialOperator`
     /// case.
@@ -326,8 +330,9 @@ private:
 
     /// The `@differentiable` attribute associated with the
     /// `DifferentiableAttribute` case.
-    DifferentiableAttr *differentiableAttribute;
-    Value(DifferentiableAttr *attr) : differentiableAttribute(attr) {}
+    std::pair<DifferentiableAttr *, FuncDecl *> differentiableAttribute;
+    Value(DifferentiableAttr *attr, FuncDecl *fd)
+        : differentiableAttribute({attr, fd}) {}
   } value;
 
   /*implicit*/
@@ -342,8 +347,8 @@ public:
     : kind(Kind::IndirectDifferentiation), value(applyInst, task) {}
   DifferentiationInvoker(ReverseAutoDiffExpr *expr)
     : kind(Kind::DifferentialOperator), value(expr) {}
-  DifferentiationInvoker(DifferentiableAttr *attr)
-    : kind(Kind::DifferentiableAttribute), value(attr) {}
+  DifferentiationInvoker(DifferentiableAttr *attr, FuncDecl *fd)
+    : kind(Kind::DifferentiableAttribute), value(attr, fd) {}
 
   Kind getKind() const { return kind; }
 
@@ -363,7 +368,8 @@ public:
     return value.differentialOperator;
   }
 
-  DifferentiableAttr *getDifferentiableAttribute() const {
+  std::pair<DifferentiableAttr *, FuncDecl *>
+  getDifferentiableAttribute() const {
     assert(kind == Kind::DifferentiableAttribute);
     return value.differentiableAttribute;
   }
@@ -745,11 +751,13 @@ void DifferentiationInvoker::print(llvm::raw_ostream &os) const {
     getDifferentialOperator()->print(os);
     os << ")";
     break;
-  case Kind::DifferentiableAttribute:
-    os << "differentiable_attribute=(";
-    getDifferentiableAttribute()->print(os);
-    os << ")";
+  case Kind::DifferentiableAttribute: {
+    auto diffAttr = getDifferentiableAttribute();
+    os << "differentiable_attribute=(attr=(";
+    diffAttr.first->print(os);
+    os << ") func_decl=" << diffAttr.second->getFullName();
     break;
+  }
   }
   os << ')';
 }
@@ -792,8 +800,7 @@ enum class PrimalValueKind {
   TapeCheckpoint
 };
 
-using GradientLookupKey = std::pair<SILFunction *,
-                                    SILReverseAutoDiffConfig>;
+using GradientLookupKey = std::pair<SILFunction *, SILReverseAutoDiffConfig>;
 
 //===----------------------------------------------------------------------===//
 // ADContext - Per-module contextual information for the Differentiation pass.
@@ -1050,19 +1057,19 @@ public:
   /// parent function, emits a "not differentiable" error based on the task. If
   /// the task is indirect, emits notes all the way up to the outermost task,
   /// and emits an error at the outer task. Otherwise, emits an error directly.
-  void emitNondifferentiabilityError(
-    SILInstruction *inst, const DifferentiationTask *task,
-    Diag<> noteAtInnermostNode = diag::autodiff_expression_is_not_differentiable
-  );
+  void emitNondifferentiabilityError(SILInstruction *inst,
+                                     const DifferentiationTask *task,
+                                     Optional<Diag<>> diag = None);
 
   /// Given a value and a differentiation task associated with the parent
   /// function, emits a "not differentiable" error based on the task. If the
   /// task is indirect, emits notes all the way up to the outermost task, and
   /// emits an error at the outer task. Otherwise, emits an error directly.
-  void emitNondifferentiabilityError(
-    SILValue value, const DifferentiationTask *task,
-    Diag<> noteAtInnermostNode = diag::autodiff_expression_is_not_differentiable
-  );
+  void emitNondifferentiabilityError(SILValue value,
+                                     const DifferentiationTask *task,
+                                     Optional<Diag<>> diag = None) {
+    emitNondifferentiabilityError(value->getDefiningInstruction(), task, diag);
+  }
 
   void setErrorOccurred() { errorOccurred = true; }
   bool hasErrorOccurred() const { return errorOccurred; }
@@ -1070,22 +1077,13 @@ public:
 } // end anonymous namespace
 
 ADContext::ADContext(SILModule &module, SILPassManager &passManager)
-  : module(module), passManager(passManager) {}
-
-void ADContext::emitNondifferentiabilityError(SILValue value,
-                                              const DifferentiationTask *task,
-                                              Diag<> noteAtInnermostNode) {
-  emitNondifferentiabilityError(value->getDefiningInstruction(), task,
-                                noteAtInnermostNode);
-}
+    : module(module), passManager(passManager) {}
 
 void ADContext::emitNondifferentiabilityError(SILInstruction *inst,
                                               const DifferentiationTask *task,
-                                              Diag<> noteAtInnermostNode) {
-  SWIFT_DEFER { setErrorOccurred(); };
+                                              Optional<Diag<>> diag) {
   // Location of the instruction.
-  auto srcLoc = inst->getLoc().getSourceLoc();
-  if (srcLoc.isInvalid()) srcLoc = SourceLoc();
+  auto opLoc = inst->getLoc().getSourceLoc();
   auto invoker = task->getInvoker();
   DEBUG(getADDebugStream() << "Diagnosing non-differentiability for value \n\t"
         << *inst << "\n" << "while performing differentiation task\n\t" << task
@@ -1094,52 +1092,43 @@ void ADContext::emitNondifferentiabilityError(SILInstruction *inst,
   // For a gradient instruction that is not associated with any source
   // location, we emit a diagnostic without source location.
   case DifferentiationInvoker::Kind::GradientInst:
-    diagnose(srcLoc, diag::autodiff_function_not_differentiable);
-    return;
+    diagnose(opLoc,
+        diag.getValueOr(diag::autodiff_expression_is_not_differentiable));
+    break;
 
   // For indirect differentiation, emit a "not differentiable" note on the
   // expression first. Then emit an error at the source invoker of
   // differentiation, and a "when differentiating this"  note at each indirect
   // invoker.
   case DifferentiationInvoker::Kind::IndirectDifferentiation: {
-    // Emit a default note at the innermost differentiation invoker.
-    diagnose(srcLoc, noteAtInnermostNode);
-    // Iteratively retrieve the outermost task, starting with the parent of the
-    // current node, until the task is no longer indirect.
-    auto *outerTask = invoker.getIndirectDifferentiation().second;
-    while (outerTask->getInvoker().getKind() ==
-             DifferentiationInvoker::Kind::IndirectDifferentiation) {
-      std::tie(inst, outerTask) =
-        outerTask->getInvoker().getIndirectDifferentiation();
-      auto applyLoc = inst->getLoc().getSourceLoc();
-      if (applyLoc.isValid())
-        diagnose(applyLoc, diag::autodiff_when_differentiating_function_call);
-    }
-    // Now we've reached a direct task, recursive once to emit an error.
-    emitNondifferentiabilityError(inst, outerTask);
-    return;
+    std::tie(inst, task) = task->getInvoker().getIndirectDifferentiation();
+    emitNondifferentiabilityError(inst, task, None);
+    diagnose(opLoc,
+        diag.getValueOr(diag::autodiff_when_differentiating_function_call));
+    break;
   }
 
-  // For a differential operator, emit a "not differentiable" note on the
-  // expression first. Then emit an error at the differential operator.
+  // For a differential operator, emit a "not differentiable" error on the
+  // attribute first and a note on the non-differentiable operation.
   case DifferentiationInvoker::Kind::DifferentialOperator: {
     auto *expr = invoker.getDifferentialOperator();
-    diagnose(srcLoc, noteAtInnermostNode);
-    diagnose(expr->getLoc(),
-      diag::autodiff_differential_operator_applied_to_nondifferentiable)
+    diagnose(expr->getLoc(), diag::autodiff_function_not_differentiable)
         .highlight(expr->getOriginalExpr()->getSourceRange());
-    return;
+    diagnose(opLoc,
+        diag.getValueOr(diag::autodiff_expression_is_not_differentiable));
+    break;
   }
 
-  // For a `@differentiable` attribute, emit a "not differentiable" note on the
-  // expression first. Then emit an error at the `@differentiable` attribute.
+  // For a `@differentiable` attribute, emit a "not differentiable" error on the
+  // attribute first and a note on the non-differentiable operation.
   case DifferentiationInvoker::Kind::DifferentiableAttribute: {
-    auto *attr = invoker.getDifferentiableAttribute();
-    diagnose(srcLoc, noteAtInnermostNode);
-    diagnose(attr->getLocation(),
-      diag::autodiff_differentiable_attr_applied_to_nondifferentiable)
-        .highlight(attr->getRangeWithAt());
-    return;
+    auto diffAttr = invoker.getDifferentiableAttribute();
+    diagnose(diffAttr.first->getLocation(),
+             diag::autodiff_function_not_differentiable)
+        .highlight(diffAttr.second->getNameLoc());
+    diagnose(opLoc,
+        diag.getValueOr(diag::autodiff_expression_is_not_differentiable));
+    break;
   }
   }
 }
@@ -1191,7 +1180,8 @@ public:
                                        SILLoopInfo &loopInfo)
     : function(function), domInfo(domInfo), loopInfo(loopInfo) {}
 
-  /// Run control flow canonicalization on the function.
+  /// Run control flow canonicalization on the function. Returns true if the
+  /// program changed.
   bool run();
 };
 }
@@ -1671,7 +1661,7 @@ static void convertToIndirectSeed(intmax_t value, CanType type,
                                             /*noNestedConflict*/ true,
                                             /*fromBuiltin*/ false);
     builder.createStore(loc, one, seedBuf,
-                        getBufferSOQ(type, context.getModule()));
+                        getBufferSOQ(type, builder.getFunction()));
     builder.createEndAccess(loc, access, /*aborted*/ false);
     return;
   }
@@ -1708,7 +1698,7 @@ static void convertToIndirectSeed(intmax_t value, CanType type,
     builder.createAllocStack(loc, SILType::getPrimitiveObjectType(scalarTy));
   convertIntToIndirectExpressible(value, scalarTyDecl, scalarBuf,
                                   loc, builder, context);
-  auto scalarLOQ = getBufferLOQ(scalarTy, module);
+  auto scalarLOQ = getBufferLOQ(scalarTy, builder.getFunction());
   auto scalarVal = builder.createLoad(loc, scalarBuf, scalarLOQ);
   // dealloc_stack %0 : $*<scalar type>
   builder.createDeallocStack(loc, scalarBuf);
@@ -1733,7 +1723,7 @@ static void convertToIndirectSeed(intmax_t value, CanType type,
                                               /*fromBuiltin*/ false);
   // store %0 : $<scalar type> to $*<scalar type>
   builder.createStore(loc, scalarVal, scalarValBuf,
-                      getBufferSOQ(scalarTy, module));
+                      getBufferSOQ(scalarTy, builder.getFunction()));
   builder.createEndAccess(loc, bufAccess, /*aborted*/ false);
   auto *vecNumProto = context.getVectorNumericProtocol();
   auto *reqr =
@@ -1767,15 +1757,21 @@ class PrimalGen {
 private:
   /// The global AD context.
   ADContext &context;
+
   /// A worklist of primal synthesis items, each of which specifies a the
   /// original function, the target primal function, AD indices, and the primal
   /// value struct.
   SmallVector<FunctionSynthesisItem, 16> worklist;
 
+  /// Flag indicating there was an error during primal generation.
+  bool errorOccurred;
+
 public:
   explicit PrimalGen(ADContext &context) : context(context) {}
 
-  void run();
+  /// Performs primal synthesis for all differentiation tasks. Returns true if
+  /// any error occurs.
+  bool run();
 
 protected:
   /// Lazily create a task to synthesize the primal function.
@@ -1786,8 +1782,8 @@ private:
   std::pair<SILFunction *, StructDecl *>
   createEmptyPrimal(DifferentiationTask *task);
 
-  /// Processes an original function and generate its adjoint.
-  void performSynthesis(FunctionSynthesisItem task);
+  /// Processes a synthesis item. Returns true if any error occurs.
+  bool performSynthesis(FunctionSynthesisItem task);
 };
 } // end anonymous namespace
 
@@ -1797,32 +1793,32 @@ ADContext::createPrimalValueStructForFunction(SILFunction *function) {
          "The function must be in the same module");
   auto &file = getPrimalValueDeclContainer();
   // Create a `<fn_name>__Type` struct.
-  std::string dependentStructName;
-  dependentStructName += function->getName();
-  dependentStructName += "__Type";
-  auto structId = astCtx.getIdentifier(dependentStructName);
+  std::string pvStructName;
+  pvStructName += function->getName();
+  pvStructName += "__Type";
+  auto structId = astCtx.getIdentifier(pvStructName);
   SourceLoc loc = function->getLocation().getSourceLoc();
-  auto ctxStruct =
+  auto pvStruct =
     new (astCtx) StructDecl(/*StructLoc*/ loc, /*Name*/ structId,
                             /*NameLoc*/ loc, /*Inherited*/ {},
                             /*GenericParams*/ nullptr, // to be set later
                             /*DC*/ &file);
-  ctxStruct->computeType();
-  ctxStruct->setAccess(AccessLevel::Internal);
+  pvStruct->computeType();
+  pvStruct->setAccess(AccessLevel::Internal);
   // If the original function has generic parameters, clone them.
   auto *genEnv = function->getGenericEnvironment();
   if (genEnv && genEnv->getGenericSignature()) {
     auto *genParams = function->getDeclContext()->getGenericParamsOfContext();
-    ctxStruct->setGenericParams(genParams->clone(ctxStruct));
+    pvStruct->setGenericParams(genParams->clone(pvStruct));
   }
-  file.addVisibleDecl(ctxStruct);
+  file.addVisibleDecl(pvStruct);
   DEBUG({
     auto &s = getADDebugStream();
     s << "Primal value struct created for function "
       << function->getName() << '\n';
-    ctxStruct->print(s); s << '\n';
+    pvStruct->print(s); s << '\n';
   });
-  return ctxStruct;
+  return pvStruct;
 }
 
 /// For a nested function call whose result tuple is active on the
@@ -1892,18 +1888,12 @@ static bool diagnoseUnsupportedControlFlow(ADContext &context,
   if (task->getOriginal()->getBlocks().size() <= 1)
     return false;
   // Find any control flow node and diagnose.
-  for (auto &bb : task->getOriginal()->getBlocks()) {
+  for (auto &bb : *task->getOriginal()) {
     auto *term = bb.getTerminator();
-    switch (term->getKind()) {
-      case SILInstructionKind::CondBranchInst:
-      case SILInstructionKind::SwitchEnumInst:
-      case SILInstructionKind::SwitchValueInst:
-      case SILInstructionKind::SwitchEnumAddrInst:
-        context.emitNondifferentiabilityError(
+    if (term->isBranch()) {
+      context.emitNondifferentiabilityError(
           term, task, diag::autodiff_control_flow_not_supported);
-        return true;
-      default:
-        break;
+      return true;
     }
   }
   return false;
@@ -1943,6 +1933,8 @@ private:
 
   /// The postdominator tree of the original function.
   const PostDominanceInfo &postDomInfo;
+
+  bool errorOccurred = false;
 
   // To be used for control flow support.
   // const SILLoopInfo &loopInfo;
@@ -2028,16 +2020,18 @@ public:
       /*loopInfo(loopInfo),*/
       primalGen(primalGen) {}
 
-  /// Entry of primal generation for a function.
-  void run() {
+  /// Entry of primal generation for a function. Returns true if any error
+  /// occurred.
+  bool run() {
     DEBUG(getADDebugStream() << "Cloning original @" << getOriginal()->getName()
           << " to primal @" << synthesis.target->getName() << '\n');
     // Kick off the cloner.
     visitSILFunction(getOriginal());
+    return errorOccurred;
   }
 
   void postProcess(SILInstruction *orig, SILInstruction *cloned) {
-    if (getContext().hasErrorOccurred())
+    if (errorOccurred)
       return;
     SILClonerWithScopes::postProcess(orig, cloned);
     switch (classifyPrimalValue(orig)) {
@@ -2065,7 +2059,7 @@ public:
   }
 
   void visitSILBasicBlock(SILBasicBlock *bb) {
-    if (getContext().hasErrorOccurred())
+    if (errorOccurred)
       return;
     SILClonerWithScopes::visitSILBasicBlock(bb);
   }
@@ -2084,7 +2078,7 @@ public:
     // Clone.
     SILClonerWithScopes::visitSILFunction(original);
     // If errors occurred, back out.
-    if (getContext().hasErrorOccurred())
+    if (errorOccurred)
       return;
     auto *origExit = &*original->findReturnBB();
     auto *exit = BBMap.lookup(origExit);
@@ -2092,9 +2086,7 @@ public:
     // Get the original's return value's corresponsing value in the primal.
     auto *origRetInst = cast<ReturnInst>(origExit->getTerminator());
     auto origRetVal = origRetInst->getOperand();
-    assert(origRetVal->getParentBlock() == origExit);
     auto origResInPrimal = getOpValue(origRetVal);
-    assert(origResInPrimal->getParentBlock() == exit);
     // Create a primal value struct containing all static primal values and
     // tapes.
     auto loc = getPrimal()->getLocation();
@@ -2143,7 +2135,7 @@ public:
   /// General visitor for all instruction. If there is any error emitted by
   /// previous visits, bail out.
   void visit(SILInstruction *inst) {
-    if (getContext().hasErrorOccurred())
+    if (errorOccurred)
       return;
     SILClonerWithScopes::visit(inst);
   }
@@ -2184,6 +2176,7 @@ public:
     // To support this, we need to emit a primal call for each active result.
     if (activeResultIndices.size() > 1) {
       context.emitNondifferentiabilityError(ai, synthesis.task);
+      errorOccurred = true;
       return;
     }
     // Form expected indices by assuming there's only one result.
@@ -2197,6 +2190,7 @@ public:
     // FIXME: Handle `partial_apply`.
     if (!calleeOriginFnRef) {
       context.emitNondifferentiabilityError(ai, synthesis.task);
+      errorOccurred = true;
       return;
     }
     // Find or register a differentiation task for this function.
@@ -2293,18 +2287,16 @@ public:
   void visitGradientInst(GradientInst *gi) {
     getContext().emitNondifferentiabilityError(
       gi, getDifferentiationTask(), diag::autodiff_nested_not_supported);
+    errorOccurred = true;
   }
 
   /// Primal has qualified ownership. We assign store ownership qualifier while
   /// cloning the `store` instruction.
   void visitStoreInst(StoreInst *si) {
-    if (si->getOwnershipQualifier() != StoreOwnershipQualifier::Unqualified) {
-      SILClonerWithScopes::visitStoreInst(si);
-      return;
-    }
+
     auto destTy = si->getDest()->getType().getASTType();
     auto loc = remapLocation(si->getLoc());
-    auto soq = getBufferSOQ(getOpASTType(destTy), getContext().getModule());
+    auto soq = getBufferSOQ(getOpASTType(destTy), *getPrimal());
     getBuilder().createStore(loc, getOpValue(si->getSrc()),
                              getOpValue(si->getDest()), soq);
   }
@@ -2312,24 +2304,21 @@ public:
   /// Primal has qualified ownership. We assign load ownership qualified while
   /// cloning the `load` instruction.
   void visitLoadInst(LoadInst *li) {
-    if (li->getOwnershipQualifier() != LoadOwnershipQualifier::Unqualified) {
-      SILClonerWithScopes::visitLoadInst(li);
-      return;
-    }
+
     auto srcTy = li->getOperand()->getType().getASTType();
     auto loc = remapLocation(li->getLoc());
-    auto loq = getBufferLOQ(getOpASTType(srcTy), getContext().getModule());
+    auto loq = getBufferLOQ(getOpASTType(srcTy), *getPrimal());
     ValueMap.insert(
       {li, getBuilder().createLoad(loc, getOpValue(li->getOperand()), loq)});
   }
 };
 } // end anonymous namespace
 
-void PrimalGen::performSynthesis(FunctionSynthesisItem item) {
+bool PrimalGen::performSynthesis(FunctionSynthesisItem item) {
   // FIXME: If the original function has multiple basic blocks, bail out since
   // AD does not support control flow yet.
   // Compute necessary analyses on the original function.
-  diagnoseUnsupportedControlFlow(context, item.task);
+  errorOccurred |= diagnoseUnsupportedControlFlow(context, item.task);
   // Synthesize the function.
   auto &passManager = context.getPassManager();
   auto *activityAnalysis =
@@ -2349,7 +2338,7 @@ void PrimalGen::performSynthesis(FunctionSynthesisItem item) {
   // Synthesize primal.
   PrimalGenCloner cloner(item, activityInfo, domInfo, pdomInfo,
                          loopInfo, *this, context);
-  cloner.run();
+  return cloner.run();
 }
 
 /// Creates a primal function.
@@ -2389,6 +2378,7 @@ PrimalGen::createEmptyPrimal(DifferentiationTask *task) {
                                             original->isBare(),
                                             original->isTransparent(),
                                             original->isSerialized());
+  primal->setUnqualifiedOwnership();
   DEBUG(getADDebugStream() << "Primal function created \n" << *primal << '\n');
   task->setPrimal(primal);
   return { primal, primalValueStructDecl };
@@ -2411,7 +2401,7 @@ PrimalGen::lookupPrimalOrScheduleSynthesis(DifferentiationTask *task) {
   return newPrimal;
 }
 
-void PrimalGen::run() {
+bool PrimalGen::run() {
   // Push everything to the list of primal synthesis items.
   for (auto &task : context.getDifferentiationTasks())
     lookupPrimalOrScheduleSynthesis(task.get());
@@ -2419,10 +2409,11 @@ void PrimalGen::run() {
   while (!worklist.empty()) {
     auto synthesis = worklist.back();
     worklist.pop_back();
-    performSynthesis(synthesis);
+    errorOccurred |= performSynthesis(synthesis);
     synthesis.task->getPrimalInfo()->computePrimalValueStructType();
     DEBUG(synthesis.target->verify());
   }
+  return errorOccurred;
 }
 
 //===----------------------------------------------------------------------===//
@@ -2442,16 +2433,21 @@ private:
   /// Work list of synthesis items.
   SmallVector<FunctionSynthesisItem, 16> worklist;
 
+  /// Flag indicating whether an error has occurred.
+  bool errorOccurred = false;
+
 public:
   explicit AdjointGen(ADContext &context) : context(context) {}
 
-  void run();
+  /// Performs adjoint generation for all differentiation tasks. Returns true if
+  /// any error occurs.
+  bool run();
 
 private:
   /// Creates an empty adjoint function.
   SILFunction *createEmptyAdjoint(DifferentiationTask *task);
-  /// Synthesize an adjoint.
-  void performSynthesis(FunctionSynthesisItem item);
+  /// Do the synthesis item. Returns true if any error occurs.
+  bool performSynthesis(FunctionSynthesisItem item);
   /// Look up the adjoint function corresponding to this task. If it does not
   /// exist, create an empty adjoint and schedule a synthesis item to be
   /// processed later in AdjointGen.
@@ -2522,7 +2518,7 @@ AdjointGen::lookupAdjointOrScheduleSynthesis(DifferentiationTask *task) {
   return newAdjoint;
 }
 
-void AdjointGen::run() {
+bool AdjointGen::run() {
   // Push everything to the worklist.
   for (auto &task : context.getDifferentiationTasks())
     lookupAdjointOrScheduleSynthesis(task.get());
@@ -2531,9 +2527,10 @@ void AdjointGen::run() {
   while (!worklist.empty()) {
     auto synthesis = worklist.back();
     worklist.pop_back();
-    performSynthesis(synthesis);
+    errorOccurred |= performSynthesis(synthesis);
     DEBUG(synthesis.target->verify());
   }
+  return errorOccurred;
 }
 
 //===----------------------------------------------------------------------===//
@@ -2753,6 +2750,8 @@ private:
 
   llvm::BumpPtrAllocator allocator;
 
+  bool errorOccurred = false;
+
   ADContext &getContext() const {
     return adjointGen.context;
   }
@@ -2844,7 +2843,9 @@ protected:
   }
 
 public:
-  void run() {
+  /// Performs adjoint synthesis on the empty adjoint function. Returns true if
+  /// any error occurs.
+  bool run() {
     auto &original = getOriginal();
     auto &adjoint = getAdjoint();
     auto adjLoc = getAdjoint().getLocation();
@@ -2902,8 +2903,8 @@ public:
     }
     
     // If errors occurred, back out.
-    if (getContext().hasErrorOccurred())
-      return;
+    if (errorOccurred)
+      return true;
     
     // Place the builder at the adjoint block corresponding to the original
     // entry. This block is going to be our exit block and we emit a `return`
@@ -2924,10 +2925,12 @@ public:
     else
       retVal = getBuilder().createTuple(adjLoc, retElts);
     getBuilder().createReturn(adjLoc, retVal);
+
+    return errorOccurred;
   }
   
   void visit(SILInstruction *inst) {
-    if (getContext().hasErrorOccurred())
+    if (errorOccurred)
       return;
     SILInstructionVisitor::visit(inst);
   }
@@ -2937,7 +2940,7 @@ public:
   }
 
   void visitSILBasicBlock(SILBasicBlock *bb) {
-    if (getContext().hasErrorOccurred())
+    if (errorOccurred)
       return;
     auto indices = getDifferentiationTask()->getIndices();
     // Get the corresponding adjoint basic block.
@@ -3099,7 +3102,7 @@ public:
                                                    /*noNestedConflict*/ true,
                                                    /*fromBuiltin*/ false);
       args.push_back(getBuilder().createLoad(
-        loc, access, getBufferLOQ(seed.getSwiftType(), getModule())));
+          loc, access, getBufferLOQ(seed.getSwiftType(), getAdjoint())));
       getBuilder().createEndAccess(loc, access, /*aborted*/ false);
     }
     // Call the adjoint function.
@@ -3197,17 +3200,17 @@ public:
                                                                 varDecl);
         if (varDecl == sei->getField()) {
           getBuilder().createStore(sei->getLoc(), adj, eltBufAddr,
-            getBufferSOQ(sei->getType().getASTType(), getModule()));
+              getBufferSOQ(sei->getType().getASTType(), getAdjoint()));
         } else {
           auto eltType = varDecl->getType()->getCanonicalType();
           auto zero =
-            AdjointValue::getZero(SILType::getPrimitiveObjectType(eltType));
+              AdjointValue::getZero(SILType::getPrimitiveObjectType(eltType));
           materializeAdjointIndirect(zero, eltBufAddr);
         }
       }
       addAdjointValue(sei->getOperand(),
                       getBuilder().createLoad(sei->getLoc(), structBuf,
-        getBufferLOQ(structDecl->getDeclaredInterfaceType(), getModule())));
+          getBufferLOQ(structDecl->getDeclaredInterfaceType(), getAdjoint())));
       break;
     }
   }
@@ -3325,6 +3328,7 @@ public:
     }
     default:
       getContext().emitNondifferentiabilityError(bi, getDifferentiationTask());
+      errorOccurred = true;
       return;
     }
   }
@@ -3359,15 +3363,14 @@ SILValue AdjointEmitter::materializeAdjoint(AdjointValue value,
   auto valueBuf = getBuilder().createAllocStack(loc, value.getType());
   SWIFT_DEFER { getBuilder().createDeallocStack(loc, valueBuf); };
   materializeAdjointIndirect(value, valueBuf);
-  auto loq = value.getType().isTrivial(getModule())
-    ? LoadOwnershipQualifier::Trivial : LoadOwnershipQualifier::Take;
+  auto loq = getBufferLOQ(value.getType().getASTType(), getAdjoint());
   return getBuilder().createLoad(loc, valueBuf, loq);
 }
 
 void AdjointEmitter::materializeAdjointIndirect(AdjointValue val,
                                                 SILValue destBuffer) {
   auto loc = destBuffer.getLoc();
-  auto soq = getBufferSOQ(val.getType().getASTType(), getModule());
+  auto soq = getBufferSOQ(val.getType().getASTType(), getAdjoint());
   switch (val.getKind()) {
   /// Given a `%buf : *T, emit instructions that produce a zero or an aggregate
   /// of zeros of the expected type. When `T` conforms to
@@ -3396,7 +3399,7 @@ void AdjointEmitter::materializeAdjointIndirect(AdjointValue val,
       auto *zero = getBuilder().createFloatLiteral(
         loc, val.getType(), APFloat(builtinFP->getAPFloatSemantics(), 0));
       getBuilder().createStore(loc, zero, access,
-                               getBufferSOQ(builtinFP, getModule()));
+                               getBufferSOQ(builtinFP, getAdjoint()));
       getBuilder().createEndAccess(loc, access, /*aborted*/ false);
     }
     else {
@@ -3501,7 +3504,7 @@ SILValue AdjointEmitter::accumulateMaterializedAdjoints(SILValue lhs,
   accumulateMaterializedAdjointsIndirect(lhs, rhs, resultBuf);
   getBuilder().createDeallocStack(resultBuf->getLoc(), resultBuf);
   return getBuilder().createLoad(resultBuf->getLoc(), resultBuf,
-    getBufferLOQ(lhs->getType().getASTType(), getModule()));
+    getBufferLOQ(lhs->getType().getASTType(), getAdjoint()));
 }
 
 void AdjointEmitter::accumulateMaterializedAdjointsIndirect(
@@ -3518,7 +3521,7 @@ void AdjointEmitter::accumulateMaterializedAdjointsIndirect(
     auto *sum = getBuilder().createBuiltinBinaryFunction(
       loc, "fadd", lhs->getType(), lhs->getType(), { lhs, rhs });
     getBuilder().createStore(loc, sum, bufAccess,
-                             getBufferSOQ(adjointTy, getModule()));
+                             getBufferSOQ(adjointTy, getAdjoint()));
     getBuilder().createEndAccess(loc, bufAccess, /*aborted*/ false);
     return;
   }
@@ -3566,10 +3569,10 @@ void AdjointEmitter::accumulateMaterializedAdjointsIndirect(
                            /*isNonThrowing*/ false);
 }
 
-void AdjointGen::performSynthesis(FunctionSynthesisItem item) {
+bool AdjointGen::performSynthesis(FunctionSynthesisItem item) {
   auto &passManager = context.getPassManager();
   auto *activityAnalysis =
-    passManager.getAnalysis<DifferentiableActivityAnalysis>();
+      passManager.getAnalysis<DifferentiableActivityAnalysis>();
   auto *domAnalysis = passManager.getAnalysis<DominanceAnalysis>();
   auto *pdomAnalysis = passManager.getAnalysis<PostDominanceAnalysis>();
   auto *loopAnalysis = passManager.getAnalysis<SILLoopAnalysis>();
@@ -3580,8 +3583,7 @@ void AdjointGen::performSynthesis(FunctionSynthesisItem item) {
                          *pdomAnalysis->get(item.original),
                          *loopAnalysis->get(item.original),
                          *this);
-  emitter.run();
-  debugDump(*item.target);
+  return emitter.run();
 }
 
 //===----------------------------------------------------------------------===//
@@ -3682,8 +3684,7 @@ static SILFunction *lookupOrSynthesizeGradient(
       if (seedSILTy.isAddressOnly(module)) {
         stackAllocsToCleanUp.push_back(seedBuf);
       } else {
-        auto loq = seedSILTy.isTrivial(module)
-          ? LoadOwnershipQualifier::Trivial : LoadOwnershipQualifier::Take;
+        auto loq = getBufferLOQ(seedSILTy.getASTType(), *gradFn);
         auto seedBufAccess = builder.createBeginAccess(
             loc, seedBuf, SILAccessKind::Read, SILAccessEnforcement::Static,
             /*noNestedConflict*/ false, /*fromBuiltin=*/ false);
@@ -3850,12 +3851,17 @@ class Differentiation : public SILModuleTransform {
 public:
   Differentiation() : SILModuleTransform() {}
   void run() override;
+
 private:
-  void processGradientInst(GradientInst *gi, ADContext &context);
+  /// Processes the given gradient instruction. This includes transforming it
+  /// into a normal `function_ref` to the synthesized gradient function, and
+  /// pushing a differentiation task onto the global list. Returns true if any
+  /// error occurred.
+  bool processGradientInst(GradientInst *gi, ADContext &context);
 };
 } // end anonymous namespace
 
-void Differentiation::processGradientInst(GradientInst *gi,
+bool Differentiation::processGradientInst(GradientInst *gi,
                                           ADContext &context) {
   SILFunction *parent = gi->getFunction();
   auto operand = gi->getOperand(0);
@@ -3864,9 +3870,6 @@ void Differentiation::processGradientInst(GradientInst *gi,
   if (auto *originalFRI = findReferenceToVisibleFunction(operand)) {
     auto *original = originalFRI->getReferencedFunction();
     gradFn = lookupOrSynthesizeGradient(context, gi, original);
-
-    // If `gradFn` is still null, errors must have occurred.
-    if (!gradFn) return;
 
     // Replace the `gradient` instruction with the reference to the specified
     // function.
@@ -3885,17 +3888,25 @@ void Differentiation::processGradientInst(GradientInst *gi,
   }
   // Differentiating opaque functions is not supported yet.
   else {
-    if (auto loc = gi->getLoc()) {
-      auto *expr = loc.castToASTNode<ReverseAutoDiffExpr>();
-      context.diagnose(expr->getOriginalExpr()->getLoc(),
+    // Find the original differential operator expression. Show an error at the
+    // operator, highlight the argument, and show a note at the definition site
+    // of the argument.
+    if (auto *expr = findDifferentialOperator(gi))
+      context.diagnose(expr->getLoc(),
+                       diag::autodiff_opaque_function_unsupported)
+          .highlight(expr->getOriginalExpr()->getSourceRange());
+    else
+      context.diagnose(gi->getLoc().getSourceLoc(),
                        diag::autodiff_opaque_function_unsupported);
-    }
-    context.setErrorOccurred();
-    return;
+    // Emit a note at the definition site.
+    context.diagnose(gi->getOriginal().getLoc().getSourceLoc(),
+                     diag::autodiff_value_defined_here);
+    return true;
   }
   // We invalidate analyses on the parent function because the `gradient`
   // instruction is transformed.
   PM->invalidateAnalysis(parent, SILAnalysis::InvalidationKind::FunctionBody);
+  return false;
 }
 
 /// AD pass entry.
@@ -3916,9 +3927,10 @@ void Differentiation::run() {
 
   // AD relies on stdlib (the Swift module). If it's not imported, it's an
   // internal error.
-  if (!module.getSwiftModule()->getASTContext().getStdlibModule()) {
-    llvm::errs() <<
-      "Internal error: AD depends on the Swift module but it's not imported.\n";
+  auto &astCtx = module.getSwiftModule()->getASTContext();
+  if (!astCtx.getStdlibModule()) {
+    astCtx.Diags.diagnose(SourceLoc(),
+                          diag::autodiff_internal_swift_not_imported);
     return;
   }
 
@@ -3940,13 +3952,14 @@ void Differentiation::run() {
 
   // Run primal generation.
   PrimalGen primalGen(context);
-  primalGen.run();
+  if (primalGen.run())
+    return;
 
   // If there were any error, back out.
   if (context.hasErrorOccurred())
     return;
 
-  // TODO: Run adjoint generation.
+  // Run adjoint generation.
   AdjointGen adjointGen(context);
   adjointGen.run();
 

--- a/test/AutoDiff/autodiff_basic.sil
+++ b/test/AutoDiff/autodiff_basic.sil
@@ -59,7 +59,7 @@ bb0(%0 : $Float):
 // CHECK:   %9 = apply %8<Float>(%1, %5, %7) : $@convention(witness_method: ExpressibleByIntegerLiteral) <τ_0_0 where τ_0_0 : ExpressibleByIntegerLiteral> (@in τ_0_0.IntegerLiteralType, @thick τ_0_0.Type) -> @out τ_0_0
 // CHECK:   dealloc_stack %5 : $*Int64
 // CHECK:   %11 = begin_access [read] [static] %1 : $*Float
-// CHECK:   %12 = load [trivial] %11 : $*Float
+// CHECK:   %12 = load %11 : $*Float
 // CHECK:   end_access %11 : $*Float
 // CHECK:   dealloc_stack %1 : $*Float
 // CHECK:   %15 = function_ref @foo__grad_src_0_wrt_0_s_p : $@convention(thin) (Float, Float) -> (Float, Float)
@@ -81,7 +81,7 @@ bb0(%0 : $Float):
 // CHECK:   %9 = apply %8<Float>(%1, %5, %7) : $@convention(witness_method: ExpressibleByIntegerLiteral) <τ_0_0 where τ_0_0 : ExpressibleByIntegerLiteral> (@in τ_0_0.IntegerLiteralType, @thick τ_0_0.Type) -> @out τ_0_0
 // CHECK:   dealloc_stack %5 : $*Int64
 // CHECK:   %11 = begin_access [read] [static] %1 : $*Float
-// CHECK:   %12 = load [trivial] %11 : $*Float
+// CHECK:   %12 = load %11 : $*Float
 // CHECK:   end_access %11 : $*Float
 // CHECK:   dealloc_stack %1 : $*Float
 // CHECK:   %15 = function_ref @foo__grad_src_0_wrt_0_s_p : $@convention(thin) (Float, Float) -> (Float, Float)

--- a/test/AutoDiff/autodiff_basic.sil
+++ b/test/AutoDiff/autodiff_basic.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -differentiation -sil-print-all %s | %FileCheck %s
+// RUN: %target-sil-opt -differentiation %s | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -1,5 +1,77 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s
 
-func foo(_ f: @escaping (Float) -> Float) -> Float {
-  return #gradient(f)(0) // expected-error {{differentiating an opaque function is not supported yet}}
+//===----------------------------------------------------------------------===//
+// Top-level (before primal/adjoint synthesis)
+//===----------------------------------------------------------------------===//
+
+// expected-note @+1 {{value defined here}}
+func foo(_ f: (Float) -> Float) -> Float {
+  // expected-error @+1 {{differentiating an opaque function is not supported yet}}
+  return #gradient(f)(0)
 }
+
+//===----------------------------------------------------------------------===//
+// Basic function
+//===----------------------------------------------------------------------===//
+
+func one_to_one_0(_ x: Float) -> Float {
+  return x + 2
+}
+
+_ = #gradient(one_to_one_0) // okay!
+
+//===----------------------------------------------------------------------===//
+// Function composition
+//===----------------------------------------------------------------------===//
+
+func uses_optionals(_ x: Float) -> Float {
+  var maybe: Float? = 10
+  maybe = x
+  // expected-note @+1 {{differentiating control flow is not supported yet}}
+  return maybe!
+}
+
+_ = #gradient(uses_optionals) // expected-error {{function is not differentiable}}
+
+func f0(_ x: Float) -> Float {
+  return x // okay!
+}
+
+func nested(_ x: Float) -> Float {
+  return #gradient(f0)(x) // expected-note {{nested differentiation is not supported yet}}
+}
+
+func middle(_ x: Float) -> Float {
+  let y = uses_optionals(x)
+  return nested(y) // expected-note {{when differentiating this function call}}
+}
+
+func middle2(_ x: Float) -> Float {
+  return middle(x) // expected-note {{when differentiating this function call}}
+}
+
+func func_to_diff(_ x: Float) -> Float {
+  return middle2(x) // expected-note {{expression is not differentiable}}
+}
+
+func calls_grad_of_nested(_ x: Float) -> Float {
+  return #gradient(func_to_diff)(x) // expected-error {{function is not differentiable}}
+}
+
+//===----------------------------------------------------------------------===//
+// Control flow
+//===----------------------------------------------------------------------===//
+
+func if_else(_ x: Float, _ flag: Bool) -> Float {
+  let y: Float
+  // expected-note @+1 {{differentiating control flow is not supported yet}}
+  if flag {
+    y = x + 1
+  } else {
+    y = x
+  }
+  return y
+}
+
+// expected-error @+1 {{function is not differentiable}}
+_ = #gradient(if_else, wrt: .0)


### PR DESCRIPTION
Revamp error propagation and differentiability diagnostics in the automatic differentiation pass. 

Also:
- Make synthesized primal and adjoint functions have unqualified ownership.

Example:

```swift
func f(_ x: Float) -> Float {
  return #gradient(g)(x)
}

func g(_ x: Float) -> Float {
  return f(y)
}
```

```console
test.swift:2:10: error: function is not differentiable
  return #gradient(g)(x)
         ^         ~
test.swift:6:10: note: expression is not differentiable
  return f(x)
         ^
test.swift:2:10: note: nested differentiation is not supported yet
  return #gradient(g)(x)
         ^
```