### PR TITLE
[SIL] Don't drop a default when switching on a non-exhaustive enum

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3388,7 +3388,7 @@ public:
   /// Note that this property is \e not necessarily true for all children of
   /// \p useDC. In particular, an inlinable function does not get to switch
   /// exhaustively over a non-exhaustive enum declared in the same module.
-  bool isExhaustive(const DeclContext *useDC) const;
+  bool isFormallyExhaustive(const DeclContext *useDC) const;
 };
 
 /// StructDecl - This is the declaration of a struct, for example:

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3266,45 +3266,6 @@ public:
     return std::distance(eltRange.begin(), eltRange.end());
   }
 
-  /// If this is an enum with two cases, return the other case. Otherwise,
-  /// return nullptr.
-  EnumElementDecl *getOppositeBinaryDecl(EnumElementDecl *decl) const {
-    ElementRange range = getAllElements();
-    auto iter = range.begin();
-    if (iter == range.end())
-      return nullptr;
-    bool seenDecl = false;
-    EnumElementDecl *result = nullptr;
-    if (*iter == decl) {
-      seenDecl = true;
-    } else {
-      result = *iter;
-    }
-
-    ++iter;
-    if (iter == range.end())
-      return nullptr;
-    if (seenDecl) {
-      assert(!result);
-      result = *iter;
-    } else {
-      if (decl != *iter)
-        return nullptr;
-      seenDecl = true;
-    }
-    ++iter;
-
-    // If we reach this point, we saw the decl we were looking for and one other
-    // case. If we have any additional cases, then we do not have a binary enum.
-    if (iter != range.end())
-      return nullptr;
-
-    // This is always true since we have already returned earlier nullptr if we
-    // did not see the decl at all.
-    assert(seenDecl);
-    return result;
-  }
-
   /// If this enum has a unique element, return it. A unique element can
   /// either hold a value or not, and the existence of one unique element does
   /// not imply the existence or non-existence of the opposite unique element.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3388,7 +3388,23 @@ public:
   /// Note that this property is \e not necessarily true for all children of
   /// \p useDC. In particular, an inlinable function does not get to switch
   /// exhaustively over a non-exhaustive enum declared in the same module.
+  ///
+  /// This is the predicate used when deciding if a switch statement needs a
+  /// default case. It should not be used for optimization or code generation.
+  ///
+  /// \sa isEffectivelyExhaustive
   bool isFormallyExhaustive(const DeclContext *useDC) const;
+
+  /// True if the enum can be exhaustively switched within a function defined
+  /// within \p M, with \p expansion specifying whether the function is
+  /// inlinable.
+  ///
+  /// This is the predicate used when making optimization and code generation
+  /// decisions. It should not be used at the AST or semantic level.
+  ///
+  /// \sa isFormallyExhaustive
+  bool isEffectivelyExhaustive(ModuleDecl *M,
+                               ResilienceExpansion expansion) const;
 };
 
 /// StructDecl - This is the declaration of a struct, for example:

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3438,7 +3438,7 @@ bool EnumDecl::hasOnlyCasesWithoutAssociatedValues() const {
   return true;
 }
 
