### PR TITLE
[stdlib] Remove vestigial _DisabledRangeIndex associated type

### DIFF
--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -3790,15 +3790,6 @@ extension ${Self} : _HasCustomAnyHashableRepresentation {
   }
 }
 
-
-// Create an ambiguity when indexing or slicing
-// Range[OfStrideable]<${Self}> outside a generic context.  See
-// Range.swift for details.
-extension ${Self} {
-  public typealias _DisabledRangeIndex = ${Self}
-}
-
-
 % for src_type in all_integer_types(word_bits):
 %   srcBits = src_type.bits
 %   srcSigned = src_type.is_signed

--- a/stdlib/public/core/Stride.swift
+++ b/stdlib/public/core/Stride.swift
@@ -147,8 +147,6 @@ public protocol Strideable : Comparable {
     after current: (index: Int?, value: Self),
     from start: Self, by distance: Self.Stride
   ) -> (index: Int?, value: Self)
-
-  associatedtype _DisabledRangeIndex = Never
 }
 
 extension Strideable {


### PR DESCRIPTION
Use of this type was removed a while back, in #13342, but this part got missed.