### PR TITLE
[SourceKit] Serialize the syntax tree in the EditorConsumer

### DIFF
--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -22,10 +22,18 @@
 #include "swift/AST/Type.h"
 #include <functional>
 #include <memory>
+#include <unordered_set>
 
 namespace llvm {
   class MemoryBuffer;
 }
+
+namespace swift {
+namespace syntax {
+class SourceFileSyntax;
+} // namespace syntax
+} // namespace swift
+
 namespace SourceKit {
 
 struct EntityInfo {
@@ -256,7 +264,9 @@ public:
 
   virtual bool handleSourceText(StringRef Text) = 0;
 
-  virtual bool handleSerializedSyntaxTree(StringRef Text) = 0;
+  virtual bool
+  handleSyntaxTree(const swift::syntax::SourceFileSyntax &SyntaxTree,
+                   std::unordered_set<unsigned> ReusedNodeIds) = 0;
   virtual bool syntaxTreeEnabled() {
     return syntaxTreeTransferMode() != SyntaxTreeTransferMode::Off;
   }

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -92,7 +92,10 @@ class NullEditorConsumer : public EditorConsumer {
   }
 
   bool handleSourceText(StringRef Text) override { return false; }
-  bool handleSerializedSyntaxTree(StringRef Text) override { return false; }
+  bool handleSyntaxTree(const swift::syntax::SourceFileSyntax &SyntaxTree,
+                        std::unordered_set<unsigned> ReusedNodeIds) override {
+    return false;
+  }
 
   SyntaxTreeTransferMode syntaxTreeTransferMode() override {
     return SyntaxTreeTransferMode::Off;

--- a/unittests/SourceKit/SwiftLang/EditingTest.cpp
+++ b/unittests/SourceKit/SwiftLang/EditingTest.cpp
@@ -101,7 +101,10 @@ private:
   }
 
   bool handleSourceText(StringRef Text) override { return false; }
-  bool handleSerializedSyntaxTree(StringRef Text) override { return false; }
+  bool handleSyntaxTree(const swift::syntax::SourceFileSyntax &SyntaxTree,
+                        std::unordered_set<unsigned> ReusedNodeIds) override {
+    return false;
+  }
 
   SyntaxTreeTransferMode syntaxTreeTransferMode() override {
     return SyntaxTreeTransferMode::Off;


### PR DESCRIPTION
This will allow us to switch to a more efficient binary serialization format in the future.