### PR TITLE
[IDE] Use collected token to retrieve range of type identifier

### DIFF
--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -960,11 +960,13 @@ bool ModelASTWalker::walkToTypeReprPre(TypeRepr *T) {
       return false;
 
   } else if (auto IdT = dyn_cast<ComponentIdentTypeRepr>(T)) {
-    if (!passNonTokenNode({ SyntaxNodeKind::TypeId,
-                            CharSourceRange(IdT->getIdLoc(),
-                                            IdT->getIdentifier().getLength())
-                          }))
+    if (!passTokenNodesUntil(IdT->getIdLoc(), ExcludeNodeAtLocation))
       return false;
+    if (TokenNodes.front().Range.getStart() != IdT->getIdLoc())
+      return false;
+    if (!passNode({SyntaxNodeKind::TypeId, TokenNodes.front().Range}))
+      return false;
+    TokenNodes = TokenNodes.slice(1);
   }
   return true;
 }

--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -406,4 +406,6 @@ class Ownership {
 let closure = { [weak x=bindtox, unowned y=bindtoy, unowned(unsafe) z=bindtoz] in }
 
 protocol FakeClassRestrictedProtocol : `class` {}
-// CHECK: <kw>protocol</kw> FakeClassRestrictedProtocol : <type>`class`</type> {}
+// CHECK-OLD: <kw>protocol</kw> FakeClassRestrictedProtocol : <type>`class`</type> {}
+// FIXME: rdar://42801404: OLD and NEW should be the same '<type>`class`</type>'.
+// CHECK-NEW: <kw>protocol</kw> FakeClassRestrictedProtocol : `<type>class</type>` {}

--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -404,3 +404,6 @@ class Ownership {
 // CHECK-OLD: <kw>let</kw> closure = { [<attr-builtin>weak</attr-builtin> x=bindtox, <attr-builtin>unowned</attr-builtin> y=bindtoy, <attr-builtin>unowned(unsafe)</attr-builtin> z=bindtoz] <kw>in</kw> }
 // FIXME: CHECK-NEW: <kw>let</kw> closure = { [weak x=bindtox, unowned y=bindtoy, unowned(unsafe) z=bindtoz] <kw>in</kw> }
 let closure = { [weak x=bindtox, unowned y=bindtoy, unowned(unsafe) z=bindtoz] in }
+
+protocol FakeClassRestrictedProtocol : `class` {}
+// CHECK: <kw>protocol</kw> FakeClassRestrictedProtocol : <type>`class`</type> {}

--- a/test/IDE/coloring_class_restriction.swift
+++ b/test/IDE/coloring_class_restriction.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-ide-test -syntax-coloring -source-filename %s | %FileCheck %s
+// RUN: %target-swift-ide-test -syntax-coloring -typecheck -source-filename %s | %FileCheck %s
+
+// NOTE: Testing 'class' at the end of the file. Don't add anything after that.
+// https://bugs.swift.org/browse/SR-8378
+
+// CHECK: <kw>protocol</kw> P : <type>class</type>
+protocol P : class


### PR DESCRIPTION
Previously, it used to use length from AST. Because AST doesn't necessarily holds actual source information, it may emits inacculate syntax info which cause mis-coloring or SourceKit crash in the worst case. Instead, use collected token info that contains actual token length.

https://bugs.swift.org/browse/SR-8378
rdar://problem/42653982
