### PR TITLE
[Runtime] Print fatal errors' messages before pausing in the debugger

### DIFF
--- a/stdlib/public/stubs/Assert.cpp
+++ b/stdlib/public/stubs/Assert.cpp
@@ -46,8 +46,6 @@ void swift::_swift_stdlib_reportFatalErrorInFile(
     uint32_t line,
     uint32_t flags
 ) {
-  logPrefixAndMessageToDebugger(prefix, prefixLength, message, messageLength);
-
   char *log;
   swift_asprintf(
       &log, "%.*s: %.*s%sfile %.*s, line %" PRIu32 "\n",
@@ -59,6 +57,8 @@ void swift::_swift_stdlib_reportFatalErrorInFile(
 
   swift_reportError(flags, log);
   free(log);
+
+  logPrefixAndMessageToDebugger(prefix, prefixLength, message, messageLength);
 }
 
 void swift::_swift_stdlib_reportFatalError(
@@ -66,8 +66,6 @@ void swift::_swift_stdlib_reportFatalError(
     const unsigned char *message, int messageLength,
     uint32_t flags
 ) {
-  logPrefixAndMessageToDebugger(prefix, prefixLength, message, messageLength);
-
   char *log;
   swift_asprintf(
       &log, "%.*s: %.*s\n",
@@ -76,6 +74,8 @@ void swift::_swift_stdlib_reportFatalError(
 
   swift_reportError(flags, log);
   free(log);
+
+  logPrefixAndMessageToDebugger(prefix, prefixLength, message, messageLength);
 }
 
 void swift::_swift_stdlib_reportUnimplementedInitializerInFile(


### PR DESCRIPTION
The message is available in the debugger (or in Xcode), but it increases the chances that the user will see it if it's also been logged at the time the debugger takes over.

<img width="100%" alt="(screenshot of Xcode UI before this change)" src="https://user-images.githubusercontent.com/15097531/43430059-ef37e8b0-941b-11e8-8b48-4b2dbcada46c.png" />

(please excuse the bits left over from other testing in my scratch project)