### PR TITLE
Add @_hasInitialValue to reliably mark variables with initialisers, and use it in TBDGen for StoredPropertyInitializer symbols

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -376,6 +376,10 @@ SIMPLE_DECL_ATTR(_forbidSerializingReference, ForbidSerializingReference,
   OnAnyDecl |
   LongAttribute | RejectByParser | UserInaccessible | NotSerialized,
   77)
+SIMPLE_DECL_ATTR(_hasInitialValue, HasInitialValue,
+  OnVar |
+  UserInaccessible,
+  78)
 
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -71,6 +71,7 @@ public:
 
 #define IGNORED_ATTR(X) void visit##X##Attr(X##Attr *) {}
   IGNORED_ATTR(Available)
+  IGNORED_ATTR(HasInitialValue)
   IGNORED_ATTR(CDecl)
   IGNORED_ATTR(ClangImporterSynthesizedType)
   IGNORED_ATTR(Convenience)
@@ -774,6 +775,7 @@ public:
     void visit##CLASS##Attr(CLASS##Attr *) {}
 
     IGNORED_ATTR(Alignment)
+    IGNORED_ATTR(HasInitialValue)
     IGNORED_ATTR(ClangImporterSynthesizedType)
     IGNORED_ATTR(Consuming)
     IGNORED_ATTR(Convenience)

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1169,6 +1169,7 @@ namespace  {
     UNINTERESTING_ATTR(ClangImporterSynthesizedType)
     UNINTERESTING_ATTR(WeakLinked)
     UNINTERESTING_ATTR(Frozen)
+    UNINTERESTING_ATTR(HasInitialValue)
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -171,9 +171,11 @@ void TBDGenVisitor::visitAbstractStorageDecl(AbstractStorageDecl *ASD) {
 void TBDGenVisitor::visitVarDecl(VarDecl *VD) {
   // statically/globally stored variables have some special handling.
   if (VD->hasStorage() && isGlobalOrStaticVar(VD)) {
-    // The actual variable has a symbol.
-    Mangle::ASTMangler mangler;
-    addSymbol(mangler.mangleEntity(VD, false));
+    if (getDeclLinkage(VD) == FormalLinkage::PublicUnique) {
+      // The actual variable has a symbol.
+      Mangle::ASTMangler mangler;
+      addSymbol(mangler.mangleEntity(VD, false));
+    }
 
     // Top-level variables (*not* statics) in the main file don't get accessors,
     // despite otherwise looking like globals.

--- a/lib/TBDGen/TBDGenVisitor.h
+++ b/lib/TBDGen/TBDGenVisitor.h
@@ -90,8 +90,6 @@ public:
   /// \brief Adds the global symbols associated with the first file.
   void addFirstFileSymbols();
 
-  void visitPatternBindingDecl(PatternBindingDecl *PBD);
-
   void visitAbstractFunctionDecl(AbstractFunctionDecl *AFD);
 
   void visitAccessorDecl(AccessorDecl *AD);

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -108,7 +108,7 @@ struct d0100_FooStruct {
 // PASS_COMMON-LABEL: {{^}}struct d0100_FooStruct {{{$}}
 
   var instanceVar1: Int = 0
-// PASS_COMMON-NEXT: {{^}}  var instanceVar1: Int{{$}}
+// PASS_COMMON-NEXT: {{^}}  @_hasInitialValue var instanceVar1: Int{{$}}
 
   var computedProp1: Int {
     get {
@@ -207,7 +207,7 @@ struct d0100_FooStruct {
 // PASS_COMMON-NEXT: {{^}}  typealias NestedTypealias = Int{{$}}
 
   static var staticVar1: Int = 42
-// PASS_COMMON-NEXT: {{^}}  static var staticVar1: Int{{$}}
+// PASS_COMMON-NEXT: {{^}}  @_hasInitialValue static var staticVar1: Int{{$}}
 
   static var computedStaticProp1: Int {
     get {
@@ -303,7 +303,7 @@ extension d0100_FooStruct.ExtNestedStruct {
 // PASS_COMMON-NEXT: {{^}}}{{$}}
 
 var fooObject: d0100_FooStruct = d0100_FooStruct()
-// PASS_ONE_LINE-DAG: {{^}}var fooObject: d0100_FooStruct{{$}}
+// PASS_ONE_LINE-DAG: {{^}}@_hasInitialValue var fooObject: d0100_FooStruct{{$}}
 
 struct d0110_ReadWriteProperties {
 // PASS_RW_PROP_GET_SET-LABEL:    {{^}}struct d0110_ReadWriteProperties {{{$}}
@@ -432,7 +432,7 @@ class d0120_TestClassBase {
   final class var baseClassVar3: Int { return 0 }
 // PASS_COMMON-NEXT: {{^}}  final class var baseClassVar3: Int { get }{{$}}
   static var baseClassVar4: Int = 0
-// PASS_COMMON-NEXT: {{^}}  static var baseClassVar4: Int{{$}}
+// PASS_COMMON-NEXT: {{^}}  @_hasInitialValue static var baseClassVar4: Int{{$}}
   static var baseClassVar5: Int { return 0 }
 // PASS_COMMON-NEXT: {{^}}  static var baseClassVar5: Int { get }{{$}}
 
@@ -541,13 +541,13 @@ class d0170_TestAvailability {
 // PASS_EXPLODE_PATTERN-LABEL: {{^}}@objc class d0181_TestIBAttrs {{{$}}
 
   @IBOutlet weak var anOutlet: d0181_TestIBAttrs!
-// PASS_EXPLODE_PATTERN-NEXT: {{^}}  @objc @IBOutlet @_implicitly_unwrapped_optional weak var anOutlet: @sil_weak d0181_TestIBAttrs!{{$}}
+// PASS_EXPLODE_PATTERN-NEXT: {{^}}  @objc @IBOutlet @_implicitly_unwrapped_optional @_hasInitialValue weak var anOutlet: @sil_weak d0181_TestIBAttrs!{{$}}
 
   @IBInspectable var inspectableProp: Int = 0
-// PASS_EXPLODE_PATTERN-NEXT: {{^}}  @objc @IBInspectable var inspectableProp: Int{{$}}
+// PASS_EXPLODE_PATTERN-NEXT: {{^}}  @objc @IBInspectable @_hasInitialValue var inspectableProp: Int{{$}}
 
   @GKInspectable var inspectableProp2: Int = 0
-// PASS_EXPLODE_PATTERN-NEXT: {{^}}  @objc @GKInspectable var inspectableProp2: Int{{$}}
+// PASS_EXPLODE_PATTERN-NEXT: {{^}}  @objc @GKInspectable @_hasInitialValue var inspectableProp2: Int{{$}}
 }
 
 struct d0190_LetVarDecls {
@@ -555,21 +555,21 @@ struct d0190_LetVarDecls {
 // PASS_PRINT_MODULE_INTERFACE-LABEL: {{^}}struct d0190_LetVarDecls {{{$}}
 
   let instanceVar1: Int = 0
-// PASS_PRINT_AST-NEXT: {{^}}  let instanceVar1: Int{{$}}
-// PASS_PRINT_MODULE_INTERFACE-NEXT: {{^}}  let instanceVar1: Int{{$}}
+// PASS_PRINT_AST-NEXT: {{^}}  @_hasInitialValue let instanceVar1: Int{{$}}
+// PASS_PRINT_MODULE_INTERFACE-NEXT: {{^}}  @_hasInitialValue let instanceVar1: Int{{$}}
 
   let instanceVar2 = 0
-// PASS_PRINT_AST-NEXT: {{^}}  let instanceVar2: Int{{$}}
-// PASS_PRINT_MODULE_INTERFACE-NEXT: {{^}}  let instanceVar2: Int{{$}}
+// PASS_PRINT_AST-NEXT: {{^}}  @_hasInitialValue let instanceVar2: Int{{$}}
+// PASS_PRINT_MODULE_INTERFACE-NEXT: {{^}}  @_hasInitialValue let instanceVar2: Int{{$}}
 
   static let staticVar1: Int = 42
-// PASS_PRINT_AST-NEXT: {{^}}  static let staticVar1: Int{{$}}
-// PASS_PRINT_MODULE_INTERFACE-NEXT: {{^}}  static let staticVar1: Int{{$}}
+// PASS_PRINT_AST-NEXT: {{^}}  @_hasInitialValue static let staticVar1: Int{{$}}
+// PASS_PRINT_MODULE_INTERFACE-NEXT: {{^}}  @_hasInitialValue static let staticVar1: Int{{$}}
 
   static let staticVar2 = 42
   // FIXME: PRINTED_WITHOUT_TYPE
-// PASS_PRINT_AST-NEXT: {{^}}  static let staticVar2: Int{{$}}
-// PASS_PRINT_MODULE_INTERFACE-NEXT: {{^}}  static let staticVar2: Int{{$}}
+// PASS_PRINT_AST-NEXT: {{^}}  @_hasInitialValue static let staticVar2: Int{{$}}
+// PASS_PRINT_MODULE_INTERFACE-NEXT: {{^}}  @_hasInitialValue static let staticVar2: Int{{$}}
 }
 
 struct d0200_EscapedIdentifiers {
@@ -612,7 +612,7 @@ struct d0200_EscapedIdentifiers {
 // PASS_COMMON-NEXT: {{^}}  func `func`<`let`, `where`>(class: Int, struct: {{(d0200_EscapedIdentifiers.)?}}`protocol`, foo: `let`, bar: `where`) where `let` : {{(d0200_EscapedIdentifiers.)?}}`protocol`, `where` : {{(d0200_EscapedIdentifiers.)?}}`protocol`{{$}}
 
   var `var`: `struct` = `struct`()
-// PASS_COMMON-NEXT: {{^}}  var `var`: {{(d0200_EscapedIdentifiers.)?}}`struct`{{$}}
+// PASS_COMMON-NEXT: {{^}}  @_hasInitialValue var `var`: {{(d0200_EscapedIdentifiers.)?}}`struct`{{$}}
 
   var tupleType: (`var`: Int, `let`: `struct`)
 // PASS_COMMON-NEXT: {{^}}  var tupleType: (`var`: Int, `let`: {{(d0200_EscapedIdentifiers.)?}}`struct`){{$}}
@@ -635,16 +635,16 @@ struct d0210_Qualifications {
 // PASS_QUAL_IF_AMBIGUOUS: {{^}}struct d0210_Qualifications {{{$}}
 
   var propFromStdlib1: Int = 0
-// PASS_QUAL_UNQUAL-NEXT:       {{^}}  var propFromStdlib1: Int{{$}}
-// PASS_QUAL_IF_AMBIGUOUS-NEXT: {{^}}  var propFromStdlib1: Int{{$}}
+// PASS_QUAL_UNQUAL-NEXT:       {{^}}  @_hasInitialValue var propFromStdlib1: Int{{$}}
+// PASS_QUAL_IF_AMBIGUOUS-NEXT: {{^}}  @_hasInitialValue var propFromStdlib1: Int{{$}}
 
   var propFromSwift1: FooSwiftStruct = FooSwiftStruct()
-// PASS_QUAL_UNQUAL-NEXT:       {{^}}  var propFromSwift1: FooSwiftStruct{{$}}
-// PASS_QUAL_IF_AMBIGUOUS-NEXT: {{^}}  var propFromSwift1: foo_swift_module.FooSwiftStruct{{$}}
+// PASS_QUAL_UNQUAL-NEXT:       {{^}}  @_hasInitialValue var propFromSwift1: FooSwiftStruct{{$}}
+// PASS_QUAL_IF_AMBIGUOUS-NEXT: {{^}}  @_hasInitialValue var propFromSwift1: foo_swift_module.FooSwiftStruct{{$}}
 
   var propFromClang1: FooStruct1 = FooStruct1(x: 0, y: 0.0)
-// PASS_QUAL_UNQUAL-NEXT:       {{^}}  var propFromClang1: FooStruct1{{$}}
-// PASS_QUAL_IF_AMBIGUOUS-NEXT: {{^}}  var propFromClang1: FooStruct1{{$}}
+// PASS_QUAL_UNQUAL-NEXT:       {{^}}  @_hasInitialValue var propFromClang1: FooStruct1{{$}}
+// PASS_QUAL_IF_AMBIGUOUS-NEXT: {{^}}  @_hasInitialValue var propFromClang1: FooStruct1{{$}}
 
 
   func instanceFuncFromStdlib1(a: Int) -> Float {
@@ -678,43 +678,43 @@ class d0250_ExplodePattern {
   var instanceVar1 = 0
   var instanceVar2 = 0.0
   var instanceVar3 = ""
-// PASS_EXPLODE_PATTERN: {{^}}  var instanceVar1: Int{{$}}
-// PASS_EXPLODE_PATTERN: {{^}}  var instanceVar2: Double{{$}}
-// PASS_EXPLODE_PATTERN: {{^}}  var instanceVar3: String{{$}}
+// PASS_EXPLODE_PATTERN: {{^}}  @_hasInitialValue var instanceVar1: Int{{$}}
+// PASS_EXPLODE_PATTERN: {{^}}  @_hasInitialValue var instanceVar2: Double{{$}}
+// PASS_EXPLODE_PATTERN: {{^}}  @_hasInitialValue var instanceVar3: String{{$}}
 
   var instanceVar4 = FooStruct()
   var (instanceVar5, instanceVar6) = (FooStruct(), FooStruct())
   var (instanceVar7, instanceVar8) = (FooStruct(), FooStruct())
   var (instanceVar9, instanceVar10) : (FooStruct, FooStruct) = (FooStruct(), FooStruct())
   final var (instanceVar11, instanceVar12) = (FooStruct(), FooStruct())
-// PASS_EXPLODE_PATTERN: {{^}}  var instanceVar4: FooStruct{{$}}
-// PASS_EXPLODE_PATTERN: {{^}}  var instanceVar5: FooStruct{{$}}
-// PASS_EXPLODE_PATTERN: {{^}}  var instanceVar6: FooStruct{{$}}
-// PASS_EXPLODE_PATTERN: {{^}}  var instanceVar7: FooStruct{{$}}
-// PASS_EXPLODE_PATTERN: {{^}}  var instanceVar8: FooStruct{{$}}
-// PASS_EXPLODE_PATTERN: {{^}}  var instanceVar9: FooStruct{{$}}
-// PASS_EXPLODE_PATTERN: {{^}}  var instanceVar10: FooStruct{{$}}
-// PASS_EXPLODE_PATTERN: {{^}}  final var instanceVar11: FooStruct{{$}}
-// PASS_EXPLODE_PATTERN: {{^}}  final var instanceVar12: FooStruct{{$}}
+// PASS_EXPLODE_PATTERN: {{^}}  @_hasInitialValue var instanceVar4: FooStruct{{$}}
+// PASS_EXPLODE_PATTERN: {{^}}  @_hasInitialValue var instanceVar5: FooStruct{{$}}
+// PASS_EXPLODE_PATTERN: {{^}}  @_hasInitialValue var instanceVar6: FooStruct{{$}}
+// PASS_EXPLODE_PATTERN: {{^}}  @_hasInitialValue var instanceVar7: FooStruct{{$}}
+// PASS_EXPLODE_PATTERN: {{^}}  @_hasInitialValue var instanceVar8: FooStruct{{$}}
+// PASS_EXPLODE_PATTERN: {{^}}  @_hasInitialValue var instanceVar9: FooStruct{{$}}
+// PASS_EXPLODE_PATTERN: {{^}}  @_hasInitialValue var instanceVar10: FooStruct{{$}}
+// PASS_EXPLODE_PATTERN: {{^}}  @_hasInitialValue final var instanceVar11: FooStruct{{$}}
+// PASS_EXPLODE_PATTERN: {{^}}  @_hasInitialValue final var instanceVar12: FooStruct{{$}}
 
   let instanceLet1 = 0
   let instanceLet2 = 0.0
   let instanceLet3 = ""
-// PASS_EXPLODE_PATTERN: {{^}}  final let instanceLet1: Int{{$}}
-// PASS_EXPLODE_PATTERN: {{^}}  final let instanceLet2: Double{{$}}
-// PASS_EXPLODE_PATTERN: {{^}}  final let instanceLet3: String{{$}}
+// PASS_EXPLODE_PATTERN: {{^}}  @_hasInitialValue final let instanceLet1: Int{{$}}
+// PASS_EXPLODE_PATTERN: {{^}}  @_hasInitialValue final let instanceLet2: Double{{$}}
+// PASS_EXPLODE_PATTERN: {{^}}  @_hasInitialValue final let instanceLet3: String{{$}}
 
   let instanceLet4 = FooStruct()
   let (instanceLet5, instanceLet6) = (FooStruct(), FooStruct())
   let (instanceLet7, instanceLet8) = (FooStruct(), FooStruct())
   let (instanceLet9, instanceLet10) : (FooStruct, FooStruct) = (FooStruct(), FooStruct())
-// PASS_EXPLODE_PATTERN: {{^}}  final let instanceLet4: FooStruct{{$}}
-// PASS_EXPLODE_PATTERN: {{^}}  final let instanceLet5: FooStruct{{$}}
-// PASS_EXPLODE_PATTERN: {{^}}  final let instanceLet6: FooStruct{{$}}
-// PASS_EXPLODE_PATTERN: {{^}}  final let instanceLet7: FooStruct{{$}}
-// PASS_EXPLODE_PATTERN: {{^}}  final let instanceLet8: FooStruct{{$}}
-// PASS_EXPLODE_PATTERN: {{^}}  final let instanceLet9: FooStruct{{$}}
-// PASS_EXPLODE_PATTERN: {{^}}  final let instanceLet10: FooStruct{{$}}
+// PASS_EXPLODE_PATTERN: {{^}}  @_hasInitialValue final let instanceLet4: FooStruct{{$}}
+// PASS_EXPLODE_PATTERN: {{^}}  @_hasInitialValue final let instanceLet5: FooStruct{{$}}
+// PASS_EXPLODE_PATTERN: {{^}}  @_hasInitialValue final let instanceLet6: FooStruct{{$}}
+// PASS_EXPLODE_PATTERN: {{^}}  @_hasInitialValue final let instanceLet7: FooStruct{{$}}
+// PASS_EXPLODE_PATTERN: {{^}}  @_hasInitialValue final let instanceLet8: FooStruct{{$}}
+// PASS_EXPLODE_PATTERN: {{^}}  @_hasInitialValue final let instanceLet9: FooStruct{{$}}
+// PASS_EXPLODE_PATTERN: {{^}}  @_hasInitialValue final let instanceLet10: FooStruct{{$}}
 }
 
 class d0260_ExplodePattern_TestClassBase {
@@ -879,11 +879,11 @@ protocol AssociatedType1 {
 //===---
 
 var d0300_topLevelVar1: Int = 42
-// PASS_COMMON: {{^}}var d0300_topLevelVar1: Int{{$}}
+// PASS_COMMON: {{^}}@_hasInitialValue var d0300_topLevelVar1: Int{{$}}
 // PASS_COMMON-NOT: d0300_topLevelVar1
 
 var d0400_topLevelVar2: Int = 42
-// PASS_COMMON: {{^}}var d0400_topLevelVar2: Int{{$}}
+// PASS_COMMON: {{^}}@_hasInitialValue var d0400_topLevelVar2: Int{{$}}
 // PASS_COMMON-NOT: d0400_topLevelVar2
 
 var d0500_topLevelVar2: Int {
@@ -902,13 +902,13 @@ class d0600_InClassVar1 {
 // PASS_COMMON-NOT: instanceVar1
 
   var instanceVar2: Int = 42
-// PASS_COMMON: {{^}}  var instanceVar2: Int{{$}}
+// PASS_COMMON: {{^}}  @_hasInitialValue var instanceVar2: Int{{$}}
 // PASS_COMMON-NOT: instanceVar2
 
   // FIXME: this is sometimes printed without a type, see PASS_EXPLODE_PATTERN.
   // FIXME: PRINTED_WITHOUT_TYPE
   var instanceVar3 = 42
-// PASS_COMMON: {{^}}  var instanceVar3
+// PASS_COMMON: {{^}}  @_hasInitialValue var instanceVar3
 // PASS_COMMON-NOT: instanceVar3
 
   var instanceVar4: Int {

--- a/test/IDE/reconstruct_type_from_mangled_name.swift
+++ b/test/IDE/reconstruct_type_from_mangled_name.swift
@@ -5,7 +5,7 @@ struct Mystruct1 {
   func s1f1() -> Int { return 0 }
 // CHECK: decl: func s1f1() -> Int
   var intField = 3
-// CHECK: decl: var intField: Int
+// CHECK: decl: @_hasInitialValue var intField: Int
 // CHECK: decl: init(intField: Int)
 // CHECK: decl: init()
 }
@@ -22,14 +22,14 @@ struct MyStruct2 {
 class Myclass1 {
 // CHECK: decl: class Myclass1
   var intField = 4
-// CHECK: decl: var intField: Int
+// CHECK: decl: @_hasInitialValue var intField: Int
 // CHECK: decl: init()
 }
 
 func f1() {
 // CHECK: decl: func f1()
   var s1ins = Mystruct1() // Implicit ctor
-// CHECK: decl: var s1ins: Mystruct1
+// CHECK: decl: @_hasInitialValue var s1ins: Mystruct1
   _ = Mystruct1(intField: 1) // Implicit ctor
 
   s1ins.intField = 34
@@ -37,7 +37,7 @@ func f1() {
 // CHECK: type: Int
 
   var c1ins = Myclass1()
-// CHECK: decl: var c1ins: Myclass1
+// CHECK: decl: @_hasInitialValue var c1ins: Myclass1
 // CHECK: type: Myclass1
 
   c1ins.intField = 3
@@ -59,7 +59,7 @@ class Myclass2 {
 // CHECK: decl: func f1()
 
     var arr1 = [1, 2]
-// CHECK: decl: var arr1: [Int]
+// CHECK: decl: @_hasInitialValue var arr1: [Int]
 // CHECK: type: Array<Int>
 
     arr1.append(1)
@@ -151,7 +151,7 @@ struct MyGenStruct1<T, U: ExpressibleByStringLiteral, V: Sequence> {
 }
 
 let genstruct1 = MyGenStruct1<Int, String, [Float]>(x: 1, y: "", z: [1.0])
-// CHECK: decl: let genstruct1: MyGenStruct1<Int, String, [Float]>
+// CHECK: decl: @_hasInitialValue let genstruct1: MyGenStruct1<Int, String, [Float]>
 
 func test001() {
 // CHECK: decl: func test001()

--- a/test/SIL/Parser/final.swift
+++ b/test/SIL/Parser/final.swift
@@ -1,14 +1,14 @@
 // RUN: %target-swift-frontend %s -emit-silgen | %FileCheck %s
 
 // CHECK: final class Rect
-// CHECK: @sil_stored final var orgx: Double
+// CHECK: @sil_stored @_hasInitialValue final var orgx: Double
 final class Rect {
   var orgx = 0.0
 }
 
 protocol P { }
 // CHECK: struct Rect2 : P {
-// CHECK: @sil_stored var orgx: Double
+// CHECK: @sil_stored @_hasInitialValue var orgx: Double
 struct Rect2 : P {
   var orgx = 0.0
 }

--- a/test/TBD/Inputs/extension_types.swift
+++ b/test/TBD/Inputs/extension_types.swift
@@ -1,10 +1,10 @@
-public protocol Foreign {
+public protocol ExtensionForeign {
     func foreignMethod()
     var foreignGet: Int { get }
     var foreignGetSet: Int { get set }
 }
-public protocol ForeignInherit: Foreign {}
-extension ForeignInherit {
+public protocol ExtensionForeignInherit: ExtensionForeign {}
+extension ExtensionForeignInherit {
     public func foreignMethod() {}
     public var foreignGet: Int { return 0 }
     public var foreignGetSet: Int {

--- a/test/TBD/all-in-one.swift
+++ b/test/TBD/all-in-one.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t)
+
+// RUN: %gyb %S/class_objc.swift.gyb > %t/class_objc.swift
+// RUN: %gyb %S/extension.swift.gyb > %t/extension.swift
+// RUN: %gyb %S/subclass.swift.gyb > %t/subclass.swift
+
+// RUN: %target-build-swift %S/Inputs/extension_types.swift -module-name ExtensionTypes -emit-module -emit-module-path %t/ExtensionTypes.swiftmodule
+// RUN: %target-build-swift %S/Inputs/subclass_super.swift -emit-library -emit-module -o %t/subclass_super.%target-dylib-extension -Xfrontend -enable-resilience
+
+// RUN: %target-build-swift -module-name all_in_one -emit-module-path %t/all_in_one.swiftmodule -emit-tbd-path %t/incremental_Onone.tbd %S/class.swift %t/class_objc.swift %S/enum.swift %t/extension.swift %S/function.swift %S/global.swift %S/main.swift %S/protocol.swift %S/struct.swift %t/subclass.swift -I %t -import-objc-header %S/Inputs/objc_class_header.h  -Xfrontend -disable-objc-attr-requires-foundation-module
+// RUN: %target-build-swift -module-name all_in_one -emit-module-path %t/all_in_one.swiftmodule -emit-tbd-path %t/wmo_Onone.tbd %S/class.swift %t/class_objc.swift %S/enum.swift %t/extension.swift %S/function.swift %S/global.swift %S/main.swift %S/protocol.swift %S/struct.swift %t/subclass.swift -I %t -import-objc-header %S/Inputs/objc_class_header.h -Xfrontend -disable-objc-attr-requires-foundation-module -wmo
+
+// RUN: %target-build-swift -module-name all_in_one -emit-module-path %t/all_in_one.swiftmodule -emit-tbd-path %t/incremental_O.tbd %S/class.swift %t/class_objc.swift %S/enum.swift %t/extension.swift %S/function.swift %S/global.swift %S/main.swift %S/protocol.swift %S/struct.swift %t/subclass.swift -I %t -import-objc-header %S/Inputs/objc_class_header.h -Xfrontend -disable-objc-attr-requires-foundation-module -O
+// RUN: %target-build-swift -module-name all_in_one -emit-module-path %t/all_in_one.swiftmodule -emit-tbd-path %t/wmo_O.tbd %S/class.swift %t/class_objc.swift %S/enum.swift %t/extension.swift %S/function.swift %S/global.swift %S/main.swift %S/protocol.swift %S/struct.swift %t/subclass.swift -I %t -import-objc-header %S/Inputs/objc_class_header.h -Xfrontend -disable-objc-attr-requires-foundation-module -wmo -O
+
+// RUN: diff %t/incremental_Onone.tbd %t/wmo_Onone.tbd
+// RUN: diff %t/incremental_O.tbd %t/wmo_O.tbd
+// RUN: diff %t/incremental_Onone.tbd %t/incremental_O.tbd
+
+// REQUIRES: objc_interop

--- a/test/TBD/extension.swift.gyb
+++ b/test/TBD/extension.swift.gyb
@@ -63,15 +63,15 @@ def conformanceBody(protocol):
 % for name in local_decl_names:
 % access = name.lower()
 
-${access} protocol ${name} {
+${access} protocol Extension${name} {
     func ${access}Method()
     var ${access}Get: Int { get }
     var ${access}GetSet: Int { get set }
 }
 
 // Defaulted methods:
-${access} protocol ${name}Inherit: Foreign {}
-extension ${name}Inherit {
+${access} protocol Extension${name}Inherit: ExtensionForeign {}
+extension Extension${name}Inherit {
     ${conformanceBody(name)}
 }
 
@@ -86,21 +86,21 @@ ${access} struct ${name}StructOneExtension {}
 
 % for pname in all_decl_names:
 // e.g. extension PublicStruct: Private { ... }
-extension ${sname}Struct: ${pname} {
+extension ${sname}Struct: Extension${pname} {
     ${conformanceBody(pname)}
 }
 
 // e.g. extension PublicStructInherit: PrivateInherit {}
-extension ${sname}StructInherit: ${pname}Inherit {}
+extension ${sname}StructInherit: Extension${pname}Inherit {}
 
 // e.g. extension PublicStructInheritNoDefault: PrivateInherit { ... }
-extension ${sname}StructInheritNoDefault: ${pname}Inherit {
+extension ${sname}StructInheritNoDefault: Extension${pname}Inherit {
     ${conformanceBody(pname)}
 }
 % end
 
-// e.g. extension PublicStructOneExtension: Foreign, Public, Internal, Private { ... }
-extension ${sname}StructOneExtension: ${", ".join(p for p in all_decl_names)} {
+// e.g. extension PublicStructOneExtension: ExtensionForeign, ExtensionPublic, ExtensionInternal, ExtensionPrivate { ... }
+extension ${sname}StructOneExtension: ${", ".join("Extension" + p for p in all_decl_names)} {
 % for pname in all_decl_names:
     ${conformanceBody(pname)}
 % end

--- a/test/TBD/global.swift
+++ b/test/TBD/global.swift
@@ -1,11 +1,11 @@
-// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s
-// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing -enable-resilience %s
-// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -enable-testing
-// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing -enable-resilience -enable-testing %s
-// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -O
-// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing -enable-resilience %s -O
-// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -enable-testing -O
-// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing -enable-resilience -enable-testing %s -O
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all -enable-resilience %s
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s -enable-testing
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all -enable-resilience -enable-testing %s
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s -O
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all -enable-resilience %s -O
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s -enable-testing -O
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all -enable-resilience -enable-testing %s -O
 
 public let publicLet: Int = 0
 internal let internalLet: Int = 0

--- a/test/TBD/multi-file.swift
+++ b/test/TBD/multi-file.swift
@@ -43,6 +43,8 @@ public func function() {}
 public class Class {
     public var property: Int
 
+    public var propertyWithInit: Int = 0
+
     public init() {
         property = 0
     }

--- a/test/TBD/struct.swift
+++ b/test/TBD/struct.swift
@@ -1,11 +1,11 @@
-// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s
-// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -enable-resilience
-// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -enable-testing
-// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -enable-resilience -enable-testing
-// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -O
-// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -enable-resilience -O
-// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -enable-testing -O
-// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -enable-resilience -enable-testing -O
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s -enable-resilience
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s -enable-testing
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s -enable-resilience -enable-testing
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s -O
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s -enable-resilience -O
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s -enable-testing -O
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s -enable-resilience -enable-testing -O
 
 public struct PublicNothing {}
 

--- a/test/TBD/struct.swift
+++ b/test/TBD/struct.swift
@@ -7,9 +7,9 @@
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s -enable-testing -O
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s -enable-resilience -enable-testing -O
 
-public struct PublicNothing {}
+public struct StructPublicNothing {}
 
-public struct PublicInit {
+public struct StructPublicInit {
     public init() {}
 
     public init(public_: Int) {}
@@ -17,14 +17,14 @@ public struct PublicInit {
     private init(private_: Int) {}
 }
 
-public struct PublicMethods {
+public struct StructPublicMethods {
     public init() {}
     public func publicMethod() {}
     internal func internalMethod() {}
     private func privateMethod() {}
 }
 
-public struct PublicProperties {
+public struct StructPublicProperties {
     public let publicLet: Int = 0
     internal let internalLet: Int = 0
     private let privateLet: Int = 0
@@ -51,7 +51,7 @@ public struct PublicProperties {
     }
 }
 
-public struct PublicSubscripts {
+public struct StructPublicSubscripts {
     public subscript(publicGet _: Int) -> Int { return 0 }
     internal subscript(internalGet _: Int) -> Int { return 0 }
     private subscript(privateGet _: Int) -> Int { return 0 }
@@ -70,7 +70,7 @@ public struct PublicSubscripts {
     }
 }
 
-public struct PublicStatics {
+public struct StructPublicStatics {
     public static func publicStaticFunc() {}
     internal static func internalStaticFunc() {}
     private static func privateStaticFunc() {}
@@ -101,7 +101,7 @@ public struct PublicStatics {
     }
 }
 
-public struct PublicGeneric<T, U, V> {
+public struct StructPublicGeneric<T, U, V> {
   public var publicVar: T
   internal var internalVar: U
   private var privateVar: V
@@ -126,22 +126,22 @@ public struct PublicGeneric<T, U, V> {
 }
 
 
-internal struct InternalNothing {}
+internal struct StructInternalNothing {}
 
-internal struct InternalInit {
+internal struct StructInternalInit {
     internal init() {}
 
     internal init(internal_: Int) {}
     private init(private_: Int) {}
 }
 
-internal struct InternalMethods {
+internal struct StructInternalMethods {
     internal init() {}
     internal func internalMethod() {}
     private func privateMethod() {}
 }
 
-internal struct InternalProperties {
+internal struct StructInternalProperties {
     internal let internalLet: Int = 0
     private let privateLet: Int = 0
 
@@ -161,7 +161,7 @@ internal struct InternalProperties {
     }
 }
 
-internal struct InternalSubscripts {
+internal struct StructInternalSubscripts {
     internal subscript(internalGet _: Int) -> Int { return 0 }
     private subscript(privateGet _: Int) -> Int { return 0 }
 
@@ -175,7 +175,7 @@ internal struct InternalSubscripts {
     }
 }
 
-internal struct InternalStatics {
+internal struct StructInternalStatics {
     internal static func internalStaticFunc() {}
     private static func privateStaticFunc() {}
 
@@ -198,7 +198,7 @@ internal struct InternalStatics {
     }
 }
 
-internal struct InternalGeneric<T, U, V> {
+internal struct StructInternalGeneric<T, U, V> {
   internal var internalVar: U
   private var privateVar: V
 
@@ -218,19 +218,19 @@ internal struct InternalGeneric<T, U, V> {
 }
 
 
-private struct PrivateNothing {}
+private struct StructPrivateNothing {}
 
-private struct PrivateInit {
+private struct StructPrivateInit {
     private init() {}
     private init(private_: Int) {}
 }
 
-private struct PrivateMethods {
+private struct StructPrivateMethods {
     private init() {}
     private func privateMethod() {}
 }
 
-private struct PrivateProperties {
+private struct StructPrivateProperties {
     private let privateLet: Int = 0
 
     private var privateVar: Int = 0
@@ -243,7 +243,7 @@ private struct PrivateProperties {
     }
 }
 
-private struct PrivateSubscripts {
+private struct StructPrivateSubscripts {
     private subscript(privateGet _: Int) -> Int { return 0 }
 
     private subscript(privateGetSet _: Int) -> Int {
@@ -252,7 +252,7 @@ private struct PrivateSubscripts {
     }
 }
 
-private struct PrivateStatics {
+private struct StructPrivateStatics {
     private static func privateStaticFunc() {}
 
     private static let privateLet: Int = 0
@@ -267,7 +267,7 @@ private struct PrivateStatics {
     }
 }
 
-private struct PrivateGeneric<T, U, V> {
+private struct StructPrivateGeneric<T, U, V> {
   private var privateVar: V
 
   private var privateVarConcrete: Int = 0

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -232,6 +232,7 @@
           "location": "",
           "moduleName": "cake",
           "declAttributes": [
+            "HasInitialValue",
             "ReferenceOwnership"
           ],
           "ownership": 1,
@@ -313,6 +314,7 @@
           "location": "",
           "moduleName": "cake",
           "declAttributes": [
+            "HasInitialValue",
             "ReferenceOwnership"
           ],
           "ownership": 2,

--- a/test/attr/attr_dynamic_infer.swift
+++ b/test/attr/attr_dynamic_infer.swift
@@ -79,7 +79,7 @@ extension FinalTests {
     set { }
   }
 
-  // CHECK: @objc static var x
+  // CHECK: @objc @_hasInitialValue static var x
   @objc static var x: Int = 0
 
   // CHECK: @objc static func bar

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -878,14 +878,14 @@ class infer_instanceVar1 {
   //===--- Tuples.
 
   var var_tuple1: ()
-// CHECK-LABEL: {{^}} var var_tuple1: ()
+// CHECK-LABEL: {{^}} @_hasInitialValue var var_tuple1: ()
 
   @objc var var_tuple1_: ()
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{empty tuple type cannot be represented in Objective-C}}
 
   var var_tuple2: Void
-// CHECK-LABEL: {{^}} var var_tuple2: Void
+// CHECK-LABEL: {{^}} @_hasInitialValue var var_tuple2: Void
 
   @objc var var_tuple2_: Void
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
@@ -1157,20 +1157,20 @@ class infer_instanceVar1 {
   var var_Optional13: UnsafeMutablePointer<Int>?
   var var_Optional14: UnsafeMutablePointer<Class_ObjC1>?
 
-// CHECK-LABEL: @objc var var_Optional1: Class_ObjC1?
-// CHECK-LABEL: @objc var var_Optional2: Protocol_ObjC1?
-// CHECK-LABEL: @objc var var_Optional3: Class_ObjC1.Type?
-// CHECK-LABEL: @objc var var_Optional4: Protocol_ObjC1.Type?
-// CHECK-LABEL: @objc var var_Optional5: AnyObject?
-// CHECK-LABEL: @objc var var_Optional6: AnyObject.Type?
-// CHECK-LABEL: @objc var var_Optional7: String?
-// CHECK-LABEL: @objc var var_Optional8: Protocol_ObjC1?
-// CHECK-LABEL: @objc var var_Optional9: Protocol_ObjC1.Type?
-// CHECK-LABEL: @objc var var_Optional10: (Protocol_ObjC1 & Protocol_ObjC2)?
-// CHECK-LABEL: @objc var var_Optional11: (Protocol_ObjC1 & Protocol_ObjC2).Type?
-// CHECK-LABEL: @objc var var_Optional12: OpaquePointer?
-// CHECK-LABEL: @objc var var_Optional13: UnsafeMutablePointer<Int>?
-// CHECK-LABEL: @objc var var_Optional14: UnsafeMutablePointer<Class_ObjC1>?
+// CHECK-LABEL: @objc @_hasInitialValue var var_Optional1: Class_ObjC1?
+// CHECK-LABEL: @objc @_hasInitialValue var var_Optional2: Protocol_ObjC1?
+// CHECK-LABEL: @objc @_hasInitialValue var var_Optional3: Class_ObjC1.Type?
+// CHECK-LABEL: @objc @_hasInitialValue var var_Optional4: Protocol_ObjC1.Type?
+// CHECK-LABEL: @objc @_hasInitialValue var var_Optional5: AnyObject?
+// CHECK-LABEL: @objc @_hasInitialValue var var_Optional6: AnyObject.Type?
+// CHECK-LABEL: @objc @_hasInitialValue var var_Optional7: String?
+// CHECK-LABEL: @objc @_hasInitialValue var var_Optional8: Protocol_ObjC1?
+// CHECK-LABEL: @objc @_hasInitialValue var var_Optional9: Protocol_ObjC1.Type?
+// CHECK-LABEL: @objc @_hasInitialValue var var_Optional10: (Protocol_ObjC1 & Protocol_ObjC2)?
+// CHECK-LABEL: @objc @_hasInitialValue var var_Optional11: (Protocol_ObjC1 & Protocol_ObjC2).Type?
+// CHECK-LABEL: @objc @_hasInitialValue var var_Optional12: OpaquePointer?
+// CHECK-LABEL: @objc @_hasInitialValue var var_Optional13: UnsafeMutablePointer<Int>?
+// CHECK-LABEL: @objc @_hasInitialValue var var_Optional14: UnsafeMutablePointer<Class_ObjC1>?
 
 
   var var_ImplicitlyUnwrappedOptional1: Class_ObjC1!
@@ -1183,15 +1183,15 @@ class infer_instanceVar1 {
   var var_ImplicitlyUnwrappedOptional8: Protocol_ObjC1!
   var var_ImplicitlyUnwrappedOptional9: (Protocol_ObjC1 & Protocol_ObjC2)!
 
-// CHECK-LABEL: @objc var var_ImplicitlyUnwrappedOptional1: Class_ObjC1!
-// CHECK-LABEL: @objc var var_ImplicitlyUnwrappedOptional2: Protocol_ObjC1!
-// CHECK-LABEL: @objc var var_ImplicitlyUnwrappedOptional3: Class_ObjC1.Type!
-// CHECK-LABEL: @objc var var_ImplicitlyUnwrappedOptional4: Protocol_ObjC1.Type!
-// CHECK-LABEL: @objc var var_ImplicitlyUnwrappedOptional5: AnyObject!
-// CHECK-LABEL: @objc var var_ImplicitlyUnwrappedOptional6: AnyObject.Type!
-// CHECK-LABEL: @objc var var_ImplicitlyUnwrappedOptional7: String!
-// CHECK-LABEL: @objc var var_ImplicitlyUnwrappedOptional8: Protocol_ObjC1!
-// CHECK-LABEL: @objc var var_ImplicitlyUnwrappedOptional9: (Protocol_ObjC1 & Protocol_ObjC2)!
+// CHECK-LABEL: @objc @_hasInitialValue var var_ImplicitlyUnwrappedOptional1: Class_ObjC1!
+// CHECK-LABEL: @objc @_hasInitialValue var var_ImplicitlyUnwrappedOptional2: Protocol_ObjC1!
+// CHECK-LABEL: @objc @_hasInitialValue var var_ImplicitlyUnwrappedOptional3: Class_ObjC1.Type!
+// CHECK-LABEL: @objc @_hasInitialValue var var_ImplicitlyUnwrappedOptional4: Protocol_ObjC1.Type!
+// CHECK-LABEL: @objc @_hasInitialValue var var_ImplicitlyUnwrappedOptional5: AnyObject!
+// CHECK-LABEL: @objc @_hasInitialValue var var_ImplicitlyUnwrappedOptional6: AnyObject.Type!
+// CHECK-LABEL: @objc @_hasInitialValue var var_ImplicitlyUnwrappedOptional7: String!
+// CHECK-LABEL: @objc @_hasInitialValue var var_ImplicitlyUnwrappedOptional8: Protocol_ObjC1!
+// CHECK-LABEL: @objc @_hasInitialValue var var_ImplicitlyUnwrappedOptional9: (Protocol_ObjC1 & Protocol_ObjC2)!
 
   var var_Optional_fail1: PlainClass?
   var var_Optional_fail2: PlainClass.Type?
@@ -1232,11 +1232,11 @@ class infer_instanceVar1 {
   weak var var_Weak7: Protocol_ObjC1?
   weak var var_Weak8: (Protocol_ObjC1 & Protocol_ObjC2)?
 
-// CHECK-LABEL: @objc weak var var_Weak1: @sil_weak Class_ObjC1
-// CHECK-LABEL: @objc weak var var_Weak2: @sil_weak Protocol_ObjC1
-// CHECK-LABEL: @objc weak var var_Weak5: @sil_weak AnyObject
-// CHECK-LABEL: @objc weak var var_Weak7: @sil_weak Protocol_ObjC1
-// CHECK-LABEL: @objc weak var var_Weak8: @sil_weak (Protocol_ObjC1 & Protocol_ObjC2)?
+// CHECK-LABEL: @objc @_hasInitialValue weak var var_Weak1: @sil_weak Class_ObjC1
+// CHECK-LABEL: @objc @_hasInitialValue weak var var_Weak2: @sil_weak Protocol_ObjC1
+// CHECK-LABEL: @objc @_hasInitialValue weak var var_Weak5: @sil_weak AnyObject
+// CHECK-LABEL: @objc @_hasInitialValue weak var var_Weak7: @sil_weak Protocol_ObjC1
+// CHECK-LABEL: @objc @_hasInitialValue weak var var_Weak8: @sil_weak (Protocol_ObjC1 & Protocol_ObjC2)?
 
   weak var var_Weak_fail1: PlainClass?
   weak var var_Weak_bad2: PlainStruct?
@@ -1525,7 +1525,7 @@ class infer_instanceVar3 : Class_ObjC1 {
 // CHECK-LABEL: @objc class infer_instanceVar3 : Class_ObjC1 {
 
   var v1: Int = 0
-// CHECK-LABEL: @objc var v1: Int
+// CHECK-LABEL: @objc @_hasInitialValue var v1: Int
 }
 
 
@@ -1556,7 +1556,7 @@ class infer_staticVar1 {
 // CHECK-LABEL: @objc class infer_staticVar1 {
 
   class var staticVar1: Int = 42 // expected-error {{class stored properties not supported}}
-  // CHECK: @objc class var staticVar1: Int
+  // CHECK: @objc @_hasInitialValue class var staticVar1: Int
 }
 
 // @!objc
@@ -1655,7 +1655,7 @@ class HasIBOutlet {
   init() {}
 
   @IBOutlet weak var goodOutlet: Class_ObjC1!
-  // CHECK-LABEL: {{^}} @objc @IBOutlet @_implicitly_unwrapped_optional weak var goodOutlet: @sil_weak Class_ObjC1!
+  // CHECK-LABEL: {{^}} @objc @IBOutlet @_implicitly_unwrapped_optional @_hasInitialValue weak var goodOutlet: @sil_weak Class_ObjC1!
 
   @IBOutlet var badOutlet: PlainStruct
   // expected-error@-1 {{@IBOutlet property cannot have non-object type 'PlainStruct'}} {{3-13=}}
@@ -1685,7 +1685,7 @@ class HasIBAction {
 // CHECK-LABEL: {{^}}class HasIBInspectable {
 class HasIBInspectable {
   @IBInspectable var goodProperty: AnyObject?
-  // CHECK: {{^}}  @objc @IBInspectable var goodProperty: AnyObject?
+  // CHECK: {{^}}  @objc @IBInspectable @_hasInitialValue var goodProperty: AnyObject?
 }
 
 //===---
@@ -1695,7 +1695,7 @@ class HasIBInspectable {
 // CHECK-LABEL: {{^}}class HasGKInspectable {
 class HasGKInspectable {
   @GKInspectable var goodProperty: AnyObject?
-  // CHECK: {{^}}  @objc @GKInspectable var goodProperty: AnyObject?
+  // CHECK: {{^}}  @objc @GKInspectable @_hasInitialValue var goodProperty: AnyObject?
 }
 
 //===---

--- a/test/attr/hasInitialValue.swift
+++ b/test/attr/hasInitialValue.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-ide-test -skip-deinit=false -print-ast-typechecked -source-filename %s -function-definitions=true -prefer-type-repr=false -print-implicit-attrs=true -explode-pattern-binding-decls=true -swift-version 4 -enable-source-import -I %S/Inputs | %FileCheck %s
+
+// CHECK-LABEL: {{^}}class C {
+class C {
+    // CHECK: {{^}}  var without: Int
+    var without: Int
+    // CHECK: {{^}}  @_hasInitialValue var with: Int
+    var with: Int = 0
+
+    // CHECK: {{^}}  @_hasInitialValue var option: Int
+    var option: Int?
+    // CHECK: {{^}}  @_implicitly_unwrapped_optional @_hasInitialValue var iuo: Int!
+    var iuo: Int!
+
+    // CHECK: {{^}}  lazy var lazyIsntARealInit: Int
+    lazy var lazyIsntARealInit: Int = 0
+
+    init() {
+        without = 0
+    }
+}

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -683,6 +683,7 @@ Optional<UIdent> SwiftLangSupport::getUIDForDeclAttribute(const swift::DeclAttri
     case DAK_ShowInInterface:
     case DAK_RawDocComment:
     case DAK_DowngradeExhaustivityCheck:
+    case DAK_HasInitialValue:
       return None;
     default:
       break;


### PR DESCRIPTION
The information about whether a variable/property is initialized is lost in the
public interface, but is, unfortunately, required because it results in a symbol
for the initializer (if a class/struct `init` is inlined, it will call
initializers for properties that it doesn't initialize itself). This is
important to preserve for TBD file generation.

Using an attribute rather than just a bit on the VarDecl means this fits into
the scheme for module interfaces: textual/valid Swift.

To validate that this is (hopefully) the only case like this, it also adds a test that is the union of all the other TBD tests, meaning multiple interesting files.