### PR TITLE
[Name lookup] Introduce requests for several name lookup operations. 

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3811,7 +3811,7 @@ public:
   llvm::TinyPtrVector<ProtocolDecl *> getInheritedProtocols() const;
 
   /// Determine whether this protocol has a superclass.
-  bool hasSuperclass() const { return (bool)getSuperclass(); }
+  bool hasSuperclass() const { return (bool)getSuperclassDecl(); }
 
   /// Retrieve the superclass of this protocol, or null if there is no superclass.
   Type getSuperclass() const;

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3497,7 +3497,7 @@ public:
   }
 
   /// Determine whether this class has a superclass.
-  bool hasSuperclass() const { return (bool)getSuperclass(); }
+  bool hasSuperclass() const { return (bool)getSuperclassDecl(); }
 
   /// Retrieve the superclass of this class, or null if there is no superclass.
   Type getSuperclass() const;

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -487,7 +487,7 @@ public:
                        SmallVectorImpl<ValueDecl *> &decls) const;
 
   /// Look for the set of declarations with the given name within the
-  /// given set of type declarations.
+  /// given set of nominal type declarations.
   ///
   /// \param types The type declarations to look into.
   ///
@@ -500,7 +500,7 @@ public:
   /// lookup.
   ///
   /// \returns true if anything was found.
-  bool lookupQualified(ArrayRef<TypeDecl *> types, DeclName member,
+  bool lookupQualified(ArrayRef<NominalTypeDecl *> types, DeclName member,
                        NLOptions options,
                        SmallVectorImpl<ValueDecl *> &decls) const;
 

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -1,0 +1,185 @@
+//===--- NameLookupRequests.h - Name Lookup Requests ------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines name-lookup requests.
+//
+//===----------------------------------------------------------------------===//
+#ifndef SWIFT_NAME_LOOKUP_REQUESTS_H
+#define SWIFT_NAME_LOOKUP_REQUESTS_H
+
+#include "swift/AST/SimpleRequest.h"
+#include "swift/Basic/Statistic.h"
+#include "llvm/ADT/TinyPtrVector.h"
+
+namespace swift {
+
+class ClassDecl;
+class TypeAliasDecl;
+class TypeDecl;
+
+/// Display a nominal type or extension thereof.
+void simple_display(
+       llvm::raw_ostream &out,
+       const llvm::PointerUnion<TypeDecl *, ExtensionDecl *> &value);
+
+/// Describes a set of type declarations that are "direct" referenced by
+/// a particular type in the AST.
+using DirectlyReferencedTypeDecls = llvm::TinyPtrVector<TypeDecl *>;
+
+/// Request the set of declarations directly referenced by the an "inherited"
+/// type of a type or extension declaration.
+///
+/// This request retrieves the set of declarations that are directly referenced
+/// by a particular type in the "inherited" clause of a type or extension
+/// declaration. For example:
+///
+/// \code
+///   protocol P { }
+///   protocol Q { }
+///   typealias Alias = P & Q
+///   class C { }
+///
+///   class D: C, Alias { }
+/// \endcode
+///
+/// The inherited declaration of \c D at index 0 is the class declaration C.
+/// The inherited declaration of \c D at index 1 is the typealias Alias.
+class InheritedDeclsReferencedRequest :
+  public SimpleRequest<InheritedDeclsReferencedRequest,
+                       CacheKind::Uncached, // FIXME: Cache these
+                       DirectlyReferencedTypeDecls,
+                       llvm::PointerUnion<TypeDecl *, ExtensionDecl *>,
+                       unsigned>
+{
+  /// Retrieve the TypeLoc for this inherited type.
+  TypeLoc &getTypeLoc(llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
+                      unsigned index) const;
+
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend class SimpleRequest;
+
+  // Evaluation.
+  DirectlyReferencedTypeDecls evaluate(
+      Evaluator &evaluator,
+      llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
+      unsigned index) const;
+
+public:
+  // Caching
+  bool isCached() const { return true; }
+
+  // Cycle handling
+  DirectlyReferencedTypeDecls breakCycle() const { return { }; }
+  void diagnoseCycle(DiagnosticEngine &diags) const;
+  void noteCycleStep(DiagnosticEngine &diags) const;
+};
+
+/// Request the set of declarations directly referenced by the underlying
+/// type of a typealias.
+///
+/// This request retrieves the set of type declarations that directly referenced
+/// by the underlying type of a typealias. For example:
+///
+/// \code
+///   protocol P { }
+///   protocol Q { }
+///   class C { }
+///   typealias PQ = P & Q
+///   typealias Alias = C & PQ
+/// \endcode
+///
+/// The set of declarations referenced by the underlying type of \c PQ
+/// contains both \c P and \c Q.
+/// The set of declarations referenced by the underlying type of \c Alias
+/// contains \c C and \c PQ. Clients can choose to look further into \c PQ
+/// using another instance of this request.
+class UnderlyingTypeDeclsReferencedRequest :
+  public SimpleRequest<UnderlyingTypeDeclsReferencedRequest,
+                       CacheKind::Uncached, // FIXME: Cache these
+                       DirectlyReferencedTypeDecls,
+                       TypeAliasDecl *>
+{
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend class SimpleRequest;
+
+  // Evaluation.
+  DirectlyReferencedTypeDecls evaluate(
+      Evaluator &evaluator,
+      TypeAliasDecl *typealias) const;
+
+public:
+  // Caching
+  bool isCached() const { return true; }
+
+  // Cycle handling
+  DirectlyReferencedTypeDecls breakCycle() const { return { }; }
+  void diagnoseCycle(DiagnosticEngine &diags) const;
+  void noteCycleStep(DiagnosticEngine &diags) const;
+};
+
+/// Request the superclass declaration for the given class.
+class SuperclassDeclRequest :
+    public SimpleRequest<SuperclassDeclRequest,
+                         CacheKind::Uncached, // FIXME: Cache these
+                         ClassDecl *,
+                         NominalTypeDecl *> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend class SimpleRequest;
+
+  // Evaluation.
+  ClassDecl *evaluate(Evaluator &evaluator, NominalTypeDecl *subject) const;
+
+public:
+  // Caching
+  bool isCached() const { return true; }
+
+  // Cycle handling
+  ClassDecl *breakCycle() const { return nullptr; }
+  void diagnoseCycle(DiagnosticEngine &diags) const;
+  void noteCycleStep(DiagnosticEngine &diags) const;
+};
+
+/// The zone number for name-lookup requests.
+#define SWIFT_NAME_LOOKUP_REQUESTS_TYPEID_ZONE 9
+
+#define SWIFT_TYPEID_ZONE SWIFT_NAME_LOOKUP_REQUESTS_TYPEID_ZONE
+#define SWIFT_TYPEID_HEADER "swift/AST/NameLookupTypeIDZone.def"
+#include "swift/Basic/DefineTypeIDZone.h"
+#undef SWIFT_TYPEID_ZONE
+#undef SWIFT_TYPEID_HEADER
+
+// Set up reporting of evaluated requests.
+template<typename Request>
+void reportEvaluatedRequest(UnifiedStatsReporter &stats,
+                            const Request &request);
+
+#define SWIFT_TYPEID(RequestType)                                \
+template<>                                                       \
+inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,  \
+                            const RequestType &request) {        \
+  ++stats.getFrontendCounters().RequestType;                     \
+}
+#include "swift/AST/NameLookupTypeIDZone.def"
+#undef SWIFT_TYPEID
+
+} // end namespace swift
+
+#endif // SWIFT_NAME_LOOKUP_REQUESTS

