### PR TITLE
[test] Fix duplicate CHECK-DAG in reference dependencies test

### DIFF
--- a/test/NameBinding/reference-dependencies-dynamic-lookup.swift
+++ b/test/NameBinding/reference-dependencies-dynamic-lookup.swift
@@ -1,8 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -primary-file %t/main.swift -emit-reference-dependencies-path - > %t.swiftdeps
-// RUN: %FileCheck %s -allow-deprecated-dag-overlap < %t.swiftdeps
+// RUN: %FileCheck %s < %t.swiftdeps
 // RUN: %FileCheck -check-prefix=NEGATIVE %s < %t.swiftdeps
+// RUN: %FileCheck -check-prefix=DUPLICATE %s < %t.swiftdeps
 
 // Check that the output is deterministic.
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -primary-file %t/main.swift -emit-reference-dependencies-path - > %t-2.swiftdeps
@@ -13,16 +14,17 @@
 import Foundation
 
 // CHECK-LABEL: provides-dynamic-lookup:
+// DUPLICATE-LABEL: provides-dynamic-lookup:
 
 @objc @objcMembers class Base : NSObject {
   // CHECK-DAG: - "foo"
   func foo() {}
 
   // CHECK-DAG: - "bar"
+  // DUPLICATE-NOT: "bar"
+  // DUPLICATE: - "bar"
+  // DUPLICATE-NOT: "bar"
   func bar(_ x: Int, y: Int) {}
-  
-  // FIXME: We don't really need this twice, but de-duplicating is effort.
-  // CHECK-DAG: - "bar"
   func bar(_ str: String) {}
     
   // CHECK-DAG: - "prop"
@@ -37,6 +39,7 @@ import Foundation
 
 func getAnyObject() -> AnyObject? { return nil }
 
+// DUPLICATE: {{^(provides|depends).+:$}}
 // CHECK-LABEL: depends-dynamic-lookup:
 
 func testDynamicLookup(_ obj: AnyObject) {


### PR DESCRIPTION
An entry used to appear twice, but now it's nicely de-duplicated. However, FileCheck used to allow matching it twice (as a degenerate case of "overlapping CHECK-DAG"), so we never updated the test. Fix that, and check that the duplicate doesn't creep back in.

[SR-8420](https://bugs.swift.org/browse/SR-8420)