### PR TITLE
[Type checker] Warn about overrides of NSObject.hashValue.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4142,6 +4142,10 @@ NOTE(redundant_particular_literal_case_here,none,
 
 WARNING(non_exhaustive_switch_warn,none, "switch must be exhaustive", ())
 
+WARNING(override_nsobject_hashvalue,none,
+        "override of 'NSObject.hashValue' is deprecated; "
+        "override 'NSObject.hash' to get consistent hashing behavior", ())
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1519,6 +1519,18 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
     diagnoseOverrideForAvailability(override, base);
   }
 
+  // Overrides of NSObject.hashValue are deprecated; one should override
+  // NSObject.hash instead.
+  if (auto baseVar = dyn_cast<VarDecl>(base)) {
+    if (auto classDecl =
+          baseVar->getDeclContext()->getAsClassOrClassExtensionContext()) {
+      if (classDecl->getBaseName().userFacingName() == "NSObject" &&
+          baseVar->getBaseName().userFacingName() == "hashValue") {
+        override->diagnose(diag::override_nsobject_hashvalue);
+      }
+    }
+  }
+
   /// Check attributes associated with the base; some may need to merged with
   /// or checked against attributes in the overriding declaration.
   AttributeOverrideChecker attrChecker(base, override);

--- a/test/ClangImporter/objc_override.swift
+++ b/test/ClangImporter/objc_override.swift
@@ -108,6 +108,14 @@ class CallbackSubC : CallbackBase {
   override func perform(optNonescapingHandler: @escaping () -> Void) {} // expected-error {{method does not override any method from its superclass}}
 }
 
+//
+class MyHashableNSObject: NSObject {
+  override var hashValue: Int { // expected-warning{{override of 'NSObject.hashValue' is deprecated}}
+    return 0
+  }
+}
+
+
 // FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: overridden declaration is here
 // <unknown>:0: error: unexpected note produced: setter for 'boolProperty' declared here

--- a/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
@@ -2,8 +2,14 @@
 @_exported import CoreGraphics
 @_exported import Foundation
 
-public func == (lhs: NSObject, rhs: NSObject) -> Bool {
-  return lhs.isEqual(rhs)
+extension NSObject : Equatable, Hashable {
+  @objc open var hashValue: Int {
+    return hash
+  }
+
+  public static func == (lhs: NSObject, rhs: NSObject) -> Bool {
+    return lhs.isEqual(rhs)
+  }
 }
 
 public let NSUTF8StringEncoding: UInt = 8

--- a/test/Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift
@@ -86,13 +86,3 @@ public func _convertObjCBoolToBool(_ x: ObjCBool) -> Bool {
 public func ~=(x: NSObject, y: NSObject) -> Bool {
   return true
 }
-
-extension NSObject : Equatable, Hashable {
-  public var hashValue: Int {
-    return hash
-  }
-}
-
-public func == (lhs: NSObject, rhs: NSObject) -> Bool {
-  return lhs.isEqual(rhs)
-}


### PR DESCRIPTION
NSObject.hashValue is provided to satisfy the hashValue constraint of
the Hashable protocol. However, it is not the correct customization
point for interoperating with Objective-C, because Objective-C code
will call through the -hash method. Warn about overrides of
NSObject.hashValue; users should override NSObject.hash instead.

Fixes rdar://problem/42780635.
