### PR TITLE
[sourcekitd] Add environment variable to stop semantic requests being temporarily disabled following a crash

### DIFF
--- a/test/SourceKit/Misc/disable-semantic-editor-delay.swift
+++ b/test/SourceKit/Misc/disable-semantic-editor-delay.swift
@@ -1,0 +1,5 @@
+// RUN: not %sourcekitd-test -req=crash 2>&1 | %FileCheck %s -check-prefix=ENABLED
+// RUN: SOURCEKIT_DISABLE_SEMA_EDITOR_DELAY=1 not %sourcekitd-test -req=crash 2>&1 | %FileCheck %s -check-prefix=DISABLED
+
+// ENABLED: disabling semantic editor for
+// DISABLED-NOT: disabling semantic editor for

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -114,6 +114,7 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
         .Case("complete.update", SourceKitRequest::CodeCompleteUpdate)
         .Case("complete.cache.ondisk", SourceKitRequest::CodeCompleteCacheOnDisk)
         .Case("complete.setpopularapi", SourceKitRequest::CodeCompleteSetPopularAPI)
+        .Case("crash", SourceKitRequest::CrashWithExit)
         .Case("cursor", SourceKitRequest::CursorInfo)
         .Case("related-idents", SourceKitRequest::RelatedIdents)
         .Case("syntax-map", SourceKitRequest::SyntaxMap)
@@ -155,7 +156,7 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
         llvm::errs() << "error: invalid request '" << InputArg->getValue()
             << "'\nexpected one of "
             << "version/demangle/mangle/index/complete/complete.open/complete.cursor/"
-               "complete.update/complete.cache.ondisk/complete.cache.setpopularapi/"
+               "complete.update/complete.cache.ondisk/complete.cache.setpopularapi/crash/"
                "cursor/related-idents/syntax-map/structure/format/expand-placeholder/"
                "doc-info/sema/interface-gen/interface-gen-openfind-usr/find-interface/"
                "open/close/edit/print-annotations/print-diags/extract-comment/module-groups/"

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
@@ -31,6 +31,7 @@ enum class SourceKitRequest {
   CodeCompleteUpdate,
   CodeCompleteCacheOnDisk,
   CodeCompleteSetPopularAPI,
+  CrashWithExit,
   CursorInfo,
   RangeInfo,
   RelatedIdents,

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -533,6 +533,10 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
     break;
   }
 
+  case SourceKitRequest::CrashWithExit:
+    sourcekitd_request_dictionary_set_uid(Req, KeyRequest, RequestCrashWithExit);
+    break;
+
   case SourceKitRequest::CursorInfo:
     sourcekitd_request_dictionary_set_uid(Req, KeyRequest, RequestCursorInfo);
     if (Opts.CollectActionables) {
@@ -989,6 +993,7 @@ static bool handleResponse(sourcekitd_response_t Resp, const TestOptions &Opts,
     case SourceKitRequest::CodeCompleteUpdate:
     case SourceKitRequest::CodeCompleteCacheOnDisk:
     case SourceKitRequest::CodeCompleteSetPopularAPI:
+    case SourceKitRequest::CrashWithExit:
       sourcekitd_response_description_dump_filedesc(Resp, STDOUT_FILENO);
       break;
 

--- a/tools/SourceKit/tools/sourcekitd/bin/XPC/Client/sourcekitd.cpp
+++ b/tools/SourceKit/tools/sourcekitd/bin/XPC/Client/sourcekitd.cpp
@@ -398,6 +398,10 @@ static void updateSemanticEditorDelay() {
   // Clear any previous setting.
   SemanticEditorDelaySecondsNum = 0;
 
+  // Leave the delay at 0 if it is explicitly disabled
+  if(::getenv("SOURCEKIT_DISABLE_SEMA_EDITOR_DELAY"))
+    return;
+
   static TimePoint gPrevCrashTime;
 
   TimePoint PrevTime = gPrevCrashTime;


### PR DESCRIPTION
Any time SourceKitService goes down there is a 10-20 second delay before semantic requests can be made. This patch adjusts the logic to ignore this delay if `SOURCEKIT_DISABLE_SEMA_EDITOR_DELAY` is set. This will make stress testing SourceKit (i.e. making semantic requests at all applicable locations in a source file to find those that trigger crashes) faster.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [rdar://problem/42741610](rdar://problem/42741610).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->