### PR TITLE
[Name lookup] Introduce a request for "extended nominal type decl"

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1640,7 +1640,10 @@ class ExtensionDecl final : public GenericContext, public Decl,
 
   /// The type being extended.
   TypeLoc ExtendedType;
-  
+
+  /// The nominal type being extended.
+  mutable NominalTypeDecl *ExtendedNominal = nullptr;
+
   MutableArrayRef<TypeLoc> Inherited;
 
   /// \brief The next extension in the linked list of extensions.
@@ -1698,7 +1701,14 @@ public:
   void setBraces(SourceRange braces) { Braces = braces; }
 
   /// Retrieve the type being extended.
+  ///
+  /// Only use this entry point when the complete type, as spelled in the source,
+  /// is required. For most clients, \c getExtendedNominal(), which provides
+  /// only the \c NominalTypeDecl, will suffice.
   Type getExtendedType() const { return ExtendedType.getType(); }
+
+  /// Retrieve the nominal type declaration that is being extended.
+  NominalTypeDecl *getExtendedNominal() const;
 
   /// Retrieve the extended type location.
   TypeLoc &getExtendedTypeLoc() { return ExtendedType; }

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3626,6 +3626,23 @@ public:
   /// might have implicitly @objc members, but will never itself be @objc.
   ObjCClassKind checkObjCAncestry() const;
 
+  /// \brief Whether this class or its superclasses has some form of generic
+  /// context.
+  ///
+  /// For example, given
+  ///
+  /// class A<X> {}
+  /// class B : A<Int> {}
+  /// struct C<T> {
+  ///   struct Inner {}
+  /// }
+  /// class D {}
+  /// class E: D {}
+  ///
+  /// Calling hasGenericAncestry() on `B` returns `A<Int>`, on `C<T>.Inner`
+  /// returns `C<T>.Inner`, but on `E` it returns null.
+  ClassDecl *getGenericAncestor() const;
+
   /// The type of metaclass to use for a class.
   enum class MetaclassKind : uint8_t {
     ObjC,

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1711,6 +1711,10 @@ public:
   /// Retrieve the nominal type declaration that is being extended.
   NominalTypeDecl *getExtendedNominal() const;
 
+  /// Determine whether this extension has already been bound to a nominal
+  /// type declaration.
+  bool alreadyBoundToNominal() const { return NextExtension.getInt(); }
+
   /// Retrieve the extended type location.
   TypeLoc &getExtendedTypeLoc() { return ExtendedType; }
 
@@ -3707,7 +3711,7 @@ public:
   ///
   /// This is true of imported Objective-C classes.
   bool usesObjCGenericsModel() const {
-    return isObjC() && hasClangNode() && isGenericContext();
+    return hasClangNode() && isGenericContext() && isObjC();
   }
   
   /// True if the class is known to be implemented in Swift.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1642,7 +1642,7 @@ class ExtensionDecl final : public GenericContext, public Decl,
   TypeLoc ExtendedType;
 
   /// The nominal type being extended.
-  mutable NominalTypeDecl *ExtendedNominal = nullptr;
+  NominalTypeDecl *ExtendedNominal = nullptr;
 
   MutableArrayRef<TypeLoc> Inherited;
 
@@ -1680,6 +1680,7 @@ class ExtensionDecl final : public GenericContext, public Decl,
   /// Slow path for \c takeConformanceLoader().
   std::pair<LazyMemberLoader *, uint64_t> takeConformanceLoaderSlow();
 
+  friend class ExtendedNominalRequest;
 public:
   using Decl::getASTContext;
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1490,7 +1490,8 @@ ERROR(extension_specialization,none,
 ERROR(extension_stored_property,none,
       "extensions must not contain stored properties", ())
 ERROR(extension_nongeneric_trailing_where,none,
-      "trailing 'where' clause for extension of non-generic type %0", (Type))
+      "trailing 'where' clause for extension of non-generic type %0",
+      (DeclName))
 ERROR(extension_protocol_inheritance,none,
       "extension of protocol %0 cannot have an inheritance clause", (Type))
 ERROR(objc_generic_extension_using_type_parameter,none,

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -157,6 +157,33 @@ public:
   void noteCycleStep(DiagnosticEngine &diags) const;
 };
 
+/// Request the nominal declaration extended by a given extension declaration.
+class ExtendedNominalRequest :
+    public SimpleRequest<ExtendedNominalRequest,
+                         CacheKind::SeparatelyCached,
+                         NominalTypeDecl *,
+                         ExtensionDecl *> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend class SimpleRequest;
+
+  // Evaluation.
+  NominalTypeDecl *evaluate(Evaluator &evaluator, ExtensionDecl *ext) const;
+
+public:
+  // Separate caching.
+  bool isCached() const { return true; }
+  Optional<NominalTypeDecl *> getCachedResult() const;
+  void cacheResult(NominalTypeDecl *value) const;
+
+  // Cycle handling
+  NominalTypeDecl *breakCycle() const { return nullptr; }
+  void diagnoseCycle(DiagnosticEngine &diags) const;
+  void noteCycleStep(DiagnosticEngine &diags) const;
+};
+
 /// The zone number for name-lookup requests.
 #define SWIFT_NAME_LOOKUP_REQUESTS_TYPEID_ZONE 9
 

--- a/include/swift/AST/NameLookupTypeIDZone.def
+++ b/include/swift/AST/NameLookupTypeIDZone.def
@@ -17,3 +17,4 @@
 SWIFT_TYPEID(InheritedDeclsReferencedRequest)
 SWIFT_TYPEID(UnderlyingTypeDeclsReferencedRequest)
 SWIFT_TYPEID(SuperclassDeclRequest)
+SWIFT_TYPEID(ExtendedNominalRequest)

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -806,23 +806,6 @@ public:
   Type getSuperclassForDecl(const ClassDecl *classDecl,
                             bool useArchetypes = true);
 
