### PR TITLE
[4.2] Guard for null result from ClangModuleUnit::getClangModule().

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -3585,7 +3585,7 @@ bool swift::isInOverlayModuleForImportedModule(const DeclContext *overlayDC,
   importedDC = importedDC->getModuleScopeContext();
 
   auto importedClangModuleUnit = dyn_cast<ClangModuleUnit>(importedDC);
-  if (!importedClangModuleUnit)
+  if (!importedClangModuleUnit || !importedClangModuleUnit->getClangModule())
     return false;
 
   auto overlayModule = overlayDC->getParentModule();


### PR DESCRIPTION
*  Explanation: Fix a commonly occurring crash in SourceKit.
*  Scope: We sometimes crash when testing if a declaration came from an overlay for a clang module. The fix is to add a null check and return a few lines above where we would otherwise dereference the pointer that crashes.
*  Issue #: rdar://problem/41888568
*  Risk: Very small. 
*  Testing: Standard regression tests plus source compatibility tests.
*  Reviewer: @jrose-apple 

Fixes: 
(cherry picked from commit f94d6535309c9c6a3f3986dcdaf5d8f168841cd0)