### PR TITLE
Better fix for null guard of ClangModuleUnit::getClangModule().

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3607,12 +3607,15 @@ bool ClangImporter::isInOverlayModuleForImportedModule(
   importedDC = importedDC->getModuleScopeContext();
 
   auto importedClangModuleUnit = dyn_cast<ClangModuleUnit>(importedDC);
-  if (!importedClangModuleUnit || !importedClangModuleUnit->getClangModule())
+  if (!importedClangModuleUnit)
     return false;
 
   auto overlayModule = overlayDC->getParentModule();
   if (overlayModule == importedClangModuleUnit->getAdapterModule())
     return true;
+
+  if (!importedClangModuleUnit->getClangModule())
+    return false;
 
   // Is this a private module that's re-exported to the public (overlay) name?
   auto clangModule =


### PR DESCRIPTION
The fix in f94d6535309c9c6a3f3986dcdaf5d8f168841cd0 may have changed
behavior (despite not being caught by our tests).

This is a safer fix that moves the null check to just prior to the
dereference where we are seeing crashes.

Fixes: rdar://problem/41888568
