### PR TITLE
[TypeChecker] SE-0213: If literal protocol is deprecated or unavailab…

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1862,6 +1862,11 @@ Expr *PreCheckExpression::simplifyTypeConstructionWithLiteralArg(Expr *E) {
   if (!protocol)
     return nullptr;
 
+  // If protocol is deprecated or available don't try to optimize.
+  if (TypeChecker::getDeprecated(protocol) ||
+      protocol->getAttrs().isUnavailable(TC.Context))
+    return nullptr;
+
   Type type;
   if (typeExpr->getTypeLoc().wasValidated()) {
     type = typeExpr->getTypeLoc().getType();


### PR DESCRIPTION
…le don't try optimization

In theory such optimizations could lead to worse solutions because
there might be another "better" initializer in such case which doesn't
come from the unavailable literal protocol.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
