### PR TITLE
Only emit one copy-to-host or copy-to-accelerator compiler warning per source location, even if it has multiple host uses.

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -612,7 +612,12 @@ template<typename T> struct DenseMapInfo;
 template<> struct DenseMapInfo<SourceRange> {
   static SourceRange getEmptyKey() { return SourceRange(); }
 
-  static SourceRange getTombstoneKey() { return SourceRange(); }
+  static SourceRange getTombstoneKey() {
+    // Make this different from empty key. See for context:
+    // http://lists.llvm.org/pipermail/llvm-dev/2015-July/088744.html
+    return SourceRange(SourceLoc(
+        SMLoc::getFromPointer(DenseMapInfo<const char *>::getTombstoneKey())));
+  }
 
   static unsigned getHashValue(const SourceRange &Val) {
     return hash_combine(

--- a/test/TensorFlow/crashers.swift
+++ b/test/TensorFlow/crashers.swift
@@ -244,7 +244,6 @@ public func testMultiResultOp_send_recv() {
   // Accelerator -> Host
   _hostOp(x)
   x += [[2.0]]
-  // expected-warning @+2{{implicitly copied to the host}}
   // expected-warning @+1{{implicitly copied to the host}}
   let results = TensorFlow.Raw.softmaxCrossEntropyWithLogits(features: x, labels: x)
   // Accelerator -> Host

--- a/test/TensorFlow/diagnostics.swift
+++ b/test/TensorFlow/diagnostics.swift
@@ -46,3 +46,23 @@ public func testDevice() {
   _hostOp(extra)
 }
 
+// This loop is unrolled, so we have multiple SIL values for `x`, but there
+// should be a single copy-to-host compiler warning.
+public func SR8412_CopyToHost() {
+  for _ in 0...10 {
+    let x = Tensor(1)  // expected-warning {{value implicitly copied to the host}}
+    _hostOp(x)
+  }
+}
+
+@inline(never)
+public func hostFunc() -> Tensor<Float> {
+  return Tensor<Float>(1.0)
+}
+
+public func SR8412_CopyToAccel(a: Int32) {
+  let x = Tensor<Float>(1.0)
+  for _ in 0...10 {
+    let _ = hostFunc() + x  // expected-warning {{value implicitly copied to the accelerator}}
+  }
+}

--- a/test/TensorFlow/integration.swift
+++ b/test/TensorFlow/integration.swift
@@ -458,8 +458,8 @@ public struct NonInlineMethodExample {
   var b = Tensor<Float>(2.0)
 
   @inline(never)
-  public mutating func mutatingMethod() {  // expected-warning 2 {{value implicitly copied}}
-    a += b   // expected-note 2 {{value used here}}
+  public mutating func mutatingMethod() {  // expected-warning {{value implicitly copied}}
+    a += b   // expected-note {{value used here}}
     b += a
   }
 }


### PR DESCRIPTION
Resolves [SR-8412](https://bugs.swift.org/browse/SR-8412).