--- a/include/swift/AST/NameLookupTypeIDZone.def
+++ b/include/swift/AST/NameLookupTypeIDZone.def
@@ -1,0 +1,19 @@
+//===--- NameLookupTypeIDZone.def -------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This definition file describes the types in the name-lookup
+//  TypeID zone, for use with the TypeID template.
+//
+//===----------------------------------------------------------------------===//
+SWIFT_TYPEID(InheritedDeclsReferencedRequest)
+SWIFT_TYPEID(UnderlyingTypeDeclsReferencedRequest)
+SWIFT_TYPEID(SuperclassDeclRequest)

--- a/include/swift/AST/SimpleRequest.h
+++ b/include/swift/AST/SimpleRequest.h
@@ -155,7 +155,7 @@ public:
     return !(lhs == rhs);
   }
 
-  friend hash_code hash_value(const SimpleRequest &request) {
+  friend llvm::hash_code hash_value(const SimpleRequest &request) {
     using llvm::hash_combine;
 
     return hash_combine(TypeID<Derived>::value, request.storage);

--- a/include/swift/Basic/CTypeIDZone.def
+++ b/include/swift/Basic/CTypeIDZone.def
@@ -35,3 +35,7 @@ SWIFT_TYPEID_NAMED(void, Void)
 
 // C++ standard library types.
 SWIFT_TYPEID_TEMPLATE1_NAMED(std::vector, Vector, typename T, T)
+
+// LLVM ADT types.
+SWIFT_TYPEID_TEMPLATE1_NAMED(llvm::TinyPtrVector, TinyPtrVector, typename T, T)
+

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -198,6 +198,7 @@ FRONTEND_STATISTIC(Sema, NumUnloadedLazyIterableDeclContexts)
 /// All type check requests go into the Sema area.
 #define SWIFT_TYPEID(NAME) FRONTEND_STATISTIC(Sema, NAME)
 #include "swift/AST/AccessTypeIDZone.def"
+#include "swift/AST/NameLookupTypeIDZone.def"
 #include "swift/AST/TypeCheckerTypeIDZone.def"
 #undef SWIFT_TYPEID
 

--- a/include/swift/Basic/TypeID.h
+++ b/include/swift/Basic/TypeID.h
@@ -20,6 +20,7 @@
 #define SWIFT_BASIC_TYPEID_H
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/TinyPtrVector.h"
 #include <cstdint>
 #include <string>
 #include <vector>

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -356,6 +356,11 @@ namespace swift {
   /// The ASTContext will automatically call these upon construction.
   void registerAccessRequestFunctions(Evaluator &evaluator);
 
+  /// Register AST-level request functions with the evaluator.
+  ///
+  /// The ASTContext will automatically call these upon construction.
+  void registerNameLookupRequestFunctions(Evaluator &evaluator);
+
   /// Register Sema-level request functions with the evaluator.
   ///
   /// Clients that form an ASTContext and will perform any semantic queries

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -514,6 +514,7 @@ ASTContext::ASTContext(LangOptions &langOpts, SearchPathOptions &SearchPathOpts,
 
   // Register any request-evaluator functions available at the AST layer.
   registerAccessRequestFunctions(evaluator);
+  registerNameLookupRequestFunctions(evaluator);
 }
 
 ASTContext::~ASTContext() {

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -41,6 +41,7 @@ add_swift_library(swiftAST STATIC
   ModuleLoader.cpp
   ModuleNameLookup.cpp
   NameLookup.cpp
+  NameLookupRequests.cpp
   Parameter.cpp
   Pattern.cpp
   PlatformKind.cpp

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3245,9 +3245,10 @@ ObjCClassKind ClassDecl::checkObjCAncestry() const {
     if (CD->isGenericContext())
       genericAncestry = true;
 
-    // FIXME: Checking isObjC() introduces cyclic dependencies here, but this
-    // doesn't account for ill-formed @objc.
-    if (CD->getAttrs().hasAttribute<ObjCAttr>())
+    // Is this class @objc? For the current class, only look at the attribute
+    // to avoid cycles; for superclasses, compute @objc completely.
+    if ((CD == this && CD->getAttrs().hasAttribute<ObjCAttr>()) ||
+        (CD != this && CD->isObjC()))
       isObjC = true;
 
     if (!CD->hasSuperclass())

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3206,8 +3206,7 @@ bool ClassDecl::inheritsSuperclassInitializers(LazyResolver *resolver) {
 
   // If there's no superclass, there's nothing to inherit.
   ClassDecl *superclassDecl;
-  if (!getSuperclass() ||
-      !(superclassDecl = getSuperclass()->getClassOrBoundGenericClass())) {
+  if (!(superclassDecl = getSuperclassDecl())) {
     setAddedImplicitInitializers();
     return false;
   }
@@ -3253,7 +3252,7 @@ ObjCClassKind ClassDecl::checkObjCAncestry() const {
 
     if (!CD->hasSuperclass())
       break;
-    CD = CD->getSuperclass()->getClassOrBoundGenericClass();
+    CD = CD->getSuperclassDecl();
     // If we don't have a valid class here, we should have diagnosed
     // elsewhere.
     if (!CD)
@@ -3369,7 +3368,7 @@ ClassDecl::findImplementingMethod(const AbstractFunctionDecl *Method) const {
     // Check the superclass
     if (!C->hasSuperclass())
       break;
-    C = C->getSuperclass()->getClassOrBoundGenericClass();
+    C = C->getSuperclassDecl();
   }
   return nullptr;
 }
@@ -5880,7 +5879,7 @@ ConstructorDecl::getDelegatingOrChainedInitKind(DiagnosticEngine *diags,
   // gets an implicit chained initializer.
   if (Kind == BodyInitKind::None) {
     if (auto classDecl = getDeclContext()->getAsClassOrClassExtensionContext()) {
-      if (classDecl->getSuperclass())
+      if (classDecl->hasSuperclass())
         Kind = BodyInitKind::ImplicitChained;
     }
   }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -31,6 +31,7 @@
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/NameLookupRequests.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/Pattern.h"
 #include "swift/AST/ProtocolConformance.h"
@@ -3564,9 +3565,8 @@ Type ProtocolDecl::getSuperclass() const {
 }
 
 ClassDecl *ProtocolDecl::getSuperclassDecl() const {
-  if (auto superclass = getSuperclass())
-    return superclass->getClassOrBoundGenericClass();
-  return nullptr;
+  ASTContext &ctx = getASTContext();
+  return ctx.evaluator(SuperclassDeclRequest{const_cast<ProtocolDecl *>(this)});
 }
 
 void ProtocolDecl::setSuperclass(Type superclass) {
@@ -6005,9 +6005,8 @@ Type ClassDecl::getSuperclass() const {
 }
 
 ClassDecl *ClassDecl::getSuperclassDecl() const {
-  if (auto superclass = getSuperclass())
-    return superclass->getClassOrBoundGenericClass();
-  return nullptr;
+  ASTContext &ctx = getASTContext();
+  return ctx.evaluator(SuperclassDeclRequest{const_cast<ClassDecl *>(this)});
 }
 
 void ClassDecl::setSuperclass(Type superclass) {

--- a/lib/AST/DocComment.cpp
+++ b/lib/AST/DocComment.cpp
@@ -410,9 +410,10 @@ getProtocolRequirementDocComment(swift::markup::MarkupContext &MC,
                                                 const ValueDecl *VD)
     -> const ValueDecl * {
       SmallVector<ValueDecl *, 2> Members;
-      P->lookupQualified(P->getDeclaredType(), VD->getFullName(),
+      P->lookupQualified(const_cast<ProtocolDecl *>(P),
+                         VD->getFullName(),
                          NLOptions::NL_ProtocolMembers,
-                         /*typeResolver=*/nullptr, Members);
+                         Members);
     SmallVector<const ValueDecl *, 1> ProtocolRequirements;
     for (auto Member : Members)
       if (isa<ProtocolDecl>(Member->getDeclContext()) &&

--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -695,7 +695,7 @@ static void lookupVisibleMemberDeclsImpl(
     // If we have a class type, look into its superclass.
     auto *CurClass = dyn_cast<ClassDecl>(CurNominal);
 
-    if (CurClass && CurClass->hasSuperclass()) {
+    if (CurClass && CurClass->getSuperclass()) {
       // FIXME: This path is no substitute for an actual circularity check.
       // The real fix is to check that the superclass doesn't introduce a
       // circular reference before it's written into the AST.

--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -695,6 +695,10 @@ static void lookupVisibleMemberDeclsImpl(
     // If we have a class type, look into its superclass.
     auto *CurClass = dyn_cast<ClassDecl>(CurNominal);
 
+    // FIXME: We check `getSuperclass()` here because we'll be using the
+    // superclass Type below, and in ill-formed code `hasSuperclass()` could
+    // be true while `getSuperclass()` returns null, because the latter
+    // looks for a declaration.
     if (CurClass && CurClass->getSuperclass()) {
       // FIXME: This path is no substitute for an actual circularity check.
       // The real fix is to check that the superclass doesn't introduce a

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -24,6 +24,7 @@
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/Initializer.h"
+#include "swift/AST/NameLookupRequests.h"
 #include "swift/AST/ReferencedNameTracker.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/Statistic.h"
@@ -1932,4 +1933,308 @@ void DeclContext::lookupAllObjCMethods(
                      return !visited.insert(func).second;
                    }),
     results.end());
+}
+
+/// Given a set of type declarations, find all of the nominal type declarations
+/// that they reference, looking through typealiases as appropriate.
+static TinyPtrVector<NominalTypeDecl *>
+resolveTypeDeclsToNominal(Evaluator &evaluator,
+                          ASTContext &ctx,
+                          ArrayRef<TypeDecl *> typeDecls,
+                          SmallVectorImpl<ModuleDecl *> &modulesFound) {
+  TinyPtrVector<NominalTypeDecl *> nominalDecls;
+
+  for (auto typeDecl : typeDecls) {
+    // Nominal type declarations get copied directly.
+    if (auto nominalDecl = dyn_cast<NominalTypeDecl>(typeDecl)) {
+      nominalDecls.push_back(nominalDecl);
+      continue;
+    }
+
+    // Recursively resolve typealiases.
+    if (auto typealias = dyn_cast<TypeAliasDecl>(typeDecl)) {
+      auto underlyingTypeReferences
+        = evaluator(UnderlyingTypeDeclsReferencedRequest{typealias});
+      auto underlyingNominalReferences
+        = resolveTypeDeclsToNominal(evaluator, ctx, underlyingTypeReferences,
+                                    modulesFound);
+      nominalDecls.insert(nominalDecls.end(),
+                          underlyingNominalReferences.begin(),
+                          underlyingNominalReferences.end());
+      continue;
+    }
+
+    // Keep track of modules we see.
+    if (auto module = dyn_cast<ModuleDecl>(typeDecl)) {
+      modulesFound.push_back(module);
+      continue;
+    }
+
+    // Make sure we didn't miss some interesting kind of type declaration.
+    assert(isa<AbstractTypeParamDecl>(typeDecl));
+  }
+
+  return nominalDecls;
+}
+
+/// Perform unqualified name lookup for types at the given location.
+static DirectlyReferencedTypeDecls
+directReferencesForUnqualifiedTypeLookup(ASTContext &ctx, DeclName name,
+                                         SourceLoc loc, DeclContext *dc) {
+  DirectlyReferencedTypeDecls results;
+  UnqualifiedLookup::Options options = UnqualifiedLookup::Flags::TypeLookup;
+  UnqualifiedLookup lookup(name, dc, ctx.getLazyResolver(), loc, options);
+  for (const auto &result : lookup.Results) {
+    if (auto typeDecl = dyn_cast<TypeDecl>(result.getValueDecl()))
+      results.push_back(typeDecl);
+  }
+
+  return results;
+}
+
+/// Perform qualified name lookup for types.
+static DirectlyReferencedTypeDecls
+directReferencesForQualifiedTypeLookup(Evaluator &evaluator,
+                                       ASTContext &ctx,
+                                       ArrayRef<TypeDecl *> baseTypes,
+                                       DeclName name,
+                                       DeclContext *dc) {
+  // Look through the base types to find something on which we can perform
+  // qualified name lookup.
+  SmallVector<ModuleDecl *, 2> moduleBaseTypes;
+  auto nominalBaseTypes =
+      resolveTypeDeclsToNominal(evaluator, ctx, baseTypes, moduleBaseTypes);
+
+  DirectlyReferencedTypeDecls result;
+  auto addResults = [&result](ArrayRef<ValueDecl *> found){
+    for (auto decl : found){
+      assert(isa<TypeDecl>(decl) &&
+             "Lookup should only have found type declarations");
+      result.push_back(cast<TypeDecl>(decl));
+    }
+  };
+
+  {
+    // Look through nominal types.
+    SmallVector<ValueDecl *, 4> nominalMembers;
+    auto options = NL_RemoveNonVisible | NL_OnlyTypes;
+    dc->lookupQualified(nominalBaseTypes, name, options, nominalMembers);
+    addResults(nominalMembers);
+  }
+
+  {
+    // Look through modules.
+    auto options = NL_RemoveNonVisible | NL_OnlyTypes;
+    for (auto module : moduleBaseTypes) {
+      SmallVector<ValueDecl *, 4> moduleMembers;
+      dc->lookupQualified(module, name, options, moduleMembers);
+      addResults(moduleMembers);
+    }
+  }
+
+  return result;
+}
+
+/// Determine the types directly referenced by the given identifier type.
+static DirectlyReferencedTypeDecls
+directReferencesForIdentTypeRepr(Evaluator &evaluator,
+                                 ASTContext &ctx, IdentTypeRepr *ident,
+                                 DeclContext *dc) {
+  DirectlyReferencedTypeDecls current;
+
+  bool firstComponent = true;
+  for (const auto &component : ident->getComponentRange()) {
+    // If we already set a declaration, use it.
+    if (auto typeDecl = component->getBoundDecl()) {
+      current = {1, typeDecl};
+      continue;
+    }
+
+    // For the first component, perform unqualified name lookup.
+    if (current.empty()) {
+      current =
+        directReferencesForUnqualifiedTypeLookup(ctx,
+                                                 component->getIdentifier(),
+                                                 component->getIdLoc(),
+                                                 dc);
+
+      // If we didn't find anything, fail now.
+      if (current.empty())
+        return current;
+
+      firstComponent = false;
+      continue;
+    }
+
+    // For subsequent components, perform qualified name lookup.
+    current =
+        directReferencesForQualifiedTypeLookup(evaluator, ctx, current,
+                                               component->getIdentifier(), dc);
+    if (current.empty())
+      return current;
+  }
+
+  return current;
+}
+
+/// Retrieve the set of type declarations that are directly referenced from
+/// the given parsed type representation.
+static DirectlyReferencedTypeDecls
+directReferencesForTypeRepr(Evaluator &evaluator,
+                            ASTContext &ctx, TypeRepr *typeRepr,
+                            DeclContext *dc) {
+  switch (typeRepr->getKind()) {
+  case TypeReprKind::Array:
+    return {1, ctx.getArrayDecl()};
+
+  case TypeReprKind::Attributed: {
+    auto attributed = cast<AttributedTypeRepr>(typeRepr);
+    return directReferencesForTypeRepr(evaluator, ctx,
+                                       attributed->getTypeRepr(), dc);
+  }
+
+  case TypeReprKind::Composition: {
+    DirectlyReferencedTypeDecls result;
+    auto composition = cast<CompositionTypeRepr>(typeRepr);
+    for (auto component : composition->getTypes()) {
+      auto componentResult =
+          directReferencesForTypeRepr(evaluator, ctx, component, dc);
+      result.insert(result.end(),
+                    componentResult.begin(),
+                    componentResult.end());
+    }
+    return result;
+  }
+
+  case TypeReprKind::CompoundIdent:
+  case TypeReprKind::GenericIdent:
+  case TypeReprKind::SimpleIdent:
+    return directReferencesForIdentTypeRepr(evaluator, ctx,
+                                            cast<IdentTypeRepr>(typeRepr), dc);
+
+  case TypeReprKind::Dictionary:
+    return { 1, ctx.getDictionaryDecl()};
+
+  case TypeReprKind::Error:
+  case TypeReprKind::Function:
+  case TypeReprKind::InOut:
+  case TypeReprKind::Metatype:
+  case TypeReprKind::Owned:
+  case TypeReprKind::Protocol:
+  case TypeReprKind::Shared:
+  case TypeReprKind::SILBox:
+  case TypeReprKind::Tuple:
+    return { };
+
+  case TypeReprKind::Fixed:
+    llvm_unreachable("Cannot get fixed TypeReprs in name lookup");
+
+  case TypeReprKind::Optional:
+  case TypeReprKind::ImplicitlyUnwrappedOptional:
+    return { 1, ctx.getOptionalDecl() };
+  }
+}
+
+/// Retrieve the set of type declarations that are directly referenced from
+/// the given type.
+static DirectlyReferencedTypeDecls
+directReferencesForType(Type type) {
+  // If it's a typealias, return that.
+  if (auto aliasType = dyn_cast<NameAliasType>(type.getPointer()))
+    return { 1, aliasType->getDecl() };
+
+  // If there is a generic declaration, return it.
+  if (auto genericDecl = type->getAnyGeneric())
+    return { 1, genericDecl };
+
+  if (type->isExistentialType()) {
+    DirectlyReferencedTypeDecls result;
+    const auto &layout = type->getExistentialLayout();
+
+    // Superclass.
+    if (auto superclassType = layout.explicitSuperclass) {
+      if (auto superclassDecl = superclassType->getAnyGeneric()) {
+        result.push_back(superclassDecl);
+      }
+    }
+
+    // Protocols.
+    for (auto protocolTy : layout.getProtocols())
+      result.push_back(protocolTy->getDecl());
+    return result;
+  }
+
+  return { };
+}
+
+DirectlyReferencedTypeDecls InheritedDeclsReferencedRequest::evaluate(
+    Evaluator &evaluator,
+    llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
+    unsigned index) const {
+
+  // Prefer syntactic information when we have it.
+  TypeLoc &typeLoc = getTypeLoc(decl, index);
+  if (auto typeRepr = typeLoc.getTypeRepr()) {
+    // Figure out the context in which name lookup will occur.
+    DeclContext *dc;
+    if (auto typeDecl = decl.dyn_cast<TypeDecl *>())
+      dc = typeDecl->getInnermostDeclContext();
+    else
+      dc = decl.get<ExtensionDecl *>();
+
+    return directReferencesForTypeRepr(evaluator, dc->getASTContext(), typeRepr,
+                                       dc);
+  }
+
+  // Fall back to semantic types.
+  // FIXME: In the long run, we shouldn't need this. Non-syntactic results
+  // should be cached.
+  if (auto type = typeLoc.getType()) {
+    return directReferencesForType(type);
+  }
+
+  return { };
+}
+
+DirectlyReferencedTypeDecls UnderlyingTypeDeclsReferencedRequest::evaluate(
+    Evaluator &evaluator,
+    TypeAliasDecl *typealias) const {
+  // Prefer syntactic information when we have it.
+  if (auto typeRepr = typealias->getUnderlyingTypeLoc().getTypeRepr()) {
+    return directReferencesForTypeRepr(evaluator, typealias->getASTContext(),
+                                       typeRepr, typealias);
+  }
+
+  // Fall back to semantic types.
+  // FIXME: In the long run, we shouldn't need this. Non-syntactic results
+  // should be cached.
+  if (auto type = typealias->getUnderlyingTypeLoc().getType()) {
+    return directReferencesForType(type);
+  }
+
+  return { };
+}
+
+/// Evaluate a superclass declaration request.
+ClassDecl *SuperclassDeclRequest::evaluate(Evaluator &evaluator,
+                                           NominalTypeDecl *subject) const {
+  for (unsigned i : indices(subject->getInherited())) {
+    // Find the inherited declarations referenced at this position.
+    auto inheritedTypes =
+      evaluator(InheritedDeclsReferencedRequest{subject, i});
+
+    // Resolve those type declarations to nominal type declarations.
+    SmallVector<ModuleDecl *, 2> modulesFound;
+    auto inheritedNominalTypes
+      = resolveTypeDeclsToNominal(evaluator, subject->getASTContext(),
+                                  inheritedTypes, modulesFound);
+
+    // Look for a class declaration.
+    for (auto inheritedNominal : inheritedNominalTypes) {
+      if (auto classDecl = dyn_cast<ClassDecl>(inheritedNominal))
+        return classDecl;
+    }
+  }
+
+  return nullptr;
 }

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -1,0 +1,100 @@
+//===--- NameLookupRequests.cpp - Name Lookup Requests --------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/NameLookupRequests.h"
+#include "swift/Subsystems.h"
+#include "swift/AST/Evaluator.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/Module.h"
+
+using namespace swift;
+
+namespace swift {
+// Implement the name lookup type zone.
+#define SWIFT_TYPEID_ZONE SWIFT_NAME_LOOKUP_REQUESTS_TYPEID_ZONE
+#define SWIFT_TYPEID_HEADER "swift/AST/NameLookupTypeIDZone.def"
+#include "swift/Basic/ImplementTypeIDZone.h"
+#undef SWIFT_TYPEID_ZONE
+#undef SWIFT_TYPEID_HEADER
+}
+
+//----------------------------------------------------------------------------//
+// Referenced inherited decls computation.
+//----------------------------------------------------------------------------//
+TypeLoc &InheritedDeclsReferencedRequest::getTypeLoc(
+                        llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
+                        unsigned index) const {
+  // FIXME: Copy-pasted from InheritedTypeRequest. We need to consolidate here.
+  if (auto typeDecl = decl.dyn_cast<TypeDecl *>())
+    return typeDecl->getInherited()[index];
+
+  return decl.get<ExtensionDecl *>()->getInherited()[index];
+}
+
+void InheritedDeclsReferencedRequest::diagnoseCycle(
+                                              DiagnosticEngine &diags) const {
+  const auto &storage = getStorage();
+  auto &typeLoc = getTypeLoc(std::get<0>(storage), std::get<1>(storage));
+  diags.diagnose(typeLoc.getLoc(), diag::circular_reference);
+}
+
+void InheritedDeclsReferencedRequest::noteCycleStep(
+                                                DiagnosticEngine &diags) const {
+  const auto &storage = getStorage();
+  auto &typeLoc = getTypeLoc(std::get<0>(storage), std::get<1>(storage));
+  diags.diagnose(typeLoc.getLoc(), diag::circular_reference_through);
+}
+
+//----------------------------------------------------------------------------//
+// Referenced underlying type declarations computation.
+//----------------------------------------------------------------------------//
+void UnderlyingTypeDeclsReferencedRequest::diagnoseCycle(
+                                               DiagnosticEngine &diags) const {
+  // FIXME: Improve this diagnostic.
+  auto subjectDecl = std::get<0>(getStorage());
+  diags.diagnose(subjectDecl, diag::circular_reference);
+}
+
+void UnderlyingTypeDeclsReferencedRequest::noteCycleStep(
+                                               DiagnosticEngine &diags) const {
+  auto subjectDecl = std::get<0>(getStorage());
+  // FIXME: Customize this further.
+  diags.diagnose(subjectDecl, diag::circular_reference_through);
+}
+
+//----------------------------------------------------------------------------//
+// Superclass declaration computation.
+//----------------------------------------------------------------------------//
+void SuperclassDeclRequest::diagnoseCycle(DiagnosticEngine &diags) const {
+  // FIXME: Improve this diagnostic.
+  auto subjectDecl = std::get<0>(getStorage());
+  diags.diagnose(subjectDecl, diag::circular_reference);
+}
+
+void SuperclassDeclRequest::noteCycleStep(DiagnosticEngine &diags) const {
+  auto subjectDecl = std::get<0>(getStorage());
+  // FIXME: Customize this further.
+  diags.diagnose(subjectDecl, diag::circular_reference_through);
+}
+
+// Define request evaluation functions for each of the name lookup requests.
+static AbstractRequestFunction *nameLookupRequestFunctions[] = {
+#define SWIFT_TYPEID(Name)                                    \
+  reinterpret_cast<AbstractRequestFunction *>(&Name::evaluateRequest),
+#include "swift/AST/NameLookupTypeIDZone.def"
+#undef SWIFT_TYPEID
+};
+
+void swift::registerNameLookupRequestFunctions(Evaluator &evaluator) {
+  evaluator.registerRequestFunctions(SWIFT_NAME_LOOKUP_REQUESTS_TYPEID_ZONE,
+                                     nameLookupRequestFunctions);
+}

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4071,9 +4071,8 @@ static bool doesOpaqueClassUseNativeReferenceCounting(const ASTContext &ctx) {
 static bool usesNativeReferenceCounting(ClassDecl *theClass,
                                         ResilienceExpansion resilience) {
   // TODO: Resilience? there might be some legal avenue of changing this.
-  while (Type supertype = theClass->getSuperclass()) {
-    theClass = supertype->getClassOrBoundGenericClass();
-    assert(theClass);
+  while (auto superclass = theClass->getSuperclassDecl()) {
+    theClass = superclass;
   }
   return !theClass->hasClangNode();
 }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3546,8 +3546,9 @@ EffectiveClangContext ClangImporter::Implementation::getEffectiveClangContext(
   // If it's an @objc entity, go look for it.
   // Note that we're stepping lightly here to avoid computing isObjC()
   // too early.
-  if (nominal->getAttrs().hasAttribute<ObjCAttr>() ||
-      (!nominal->getParentSourceFile() && nominal->isObjC())) {
+  if (isa<ClassDecl>(nominal) &&
+      (nominal->getAttrs().hasAttribute<ObjCAttr>() ||
+       (!nominal->getParentSourceFile() && nominal->isObjC()))) {
     // Map the name. If we can't represent the Swift name in Clang.
     // FIXME: We should be using the Objective-C name here!
     auto clangName = exportName(nominal->getName());

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3544,7 +3544,10 @@ EffectiveClangContext ClangImporter::Implementation::getEffectiveClangContext(
   }
 
   // If it's an @objc entity, go look for it.
-  if (nominal->isObjC()) {
+  // Note that we're stepping lightly here to avoid computing isObjC()
+  // too early.
+  if (nominal->getAttrs().hasAttribute<ObjCAttr>() ||
+      (!nominal->getParentSourceFile() && nominal->isObjC())) {
     // Map the name. If we can't represent the Swift name in Clang.
     // FIXME: We should be using the Objective-C name here!
     auto clangName = exportName(nominal->getName());

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4766,18 +4766,19 @@ namespace {
         // Check whether there is a function with the same name as this
         // property. If so, suppress the property; the user will have to use
         // the methods directly, to avoid ambiguities.
-        Type containerTy = dc->getDeclaredInterfaceType();
-        Type lookupContextTy = containerTy;
+        NominalTypeDecl *lookupContext =
+          dc->getAsNominalTypeOrNominalTypeExtensionContext();
+
         if (auto *classDecl = dyn_cast<ClassDecl>(dc)) {
           // If we're importing into the primary @interface for something, as
           // opposed to an extension, make sure we don't try to load any
           // categories...by just looking into the super type.
-          lookupContextTy = classDecl->getSuperclass();
+          lookupContext = classDecl->getSuperclassDecl  ();
         }
 
-        if (lookupContextTy) {
+        if (lookupContext) {
           SmallVector<ValueDecl *, 2> lookup;
-          dc->lookupQualified(lookupContextTy, name,
+          dc->lookupQualified(lookupContext, name,
                               NL_QualifiedDefault | NL_KnownNoDependency,
                               Impl.getTypeResolver(), lookup);
           for (auto result : lookup) {
@@ -4802,7 +4803,8 @@ namespace {
           // It's okay to compare interface types directly because Objective-C
           // does not have constrained extensions.
           if (overrideContext != dc && overridden->hasClangNode() &&
-              overrideContext->getDeclaredInterfaceType()->isEqual(containerTy)) {
+              overrideContext->getAsNominalTypeOrNominalTypeExtensionContext()
+                == lookupContext) {
             // We've encountered a redeclaration of the property.
             // HACK: Just update the original declaration instead of importing a
             // second property.
@@ -6300,15 +6302,14 @@ void SwiftDeclConverter::recordObjCOverride(AbstractFunctionDecl *decl) {
   auto classDecl = decl->getDeclContext()->getAsClassOrClassExtensionContext();
   if (!classDecl)
     return;
-  auto superTy = classDecl->getSuperclass();
-  if (!superTy)
+  auto superDecl = classDecl->getSuperclassDecl();
+  if (!superDecl)
     return;
   // Dig out the Objective-C superclass.
-  auto superDecl = superTy->getAnyNominal();
   SmallVector<ValueDecl *, 4> results;
-  superDecl->lookupQualified(superTy, decl->getFullName(),
+  superDecl->lookupQualified(superDecl, decl->getFullName(),
                              NL_QualifiedDefault | NL_KnownNoDependency,
-                             Impl.getTypeResolver(), results);
+                             results);
   for (auto member : results) {
     if (member->getKind() != decl->getKind() ||
         member->isInstanceMember() != decl->isInstanceMember() ||
@@ -6351,17 +6352,16 @@ void SwiftDeclConverter::recordObjCOverride(SubscriptDecl *subscript) {
   if (!classTy)
     return;
 
-  auto superTy = classTy->getSuperclass();
-  if (!superTy)
+  auto superDecl = classTy->getSuperclassDecl();
+  if (!superDecl)
     return;
 
   // Determine whether this subscript operation overrides another subscript
   // operation.
   SmallVector<ValueDecl *, 2> lookup;
   subscript->getModuleContext()->lookupQualified(
-      superTy, subscript->getFullName(),
-      NL_QualifiedDefault | NL_KnownNoDependency, Impl.getTypeResolver(),
-      lookup);
+      superDecl, subscript->getFullName(),
+      NL_QualifiedDefault | NL_KnownNoDependency, lookup);
   Type unlabeledIndices;
   for (auto result : lookup) {
     auto parentSub = dyn_cast<SubscriptDecl>(result);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1939,7 +1939,7 @@ static bool shouldAlsoImportAsClassMethod(FuncDecl *method) {
     return false;
 
   // The class must not have a superclass.
-  if (classDecl->getSuperclass())
+  if (classDecl->hasSuperclass())
     return false;
 
   // There must not already be a class method with the same
@@ -7173,10 +7173,9 @@ void SwiftDeclConverter::importInheritedConstructors(
   if (hasDesignatedInitializers(curObjCClass))
     kind = CtorInitializerKind::Convenience;
 
-  auto superclass =
-      cast<ClassDecl>(classDecl->getSuperclass()->getAnyNominal());
 
   // If we have a superclass, import from it.
+  auto superclass = classDecl->getSuperclassDecl();
   if (auto superclassClangDecl = superclass->getClangDecl()) {
     if (isa<clang::ObjCInterfaceDecl>(superclassClangDecl)) {
       inheritConstructors(superclass->lookupDirect(DeclBaseName::createConstructor()),

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4780,7 +4780,7 @@ namespace {
           SmallVector<ValueDecl *, 2> lookup;
           dc->lookupQualified(lookupContext, name,
                               NL_QualifiedDefault | NL_KnownNoDependency,
-                              Impl.getTypeResolver(), lookup);
+                              lookup);
           for (auto result : lookup) {
             if (isa<FuncDecl>(result) &&
                 result->isInstanceMember() == decl->isInstanceProperty() &&
@@ -4804,7 +4804,7 @@ namespace {
           // does not have constrained extensions.
           if (overrideContext != dc && overridden->hasClangNode() &&
               overrideContext->getAsNominalTypeOrNominalTypeExtensionContext()
-                == lookupContext) {
+                == dc->getAsNominalTypeOrNominalTypeExtensionContext()) {
             // We've encountered a redeclaration of the property.
             // HACK: Just update the original declaration instead of importing a
             // second property.

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -4451,9 +4451,9 @@ public:
     const auto *CD = dyn_cast_or_null<ClassDecl>(CurrTy->getAnyNominal());
     if (!CD)
       return;
-    if (!CD->getSuperclass())
+    if (!CD->getSuperclassDecl())
       return;
-    CD = CD->getSuperclass()->getClassOrBoundGenericClass();
+    CD = CD->getSuperclassDecl();
     for (const auto *Member : CD->getMembers()) {
       const auto *Constructor = dyn_cast<ConstructorDecl>(Member);
       if (!Constructor)

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -4451,7 +4451,7 @@ public:
     const auto *CD = dyn_cast_or_null<ClassDecl>(CurrTy->getAnyNominal());
     if (!CD)
       return;
-    if (!CD->getSuperclassDecl())
+    if (!CD->hasSuperclass())
       return;
     CD = CD->getSuperclassDecl();
     for (const auto *Member : CD->getMembers()) {

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -448,8 +448,8 @@ struct SynthesizedExtensionAnalyzer::Implementation {
       Unhandled.push_back(Conf->getProtocol());
     }
     if (auto *CD = dyn_cast<ClassDecl>(Target)) {
-      if (auto Super = CD->getSuperclass())
-        Unhandled.push_back(Super->getAnyNominal());
+      if (auto Super = CD->getSuperclassDecl())
+        Unhandled.push_back(Super);
     }
     while (!Unhandled.empty()) {
       NominalTypeDecl* Back = Unhandled.back();

--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -100,8 +100,7 @@ private:
     if (!entry)
       return false;
     size_t decls_size = decls.size();
-    entry->lookupQualified(ModuleType::get(entry), name, options, typeResolver,
-                           decls);
+    entry->lookupQualified(entry, name, options, decls);
     return decls.size() > decls_size;
   }
 

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -854,8 +854,8 @@ static bool getInstanceSizeByMethod(IRGenFunction &IGF,
   FuncDecl *fn; {
     auto name = IGF.IGM.Context.getIdentifier("__getInstanceSizeAndAlignMask");
     SmallVector<ValueDecl*, 4> results;
-    selfClass->lookupQualified(selfType, name, NL_KnownNonCascadingDependency,
-                               nullptr, results);
+    selfClass->lookupQualified(selfClass, name,
+                               NL_KnownNonCascadingDependency, results);
     if (results.size() != 1)
       return false;
     fn = dyn_cast<FuncDecl>(results[0]);

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1287,7 +1287,7 @@ namespace {
       // superclass is SwiftObject, i.e. the root class.
       llvm::Constant *superPtr;
       if (getClass()->hasSuperclass()) {
-        auto base = getClass()->getSuperclass()->getClassOrBoundGenericClass();
+        auto base = getClass()->getSuperclassDecl();
         superPtr = getMetaclassRefOrNull(base);
       } else {
         superPtr = getMetaclassRefOrNull(
@@ -2277,8 +2277,8 @@ IRGenModule::getObjCRuntimeBaseForSwiftRootClass(ClassDecl *theClass) {
 }
 
 ClassDecl *irgen::getRootClassForMetaclass(IRGenModule &IGM, ClassDecl *C) {
-  while (auto superclass = C->getSuperclass())
-    C = superclass->getClassOrBoundGenericClass();
+  while (auto superclass = C->getSuperclassDecl())
+    C = superclass;
 
   // If the formal root class is imported from Objective-C, then
   // we should use that.  For a class that's really implemented in

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -1920,7 +1920,7 @@ llvm::Value *irgen::emitDynamicTypeOfHeapObject(IRGenFunction &IGF,
 
 static ClassDecl *getRootClass(ClassDecl *theClass) {
   while (theClass->hasSuperclass()) {
-    theClass = theClass->getSuperclass()->getClassOrBoundGenericClass();
+    theClass = theClass->getSuperclassDecl();
     assert(theClass && "base type of class not a class?");
   }
   return theClass;

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -338,8 +338,8 @@ private:
       os << "\n@interface " << customName;
     }
 
-    if (Type superTy = CD->getSuperclass())
-      os << " : " << getNameForObjC(superTy->getClassOrBoundGenericClass());
+    if (auto superDecl = CD->getSuperclassDecl())
+      os << " : " << getNameForObjC(superDecl);
     printProtocols(CD->getLocalProtocols(ConformanceLookupKind::OnlyExplicit));
     os << "\n";
     printMembers(CD->getMembers());
@@ -2354,8 +2354,7 @@ public:
     bool allRequirementsSatisfied = true;
 
     const ClassDecl *superclass = nullptr;
-    if (Type superTy = CD->getSuperclass()) {
-      superclass = superTy->getClassOrBoundGenericClass();
+    if ((superclass = CD->getSuperclassDecl())) {
       allRequirementsSatisfied &= require(superclass);
     }
     for (auto proto : CD->getLocalProtocols(

--- a/lib/SIL/DynamicCasts.cpp
+++ b/lib/SIL/DynamicCasts.cpp
@@ -71,7 +71,7 @@ static bool canClassOrSuperclassesHaveExtensions(ClassDecl *CD,
     if (!CD->hasSuperclass())
       break;
 
-    CD = CD->getSuperclass()->getClassOrBoundGenericClass();
+    CD = CD->getSuperclassDecl();
   }
 
   return false;

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -142,9 +142,9 @@ static CanType getKnownType(Optional<CanType> &cacheSlot, ASTContext &C,
       // lookupValue would only give us types actually declared in the overlays
       // themselves.
       SmallVector<ValueDecl *, 2> decls;
-      mod->lookupQualified(ModuleType::get(mod), C.getIdentifier(typeName),
+      mod->lookupQualified(mod, C.getIdentifier(typeName),
                            NL_QualifiedDefault | NL_KnownNonCascadingDependency,
-                           /*typeResolver=*/nullptr, decls);
+                           decls);
       if (decls.size() != 1)
         return CanType();
 

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -2255,7 +2255,7 @@ public:
     require(class2,
             "Second operand of dealloc_partial_ref must be a class metatype");
     while (class1 != class2) {
-      class1 = class1->getSuperclass()->getClassOrBoundGenericClass();
+      class1 = class1->getSuperclassDecl();
       require(class1, "First operand not superclass of second instance type");
     }
   }
@@ -4855,10 +4855,7 @@ void SILVTable::verify(const SILModule &M) const {
     do {
       if (c == theClass)
         break;
-      if (auto ty = c->getSuperclass())
-        c = ty->getClassOrBoundGenericClass();
-      else
-        c = nullptr;
+      c = c->getSuperclassDecl();
     } while (c);
     assert(c && "vtable entry must refer to a member of the vtable's class");
 

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -450,7 +450,7 @@ bool Lowering::usesObjCAllocator(ClassDecl *theClass) {
     if (!theClass->hasSuperclass())
       return theClass->hasClangNode();
 
-    theClass = theClass->getSuperclass()->getClassOrBoundGenericClass();
+    theClass = theClass->getSuperclassDecl();
   }
 }
 

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -450,10 +450,9 @@ void SILGenFunction::emitArtificialTopLevel(ClassDecl *mainClass) {
       ->loadModule(SourceLoc(), UIKitName);
     assert(UIKit && "couldn't find UIKit objc module?!");
     SmallVector<ValueDecl *, 1> results;
-    UIKit->lookupQualified(UIKit->getInterfaceType(),
+    UIKit->lookupQualified(UIKit,
                            ctx.getIdentifier("UIApplicationMain"),
                            NL_QualifiedDefault,
-                           /*resolver*/nullptr,
                            results);
     assert(results.size() == 1
            && "couldn't find a unique UIApplicationMain in the UIKit ObjC "

--- a/lib/SILOptimizer/Analysis/ClassHierarchyAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ClassHierarchyAnalysis.cpp
@@ -28,7 +28,7 @@ void ClassHierarchyAnalysis::init() {
       continue;
 
     // Add the superclass to the list of inherited classes.
-    ClassDecl *Super = C->getSuperclass()->getClassOrBoundGenericClass();
+    ClassDecl *Super = C->getSuperclassDecl();
     auto &K = DirectSubclassesCache[Super];
     assert(std::find(K.begin(), K.end(), C) == K.end() &&
            "Class vector must be unique");

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -261,7 +261,7 @@ protected:
         return true;
       if (!Derived->hasSuperclass())
         break;
-      Derived = Derived->getSuperclass()->getClassOrBoundGenericClass();
+      Derived = Derived->getSuperclassDecl();
     }
     return false;
   }

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -655,10 +655,9 @@ static ProtocolDecl *getNSCopyingProtocol(TypeChecker &TC,
     return nullptr;
 
   SmallVector<ValueDecl *, 2> results;
-  DC->lookupQualified(ModuleType::get(foundation),
+  DC->lookupQualified(foundation,
                       ctx.getSwiftId(KnownFoundationEntity::NSCopying),
                       NL_QualifiedDefault | NL_KnownNonCascadingDependency,
-                      /*typeResolver=*/nullptr,
                       results);
 
   if (results.size() != 1)

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3406,10 +3406,7 @@ public:
 
       // If the best method was from a subclass of the place where
       // this method was declared, we have a new best.
-      while (auto superclassTy = bestClassDecl->getSuperclass()) {
-        auto superclassDecl = superclassTy->getClassOrBoundGenericClass();
-        if (!superclassDecl) break;
-
+      while (auto superclassDecl = bestClassDecl->getSuperclassDecl()) {
         if (classDecl == superclassDecl) {
           bestMethod = method;
           break;

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -615,9 +615,7 @@ void AccessControlChecker::check(Decl *D) {
 
     checkGenericParamAccess(CD->getGenericParams(), CD);
 
-    if (CD->hasSuperclass()) {
-      const NominalTypeDecl *superclassDecl =
-          CD->getSuperclass()->getAnyNominal();
+    if (const NominalTypeDecl *superclassDecl = CD->getSuperclassDecl()) {
       // Be slightly defensive here in the presence of badly-ordered
       // inheritance clauses.
       auto superclassLocIter = std::find_if(CD->getInherited().begin(),
@@ -1134,8 +1132,7 @@ void UsableFromInlineChecker::check(Decl *D) {
     checkGenericParamAccess(CD->getGenericParams(), CD);
 
     if (CD->hasSuperclass()) {
-      const NominalTypeDecl *superclassDecl =
-          CD->getSuperclass()->getAnyNominal();
+      const NominalTypeDecl *superclassDecl = CD->getSuperclassDecl();
       // Be slightly defensive here in the presence of badly-ordered
       // inheritance clauses.
       auto superclassLocIter = std::find_if(CD->getInherited().begin(),

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2793,7 +2793,7 @@ public:
       if (!classDecl->hasSuperclass())
         return false;
 
-      classDecl = classDecl->getSuperclass()->getClassOrBoundGenericClass();
+      classDecl = classDecl->getSuperclassDecl();
     }
 
     // If all of the variables are @objc, we can use @NSManaged.
@@ -2865,8 +2865,7 @@ public:
           // If the superclass doesn't require in-class initial
           // values, the requirement was introduced at this point, so
           // stop here.
-          auto superclass = cast<ClassDecl>(
-                              source->getSuperclass()->getAnyNominal());
+          auto superclass = source->getSuperclassDecl();
           if (!superclass->requiresStoredPropertyInits())
             break;
 
@@ -3885,8 +3884,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
       // Determine whether we require in-class initializers.
       if (CD->getAttrs().hasAttribute<RequiresStoredPropertyInitsAttr>() ||
           (CD->hasSuperclass() &&
-           CD->getSuperclass()->getClassOrBoundGenericClass()
-             ->requiresStoredPropertyInits()))
+           CD->getSuperclassDecl()->requiresStoredPropertyInits()))
         CD->setRequiresStoredPropertyInits(true);
 
       // Inherit @objcMembers.
@@ -4648,9 +4646,7 @@ void TypeChecker::requestNominalLayout(NominalTypeDecl *nominalDecl) {
 }
 
 void TypeChecker::requestSuperclassLayout(ClassDecl *classDecl) {
-  auto superclassTy = classDecl->getSuperclass();
-  if (superclassTy) {
-    auto *superclassDecl = superclassTy->getClassOrBoundGenericClass();
+  if (auto *superclassDecl = classDecl->getSuperclassDecl()) {
     if (superclassDecl)
       requestNominalLayout(superclassDecl);
   }
@@ -5454,7 +5450,7 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
   // for all of the superclass's designated initializers.
   // FIXME: Currently skipping generic classes.
   auto classDecl = cast<ClassDecl>(decl);
-  if (classDecl->hasSuperclass()) {
+  if (Type superclassTy = classDecl->getSuperclass()) {
     bool canInheritInitializers = (!SuppressDefaultInitializer &&
                                    !FoundDesignatedInit);
 
@@ -5465,7 +5461,6 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
       return;
     }
 
-    auto superclassTy = classDecl->getSuperclass();
     auto *superclassDecl = superclassTy->getClassOrBoundGenericClass();
     assert(superclassDecl && "Superclass of class is not a class?");
     if (!superclassDecl->addedImplicitInitializers())

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -897,8 +897,7 @@ static Type getObjectiveCNominalType(Type &cache,
 
   SmallVector<ValueDecl *, 4> decls;
   NLOptions options = NL_QualifiedDefault | NL_OnlyTypes;
-  dc->lookupQualified(ModuleType::get(module), TypeName, options, nullptr,
-                      decls);
+  dc->lookupQualified(module, TypeName, options, decls);
   for (auto decl : decls) {
     if (auto nominal = dyn_cast<NominalTypeDecl>(decl)) {
       cache = nominal->getDeclaredType();

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -961,10 +961,9 @@ resolveGenericSignatureComponent(TypeChecker &TC, DeclContext *DC,
           comp->getIdLoc())) {
     auto nominal = DC->getAsNominalTypeOrNominalTypeExtensionContext();
     SmallVector<ValueDecl *, 4> decls;
-    if (DC->lookupQualified(nominal->getDeclaredInterfaceType(),
+    if (DC->lookupQualified(nominal,
                             comp->getIdentifier(),
                             NL_OnlyTypes|NL_QualifiedDefault|NL_ProtocolMembers,
-                            &TC,
                             decls)) {
       for (const auto decl : decls) {
         // FIXME: Better ambiguity handling.

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1330,9 +1330,9 @@ ModuleFile::resolveCrossReference(ModuleDecl *baseModule, uint32_t pathLen) {
       baseModule->lookupMember(values, baseModule, name,
                                getIdentifier(privateDiscriminator));
     } else {
-      baseModule->lookupQualified(ModuleType::get(baseModule), name,
+      baseModule->lookupQualified(baseModule, name,
                                   NL_QualifiedDefault | NL_KnownNoDependency,
-                                  /*typeResolver=*/nullptr, values);
+                                  values);
     }
     filterValues(filterTy, nullptr, nullptr, isType, inProtocolExt,
                  importedFromClang, isStatic, None, values);

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1664,8 +1664,8 @@ void ModuleFile::getImportDecls(SmallVectorImpl<Decl *> &Results) {
 
           SmallVector<ValueDecl *, 8> Decls;
           TopLevelModule->lookupQualified(
-              ModuleType::get(TopLevelModule), ScopeID,
-              NL_QualifiedDefault | NL_KnownNoDependency, nullptr, Decls);
+              TopLevelModule, ScopeID,
+              NL_QualifiedDefault | NL_KnownNoDependency, Decls);
           Optional<ImportKind> FoundKind = ImportDecl::findBestImportKind(Decls);
           assert(FoundKind.hasValue() &&
                  "deserialized imports should not be ambiguous");

--- a/test/decl/class/circular_inheritance.swift
+++ b/test/decl/class/circular_inheritance.swift
@@ -47,11 +47,11 @@ class Outer3
 }
 
 // CHECK: ===CYCLE DETECTED===
-// CHECK-NEXT: `--{{.*}}SuperclassTypeRequest({{.*Left}}
-// CHECK:      `--{{.*}}InheritedTypeRequest(circular_inheritance.(file).Left@
-// CHECK:          `--{{.*}}SuperclassTypeRequest
-// CHECK:              `--{{.*}}InheritedTypeRequest(circular_inheritance.(file).Right@
-// CHECK:                  `--{{.*}}SuperclassTypeRequest{{.*(cyclic dependency)}}
+// CHECK-NEXT: `--{{.*}}SuperclassDeclRequest({{.*Left}}
+// CHECK:      `--{{.*}}InheritedDeclsReferencedRequest(circular_inheritance.(file).Left@
+// CHECK:          `--{{.*}}SuperclassDeclRequest
+// CHECK:              `--{{.*}}InheritedDeclsReferencedRequest(circular_inheritance.(file).Right@
+// CHECK:                  `--{{.*}}SuperclassDeclRequest{{.*(cyclic dependency)}}
 
 // CHECK-DOT: digraph Dependencies
 // CHECK-DOT: label="InheritedTypeRequest

--- a/test/decl/ext/ordering.swift
+++ b/test/decl/ext/ordering.swift
@@ -122,7 +122,7 @@ extension OtherOuter5 {
   class Super {}
 }
 
-///
+/// SR-5993
 
 enum Outer5A {}
 
@@ -130,8 +130,6 @@ enum OtherOuter5A {}
 
 extension Outer5A {
   class Inner : OtherOuter5A.Super {}
-  // expected-error@-1 {{'Super' is not a member type of 'OtherOuter5A'}}
-  // FIXME
 }
 
 extension Outer5A.Inner {}


### PR DESCRIPTION
[Name lookup] Introduce requests for several name lookup operations.  …
Introduce three new requests for name lookup operations that avoid performing
type checking/semantic analysis. They work using syntactic information
(e.g., TypeReprs) and AST-level name lookup operations that will (eventually)
avoid and calls back into type checking. The new requests are:

* Retrieve the superclass declaration of a protocol or class declaration. Use
this request for `ClassDecl::getSuperclassDecl()` and
`ProtocolDecl::getSuperclassDecl()`.
* Retrieve the types “directly referenced” by a particular location in
an inheritance clause. This query is based on looking at the `TypeRepr`s
and performing fairly-minimal lookup, so it does not involve any Type
computations.
* Retrieve the types “directly referenced” by the underlying type of
a typealias. This query allows us to desugar a typealias without forming
a type.

Along with these is a core operation to transform a set of `TypeDecl`s
into a set of `NominalTypeDecl`s, looking through type aliases, and
without involving Type at all. The superclass-decl request does this
to find a `ClassDecl`; other requests will eventually do this to (e.g.)
find all of the protocols mentioned in an inheritance clause.