### PR TITLE
[SwiftSyntax] Refactor AbsolutePosition

### DIFF
--- a/tools/SwiftSyntax/AbsolutePosition.swift
+++ b/tools/SwiftSyntax/AbsolutePosition.swift
@@ -13,47 +13,15 @@
 /// An absolute position in a source file as text - the absolute utf8Offset from
 /// the start, line, and column.
 public final class AbsolutePosition {
-  public fileprivate(set) var utf8Offset: Int
-  public fileprivate(set) var line: Int
-  public fileprivate(set) var column: Int
+  public let utf8Offset: Int
+  public let line: Int
+  public let column: Int
 
-  public init(line: Int = 1, column: Int = 1, utf8Offset: Int = 0) {
+  static let startOfFile = AbsolutePosition(line: 1, column: 1, utf8Offset: 0)
+
+  public init(line: Int, column: Int, utf8Offset: Int) {
     self.line = line
     self.column = column
     self.utf8Offset = utf8Offset
-  }
-
-  internal func add(columns: Int) {
-    self.column += columns
-    self.utf8Offset += columns
-  }
-
-  internal func add(lines: Int, size: Int) {
-    self.line += lines * size
-    self.column = 1
-    self.utf8Offset += lines * size
-  }
-
-  /// Use some text as a reference for adding to the absolute position,
-  /// taking note of newlines, etc.
-  internal func add(text: String) {
-    for char in text {
-      switch char {
-      case "\n", "\r\n":
-        line += 1
-        column = 1
-      default:
-        column += 1
-      }
-
-      // FIXME: This is currently very wasteful, but should be fast once the
-      //        small-string optimization lands.
-      utf8Offset += String(char).utf8.count
-    }
-  }
-
-  internal func copy() -> AbsolutePosition {
-    return AbsolutePosition(line: line, column: column,
-      utf8Offset: utf8Offset)
   }
 }

--- a/tools/SwiftSyntax/CMakeLists.txt
+++ b/tools/SwiftSyntax/CMakeLists.txt
@@ -11,6 +11,7 @@ add_swift_library(swiftSwiftSyntax SHARED
   PrintingDiagnosticConsumer.swift
   RawSyntax.swift
   SourcePresence.swift
+  SourceLength.swift
   SwiftcInvocation.swift
   Syntax.swift
   SyntaxData.swift

--- a/tools/SwiftSyntax/SourceLength.swift
+++ b/tools/SwiftSyntax/SourceLength.swift
@@ -1,0 +1,93 @@
+//===------------------ SourceLength.swift - Source Length ----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// The length a syntax node spans in the source code. From any AbsolutePosition
+/// you reach a node's end location by either adding its UTF-8 length or by
+/// inserting `lines` newlines and then moving `columns` columns to the right.
+public final class SourceLength {
+  public let newlines: Int
+  public let columnsAtLastLine: Int
+  public let utf8Length: Int
+
+  /// Construct the source length of a given text
+  public init(of text: String) {
+    var newlines = 0
+    var columnsAtLastLine = 0
+    var utf8Length = 0
+    for char in text {
+      let charLength = String(char).utf8.count
+      utf8Length += charLength
+      switch char {
+      case "\n", "\r\n", "\r":
+        newlines += 1
+        columnsAtLastLine = 0
+      default:
+        columnsAtLastLine += charLength
+      }
+    }
+    self.newlines = newlines
+    self.columnsAtLastLine = columnsAtLastLine
+    self.utf8Length = utf8Length
+  }
+
+  public init(newlines: Int, columnsAtLastLine: Int, utf8Length: Int) {
+    self.newlines = newlines
+    self.columnsAtLastLine = columnsAtLastLine
+    self.utf8Length = utf8Length
+  }
+
+  /// A zero-length source length
+  public static let zero: SourceLength = 
+      SourceLength(newlines: 0, columnsAtLastLine: 0, utf8Length: 0)
+
+  /// Combine the length of two source length. Note that the addition is *not*
+  /// commutative (3 columns + 1 line = 1 line but 1 line + 3 columns = 1 line
+  /// and 3 columns)
+  public static func +(lhs: SourceLength, rhs: SourceLength) -> SourceLength {
+    let utf8Length = lhs.utf8Length + rhs.utf8Length
+    let newlines = lhs.newlines + rhs.newlines
+    let columnsAtLastLine: Int
+    if rhs.newlines == 0 {
+      columnsAtLastLine = lhs.columnsAtLastLine + rhs.columnsAtLastLine
+    } else {
+      columnsAtLastLine = rhs.columnsAtLastLine
+    }
+    return SourceLength(newlines: newlines, 
+                        columnsAtLastLine: columnsAtLastLine, 
+                        utf8Length: utf8Length)
+  }
+
+  public static func +=(lhs: inout SourceLength, rhs: SourceLength) {
+    lhs = lhs + rhs
+  }
+}
+
+extension AbsolutePosition {
+  /// Determine the AbsolutePosition by advancing the `lhs` by the given source
+  /// length.
+  public static func +(lhs: AbsolutePosition, rhs: SourceLength) 
+      -> AbsolutePosition {
+    let utf8Offset = lhs.utf8Offset + rhs.utf8Length
+    let line = lhs.line + rhs.newlines
+    let column: Int
+    if rhs.newlines == 0 {
+      column = lhs.column + rhs.columnsAtLastLine
+    } else {
+      column = rhs.columnsAtLastLine + 1 // AbsolutePosition has 1-based columns
+    }
+    return AbsolutePosition(line: line, column: column, utf8Offset: utf8Offset)
+  }
+
+  public static func +=(lhs: inout AbsolutePosition, rhs: SourceLength) {
+    lhs = lhs + rhs
+  }
+}

--- a/tools/SwiftSyntax/SyntaxData.swift
+++ b/tools/SwiftSyntax/SyntaxData.swift
@@ -40,11 +40,10 @@ final class SyntaxData: Equatable {
 
   let positionCache: AtomicCache<AbsolutePosition>
 
-  fileprivate func calculatePosition(_ initPos: AbsolutePosition) ->
-      AbsolutePosition {
+  fileprivate func calculatePosition() -> AbsolutePosition {
     guard let parent = parent else {
       // If this node is SourceFileSyntax, its location is the start of the file.
-      return initPos
+      return AbsolutePosition.startOfFile
     }
 
     // If the node is the first child of its parent, the location is same with
@@ -55,44 +54,30 @@ final class SyntaxData: Equatable {
     // adding the stride of the sibling.
     for idx in (0..<indexInParent).reversed() {
       if let sibling = parent.cachedChild(at: idx) {
-        let pos = sibling.position.copy()
-        sibling.raw.accumulateAbsolutePosition(pos)
-        return pos
+        return sibling.position + sibling.raw.totalLength
       }
     }
     return parent.position
   }
 
+  /// The position of the start of this node's leading trivia
   var position: AbsolutePosition {
-    return positionCache.value { return calculatePosition(AbsolutePosition()) }
+    return positionCache.value { return calculatePosition() }
   }
 
+  /// The position of the start of this node's content, skipping its trivia
   var positionAfterSkippingLeadingTrivia: AbsolutePosition {
-    let result = position.copy()
-    _ = raw.accumulateLeadingTrivia(result)
-    return result
+    return position + raw.leadingTriviaLength
   }
 
-  fileprivate func getNextSiblingPos() -> AbsolutePosition {
-    // If this node is root, the position of the next sibling is the end of
-    // this node.
-    guard let parent = parent else {
-      let result = self.position.copy()
-      raw.accumulateAbsolutePosition(result)
-      return result
-    }
-
-    // Find the first valid sibling and return its position.
-    for i in indexInParent+1..<parent.raw.layout.count {
-      guard let sibling = parent.cachedChild(at: i) else { continue }
-      return sibling.position
-    }
-    // Otherwise, use the parent's sibling instead.
-    return parent.getNextSiblingPos()
+  /// The end position of this node's content, excluding its trivia
+  var endPosition: AbsolutePosition {
+    return positionAfterSkippingLeadingTrivia + raw.contentLength
   }
 
-  var byteSize: Int {
-    return getNextSiblingPos().utf8Offset - self.position.utf8Offset
+  /// The end position of this node's trivia
+  var endPositionAfterTrailingTrivia: AbsolutePosition {
+    return endPosition + raw.trailingTriviaLength
   }
 
   /// Creates a SyntaxData with the provided raw syntax, pointing to the

--- a/tools/SwiftSyntax/Trivia.swift.gyb
+++ b/tools/SwiftSyntax/Trivia.swift.gyb
@@ -142,6 +142,15 @@ public struct Trivia: Codable {
     return Trivia(pieces: copy)
   }
 
+  public var sourceLength: SourceLength {
+    return pieces.map({ $0.sourceLength }).reduce(.zero, +)
+  }
+
+  /// Get the byteSize of this trivia
+  public var byteSize: Int {
+    return sourceLength.utf8Length
+  }
+
 % for trivia in TRIVIAS:
 %   if trivia.is_collection():
 %   joined = ''.join(trivia.swift_characters)
@@ -175,15 +184,6 @@ extension Trivia: Collection {
   public subscript(_ index: Int) -> TriviaPiece {
     return pieces[index]
   }
-
-  /// Get the byteSize of this trivia
-  public var byteSize: Int {
-    let pos = AbsolutePosition()
-    for piece in pieces {
-      piece.accumulateAbsolutePosition(pos)
-    }
-    return pos.utf8Offset
-  }
 }
 
 
@@ -200,18 +200,20 @@ public func +(lhs: Trivia, rhs: Trivia) -> Trivia {
 }
 
 extension TriviaPiece {
-  func accumulateAbsolutePosition(_ pos: AbsolutePosition) {
+  public var sourceLength: SourceLength {
     switch self {
 % for trivia in TRIVIAS:
 %   if trivia.is_new_line:
     case let .${trivia.lower_name}s(count):
-      pos.add(lines: count, size: ${trivia.characters_len()})
+      return SourceLength(newlines: count, columnsAtLastLine: 0, 
+                          utf8Length: count * ${trivia.characters_len()})
 %   elif trivia.is_collection():
     case let .${trivia.lower_name}s(count):
-      pos.add(columns: count)
+      return SourceLength(newlines: 0, columnsAtLastLine: count, 
+                          utf8Length: count)
 %   else:
     case let .${trivia.lower_name}(text):
-      pos.add(text: text)
+      return SourceLength(of: text)
 %   end
 % end
     }


### PR DESCRIPTION
`AbsolutePosition` being a mutable reference type easily leads to bugs where an AbsolutePosition is modified. Making it immutable eliminates this issue. Furthermore, the introduction of `SourceLength` should allow easier manipulation of `AbsolutePosition`s on the client side.

We still cannot make `AbsolutePosition` a value type since it is used inside `AtomicCache`, but the immutability should give the same safety.