### PR TITLE
Added a test case for the const-folding crash due to MultipleValueInstructionResult

### DIFF
--- a/test/TensorFlow/crashers.swift
+++ b/test/TensorFlow/crashers.swift
@@ -351,3 +351,14 @@ func SR8316_main() {
   let float: Float = 0.1 // expected-warning {{immutable value 'float' was never used}}
   _ = SR8316_helper()
 }
+
+func readDataset() -> (images: Tensor<Float>, labels: Tensor<Int32>)? {
+    print("Reading the data.")
+    return (Tensor<Float>(1.0), Tensor<Int32>(1))
+}
+
+public func constFoldingBug() {
+  guard let _ = readDataset() else {
+    return
+  }
+}


### PR DESCRIPTION
The bug was fixed in https://github.com/apple/swift/pull/18272.

Confirmed this test crashes without that fix.
