### PR TITLE
[Sema] NFC: Refactor `AllowIUO` policy into individual flags

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1248,7 +1248,6 @@ bool PreCheckExpression::walkToClosureExprPre(ClosureExpr *closure) {
   options |= TypeResolutionFlags::AllowUnspecifiedTypes;
   options |= TypeResolutionFlags::AllowUnboundGenerics;
   options |= TypeResolutionFlags::InExpression;
-  options |= TypeResolutionFlags::AllowIUO;
   bool hadParameterError = false;
 
   GenericTypeToArchetypeResolver resolver(closure);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1045,9 +1045,10 @@ static void validatePatternBindingEntry(TypeChecker &tc,
   // In particular, it's /not/ correct to check the PBD's DeclContext because
   // top-level variables in a script file are accessible from other files,
   // even though the PBD is inside a TopLevelCodeDecl.
-  TypeResolutionOptions options = TypeResolutionFlags::InExpression;
+  TypeResolutionOptions options = TypeResolutionFlags::PatternBindingEntry;
+  options |= TypeResolutionFlags::InExpression;
+  options |= TypeResolutionFlags::Direct;
 
-  options |= TypeResolutionFlags::AllowIUO;
   if (binding->getInit(entryNumber)) {
     // If we have an initializer, we can also have unknown types.
     options |= TypeResolutionFlags::AllowUnspecifiedTypes;

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -531,7 +531,8 @@ static bool checkGenericFuncSignature(TypeChecker &tc,
   if (auto fn = dyn_cast<FuncDecl>(func)) {
     if (!fn->getBodyResultTypeLoc().isNull()) {
       // Check the result type of the function.
-      TypeResolutionOptions options = TypeResolutionFlags::AllowIUO;
+      TypeResolutionOptions options = TypeResolutionFlags::FunctionResult;
+      options |= TypeResolutionFlags::Direct;
       if (fn->hasDynamicSelf())
         options |= TypeResolutionFlags::DynamicSelfResult;
 
@@ -899,8 +900,10 @@ static bool checkGenericSubscriptSignature(TypeChecker &tc,
                     &resolver);
 
   // Check the element type.
+  TypeResolutionOptions elementOptions = TypeResolutionFlags::Direct;
+  elementOptions |= TypeResolutionFlags::FunctionResult;
   badType |= tc.validateType(subscript->getElementTypeLoc(), subscript,
-                             TypeResolutionFlags::AllowIUO, &resolver);
+                             elementOptions, &resolver);
 
   // Infer requirements from it.
   if (genericParams && builder) {

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -839,7 +839,6 @@ bool swift::performTypeLocChecking(ASTContext &Ctx, TypeLoc &T,
   options |= TypeResolutionFlags::AllowUnboundGenerics;
   if (isSILMode) {
     options |= TypeResolutionFlags::SILMode;
-    options |= TypeResolutionFlags::AllowIUO;
   }
   if (isSILType)
     options |= TypeResolutionFlags::SILType;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -479,6 +479,7 @@ enum class TypeResolutionFlags : unsigned {
 
   /// Whether we are in the input type of a function, or under one level of
   /// tuple type.  This is not set for multi-level tuple arguments.
+  /// See also: TypeResolutionFlags::Direct
   FunctionInput = 1 << 5,
 
   /// Whether this is a variadic function input.
@@ -543,8 +544,8 @@ enum class TypeResolutionFlags : unsigned {
   /// Whether we are checking the parameter list of a subscript.
   SubscriptParameters = 1 << 23,
 
-  /// Is it okay to resolve an IUO sigil ("!") here?
-  AllowIUO = 1 << 24,
+  /// Whether we are at the direct base of a type expression.
+  Direct = 1 << 24,
 
   /// Whether this type is being used in a cast or coercion expression.
   InCastOrCoercionExpression = 1 << 25,
@@ -557,6 +558,13 @@ enum class TypeResolutionFlags : unsigned {
 
   /// Whether we should not produce diagnostics if the type is invalid.
   SilenceErrors = 1 << 28,
+
+  /// Whether we are in the result type of a function, including multi-level
+  /// tuple return values. See also: TypeResolutionFlags::Direct
+  FunctionResult = 1 << 29,
+
+  /// Whether this is a pattern binding entry.
+  PatternBindingEntry = 1 << 30,
 };
 
 /// Option set describing how type resolution should work.
@@ -565,12 +573,14 @@ using TypeResolutionOptions = OptionSet<TypeResolutionFlags>;
 /// Strip the contextual options from the given type resolution options.
 static inline TypeResolutionOptions
 withoutContext(TypeResolutionOptions options, bool preserveSIL = false) {
+  options -= TypeResolutionFlags::Direct;
   options -= TypeResolutionFlags::FunctionInput;
   options -= TypeResolutionFlags::VariadicFunctionInput;
+  options -= TypeResolutionFlags::FunctionResult;
   options -= TypeResolutionFlags::EnumCase;
   options -= TypeResolutionFlags::SubscriptParameters;
   options -= TypeResolutionFlags::ImmediateOptionalTypeArgument;
-  options -= TypeResolutionFlags::AllowIUO;
+  options -= TypeResolutionFlags::PatternBindingEntry;
   if (!preserveSIL) options -= TypeResolutionFlags::SILType;
   return options;
 }


### PR DESCRIPTION
Whether implicitly unwrapped optionals are allowed or not it is separable from the contexts in which they are allowed.

Review questions:
1) The subscript element type was/is essentially context free as far as type resolver flag system is concerned. Because `AllowIUO` is effectively removed with this change, I needed something to replace it, so I used `FunctionResult` instead. Should we OR in `FunctionInput` too? Leave it as is? Or create a new flag specifically for subscript element types?
2) I changed `AllowIUO` into a union of the flags that make up the policy. I'm worried that this might confuse people that assume that `AllowIUO` is still a discrete flag. Should we rename it? `AllowIUOMask`? Something else?