### PR TITLE
[Sema] SE-0213: Fix `LinkedExprAnalyzer` to not record types for lite…

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -304,9 +304,12 @@ namespace {
 
       // Coercion exprs have a rigid type, so there's no use in gathering info
       // about them.
-      if (isa<CoerceExpr>(expr)) {
-        LTI.collectedTypes.insert(CS.getType(expr).getPointer());
-
+      if (auto *coercion = dyn_cast<CoerceExpr>(expr)) {
+        // Let's not collect information about types initialized by
+        // coercions just like we don't for regular initializer calls,
+        // because that might lead to overly eager type variable merging.
+        if (!coercion->isLiteralInit())
+          LTI.collectedTypes.insert(CS.getType(expr).getPointer());
         return { false, expr };
       }
 

--- a/test/Constraints/rdar42750089.swift
+++ b/test/Constraints/rdar42750089.swift
@@ -1,0 +1,74 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P : Equatable {
+  associatedtype T = String
+}
+
+struct S : Hashable {
+  var key: String
+
+  init(_ key: String) {
+    self.key = key
+  }
+}
+
+extension S : ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
+        self.init(value)
+    }
+}
+
+extension S : _ExpressibleByStringInterpolation {
+  init(stringInterpolation strings: S...) {
+    self.key = "foo"
+  }
+
+  init<T>(stringInterpolationSegment expr: T) {
+    self.init(String(describing: expr))
+  }
+}
+
+extension S : P {}
+
+struct ConcP<F: P, S: P> : P where F.T == S.T {
+  var lhs: F
+  var rhs: S
+}
+
+struct Z : P {
+}
+
+extension P {
+  func bar() -> Z { fatalError() }
+
+  static func +<T : P>(lhs: Self, rhs: T) -> ConcP<Self, T> {
+    return ConcP(lhs: lhs, rhs: rhs)
+  }
+}
+
+class Container<V> {
+  var value: V
+  init(_ value: V) {
+    self.value = value
+  }
+}
+
+struct A {
+  enum Value : CustomStringConvertible {
+    case foo, bar
+
+    var description: String {
+      switch self {
+        case .foo: return "foo"
+        case .bar: return "bar"
+      }
+    }
+  }
+
+  var value: Container<Value>
+
+  func foo() {
+    let value = self.value.value
+    _ = S("A") + S("\(value)").bar() + S("B") // Ok
+  }
+}


### PR DESCRIPTION
…ral init

Literal initialization via coercion makes current incorrect logic
slightly more eager still, which leads to more chained arithmetic
operator expressions to be recognized as "symmetric" and their type
variables merged.

Although literal init via coercion does provide more type information,
let's treat it as regular initializer calls and don't record the types.

Resolves: rdar://problem/42750089

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
