### PR TITLE
[tensorflow] Handle in-place array element initialization when decoding _allocateUninitialized.

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFConstExpr.h
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.h
@@ -87,7 +87,7 @@ public:
   /// function in the standard library.  This attempts to figure out how the
   /// resulting elements will be initialized.  This fills in the result with
   /// a lists of operands used to pass element addresses for initialization,
-  /// and returns true on success.
+  /// and returns false on success.
   ///
   /// If arrayInsts is non-null and if decoding succeeds, this function adds
   /// all of the instructions relevant to the definition of this array into

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.h
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.h
@@ -30,6 +30,7 @@
 
 namespace swift {
 class ApplyInst;
+class Operand;
 class SILInstruction;
 class SILModule;
 class SILNode;
@@ -83,9 +84,10 @@ public:
                              SmallVectorImpl<SymbolicValue> &results);
 
   /// Try to decode the specified apply of the _allocateUninitializedArray
-  /// function in the standard library.  This attempts to figure out what the
-  /// resulting elements will be.  This fills in the elements result and returns
-  /// true on success.
+  /// function in the standard library.  This attempts to figure out how the
+  /// resulting elements will be initialized.  This fills in the result with
+  /// a lists of operands used to pass element addresses for initialization,
+  /// and returns true on success.
   ///
   /// If arrayInsts is non-null and if decoding succeeds, this function adds
   /// all of the instructions relevant to the definition of this array into
@@ -93,8 +95,8 @@ public:
   ///
   static bool
   decodeAllocUninitializedArray(ApplyInst *apply, uint64_t numElements,
-                                SmallVectorImpl<SILValue> &elements,
-                                SmallPtrSet<SILInstruction *, 8> *arrayInsts);
+                                SmallVectorImpl<Operand*> &elementsAtInit,
+                                SmallPtrSet<SILInstruction*, 8> *arrayInsts);
 };
 
 } // end namespace tf

--- a/test/TensorFlow/no_copy.swift
+++ b/test/TensorFlow/no_copy.swift
@@ -119,7 +119,7 @@ public func test75494462() {
     x += 1
     i += 1
   } while i < 5
-  print(x.array)
+  _hostOp(x)
 }
 
 public func paddingTuplesHoistable() {
@@ -210,7 +210,7 @@ public func testMultiOutputs() {
 // TODO: Eliminate the sends/recvs when -Onone is enabled.
 public func SR8395() {
   let x: Tensor<Float> = [[1, 2], [3, 4]]
-  print(matmul(x, x) + x)
+  _hostOp(matmul(x, x) + x)
 }
 
 // Tuples should be deabstracted away.
@@ -227,6 +227,6 @@ public func SR8399() {
   let x = Tensor<Float>(ones: [2, 2])
   let y = x.reshaped(toShape: Tensor<Int32>([4, Int32(1)]))
   let z = x.reshaped(toShape: Tensor<Int32>([Int32(4), 1]))
-  print(y)
-  print(z)
+  _hostOp(y)
+  _hostOp(z)
 }

--- a/test/TensorFlow/no_copy.swift
+++ b/test/TensorFlow/no_copy.swift
@@ -221,3 +221,12 @@ public func noTupleExtractOverTensorValues() {
   let e = c + d.1
   _hostOp(e)
 }
+
+// Non-top-level array element
+public func SR8399() {
+  let x = Tensor<Float>(ones: [2, 2])
+  let y = x.reshaped(toShape: Tensor<Int32>([4, Int32(1)]))
+  let z = x.reshaped(toShape: Tensor<Int32>([Int32(4), 1]))
+  print(y)
+  print(z)
+}


### PR DESCRIPTION
When it comes to literal arrays that have some element(s) constructed in place rather than copied from a top level value, `ConstExprEvaluator` fails to decode such arrays, because the decoder requires every element to correspond to a top level value.

~~This patches tries to add stack variables to temporarily hold those element values and then store into the array. The code after this transformation can thus be properly handled by the decoder.~~

This updated patches adds supports to handle in-place element initilization. This is better compared to the previous solution which may change IR when decoding arrays.

Resolves [SR-8399](https://bugs.swift.org/browse/SR-8399).