### PR TITLE
[Sema] Avoid opening base requirements in static/init calls

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2147,7 +2147,8 @@ public:
   /// \returns The opened type.
   Type openUnboundGenericType(UnboundGenericType *unbound,
                               ConstraintLocatorBuilder locator,
-                              OpenedTypeMap &replacements);
+                              OpenedTypeMap &replacements,
+                              bool openRequirements = true);
 
   /// \brief "Open" the given type by replacing any occurrences of unbound
   /// generic types with bound generic types with fresh type variables as
@@ -2156,7 +2157,8 @@ public:
   /// \param type The type to open.
   ///
   /// \returns The opened type.
-  Type openUnboundGenericType(Type type, ConstraintLocatorBuilder locator);
+  Type openUnboundGenericType(Type type, ConstraintLocatorBuilder locator,
+                              bool openRequirements = true);
 
   /// \brief "Open" the given type by replacing any occurrences of generic
   /// parameter types and dependent member types with fresh type variables.
@@ -2196,12 +2198,10 @@ public:
 
   /// Open the generic parameter list and its requirements, creating
   /// type variables for each of the type parameters.
-  void openGeneric(DeclContext *innerDC,
-                   DeclContext *outerDC,
-                   GenericSignature *signature,
-                   bool skipProtocolSelfConstraint,
+  void openGeneric(DeclContext *innerDC, DeclContext *outerDC,
+                   GenericSignature *signature, bool skipProtocolSelfConstraint,
                    ConstraintLocatorBuilder locator,
-                   OpenedTypeMap &replacements);
+                   OpenedTypeMap &replacements, bool openRequirements = true);
 
   /// Given generic signature open its generic requirements,
   /// using substitution function, and record them in the

--- a/test/Constraints/no_duplicate_generic_reqs.swift
+++ b/test/Constraints/no_duplicate_generic_reqs.swift
@@ -1,0 +1,31 @@
+// RUN: %target-typecheck-verify-swift -debug-constraints %s > %t.dump 2>&1
+// RUN: %FileCheck %s < %t.dump
+
+struct B<T: Equatable> {
+  static func foo(_: [T]) {}
+}
+
+// CHECK: $T2 equivalent to $T0
+// CHECK-NOT: $T0 conforms to Equatable
+// CHECK: $T2 conforms to Equatable
+B.foo([42])
+
+
+struct P {
+  var id: Int64
+}
+
+struct List<T: Collection, E: Hashable> {
+  typealias Data = T.Element
+  init(_: T, id: KeyPath<Data, E>) {}
+}
+
+var arr: [P] = []
+
+// CHECK: $T10 equivalent to $T1
+// CHECK: $T11 equivalent to $T2
+// CHECK-NOT: $T1 conforms to Collection
+// CHECK: $T10 conforms to Collection
+// CHECK-NOT: $T2 conforms to Hashable
+// CHECK: $T11 conforms to Hashable
+_ = List(arr, id: \.id)


### PR DESCRIPTION
Avoid re-introducing the same base generic requirements
into constraint system multiple times for static member
and init calls, the problem is related to the fact that
constraint generation is opening base type and solver is
opening function overload choice and signatures have
intersecting requirements, e.g.

```swift
class A<T: Hashable> {
  init(_: [T]) {}
}

_ = A([0, 42])
```

Since call has reference to a type `A<T>.Type` by the time we
attempt to open reference to initializer `(A<T>) -> ([T]) -> A<T>`
`T` would already be opened and all of its generic requirements
would be registered in the constraint system.

Alternative approach to https://github.com/apple/swift/pull/18326

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
