### PR TITLE
[BatchMode] <rdar://41271283> Limit memory pressure on large modules.

### DIFF
--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -172,8 +172,13 @@ private:
   /// Provides a randomization seed to batch-mode partitioning, for debugging.
   const unsigned BatchSeed;
 
-  /// Overrides parallelism level as count of batches, if in batch-mode.
+  /// Overrides parallelism level and \c BatchSizeLimit, sets exact
+  /// count of batches, if in batch-mode.
   const Optional<unsigned> BatchCount;
+
+  /// Overrides maximum batch size, if in batch-mode and not overridden
+  /// by \c BatchCount.
+  const Optional<unsigned> BatchSizeLimit;
 
   /// In order to test repartitioning, set to true if
   /// -driver-force-one-batch-repartition is present.
@@ -230,6 +235,7 @@ public:
               bool EnableBatchMode = false,
               unsigned BatchSeed = 0,
               Optional<unsigned> BatchCount = None,
+              Optional<unsigned> BatchSizeLimit = None,
               bool ForceOneBatchRepartition = false,
               bool SaveTemps = false,
               bool ShowDriverTimeCompilation = false,
@@ -341,6 +347,10 @@ public:
 
   Optional<unsigned> getBatchCount() const {
     return BatchCount;
+  }
+
+  Optional<unsigned> getBatchSizeLimit() const {
+    return BatchSizeLimit;
   }
 
   /// Requests the path to a file containing all input source files. This can

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -112,7 +112,10 @@ def driver_batch_seed : Separate<["-"], "driver-batch-seed">,
   HelpText<"Use the given seed value to randomize batch-mode partitions">;
 def driver_batch_count : Separate<["-"], "driver-batch-count">,
   InternalDebugOpt,
-  HelpText<"Use the given number of batch-mode partitions, rather than default parallelism level">;
+  HelpText<"Use the given number of batch-mode partitions, rather than partitioning dynamically">;
+def driver_batch_size_limit : Separate<["-"], "driver-batch-size-limit">,
+  InternalDebugOpt,
+  HelpText<"Use the given number as the upper limit on dynamic batch-mode partition size">;
 def driver_force_one_batch_repartition : Flag<["-"], "driver-force-one-batch-repartition">,
   InternalDebugOpt,
   HelpText<"Force one batch repartitioning for testing">;

--- a/validation-test/Driver/batch_mode_overlong_argv.swift
+++ b/validation-test/Driver/batch_mode_overlong_argv.swift
@@ -103,7 +103,7 @@
 // RUN: touch  %t/f_100_1.swift %t/f_100_2.swift %t/f_100_3.swift %t/f_100_4.swift %t/f_100_5.swift %t/f_100_6.swift %t/f_100_7.swift %t/f_100_8.swift %t/f_100_9.swift %t/f_100_10.swift
 // RUN: mkdir -p %t/additional/path/elements/often/make/filenames/longer/than/one/might/expect/especially/given/output/directories/deep/within/a/derived/data/folder/of/a/CI/machine/
 // Force the repartitioning:
-// RUN: %swiftc_driver -driver-show-job-lifecycle -driver-force-one-batch-repartition -v -c -module-name foo -o %t/additional/path/elements/often/make/filenames/longer/than/one/might/expect/especially/given/output/directories/deep/within/a/derived/data/folder/of/a/CI/machine/foo.o -emit-module -serialize-diagnostics -emit-dependencies -j 1 -enable-batch-mode %t/f_*.swift >%t/out.txt 2>&1
+// RUN: %swiftc_driver -driver-show-job-lifecycle -driver-batch-size-limit 10000 -driver-force-one-batch-repartition -v -c -module-name foo -o %t/additional/path/elements/often/make/filenames/longer/than/one/might/expect/especially/given/output/directories/deep/within/a/derived/data/folder/of/a/CI/machine/foo.o -emit-module -serialize-diagnostics -emit-dependencies -j 1 -enable-batch-mode %t/f_*.swift >%t/out.txt 2>&1
 // RUN: %FileCheck %s <%t/out.txt
 // CHECK-NOT: unable to execute command
 // CHECK: Forming into 1 batches
@@ -113,7 +113,7 @@
 // CHECK: Forming batch job from 500 constituents
 //
 // Try it without the force; supplementary output file maps should obviate the repartition:
-// RUN: %swiftc_driver -driver-show-job-lifecycle -v -c -module-name foo -o %t/additional/path/elements/often/make/filenames/longer/than/one/might/expect/especially/given/output/directories/deep/within/a/derived/data/folder/of/a/CI/machine/foo.o -emit-module -serialize-diagnostics -emit-dependencies -j 1 -enable-batch-mode %t/f_*.swift >%t/out2.txt 2>&1
+// RUN: %swiftc_driver -driver-show-job-lifecycle -driver-batch-size-limit 10000 -v -c -module-name foo -o %t/additional/path/elements/often/make/filenames/longer/than/one/might/expect/especially/given/output/directories/deep/within/a/derived/data/folder/of/a/CI/machine/foo.o -emit-module -serialize-diagnostics -emit-dependencies -j 1 -enable-batch-mode %t/f_*.swift >%t/out2.txt 2>&1
 // RUN: %FileCheck %s <%t/out2.txt -check-prefix=NO-REPARTITION
 // CHECK-NOT: unable to execute command
 // NO-REPARTITION: Forming into 1 batches