-bool EnumDecl::isExhaustive(const DeclContext *useDC) const {
+bool EnumDecl::isFormallyExhaustive(const DeclContext *useDC) const {
   // Enums explicitly marked frozen are exhaustive.
   if (getAttrs().hasAttribute<FrozenAttr>())
     return true;

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -421,7 +421,8 @@ private:
       os << ", " << customName
          << ", \"" << ED->getName() << "\"";
     }
-    os << ", " << (ED->isExhaustive(/*useDC*/nullptr) ? "closed" : "open")
+    os << ", "
+       << (ED->isFormallyExhaustive(/*useDC*/nullptr) ? "closed" : "open")
        << ") {\n";
 
     for (auto Elt : ED->getAllElements()) {

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -1424,9 +1424,9 @@ namespace {
     EnumDecl *decl = enumType.getEnumOrBoundGenericEnum();
     assert(decl && "switch_enum operand is not an enum");
 
-    // FIXME: Get expansion from SILFunction
-    if (!decl->isEffectivelyExhaustive(inst->getModule().getSwiftModule(),
-                                       ResilienceExpansion::Maximal)) {
+    const SILFunction *F = inst->getFunction();
+    if (!decl->isEffectivelyExhaustive(F->getModule().getSwiftModule(),
+                                       F->getResilienceExpansion())) {
       return nullptr;
     }
 

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -1425,9 +1425,8 @@ namespace {
     assert(decl && "switch_enum operand is not an enum");
 
     // FIXME: Get expansion from SILFunction
-    if (decl->isResilient(inst->getModule().getSwiftModule(),
-                          ResilienceExpansion::Maximal) ||
-        decl->isObjC()) {
+    if (!decl->isEffectivelyExhaustive(inst->getModule().getSwiftModule(),
+                                       ResilienceExpansion::Maximal)) {
       return nullptr;
     }
 

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -1426,8 +1426,10 @@ namespace {
 
     // FIXME: Get expansion from SILFunction
     if (decl->isResilient(inst->getModule().getSwiftModule(),
-                          ResilienceExpansion::Maximal))
+                          ResilienceExpansion::Maximal) ||
+        decl->isObjC()) {
       return nullptr;
+    }
 
     llvm::SmallPtrSet<EnumElementDecl *, 4> unswitchedElts;
     for (auto elt : decl->getAllElements())

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -3706,11 +3706,10 @@ public:
 
     // If the select is non-exhaustive, we require a default.
     // FIXME: Get the resilience expansion from the function.
-    bool isNonExhaustive = eDecl->isResilient(I->getModule().getSwiftModule(),
-                                              ResilienceExpansion::Maximal);
-    isNonExhaustive |= eDecl->isObjC();
-    require((!isNonExhaustive && unswitchedElts.empty()) ||
-            I->hasDefault(),
+    bool isExhaustive =
+        eDecl->isEffectivelyExhaustive(F.getModule().getSwiftModule(),
+                                       ResilienceExpansion::Maximal);
+    require((isExhaustive && unswitchedElts.empty()) || I->hasDefault(),
             "nonexhaustive select_enum must have a default destination");
     if (I->hasDefault()) {
       requireSameType(I->getDefaultResult()->getType(),
@@ -3879,11 +3878,10 @@ public:
 
     // If the switch is non-exhaustive, we require a default.
     // FIXME: Get the resilience expansion from the function.
-    bool isNonExhaustive = uDecl->isResilient(SOI->getModule().getSwiftModule(),
-                                              ResilienceExpansion::Maximal);
-    isNonExhaustive |= uDecl->isObjC();
-    require((!isNonExhaustive && unswitchedElts.empty()) ||
-            SOI->hasDefault(),
+    bool isExhaustive =
+        uDecl->isEffectivelyExhaustive(F.getModule().getSwiftModule(),
+                                       ResilienceExpansion::Maximal);
+    require((isExhaustive && unswitchedElts.empty()) || SOI->hasDefault(),
             "nonexhaustive switch_enum must have a default destination");
     if (SOI->hasDefault()) {
       // When SIL ownership is enabled, we require all default branches to take

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -3705,10 +3705,9 @@ public:
     }
 
     // If the select is non-exhaustive, we require a default.
-    // FIXME: Get the resilience expansion from the function.
     bool isExhaustive =
         eDecl->isEffectivelyExhaustive(F.getModule().getSwiftModule(),
-                                       ResilienceExpansion::Maximal);
+                                       F.getResilienceExpansion());
     require((isExhaustive && unswitchedElts.empty()) || I->hasDefault(),
             "nonexhaustive select_enum must have a default destination");
     if (I->hasDefault()) {
@@ -3877,10 +3876,9 @@ public:
     }
 
     // If the switch is non-exhaustive, we require a default.
-    // FIXME: Get the resilience expansion from the function.
     bool isExhaustive =
         uDecl->isEffectivelyExhaustive(F.getModule().getSwiftModule(),
-                                       ResilienceExpansion::Maximal);
+                                       F.getResilienceExpansion());
     require((isExhaustive && unswitchedElts.empty()) || SOI->hasDefault(),
             "nonexhaustive switch_enum must have a default destination");
     if (SOI->hasDefault()) {

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -1802,15 +1802,9 @@ CaseBlocks::CaseBlocks(
   // Check to see if the enum may have values beyond the cases we can see
   // at compile-time. This includes future cases (for resilient enums) and
   // random values crammed into C enums.
-  //
-  // Note: This relies on the fact that there are no "non-resilient" enums that
-  // are still non-exhaustive, except for @objc enums.
-  bool canAssumeExhaustive = !enumDecl->isObjC();
-  if (canAssumeExhaustive) {
-    canAssumeExhaustive =
-        !enumDecl->isResilient(SGF.SGM.SwiftModule,
-                               SGF.F.getResilienceExpansion());
-  }
+  bool canAssumeExhaustive =
+      enumDecl->isEffectivelyExhaustive(SGF.getModule().getSwiftModule(),
+                                        SGF.F.getResilienceExpansion());
   if (canAssumeExhaustive) {
     // Check that Sema didn't let any cases slip through. (This can happen
     // with @_downgrade_exhaustivity_check.)

--- a/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
@@ -317,10 +317,10 @@ void BBEnumTagDataflowState::handlePredCondSelectEnum(CondBranchInst *CondBr) {
   // know the true branch must be the other tag.
   if (EnumDecl *E = Operand->getType().getEnumOrBoundGenericEnum()) {
     // We can't do this optimization on non-exhaustive enums.
-    // FIXME: Get resilience expansion from the function.
+    const SILFunction *Fn = CondBr->getFunction();
     bool IsExhaustive =
-        E->isEffectivelyExhaustive(CondBr->getModule().getSwiftModule(),
-                                   ResilienceExpansion::Maximal);
+        E->isEffectivelyExhaustive(Fn->getModule().getSwiftModule(),
+                                   Fn->getResilienceExpansion());
     if (!IsExhaustive)
       return;
     // Look for a single other element on this enum.

--- a/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
@@ -12,6 +12,7 @@
 
 #define DEBUG_TYPE "sil-codemotion"
 #include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/AST/Module.h"
 #include "swift/Basic/BlotMapVector.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILModule.h"
@@ -315,6 +316,12 @@ void BBEnumTagDataflowState::handlePredCondSelectEnum(CondBranchInst *CondBr) {
   // If the enum only has 2 values and its tag isn't the true branch, then we
   // know the true branch must be the other tag.
   if (EnumDecl *E = Operand->getType().getEnumOrBoundGenericEnum()) {
+    // We can't do this optimization on non-exhaustive enums.
+    bool isNonExhaustive = E->isResilient(CondBr->getModule().getSwiftModule(),
+                                          ResilienceExpansion::Maximal);
+    isNonExhaustive |= E->isObjC();
+    if (isNonExhaustive)
+      return;
     // Look for a single other element on this enum.
     EnumElementDecl *OtherElt = nullptr;
     for (EnumElementDecl *Elt : E->getAllElements()) {

--- a/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
@@ -317,10 +317,11 @@ void BBEnumTagDataflowState::handlePredCondSelectEnum(CondBranchInst *CondBr) {
   // know the true branch must be the other tag.
   if (EnumDecl *E = Operand->getType().getEnumOrBoundGenericEnum()) {
     // We can't do this optimization on non-exhaustive enums.
-    bool isNonExhaustive = E->isResilient(CondBr->getModule().getSwiftModule(),
-                                          ResilienceExpansion::Maximal);
-    isNonExhaustive |= E->isObjC();
-    if (isNonExhaustive)
+    // FIXME: Get resilience expansion from the function.
+    bool IsExhaustive =
+        E->isEffectivelyExhaustive(CondBr->getModule().getSwiftModule(),
+                                   ResilienceExpansion::Maximal);
+    if (!IsExhaustive)
       return;
     // Look for a single other element on this enum.
     EnumElementDecl *OtherElt = nullptr;

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -1583,10 +1583,9 @@ bool SimplifyCFG::simplifyCondBrBlock(CondBranchInst *BI) {
     EnumElementDecl *FirstElt = *Iter;
 
     // We can't do this optimization on non-exhaustive enums.
-    // FIXME: Get the resilience expansion from the function.
     bool IsExhaustive =
         E->isEffectivelyExhaustive(Fn.getModule().getSwiftModule(),
-                                   ResilienceExpansion::Maximal);
+                                   Fn.getResilienceExpansion());
 
     if (IsExhaustive
         && SEI->getNumCases() >= 1

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -1583,11 +1583,12 @@ bool SimplifyCFG::simplifyCondBrBlock(CondBranchInst *BI) {
     EnumElementDecl *FirstElt = *Iter;
 
     // We can't do this optimization on non-exhaustive enums.
-    bool isNonExhaustive = E->isResilient(Fn.getModule().getSwiftModule(),
-                                          ResilienceExpansion::Maximal);
-    isNonExhaustive |= E->isObjC();
+    // FIXME: Get the resilience expansion from the function.
+    bool IsExhaustive =
+        E->isEffectivelyExhaustive(Fn.getModule().getSwiftModule(),
+                                   ResilienceExpansion::Maximal);
 
-    if (!isNonExhaustive
+    if (IsExhaustive
         && SEI->getNumCases() >= 1
         && SEI->getCase(0).first != FirstElt) {
       ++Iter;

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "sil-simplify-cfg"
+#include "swift/AST/Module.h"
 #include "swift/SIL/DebugUtils.h"
 #include "swift/SIL/Dominance.h"
 #include "swift/SIL/InstructionUtils.h"
@@ -1581,7 +1582,13 @@ bool SimplifyCFG::simplifyCondBrBlock(CondBranchInst *BI) {
     auto Iter = AllElts.begin();
     EnumElementDecl *FirstElt = *Iter;
 
-    if (SEI->getNumCases() >= 1
+    // We can't do this optimization on non-exhaustive enums.
+    bool isNonExhaustive = E->isResilient(Fn.getModule().getSwiftModule(),
+                                          ResilienceExpansion::Maximal);
+    isNonExhaustive |= E->isObjC();
+
+    if (!isNonExhaustive
+        && SEI->getNumCases() >= 1
         && SEI->getCase(0).first != FirstElt) {
       ++Iter;
 

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -818,7 +818,7 @@ namespace {
                                          constElemSpaces);
           });
 
-          if (!E->isExhaustive(DC)) {
+          if (!E->isFormallyExhaustive(DC)) {
             arr.push_back(Space::forUnknown(/*allowedButNotRequired*/false));
           } else if (!E->getAttrs().hasAttribute<FrozenAttr>()) {
             arr.push_back(Space::forUnknown(/*allowedButNotRequired*/true));

--- a/test/SILOptimizer/Inputs/switch_enum_objc.h
+++ b/test/SILOptimizer/Inputs/switch_enum_objc.h
@@ -1,0 +1,14 @@
+// Even though these are marked "closed", Swift shouldn't trust it.
+
+enum Alpha {
+  AlphaA __attribute__((swift_name("a"))),
+  AlphaB __attribute__((swift_name("b"))),
+  AlphaC __attribute__((swift_name("c"))),
+  AlphaD __attribute__((swift_name("d"))),
+  AlphaE __attribute__((swift_name("e")))
+} __attribute__((enum_extensibility(closed)));
+
+enum Coin {
+  CoinHeads,
+  CoinTails
+} __attribute__((enum_extensibility(closed)));

--- a/test/SILOptimizer/switch_enum_objc.swift
+++ b/test/SILOptimizer/switch_enum_objc.swift
@@ -1,0 +1,235 @@
+// RUN: %target-swift-frontend -emit-sil -O -primary-file %s -import-objc-header %S/Inputs/switch_enum_objc.h | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -Osize -primary-file %s -import-objc-header %S/Inputs/switch_enum_objc.h | %FileCheck %s
+
+@inline(never)
+func action0() {}
+
+@inline(never)
+func action1(_: Int) {}
+
+@inline(never)
+func action2(_: Int, _: Int) {}
+
+@inline(never)
+func action3(_: Int, _: Int, _: Int) {}
+
+@inline(never)
+func action4(_: Int, _: Int, _: Int, _: Int) {}
+
+
+// CHECK-LABEL: sil hidden @$S16switch_enum_objc14testImperativeyySo5AlphaVF
+func testImperative(_ letter: Alpha) {
+  // CHECK: switch_enum %0 : $Alpha, case #Alpha.a!enumelt: bb1, case #Alpha.b!enumelt: bb2, case #Alpha.c!enumelt: bb3, case #Alpha.d!enumelt: bb4, case #Alpha.e!enumelt: bb5, default bb6
+  switch letter {
+  case .a:
+    action0()
+  case .b:
+    action1(0)
+  case .c:
+    action2(0, 0)
+  case .d:
+    action3(0, 0, 0)
+  case .e:
+    action4(0, 0, 0, 0)
+  }
+  // CHECK: bb6:
+  // CHECK: function_ref @$Ss32_diagnoseUnexpectedEnumCaseValue
+} // CHECK: end sil function '$S16switch_enum_objc14testImperativeyySo5AlphaVF'
+
+// CHECK-LABEL: sil hidden @$S16switch_enum_objc27testImperativeDefaultMiddleyySo5AlphaVF
+func testImperativeDefaultMiddle(_ letter: Alpha) {
+  // CHECK: switch_enum %0 : $Alpha, case #Alpha.a!enumelt: bb1, case #Alpha.b!enumelt: bb2, case #Alpha.d!enumelt: bb3, case #Alpha.e!enumelt: bb4, default bb5
+  switch letter {
+  case .a:
+    action0()
+  case .b:
+    action1(0)
+  // case .c:
+  case .d:
+    action2(0, 0)
+  case .e:
+    action3(0, 0, 0)
+  default:
+    // CHECK: bb5:
+    // CHECK: function_ref @$S16switch_enum_objc7action4
+    action4(0, 0, 0, 0)
+  }
+} // CHECK: end sil function '$S16switch_enum_objc27testImperativeDefaultMiddleyySo5AlphaVF'
+
+// CHECK-LABEL: sil hidden @$S16switch_enum_objc24testImperativeDefaultEndyySo5AlphaVF
+func testImperativeDefaultEnd(_ letter: Alpha) {
+  // CHECK: switch_enum %0 : $Alpha, case #Alpha.a!enumelt: bb1, case #Alpha.b!enumelt: bb2, case #Alpha.c!enumelt: bb3, case #Alpha.d!enumelt: bb4, default bb5
+  switch letter {
+  case .a:
+    action0()
+  case .b:
+    action1(0)
+  case .c:
+    action2(0, 0)
+  case .d:
+    action3(0, 0, 0)
+  // case .e:
+  default:
+    // CHECK: bb5:
+    // CHECK: function_ref @$S16switch_enum_objc7action4
+    action4(0, 0, 0, 0)
+  }
+} // CHECK: end sil function '$S16switch_enum_objc24testImperativeDefaultEndyySo5AlphaVF'
+
+// CHECK-LABEL: sil hidden @$S16switch_enum_objc26testImperativeDefaultMultiyySo5AlphaVF
+func testImperativeDefaultMulti(_ letter: Alpha) {
+  // CHECK: switch_enum %0 : $Alpha, case #Alpha.a!enumelt: bb1, case #Alpha.b!enumelt: bb2, case #Alpha.d!enumelt: bb3, default bb4
+  switch letter {
+  case .a:
+    action0()
+  case .b:
+    action1(0)
+  // case .c:
+  case .d:
+    action2(0, 0)
+  // case .e:
+  default:
+    // CHECK: bb4:
+    // CHECK: function_ref @$S16switch_enum_objc7action3
+    action3(0, 0, 0)
+  }
+} // CHECK: end sil function '$S16switch_enum_objc26testImperativeDefaultMultiyySo5AlphaVF'
+
+// CHECK-LABEL: sil hidden @$S16switch_enum_objc14testFunctionalySiSo5AlphaVF
+func testFunctional(_ letter: Alpha) -> Int {
+  // This one can't be converted to select_enum because of the generated trap.
+  // CHECK: switch_enum %0 : $Alpha, case #Alpha.a!enumelt: bb1, case #Alpha.b!enumelt: bb2, case #Alpha.c!enumelt: bb3, case #Alpha.d!enumelt: bb4, case #Alpha.e!enumelt: bb5, default bb6
+  switch letter {
+  case .a:
+    return 3
+  case .b:
+    return 5
+  case .c:
+    return 8
+  case .d:
+    return 13
+  case .e:
+    return 21
+  }
+  // CHECK: bb6:
+  // CHECK: function_ref @$Ss32_diagnoseUnexpectedEnumCaseValue
+} // CHECK: end sil function '$S16switch_enum_objc14testFunctionalySiSo5AlphaVF'
+
+// CHECK-LABEL: sil hidden @$S16switch_enum_objc27testFunctionalDefaultMiddleySiSo5AlphaVF
+func testFunctionalDefaultMiddle(_ letter: Alpha) -> Int {
+  // CHECK: [[THREE:%.+]]      = integer_literal ${{.+}}, 3
+  // CHECK: [[FIVE:%.+]]       = integer_literal ${{.+}}, 5
+  // CHECK: [[EIGHT:%.+]]      = integer_literal ${{.+}}, 8
+  // CHECK: [[THIRTEEN:%.+]]   = integer_literal ${{.+}}, 13
+  // CHECK: [[TWENTY_ONE:%.+]] = integer_literal ${{.+}}, 21
+  // CHECK: = select_enum %0 : $Alpha, case #Alpha.a!enumelt: [[THREE]], case #Alpha.b!enumelt: [[FIVE]], case #Alpha.d!enumelt: [[EIGHT]], case #Alpha.e!enumelt: [[THIRTEEN]], default [[TWENTY_ONE]] :
+  switch letter {
+  case .a:
+    return 3
+  case .b:
+    return 5
+  // case .c:
+  case .d:
+    return 8
+  case .e:
+    return 13
+  default:
+    return 21
+  }
+} // CHECK: end sil function '$S16switch_enum_objc27testFunctionalDefaultMiddleySiSo5AlphaVF'
+
+// CHECK-LABEL: sil hidden @$S16switch_enum_objc24testFunctionalDefaultEndySiSo5AlphaVF
+func testFunctionalDefaultEnd(_ letter: Alpha) -> Int {
+  // CHECK: [[THREE:%.+]]      = integer_literal ${{.+}}, 3
+  // CHECK: [[FIVE:%.+]]       = integer_literal ${{.+}}, 5
+  // CHECK: [[EIGHT:%.+]]      = integer_literal ${{.+}}, 8
+  // CHECK: [[THIRTEEN:%.+]]   = integer_literal ${{.+}}, 13
+  // CHECK: [[TWENTY_ONE:%.+]] = integer_literal ${{.+}}, 21
+  // CHECK: = select_enum %0 : $Alpha, case #Alpha.a!enumelt: [[THREE]], case #Alpha.b!enumelt: [[FIVE]], case #Alpha.c!enumelt: [[EIGHT]], case #Alpha.d!enumelt: [[THIRTEEN]], default [[TWENTY_ONE]] :
+  switch letter {
+  case .a:
+    return 3
+  case .b:
+    return 5
+  case .c:
+    return 8
+  case .d:
+    return 13
+  // case .e:
+  default:
+    return 21
+  }
+} // CHECK: end sil function '$S16switch_enum_objc24testFunctionalDefaultEndySiSo5AlphaVF'
+
+// CHECK-LABEL: sil hidden @$S16switch_enum_objc26testFunctionalDefaultMultiySiSo5AlphaVF
+func testFunctionalDefaultMulti(_ letter: Alpha) -> Int {
+  // CHECK: [[THREE:%.+]]      = integer_literal ${{.+}}, 3
+  // CHECK: [[FIVE:%.+]]       = integer_literal ${{.+}}, 5
+  // CHECK: [[EIGHT:%.+]]      = integer_literal ${{.+}}, 8
+  // CHECK: [[THIRTEEN:%.+]]   = integer_literal ${{.+}}, 13
+  // CHECK: = select_enum %0 : $Alpha, case #Alpha.a!enumelt: [[THREE]], case #Alpha.b!enumelt: [[FIVE]], case #Alpha.d!enumelt: [[EIGHT]], default [[THIRTEEN]] :
+  switch letter {
+  case .a:
+    return 3
+  case .b:
+    return 5
+  // case .c:
+  case .d:
+    return 8
+  // case .e:
+  default:
+    return 13
+  }
+} // CHECK: end sil function '$S16switch_enum_objc26testFunctionalDefaultMultiySiSo5AlphaVF'
+
+// CHECK-LABEL: sil hidden @$S16switch_enum_objc19testImperativeHeadsyySo4CoinVF
+func testImperativeHeads(_ coin: Coin) {
+  // CHECK: switch_enum %0 : $Coin, case #Coin.heads!enumelt: bb2, default bb1
+  // CHECK: bb1:
+  // CHECK: function_ref @$S16switch_enum_objc7action1
+  // CHECK: bb2:
+  // CHECK: function_ref @$S16switch_enum_objc7action0
+  if case .heads = coin {
+    action0()
+  } else {
+    action1(0)
+  }
+} // CHECK: end sil function '$S16switch_enum_objc19testImperativeHeadsyySo4CoinVF'
+
+// CHECK-LABEL: sil hidden @$S16switch_enum_objc19testImperativeTailsyySo4CoinVF
+func testImperativeTails(_ coin: Coin) {
+  // CHECK: switch_enum %0 : $Coin, case #Coin.tails!enumelt: bb2, default bb1
+  // CHECK: bb1:
+  // CHECK: function_ref @$S16switch_enum_objc7action1
+  // CHECK: bb2:
+  // CHECK: function_ref @$S16switch_enum_objc7action0
+  if case .tails = coin {
+    action0()
+  } else {
+    action1(0)
+  }
+} // CHECK: end sil function '$S16switch_enum_objc19testImperativeTailsyySo4CoinVF'
+
+// CHECK-LABEL: sil hidden @$S16switch_enum_objc19testFunctionalHeadsySiSo4CoinVF
+func testFunctionalHeads(_ coin: Coin) -> Int {
+  // CHECK: [[FIVE:%.+]] = integer_literal ${{.+}}, 5000
+  // CHECK: [[NINE:%.+]] = integer_literal ${{.+}}, 9001
+  // CHECK: = select_enum %0 : $Coin, case #Coin.heads!enumelt: [[FIVE]], default [[NINE]]
+  if case .heads = coin {
+    return 5000
+  } else {
+    return 9001
+  }
+} // CHECK: end sil function '$S16switch_enum_objc19testFunctionalHeadsySiSo4CoinVF'
+
+// CHECK-LABEL: sil hidden @$S16switch_enum_objc19testFunctionalTailsySiSo4CoinVF
+func testFunctionalTails(_ coin: Coin) -> Int {
+  // CHECK: [[FIVE:%.+]] = integer_literal ${{.+}}, 5000
+  // CHECK: [[NINE:%.+]] = integer_literal ${{.+}}, 9001
+  // CHECK: = select_enum %0 : $Coin, case #Coin.tails!enumelt: [[FIVE]], default [[NINE]]
+  if case .tails = coin {
+    return 5000
+  } else {
+    return 9001
+  }
+} // CHECK: end sil function '$S16switch_enum_objc19testFunctionalTailsySiSo4CoinVF'

--- a/test/SILOptimizer/switch_enum_resilient.swift
+++ b/test/SILOptimizer/switch_enum_resilient.swift
@@ -1,0 +1,490 @@
+// RUN: %empty-directory(%t)
+
+// Check all combinations of -O/-Osize, fragile/resilient, and SIL within the
+// module vs. inlinable SIL.
+
+// RUN: %target-swift-frontend -emit-sil -O -primary-file %s -emit-module-path %t/O-fragile.swiftmodule | %FileCheck -check-prefix CHECK-ALL -check-prefix CHECK-NOINLINE -check-prefix CHECK-FRAGILE -check-prefix CHECK-FRAGILE-NOINLINE %s
+// RUN: %target-sil-opt %t/O-fragile.swiftmodule -module-name switch_enum_resilient -emit-sorted-sil -disable-sil-linking | %FileCheck -check-prefix CHECK-ALL -check-prefix CHECK-FRAGILE %s
+
+// RUN: %target-swift-frontend -emit-sil -Osize -primary-file %s -emit-module-path %t/Osize-fragile.swiftmodule | %FileCheck -check-prefix CHECK-ALL -check-prefix CHECK-NOINLINE -check-prefix CHECK-FRAGILE -check-prefix CHECK-FRAGILE-NOINLINE %s
+// RUN: %target-sil-opt %t/Osize-fragile.swiftmodule -module-name switch_enum_resilient -emit-sorted-sil -disable-sil-linking | %FileCheck -check-prefix CHECK-ALL -check-prefix CHECK-FRAGILE %s
+
+// RUN: %target-swift-frontend -emit-sil -enable-resilience -O -primary-file %s -emit-module-path %t/O-resilient.swiftmodule | %FileCheck -check-prefix CHECK-ALL -check-prefix CHECK-NOINLINE -check-prefix=CHECK-RESILIENT -check-prefix=CHECK-RESILIENT-NOINLINE %s
+// RUN: %target-sil-opt %t/O-resilient.swiftmodule -module-name switch_enum_resilient -emit-sorted-sil -disable-sil-linking | %FileCheck -check-prefix CHECK-ALL -check-prefix=CHECK-RESILIENT -check-prefix CHECK-RESILIENT-INLINE %s
+
+// RUN: %target-swift-frontend -emit-sil -enable-resilience -Osize -primary-file %s -emit-module-path %t/Osize-resilient.swiftmodule | %FileCheck -check-prefix CHECK-ALL -check-prefix CHECK-NOINLINE -check-prefix=CHECK-RESILIENT -check-prefix=CHECK-RESILIENT-NOINLINE %s
+// RUN: %target-sil-opt %t/Osize-resilient.swiftmodule -module-name switch_enum_resilient -emit-sorted-sil -disable-sil-linking | %FileCheck -check-prefix CHECK-ALL -check-prefix=CHECK-RESILIENT -check-prefix CHECK-RESILIENT-INLINE %s
+
+public enum Alpha : Int {
+  case a, b, c, d, e
+}
+
+@inline(never)
+public func action0() {}
+
+@inline(never)
+public func action1(_: Int) {}
+
+@inline(never)
+public func action2(_: Int, _: Int) {}
+
+@inline(never)
+public func action3(_: Int, _: Int, _: Int) {}
+
+@inline(never)
+public func action4(_: Int, _: Int, _: Int, _: Int) {}
+
+
+// CHECK-NOINLINE-LABEL: sil{{.*}} @$S21switch_enum_resilient14testImperativeyyAA5AlphaOF
+public func testImperative(_ letter: Alpha) {
+  // CHECK-NOINLINE: switch_enum{{_addr %.+ : [$][*]Alpha| %0 : [$]Alpha}}, case #Alpha.a!enumelt: bb1, case #Alpha.b!enumelt: bb2, case #Alpha.c!enumelt: bb3, case #Alpha.d!enumelt: bb4, case #Alpha.e!enumelt: bb5 //
+  switch letter {
+  case .a:
+    action0()
+  case .b:
+    action1(0)
+  case .c:
+    action2(0, 0)
+  case .d:
+    action3(0, 0, 0)
+  case .e:
+    action4(0, 0, 0, 0)
+  }
+} // CHECK-NOINLINE: end sil function '$S21switch_enum_resilient14testImperativeyyAA5AlphaOF'
+
+// CHECK-NOINLINE-LABEL: sil{{.*}} @$S21switch_enum_resilient27testImperativeDefaultMiddleyyAA5AlphaOF
+public func testImperativeDefaultMiddle(_ letter: Alpha) {
+  // CHECK-NOINLINE: switch_enum{{_addr %.+ : [$][*]Alpha| %0 : [$]Alpha}}, case #Alpha.a!enumelt: bb1, case #Alpha.b!enumelt: bb2, case #Alpha.d!enumelt: bb3, case #Alpha.e!enumelt: bb4, case #Alpha.c!enumelt: bb5 //
+  switch letter {
+  case .a:
+    action0()
+  case .b:
+    action1(0)
+  // case .c:
+  case .d:
+    action2(0, 0)
+  case .e:
+    action3(0, 0, 0)
+  default:
+    // CHECK-NOINLINE: bb5:
+    // CHECK-NOINLINE: function_ref @$S21switch_enum_resilient7action4
+    action4(0, 0, 0, 0)
+  }
+} // CHECK-NOINLINE: end sil function '$S21switch_enum_resilient27testImperativeDefaultMiddleyyAA5AlphaOF'
+
+// CHECK-NOINLINE-LABEL: sil{{.*}} @$S21switch_enum_resilient24testImperativeDefaultEndyyAA5AlphaOF
+public func testImperativeDefaultEnd(_ letter: Alpha) {
+  // CHECK-NOINLINE: switch_enum{{_addr %.+ : [$][*]Alpha| %0 : [$]Alpha}}, case #Alpha.a!enumelt: bb1, case #Alpha.b!enumelt: bb2, case #Alpha.c!enumelt: bb3, case #Alpha.d!enumelt: bb4, case #Alpha.e!enumelt: bb5 //
+  switch letter {
+  case .a:
+    action0()
+  case .b:
+    action1(0)
+  case .c:
+    action2(0, 0)
+  case .d:
+    action3(0, 0, 0)
+  // case .e:
+  default:
+    // CHECK-NOINLINE: bb5:
+    // CHECK-NOINLINE: function_ref @$S21switch_enum_resilient7action4
+    action4(0, 0, 0, 0)
+  }
+} // CHECK-NOINLINE: end sil function '$S21switch_enum_resilient24testImperativeDefaultEndyyAA5AlphaOF'
+
+// CHECK-NOINLINE-LABEL: sil{{.*}} @$S21switch_enum_resilient26testImperativeDefaultMultiyyAA5AlphaOF
+public func testImperativeDefaultMulti(_ letter: Alpha) {
+  // CHECK-NOINLINE: switch_enum{{_addr %.+ : [$][*]Alpha| %0 : [$]Alpha}}, case #Alpha.a!enumelt: bb1, case #Alpha.b!enumelt: bb2, case #Alpha.d!enumelt: bb3, default bb4
+  switch letter {
+  case .a:
+    action0()
+  case .b:
+    action1(0)
+  // case .c:
+  case .d:
+    action2(0, 0)
+  // case .e:
+  default:
+    // CHECK-NOINLINE: bb4:
+    // CHECK-NOINLINE: function_ref @$S21switch_enum_resilient7action3
+    action3(0, 0, 0)
+  }
+} // CHECK-NOINLINE: end sil function '$S21switch_enum_resilient26testImperativeDefaultMultiyyAA5AlphaOF'
+
+// CHECK-NOINLINE-LABEL: sil{{.*}} @$S21switch_enum_resilient14testFunctionalySiAA5AlphaOF
+public func testFunctional(_ letter: Alpha) -> Int {
+  // CHECK-FRAGILE-NOINLINE: [[THREE:%.+]]      = integer_literal ${{.+}}, 3
+  // CHECK-FRAGILE-NOINLINE: [[FIVE:%.+]]       = integer_literal ${{.+}}, 5
+  // CHECK-FRAGILE-NOINLINE: [[EIGHT:%.+]]      = integer_literal ${{.+}}, 8
+  // CHECK-FRAGILE-NOINLINE: [[THIRTEEN:%.+]]   = integer_literal ${{.+}}, 13
+  // CHECK-FRAGILE-NOINLINE: [[TWENTY_ONE:%.+]] = integer_literal ${{.+}}, 21
+  // CHECK-FRAGILE-NOINLINE: = select_enum %0 : $Alpha, case #Alpha.a!enumelt: [[THREE]], case #Alpha.b!enumelt: [[FIVE]], case #Alpha.c!enumelt: [[EIGHT]], case #Alpha.d!enumelt: [[THIRTEEN]], case #Alpha.e!enumelt: [[TWENTY_ONE]] :
+  // CHECK-RESILIENT-NOINLINE: switch_enum_addr {{%.+}} : $*Alpha, case #Alpha.a!enumelt: bb1, case #Alpha.b!enumelt: bb2, case #Alpha.c!enumelt: bb3, case #Alpha.d!enumelt: bb4, case #Alpha.e!enumelt: bb5 //
+  switch letter {
+  case .a:
+    return 3
+  case .b:
+    return 5
+  case .c:
+    return 8
+  case .d:
+    return 13
+  case .e:
+    return 21
+  }
+} // CHECK-NOINLINE: end sil function '$S21switch_enum_resilient14testFunctionalySiAA5AlphaOF'
+
+// CHECK-NOINLINE-LABEL: sil{{.*}} @$S21switch_enum_resilient27testFunctionalDefaultMiddleySiAA5AlphaOF
+public func testFunctionalDefaultMiddle(_ letter: Alpha) -> Int {
+  // CHECK-FRAGILE-NOINLINE: [[THREE:%.+]]      = integer_literal ${{.+}}, 3
+  // CHECK-FRAGILE-NOINLINE: [[FIVE:%.+]]       = integer_literal ${{.+}}, 5
+  // CHECK-FRAGILE-NOINLINE: [[EIGHT:%.+]]      = integer_literal ${{.+}}, 8
+  // CHECK-FRAGILE-NOINLINE: [[THIRTEEN:%.+]]   = integer_literal ${{.+}}, 13
+  // CHECK-FRAGILE-NOINLINE: [[TWENTY_ONE:%.+]] = integer_literal ${{.+}}, 21
+  // CHECK-FRAGILE-NOINLINE: = select_enum %0 : $Alpha, case #Alpha.a!enumelt: [[THREE]], case #Alpha.b!enumelt: [[FIVE]], case #Alpha.d!enumelt: [[EIGHT]], case #Alpha.e!enumelt: [[THIRTEEN]], case #Alpha.c!enumelt: [[TWENTY_ONE]] :
+  // CHECK-RESILIENT-NOINLINE: switch_enum_addr {{%.+}} : $*Alpha, case #Alpha.a!enumelt: bb1, case #Alpha.b!enumelt: bb2, case #Alpha.d!enumelt: bb3, case #Alpha.e!enumelt: bb4, case #Alpha.c!enumelt: bb5 //
+  switch letter {
+  case .a:
+    return 3
+  case .b:
+    return 5
+  // case .c:
+  case .d:
+    return 8
+  case .e:
+    return 13
+  default:
+    return 21
+  }
+} // CHECK-NOINLINE: end sil function '$S21switch_enum_resilient27testFunctionalDefaultMiddleySiAA5AlphaOF'
+
+// CHECK-NOINLINE-LABEL: sil{{.*}} @$S21switch_enum_resilient24testFunctionalDefaultEndySiAA5AlphaOF
+public func testFunctionalDefaultEnd(_ letter: Alpha) -> Int {
+  // CHECK-FRAGILE-NOINLINE: [[THREE:%.+]]      = integer_literal ${{.+}}, 3
+  // CHECK-FRAGILE-NOINLINE: [[FIVE:%.+]]       = integer_literal ${{.+}}, 5
+  // CHECK-FRAGILE-NOINLINE: [[EIGHT:%.+]]      = integer_literal ${{.+}}, 8
+  // CHECK-FRAGILE-NOINLINE: [[THIRTEEN:%.+]]   = integer_literal ${{.+}}, 13
+  // CHECK-FRAGILE-NOINLINE: [[TWENTY_ONE:%.+]] = integer_literal ${{.+}}, 21
+  // CHECK-FRAGILE-NOINLINE: = select_enum %0 : $Alpha, case #Alpha.a!enumelt: [[THREE]], case #Alpha.b!enumelt: [[FIVE]], case #Alpha.c!enumelt: [[EIGHT]], case #Alpha.d!enumelt: [[THIRTEEN]], case #Alpha.e!enumelt: [[TWENTY_ONE]] :
+  // CHECK-RESILIENT-NOINLINE: switch_enum_addr {{%.+}} : $*Alpha, case #Alpha.a!enumelt: bb1, case #Alpha.b!enumelt: bb2, case #Alpha.c!enumelt: bb3, case #Alpha.d!enumelt: bb4, case #Alpha.e!enumelt: bb5 //
+  switch letter {
+  case .a:
+    return 3
+  case .b:
+    return 5
+  case .c:
+    return 8
+  case .d:
+    return 13
+  // case .e:
+  default:
+    return 21
+  }
+} // CHECK-NOINLINE: end sil function '$S21switch_enum_resilient24testFunctionalDefaultEndySiAA5AlphaOF'
+
+// CHECK-NOINLINE-LABEL: sil{{.*}} @$S21switch_enum_resilient26testFunctionalDefaultMultiySiAA5AlphaOF
+public func testFunctionalDefaultMulti(_ letter: Alpha) -> Int {
+  // CHECK-FRAGILE-NOINLINE: [[THREE:%.+]]      = integer_literal ${{.+}}, 3
+  // CHECK-FRAGILE-NOINLINE: [[FIVE:%.+]]       = integer_literal ${{.+}}, 5
+  // CHECK-FRAGILE-NOINLINE: [[EIGHT:%.+]]      = integer_literal ${{.+}}, 8
+  // CHECK-FRAGILE-NOINLINE: [[THIRTEEN:%.+]]   = integer_literal ${{.+}}, 13
+  // CHECK-FRAGILE-NOINLINE: = select_enum %0 : $Alpha, case #Alpha.a!enumelt: [[THREE]], case #Alpha.b!enumelt: [[FIVE]], case #Alpha.d!enumelt: [[EIGHT]], default [[THIRTEEN]] :
+  // CHECK-RESILIENT-NOINLINE: switch_enum_addr {{%.+}} : $*Alpha, case #Alpha.a!enumelt: bb1, case #Alpha.b!enumelt: bb2, case #Alpha.d!enumelt: bb3, default bb4
+  switch letter {
+  case .a:
+    return 3
+  case .b:
+    return 5
+  // case .c:
+  case .d:
+    return 8
+  // case .e:
+  default:
+    return 13
+  }
+} // CHECK-NOINLINE: end sil function '$S21switch_enum_resilient26testFunctionalDefaultMultiySiAA5AlphaOF'
+
+public enum Coin : Int {
+  case heads, tails
+}
+
+// CHECK-NOINLINE-LABEL: sil{{.*}} @$S21switch_enum_resilient19testImperativeHeadsyyAA4CoinOF
+public func testImperativeHeads(_ coin: Coin) {
+  // CHECK-NOINLINE: switch_enum{{_addr %.+ : [$][*]Coin| %0 : [$]Coin}}, case #Coin.heads!enumelt: bb2, case #Coin.tails!enumelt: bb1 //
+  if case .heads = coin {
+    action0()
+  } else {
+    action1(0)
+  }
+} // CHECK-NOINLINE: end sil function '$S21switch_enum_resilient19testImperativeHeadsyyAA4CoinOF'
+
+// CHECK-NOINLINE-LABEL: sil{{.*}} @$S21switch_enum_resilient19testImperativeTailsyyAA4CoinOF
+public func testImperativeTails(_ coin: Coin) {
+  // CHECK-NOINLINE: switch_enum{{_addr %.+ : [$][*]Coin| %0 : [$]Coin}}, case #Coin.tails!enumelt: bb2, case #Coin.heads!enumelt: bb1 //
+  if case .tails = coin {
+    action0()
+  } else {
+    action1(0)
+  }
+} // CHECK-NOINLINE: end sil function '$S21switch_enum_resilient19testImperativeTailsyyAA4CoinOF'
+
+// CHECK-NOINLINE-LABEL: sil @$S21switch_enum_resilient19testFunctionalHeadsySiAA4CoinOF
+public func testFunctionalHeads(_ coin: Coin) -> Int {
+  // CHECK-FRAGILE-NOINLINE: [[FIVE:%.+]] = integer_literal ${{.+}}, 5000
+  // CHECK-FRAGILE-NOINLINE: [[NINE:%.+]] = integer_literal ${{.+}}, 9001
+  // CHECK-FRAGILE-NOINLINE: = select_enum %0 : $Coin, case #Coin.heads!enumelt: [[FIVE]], case #Coin.tails!enumelt: [[NINE]] :
+  // CHECK-RESILIENT-NOINLINE: switch_enum_addr {{%.+}} : $*Coin, case #Coin.heads!enumelt: bb2, case #Coin.tails!enumelt: bb1
+  if case .heads = coin {
+    return 5000
+  } else {
+    return 9001
+  }
+} // CHECK-NOINLINE: end sil function '$S21switch_enum_resilient19testFunctionalHeadsySiAA4CoinOF'
+
+// CHECK-NOINLINE-LABEL: sil @$S21switch_enum_resilient19testFunctionalTailsySiAA4CoinOF
+public func testFunctionalTails(_ coin: Coin) -> Int {
+  // CHECK-FRAGILE-NOINLINE: [[FIVE:%.+]] = integer_literal ${{.+}}, 5000
+  // CHECK-FRAGILE-NOINLINE: [[NINE:%.+]] = integer_literal ${{.+}}, 9001
+  // CHECK-FRAGILE-NOINLINE: = select_enum %0 : $Coin, case #Coin.tails!enumelt: [[FIVE]], case #Coin.heads!enumelt: [[NINE]] :
+  // CHECK-RESILIENT-NOINLINE: switch_enum_addr {{%.+}} : $*Coin, case #Coin.tails!enumelt: bb2, case #Coin.heads!enumelt: bb1
+  if case .tails = coin {
+    return 5000
+  } else {
+    return 9001
+  }
+} // CHECK-NOINLINE: end sil function '$S21switch_enum_resilient19testFunctionalTailsySiAA4CoinOF'
+
+// *** The following are in -emit-sorted-sil order ***
+
+// CHECK-ALL-LABEL: sil{{.*}} @$S21switch_enum_resilient16inlineFunctionalySiAA5AlphaOF
+@inlinable public func inlineFunctional(_ letter: Alpha) -> Int {
+  // CHECK-FRAGILE: [[THREE:%.+]]      = integer_literal ${{.+}}, 3
+  // CHECK-FRAGILE: [[FIVE:%.+]]       = integer_literal ${{.+}}, 5
+  // CHECK-FRAGILE: [[EIGHT:%.+]]      = integer_literal ${{.+}}, 8
+  // CHECK-FRAGILE: [[THIRTEEN:%.+]]   = integer_literal ${{.+}}, 13
+  // CHECK-FRAGILE: [[TWENTY_ONE:%.+]] = integer_literal ${{.+}}, 21
+  // CHECK-FRAGILE: = select_enum %0 : $Alpha, case #Alpha.a!enumelt: [[THREE]], case #Alpha.b!enumelt: [[FIVE]], case #Alpha.c!enumelt: [[EIGHT]], case #Alpha.d!enumelt: [[THIRTEEN]], case #Alpha.e!enumelt: [[TWENTY_ONE]] :
+
+  // This one can't be converted to select_enum because of the generated trap.
+  // CHECK-RESILIENT: switch_enum_addr {{%.+}} : $*Alpha, case #Alpha.a!enumelt: {{bb.+}}, case #Alpha.b!enumelt: {{bb.+}}, case #Alpha.c!enumelt: {{bb.+}}, case #Alpha.d!enumelt: {{bb.+}}, case #Alpha.e!enumelt: {{bb.+}}, default {{bb.+}}
+  switch letter {
+  case .a:
+    return 3
+  case .b:
+    return 5
+  case .c:
+    return 8
+  case .d:
+    return 13
+  case .e:
+    return 21
+  }
+  // CHECK-RESILIENT-NOINLINE: bb6:
+  // CHECK-RESILIENT-NOINLINE: function_ref @$Ss27_diagnoseUnexpectedEnumCase
+} // CHECK-ALL: end sil function '$S21switch_enum_resilient16inlineFunctionalySiAA5AlphaOF'
+
+// CHECK-ALL-LABEL: sil{{.*}} @$S21switch_enum_resilient16inlineImperativeyyAA5AlphaOF
+@inlinable public func inlineImperative(_ letter: Alpha) {
+  // CHECK-FRAGILE: switch_enum %0 : $Alpha, case #Alpha.a!enumelt: {{bb.+}}, case #Alpha.b!enumelt: {{bb.+}}, case #Alpha.c!enumelt: {{bb.+}}, case #Alpha.d!enumelt: {{bb.+}}, case #Alpha.e!enumelt: {{bb.+}} //
+  // CHECK-RESILIENT: switch_enum_addr {{%.+}} : $*Alpha, case #Alpha.a!enumelt: {{bb.+}}, case #Alpha.b!enumelt: {{bb.+}}, case #Alpha.c!enumelt: {{bb.+}}, case #Alpha.d!enumelt: {{bb.+}}, case #Alpha.e!enumelt: {{bb.+}}, default {{bb.+}}
+  switch letter {
+  case .a:
+    action0()
+  case .b:
+    action1(0)
+  case .c:
+    action2(0, 0)
+  case .d:
+    action3(0, 0, 0)
+  case .e:
+    action4(0, 0, 0, 0)
+  }
+} // CHECK-ALL: end sil function '$S21switch_enum_resilient16inlineImperativeyyAA5AlphaOF'
+
+// CHECK-ALL-LABEL: sil{{.*}} @$S21switch_enum_resilient21inlineFunctionalHeadsySiAA4CoinOF
+@inlinable public func inlineFunctionalHeads(_ coin: Coin) -> Int {
+  // CHECK-FRAGILE: [[FIVE:%.+]] = integer_literal ${{.+}}, 5000
+  // CHECK-FRAGILE: [[NINE:%.+]] = integer_literal ${{.+}}, 9001
+  // CHECK-FRAGILE: = select_enum %0 : $Coin, case #Coin.heads!enumelt: [[FIVE]], case #Coin.tails!enumelt: [[NINE]] :
+  // CHECK-RESILIENT-NOINLINE: switch_enum_addr {{%.+}} : $*Coin, case #Coin.heads!enumelt: bb2, case #Coin.tails!enumelt: bb1 //
+  // CHECK-RESILIENT-INLINE: switch_enum_addr {{%.+}} : $*Coin, case #Coin.heads!enumelt: bb2, default bb1
+  if case .heads = coin {
+    return 5000
+  } else {
+    return 9001
+  }
+} // CHECK-ALL: end sil function '$S21switch_enum_resilient21inlineFunctionalHeadsySiAA4CoinOF'
+
+// CHECK-ALL-LABEL: sil{{.*}} @$S21switch_enum_resilient21inlineFunctionalTailsySiAA4CoinOF
+@inlinable public func inlineFunctionalTails(_ coin: Coin) -> Int {
+  // CHECK-FRAGILE: [[FIVE:%.+]] = integer_literal ${{.+}}, 5000
+  // CHECK-FRAGILE: [[NINE:%.+]] = integer_literal ${{.+}}, 9001
+  // CHECK-FRAGILE: = select_enum %0 : $Coin, case #Coin.tails!enumelt: [[FIVE]], case #Coin.heads!enumelt: [[NINE]] :
+  // CHECK-RESILIENT-NOINLINE: switch_enum_addr {{%.+}} : $*Coin, case #Coin.tails!enumelt: bb2, case #Coin.heads!enumelt: bb1 //
+  // CHECK-RESILIENT-INLINE: switch_enum_addr {{%.+}} : $*Coin, case #Coin.tails!enumelt: bb2, default bb1
+  if case .tails = coin {
+    return 5000
+  } else {
+    return 9001
+  }
+} // CHECK-ALL: end sil function '$S21switch_enum_resilient21inlineFunctionalTailsySiAA4CoinOF'
+
+
+// CHECK-ALL-LABEL: sil{{.*}} @$S21switch_enum_resilient21inlineImperativeHeadsyyAA4CoinOF
+@inlinable public func inlineImperativeHeads(_ coin: Coin) {
+  // CHECK-FRAGILE: switch_enum %0 : $Coin, case #Coin.heads!enumelt: bb2, case #Coin.tails!enumelt: bb1 //
+  // CHECK-RESILIENT-NOINLINE: switch_enum_addr {{%.+}} : $*Coin, case #Coin.heads!enumelt: bb2, case #Coin.tails!enumelt: bb1 //
+  // CHECK-RESILIENT-INLINE: switch_enum_addr {{%.+}} : $*Coin, case #Coin.heads!enumelt: bb2, default bb1
+  if case .heads = coin {
+    action0()
+  } else {
+    action1(0)
+  }
+} // CHECK-ALL: end sil function '$S21switch_enum_resilient21inlineImperativeHeadsyyAA4CoinOF'
+
+// CHECK-ALL-LABEL: sil{{.*}} @$S21switch_enum_resilient21inlineImperativeTailsyyAA4CoinOF
+@inlinable public func inlineImperativeTails(_ coin: Coin) {
+  // CHECK-FRAGILE: switch_enum %0 : $Coin, case #Coin.tails!enumelt: bb2, case #Coin.heads!enumelt: bb1 //
+  // CHECK-RESILIENT-NOINLINE: switch_enum_addr {{%.+}} : $*Coin, case #Coin.tails!enumelt: bb2, case #Coin.heads!enumelt: bb1 //
+  // CHECK-RESILIENT-INLINE: switch_enum_addr {{%.+}} : $*Coin, case #Coin.tails!enumelt: bb2, default bb1
+  if case .tails = coin {
+    action0()
+  } else {
+    action1(0)
+  }
+} // CHECK-ALL: end sil function '$S21switch_enum_resilient21inlineImperativeTailsyyAA4CoinOF'
+
+// CHECK-ALL-LABEL: sil{{.*}} @$S21switch_enum_resilient26inlineFunctionalDefaultEndySiAA5AlphaOF
+@inlinable public func inlineFunctionalDefaultEnd(_ letter: Alpha) -> Int {
+  // CHECK-FRAGILE: [[THREE:%.+]]      = integer_literal ${{.+}}, 3
+  // CHECK-FRAGILE: [[FIVE:%.+]]       = integer_literal ${{.+}}, 5
+  // CHECK-FRAGILE: [[EIGHT:%.+]]      = integer_literal ${{.+}}, 8
+  // CHECK-FRAGILE: [[THIRTEEN:%.+]]   = integer_literal ${{.+}}, 13
+  // CHECK-FRAGILE: [[TWENTY_ONE:%.+]] = integer_literal ${{.+}}, 21
+  // CHECK-FRAGILE: = select_enum %0 : $Alpha, case #Alpha.a!enumelt: [[THREE]], case #Alpha.b!enumelt: [[FIVE]], case #Alpha.c!enumelt: [[EIGHT]], case #Alpha.d!enumelt: [[THIRTEEN]], case #Alpha.e!enumelt: [[TWENTY_ONE]] :
+  // CHECK-RESILIENT-NOINLINE: switch_enum_addr {{%.+}} : $*Alpha, case #Alpha.a!enumelt: bb1, case #Alpha.b!enumelt: bb2, case #Alpha.c!enumelt: bb3, case #Alpha.d!enumelt: bb4, case #Alpha.e!enumelt: bb5 //
+  // CHECK-RESILIENT-INLINE: switch_enum_addr {{%.+}} : $*Alpha, case #Alpha.a!enumelt: {{bb.+}}, case #Alpha.b!enumelt: {{bb.+}}, case #Alpha.c!enumelt: {{bb.+}}, case #Alpha.d!enumelt: {{bb.+}}, default {{bb.+}}
+  switch letter {
+  case .a:
+    return 3
+  case .b:
+    return 5
+  case .c:
+    return 8
+  case .d:
+    return 13
+  // case .e:
+  default:
+    return 21
+  }
+} // CHECK-ALL: end sil function '$S21switch_enum_resilient26inlineFunctionalDefaultEndySiAA5AlphaOF'
+
+// CHECK-ALL-LABEL: sil{{.*}} @$S21switch_enum_resilient26inlineImperativeDefaultEndyyAA5AlphaOF
+@inlinable public func inlineImperativeDefaultEnd(_ letter: Alpha) {
+  // CHECK-FRAGILE: switch_enum %0 : $Alpha, case #Alpha.a!enumelt: {{bb.+}}, case #Alpha.b!enumelt: {{bb.+}}, case #Alpha.c!enumelt: {{bb.+}}, case #Alpha.d!enumelt: {{bb.+}}, case #Alpha.e!enumelt: {{bb.+}} //
+  // CHECK-RESILIENT-NOINLINE: switch_enum_addr {{%.+}} : $*Alpha, case #Alpha.a!enumelt: bb1, case #Alpha.b!enumelt: bb2, case #Alpha.c!enumelt: bb3, case #Alpha.d!enumelt: bb4, case #Alpha.e!enumelt: bb5 //
+  // CHECK-RESILIENT-INLINE: switch_enum_addr {{%.+}} : $*Alpha, case #Alpha.a!enumelt: {{bb.+}}, case #Alpha.b!enumelt: {{bb.+}}, case #Alpha.c!enumelt: {{bb.+}}, case #Alpha.d!enumelt: {{bb.+}}, default {{bb.+}}
+  switch letter {
+  case .a:
+    action0()
+  case .b:
+    action1(0)
+  case .c:
+    action2(0, 0)
+  case .d:
+    action3(0, 0, 0)
+  // case .e:
+  default:
+    // CHECK-NOINLINE: bb5:
+    // CHECK-NOINLINE: function_ref @$S21switch_enum_resilient7action4
+    action4(0, 0, 0, 0)
+  }
+} // CHECK-ALL: end sil function '$S21switch_enum_resilient26inlineImperativeDefaultEndyyAA5AlphaOF'
+
+// CHECK-ALL-LABEL: sil{{.*}} @$S21switch_enum_resilient28inlineFunctionalDefaultMultiySiAA5AlphaOF
+@inlinable public func inlineFunctionalDefaultMulti(_ letter: Alpha) -> Int {
+  // CHECK-FRAGILE: [[THREE:%.+]]      = integer_literal ${{.+}}, 3
+  // CHECK-FRAGILE: [[FIVE:%.+]]       = integer_literal ${{.+}}, 5
+  // CHECK-FRAGILE: [[EIGHT:%.+]]      = integer_literal ${{.+}}, 8
+  // CHECK-FRAGILE: [[THIRTEEN:%.+]]   = integer_literal ${{.+}}, 13
+  // CHECK-FRAGILE: = select_enum %0 : $Alpha, case #Alpha.a!enumelt: [[THREE]], case #Alpha.b!enumelt: [[FIVE]], case #Alpha.d!enumelt: [[EIGHT]], default [[THIRTEEN]] :
+  // CHECK-RESILIENT: switch_enum_addr {{%.+}} : $*Alpha, case #Alpha.a!enumelt: {{bb.+}}, case #Alpha.b!enumelt: {{bb.+}}, case #Alpha.d!enumelt: {{bb.+}}, default {{bb.+}}
+  switch letter {
+  case .a:
+    return 3
+  case .b:
+    return 5
+  // case .c:
+  case .d:
+    return 8
+  // case .e:
+  default:
+    return 13
+  }
+} // CHECK-ALL: end sil function '$S21switch_enum_resilient28inlineFunctionalDefaultMultiySiAA5AlphaOF'
+
+// CHECK-ALL-LABEL: sil{{.*}} @$S21switch_enum_resilient28inlineImperativeDefaultMultiyyAA5AlphaOF
+@inlinable public func inlineImperativeDefaultMulti(_ letter: Alpha) {
+  // CHECK-ALL: switch_enum{{_addr %.+ : [$][*]Alpha| %0 : [$]Alpha}}, case #Alpha.a!enumelt: {{bb.+}}, case #Alpha.b!enumelt: {{bb.+}}, case #Alpha.d!enumelt: {{bb.+}}, default {{bb.+}}
+  switch letter {
+  case .a:
+    action0()
+  case .b:
+    action1(0)
+  // case .c:
+  case .d:
+    action2(0, 0)
+  // case .e:
+  default:
+    // CHECK-NOINLINE: bb4:
+    // CHECK-NOINLINE: function_ref @$S21switch_enum_resilient7action3
+    action3(0, 0, 0)
+  }
+} // CHECK-ALL: end sil function '$S21switch_enum_resilient28inlineImperativeDefaultMultiyyAA5AlphaOF'
+
+// CHECK-ALL-LABEL: sil{{.*}} @$S21switch_enum_resilient29inlineFunctionalDefaultMiddleySiAA5AlphaOF
+@inlinable public func inlineFunctionalDefaultMiddle(_ letter: Alpha) -> Int {
+  // CHECK-FRAGILE: [[THREE:%.+]]      = integer_literal ${{.+}}, 3
+  // CHECK-FRAGILE: [[FIVE:%.+]]       = integer_literal ${{.+}}, 5
+  // CHECK-FRAGILE: [[EIGHT:%.+]]      = integer_literal ${{.+}}, 8
+  // CHECK-FRAGILE: [[THIRTEEN:%.+]]   = integer_literal ${{.+}}, 13
+  // CHECK-FRAGILE: [[TWENTY_ONE:%.+]] = integer_literal ${{.+}}, 21
+  // CHECK-FRAGILE: = select_enum %0 : $Alpha, case #Alpha.a!enumelt: [[THREE]], case #Alpha.b!enumelt: [[FIVE]], case #Alpha.d!enumelt: [[EIGHT]], case #Alpha.e!enumelt: [[THIRTEEN]], case #Alpha.c!enumelt: [[TWENTY_ONE]] :
+  // CHECK-RESILIENT-NOINLINE: switch_enum_addr {{%.+}} : $*Alpha, case #Alpha.a!enumelt: bb1, case #Alpha.b!enumelt: bb2, case #Alpha.d!enumelt: bb3, case #Alpha.e!enumelt: bb4, case #Alpha.c!enumelt: bb5 //
+  // CHECK-RESILIENT-INLINE: switch_enum_addr {{%.+}} : $*Alpha, case #Alpha.a!enumelt: {{bb.+}}, case #Alpha.b!enumelt: {{bb.+}}, case #Alpha.d!enumelt: {{bb.+}}, case #Alpha.e!enumelt: {{bb.+}}, default {{bb.+}}
+  switch letter {
+  case .a:
+    return 3
+  case .b:
+    return 5
+  // case .c:
+  case .d:
+    return 8
+  case .e:
+    return 13
+  default:
+    return 21
+  }
+} // CHECK-ALL: end sil function '$S21switch_enum_resilient29inlineFunctionalDefaultMiddleySiAA5AlphaOF'
+
+// CHECK-ALL-LABEL: sil{{.*}} @$S21switch_enum_resilient29inlineImperativeDefaultMiddleyyAA5AlphaOF
+@inlinable public func inlineImperativeDefaultMiddle(_ letter: Alpha) {
+  // CHECK-FRAGILE: switch_enum %0 : $Alpha, case #Alpha.a!enumelt: {{bb.+}}, case #Alpha.b!enumelt: {{bb.+}}, case #Alpha.d!enumelt: {{bb.+}}, case #Alpha.e!enumelt: {{bb.+}}, case #Alpha.c!enumelt: {{bb.+}} //
+  // CHECK-RESILIENT-NOINLINE: switch_enum_addr {{%.+}} : $*Alpha, case #Alpha.a!enumelt: bb1, case #Alpha.b!enumelt: bb2, case #Alpha.d!enumelt: bb3, case #Alpha.e!enumelt: bb4, case #Alpha.c!enumelt: bb5
+  // CHECK-RESILIENT-INLINE: switch_enum_addr {{%.+}} : $*Alpha, case #Alpha.a!enumelt: {{bb.+}}, case #Alpha.b!enumelt: {{bb.+}}, case #Alpha.d!enumelt: {{bb.+}}, case #Alpha.e!enumelt: {{bb.+}}, default {{bb.+}}
+  switch letter {
+  case .a:
+    action0()
+  case .b:
+    action1(0)
+  // case .c:
+  case .d:
+    action2(0, 0)
+  case .e:
+    action3(0, 0, 0)
+  default:
+    // CHECK-NOINLINE: bb5:
+    // CHECK-NOINLINE: function_ref @$S21switch_enum_resilient7action4
+    action4(0, 0, 0, 0)
+  }
+} // CHECK-ALL: end sil function '$S21switch_enum_resilient29inlineImperativeDefaultMiddleyyAA5AlphaOF'


### PR DESCRIPTION
This was undoing the effects of #14724, which is supposed to guarantee trapping behavior on unexpected values. Worse, it put switches that *actually had defaults* back into undefined-behavior-land if a case were added.

~The verifier changes are in lieu of test changes;~ this was originally caught by IRGen/CoreGraphics_test.swift.

rdar://problem/42775178