### PR TITLE
Temporarily disable performance test that is 'failing' by running too…

### DIFF
--- a/validation-test/Sema/type_checker_perf/slow/rdar32034560.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar32034560.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// REQUIRES: rdar42744631
 // REQUIRES: tools-release,no_asserts
 
 struct S {


### PR DESCRIPTION
… fast.

I am reworking these to be based on the scope counter rather than a
timer.

rdar://problem/42744631
