### PR TITLE
tests: adapt a SIL test to the new block argument ownership syntax

### DIFF
--- a/test/IRGen/class_isa_pointers_armv7k_watchos.sil
+++ b/test/IRGen/class_isa_pointers_armv7k_watchos.sil
@@ -23,7 +23,7 @@ sil_vtable Purebred {}
 // CHECK:         [[VTABLE:%.*]] = bitcast %swift.type* [[ISA]]
 // CHECK:         getelementptr inbounds {{.*}} [[VTABLE]]
 sil @purebred_method : $@convention(thin) (@owned Purebred) -> () {
-entry(%0 : $Purebred):
+entry(%0 : @owned $Purebred):
   %m = class_method %0 : $Purebred, #Purebred.method!1 : (Purebred) -> () -> (), $@convention(method) (@guaranteed Purebred) -> ()
   %z = apply %m(%0) : $@convention(method) (@guaranteed Purebred) -> ()
   return %z : $()
@@ -45,7 +45,7 @@ sil_vtable Mongrel {}
 // CHECK:         [[VTABLE:%.*]] = bitcast %swift.type* [[ISA]]
 // CHECK:         getelementptr inbounds {{.*}} [[VTABLE]]
 sil @mongrel_method : $@convention(thin) (@owned Mongrel) -> () {
-entry(%0 : $Mongrel):
+entry(%0 : @owned $Mongrel):
   %m = class_method %0 : $Mongrel, #Mongrel.method!1 : (Mongrel) -> () -> (), $@convention(method) (@guaranteed Mongrel) -> ()
   %z = apply %m(%0) : $@convention(method) (@guaranteed Mongrel) -> ()
   return %z : $()
@@ -54,14 +54,14 @@ entry(%0 : $Mongrel):
 // ObjC stubs expected by ObjC metadata emission
 
 sil private @$S33class_isa_pointers_armv7k_watchos7MongrelC6methodyyFTo : $@convention(objc_method) (Purebred) -> () {
-entry(%0 : $Purebred):
+entry(%0 : @unowned $Purebred):
   unreachable
 }
 sil private @$S33class_isa_pointers_armv7k_watchos7MongrelC7bellsOnACSgSi_tcfcTo : $@convention(objc_method) (Int, Purebred) -> () {
-entry(%0 : $Int, %1 : $Purebred):
+entry(%0 : @trivial $Int, %1 : @unowned $Purebred):
   unreachable
 }
 sil private @$S33class_isa_pointers_armv7k_watchos7MongrelCACycfcTo : $@convention(objc_method) (Purebred) -> () {
-entry(%0 : $Purebred):
+entry(%0 : @unowned $Purebred):
   unreachable
 }


### PR DESCRIPTION
rdar://problem/42631990