### PR TITLE
[+0-all-args] Remove the SILOption EnableGuaranteedNormalArguments an…

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -99,9 +99,6 @@ public:
   /// Should we use a pass pipeline passed in via a json file? Null by default.
   llvm::StringRef ExternalPassPipelineFilename;
 
-  /// Emit normal function arguments using the +0 guaranteed convention.
-  bool EnableGuaranteedNormalArguments = true;
-
   /// Don't generate code using partial_apply in SIL generation.
   bool DisableSILPartialApply = false;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -684,8 +684,6 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   Opts.EnableMandatorySemanticARCOpts |=
       !Args.hasArg(OPT_disable_mandatory_semantic_arc_opts);
   Opts.EnableLargeLoadableTypes |= Args.hasArg(OPT_enable_large_loadable_types);
-  Opts.EnableGuaranteedNormalArguments &=
-      !Args.hasArg(OPT_disable_guaranteed_normal_arguments);
 
   if (const Arg *A = Args.getLastArg(OPT_save_optimization_record_path))
     Opts.OptRecordFile = A->getValue();

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -1306,9 +1306,7 @@ getSILFunctionTypeForAbstractCFunction(SILModule &M,
 /// If EnableGuaranteedNormalArguments is set, return a default convention that
 /// uses guaranteed.
 static DefaultConventions getNormalArgumentConvention(SILModule &M) {
-  if (M.getOptions().EnableGuaranteedNormalArguments)
-    return DefaultConventions(NormalParameterConvention::Guaranteed);
-  return DefaultConventions(NormalParameterConvention::Owned);
+  return DefaultConventions(NormalParameterConvention::Guaranteed);
 }
 
 static CanSILFunctionType getNativeSILFunctionType(

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -241,11 +241,7 @@ void verifyKeyPathComponent(SILModule &M,
               "component for subscript should have indices");
     }
     
-    ParameterConvention normalArgConvention;
-    if (M.getOptions().EnableGuaranteedNormalArguments)
-      normalArgConvention = ParameterConvention::Indirect_In_Guaranteed;
-    else
-      normalArgConvention = ParameterConvention::Indirect_In;
+    auto normalArgConvention = ParameterConvention::Indirect_In_Guaranteed;
   
     // Getter should be <Sig...> @convention(thin) (@in_guaranteed Base) -> @out Result
     {

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1144,16 +1144,9 @@ ManagedValue SILGenFunction::emitBridgedToNativeError(SILLocation loc,
          == ResultConvention::Owned);
   auto nativeErrorType = bridgeFnConv.getSILType(bridgeFnType->getResults()[0]);
 
-  SILValue arg;
-  if (SGM.M.getOptions().EnableGuaranteedNormalArguments) {
-    assert(bridgeFnType->getParameters()[0].getConvention() ==
-           ParameterConvention::Direct_Guaranteed);
-    arg = bridgedError.getValue();
-  } else {
-    assert(bridgeFnType->getParameters()[0].getConvention() ==
-           ParameterConvention::Direct_Owned);
-    arg = bridgedError.forward(*this);
-  }
+  assert(bridgeFnType->getParameters()[0].getConvention() ==
+	 ParameterConvention::Direct_Guaranteed);
+  SILValue arg = bridgedError.getValue();
 
   SILValue nativeError = B.createApply(loc, bridgeFn, bridgeFn->getType(),
                                        nativeErrorType, {}, arg);
@@ -1200,16 +1193,9 @@ ManagedValue SILGenFunction::emitNativeToBridgedError(SILLocation loc,
   auto loweredBridgedErrorType =
     bridgeFnConv.getSILType(bridgeFnType->getResults()[0]);
 
-  SILValue arg;
-  if (SGM.M.getOptions().EnableGuaranteedNormalArguments) {
-    assert(bridgeFnType->getParameters()[0].getConvention() ==
-           ParameterConvention::Direct_Guaranteed);
-    arg = nativeError.getValue();
-  } else {
-    assert(bridgeFnType->getParameters()[0].getConvention() ==
-           ParameterConvention::Direct_Owned);
-    arg = nativeError.forward(*this);
-  }
+  assert(bridgeFnType->getParameters()[0].getConvention() ==
+	 ParameterConvention::Direct_Guaranteed);
+  SILValue arg = nativeError.getValue();
 
   SILValue bridgedError = B.createApply(loc, bridgeFn, bridgeFn->getType(),
                                         loweredBridgedErrorType, {}, arg);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2851,14 +2851,8 @@ emitKeyPathRValueBase(SILGenFunction &subSGF,
   if (!storage->getDeclContext()->isTypeContext())
     return ManagedValue();
   
-  ManagedValue paramOrigValue;
-  
-  if (subSGF.SGM.M.getOptions().EnableGuaranteedNormalArguments) {
-    paramOrigValue =
+  auto paramOrigValue =
       ManagedValue::forBorrowedRValue(paramArg).copy(subSGF, loc);
-  } else {
-    paramOrigValue = subSGF.emitManagedRValueWithCleanup(paramArg);
-  }
   auto paramSubstValue = subSGF.emitOrigToSubstValue(loc, paramOrigValue,
                                              AbstractionPattern::getOpaque(),
                                              baseType);
@@ -2968,11 +2962,7 @@ static SILFunction *getOrCreateKeyPathGetter(SILGenModule &SGM,
                                              propertyType);
   }
   
-  ParameterConvention paramConvention;
-  if (SGM.M.getOptions().EnableGuaranteedNormalArguments)
-    paramConvention = ParameterConvention::Indirect_In_Guaranteed;
-  else
-    paramConvention = ParameterConvention::Indirect_In;
+  auto paramConvention = ParameterConvention::Indirect_In_Guaranteed;
 
   SmallVector<SILParameterInfo, 2> params;
   params.push_back({loweredBaseTy.getASTType(),
@@ -3087,11 +3077,7 @@ static SILFunction *getOrCreateKeyPathSetter(SILGenModule &SGM,
   
   auto &C = SGM.getASTContext();
   
-  ParameterConvention paramConvention;
-  if (SGM.M.getOptions().EnableGuaranteedNormalArguments)
-    paramConvention = ParameterConvention::Indirect_In_Guaranteed;
-  else
-    paramConvention = ParameterConvention::Indirect_In;
+  auto paramConvention = ParameterConvention::Indirect_In_Guaranteed;
 
   SmallVector<SILParameterInfo, 3> params;
   // property value
@@ -3166,12 +3152,8 @@ static SILFunction *getOrCreateKeyPathSetter(SILGenModule &SGM,
                                                          indexes,
                                                          indexPtrArg);
   
-  ManagedValue valueOrig;
-  if (SGM.M.getOptions().EnableGuaranteedNormalArguments)
-    valueOrig = ManagedValue::forBorrowedRValue(valueArg)
+  auto valueOrig = ManagedValue::forBorrowedRValue(valueArg)
       .copy(subSGF, loc);
-  else
-    valueOrig = subSGF.emitManagedRValueWithCleanup(valueArg);
   auto valueSubst = subSGF.emitOrigToSubstValue(loc, valueOrig,
                                                 AbstractionPattern::getOpaque(),
                                                 propertyType);

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -218,14 +218,8 @@ SILInstruction *CastOptimizer::optimizeBridgedObjCToSwiftCast(
   }
 
   (void)ParamTypes;
-  if (M.getOptions().EnableGuaranteedNormalArguments) {
-    assert(ParamTypes[0].getConvention() ==
-               ParameterConvention::Direct_Guaranteed &&
-           "Parameter should be @owned");
-  } else {
-    assert(ParamTypes[0].getConvention() == ParameterConvention::Direct_Owned &&
-           "Parameter should be @owned");
-  }
+  assert(ParamTypes[0].getConvention() == ParameterConvention::Direct_Guaranteed &&
+	 "Parameter should be @guaranteed");
 
   // Emit a retain.
   Builder.createRetainValue(Loc, SrcOp, Builder.getDefaultAtomicity());
@@ -239,9 +233,7 @@ SILInstruction *CastOptimizer::optimizeBridgedObjCToSwiftCast(
   // If we have guaranteed normal arguments, insert the destroy.
   //
   // TODO: Is it safe to just eliminate the initial retain?
-  if (M.getOptions().EnableGuaranteedNormalArguments) {
-    Builder.createReleaseValue(Loc, SrcOp, Builder.getDefaultAtomicity());
-  }
+  Builder.createReleaseValue(Loc, SrcOp, Builder.getDefaultAtomicity());
 
   // If the source of a cast should be destroyed, emit a release.
   if (isa<UnconditionalCheckedCastAddrInst>(Inst)) {

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -336,7 +336,6 @@ int main(int argc, char **argv) {
   SILOpts.EnableSILOwnership = EnableSILOwnershipOpt;
   SILOpts.AssumeUnqualifiedOwnershipWhenParsing =
     AssumeUnqualifiedOwnershipWhenParsing;
-  SILOpts.EnableGuaranteedNormalArguments &= !DisableGuaranteedNormalArguments;
 
   SILOpts.VerifyExclusivity = VerifyExclusivity;
   if (EnforceExclusivity.getNumOccurrences() != 0) {


### PR DESCRIPTION
…d minimally simplify code.

I made this change by removing the SILOption and then doing a compile, fix loop. I
purposely did not move around the code to make the refactoring really easy to
see.