--- a/validation-test/Driver/batch_mode_size_limit.swift
+++ b/validation-test/Driver/batch_mode_size_limit.swift
@@ -1,0 +1,34 @@
+// RUN: %empty-directory(%t)
+// RUN: touch  %t/f_1_1.swift %t/f_1_2.swift %t/f_1_3.swift %t/f_1_4.swift %t/f_1_5.swift %t/f_1_6.swift %t/f_1_7.swift %t/f_1_8.swift %t/f_1_9.swift %t/f_1_10.swift
+// RUN: touch  %t/f_2_1.swift %t/f_2_2.swift %t/f_2_3.swift %t/f_2_4.swift %t/f_2_5.swift %t/f_2_6.swift %t/f_2_7.swift %t/f_2_8.swift %t/f_2_9.swift %t/f_2_10.swift
+// RUN: touch  %t/f_3_1.swift %t/f_3_2.swift %t/f_3_3.swift %t/f_3_4.swift %t/f_3_5.swift %t/f_3_6.swift %t/f_3_7.swift %t/f_3_8.swift %t/f_3_9.swift %t/f_3_10.swift
+// RUN: touch  %t/f_4_1.swift %t/f_4_2.swift %t/f_4_3.swift %t/f_4_4.swift %t/f_4_5.swift %t/f_4_6.swift %t/f_4_7.swift %t/f_4_8.swift %t/f_4_9.swift %t/f_4_10.swift
+// RUN: touch  %t/f_5_1.swift %t/f_5_2.swift %t/f_5_3.swift %t/f_5_4.swift %t/f_5_5.swift %t/f_5_6.swift %t/f_5_7.swift %t/f_5_8.swift %t/f_5_9.swift %t/f_5_10.swift
+// RUN: touch  %t/f_6_1.swift %t/f_6_2.swift %t/f_6_3.swift %t/f_6_4.swift %t/f_6_5.swift %t/f_6_6.swift %t/f_6_7.swift %t/f_6_8.swift %t/f_6_9.swift %t/f_6_10.swift
+// RUN: touch  %t/f_7_1.swift %t/f_7_2.swift %t/f_7_3.swift %t/f_7_4.swift %t/f_7_5.swift %t/f_7_6.swift %t/f_7_7.swift %t/f_7_8.swift %t/f_7_9.swift %t/f_7_10.swift
+// RUN: touch  %t/f_8_1.swift %t/f_8_2.swift %t/f_8_3.swift %t/f_8_4.swift %t/f_8_5.swift %t/f_8_6.swift %t/f_8_7.swift %t/f_8_8.swift %t/f_8_9.swift %t/f_8_10.swift
+// RUN: touch  %t/f_9_1.swift %t/f_9_2.swift %t/f_9_3.swift %t/f_9_4.swift %t/f_9_5.swift %t/f_9_6.swift %t/f_9_7.swift %t/f_9_8.swift %t/f_9_9.swift %t/f_9_10.swift
+// RUN: touch  %t/f_10_1.swift %t/f_10_2.swift %t/f_10_3.swift %t/f_10_4.swift %t/f_10_5.swift %t/f_10_6.swift %t/f_10_7.swift %t/f_10_8.swift %t/f_10_9.swift %t/f_10_10.swift
+// RUN: %swiftc_driver -driver-show-job-lifecycle -v -c -module-name foo -emit-module -serialize-diagnostics -emit-dependencies -j 1 -enable-batch-mode %t/f_*.swift >%t/out.txt 2>&1
+// RUN: %FileCheck %s <%t/out.txt
+// CHECK-NOT: unable to execute command
+// CHECK: Forming into 4 batches
+// CHECK: Forming batch job from 25 constituents
+// CHECK: Forming batch job from 25 constituents
+// CHECK: Forming batch job from 25 constituents
+// CHECK: Forming batch job from 25 constituents
+//
+// RUN: %swiftc_driver -driver-show-job-lifecycle -driver-batch-size-limit 10 -v -c -module-name foo -emit-module -serialize-diagnostics -emit-dependencies -j 1 -enable-batch-mode %t/f_*.swift >%t/out.txt 2>&1
+// RUN: %FileCheck %s <%t/out.txt -check-prefix=EXPLICIT-ARG
+// EXPLICIT-ARG-NOT: unable to execute command
+// EXPLICIT-ARG: Forming into 10 batches
+// EXPLICIT-ARG: Forming batch job from 10 constituents
+// EXPLICIT-ARG: Forming batch job from 10 constituents
+// EXPLICIT-ARG: Forming batch job from 10 constituents
+// EXPLICIT-ARG: Forming batch job from 10 constituents
+// EXPLICIT-ARG: Forming batch job from 10 constituents
+// EXPLICIT-ARG: Forming batch job from 10 constituents
+// EXPLICIT-ARG: Forming batch job from 10 constituents
+// EXPLICIT-ARG: Forming batch job from 10 constituents
+// EXPLICIT-ARG: Forming batch job from 10 constituents
+// EXPLICIT-ARG: Forming batch job from 10 constituents


### PR DESCRIPTION
The comment in Compilation.cpp explains the rationale in gory detail, but the short version is "this PR limits the size of a batch-mode batch to 25 files by default, while adding another option to override that if the user is in an extreme case".

In the majority of cases this will do nothing since batches were smaller than 25 files anyways, and in a few cases of multiple large-module targets building on (say) smaller laptops it will break batches into a few extra pieces, maybe as many as 10 or 20, but only in cases where this happens to be important to avoid overrunning physical memory / pushing such systems into paging.

The performance effect ought to be (and appears to be, in my limited testing) negligible: a few percent on cases where batch mode was already an order-of-magnitude win, and nothing everywhere else.

rdar://41271283