### PR TITLE
[Batch mode] Fix build failure to produce diagnostics swift 4.2 branch

### DIFF
--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -226,7 +226,7 @@ bool ide::printDeclUSR(const ValueDecl *D, raw_ostream &OS) {
     return printObjCUSR(D, OS);
   }
 
-  if (!D->hasInterfaceType())
+  if (!D->hasInterfaceType() || D->getInterfaceType()->is<ErrorType>())
     return true;
 
   // Invalid code.

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -252,6 +252,8 @@ static Optional<AccessKind> getAccessKind(Expr *E) {
 }
 
 std::pair<bool, Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
+  assert(E);
+
   if (isDone())
     return { false, nullptr };
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
In some circumstances when assertions are off and an underlying Objective-C module cannot be built, two bad things happen:
1. The frontend jobs abort because the indexer tries to demangle an error type, and if that is fixed,
2. Every serialized diagnostics file gets truncated because each primary file has only errors in non-primaries, and so the frontend tries to tell the driver that every primary compilation has been cancelled.

Unless both conditions are fixed, the developer never gets to see any diagnostics, and cannot fix the offending code.

This PR includes fixes for 1 and 2:
1. It does not demangle an error type, and 
2. If every serialized diagnostic file would be truncated, one of them is left alone.

It also adds an assertion check for indexing into a null part of the AST.

Also see https://github.com/apple/swift/pull/18351 , which incorporates the diagnostics fix into master.

Addresses rdar://42314665 when assertions are disabled.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
