### PR TITLE
Change the ABI for the type descriptors of imported declarations

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -47,7 +47,6 @@
 #include "llvm/Support/Casting.h"
 
 namespace swift {
-
 template <unsigned PointerSize>
 struct RuntimeTarget;
 
@@ -3355,21 +3354,6 @@ public:
   }
 
   llvm::ArrayRef<GenericParamDescriptor> getGenericParams() const;
-
-  bool isSynthesizedRelatedEntity() const {
-    return getTypeContextDescriptorFlags().isSynthesizedRelatedEntity();
-  }
-
-  /// Return the tag used to discriminate declarations synthesized by the
-  /// Clang importer and give them stable identities.
-  StringRef getSynthesizedDeclRelatedEntityTag() const {
-    if (!isSynthesizedRelatedEntity())
-      return {};
-    // The tag name comes after the null terminator for the name.
-    const char *nameBegin = Name.get();
-    auto *nameEnd = nameBegin + strlen(nameBegin) + 1;
-    return nameEnd;
-  }
 
   /// Return the offset of the start of generic arguments in the nominal
   /// type's metadata. The returned value is measured in sizeof(void*).

--- a/include/swift/ABI/TypeIdentity.h
+++ b/include/swift/ABI/TypeIdentity.h
@@ -1,0 +1,218 @@
+//===--- TypeIdentity.h - Identity info about imported types -----*- C++ -*-==//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This header declares structures useful for working with the identity of
+// a type, especially for imported types.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_ABI_TYPEIDENTITY_H
+#define SWIFT_ABI_TYPEIDENTITY_H
+
+#include "swift/Basic/LLVM.h"
+
+namespace swift {
+template <class> class TargetTypeContextDescriptor;
+struct InProcess;
+using TypeContextDescriptor = TargetTypeContextDescriptor<InProcess>;
+
+/// The different components that can appear in a TypeImportInfo sequence.
+///
+/// The declaration order here is the canonical order for these components
+/// in the sequence; the sequence is ill-formed if they are out of order.
+///
+/// Note that the ABI name (or the ordinary formal name, which
+/// immediately precedes it), symbol namespace, and related entity
+/// name together form the identity of the TypeImportInfo.
+enum class TypeImportComponent : char {
+  ABIName = 'N',
+  SymbolNamespace = 'S',
+  RelatedEntityName = 'R',
+};
+
+namespace TypeImportSymbolNamespace {
+
+/// A value for `SymbolNamespace` which indicates that this type came
+/// from a C `typedef` that was imported as a distinct type instead
+/// of a `typealias`.  This can happen for reasons like:
+///
+/// - the `typedef` was declared with the `swift_wrapper` attribute
+/// - the `typedef` is a CF type
+constexpr static const char CTypedef[] = "t";
+
+}
+
+/// A class containing information from the type-import info.
+template <class StringType>
+class TypeImportInfo {
+public:
+  /// The ABI name of the declaration, if different from the user-facing
+  /// name.
+  StringType ABIName;
+
+  /// Set if the type doesn't come from the default symbol namespace for
+  /// its kind and source language.  (Source language can be determined
+  /// from the parent context.)
+  ///
+  /// Some languages (most importantly, C/C++/Objective-C) have different
+  /// symbol namespaces in which types can be declared; for example,
+  /// `struct A` and `typedef ... A` can be declared in the same scope and
+  /// resolve to unrelated types.  When these declarations are imported,
+  /// there are several possible ways to distinguish them in Swift, e.g.
+  /// by implicitly renaming them; however, the external name used for
+  /// mangling and metadata must be stable and so is based on the original
+  /// declared name.  Therefore, in these languages, we privilege one
+  /// symbol namespace as the default (although which may depend on the
+  /// type kind), and declarations from the other(s) must be marked in
+  /// order to differentiate them.
+  ///
+  /// C, C++, and Objective-C
+  /// -----------------------
+  ///
+  /// C, C++, and Objective-C have several different identifier namespaces
+  /// that can declare types: the ordinary namespace (`typedef`s and ObjC
+  /// `@interface`s), the tag namespace (`struct`s, `enum`s, `union`s, and
+  /// C++ `class`es), and the ObjC protocol namespace (ObjC `@protocol`s).
+  /// The languages all forbid multiple types from being declared in a given
+  /// scope and namespace --- at least, they do within a translation unit,
+  /// and for the most part we have to assume in Swift that that applies
+  /// across translation units as well.
+  //
+  /// Swift's default symbol-namespace rules for C/C++/ObjC are as follows:
+  /// - Protocols are assumed to come from the ObjC protocol namespace.
+  /// - Classes are assumed to come from the ordinary namespace (as an
+  ///   Objective-C class would).
+  /// - Structs and enums are assumed to come from the tag namespace
+  ///   (as a C `struct`, `union`, or `enum` would).
+  //;
+  /// Note that there are some special mangling rules for types imported
+  /// from C tag types in addition to the symbol-namespace rules.
+  StringType SymbolNamespace;
+
+  /// Set if the type is an importer-synthesized related entity.
+  /// A related entity is an entity synthesized in response to an imported
+  /// type which is not the type itself; for example, when the importer
+  /// sees an ObjC error domain, it creates an error-wrapper type (a
+  /// related entity) and a `Code` enum (not a related entity because it's
+  /// exactly the original type).
+  ///
+  /// The name and import namespace (together with the parent context)
+  /// identify the original declaration.
+  StringType RelatedEntityName;
+
+  /// Attempt to collect information from the given info chunk.
+  ///
+  /// \return true if collection was successful.
+  template <bool Asserting>
+  bool collect(StringRef value) {
+#define check(CONDITION, COMMENT)            \
+    do {                                     \
+      if (!Asserting) {                      \
+        if (!(CONDITION)) return false;      \
+      } else {                               \
+        assert((CONDITION) && COMMENT);      \
+      }                                      \
+    } while (false)
+
+    check(!value.empty(), "string was empty on entrance");
+    auto component = TypeImportComponent(value[0]);
+    value = value.drop_front(1);
+
+    switch (component) {
+#define case_setIfNonEmpty(FIELD)                                      \
+    case TypeImportComponent::FIELD:                                   \
+      check(!value.empty(), "incoming value of " #FIELD " was empty"); \
+      check(FIELD.empty(), #FIELD " was already set");                 \
+      FIELD = value;                                                   \
+      return true;                                                     \
+
+    case_setIfNonEmpty(ABIName)
+    case_setIfNonEmpty(SymbolNamespace)
+    case_setIfNonEmpty(RelatedEntityName)
+
+#undef case_setIfNonEmpty
+#undef check
+    }
+
+    // Even with Asserting=true (i.e. in the runtime), we do want to be
+    // future-proof against new components.
+    return false;
+  }
+
+  /// Append all the information in this structure to the given buffer,
+  /// including all necessary internal and trailing '\0' characters.
+  /// The buffer is assumed to already contain the '\0'-terminated
+  /// user-facing name of the type.
+  template <class BufferTy>
+  void appendTo(BufferTy &buffer) const {
+#define append(FIELD)                               \
+    do {                                            \
+      if (!FIELD.empty()) {                         \
+        buffer += char(TypeImportComponent::FIELD); \
+        buffer += FIELD;                            \
+        buffer += '\0';                             \
+      }                                             \
+    } while (false)
+
+    append(ABIName);
+    append(SymbolNamespace);
+    append(RelatedEntityName);
+    buffer += '\0';
+
+#undef append
+  }
+};
+
+/// Parsed information about the identity of a type.
+class ParsedTypeIdentity {
+public:
+  /// The user-facing name of the type.
+  StringRef UserFacingName;
+
+  /// The full identity of the type.
+  /// Note that this may include interior '\0' characters.
+  StringRef FullIdentity;
+
+  /// Any extended information that type might have.
+  Optional<TypeImportInfo<StringRef>> ImportInfo;
+
+  /// The ABI name of the type.
+  StringRef getABIName() const {
+    if (ImportInfo && !ImportInfo->ABIName.empty())
+      return ImportInfo->ABIName;
+    return UserFacingName;
+  }
+
+  bool isCTypedef() const {
+    return ImportInfo &&
+           ImportInfo->SymbolNamespace == TypeImportSymbolNamespace::CTypedef;
+  }
+
+  bool isAnyRelatedEntity() const {
+    return ImportInfo && !ImportInfo->RelatedEntityName.empty();
+  }
+
+  bool isRelatedEntity(StringRef entityName) const {
+    return ImportInfo && ImportInfo->RelatedEntityName == entityName;
+  }
+
+  StringRef getRelatedEntityName() const {
+    assert(isAnyRelatedEntity());
+    return ImportInfo->RelatedEntityName;
+  }
+
+  static ParsedTypeIdentity parse(const TypeContextDescriptor *type);
+};
+
+} // end namespace swift
+
+#endif  /* SWIFT_ABI_TYPEIDENTITY_H */

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -20,6 +20,7 @@
 #include "swift/Basic/Lazy.h"
 #include "swift/Basic/Range.h"
 #include "swift/Demangling/Demangler.h"
+#include "swift/ABI/TypeIdentity.h"
 #include "swift/Runtime/Casting.h"
 #include "swift/Runtime/ExistentialContainer.h"
 #include "swift/Runtime/HeapObject.h"
@@ -1646,18 +1647,7 @@ namespace {
     StringRef Name;
   public:
     explicit TypeContextIdentity(const TypeContextDescriptor *type) {
-      // Use the name of the type context.
-      Name = type->Name.get();
-
-      // If this is a synthesized entity, include the related entity tag.
-      if (type->isSynthesizedRelatedEntity()) {
-        auto tag = type->getSynthesizedDeclRelatedEntityTag();
-        assert(Name.end() + 1 == tag.begin());
-
-        // The length computation needs to include the \0 at the
-        // end of the name.
-        Name = StringRef(Name.begin(), Name.size() + tag.size() + 1);
-      }
+      Name = ParsedTypeIdentity::parse(type).FullIdentity;
     }
 
     bool operator==(const TypeContextIdentity &other) const {

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -28,6 +28,7 @@
 #endif
 
 namespace swift {
+class ParsedTypeIdentity;
 
 class TypeReferenceOwnership {
   enum : uint8_t {
@@ -315,7 +316,8 @@ public:
   };
 
   /// Is the given type imported from a C tag type?
-  bool isCImportedTagType(const TypeContextDescriptor *type);
+  bool _isCImportedTagType(const TypeContextDescriptor *type,
+                           const ParsedTypeIdentity &identity);
 
   /// Check whether a type conforms to a protocol.
   ///

--- a/test/IRGen/Inputs/error_domains.h
+++ b/test/IRGen/Inputs/error_domains.h
@@ -1,0 +1,25 @@
+#define MY_ERROR_ENUM(_type, _name, _domain)                                   \
+  enum _name : _type _name;                                                    \
+  enum __attribute__((ns_error_domain(_domain))) _name : _type
+
+@class NSString;
+
+extern NSString * const TagDomain1;
+typedef MY_ERROR_ENUM(int, TagError1, TagDomain1) {
+  Badness
+};
+
+extern NSString * const TagDomain2;
+typedef MY_ERROR_ENUM(int, TagError2, TagDomain2) {
+  Sickness
+};
+
+extern NSString * const TypedefDomain1;
+typedef enum __attribute__((ns_error_domain(TypedefDomain1))) {
+  Wrongness
+} TypedefError1;
+
+extern NSString *TypedefDomain2;
+typedef enum __attribute__((ns_error_domain(TypedefDomain2))) {
+  Illness
+} TypedefError2;

--- a/test/IRGen/Inputs/usr/include/module.map
+++ b/test/IRGen/Inputs/usr/include/module.map
@@ -26,3 +26,7 @@ module CoreFoundation {
 module ObjCInterop {
   header "ObjCInterop.h"
 }
+
+module error_domains {
+  header "error_domains.h"
+}

--- a/test/IRGen/cf.sil
+++ b/test/IRGen/cf.sil
@@ -11,11 +11,11 @@
 
 // CHECK: @"$SSo17CCRefrigeratorRefaN" = linkonce_odr hidden constant <{ {{.*}} }> <{ i8** @"$SBOWV", [[INT]] 16, {{.*}}"$SSo17CCRefrigeratorRefaMn", [[TYPE]]* null, i8* null }>
 
-// CHECK: [[MUTABLE_REFRIGERATOR_NAME:@.*]] = private constant [25 x i8] c"CCMutableRefrigeratorRef\00"
+// CHECK: [[MUTABLE_REFRIGERATOR_NAME:@.*]] = private constant [52 x i8] c"CCMutableRefrigerator\00NCCMutableRefrigeratorRef\00St\00\00"
 
 // CHECK-64: @"$SSo24CCMutableRefrigeratorRefaMn" = linkonce_odr hidden constant
-// -- is imported C typedef, foreign init, reflectable, is class, is nonunique
-// CHECK-64-SAME: <i32 0x0015_0010>
+// -- is imported, foreign init, reflectable, is class, is nonunique
+// CHECK-64-SAME: <i32 0x000d_0010>
 // CHECK-64-SAME: [[MUTABLE_REFRIGERATOR_NAME]]
 // CHECK-64-SAME: @"$SSo24CCMutableRefrigeratorRefaMa"
 // CHECK-64-SAME: @"$SSo24CCMutableRefrigeratorRefaMr"

--- a/test/IRGen/related_entity.sil
+++ b/test/IRGen/related_entity.sil
@@ -1,0 +1,50 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/chex.py < %s > %t/checkfile
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-ir -o - -primary-file %s -import-objc-header %S/Inputs/error_domains.h | %FileCheck %t/checkfile --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
+
+sil_stage canonical
+
+import Swift
+import Foundation
+
+sil public_external @take_metatype : $@convention(thin) <T> (@thick T.Type) -> ()
+
+sil @use_metatypes : $@convention(thin) () -> () {
+bb0:
+  %take = function_ref @take_metatype : $@convention(thin) <T> (@thick T.Type) -> ()
+
+// CHECK:         [[TagError1_NAME:@[0-9]+]] = private constant [14 x i8] c"TagError1\00Re\00\00"
+// CHECK:         @"$SSC9TagError1LeVMn" = linkonce_odr hidden constant
+// CHECK-SAME:    <i32 0x000d_0011>
+// CHECK-SAME:    @"$SSCMXM"
+// CHECK-SAME:    [14 x i8]* [[TagError1_NAME]]
+  %0 = metatype $@thick TagError1.Type
+  apply %take<TagError1>(%0) : $@convention(thin) <T> (@thick T.Type) -> ()
+
+// CHECK:         [[TagError2_NAME:@[0-9]+]] = private constant [17 x i8] c"Code\00NTagError2\00\00"
+// CHECK:         @"$SSo9TagError2VMn" = linkonce_odr hidden constant
+// CHECK-SAME:    <i32 0x000c_0012>
+// CHECK-SAME:    @"$SSoMXM"
+// CHECK-SAME:    [17 x i8]* [[TagError2_NAME]]
+  %1 = metatype $@thick TagError2.Code.Type
+  apply %take<TagError2.Code>(%1) : $@convention(thin) <T> (@thick T.Type) -> ()
+
+// CHECK:         [[TypedefError1_NAME:@[0-9]+]] = private constant [18 x i8] c"TypedefError1\00RE\00\00"
+// CHECK:         @"$SSC13TypedefError1LEVMn" = linkonce_odr hidden constant
+// CHECK-SAME:    <i32 0x000d_0011>
+// CHECK-SAME:    @"$SSCMXM"
+// CHECK-SAME:    [18 x i8]* [[TypedefError1_NAME]]
+  %2 = metatype $@thick TypedefError1.Type
+  apply %take<TypedefError1>(%2) : $@convention(thin) <T> (@thick T.Type) -> ()
+
+// CHECK:         [[TypedefError2Code_NAME:@[0-9]+]] = private constant [24 x i8] c"Code\00NTypedefError2\00St\00\00"
+// CHECK:         @"$SSo13TypedefError2aMn" = linkonce_odr hidden constant
+// CHECK-SAME:    <i32 0x000c_0012>
+// CHECK-SAME:    @"$SSoMXM"
+// CHECK-SAME:    [24 x i8]* [[TypedefError2Code_NAME]]
+  %3 = metatype $@thick TypedefError2.Code.Type
+  apply %take<TypedefError2.Code>(%3) : $@convention(thin) <T> (@thick T.Type) -> ()
+
+  %ret = tuple ()
+  return %ret : $()
+}


### PR DESCRIPTION
- Instead of keeping multiple flags in the type descriptor flags, just keep a single flag indicating the presence of additional import information after the name.

- That import information consists of a sequence of null-terminated C strings, terminated by an empty string (i.e. by a double null terminator), each prefixed with a character describing its purpose.

- In addition to the symbol namespace and related entity name, include the ABI name if it differs from the user-facing name of the type, and make the name the user-facing Swift name.

There's a remaining issue here that isn't great: we don't correctly represent the parent relationship between error types and their codes, and instead we just use the Clang module as the parent.  But I'll leave that for a later commit.