### PR TITLE
Don’t mangle an error type.

### DIFF
--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -226,7 +226,7 @@ bool ide::printDeclUSR(const ValueDecl *D, raw_ostream &OS) {
     return printObjCUSR(D, OS);
   }
 
-  if (!D->hasInterfaceType())
+  if (!D->hasInterfaceType() || D->getInterfaceType()->hasError())
     return true;
 
   // Invalid code.

--- a/test/SourceKit/Indexing/index_constructors.swift.response
+++ b/test/SourceKit/Indexing/index_constructors.swift.response
@@ -34,29 +34,6 @@
           key.column: 21
         },
         {
-          key.kind: source.lang.swift.decl.var.instance,
-          key.name: "name",
-          key.usr: "s:18index_constructors11HorseObjectC4nameXevp",
-          key.line: 7,
-          key.column: 7,
-          key.entities: [
-            {
-              key.kind: source.lang.swift.decl.function.accessor.getter,
-              key.usr: "s:18index_constructors11HorseObjectC4nameXevg",
-              key.line: 7,
-              key.column: 7,
-              key.is_dynamic: 1
-            },
-            {
-              key.kind: source.lang.swift.decl.function.accessor.setter,
-              key.usr: "s:18index_constructors11HorseObjectC4nameXevs",
-              key.line: 7,
-              key.column: 7,
-              key.is_dynamic: 1
-            }
-          ]
-        },
-        {
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "flip()",
           key.usr: "s:18index_constructors11HorseObjectC4flipyyF",


### PR DESCRIPTION
<!-- What's in this pull request? -->
Under certain conditions, errors in the code being compiled result in the indexer attempting to demangle a type with an error type which causes the compiler to abort.
This PR stops the demangling.

Explanation: Add a conjunction when indexing calls demangle to avoid demangling a type containing errors.
Scope of issue: Compiler aborts in WMO or batch mode when compiling some erroneous input, and user gets no diagnostics. With this fix WMO works. Batch mode still omits diagnostics, but exits instead of aborting.
Origination: Probably originated when we decided to index files with errors.
Risk: Minimal, will reduce index information for code with errors.
Reviewed by: Reviewed by Argyrios.
Testing: Normal regression tests.
Radar: rdar://42314665

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Was one of the causes of rdar://42314665

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->