### PR TITLE
Disable overlay resilience in the 4.2 release

### DIFF
--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -232,8 +232,8 @@ function(_compile_swift_files
     list(APPEND swift_flags "-Xfrontend" "-sil-verify-all")
   endif()
 
-  # The standard library and overlays are always built with resilience.
-  if(SWIFTFILE_IS_STDLIB)
+  # The standard library are always built with resilience, but not the overlays yet.
+  if(SWIFTFILE_IS_STDLIB_CORE)
     list(APPEND swift_flags "-Xfrontend" "-enable-resilience")
   endif()
 

--- a/test/IRGen/availability.swift
+++ b/test/IRGen/availability.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir | %FileCheck %s
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -O -emit-ir | %FileCheck %s
 
-// REQUIRES: objc_interop
+// REQUIRES: objc_interop, overlay_resilience
 
 import Foundation
 


### PR DESCRIPTION
The 4.2 release is not ABI-stable, so it's not strictly necessary to enable resilience.  We did so in order to gain information and find unanticipated bugs ahead of ABI stability.  Now that a number of such bugs have been discovered, it makes sense to disable resilience in the release in order to reduce the impact on users.

rdar://42756146