-  /// \brief Whether this type or its superclasses has some form of generic
-  /// context.
-  ///
-  /// For example, given
-  ///
-  /// class A<X> {}
-  /// class B : A<Int> {}
-  /// struct C<T> {
-  ///   struct Inner {}
-  /// }
-  /// class D {}
-  /// class E: D {}
-  ///
-  /// Calling hasGenericAncestry() on `B` returns `A<Int>`, on `C<T>.Inner`
-  /// returns `C<T>.Inner`, but on `E` it returns null.
-  Type getGenericAncestor();
-
   /// \brief True if this type is the superclass of another type, or a generic
   /// type that could be bound to the superclass.
   ///

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1295,11 +1295,8 @@ void swift::printContext(raw_ostream &os, DeclContext *dc) {
     break;
 
   case DeclContextKind::ExtensionDecl:
-    if (auto extendedTy = cast<ExtensionDecl>(dc)->getExtendedType()) {
-      if (auto nominal = extendedTy->getAnyNominal()) {
-        printName(os, nominal->getName());
-        break;
-      }
+    if (auto extendedNominal = cast<ExtensionDecl>(dc)->getExtendedNominal()) {
+      printName(os, extendedNominal->getName());
     }
     os << " extension";
     break;

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1402,13 +1402,11 @@ void ASTMangler::appendContext(const DeclContext *ctx) {
 
   case DeclContextKind::ExtensionDecl: {
     auto ExtD = cast<ExtensionDecl>(ctx);
-    auto ExtTy = ExtD->getExtendedType();
+    auto decl = ExtD->getExtendedNominal();
     // Recover from erroneous extension.
-    if (ExtTy.isNull() || ExtTy->hasError())
+    if (!decl)
       return appendContext(ExtD->getDeclContext());
 
-    auto decl = ExtTy->getAnyNominal();
-    assert(decl && "extension of non-nominal type?");
     if (!ExtD->isEquivalentToExtendedContext()) {
     // Mangle the extension if:
     // - the extension is defined in a different module from the original

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1817,8 +1817,7 @@ void PrintAST::printExtension(ExtensionDecl *decl) {
     recordDeclLoc(decl, [&]{
       // We cannot extend sugared types.
       Type extendedType = decl->getExtendedType();
-      NominalTypeDecl *nominal = extendedType ? extendedType->getAnyNominal() : nullptr;
-      if (!nominal) {
+      if (!extendedType || !extendedType->getAnyNominal()) {
         // Fallback to TypeRepr.
         printTypeLoc(decl->getExtendedTypeLoc());
         return;

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -1761,7 +1761,7 @@ SmallVector<ValueDecl *, 4> ASTScope::getLocalBindings() const {
       break;
 
     // Bind this extension, if we haven't done so already.
-    if (!extension->getExtendedType())
+    if (!extension->getExtendedNominal())
       if (auto resolver = extension->getASTContext().getLazyResolver())
         resolver->bindExtension(extension);
 
@@ -1915,8 +1915,8 @@ void ASTScope::print(llvm::raw_ostream &out, unsigned level,
     out << " extension of '";
     if (auto typeRepr = extension->getExtendedTypeLoc().getTypeRepr())
       typeRepr->print(out);
-    else
-      extension->getExtendedType()->print(out);
+    else if (auto nominal = extension->getExtendedNominal())
+      out << nominal->getName();
     out << "'";
     printRange();
     break;

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -1760,11 +1760,6 @@ SmallVector<ValueDecl *, 4> ASTScope::getLocalBindings() const {
     if (range.Start == range.End)
       break;
 
-    // Bind this extension, if we haven't done so already.
-    if (!extension->getExtendedNominal())
-      if (auto resolver = extension->getASTContext().getLazyResolver())
-        resolver->bindExtension(extension);
-
     // If there are generic parameters, add them.
     for (auto genericParams = extension->getGenericParams();
          genericParams;

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2619,8 +2619,14 @@ public:
       verifyProtocolList(nominal, nominal->getLocalProtocols());
 
       // Make sure that the protocol conformances are complete.
-      for (auto conformance : nominal->getLocalConformances()) {
-        verifyConformance(nominal, conformance);
+      // Only do so within the source file of the nominal type,
+      // because anywhere else this can trigger new type-check requests.
+      if (auto sf = M.dyn_cast<SourceFile *>()) {
+        if (nominal->getParentSourceFile() == sf) {
+          for (auto conformance : nominal->getLocalConformances()) {
+            verifyConformance(nominal, conformance);
+          }
+        }
       }
 
       verifyCheckedBase(nominal);

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2471,7 +2471,7 @@ public:
       } else {
         auto ext = cast<ExtensionDecl>(decl);
         conformingDC = ext;
-        nominal = ext->getExtendedType()->getAnyNominal();
+        nominal = ext->getExtendedNominal();
       }
 
       auto proto = conformance->getProtocol();
@@ -3491,7 +3491,7 @@ void swift::verify(SourceFile &SF) {
 bool swift::shouldVerify(const Decl *D, const ASTContext &Context) {
 #if !(defined(NDEBUG) || defined(SWIFT_DISABLE_AST_VERIFIER))
   if (const auto *ED = dyn_cast<ExtensionDecl>(D)) {
-    return shouldVerify(ED->getExtendedType()->getAnyNominal(), Context);
+    return shouldVerify(ED->getExtendedNominal(), Context);
   }
 
   const auto *VD = dyn_cast<ValueDecl>(D);

--- a/lib/AST/AccessRequests.cpp
+++ b/lib/AST/AccessRequests.cpp
@@ -206,12 +206,9 @@ DefaultAndMaxAccessLevelRequest::evaluate(Evaluator &evaluator,
 
   AccessLevel maxAccess = AccessLevel::Public;
 
-  if (!ED->getExtendedType().isNull() &&
-      !ED->getExtendedType()->hasError()) {
-    if (NominalTypeDecl *nominal = ED->getExtendedType()->getAnyNominal()) {
-      maxAccess = std::max(nominal->getFormalAccess(),
-                           AccessLevel::FilePrivate);
-    }
+  if (NominalTypeDecl *nominal = ED->getExtendedNominal()) {
+    maxAccess = std::max(nominal->getFormalAccess(),
+                         AccessLevel::FilePrivate);
   }
 
   if (const GenericParamList *genericParams = ED->getGenericParams()) {

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -865,6 +865,11 @@ ConformanceLookupTable::getConformance(NominalTypeDecl *nominal,
         ctx.getInheritedConformance(type, inheritedConformance->getConcrete());
   } else {
     // Create or find the normal conformance.
+    if (auto ext = dyn_cast<ExtensionDecl>(conformingDC)) {
+      if (auto resolver = ctx.getLazyResolver())
+        resolver->bindExtension(ext);
+    }
+
     Type conformingType = conformingDC->getDeclaredInterfaceType();
     SourceLoc conformanceLoc
       = conformingNominal == conformingDC

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3376,6 +3376,18 @@ ClassDecl::findImplementingMethod(const AbstractFunctionDecl *Method) const {
   return nullptr;
 }
 
+ClassDecl *ClassDecl::getGenericAncestor() const {
+  ClassDecl *current = const_cast<ClassDecl *>(this);
+
+  while (current) {
+    if (current->isGenericContext())
+      return current;
+
+    current = current->getSuperclassDecl();
+  }
+
+  return nullptr;
+}
 
 EnumCaseDecl *EnumCaseDecl::create(SourceLoc CaseLoc,
                                    ArrayRef<EnumElementDecl *> Elements,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2883,7 +2883,7 @@ ExtensionRange NominalTypeDecl::getExtensions() {
 }
 
 void NominalTypeDecl::addExtension(ExtensionDecl *extension) {
-  assert(!extension->NextExtension.getInt() && "Already added extension");
+  assert(!extension->alreadyBoundToNominal() && "Already added extension");
   extension->NextExtension.setInt(true);
   
   // First extension; set both first and last.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -982,33 +982,9 @@ ExtensionDecl::takeConformanceLoaderSlow() {
 }
 
 NominalTypeDecl *ExtensionDecl::getExtendedNominal() const {
-  if (ExtendedNominal)
-    return ExtendedNominal;
-
-  if (auto extendedTy = getExtendedType()) {
-    while (true) {
-      // expected case: we reference a nominal type (potentially through sugar)
-      ExtendedNominal = extendedTy->getAnyNominal();
-      if (ExtendedNominal)
-        return ExtendedNominal;
-
-      // early type checking case: we have a typealias reference that is still
-      // unsugared, so explicitly look through the underlying type if there is
-      // one.
-      // FIXME: This should be replaced with the new name-lookup requests.
-      if (auto typealias =
-            dyn_cast_or_null<TypeAliasDecl>(extendedTy->getAnyGeneric())) {
-        extendedTy = typealias->getUnderlyingTypeLoc().getType();
-        if (!extendedTy) return nullptr;
-
-        continue;
-      }
-
-      return nullptr;
-    }
-  }
-
-  return nullptr;
+  ASTContext &ctx = getASTContext();
+  return ctx.evaluator(
+      ExtendedNominalRequest{const_cast<ExtensionDecl *>(this)});;
 }
 
 Type ExtensionDecl::getInheritedType(unsigned index) const {

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -53,27 +53,7 @@ DeclContext::getAsTypeOrTypeExtensionContext() const {
   auto ext = dyn_cast<ExtensionDecl>(decl);
   if (!ext) return dyn_cast<GenericTypeDecl>(decl);
 
-  auto type = ext->getExtendedType();
-  if (!type) return nullptr;
-
-  while (true) {
-    // expected case: we reference a nominal type (potentially through sugar)
-    if (auto nominal = type->getAnyNominal())
-      return nominal;
-
-    // early type checking case: we have a typealias reference that is still
-    // unsugared, so explicitly look through the underlying type if there is
-    // one.
-    if (auto typealias =
-          dyn_cast_or_null<TypeAliasDecl>(type->getAnyGeneric())) {
-      type = typealias->getUnderlyingTypeLoc().getType();
-      if (!type) return nullptr;
-
-      continue;
-    }
-
-    return nullptr;
-  }
+  return ext->getExtendedNominal();
 }
 
 /// If this DeclContext is a NominalType declaration or an
@@ -104,8 +84,7 @@ ProtocolDecl *DeclContext::getAsProtocolOrProtocolExtensionContext() const {
 ProtocolDecl *DeclContext::getAsProtocolExtensionContext() const {
   if (auto decl = const_cast<Decl*>(getAsDeclOrDeclExtensionContext()))
     if (auto ED = dyn_cast<ExtensionDecl>(decl))
-      if (auto type = ED->getExtendedType())
-        return dyn_cast_or_null<ProtocolDecl>(type->getAnyNominal());
+      return dyn_cast_or_null<ProtocolDecl>(ED->getExtendedNominal());
   return nullptr;
 }
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1169,10 +1169,10 @@ void NominalTypeDecl::addedMember(Decl *member) {
 
 void ExtensionDecl::addedMember(Decl *member) {
   if (NextExtension.getInt()) {
-    if (getExtendedType()->hasError())
+    auto nominal = getExtendedNominal();
+    if (!nominal)
       return;
 
-    auto nominal = getExtendedType()->getAnyNominal();
     if (nominal->LookupTable.getPointer() &&
         nominal->LookupTable.getInt()) {
       // Make sure we have the complete list of extensions.

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -86,6 +86,38 @@ void SuperclassDeclRequest::noteCycleStep(DiagnosticEngine &diags) const {
   diags.diagnose(subjectDecl, diag::circular_reference_through);
 }
 
+//----------------------------------------------------------------------------//
+// Superclass declaration computation.
+//----------------------------------------------------------------------------//
+Optional<NominalTypeDecl *> ExtendedNominalRequest::getCachedResult() const {
+  // Note: if we fail to compute any nominal declaration, it's considered
+  // a cache miss. This allows us to recompute the extended nominal types
+  // during extension binding.
+  auto ext = std::get<0>(getStorage());
+  if (ext->ExtendedNominal)
+    return ext->ExtendedNominal;
+
+  return None;
+}
+
+void ExtendedNominalRequest::cacheResult(NominalTypeDecl *value) const {
+  auto ext = std::get<0>(getStorage());
+  if (value)
+    ext->ExtendedNominal = value;
+}
+
+void ExtendedNominalRequest::diagnoseCycle(DiagnosticEngine &diags) const {
+  // FIXME: Improve this diagnostic.
+  auto ext = std::get<0>(getStorage());
+  diags.diagnose(ext, diag::circular_reference);
+}
+
+void ExtendedNominalRequest::noteCycleStep(DiagnosticEngine &diags) const {
+  auto ext = std::get<0>(getStorage());
+  // FIXME: Customize this further.
+  diags.diagnose(ext, diag::circular_reference_through);
+}
+
 // Define request evaluation functions for each of the name lookup requests.
 static AbstractRequestFunction *nameLookupRequestFunctions[] = {
 #define SWIFT_TYPEID(Name)                                    \

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -444,8 +444,8 @@ void NormalProtocolConformance::differenceAndStoreConditionalRequirements()
     return;
   }
 
-  auto typeSig = DC->getAsNominalTypeOrNominalTypeExtensionContext()
-                     ->getGenericSignature();
+  auto nominal = DC->getAsNominalTypeOrNominalTypeExtensionContext();
+  auto typeSig = nominal->getGenericSignature();
 
   // A non-generic type won't have conditional requirements.
   if (!typeSig) {
@@ -454,6 +454,13 @@ void NormalProtocolConformance::differenceAndStoreConditionalRequirements()
   }
 
   auto extensionSig = DC->getGenericSignatureOfContext();
+  if (!extensionSig) {
+    if (auto lazyResolver = ctxt.getLazyResolver()) {
+      lazyResolver->resolveExtension(cast<ExtensionDecl>(DC));
+      extensionSig = DC->getGenericSignatureOfContext();
+    }
+  }
+
   // The type is generic, but the extension doesn't have a signature yet, so
   // we can't do any differencing.
   if (!extensionSig) {

--- a/lib/AST/RawComment.cpp
+++ b/lib/AST/RawComment.cpp
@@ -163,8 +163,8 @@ static const Decl* getGroupDecl(const Decl *D) {
   // Extensions always exist in the same group with the nominal.
   if (auto ED = dyn_cast_or_null<ExtensionDecl>(D->getDeclContext()->
                                                 getInnermostTypeContext())) {
-    if (auto ExtTy = ED->getExtendedType())
-      GroupD = ExtTy->getAnyNominal();
+    if (auto ExtNominal = ED->getExtendedNominal())
+      GroupD = ExtNominal;
   }
   return GroupD;
 }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3244,24 +3244,6 @@ Type TypeBase::getSuperclassForDecl(const ClassDecl *baseClass,
   llvm_unreachable("no inheritance relationship between given classes");
 }
 
-Type TypeBase::getGenericAncestor() {
-  Type t = getConcreteTypeForSuperclassTraversing(this);
-
-  while (t && !t->hasError()) {
-    auto NTD = t->getAnyNominal();
-    assert(NTD && "expected nominal type in NTD");
-    if (!NTD)
-      return Type();
-
-    if (NTD->isGenericContext())
-      return t;
-
-    t = t->getSuperclass();
-  }
-
-  return Type();
-}
-
 TypeSubstitutionMap
 TypeBase::getContextSubstitutions(const DeclContext *dc,
                                   GenericEnvironment *genericEnv) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8347,7 +8347,7 @@ void ClangImporter::Implementation::loadAllMembersIntoExtension(
     Decl *D, uint64_t extra) {
   // We have extension.
   auto ext = cast<ExtensionDecl>(D);
-  auto nominal = ext->getExtendedType()->getAnyNominal();
+  auto nominal = ext->getExtendedNominal();
 
   // The submodule of the extension is encoded in the extra data.
   clang::Module *submodule =
@@ -8445,7 +8445,7 @@ figureOutTheDeclarationContextToImportInto(Decl *D, DeclContext *&DC,
 }
 
 static void loadMembersOfBaseImportedFromClang(ExtensionDecl *ext) {
-  const NominalTypeDecl *base = ext->getExtendedType()->getAnyNominal();
+  const NominalTypeDecl *base = ext->getExtendedNominal();
   auto *clangBase = base->getClangDecl();
   if (!clangBase)
     return;

--- a/lib/FrontendTool/ReferenceDependencies.cpp
+++ b/lib/FrontendTool/ReferenceDependencies.cpp
@@ -340,7 +340,7 @@ void ProvidesEmitter::emitTopLevelDecl(const Decl *const D,
 
 void ProvidesEmitter::emitExtensionDecl(const ExtensionDecl *const ED,
                                         CollectedDeclarations &cpd) const {
-  auto *NTD = ED->getExtendedType()->getAnyNominal();
+  auto *NTD = ED->getExtendedNominal();
   if (!NTD)
     return;
   if (NTD->hasAccess() && NTD->getFormalAccess() <= AccessLevel::FilePrivate) {
@@ -431,8 +431,7 @@ void ProvidesEmitter::emitMembers(const CollectedDeclarations &cpd) const {
 
   // This is also part of providesMember.
   for (auto *ED : cpd.extensionsWithJustMembers) {
-    auto mangledName =
-        mangleTypeAsContext(ED->getExtendedType()->getAnyNominal());
+    auto mangledName = mangleTypeAsContext(ED->getExtendedNominal());
 
     for (auto *member : ED->getMembers()) {
       auto *VD = dyn_cast<ValueDecl>(member);

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1971,6 +1971,9 @@ public:
   ///
   /// FIXME: Perhaps this should be an option in PrintOptions instead.
   Type eraseArchetypes(ModuleDecl *M, Type type, GenericSignature *genericSig) {
+    if (!genericSig)
+      return type;
+
     auto buildProtocolComposition = [&](ArrayRef<ProtocolDecl *> protos) -> Type {
       SmallVector<Type, 2> types;
       for (auto proto : protos)

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -533,7 +533,7 @@ void swift::ide::printSubmoduleInterface(
       // Swift extensions are printed with their associated type unless it's
       // a cross-module extension.
       if (!extensionHasClangNode(Ext)) {
-        auto ExtendedNominal = Ext->getExtendedType()->getAnyNominal();
+        auto ExtendedNominal = Ext->getExtendedNominal();
         if (Ext->getModuleContext() == ExtendedNominal->getModuleContext())
           return false;
       }

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -798,7 +798,7 @@ IRGenModule::getAddrOfParentContextDescriptor(DeclContext *from) {
     // has no constraints), then we can use the original nominal type context
     // (assuming there is one).
     if (ext->isEquivalentToExtendedContext()) {
-      auto nominal = ext->getExtendedType()->getAnyNominal();
+      auto nominal = ext->getExtendedNominal();
       // If the extended type is an ObjC class, it won't have a nominal type
       // descriptor, so we'll just emit an extension context.
       auto clas = dyn_cast<ClassDecl>(nominal);
@@ -3834,7 +3834,7 @@ void IRGenModule::emitExtension(ExtensionDecl *ext) {
   // Generate a category if the extension either introduces a
   // conformance to an ObjC protocol or introduces a method
   // that requires an Objective-C entry point.
-  ClassDecl *origClass = ext->getExtendedType()->getClassOrBoundGenericClass();
+  ClassDecl *origClass = ext->getAsClassOrClassExtensionContext();
   if (!origClass)
     return;
 

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -221,7 +221,7 @@ class IndexSwiftASTWalker : public SourceEntityWalker {
     if (SymInfo.Kind == SymbolKind::Unknown)
       return true;
     if (auto *ExtD = dyn_cast<ExtensionDecl>(D)) {
-      NominalTypeDecl *NTD = ExtD->getExtendedType()->getAnyNominal();
+      NominalTypeDecl *NTD = ExtD->getExtendedNominal();
       if (getNameAndUSR(NTD, ExtD, Name, USR))
         return true;
     } else {
@@ -667,7 +667,7 @@ bool IndexSwiftASTWalker::startEntityDecl(ValueDecl *D) {
         return false;
 
     } else if (auto ParentED = dyn_cast<ExtensionDecl>(Parent)) {
-      if (ParentED->getExtendedType()->getAnyNominal()) {
+      if (ParentED->getExtendedNominal()) {
         if (addRelation(Info, (SymbolRoleSet) SymbolRole::RelationChildOf, ParentED))
           return false;
       }
@@ -841,9 +841,7 @@ bool IndexSwiftASTWalker::reportExtension(ExtensionDecl *D) {
   //   extension A.B {}
   // we want the location of 'B' token.
   SourceLoc Loc = D->getExtendedTypeLoc().getSourceRange().End;
-  if (!D->getExtendedType())
-    return true;
-  NominalTypeDecl *NTD = D->getExtendedType()->getAnyNominal();
+  NominalTypeDecl *NTD = D->getExtendedNominal();
   if (!NTD)
     return true;
   if (!shouldIndex(NTD, /*IsRef=*/false))

--- a/lib/Index/IndexSymbol.cpp
+++ b/lib/Index/IndexSymbol.cpp
@@ -149,9 +149,7 @@ SymbolInfo index::getSymbolInfoForDecl(const Decl *D) {
     case DeclKind::Extension: {
       info.Kind = SymbolKind::Extension;
       auto *ED = cast<ExtensionDecl>(D);
-      if (!ED->getExtendedType())
-        break;
-      NominalTypeDecl *NTD = ED->getExtendedType()->getAnyNominal();
+      NominalTypeDecl *NTD = ED->getExtendedNominal();
       if (!NTD)
         break;
       if (isa<StructDecl>(NTD))

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -193,11 +193,7 @@ public:
     assert(members.begin() != members.end());
 
     const DeclContext *origDC = (*members.begin())->getDeclContext();
-    auto *baseClass = dyn_cast<ClassDecl>(origDC);
-    if (!baseClass) {
-      Type extendedTy = cast<ExtensionDecl>(origDC)->getExtendedType();
-      baseClass = extendedTy->getClassOrBoundGenericClass();
-    }
+    auto *baseClass = origDC->getAsClassOrClassExtensionContext();
 
     os << "@interface " << getNameForObjC(baseClass);
     maybePrintObjCGenericParameters(baseClass);
@@ -369,7 +365,7 @@ private:
     if (isEmptyExtensionDecl(ED))
       return;
 
-    auto baseClass = ED->getExtendedType()->getClassOrBoundGenericClass();
+    auto baseClass = ED->getAsClassOrClassExtensionContext();
 
     if (printAvailability(ED, PrintLeadingSpace::No))
       os << "\n";
@@ -2410,7 +2406,7 @@ public:
   bool writeExtension(const ExtensionDecl *ED) {
     bool allRequirementsSatisfied = true;
 
-    const ClassDecl *CD = ED->getExtendedType()->getClassOrBoundGenericClass();
+    const ClassDecl *CD = ED->getAsClassOrClassExtensionContext();
     allRequirementsSatisfied &= require(CD);
     for (auto proto : ED->getLocalProtocols())
       if (printer.shouldInclude(proto))
@@ -2772,7 +2768,7 @@ public:
         return !printer.shouldInclude(VD);
 
       if (auto ED = dyn_cast<ExtensionDecl>(D)) {
-        auto baseClass = ED->getExtendedType()->getClassOrBoundGenericClass();
+        auto baseClass = ED->getAsClassOrClassExtensionContext();
         return !baseClass || !printer.shouldInclude(baseClass) ||
                baseClass->isForeign();
       }
@@ -2796,7 +2792,7 @@ public:
           return VD->getBaseName().userFacingName();
 
         if (auto ED = dyn_cast<ExtensionDecl>(D)) {
-          auto baseClass = ED->getExtendedType()->getClassOrBoundGenericClass();
+          auto baseClass = ED->getAsClassOrClassExtensionContext();
           return baseClass->getName().str();
         }
         llvm_unreachable("unknown top-level ObjC decl");

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -192,34 +192,8 @@ static void printFullContext(const DeclContext *Context, raw_ostream &Buffer) {
   }
 
   case DeclContextKind::ExtensionDecl: {
-    Type Ty = cast<ExtensionDecl>(Context)->getExtendedType();
-    TypeBase *Base = Ty->getCanonicalType().getPointer();
-    const NominalTypeDecl *ExtNominal = nullptr;
-    switch (Base->getKind()) {
-      default:
-        llvm_unreachable("unhandled context kind in SILPrint!");
-      case TypeKind::Protocol:
-        ExtNominal = cast<ProtocolType>(Base)->getDecl();
-        break;
-      case TypeKind::Enum:
-        ExtNominal = cast<EnumType>(Base)->getDecl();
-        break;
-      case TypeKind::Struct:
-        ExtNominal = cast<StructType>(Base)->getDecl();
-        break;
-      case TypeKind::Class:
-        ExtNominal = cast<ClassType>(Base)->getDecl();
-        break;
-      case TypeKind::BoundGenericEnum:
-        ExtNominal = cast<BoundGenericEnumType>(Base)->getDecl();
-        break;
-      case TypeKind::BoundGenericStruct:
-        ExtNominal = cast<BoundGenericStructType>(Base)->getDecl();
-        break;
-      case TypeKind::BoundGenericClass:
-        ExtNominal = cast<BoundGenericClassType>(Base)->getDecl();
-        break;
-    }
+    const NominalTypeDecl *ExtNominal =
+      cast<ExtensionDecl>(Context)->getExtendedNominal();
     printFullContext(ExtNominal->getDeclContext(), Buffer);
     Buffer << ExtNominal->getName() << ".";
     return;

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -93,8 +93,8 @@ DeclName SILGenModule::getMagicFunctionName(DeclContext *dc) {
     return m->getName();
   }
   if (auto e = dyn_cast<ExtensionDecl>(dc)) {
-    assert(e->getExtendedType()->getAnyNominal() && "extension for nonnominal");
-    return e->getExtendedType()->getAnyNominal()->getName();
+    assert(e->getExtendedNominal() && "extension for nonnominal");
+    return e->getExtendedNominal()->getName();
   }
   llvm_unreachable("unexpected #function context");
 }

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -916,7 +916,7 @@ public:
     for (Decl *member : e->getMembers())
       visit(member);
 
-    if (!e->getExtendedType()->isExistentialType()) {
+    if (!isa<ProtocolDecl>(e->getExtendedNominal())) {
       // Emit witness tables for protocol conformances introduced by the
       // extension.
       for (auto *conformance : e->getLocalConformances(

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -814,7 +814,8 @@ Type TypeChecker::getUnopenedTypeOfReference(
 
   // Qualify storage declarations with an lvalue when appropriate.
   // Otherwise, they yield rvalues (and the access must be a load).
-  if (doesStorageProduceLValue(*this, value, baseType, UseDC, base)) {
+  if (doesStorageProduceLValue(*this, value, baseType, UseDC, base) &&
+      !requestedType->hasError()) {
     return LValueType::get(requestedType);
   }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4954,6 +4954,8 @@ void TypeChecker::validateExtension(ExtensionDecl *ext) {
   if (ext->hasValidationStarted())
     return;
 
+  bindExtension(ext);
+
   DeclValidationRAII IBV(ext);
 
   // If the extension is already known to be invalid, we're done.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3194,18 +3194,16 @@ public:
     }
 
     TC.checkInheritanceClause(ED);
-    if (auto extendedTy = ED->getExtendedType()) {
-      if (auto nominal = extendedTy->getAnyNominal()) {
-        TC.validateDecl(nominal);
-        if (auto *classDecl = dyn_cast<ClassDecl>(nominal))
-          TC.requestNominalLayout(classDecl);
+    if (auto nominal = ED->getExtendedNominal()) {
+      TC.validateDecl(nominal);
+      if (auto *classDecl = dyn_cast<ClassDecl>(nominal))
+        TC.requestNominalLayout(classDecl);
 
-        // Check the raw values of an enum, since we might synthesize
-        // RawRepresentable while checking conformances on this extension.
-        if (auto enumDecl = dyn_cast<EnumDecl>(nominal)) {
-          if (enumDecl->hasRawType())
-            checkEnumRawValues(TC, enumDecl);
-        }
+      // Check the raw values of an enum, since we might synthesize
+      // RawRepresentable while checking conformances on this extension.
+      if (auto enumDecl = dyn_cast<EnumDecl>(nominal)) {
+        if (enumDecl->hasRawType())
+          checkEnumRawValues(TC, enumDecl);
       }
     }
 

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -382,13 +382,14 @@ static bool checkObjCInExtensionContext(const ValueDecl *value,
     // parameters.
     // FIXME: This is a current limitation, not inherent. We don't have
     // a concrete class to attach Objective-C category metadata to.
-    if (auto generic = ED->getDeclaredInterfaceType()
-                           ->getGenericAncestor()) {
-      if (!generic->getClassOrBoundGenericClass()->hasClangNode()) {
-        if (diagnose) {
-          value->diagnose(diag::objc_in_generic_extension);
+    if (auto classDecl = ED->getAsClassOrClassExtensionContext()) {
+      if (auto generic = classDecl->getGenericAncestor()) {
+        if (!generic->usesObjCGenericsModel()) {
+          if (diagnose) {
+            value->diagnose(diag::objc_in_generic_extension);
+          }
+          return true;
         }
-        return true;
       }
     }
   }

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -81,15 +81,15 @@ Type swift::getMemberTypeForComparison(ASTContext &ctx, ValueDecl *member,
 
   auto memberType = member->getInterfaceType();
   if (derivedDecl) {
-    auto *dc = derivedDecl->getDeclContext();
-    auto owningType = dc->getDeclaredInterfaceType();
-    assert(owningType);
-
     if (!derivedDecl->hasInterfaceType()) {
       auto lazyResolver = ctx.getLazyResolver();
       assert(lazyResolver && "Need to resolve interface type");
       lazyResolver->resolveDeclSignature(derivedDecl);
     }
+
+    auto *dc = derivedDecl->getDeclContext();
+    auto owningType = dc->getDeclaredInterfaceType();
+    assert(owningType);
 
     memberType = owningType->adjustSuperclassMemberDeclType(member, derivedDecl,
                                                             memberType);
@@ -590,12 +590,7 @@ OverrideMatcher::OverrideMatcher(ValueDecl *decl)
     return;
 
   auto *dc = decl->getDeclContext();
-
-  auto owningTy = dc->getDeclaredInterfaceType();
-  if (!owningTy)
-    return;
-
-  auto classDecl = owningTy->getClassOrBoundGenericClass();
+  auto classDecl = dc->getAsClassOrClassExtensionContext();
   if (!classDecl)
     return;
 

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -118,7 +118,8 @@ Type CompleteGenericTypeResolver::resolveDependentMemberType(
     builder->resolveEquivalenceClass(
                                 baseTy,
                                 ArchetypeResolutionKind::CompleteWellFormed);
-  assert(baseEquivClass && "Unknown base type?");
+  if (!baseEquivClass)
+    return ErrorType::get(baseTy);
 
   // Look for a nested type with the given name.
   if (auto nestedType =

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1525,17 +1525,17 @@ checkIndividualConformance(NormalProtocolConformance *conformance,
     // @objc protocols in extensions of Swift generic classes, because there's
     // no stable Objective-C class object to install the protocol conformance
     // category onto.
-    if (isa<ExtensionDecl>(DC)) {
-      if (auto genericT = T->getGenericAncestor()) {
-        if (!cast<ClassDecl>(genericT->getAnyNominal())
-               ->usesObjCGenericsModel()) {
-          auto isSubclass = !genericT->isEqual(T);
-          auto genericTIsGeneric = (bool)genericT->getAnyGeneric()
-                                                 ->getGenericParams();
-          TC.diagnose(ComplainLoc, diag::objc_protocol_in_generic_extension, T,
-                      ProtoType, isSubclass, genericTIsGeneric);
-          conformance->setInvalid();
-          return conformance;
+    if (auto ext = dyn_cast<ExtensionDecl>(DC)) {
+      if (auto classDecl = ext->getAsClassOrClassExtensionContext()) {
+        if (auto genericClassDecl = classDecl->getGenericAncestor()) {
+          if (!genericClassDecl->usesObjCGenericsModel()) {
+            auto isSubclass = genericClassDecl != classDecl;
+            auto genericTIsGeneric = (bool)genericClassDecl->getGenericParams();
+            TC.diagnose(ComplainLoc, diag::objc_protocol_in_generic_extension,
+                        T, ProtoType, isSubclass, genericTIsGeneric);
+            conformance->setInvalid();
+            return conformance;
+          }
         }
       }
     }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4540,10 +4540,7 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
   Decl *currentDecl = nullptr;
   AccessLevel defaultAccess;
   if (auto ext = dyn_cast<ExtensionDecl>(dc)) {
-    Type extendedTy = ext->getExtendedType();
-    if (!extendedTy)
-      return;
-    const NominalTypeDecl *nominal = extendedTy->getAnyNominal();
+    const NominalTypeDecl *nominal = ext->getExtendedNominal();
     if (!nominal)
       return;
     defaultAccess = nominal->getFormalAccess();

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -541,8 +541,10 @@ static void typeCheckFunctionsAndExternalDecls(SourceFile &SF, TypeChecker &TC) 
         TC.checkFunctionErrorHandling(AFD);
         continue;
       }
-      if (isa<NominalTypeDecl>(decl))
+      if (auto nominal = dyn_cast<NominalTypeDecl>(decl)) {
+        (void)nominal->getAllConformances();
         continue;
+      }
       if (isa<VarDecl>(decl))
         continue;
       llvm_unreachable("Unhandled external definition kind");

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -284,7 +284,7 @@ static GenericParamList *cloneGenericParams(ASTContext &ctx,
 
 static void bindExtensionDecl(ExtensionDecl *ED, TypeChecker &TC) {
   if (ED->getExtendedType())
-    return;
+    return; 
 
   // If we didn't parse a type, fill in an error type and bail out.
   if (!ED->getExtendedTypeLoc().getTypeRepr()) {
@@ -396,24 +396,12 @@ static void bindExtensions(SourceFile &SF, TypeChecker &TC) {
   // Utility function to try and resolve the extended type without diagnosing.
   // If we succeed, we go ahead and bind the extension. Otherwise, return false.
   auto tryBindExtension = [&](ExtensionDecl *ext) -> bool {
-    auto *extendedTy = ext->getExtendedTypeLoc().getTypeRepr();
-    if (auto *identTy = dyn_cast_or_null<IdentTypeRepr>(extendedTy)) {
-      auto *dc = ext->getDeclContext();
-
-      GenericTypeToArchetypeResolver resolver(dc);
-
-      TypeResolutionOptions options;
-      options |= TypeResolutionFlags::AllowUnboundGenerics;
-      options |= TypeResolutionFlags::ExtensionBinding;
-      options |= TypeResolutionFlags::SilenceErrors;
-
-      auto type = TC.resolveIdentifierType(dc, identTy, options, &resolver);
-      if (type->is<ErrorType>())
-        return false;
+    if (ext->getExtendedNominal()) {
+      bindExtensionDecl(ext, TC);
+      return true;
     }
 
-    bindExtensionDecl(ext, TC);
-    return true;
+    return false;
   };
 
   // Phase 1 - try to bind each extension, adding those whose type cannot be

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1918,9 +1918,9 @@ void Serializer::writeCrossReference(const DeclContext *DC, uint32_t pathLen) {
 
   case DeclContextKind::ExtensionDecl: {
     auto ext = cast<ExtensionDecl>(DC);
-    Type baseTy = ext->getExtendedType();
-    assert(!baseTy->hasUnboundGenericType());
-    writeCrossReference(baseTy->getAnyNominal(), pathLen + 1);
+    auto nominal = ext->getExtendedNominal();
+    assert(nominal);
+    writeCrossReference(nominal, pathLen + 1);
 
     abbrCode = DeclTypeAbbrCodes[XRefExtensionPathPieceLayout::Code];
     CanGenericSignature genericSig(nullptr);
@@ -4894,9 +4894,7 @@ void Serializer::writeAST(ModuleOrSourceFile DC,
         topLevelDecls[VD->getBaseName()]
           .push_back({ getKindForTable(D), addDeclRef(D) });
       } else if (auto ED = dyn_cast<ExtensionDecl>(D)) {
-        Type extendedTy = ED->getExtendedType();
-        assert(!extendedTy->hasUnboundGenericType());
-        const NominalTypeDecl *extendedNominal = extendedTy->getAnyNominal();
+        const NominalTypeDecl *extendedNominal = ED->getExtendedNominal();
         extensionDecls[extendedNominal->getName()]
           .push_back({ extendedNominal, addDeclRef(D) });
       } else if (auto OD = dyn_cast<OperatorDecl>(D)) {

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -309,7 +309,7 @@ void TBDGenVisitor::visitDestructorDecl(DestructorDecl *DD) {
 }
 
 void TBDGenVisitor::visitExtensionDecl(ExtensionDecl *ED) {
-  if (!ED->getExtendedType()->isExistentialType()) {
+  if (!isa<ProtocolDecl>(ED->getExtendedNominal())) {
     addConformances(ED);
   }
 

--- a/test/Frontend/debug-generic-signatures.swift
+++ b/test/Frontend/debug-generic-signatures.swift
@@ -76,7 +76,7 @@ struct Generic<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Generic<T>
 // CHECK-NEXT: (normal_conformance type=Generic<T> protocol=P1
 // CHECK-NEXT:   (assoc_type req=A type=T)
-// CHECK-NEXT:   (value req=f() witness=main.(file).Generic.f()@{{.*}})
+// CHECK-NEXT:   (value req=f() witness=main.(file).Generic extension.f()@{{.*}})
 // CHECK-NEXT:   conforms_to: T P1)
 extension Generic: P1 where T: P1 {
     typealias A = T

--- a/test/NameBinding/scope_map_lookup.swift
+++ b/test/NameBinding/scope_map_lookup.swift
@@ -23,9 +23,9 @@ protocol P1 {
 }
 
 // Protocols involving associated types.
-protocol AProtocol {
+protocol AProtocol { // expected-error{{type 'Self.e' constrained to non-protocol, non-class type 'Self.e'}}
   associatedtype e : e
-  // expected-error@-1 {{use of undeclared type 'e'}}
+  // expected-error@-1 {{inheritance from non-protocol, non-class type 'Self.e'}}
 }
 
 // Extensions.

--- a/test/Sema/Inputs/availability_multi_other.swift
+++ b/test/Sema/Inputs/availability_multi_other.swift
@@ -66,8 +66,7 @@ class SubOtherIntroduced10_51 : OtherIntroduced10_51 {
 class OtherIntroduced10_52 : OtherIntroduced10_51 {
 }
 
-extension OtherIntroduced10_51 { // expected-error {{'OtherIntroduced10_51' is only available on OS X 10.51 or newer}}
-    // expected-note@-1 {{add @available attribute to enclosing extension}}
+extension OtherIntroduced10_51 {
 }
 
 extension OtherIntroduced10_9 {

--- a/test/Sema/diag_variable_used_in_initial.swift
+++ b/test/Sema/diag_variable_used_in_initial.swift
@@ -44,6 +44,7 @@ func localContext() {
     }
 
     extension E { // expected-error {{declaration is only valid at file scope}}
+      // expected-error@-1{{use of undeclared type 'E'}}
       class A7 {
         func foo1() {}
         func foo2() {

--- a/test/SourceKit/Indexing/rdar_21602898.swift.response
+++ b/test/SourceKit/Indexing/rdar_21602898.swift.response
@@ -25,6 +25,43 @@
       key.column: 7,
       key.entities: [
         {
+          key.kind: source.lang.swift.decl.extension.struct,
+          key.name: "Int",
+          key.usr: "s:e:s:Sis:13rdar_216028981PP",
+          key.line: 6,
+          key.column: 11,
+          key.related: [
+            {
+              key.kind: source.lang.swift.ref.protocol,
+              key.name: "P",
+              key.usr: "s:13rdar_216028981PP",
+              key.line: 6,
+              key.column: 16
+            }
+          ],
+          key.entities: [
+            {
+              key.kind: source.lang.swift.ref.struct,
+              key.name: "Int",
+              key.usr: "s:Si",
+              key.line: 6,
+              key.column: 11
+            },
+            {
+              key.kind: source.lang.swift.ref.protocol,
+              key.name: "P",
+              key.usr: "s:13rdar_216028981PP",
+              key.line: 6,
+              key.column: 16
+            }
+          ],
+          key.attributes: [
+            {
+              key.attribute: source.decl.attribute._fixed_layout
+            }
+          ]
+        },
+        {
           key.kind: source.lang.swift.decl.function.constructor,
           key.usr: "s:13rdar_216028981CCACycfc",
           key.line: 5,

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -17,6 +17,7 @@ extension extension_for_invalid_type_5 { // expected-error {{use of undeclared t
 }
 
 //===--- Test that we only allow extensions at file scope.
+struct Foo { }
 
 extension NestingTest1 { // expected-error {{use of undeclared type 'NestingTest1'}}
   extension Foo {} // expected-error {{declaration is only valid at file scope}}
@@ -120,6 +121,6 @@ extension C1.NestedStruct {
 }
 struct WrapperContext {
   extension C1.NestedStruct { // expected-error {{declaration is only valid at file scope}}
-    static let propUsingMember = originalValue // expected-error {{use of unresolved identifier 'originalValue'}}
+    static let propUsingMember = originalValue
   }
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -114,15 +114,13 @@ class AnnotatingPrinter : public StreamPrinter {
     const auto *ED = dyn_cast<ExtensionDecl>(D);
     if (!ED)
       return;
-    if (ED->getExtendedType()) {
-      if (auto NTD = ED->getExtendedType()->getAnyNominal()) {
-        if (auto *PD = dyn_cast<ProtocolDecl>(NTD)) {
-          auto Pair = AllDefaultMaps.insert({PD, DefaultImplementMap()});
-          DefaultMapToUse = &Pair.first->getSecond();
-          if (Pair.second) {
-            swift::collectDefaultImplementationForProtocolMembers(PD,
-                                                      Pair.first->getSecond());
-          }
+    if (auto NTD = ED->getExtendedNominal()) {
+      if (auto *PD = dyn_cast<ProtocolDecl>(NTD)) {
+        auto Pair = AllDefaultMaps.insert({PD, DefaultImplementMap()});
+        DefaultMapToUse = &Pair.first->getSecond();
+        if (Pair.second) {
+          swift::collectDefaultImplementationForProtocolMembers(PD,
+                                                    Pair.first->getSecond());
         }
       }
     }
@@ -374,8 +372,8 @@ static bool initDocEntityInfo(const Decl *D,
         assert(DocRef.find(Open) != StringRef::npos);
         auto FirstPart = DocRef.substr(0, DocRef.find(Open) + (Open).size());
         auto SecondPart = DocRef.substr(FirstPart.size());
-        auto ExtendedName = ((const ExtensionDecl*)D)->getExtendedType()->
-          getAnyNominal()->getName().str();
+        auto ExtendedName = ((const ExtensionDecl*)D)->getExtendedNominal()
+            ->getName().str();
         assert(SecondPart.startswith(ExtendedName));
         SecondPart = SecondPart.substr(ExtendedName.size());
         llvm::SmallString<128> UpdatedDocBuffer;

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -159,7 +159,7 @@ UIdent UIdentVisitor::visitParamDecl(const ParamDecl *D) {
 
 UIdent UIdentVisitor::visitExtensionDecl(const ExtensionDecl *D) {
   assert(!IsRef && "reference to an extension ?");
-  if (NominalTypeDecl *NTD = D->getExtendedType()->getAnyNominal()) {
+  if (NominalTypeDecl *NTD = D->getExtendedNominal()) {
     if (isa<StructDecl>(NTD))
       return KindDeclExtensionStruct;
     if (isa<ClassDecl>(NTD))

--- a/validation-test/compiler_crashers_2_fixed/0145-sr7097.swift
+++ b/validation-test/compiler_crashers_2_fixed/0145-sr7097.swift
@@ -25,7 +25,7 @@ protocol P5 {
 }
 
 extension P5 {
-  // CHECK-LABEL: P5.testSR7097
+  // CHECK-LABEL: P5 extension.testSR7097
   // CHECK-NEXT: Generic signature: <Self, M where Self : P5, M : P3>
   // CHECK-NEXT: <τ_0_0, τ_1_0 where τ_0_0 : P5, τ_1_0 : P3>
   func testSR7097<M>(_: S0<M>.Type) {}

--- a/validation-test/compiler_crashers_2_fixed/0145-sr7097.swift
+++ b/validation-test/compiler_crashers_2_fixed/0145-sr7097.swift
@@ -30,5 +30,3 @@ extension P5 {
   // CHECK-NEXT: <τ_0_0, τ_1_0 where τ_0_0 : P5, τ_1_0 : P3>
   func testSR7097<M>(_: S0<M>.Type) {}
 }
-
-


### PR DESCRIPTION
Introduce `ExtensionDecl::getExtendedNominal()` to provide the nominal
type declaration that the extension declaration extends. Move most
of the existing callers of the callers of `getExtendedType()` over to
`getExtendedNominal()`, because they don’t need the full type information.

Introduce a request to back `ExtensionDecl::getExtendedNominal()`, which 
uses the type-decl-resolution path that doesn't go through a `Type`. Use that
to reduce the dependence of the early "extension binding" pass (which associates
extension declarations with nominal types) on the type checker.