### PR TITLE
Refine The Frontend's Understanding of SwiftOnoneSupport

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -310,7 +310,7 @@ private:
   static bool canActionEmitInterface(ActionType);
 
 public:
-  static bool doesActionRunSILPasses(ActionType);
+  static bool doesActionGenerateSIL(ActionType);
   static bool doesActionProduceOutput(ActionType);
   static bool doesActionProduceTextualOutput(ActionType);
   static bool needsProperModuleName(ActionType);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -413,14 +413,21 @@ shouldImplicityImportSwiftOnoneSupportModule(CompilerInvocation &Invocation) {
   if (Invocation.getSILOptions().shouldOptimize())
     return false;
 
-  // If we are not going through the SIL Optimizer with the
-  // given frontend action, do not load SwiftOnoneSupport.
+  // If we are not executing an action that has a dependency on
+  // SwiftOnoneSupport, don't load it.
+  //
+  // FIXME: Knowledge of SwiftOnoneSupport loading in the Frontend is a layering
+  // violation. However, SIL currently does not have a way to express this
+  // dependency itself for the benefit of autolinking.  In the mean time, we
+  // will be conservative and say that actions like -emit-silgen and
+  // -emit-sibgen - that don't really involve the optimizer - have a
+  // strict dependency on SwiftOnoneSupport.
   //
   // This optimization is disabled by -track-system-dependencies to preserve
   // the explicit dependency.
   const auto &options = Invocation.getFrontendOptions();
   return options.TrackSystemDeps
-      || FrontendOptions::doesActionRunSILPasses(options.RequestedAction);
+      || FrontendOptions::doesActionGenerateSIL(options.RequestedAction);
 }
 
 void CompilerInstance::performParseAndResolveImportsOnly() {

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -465,7 +465,7 @@ bool FrontendOptions::doesActionProduceTextualOutput(ActionType action) {
   }
 }
 
-bool FrontendOptions::doesActionRunSILPasses(ActionType action) {
+bool FrontendOptions::doesActionGenerateSIL(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
   case ActionType::Parse:
@@ -478,22 +478,22 @@ bool FrontendOptions::doesActionRunSILPasses(ActionType action) {
   case ActionType::PrintAST:
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeRefinementContexts:
-  case ActionType::DumpTypeInfo:
   case ActionType::EmitImportedModules:
   case ActionType::EmitPCH:
-  case ActionType::EmitSILGen:
     return false;
+  case ActionType::EmitSILGen:
+  case ActionType::EmitSIBGen:
   case ActionType::EmitSIL:
+  case ActionType::EmitSIB:
   case ActionType::EmitModuleOnly:
   case ActionType::MergeModules:
-  case ActionType::EmitSIBGen:
-  case ActionType::EmitSIB:
   case ActionType::Immediate:
   case ActionType::REPL:
   case ActionType::EmitAssembly:
   case ActionType::EmitIR:
   case ActionType::EmitBC:
   case ActionType::EmitObject:
+  case ActionType::DumpTypeInfo:
     return true;
   }
 }

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -996,7 +996,7 @@ static bool performCompile(CompilerInstance &Instance,
   if (writeTBDIfNeeded(Invocation, Instance))
     return true;
 
-  assert(Action >= FrontendOptions::ActionType::EmitSILGen &&
+  assert(FrontendOptions::doesActionGenerateSIL(Action) &&
          "All actions not requiring SILGen must have been handled!");
 
   std::deque<PostSILGenInputs> PSGIs = generateSILModules(Invocation, Instance);

--- a/test/Driver/emit-sib-single-file.swift
+++ b/test/Driver/emit-sib-single-file.swift
@@ -18,6 +18,9 @@
 // CHECK: Hello World
 // CHECK: Hello Bob, today is Tuesday.
 
+// This test intentionally mirrors /Driver/emit-sil-single-file to ensure that
+// SwiftOnoneSupport is always a dependency of -Onone -emit-si*gen builds.
+
 @inlinable
 @usableFromInline
 func greet(_ name: String, _ day: String) -> String {

--- a/test/Driver/emit-sil-single-file.swift
+++ b/test/Driver/emit-sil-single-file.swift
@@ -1,0 +1,28 @@
+// RUN: %target-build-swift -Onone -emit-silgen %s -o %t.sil
+// RUN: %target-build-swift -parse-sil %t.sil -o %t
+// RUN: %target-run %t | %FileCheck %s
+
+// RUN: %target-build-swift -Onone -c %t.sil -o %t.o
+// RUN: %target-build-swift %t.o -o %t
+// RUN: %target-run %t | %FileCheck %s
+// REQUIRES: executable_test
+
+// CHECK: Hello World
+// CHECK: Hello Bob, today is Tuesday.
+
+// This test intentionally mirrors /Driver/emit-sib-single-file to ensure that
+// SwiftOnoneSupport is always a dependency of -Onone -emit-si*gen builds.
+
+// FIXME: The Frontend's understanding of the situations in which to load
+// SwiftOnoneSupport is a tacit part of the rest of the compile pipeline and
+// pervades the AST.  SIL could probably sink knowledge of module dependencies
+// internally and make this test unnecessary.
+
+@inlinable
+@usableFromInline
+func greet(_ name: String, _ day: String) -> String {
+  return "Hello \(name), today is \(day)."
+}
+
+print("Hello World")
+print(greet("Bob", "Tuesday"))


### PR DESCRIPTION
Continuing work from #18344, be more conservative about when we load
SwiftOnoneSupport.  Specifically, -emit-silgen and -emit-sibgen, despite
not going through the SIL Optimizer, may silently introduce dependencies
on SwiftOnoneSupport.

Because we want to support the ability to posthumously compile SILGen
and SIBGen'd files with these implicit dependencies, and because SIL
is not yet capable of expressing the dependency itself, we must always
assume we need to load SwiftOnoneSupport.