### PR TITLE
Don’t mangle if contains error types.

### DIFF
--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -226,7 +226,7 @@ bool ide::printDeclUSR(const ValueDecl *D, raw_ostream &OS) {
     return printObjCUSR(D, OS);
   }
 
-  if (!D->hasInterfaceType())
+  if (!D->hasInterfaceType() || D->getInterfaceType()->hasError())
     return true;
 
   // Invalid code.

--- a/test/SourceKit/Indexing/index_constructors.swift.response
+++ b/test/SourceKit/Indexing/index_constructors.swift.response
@@ -34,29 +34,6 @@
           key.column: 21
         },
         {
-          key.kind: source.lang.swift.decl.var.instance,
-          key.name: "name",
-          key.usr: "s:18index_constructors11HorseObjectC4nameXevp",
-          key.line: 7,
-          key.column: 7,
-          key.entities: [
-            {
-              key.kind: source.lang.swift.decl.function.accessor.getter,
-              key.usr: "s:18index_constructors11HorseObjectC4nameXevg",
-              key.line: 7,
-              key.column: 7,
-              key.is_dynamic: 1
-            },
-            {
-              key.kind: source.lang.swift.decl.function.accessor.setter,
-              key.usr: "s:18index_constructors11HorseObjectC4nameXevs",
-              key.line: 7,
-              key.column: 7,
-              key.is_dynamic: 1
-            }
-          ]
-        },
-        {
           key.kind: source.lang.swift.decl.function.method.instance,
           key.name: "flip()",
           key.usr: "s:18index_constructors11HorseObjectC4flipyyF",


### PR DESCRIPTION
<!-- What's in this pull request? -->
Prevent aborts by not trying to demangle a type containing an error type. These aborts can happen when indexing incorrect code.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Part of the problem in rdar://42314665

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
