### PR TITLE
[SourceKit] Change return value of functions in EditorConsumer to void

### DIFF
--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -222,15 +222,15 @@ public:
   virtual void handleRequestError(const char *Description) = 0;
 
   virtual bool syntaxMapEnabled() = 0;
-  virtual bool handleSyntaxMap(unsigned Offset, unsigned Length,
+  virtual void handleSyntaxMap(unsigned Offset, unsigned Length,
                                UIdent Kind) = 0;
 
   virtual bool documentStructureEnabled() = 0;
 
-  virtual bool handleSemanticAnnotation(unsigned Offset, unsigned Length,
+  virtual void handleSemanticAnnotation(unsigned Offset, unsigned Length,
                                         UIdent Kind, bool isSystem) = 0;
 
-  virtual bool beginDocumentSubStructure(unsigned Offset, unsigned Length,
+  virtual void beginDocumentSubStructure(unsigned Offset, unsigned Length,
                                          UIdent Kind, UIdent AccessLevel,
                                          UIdent SetterAccessLevel,
                                          unsigned NameOffset,
@@ -246,25 +246,24 @@ public:
                                          ArrayRef<StringRef> InheritedTypes,
                                          ArrayRef<std::tuple<UIdent, unsigned, unsigned>> Attrs) = 0;
 
-  virtual bool endDocumentSubStructure() = 0;
+  virtual void endDocumentSubStructure() = 0;
 
-  virtual bool handleDocumentSubStructureElement(UIdent Kind,
-                                                 unsigned Offset,
+  virtual void handleDocumentSubStructureElement(UIdent Kind, unsigned Offset,
                                                  unsigned Length) = 0;
 
-  virtual bool recordAffectedRange(unsigned Offset, unsigned Length) = 0;
+  virtual void recordAffectedRange(unsigned Offset, unsigned Length) = 0;
 
-  virtual bool recordAffectedLineRange(unsigned Line, unsigned Length) = 0;
+  virtual void recordAffectedLineRange(unsigned Line, unsigned Length) = 0;
 
-  virtual bool recordFormattedText(StringRef Text) = 0;
+  virtual void recordFormattedText(StringRef Text) = 0;
 
-  virtual bool setDiagnosticStage(UIdent DiagStage) = 0;
-  virtual bool handleDiagnostic(const DiagnosticEntryInfo &Info,
+  virtual void setDiagnosticStage(UIdent DiagStage) = 0;
+  virtual void handleDiagnostic(const DiagnosticEntryInfo &Info,
                                 UIdent DiagStage) = 0;
 
-  virtual bool handleSourceText(StringRef Text) = 0;
+  virtual void handleSourceText(StringRef Text) = 0;
 
-  virtual bool
+  virtual void
   handleSyntaxTree(const swift::syntax::SourceFileSyntax &SyntaxTree,
                    std::unordered_set<unsigned> ReusedNodeIds) = 0;
   virtual bool syntaxTreeEnabled() {
@@ -273,8 +272,8 @@ public:
   virtual SyntaxTreeTransferMode syntaxTreeTransferMode() = 0;
 
   virtual bool syntaxReuseInfoEnabled() = 0;
-  virtual bool handleSyntaxReuseRegions(
-      std::vector<SourceFileRange> ReuseRegions) = 0;
+  virtual void
+  handleSyntaxReuseRegions(std::vector<SourceFileRange> ReuseRegions) = 0;
 
   virtual void finished() {}
 };

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1856,8 +1856,7 @@ void SwiftEditorDocument::readSemanticInfo(ImmutableTextSnapshotRef Snapshot,
     UIdent Kind = SemaTok.getUIdentForKind();
     bool IsSystem = SemaTok.getIsSystem();
     if (Kind.isValid())
-      if (!Consumer.handleSemanticAnnotation(Offset, Length, Kind, IsSystem))
-        break;
+      Consumer.handleSemanticAnnotation(Offset, Length, Kind, IsSystem);
   }
 
   static UIdent SemaDiagStage("source.diagnostic.stage.swift.sema");

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -38,18 +38,15 @@ class NullEditorConsumer : public EditorConsumer {
 
   bool syntaxMapEnabled() override { return true; }
 
-  bool handleSyntaxMap(unsigned Offset, unsigned Length, UIdent Kind) override {
-    return false;
+  void handleSyntaxMap(unsigned Offset, unsigned Length, UIdent Kind) override {
   }
 
-  bool handleSemanticAnnotation(unsigned Offset, unsigned Length,
-                                UIdent Kind, bool isSystem) override {
-    return false;
-  }
-  
+  void handleSemanticAnnotation(unsigned Offset, unsigned Length, UIdent Kind,
+                                bool isSystem) override {}
+
   bool documentStructureEnabled() override { return false; }
 
-  bool beginDocumentSubStructure(unsigned Offset, unsigned Length,
+  void beginDocumentSubStructure(unsigned Offset, unsigned Length,
                                  UIdent Kind, UIdent AccessLevel,
                                  UIdent SetterAccessLevel,
                                  unsigned NameOffset,
@@ -64,38 +61,25 @@ class NullEditorConsumer : public EditorConsumer {
                                  StringRef SelectorName,
                                  ArrayRef<StringRef> InheritedTypes,
                                  ArrayRef<std::tuple<UIdent, unsigned, unsigned>> Attrs) override {
-    return false;
   }
 
-  bool endDocumentSubStructure() override { return false; }
+  void endDocumentSubStructure() override {}
 
-  bool handleDocumentSubStructureElement(UIdent Kind,
-                                         unsigned Offset,
-                                         unsigned Length) override {
-    return false;
-  }
+  void handleDocumentSubStructureElement(UIdent Kind, unsigned Offset,
+                                         unsigned Length) override {}
 
-  bool recordAffectedRange(unsigned Offset, unsigned Length) override {
-    return false;
-  }
-  
-  bool recordAffectedLineRange(unsigned Line, unsigned Length) override {
-    return false;
-  }
+  void recordAffectedRange(unsigned Offset, unsigned Length) override {}
 
-  bool recordFormattedText(StringRef Text) override { return false; }
+  void recordAffectedLineRange(unsigned Line, unsigned Length) override {}
 
-  bool setDiagnosticStage(UIdent DiagStage) override { return false; }
-  bool handleDiagnostic(const DiagnosticEntryInfo &Info,
-                        UIdent DiagStage) override {
-    return false;
-  }
+  void setDiagnosticStage(UIdent DiagStage) override {}
+  void handleDiagnostic(const DiagnosticEntryInfo &Info,
+                        UIdent DiagStage) override {}
+  void recordFormattedText(StringRef Text) override {}
 
-  bool handleSourceText(StringRef Text) override { return false; }
-  bool handleSyntaxTree(const swift::syntax::SourceFileSyntax &SyntaxTree,
-                        std::unordered_set<unsigned> ReusedNodeIds) override {
-    return false;
-  }
+  void handleSourceText(StringRef Text) override {}
+  void handleSyntaxTree(const swift::syntax::SourceFileSyntax &SyntaxTree,
+                        std::unordered_set<unsigned> ReusedNodeIds) override {}
 
   SyntaxTreeTransferMode syntaxTreeTransferMode() override {
     return SyntaxTreeTransferMode::Off;
@@ -103,10 +87,10 @@ class NullEditorConsumer : public EditorConsumer {
 
   bool syntaxReuseInfoEnabled() override { return false; }
 
-  bool handleSyntaxReuseRegions(
-      std::vector<SourceFileRange> ReuseRegions) override {
-    return false;
+  void
+  handleSyntaxReuseRegions(std::vector<SourceFileRange> ReuseRegions) override {
   }
+
 public:
   bool needsSema = false;
 };

--- a/unittests/SourceKit/SwiftLang/EditingTest.cpp
+++ b/unittests/SourceKit/SwiftLang/EditingTest.cpp
@@ -43,18 +43,15 @@ private:
 
   bool syntaxMapEnabled() override { return true; }
 
-  bool handleSyntaxMap(unsigned Offset, unsigned Length, UIdent Kind) override {
-    return false;
+  void handleSyntaxMap(unsigned Offset, unsigned Length, UIdent Kind) override {
   }
 
-  bool handleSemanticAnnotation(unsigned Offset, unsigned Length,
-                                UIdent Kind, bool isSystem) override {
-    return false;
-  }
-  
+  void handleSemanticAnnotation(unsigned Offset, unsigned Length, UIdent Kind,
+                                bool isSystem) override {}
+
   bool documentStructureEnabled() override { return false; }
 
-  bool beginDocumentSubStructure(unsigned Offset, unsigned Length,
+  void beginDocumentSubStructure(unsigned Offset, unsigned Length,
                                  UIdent Kind, UIdent AccessLevel,
                                  UIdent SetterAccessLevel,
                                  unsigned NameOffset,
@@ -69,42 +66,28 @@ private:
                                  StringRef SelectorName,
                                  ArrayRef<StringRef> InheritedTypes,
                                  ArrayRef<std::tuple<UIdent, unsigned, unsigned>> Attrs) override {
-    return false;
   }
 
-  bool endDocumentSubStructure() override { return false; }
+  void endDocumentSubStructure() override {}
 
-  bool handleDocumentSubStructureElement(UIdent Kind,
-                                         unsigned Offset,
-                                         unsigned Length) override {
-    return false;
-  }
+  void handleDocumentSubStructureElement(UIdent Kind, unsigned Offset,
+                                         unsigned Length) override {}
 
-  bool recordAffectedRange(unsigned Offset, unsigned Length) override {
-    return false;
-  }
-  
-  bool recordAffectedLineRange(unsigned Line, unsigned Length) override {
-    return false;
-  }
+  void recordAffectedRange(unsigned Offset, unsigned Length) override {}
 
-  bool recordFormattedText(StringRef Text) override { return false; }
+  void recordAffectedLineRange(unsigned Line, unsigned Length) override {}
 
-  bool setDiagnosticStage(UIdent diagStage) override {
-    DiagStage = diagStage;
-    return true;
-  }
-  bool handleDiagnostic(const DiagnosticEntryInfo &Info,
+  void recordFormattedText(StringRef Text) override {}
+
+  void setDiagnosticStage(UIdent diagStage) override { DiagStage = diagStage; }
+  void handleDiagnostic(const DiagnosticEntryInfo &Info,
                         UIdent DiagStage) override {
     Diags.push_back(Info);
-    return true;
   }
 
-  bool handleSourceText(StringRef Text) override { return false; }
-  bool handleSyntaxTree(const swift::syntax::SourceFileSyntax &SyntaxTree,
-                        std::unordered_set<unsigned> ReusedNodeIds) override {
-    return false;
-  }
+  void handleSourceText(StringRef Text) override {}
+  void handleSyntaxTree(const swift::syntax::SourceFileSyntax &SyntaxTree,
+                        std::unordered_set<unsigned> ReusedNodeIds) override {}
 
   SyntaxTreeTransferMode syntaxTreeTransferMode() override {
     return SyntaxTreeTransferMode::Off;
@@ -112,9 +95,8 @@ private:
 
   bool syntaxReuseInfoEnabled() override { return false; }
 
-  bool handleSyntaxReuseRegions(
-      std::vector<SourceFileRange> ReuseRegions) override {
-    return false;
+  void
+  handleSyntaxReuseRegions(std::vector<SourceFileRange> ReuseRegions) override {
   }
 };
 


### PR DESCRIPTION
We were always returning `true` from those functions in  `SKEditorConsumer and false in the test consumers. On the client side we would then ignore the return value. So it's clearer to have the functions not return anything.