### PR TITLE
[TF] Enable optional run metadata output in TF runtime for debugging

### DIFF
--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -453,16 +453,10 @@ private class TFState {
 
   /// The TF_Session to execute the function.
   fileprivate let cSession: CTFSession
-  
   /// The graph that contains the function to execute. Not owned.
   let graph: CTFGraph
-  
   /// The input tensors.
   var inputTensors: [CTensor?] = []
-  
-  /// The buffer that stores the run metadata during execution. This is non-nil
-  /// only when `_RuntimeConfig.runMetadataOutputPath` is non-nil.
-  private var runMetadataOutput: UnsafeMutablePointer<TF_Buffer>? = nil
 
   init(_ programByteAddress: UnsafeRawPointer, programByteCount: Int) {
     let context = _ExecutionContext.global
@@ -472,7 +466,6 @@ private class TFState {
 
   deinit {
     TF_DeleteStatus(status)
-    TF_DeleteBuffer(runMetadataOutput)
   }
 }
 
@@ -554,6 +547,7 @@ extension TFState {
       }
     }
     var runOptions: UnsafePointer<TF_Buffer>? = nil
+    var runMetadataOutput: UnsafeMutablePointer<TF_Buffer>? = nil
     // When there's a run metadata output path specified, we enable `FULL_TRACE`
     // in run options and dump that to the specified path after execution.
     if _RuntimeConfig.runMetadataOutputPath != nil {

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -95,11 +95,13 @@ public enum _RuntimeConfig {
   /// TPU execution, set the enum value accordingly.
   static public var executionMode: _ExecutionMode = .auto
 
-  /// When true, let TensorFlow GPU memory allocation start small and grow as needed.
-  /// Otherwise, The entire GPU memory region is pre-allocated.
+  /// When true, let TensorFlow GPU memory allocation start small and grow as
+  /// needed. Otherwise, The entire GPU memory region is pre-allocated.
   // TODO: assess whether we should default to true.
   static public var gpuMemoryAllowGrowth = false
   
+  /// When non-nil, run metadata (with full trace) of each session execution
+  /// will be dumped to the give path.
   static public var runMetadataOutputPath: String? = nil
 
   /// Specifies whether the TensorFlow computation runs in a local (in-process)

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -316,7 +316,6 @@ public final class _ExecutionContext {
       TF_DeleteGraph(graph)
     }
     TFE_DeleteContext(cContext)
-    checkOk(status)
     TF_DeleteBuffer(tensorFlowConfig)
     TF_DeleteStatus(status)
     pthread_mutex_destroy(&mutex)

--- a/stdlib/public/TensorFlow/Utilities.swift
+++ b/stdlib/public/TensorFlow/Utilities.swift
@@ -130,6 +130,8 @@ func debugLog(_ message: @autoclosure () -> String,
 // File writing
 //===----------------------------------------------------------------------===//
 
+/// Given the address of a `TF_Buffer` and a file path, write the buffer's
+/// contents to the file.
 func writeContents(of buffer: UnsafePointer<TF_Buffer>,
                    toFile path: String) {
   let fp = fopen(path, "w+")

--- a/stdlib/public/TensorFlow/Utilities.swift
+++ b/stdlib/public/TensorFlow/Utilities.swift
@@ -127,6 +127,17 @@ func debugLog(_ message: @autoclosure () -> String,
 }
 
 //===----------------------------------------------------------------------===//
+// File writing
+//===----------------------------------------------------------------------===//
+
+func writeContents(of buffer: UnsafePointer<TF_Buffer>,
+                   toFile path: String) {
+  let fp = fopen(path, "w+")
+  fwrite(buffer.pointee.data, /*size*/ 1, /*count*/ buffer.pointee.length, fp)
+  fclose(fp)
+}
+
+//===----------------------------------------------------------------------===//
 // Pseudorandom number generation
 //===----------------------------------------------------------------------===//
 

--- a/utils/update-checkout-config.json
+++ b/utils/update-checkout-config.json
@@ -304,7 +304,7 @@
                 "swift-integration-tests": "swift-DEVELOPMENT-SNAPSHOT-2018-07-14-a",
                 "swift-xcode-playground-support": "swift-DEVELOPMENT-SNAPSHOT-2018-07-14-a",
                 "ninja": "253e94c1fa511704baeb61cf69995bbf09ba435e",
-                "tensorflow": "31b9c1fd4e4e8abd1c8528dc84ab54bb33d7a934",
+                "tensorflow": "f943f0c2012e3820ddfe0fa86f002a80998e1faf",
                 "tensorflow-swift-bindings": "489fcb7c4ca0ee11f3453ee7b0749a4f0742e780"
             }
         }


### PR DESCRIPTION
[Run metadata](https://www.tensorflow.org/api_docs/python/tf/RunMetadata) in TensorFlow provides detailed execution information and is useful for debugging. As part of the profiling effort, we add support for this feature in the compiler runtime.

The runtime looks for an environment variable `SWIFT_TENSORFLOW_RUN_METADATA_OUTPUT` which specifies the file path to write the runtime metadata protobuf to. Then we can use Python to load file this as a `tf.RunMetadata` and get a timeline of execution.

This patch is based on https://github.com/tensorflow/tensorflow/commit/f943f0c2012e3820ddfe0fa86f002a80998e1faf, so the TensorFlow rev in update-checkout has been bumped up.

Also includes a few minor Swift style lints.