### PR TITLE
[test] Tweak resolve-cross-language.swift to avoid a Clang bug

### DIFF
--- a/test/ClangImporter/MixedSource/Inputs/resolve-cross-language/Base-module.map
+++ b/test/ClangImporter/MixedSource/Inputs/resolve-cross-language/Base-module.map
@@ -1,3 +1,4 @@
 module Base {
   header "Base.h"
+  export *
 }

--- a/test/ClangImporter/MixedSource/resolve-cross-language.swift
+++ b/test/ClangImporter/MixedSource/resolve-cross-language.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar42570029
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -emit-module -enable-objc-interop -emit-objc-header -o %t %S/Inputs/resolve-cross-language/Base.swift -disable-objc-attr-requires-foundation-module


### PR DESCRIPTION
We don't really care about modules without `export *`, but I filed [PR38392](https://bugs.llvm.org/show_bug.cgi?id=38392) anyway.

rdar://problem/42570029