### PR TITLE
Make swift::SourceLoc and swift::SourceRange usable as a key type for DenseSet/DenseMap.

### DIFF
--- a/include/swift/Basic/SourceLoc.h
+++ b/include/swift/Basic/SourceLoc.h
@@ -18,6 +18,7 @@
 #define SWIFT_BASIC_SOURCELOC_H
 
 #include "swift/Basic/LLVM.h"
+#include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/SMLoc.h"
 #include <functional>
@@ -213,5 +214,32 @@ public:
 };
 
 } // end namespace swift
+
+namespace llvm {
+template <typename T> struct DenseMapInfo;
+
+template <> struct DenseMapInfo<swift::SourceRange> {
+  static swift::SourceRange getEmptyKey() { return swift::SourceRange(); }
+
+  static swift::SourceRange getTombstoneKey() {
+    // Make this different from empty key. See for context:
+    // http://lists.llvm.org/pipermail/llvm-dev/2015-July/088744.html
+    return swift::SourceRange(swift::SourceLoc(
+        SMLoc::getFromPointer(DenseMapInfo<const char *>::getTombstoneKey())));
+  }
+
+  static unsigned getHashValue(const swift::SourceRange &Val) {
+    return hash_combine(DenseMapInfo<const void *>::getHashValue(
+                            Val.Start.getOpaquePointerValue()),
+                        DenseMapInfo<const void *>::getHashValue(
+                            Val.End.getOpaquePointerValue()));
+  }
+
+  static bool isEqual(const swift::SourceRange &LHS,
+                      const swift::SourceRange &RHS) {
+    return LHS == RHS;
+  }
+};
+} // namespace llvm
 
 #endif // SWIFT_BASIC_SOURCELOC_H

--- a/include/swift/Basic/SourceLoc.h
+++ b/include/swift/Basic/SourceLoc.h
@@ -220,7 +220,8 @@ template <typename T> struct DenseMapInfo;
 
 template <> struct DenseMapInfo<swift::SourceLoc> {
   static swift::SourceLoc getEmptyKey() {
-    return SMLoc::getFromPointer(DenseMapInfo<const char *>::getEmptyKey());
+    return swift::SourceLoc(
+        SMLoc::getFromPointer(DenseMapInfo<const char *>::getEmptyKey()));
   }
 
   static swift::SourceLoc getTombstoneKey() {
@@ -231,7 +232,8 @@ template <> struct DenseMapInfo<swift::SourceLoc> {
   }
 
   static unsigned getHashValue(const swift::SourceLoc &Val) {
-    return DenseMapInfo<const void *>::getHashValue(getOpaquePointerValue());
+    return DenseMapInfo<const void *>::getHashValue(
+        Val.getOpaquePointerValue());
   }
 
   static bool isEqual(const swift::SourceLoc &LHS,


### PR DESCRIPTION
One use case is using DenseSet to manage a set of source locations, so that we
emit at most one compiler diagnostic per location (see
https://github.com/apple/swift/pull/18402).
