### PR TITLE
[Parse] Fix end location of dummy top level code for code completion

### DIFF
--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -403,7 +403,7 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
       ParserStatus Status = parseExprOrStmt(Result);
       if (Status.hasCodeCompletion() && isCodeCompletionFirstPass()) {
         consumeTopLevelDecl(BeginParserPosition, TLCD);
-        auto Brace = BraceStmt::create(Context, StartLoc, {}, Tok.getLoc());
+        auto Brace = BraceStmt::create(Context, StartLoc, {}, PreviousLoc);
         TLCD->setBody(Brace);
         Entries.push_back(TLCD);
         return Status;

--- a/test/IDE/complete_pound_decl.swift
+++ b/test/IDE/complete_pound_decl.swift
@@ -6,8 +6,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_ELSE_MEMATTR | %FileCheck %s -check-prefix=ATTR
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_IF_GBLATTR | %FileCheck %s -check-prefix=ATTR
-// FIXME: SR-2364 the following line triggers an assertion
-// RUN_DISABLED: not --crash %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_IF_GBLNAME
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_IF_GBLNAME | %FileCheck %s -check-prefix=GLOBAL
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_ELIF_GBLNAME | %FileCheck %s -check-prefix=GLOBAL
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_ELIF_GBLATTR | %FileCheck %s -check-prefix=ATTR
 

--- a/validation-test/IDE/crashers_2/0015-pound-if-without-endif.swift
+++ b/validation-test/IDE/crashers_2/0015-pound-if-without-endif.swift
@@ -1,5 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
-
-#if a
-#^A^#

--- a/validation-test/IDE/crashers_2_fixed/0015-pound-if-without-endif.swift
+++ b/validation-test/IDE/crashers_2_fixed/0015-pound-if-without-endif.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+
+#if a
+#^A^#


### PR DESCRIPTION
Fix ASTVerifier error for end location of `IfConfigDecl`.
Previously, for:

```swift
#if CONDITION
// something
<TOKEN>
```

End location of the dummy body of `TopLevelCodeDecl` was at the eof, but the end loc of the `IfConfigDecl` was at the code-completion token. That caused the ASTVerifier error `"invalid IfConfigStmt end location"`.

https://bugs.swift.org/browse/SR-2364
rdar://problem/41217187
