### PR TITLE
[tensorflow] Fix a typo of the TFPartition pass name.

### DIFF
--- a/include/swift/SILOptimizer/PassManager/PassPipeline.def
+++ b/include/swift/SILOptimizer/PassManager/PassPipeline.def
@@ -36,7 +36,7 @@ PASSPIPELINE_WITH_OPTIONS(SILOptPrepare, "Passes that prepare SIL for -O")
 PASSPIPELINE_WITH_OPTIONS(Performance, "Passes run at -O")
 PASSPIPELINE(Onone, "Passes run at -Onone")
 // SWIFT_ENABLE_TENSORFLOW
-PASSPIPELINE(TFParition, "TensorFlow Partitioning Passes")
+PASSPIPELINE(TFPartition, "TensorFlow Partitioning Passes")
 PASSPIPELINE(InstCount, "Utility pipeline to just run the inst count pass")
 PASSPIPELINE(Lowering, "SIL Address Lowering")
 PASSPIPELINE_WITH_OPTIONS(IRGenPrepare, "Pipeline to run during IRGen")

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -605,7 +605,7 @@ SILPassPipelinePlan SILPassPipelinePlan::getOnonePassPipeline() {
 //                          TensorFlow Pass Pipeline
 //===----------------------------------------------------------------------===//
 
-SILPassPipelinePlan SILPassPipelinePlan::getTFParitionPassPipeline() {
+SILPassPipelinePlan SILPassPipelinePlan::getTFPartitionPassPipeline() {
   SILPassPipelinePlan P;
   P.startPipeline("TensorFlow Partitioning");
   P.addTFPartition();

--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -139,7 +139,7 @@ void swift::runSILTFPartitionPass(SILModule &Module) {
     Module.verify();
 
   SILPassManager PM(&Module, "TensorFlow", /*isMandatoryPipeline=*/ true);
-  PM.executePassPipelinePlan(SILPassPipelinePlan::getTFParitionPassPipeline());
+  PM.executePassPipelinePlan(SILPassPipelinePlan::getTFPartitionPassPipeline());
 
   // Verify the module, if required.
   if (Module.getOptions().VerifyAll)


### PR DESCRIPTION
Came across this issue when trying to search pass name via keyword `TFPartition`. It turns out to be a typo.