### PR TITLE
Improve -O0 support, as progress towards fixing SR-8395:

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -1909,18 +1909,17 @@ void TFDeabstraction::formGraphOp(SILTensorOpInfo &opInfo,
         // Check to see if it was constant foldable.  If so, we can turn this
         // into a Const node to avoid a send.
         auto it = constants.find(operand);
-        if (it != constants.end()) {
+        if (it != constants.end() && it->second.isConstant()) {
           // Dig the element type out of the TensorHandle result type.
           auto eltType =
             getTensorHandleElementType(inst->getType().getASTType());
+          // We use int32 as the element type of the zero-d shape array.
           auto int32Ty =
             context.getInt32Decl()->getDeclaredType()->getCanonicalType();
-
           auto constant =
             createConstTensor(eltType, it->second,
-                              SymbolicValue::getArray({}, int32Ty,
-                                                      allocator),
-                              inst->getType(),  inst->getLoc(),
+                              SymbolicValue::getArray({}, int32Ty, allocator),
+                              inst->getType(),  getUserSourceLocation(inst),
                               DeviceType::ALL, B);
           inst->replaceAllUsesWith(constant->getResult(0));
           inst->eraseFromParent();

--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -1548,8 +1548,7 @@ tf::createConstTensor(Type elementType, SymbolicValue scalars,
   // Ensure that the array of initializer values is in the module's allocator.
   scalars = scalars.cloneInto(allocator);
   shape = shape.cloneInto(allocator);
-  assert(scalars.getKind() == SymbolicValue::Array &&
-         shape.getKind() == SymbolicValue::Array &&
+  assert(shape.getKind() == SymbolicValue::Array &&
          "expected array constants for scalars and shape");
 
   SmallVector<GraphOperationAttribute, 8> attributes;
@@ -1567,12 +1566,14 @@ tf::createConstTensor(Type elementType, SymbolicValue scalars,
     context.getIdentifier(std::string("value") + tensorSuffix), scalars
   });
 
-  // Add the value$shape attribute.
-  auto shapeSuffix =
-  SILTensorOpInfo::getOperandClassSuffix(SILTensorOpInfo::OperandClass::Shape);
-  attributes.push_back({
-    context.getIdentifier(std::string("value") + shapeSuffix), shape
-  });
+  // Add the value$shape attribute if we have an array value.
+  if (scalars.getKind() == SymbolicValue::Array) {
+    auto shapeId = SILTensorOpInfo::OperandClass::Shape;
+    auto shapeSuffix = SILTensorOpInfo::getOperandClassSuffix(shapeId);
+    attributes.push_back({
+      context.getIdentifier(std::string("value") + shapeSuffix), shape
+    });
+  }
 
   // All graph_op's get a device.
   attributes.push_back({

--- a/test/TensorFlow/deabstraction_finished.swift
+++ b/test/TensorFlow/deabstraction_finished.swift
@@ -33,15 +33,10 @@ public func constexprCall(a: Tensor<Float>, idx: Tensor<Int32>) -> Tensor<Float>
 
 /*
  CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}constexprCall
- CHECK: [[A:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.Int64, value$tensor: i64 0
- CHECK: [[AC:%.*]] = graph_op "Cast,i"
+ CHECK: [[A:%.*]] = graph_op "Const"() {dtype: $Int32, value$tensor: i32 0
  CHECK: [[B:%.*]] = graph_op "Const"
- CHECK: [[BC:%.*]] = graph_op "Cast,i"
  CHECK: [[C:%.*]] = graph_op "Const"
- CHECK: [[CX:%.*]] = unchecked_ref_cast [[C]] : $TensorHandle<Builtin.Int32> to $TensorHandle<Int32>
- CHECK: [[BX:%.*]] = unchecked_ref_cast [[BC]] : $TensorHandle<Builtin.FPIEEE32> to $TensorHandle<Float>
- CHECK: [[AX:%.*]] = unchecked_ref_cast [[AC]] : $TensorHandle<Builtin.FPIEEE32> to $TensorHandle<Float>
- CHECK: [[RESULT:%.*]] = graph_op "OneHot,i,i,i,i"(%0 : $TensorHandle<Int32>, [[CX]] : $TensorHandle<Int32>, [[BX]] : $TensorHandle<Float>, [[AX]] : $TensorHandle<Float>) {T: $Float, TI: $Int32, axis: i64 1, __device: "/device:CPU:0"} : $TensorHandle<Float>
+ CHECK: [[RESULT:%.*]] = graph_op "OneHot,i,i,i,i"(%0 : $TensorHandle<Int32>, [[A]] : $TensorHandle<Int32>, [[B]] : $TensorHandle<Float>, [[C]] : $TensorHandle<Float>) {T: $Float, TI: $Int32, axis: i64 1, __device: "/device:CPU:0"} : $TensorHandle<Float>
   CHECK: return [[RESULT]]
 */
 
@@ -117,10 +112,10 @@ public func test75407624() {
 /* CHECK-LABEL: ---- INPUT FUNCTION {{.*}}test75407624
  * CHECK: graph_op "Const"() {dtype: $Float, value$tensor: [$Float: (f32 0x3F800000 /* 1 */)], value$shape: [$Int32: i32 1]
  * CHECK: [[B1X:%.*]] = graph_op "Const"() {dtype: $Int32, value$tensor: [$Int32: (i32 1)], value$shape: [$Int32: i32 1],
- * CHECK: [[BX2:%.*]] = graph_op "tfc.scalarToTensor,s"(
+ * CHECK: [[BX2:%.*]] = graph_op "Const"() {dtype: $Float, value$tensor: f32 0x3F800000 /* 1 */
  * CHECK:  graph_op "Fill,i,i"([[B1X]] : $TensorHandle<Int32>, [[BX2]] : $TensorHandle<Float>)
  * CHECK: [[C1X:%.*]] = graph_op "Const"() {dtype: $Int32, value$tensor: [$Int32: (i32 1)], value$shape: [$Int32: i32 1],
- * CHECK: [[CX2:%.*]] = graph_op "tfc.scalarToTensor,s"(
+ * CHECK: [[CX2:%.*]] = graph_op "Const"() {dtype: $Float, value$tensor: f32 0x3F800000 /* 1 */
  * CHECK:  graph_op "Fill,i,i"([[C1X]] : $TensorHandle<Int32>, [[CX2]] : $TensorHandle<Float>)
  * CHECK: graph_op "Const"() {dtype: $Float, value$tensor: [$Float: (f32 0x3F800000 /* 1 */), (f32 0x40000000 /* 2 */), (f32 0x40400000 /* 3 */), (f32 0x40800000 /* 4 */)], value$shape: [$Int32: (i32 2), (i32 2)],
  * CHECK-LABEL: ---- END OF 

--- a/test/TensorFlow/debugging.swift
+++ b/test/TensorFlow/debugging.swift
@@ -18,11 +18,10 @@ public func debugValuesInLoop(_ x: Tensor<Float>) {
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}basicDebugValues{{.*}}
 // CHECK: @{{.*}}basicDebugValues{{.*}}.tf
 // CHECK: [[ONE:%.*]] = graph_op "Const"
-// CHECK: [[ONE_FP:%.*]] = unchecked_ref_cast [[ONE]] : $TensorHandle<Builtin.FPIEEE32> to $TensorHandle<Float> // users: %3, %4
 // CHECK-NEXT: graph_op "tfc.SendToHost,i"
 // CHECK: [[ADD_RESULT:%.*]] = graph_op "Add,i,i"
 // CHECK-NEXT: graph_op "tfc.SendToHost,i"([[ADD_RESULT]] : $TensorHandle<Float>)
-// CHECK: graph_op "Square,i"([[ADD_RESULT]] : $TensorHandle<Float>) {T: $Float, __device: "/device:CPU:0"} : $TensorHandle<Float> // user: %7
+// CHECK: graph_op "Square,i"([[ADD_RESULT]] : $TensorHandle<Float>) {T: $Float, __device: "/device:CPU:0"} : $TensorHandle<Float>
 
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}debugValuesInLoop{{.*}}

--- a/test/TensorFlow/device_placement.swift
+++ b/test/TensorFlow/device_placement.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph  -Xllvm -tf-strict-deabstraction -Xllvm -tf-module-level-graph=false -O -emit-sil -verify %s | %FileCheck %s
-
 import TensorFlow
 
 public func implicitDevicePlacement() {
@@ -16,7 +15,7 @@ public func implicitDeviceConfig() {
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}implicitDeviceConfig{{.*}}
-// CHECK: graph_op "Const"() {dtype$dtype: $Builtin.FPIEEE32, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"
+// CHECK: graph_op "Const"() {dtype: $Float, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"
 
 public func explicitDeviceConfigGPU() {
   TensorFlow.enableGPU()
@@ -25,7 +24,7 @@ public func explicitDeviceConfigGPU() {
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}explicitDeviceConfigGPU{{.*}}
-// CHECK: graph_op "Const"() {dtype$dtype: $Builtin.FPIEEE32, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"
+// CHECK: graph_op "Const"() {dtype: $Float, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"
 
 // Check that in the TF graph, both the function node itself, and ops in the
 // function, are placed on GPU.

--- a/test/TensorFlow/integration.swift
+++ b/test/TensorFlow/integration.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -verify -Xllvm -tf-strict-deabstraction -Xllvm -tf-module-level-graph=false %s | %FileCheck %s 
+// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -verify -Xllvm -tf-strict-deabstraction -Xllvm -tf-module-level-graph=false %s | %FileCheck %s
 
 import TensorFlow
 
@@ -55,9 +55,8 @@ public func testScalar(f: Float) { // expected-warning {{'f' implicitly copied t
 // CHECK: sil private @{{.*}}testScalar{{.*}} : $@callee_owned (TensorHandle<Builtin.FPIEEE32>) -> TensorHandle<Float> {
 // CHECK: bb0(%0 : $TensorHandle<Builtin.FPIEEE32>):
 // CHECK-NEXT:   %1 = unchecked_ref_cast %0 : $TensorHandle<Builtin.FPIEEE32> to $TensorHandle<Float>
-// CHECK:        [[CONST:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.FPIEEE32, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.FPIEEE32>
-// CHECK-NEXT:   [[CAST:%.*]] = unchecked_ref_cast [[CONST]] : $TensorHandle<Builtin.FPIEEE32> to $TensorHandle<Float>
-// CHECK:        [[ADD1:%.*]] = graph_op "Add,i,i"(%1 : $TensorHandle<Float>, [[CAST]] : $TensorHandle<Float>) {{.*}} : $TensorHandle<Float>
+// CHECK:        [[CONST:%.*]] = graph_op "Const"() {dtype: $Float, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"} : $TensorHandle<Float>
+// CHECK:        [[ADD1:%.*]] = graph_op "Add,i,i"(%1 : $TensorHandle<Float>, [[CONST]] : $TensorHandle<Float>) {{.*}} : $TensorHandle<Float>
 // CHECK:        [[ADD2:%.*]] = graph_op "Add,i,i"([[ADD1]] : $TensorHandle<Float>, [[ADD1:%.*]] : $TensorHandle<Float>) {{.*}} : $TensorHandle<Float>
 // CHECK-NEXT:   return [[ADD2]] : $TensorHandle<Float>
 // CHECK-NEXT: }
@@ -95,9 +94,8 @@ public func testExitBranch1(i: Int) {
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testExitBranch1{{.*}}
 // CHECK: sil private @{{.*}}testExitBranch1{{.*}} : $@callee_owned () -> TensorHandle<Float> {
 // CHECK: bb0:
-// CHECK-NEXT:   [[CONST:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.FPIEEE32, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.FPIEEE32>
-// CHECK-NEXT:   [[TH:%.*]] = unchecked_ref_cast [[CONST]] : $TensorHandle<Builtin.FPIEEE32> to $TensorHandle<Float>
-// CHECK:        [[RET:%.*]] = graph_op "Add,i,i"([[TH]] : $TensorHandle<Float>, [[TH]] : $TensorHandle<Float>) {{.*}} : $TensorHandle<Float>
+// CHECK-NEXT:   [[CONST:%.*]] = graph_op "Const"() {dtype: $Float, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"} : $TensorHandle<Float>
+// CHECK:        [[RET:%.*]] = graph_op "Add,i,i"([[CONST]] : $TensorHandle<Float>, [[CONST]] : $TensorHandle<Float>) {{.*}} : $TensorHandle<Float>
 // CHECK-NEXT:   return [[RET]] : $TensorHandle<Float>
 // CHECK-NEXT: }
 
@@ -310,10 +308,8 @@ public func scalar_manipulation(a : Float) -> Tensor<Float> {
 // CHECK: sil private @{{.*}}scalar_manipulation{{.*}} : $@callee_owned (TensorHandle<Builtin.FPIEEE32>) -> TensorHandle<Float> {
 // CHECK: bb0(%0 : $TensorHandle<Builtin.FPIEEE32>):
 // CHECK-NEXT:  %1 = unchecked_ref_cast %0 : $TensorHandle<Builtin.FPIEEE32> to $TensorHandle<Float>
-// CHECK-NEXT:  [[CONST:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.FPIEEE32, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.FPIEEE32>
-// CHECK-NEXT:  [[CAST:%.*]] = unchecked_ref_cast [[CONST]] : $TensorHandle<Builtin.FPIEEE32> to $TensorHandle<Float>
-
-// CHECK:       graph_op "Add,i,i"(%1 : $TensorHandle<Float>, [[CAST]] : $TensorHandle<Float>) {{.*}} : $TensorHandle<Float>
+// CHECK-NEXT:  [[CONST:%.*]] = graph_op "Const"() {dtype: $Float, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"} : $TensorHandle<Float>
+// CHECK:       graph_op "Add,i,i"(%1 : $TensorHandle<Float>, [[CONST]] : $TensorHandle<Float>) {{.*}} : $TensorHandle<Float>
 // CHECK:       graph_op "tfc.SendToHost
 // CHECK-NEXT:  graph_op "Const"()
 // CHECK:       graph_op "tfc.RecvFromHost

--- a/test/TensorFlow/no_copy.swift
+++ b/test/TensorFlow/no_copy.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-strict-deabstraction=false -O -emit-sil -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-strict-deabstraction=false -O -emit-sil %s | %FileCheck %s
 // RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-strict-deabstraction -O -emit-sil -verify %s | %FileCheck %s -check-prefix=STRICTDA
 
 import TensorFlow
@@ -236,7 +236,6 @@ struct Classifier {
 
 public func mnist() {
   // Training data
-  // expected-warning @+1 {{'Tensor<Float>' implicitly copied to the accelerator, use .toAccelerator}}
   let images = Tensor<Float>(randomNormal: [10, 784])
   let labels = Tensor<Float>(randomNormal: [10, 10])
   var classifier = Classifier()

--- a/test/TensorFlow/optimization-disabled.swift
+++ b/test/TensorFlow/optimization-disabled.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Onone -emit-sil -Xllvm -tf-strict-deabstraction -Xllvm -tf-module-level-graph=false -verify %s | %FileCheck %s
+import TensorFlow
+
+// expected-warning @+1 8 {{value implicitly copied to the host}}
+public func testArrayValues() -> Tensor<Float> {
+// expected-warning @+1 6 {{value implicitly copied to the host}}
+  let x: Tensor<Float> = [[1, 2], [3, 4]]
+  // expected-note @-1 8 {{value used here}}
+  return (matmul(x, x) + x).toHost()
+// expected-warning {{value implicitly copied to the host}}
+}
+
+/*
+CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testArrayValues
+CHECK: %0 = graph_op "Const"() {dtype: $Float, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"} : $TensorHandle<Float>
+CHECK: %1 = graph_op "tfc.SendToHost,i"(%0 : $TensorHandle<Float>) {tensorId: i32 0, __device: "/device:CPU:0"}
+CHECK-NOT: tfc.RecvFromHost
+CHECK-LABEL: ----
+*/
+

--- a/test/TensorFlow/optimization-disabled.swift
+++ b/test/TensorFlow/optimization-disabled.swift
@@ -1,13 +1,11 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Onone -emit-sil -Xllvm -tf-strict-deabstraction -Xllvm -tf-module-level-graph=false -verify %s | %FileCheck %s
 import TensorFlow
 
-// expected-warning @+1 8 {{value implicitly copied to the host}}
 public func testArrayValues() -> Tensor<Float> {
-// expected-warning @+1 6 {{value implicitly copied to the host}}
+  // expected-warning @+1 14 {{value implicitly copied to the host}}
   let x: Tensor<Float> = [[1, 2], [3, 4]]
-  // expected-note @-1 8 {{value used here}}
   return (matmul(x, x) + x).toHost()
-// expected-warning {{value implicitly copied to the host}}
+// expected-warning @-1 {{value implicitly copied to the host}}
 }
 
 /*

--- a/test/TensorFlow/top_level_code_1.swift
+++ b/test/TensorFlow/top_level_code_1.swift
@@ -36,11 +36,11 @@ x -= one
 let y = Tensor<Float>(2.0)
 let y2 = y*y*y*y
 
-// CHECK:   [[ONE:%.*]] = graph_op "tfc.scalarToTensor,s"
+// CHECK:   [[ONE:%.*]] = graph_op "Const"(){{.*}} /* 1 */
 // CHECK:   [[ADD1:%.*]] = graph_op "Add,i,i"([[ONE]] : $TensorHandle<Float>, [[ONE]] : $TensorHandle<Float>)
 // CHECK:   [[ADD2:%.*]] = graph_op "Add,i,i"([[ADD1]] : $TensorHandle<Float>, [[ONE]] : $TensorHandle<Float>)
 // CHECK:   graph_op "Sub,i,i"([[ONE]] : $TensorHandle<Float>, [[ONE]] : $TensorHandle<Float>)
-// CHECK:   [[TWO:%.*]] = graph_op "tfc.scalarToTensor
+// CHECK:   [[TWO:%.*]] = graph_op "Const"(){{.*}} /* 2 */
 // CHECK:   [[MUL1:%.*]] = graph_op "Mul,i,i"([[TWO]] : $TensorHandle<Float>, [[TWO]] : $TensorHandle<Float>)
 // CHECK:   [[MUL2:%.*]] = graph_op "Mul,i,i"([[MUL1]] : $TensorHandle<Float>, [[TWO]] : $TensorHandle<Float>)
 // CHECK:   [[MUL3:%.*]] = graph_op "Mul,i,i"([[MUL2]] : $TensorHandle<Float>, [[TWO]] : $TensorHandle<Float>)


### PR DESCRIPTION
  Enhance constant expressions to handle copy_addr in top level context.
  Enhance deabstraction to constantfold scalarToTensor into a Const node.

There is still more to do, all of the warnings in the testcase are bogus.
