### PR TITLE
[Serialization] Preserve source order in serialization

### DIFF
--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -379,7 +379,7 @@ private:
 
   using DeclIDVector = SmallVector<serialization::DeclID, 4>;
 
-  DeclIDVector EagerDeserializationDecls;
+  DeclIDVector OrderedTopLevelDecls;
 
   class DeclCommentTableInfo;
   using SerializedDeclCommentTable =

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t VERSION_MINOR = 429; // Last change: coroutine accessors
+const uint16_t VERSION_MINOR = 430; // Last change: ordered top-level decls
 
 using DeclIDField = BCFixed<31>;
 
@@ -1635,6 +1635,8 @@ namespace index_block {
     NESTED_TYPE_DECLS,
     DECL_MEMBER_NAMES,
 
+    ORDERED_TOP_LEVEL_DECLS,
+
     GENERIC_SIGNATURE_OFFSETS,
     SUBSTITUTION_MAP_OFFSETS,
     LastRecordKind = SUBSTITUTION_MAP_OFFSETS,
@@ -1688,6 +1690,11 @@ namespace index_block {
   using EntryPointLayout = BCRecordLayout<
     ENTRY_POINT,
     DeclIDField  // the ID of the main class; 0 if there was a main source file
+  >;
+
+  using OrderedDeclsLayout = BCGenericRecordLayout<
+    RecordIDField,        // record ID
+    BCArray<DeclIDField>  // list of decls by ID
   >;
 }
 

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -497,7 +497,7 @@ void swift::ide::printSubmoduleInterface(
   // If the group name is specified, we sort them according to their source order,
   // which is the order preserved by getTopLevelDecls.
   if (GroupNames.empty()) {
-    std::sort(SwiftDecls.begin(), SwiftDecls.end(),
+    std::stable_sort(SwiftDecls.begin(), SwiftDecls.end(),
       [&](Decl *LHS, Decl *RHS) -> bool {
         auto *LHSValue = dyn_cast<ValueDecl>(LHS);
         auto *RHSValue = dyn_cast<ValueDecl>(RHS);

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -828,6 +828,9 @@ bool ModuleFile::readIndexBlock(llvm::BitstreamCursor &cursor) {
         assert(blobData.empty());
         setEntryPointClassID(scratch.front());
         break;
+      case index_block::ORDERED_TOP_LEVEL_DECLS:
+        OrderedTopLevelDecls.assign(scratch.begin(), scratch.end());
+        break;
       case index_block::LOCAL_TYPE_DECLS:
         LocalTypeDecls = readLocalDeclTable(scratch, blobData);
         break;
@@ -1980,48 +1983,15 @@ ModuleFile::collectLinkLibraries(ModuleDecl::LinkLibraryCallback callback) const
 
 void ModuleFile::getTopLevelDecls(SmallVectorImpl<Decl *> &results) {
   PrettyStackTraceModuleFile stackEntry(*this);
-  if (PrecedenceGroupDecls) {
-    for (auto entry : PrecedenceGroupDecls->data()) {
-      for (auto item : entry)
-        results.push_back(getDecl(item.second));
+  for (DeclID entry : OrderedTopLevelDecls) {
+    Expected<Decl *> declOrError = getDeclChecked(entry);
+    if (!declOrError) {
+      if (!getContext().LangOpts.EnableDeserializationRecovery)
+        fatal(declOrError.takeError());
+      llvm::consumeError(declOrError.takeError());
+      continue;
     }
-  }
-
-  if (OperatorDecls) {
-    for (auto entry : OperatorDecls->data()) {
-      for (auto item : entry)
-        results.push_back(getDecl(item.second));
-    }
-  }
-
-  if (TopLevelDecls) {
-    for (auto entry : TopLevelDecls->data()) {
-      for (auto item : entry) {
-        Expected<Decl *> declOrError = getDeclChecked(item.second);
-        if (!declOrError) {
-          if (!getContext().LangOpts.EnableDeserializationRecovery)
-            fatal(declOrError.takeError());
-          llvm::consumeError(declOrError.takeError());
-          continue;
-        }
-        results.push_back(declOrError.get());
-      }
-    }
-  }
-
-  if (ExtensionDecls) {
-    for (auto entry : ExtensionDecls->data()) {
-      for (auto item : entry) {
-        Expected<Decl *> declOrError = getDeclChecked(item.second);
-        if (!declOrError) {
-          if (!getContext().LangOpts.EnableDeserializationRecovery)
-            fatal(declOrError.takeError());
-          llvm::consumeError(declOrError.takeError());
-          continue;
-        }
-        results.push_back(declOrError.get());
-      }
-    }
+    results.push_back(declOrError.get());
   }
 }
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -822,6 +822,7 @@ void Serializer::writeBlockInfoBlock() {
   BLOCK_RECORD(index_block, PRECEDENCE_GROUPS);
   BLOCK_RECORD(index_block, NESTED_TYPE_DECLS);
   BLOCK_RECORD(index_block, DECL_MEMBER_NAMES);
+  BLOCK_RECORD(index_block, ORDERED_TOP_LEVEL_DECLS);
 
   BLOCK(DECL_MEMBER_TABLES_BLOCK);
   BLOCK_RECORD(decl_member_tables_block, DECL_MEMBERS);
@@ -4865,6 +4866,7 @@ void Serializer::writeAST(ModuleOrSourceFile DC,
   bool hasLocalTypes = false;
 
   Optional<DeclID> entryPointClassID;
+  SmallVector<DeclID, 16> orderedTopLevelDecls;
 
   ArrayRef<const FileUnit *> files;
   SmallVector<const FileUnit *, 1> Scratch;
@@ -4883,8 +4885,10 @@ void Serializer::writeAST(ModuleOrSourceFile DC,
     nextFile->getTopLevelDecls(fileDecls);
 
     for (auto D : fileDecls) {
-      if (isa<ImportDecl>(D))
+      if (isa<ImportDecl>(D) || isa<IfConfigDecl>(D) ||
+          isa<PoundDiagnosticDecl>(D) || isa<TopLevelCodeDecl>(D)) {
         continue;
+      }
 
       if (auto VD = dyn_cast<ValueDecl>(D)) {
         if (!VD->hasName())
@@ -4903,7 +4907,13 @@ void Serializer::writeAST(ModuleOrSourceFile DC,
       } else if (auto PGD = dyn_cast<PrecedenceGroupDecl>(D)) {
         precedenceGroupDecls[PGD->getName()]
           .push_back({ decls_block::PRECEDENCE_GROUP_DECL, addDeclRef(D) });
+      } else if (isa<PatternBindingDecl>(D)) {
+        // No special handling needed.
+      } else {
+        llvm_unreachable("all top-level declaration kinds accounted for");
       }
+
+      orderedTopLevelDecls.push_back(addDeclRef(D));
 
       // If this is a global variable, force the accessors to be
       // serialized.
@@ -4975,6 +4985,10 @@ void Serializer::writeAST(ModuleOrSourceFile DC,
       index_block::ExtensionTableLayout ExtensionTable(Out);
       writeExtensionTable(ExtensionTable, extensionDecls, *this);
     }
+
+    index_block::OrderedDeclsLayout OrderedDecls(Out);
+    OrderedDecls.emit(ScratchRecord, index_block::ORDERED_TOP_LEVEL_DECLS,
+                      orderedTopLevelDecls);
 
     index_block::ObjCMethodTableLayout ObjCMethodTable(Out);
     writeObjCMethodTable(ObjCMethodTable, objcMethods);

--- a/test/IDE/Inputs/foo_swift_module.printed.comments.txt
+++ b/test/IDE/Inputs/foo_swift_module.printed.comments.txt
@@ -60,7 +60,7 @@ precedencegroup High {
 
 infix operator %%% : High
 
-postfix operator =->
-
 postfix operator =>
+
+postfix operator =->
 

--- a/test/Index/index_module.swift
+++ b/test/Index/index_module.swift
@@ -22,14 +22,14 @@ public class CCC {}
 
 // --- Check the module ---
 
-// CHECK: 0:0 | function/Swift | someFunc() | [[SOMEFUNC_USR]] | Def | rel: 0
-
-// CHECK: 0:0 | class/Swift | CCC | [[CCC_USR]] | Def | rel: 0
-// CHECK: 0:0 | constructor/Swift | init() | [[CCC_init_USR]] | Def,Impl,RelChild | rel: 1
-// CHECK-NEXT:  RelChild | class/Swift | CCC | [[CCC_USR]]
-
 // CHECK: 0:0 | variable/Swift | someGlobal | [[SOMEGLOBAL_USR]] | Def | rel: 0
 // CHECK: 0:0 | function/acc-get/Swift | getter:someGlobal | [[SOMEGLOBAL_GET_USR:.*]] | Def,Impl,RelChild,RelAcc | rel: 1
 // CHECK-NEXT:   RelChild,RelAcc | variable/Swift | someGlobal | [[SOMEGLOBAL_USR]]
 // CHECK: 0:0 | function/acc-set/Swift | setter:someGlobal | [[SOMEGLOBAL_SET_USR:.*]] | Def,Impl,RelChild,RelAcc | rel: 1
 // CHECK-NEXT:   RelChild,RelAcc | variable/Swift | someGlobal | [[SOMEGLOBAL_USR]]
+
+// CHECK: 0:0 | function/Swift | someFunc() | [[SOMEFUNC_USR]] | Def | rel: 0
+
+// CHECK: 0:0 | class/Swift | CCC | [[CCC_USR]] | Def | rel: 0
+// CHECK: 0:0 | constructor/Swift | init() | [[CCC_init_USR]] | Def,Impl,RelChild | rel: 1
+// CHECK-NEXT:  RelChild | class/Swift | CCC | [[CCC_USR]]

--- a/test/Index/index_system_module.swift
+++ b/test/Index/index_system_module.swift
@@ -4,13 +4,13 @@
 // RUN: %target-swift-ide-test -print-indexed-symbols -module-to-print my_system_overlay -source-filename %s -I %t -Xcc -I -Xcc %S/Inputs/my_system_overlay > %t.out
 // RUN: %FileCheck %s -input-file=%t.out
 
+// CHECK: function/Swift | some_func() | [[SOMEFUNC_USR:.*]] | Def | rel: 0
+// CHECK: class/Swift | BaseCls | [[BASECLS_USR:.*]] | Def | rel: 0
+// CHECK: instance-method/Swift | theMeth() | [[BASECLSMETH_USR:.*]] | Def,Dyn,RelChild | rel: 1
+// CHECK-NEXT: RelChild | class/Swift | BaseCls | [[BASECLS_USR]]
 // CHECK: class/Swift | SubCls | [[SUBCLS_USR:.*]] | Def | rel: 0
-// CHECK: class/Swift | BaseCls | [[BASECLS_USR:.*]] | Ref,RelBase | rel: 1
+// CHECK: class/Swift | BaseCls | [[BASECLS_USR]] | Ref,RelBase | rel: 1
 // CHECK-NEXT: RelBase | class/Swift | SubCls | [[SUBCLS_USR]]
 // CHECK: instance-method/Swift | theMeth() | [[SUBCLSMETH_USR:.*]] | Def,Dyn,RelChild,RelOver | rel: 2
-// CHECK-NEXT: RelOver | instance-method/Swift | theMeth() | [[BASECLSMETH_USR:.*]]
+// CHECK-NEXT: RelOver | instance-method/Swift | theMeth() | [[BASECLSMETH_USR]]
 // CHECK-NEXT: RelChild | class/Swift | SubCls | [[SUBCLS_USR]]
-// CHECK: class/Swift | BaseCls | [[BASECLS_USR]] | Def | rel: 0
-// CHECK: instance-method/Swift | theMeth() | [[BASECLSMETH_USR]] | Def,Dyn,RelChild | rel: 1
-// CHECK-NEXT: RelChild | class/Swift | BaseCls | [[BASECLS_USR]]
-// CHECK: function/Swift | some_func() | [[SOMEFUNC_USR:.*]] | Def | rel: 0

--- a/test/Serialization/comments-hidden.swift
+++ b/test/Serialization/comments-hidden.swift
@@ -44,10 +44,10 @@ private class PrivateClass {
 // NORMAL: Public Function Documentation
 
 // TESTING-NEGATIVE-NOT: NotForTesting
-// TESTING: InternalClass Documentation
-// TESTING: Internal Function Documentation
 // TESTING: PublicClass Documentation
 // TESTING: Public Function Documentation
+// TESTING: Internal Function Documentation
+// TESTING: InternalClass Documentation
 // TESTING: Internal Function Documentation
 
 

--- a/test/Serialization/comments.swift
+++ b/test/Serialization/comments.swift
@@ -65,7 +65,7 @@ extension first_decl_class_1 : P1 {}
 // FIRST: Func/first_decl_class_1.decl_func_2 RawComment=[/**\n   * decl_func_3 Aaa.\n   */]
 // FIRST: Func/first_decl_class_1.decl_func_3 RawComment=[/// decl_func_3 Aaa.\n/** Bbb. */]
 
-// SECOND: Class/second_decl_class_1 RawComment=[/// second_decl_class_1 Aaa.\n]
 // SECOND: Extension/ RawComment=[/// Comment for bar1\n] BriefComment=[Comment for bar1]
 // SECOND: Extension/ RawComment=[/// Comment for bar2\n] BriefComment=[Comment for bar2]
 // SECOND: Extension/ RawComment=[/// Comment for no member extension\n] BriefComment=[Comment for no member extension]
+// SECOND: Class/second_decl_class_1 RawComment=[/// second_decl_class_1 Aaa.\n]

--- a/test/SourceKit/Indexing/Inputs/test_module.index.response
+++ b/test/SourceKit/Indexing/Inputs/test_module.index.response
@@ -27,12 +27,58 @@
   key.entities: [
     {
       key.kind: source.lang.swift.decl.class,
-      key.name: "C2",
-      key.usr: "s:11test_module2C2C",
+      key.name: "Empty",
+      key.usr: "s:11test_module5EmptyC",
       key.entities: [
         {
           key.kind: source.lang.swift.decl.function.constructor,
-          key.usr: "s:11test_module2C2CACycfc"
+          key.usr: "s:11test_module5EmptyCACycfc"
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.class,
+      key.name: "TwoInts",
+      key.usr: "s:11test_module7TwoIntsC",
+      key.entities: [
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "x",
+          key.usr: "s:11test_module7TwoIntsC1xSivp",
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:11test_module7TwoIntsC1xSivg",
+              key.is_dynamic: 1
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:11test_module7TwoIntsC1xSivs",
+              key.is_dynamic: 1
+            }
+          ]
+        },
+        {
+          key.kind: source.lang.swift.decl.var.instance,
+          key.name: "y",
+          key.usr: "s:11test_module7TwoIntsC1ySivp",
+          key.entities: [
+            {
+              key.kind: source.lang.swift.decl.function.accessor.getter,
+              key.usr: "s:11test_module7TwoIntsC1ySivg",
+              key.is_dynamic: 1
+            },
+            {
+              key.kind: source.lang.swift.decl.function.accessor.setter,
+              key.usr: "s:11test_module7TwoIntsC1ySivs",
+              key.is_dynamic: 1
+            }
+          ]
+        },
+        {
+          key.kind: source.lang.swift.decl.function.constructor,
+          key.name: "init(a:b:)",
+          key.usr: "s:11test_module7TwoIntsC1a1bACSi_Sitcfc"
         }
       ]
     },
@@ -84,69 +130,18 @@
       ]
     },
     {
-      key.kind: source.lang.swift.decl.class,
-      key.name: "TwoInts",
-      key.usr: "s:11test_module7TwoIntsC",
-      key.entities: [
-        {
-          key.kind: source.lang.swift.decl.var.instance,
-          key.name: "x",
-          key.usr: "s:11test_module7TwoIntsC1xSivp",
-          key.entities: [
-            {
-              key.kind: source.lang.swift.decl.function.accessor.getter,
-              key.usr: "s:11test_module7TwoIntsC1xSivg",
-              key.is_dynamic: 1
-            },
-            {
-              key.kind: source.lang.swift.decl.function.accessor.setter,
-              key.usr: "s:11test_module7TwoIntsC1xSivs",
-              key.is_dynamic: 1
-            }
-          ]
-        },
-        {
-          key.kind: source.lang.swift.decl.var.instance,
-          key.name: "y",
-          key.usr: "s:11test_module7TwoIntsC1ySivp",
-          key.entities: [
-            {
-              key.kind: source.lang.swift.decl.function.accessor.getter,
-              key.usr: "s:11test_module7TwoIntsC1ySivg",
-              key.is_dynamic: 1
-            },
-            {
-              key.kind: source.lang.swift.decl.function.accessor.setter,
-              key.usr: "s:11test_module7TwoIntsC1ySivs",
-              key.is_dynamic: 1
-            }
-          ]
-        },
-        {
-          key.kind: source.lang.swift.decl.function.constructor,
-          key.name: "init(a:b:)",
-          key.usr: "s:11test_module7TwoIntsC1a1bACSi_Sitcfc"
-        }
-      ]
-    },
-    {
       key.kind: source.lang.swift.decl.protocol,
       key.name: "Prot3",
       key.usr: "s:11test_module5Prot3P"
     },
     {
-      key.kind: source.lang.swift.decl.function.free,
-      key.name: "globalFunc()",
-      key.usr: "s:11test_module10globalFuncyyF"
-    },
-    {
       key.kind: source.lang.swift.decl.class,
-      key.name: "Empty",
-      key.usr: "s:11test_module5EmptyC",
+      key.name: "C2",
+      key.usr: "s:11test_module2C2C",
       key.entities: [
         {
           key.kind: source.lang.swift.decl.function.constructor,
-          key.usr: "s:11test_module5EmptyCACycfc"
+          key.usr: "s:11test_module2C2CACycfc"
         }
       ]
     },
@@ -171,6 +166,11 @@
           key.usr: "s:11test_module5Prot2P"
         }
       ]
+    },
+    {
+      key.kind: source.lang.swift.decl.function.free,
+      key.name: "globalFunc()",
+      key.usr: "s:11test_module10globalFuncyyF"
     }
   ]
 }

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -23,89 +23,6 @@
     },
     {
       "kind": "TypeDecl",
-      "name": "C0",
-      "printedName": "C0",
-      "declKind": "Class",
-      "usr": "s:4cake2C0C",
-      "location": "",
-      "moduleName": "cake",
-      "children": [
-        {
-          "kind": "Constructor",
-          "name": "init",
-          "printedName": "init()",
-          "declKind": "Constructor",
-          "usr": "s:4cake2C0CACyxq_q0_Gycfc",
-          "location": "",
-          "moduleName": "cake",
-          "children": [
-            {
-              "kind": "TypeNominal",
-              "name": "C0",
-              "printedName": "C0<T1, T2, T3>",
-              "usr": "s:4cake2C0C",
-              "children": [
-                {
-                  "kind": "TypeNominal",
-                  "name": "GenericTypeParam",
-                  "printedName": "T1"
-                },
-                {
-                  "kind": "TypeNominal",
-                  "name": "GenericTypeParam",
-                  "printedName": "T2"
-                },
-                {
-                  "kind": "TypeNominal",
-                  "name": "GenericTypeParam",
-                  "printedName": "T3"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "kind": "Function",
-          "name": "conditionalFooExt",
-          "printedName": "conditionalFooExt()",
-          "declKind": "Func",
-          "usr": "s:4cake2C0CA2A2S1VRszAERs_AERs0_rlE17conditionalFooExtyyF",
-          "location": "",
-          "moduleName": "cake",
-          "parentExtensionReqs": [
-            "T1 == cake.S1",
-            "T2 == cake.S1",
-            "T3 == cake.S1"
-          ],
-          "children": [
-            {
-              "kind": "TypeNominal",
-              "name": "Void",
-              "printedName": "()"
-            }
-          ]
-        },
-        {
-          "kind": "Function",
-          "name": "unconditionalFooExt",
-          "printedName": "unconditionalFooExt()",
-          "declKind": "Func",
-          "usr": "s:4cake2C0C19unconditionalFooExtyyF",
-          "location": "",
-          "moduleName": "cake",
-          "parentExtensionReqs": [],
-          "children": [
-            {
-              "kind": "TypeNominal",
-              "name": "Void",
-              "printedName": "()"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "kind": "TypeDecl",
       "name": "S1",
       "printedName": "S1",
       "declKind": "Struct",
@@ -191,6 +108,89 @@
               "name": "S1",
               "printedName": "S1",
               "usr": "s:4cake2S1V"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "C0",
+      "printedName": "C0",
+      "declKind": "Class",
+      "usr": "s:4cake2C0C",
+      "location": "",
+      "moduleName": "cake",
+      "children": [
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init()",
+          "declKind": "Constructor",
+          "usr": "s:4cake2C0CACyxq_q0_Gycfc",
+          "location": "",
+          "moduleName": "cake",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "C0",
+              "printedName": "C0<T1, T2, T3>",
+              "usr": "s:4cake2C0C",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "T1"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "T2"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "T3"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "conditionalFooExt",
+          "printedName": "conditionalFooExt()",
+          "declKind": "Func",
+          "usr": "s:4cake2C0CA2A2S1VRszAERs_AERs0_rlE17conditionalFooExtyyF",
+          "location": "",
+          "moduleName": "cake",
+          "parentExtensionReqs": [
+            "T1 == cake.S1",
+            "T2 == cake.S1",
+            "T3 == cake.S1"
+          ],
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "unconditionalFooExt",
+          "printedName": "unconditionalFooExt()",
+          "declKind": "Func",
+          "usr": "s:4cake2C0C19unconditionalFooExtyyF",
+          "location": "",
+          "moduleName": "cake",
+          "parentExtensionReqs": [],
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
             }
           ]
         }
@@ -429,42 +429,6 @@
       ]
     },
     {
-      "kind": "Function",
-      "name": "foo3",
-      "printedName": "foo3(_:)",
-      "declKind": "Func",
-      "usr": "s:4cake4foo3yySDySiSSGF",
-      "location": "",
-      "moduleName": "cake",
-      "children": [
-        {
-          "kind": "TypeNominal",
-          "name": "Void",
-          "printedName": "()"
-        },
-        {
-          "kind": "TypeNominal",
-          "name": "Dictionary",
-          "printedName": "[Int : String]",
-          "usr": "s:SD",
-          "children": [
-            {
-              "kind": "TypeNominal",
-              "name": "Int",
-              "printedName": "Int",
-              "usr": "s:Si"
-            },
-            {
-              "kind": "TypeNominal",
-              "name": "String",
-              "printedName": "String",
-              "usr": "s:SS"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "kind": "TypeDecl",
       "name": "Number",
       "printedName": "Number",
@@ -651,6 +615,42 @@
                   "usr": "s:Si"
                 }
               ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "Function",
+      "name": "foo3",
+      "printedName": "foo3(_:)",
+      "declKind": "Func",
+      "usr": "s:4cake4foo3yySDySiSSGF",
+      "location": "",
+      "moduleName": "cake",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "Void",
+          "printedName": "()"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "Dictionary",
+          "printedName": "[Int : String]",
+          "usr": "s:SD",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Int",
+              "printedName": "Int",
+              "usr": "s:Si"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "String",
+              "printedName": "String",
+              "usr": "s:SS"
             }
           ]
         }


### PR DESCRIPTION
We previously shied away from this in order to not *accidentally* depend on it, but it becomes interesting again with textual interfaces, which can certainly be read by humans. The cross-file order is the order of input files, which is at least controllable by users.