### PR TITLE
Clean up code around VarDecl::setType()

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4463,7 +4463,7 @@ protected:
   llvm::PointerUnion<PatternBindingDecl*, Stmt*> ParentPattern;
 
   VarDecl(DeclKind Kind, bool IsStatic, Specifier Sp, bool IsCaptureList,
-          SourceLoc NameLoc, Identifier Name, Type Ty, DeclContext *DC)
+          SourceLoc NameLoc, Identifier Name, DeclContext *DC)
     : AbstractStorageDecl(Kind, DC, Name, NameLoc, !isImmutableSpecifier(Sp))
   {
     Bits.VarDecl.IsStatic = IsStatic;
@@ -4472,7 +4472,6 @@ protected:
     Bits.VarDecl.IsDebuggerVar = false;
     Bits.VarDecl.IsREPLVar = false;
     Bits.VarDecl.HasNonPatternBindingInit = false;
-    setType(Ty);
   }
 
   /// This is the type specified, including location information.
@@ -4482,9 +4481,8 @@ protected:
 
 public:
   VarDecl(bool IsStatic, Specifier Sp, bool IsCaptureList, SourceLoc NameLoc,
-          Identifier Name, Type Ty, DeclContext *DC)
-    : VarDecl(DeclKind::Var, IsStatic, Sp, IsCaptureList, NameLoc, Name, Ty,
-              DC) {}
+          Identifier Name, DeclContext *DC)
+    : VarDecl(DeclKind::Var, IsStatic, Sp, IsCaptureList, NameLoc, Name, DC) {}
 
   SourceRange getSourceRange() const;
 
@@ -4712,7 +4710,7 @@ public:
   ParamDecl(VarDecl::Specifier specifier,
             SourceLoc specifierLoc, SourceLoc argumentNameLoc,
             Identifier argumentName, SourceLoc parameterNameLoc,
-            Identifier parameterName, Type ty, DeclContext *dc);
+            Identifier parameterName, DeclContext *dc);
 
   /// Clone constructor, allocates a new ParamDecl identical to the first.
   /// Intentionally not defined as a typical copy constructor to avoid

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3585,7 +3585,9 @@ Type AnyFunctionType::composeInput(ASTContext &ctx, ArrayRef<Param> params,
   for (const auto &param : params) {
     Type eltType = param.getPlainType();
     if (param.isVariadic()) {
-      if (canonicalVararg)
+      if (!ctx.getArrayDecl())
+        eltType = ErrorType::get(ctx);
+      else if (canonicalVararg)
         eltType = BoundGenericType::get(ctx.getArrayDecl(), Type(), {eltType});
       else
         eltType = ArraySliceType::get(eltType);

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -155,7 +155,7 @@ getBuiltinFunction(Identifier Id, ArrayRef<Type> argTypes, Type ResType,
   for (Type argType : argTypes) {
     auto PD = new (Context)
         ParamDecl(VarDecl::Specifier::Default, SourceLoc(), SourceLoc(),
-                  Identifier(), SourceLoc(), Identifier(), argType, DC);
+                  Identifier(), SourceLoc(), Identifier(), DC);
     PD->setInterfaceType(argType);
     PD->setValidationToChecked();
     PD->setImplicit();
@@ -203,8 +203,7 @@ getBuiltinGenericFunction(Identifier Id,
     auto PD = new (Context) ParamDecl(specifier,
                                       SourceLoc(), SourceLoc(),
                                       Identifier(), SourceLoc(),
-                                      Identifier(),
-                                      Type(), DC);
+                                      Identifier(), DC);
     PD->setInterfaceType(paramIfaceType);
     PD->setValidationToChecked();
     PD->setImplicit();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4696,9 +4696,9 @@ void VarDecl::emitLetToVarNoteIfSimple(DeclContext *UseDC) const {
 ParamDecl::ParamDecl(Specifier specifier,
                      SourceLoc specifierLoc, SourceLoc argumentNameLoc,
                      Identifier argumentName, SourceLoc parameterNameLoc,
-                     Identifier parameterName, Type ty, DeclContext *dc)
+                     Identifier parameterName, DeclContext *dc)
   : VarDecl(DeclKind::Param, /*IsStatic*/false, specifier,
-            /*IsCaptureList*/false, parameterNameLoc, parameterName, ty, dc),
+            /*IsCaptureList*/false, parameterNameLoc, parameterName, dc),
   ArgumentName(argumentName), ArgumentNameLoc(argumentNameLoc),
   SpecifierLoc(specifierLoc) {
 
@@ -4714,9 +4714,6 @@ ParamDecl::ParamDecl(Specifier specifier,
 ParamDecl::ParamDecl(ParamDecl *PD, bool withTypes)
   : VarDecl(DeclKind::Param, /*IsStatic*/false, PD->getSpecifier(),
             /*IsCaptureList*/false, PD->getNameLoc(), PD->getName(),
-            PD->hasType() && withTypes
-              ? PD->getType()
-              : Type(),
             PD->getDeclContext()),
     ArgumentName(PD->getArgumentName()),
     ArgumentNameLoc(PD->getArgumentNameLoc()),
@@ -4759,7 +4756,6 @@ Type DeclContext::getSelfInterfaceType() const {
 }
 
 /// Create an implicit 'self' decl for a method in the specified decl context.
-/// If 'static' is true, then this is self for a static method in the type.
 ///
 /// Note that this decl is created, but it is returned with an incorrect
 /// DeclContext that needs to be set correctly.  This is automatically handled
@@ -4771,7 +4767,7 @@ ParamDecl *ParamDecl::createUnboundSelf(SourceLoc loc, DeclContext *DC) {
   ASTContext &C = DC->getASTContext();
   auto *selfDecl =
       new (C) ParamDecl(VarDecl::Specifier::Default, SourceLoc(), SourceLoc(),
-                        Identifier(), loc, C.Id_self, Type(), DC);
+                        Identifier(), loc, C.Id_self, DC);
   selfDecl->setImplicit();
   return selfDecl;
 }
@@ -4801,7 +4797,7 @@ ParamDecl *ParamDecl::createSelf(SourceLoc loc, DeclContext *DC,
   }
 
   auto *selfDecl = new (C) ParamDecl(specifier, SourceLoc(),SourceLoc(),
-                                     Identifier(), loc, C.Id_self, Type(), DC);
+                                     Identifier(), loc, C.Id_self, DC);
   selfDecl->setImplicit();
   selfDecl->setInterfaceType(selfInterfaceType);
   selfDecl->setValidationToChecked();

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1697,7 +1697,6 @@ ParameterList *ClangImporter::Implementation::importFunctionParameterList(
         param, AccessLevel::Private,
         VarDecl::Specifier::Default, SourceLoc(), SourceLoc(), name,
         importSourceLoc(param->getLocation()), bodyName,
-        dc->mapTypeIntoContext(swiftParamTy),
         ImportedHeaderUnit);
 
     paramInfo->setInterfaceType(swiftParamTy);
@@ -1716,7 +1715,7 @@ ParameterList *ClangImporter::Implementation::importFunctionParameterList(
     auto param = new (SwiftContext) ParamDecl(VarDecl::Specifier::Default,
                                               SourceLoc(), SourceLoc(),
                                               Identifier(), SourceLoc(),
-                                              name, paramTy,
+                                              name,
                                               ImportedHeaderUnit);
     param->setInterfaceType(paramTy);
 
@@ -2018,7 +2017,7 @@ ImportedType ClangImporter::Implementation::importMethodType(
     auto type = TupleType::getEmpty(SwiftContext);
     auto var = new (SwiftContext) ParamDecl(VarDecl::Specifier::Default, SourceLoc(),
                                             SourceLoc(), argName,
-                                            SourceLoc(), argName, type,
+                                            SourceLoc(), argName,
                                             ImportedHeaderUnit);
     var->setInterfaceType(type);
     swiftParams.push_back(var);
@@ -2143,7 +2142,6 @@ ImportedType ClangImporter::Implementation::importMethodType(
                                            SourceLoc(), SourceLoc(), name,
                                            importSourceLoc(param->getLocation()),
                                            bodyName,
-                                           swiftParamTy,
                                            ImportedHeaderUnit);
     paramInfo->setInterfaceType(swiftParamTy->mapTypeOutOfContext());
     recordImplicitUnwrapForDecl(paramInfo, paramIsIUO);
@@ -2263,7 +2261,6 @@ ImportedType ClangImporter::Implementation::importAccessorMethodType(
                                            /*let loc*/SourceLoc(),
                                            /*label loc*/SourceLoc(),
                                            argLabel, nameLoc, bodyName,
-                                           propertyTy,
                                            /*dummy DC*/ImportedHeaderUnit);
     paramInfo->setInterfaceType(propertyTy->mapTypeOutOfContext());
 

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -1304,7 +1304,7 @@ void LoadableStorageAllocation::insertIndirectReturnArgs() {
       VarDecl::Specifier::InOut, SourceLoc(), SourceLoc(),
       ctx.getIdentifier("$return_value"), SourceLoc(),
       ctx.getIdentifier("$return_value"),
-      resultStorageType.getASTType(), pass.F->getDeclContext());
+      pass.F->getDeclContext());
   pass.F->begin()->insertFunctionArgument(0, resultStorageType.getAddressType(),
                                           ValueOwnershipKind::Trivial, var);
 }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3740,7 +3740,6 @@ static AccessorDecl *createAccessorFunc(SourceLoc DeclLoc,
                                      storageParam->getArgumentName(),
                                      storageParam->getNameLoc(),
                                      storageParam->getName(),
-                                     Type(),
                                      P->CurDeclContext);
         accessorParam->setVariadic(storageParam->isVariadic());
 
@@ -3825,7 +3824,7 @@ static ParamDecl *createSetterAccessorArgument(SourceLoc nameLoc,
 
   auto result = new (P.Context)
       ParamDecl(VarDecl::Specifier::Default, SourceLoc(), SourceLoc(),
-                Identifier(), nameLoc, name, Type(), P.CurDeclContext);
+                Identifier(), nameLoc, name, P.CurDeclContext);
   if (isNameImplicit)
     result->setImplicit();
 
@@ -4457,7 +4456,7 @@ VarDecl *Parser::parseDeclVarGetSet(Pattern *pattern,
     storage = new (Context) VarDecl(StaticLoc.isValid(),
                                     VarDecl::Specifier::Var,
                                     /*is capture list*/ false,
-                                    VarLoc, Identifier(), Type(),
+                                    VarLoc, Identifier(),
                                     CurDeclContext);
     storage->setImplicit(true);
     storage->setInvalid(true);

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2470,7 +2470,7 @@ parseClosureSignatureIfPresent(SmallVectorImpl<CaptureListEntry> &captureList,
       auto *VD = new (Context) VarDecl(/*isStatic*/false,
                                        specifierKind,
                                        /*isCaptureList*/true,
-                                       nameLoc, name, Type(), CurDeclContext);
+                                       nameLoc, name, CurDeclContext);
 
       // Attributes.
       if (ownershipKind != ReferenceOwnership::Strong)
@@ -2524,7 +2524,7 @@ parseClosureSignatureIfPresent(SmallVectorImpl<CaptureListEntry> &captureList,
             Context.getIdentifier(Tok.getText()) : Identifier();
         auto var = new (Context)
             ParamDecl(VarDecl::Specifier::Default, SourceLoc(), SourceLoc(),
-                      Identifier(), Tok.getLoc(), name, Type(), nullptr);
+                      Identifier(), Tok.getLoc(), name, nullptr);
         elements.push_back(var);
         consumeToken();
 
@@ -2826,7 +2826,7 @@ Expr *Parser::parseExprAnonClosureArg() {
     SourceLoc varLoc = leftBraceLoc;
     auto *var = new (Context)
         ParamDecl(VarDecl::Specifier::Default, SourceLoc(), SourceLoc(),
-                  Identifier(), varLoc, ident, Type(), closure);
+                  Identifier(), varLoc, ident, closure);
     var->setImplicit();
     decls.push_back(var);
   }

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -426,7 +426,7 @@ mapParsedParameters(Parser &parser,
     auto param = new (ctx) ParamDecl(VarDecl::Specifier::Default,
                                      paramInfo.SpecifierLoc,
                                      argNameLoc, argName,
-                                     paramNameLoc, paramName, Type(),
+                                     paramNameLoc, paramName,
                                      parser.CurDeclContext);
     param->getAttrs() = paramInfo.Attrs;
     bool parsingEnumElt
@@ -967,7 +967,7 @@ ParserResult<Pattern> Parser::parsePattern() {
 Pattern *Parser::createBindingFromPattern(SourceLoc loc, Identifier name,
                                           VarDecl::Specifier specifier) {
   auto var = new (Context) VarDecl(/*IsStatic*/false, specifier,
-                                   /*IsCaptureList*/false, loc, name, Type(),
+                                   /*IsCaptureList*/false, loc, name,
                                    CurDeclContext);
   return new (Context) NamedPattern(var);
 }

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1038,7 +1038,7 @@ static void parseGuardedPattern(Parser &P, GuardedPattern &result,
     auto var = new (P.Context) VarDecl(/*IsStatic*/false,
                                        VarDecl::Specifier::Let,
                                        /*IsCaptureList*/false, loc, errorName,
-                                       Type(), P.CurDeclContext);
+                                       P.CurDeclContext);
     var->setImplicit();
     auto namePattern = new (P.Context) NamedPattern(var);
     auto varPattern = new (P.Context) VarPattern(loc, /*isLet*/true,

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -41,7 +41,7 @@ static SILValue emitConstructorMetatypeArg(SILGenFunction &SGF,
   auto VD =
       new (AC) ParamDecl(VarDecl::Specifier::Default, SourceLoc(), SourceLoc(),
                          AC.getIdentifier("$metatype"), SourceLoc(),
-                         AC.getIdentifier("$metatype"), Type(), DC);
+                         AC.getIdentifier("$metatype"), DC);
   VD->setInterfaceType(metatype);
 
   SGF.AllocatorMetatype = SGF.F.begin()->createFunctionArgument(
@@ -68,7 +68,7 @@ static RValue emitImplicitValueConstructorArg(SILGenFunction &SGF,
   auto VD = new (AC) ParamDecl(VarDecl::Specifier::Default, SourceLoc(), SourceLoc(),
                                AC.getIdentifier("$implicit_value"),
                                SourceLoc(),
-                               AC.getIdentifier("$implicit_value"), Type(),
+                               AC.getIdentifier("$implicit_value"),
                                DC);
   VD->setInterfaceType(interfaceType);
   SILFunctionArgument *arg =
@@ -101,7 +101,7 @@ static void emitImplicitValueConstructor(SILGenFunction &SGF,
                                  SourceLoc(), SourceLoc(),
                                  AC.getIdentifier("$return_value"),
                                  SourceLoc(),
-                                 AC.getIdentifier("$return_value"), Type(),
+                                 AC.getIdentifier("$return_value"),
                                  ctor);
     VD->setInterfaceType(selfIfaceTyCan);
     resultSlot = SGF.F.begin()->createFunctionArgument(selfTy, VD);
@@ -400,7 +400,7 @@ void SILGenFunction::emitEnumConstructor(EnumElementDecl *element) {
                                  SourceLoc(), SourceLoc(),
                                  AC.getIdentifier("$return_value"),
                                  SourceLoc(),
-                                 AC.getIdentifier("$return_value"), Type(),
+                                 AC.getIdentifier("$return_value"),
                                  element->getDeclContext());
     VD->setInterfaceType(enumIfaceTy);
     auto resultSlot =

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -481,7 +481,7 @@ static void emitIndirectResultParameters(SILGenFunction &SGF, Type resultType,
   auto var = new (ctx) ParamDecl(VarDecl::Specifier::InOut,
                                  SourceLoc(), SourceLoc(),
                                  ctx.getIdentifier("$return_value"), SourceLoc(),
-                                 ctx.getIdentifier("$return_value"), Type(),
+                                 ctx.getIdentifier("$return_value"),
                                  DC);
   var->setInterfaceType(resultType);
 

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -463,7 +463,7 @@ unsigned OpaqueStorageAllocation::insertIndirectReturnArgs() {
         ParamDecl(VarDecl::Specifier::InOut, SourceLoc(), SourceLoc(),
                   ctx.getIdentifier("$return_value"), SourceLoc(),
                   ctx.getIdentifier("$return_value"),
-                  bodyResultTy.getASTType(), pass.F->getDeclContext());
+                  pass.F->getDeclContext());
 
     pass.F->begin()->insertFunctionArgument(argIdx,
                                             bodyResultTy.getAddressType(),

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -78,33 +78,16 @@ static VarDecl *getFirstParamDecl(FuncDecl *fn) {
 
 static ParamDecl *buildArgument(SourceLoc loc, DeclContext *DC,
                                 StringRef name,
-                                Type type,
                                 Type interfaceType,
                                 VarDecl::Specifier specifier) {
   auto &context = DC->getASTContext();
   auto *param = new (context) ParamDecl(specifier, SourceLoc(), SourceLoc(),
                                         Identifier(), loc,
                                         context.getIdentifier(name),
-                                        type, DC);
+                                        DC);
   param->setImplicit();
   param->setInterfaceType(interfaceType);
   return param;
-}
-
-static Type getTypeOfStorage(AbstractStorageDecl *storage,
-                             bool wantInterfaceType) {
-  if (auto var = dyn_cast<VarDecl>(storage)) {
-    auto type = (wantInterfaceType
-                 ? var->getInterfaceType()
-                 : var->getType());
-    return type->getReferenceStorageReferent();
-  }
-
-  auto subscript = cast<SubscriptDecl>(storage);
-  auto type = subscript->getElementInterfaceType();
-  if (!wantInterfaceType)
-    type = storage->getDeclContext()->mapTypeIntoContext(type);
-  return type;
 }
 
 /// Build a parameter list which can forward the formal index parameters of a
@@ -182,7 +165,7 @@ static AccessorDecl *createGetterPrototype(TypeChecker &TC,
       staticLoc = var->getLoc();
   }
 
-  auto storageInterfaceType = getTypeOfStorage(storage, true);
+  auto storageInterfaceType = storage->getValueInterfaceType();
 
   auto getter = AccessorDecl::create(
       TC.Context, loc, /*AccessorKeywordLoc*/ loc,
@@ -240,10 +223,9 @@ static AccessorDecl *createSetterPrototype(TypeChecker &TC,
   }
   
   // Add a "(value : T, indices...)" argument list.
-  auto storageType = getTypeOfStorage(storage, false);
-  auto storageInterfaceType = getTypeOfStorage(storage, true);
+  auto storageInterfaceType = storage->getValueInterfaceType();
   auto valueDecl = buildArgument(storage->getLoc(), storage->getDeclContext(),
-                                 "value", storageType, storageInterfaceType,
+                                 "value", storageInterfaceType,
                                  VarDecl::Specifier::Default);
   auto *params = buildIndexForwardingParamList(storage, valueDecl);
 
@@ -356,9 +338,9 @@ createMaterializeForSetPrototype(AbstractStorageDecl *storage,
   //                           indices...).
   ParamDecl *bufferElements[] = {
       buildArgument(loc, DC, "buffer", ctx.TheRawPointerType,
-                    ctx.TheRawPointerType, VarDecl::Specifier::Default),
+                    VarDecl::Specifier::Default),
       buildArgument(loc, DC, "callbackStorage", ctx.TheUnsafeValueBufferType,
-                    ctx.TheUnsafeValueBufferType, VarDecl::Specifier::InOut)};
+                    VarDecl::Specifier::InOut)};
   auto *params = buildIndexForwardingParamList(storage, bufferElements);
 
   // The accessor returns (temporary: Builtin.RawPointer,
@@ -1093,7 +1075,7 @@ static void synthesizeObservedSetterBody(TypeChecker &TC, AccessorDecl *Set,
 
     OldValue = new (Ctx) VarDecl(/*IsStatic*/false, VarDecl::Specifier::Let,
                                  /*IsCaptureList*/false, SourceLoc(),
-                                 Ctx.getIdentifier("tmp"), Type(), Set);
+                                 Ctx.getIdentifier("tmp"), Set);
     OldValue->setImplicit();
     auto *tmpPattern = new (Ctx) NamedPattern(OldValue, /*implicit*/ true);
     auto *tmpPBD = PatternBindingDecl::createImplicit(
@@ -1217,7 +1199,7 @@ static void synthesizeLazyGetterBody(TypeChecker &TC, AccessorDecl *Get,
   // Load the existing storage and store it into the 'tmp1' temporary.
   auto *Tmp1VD = new (Ctx) VarDecl(/*IsStatic*/false, VarDecl::Specifier::Let,
                                    /*IsCaptureList*/false, SourceLoc(),
-                                   Ctx.getIdentifier("tmp1"), Type(), Get);
+                                   Ctx.getIdentifier("tmp1"), Get);
   Tmp1VD->setImplicit();
 
   auto *Tmp1PBDPattern = new (Ctx) NamedPattern(Tmp1VD, /*implicit*/true);
@@ -1255,8 +1237,9 @@ static void synthesizeLazyGetterBody(TypeChecker &TC, AccessorDecl *Get,
 
   auto *Tmp2VD = new (Ctx) VarDecl(/*IsStatic*/false, VarDecl::Specifier::Let,
                                    /*IsCaptureList*/false, SourceLoc(),
-                                   Ctx.getIdentifier("tmp2"), VD->getType(),
+                                   Ctx.getIdentifier("tmp2"),
                                    Get);
+  Tmp2VD->setType(VD->getType());
   Tmp2VD->setImplicit();
 
 
@@ -1345,7 +1328,7 @@ void TypeChecker::completePropertyBehaviorStorage(VarDecl *VD,
                         : VarDecl::Specifier::Let;
   auto *Storage = new (Context) VarDecl(
       /*IsStatic*/VD->isStatic(), storageSpecifier,
-      /*IsCaptureList*/false, VD->getLoc(), StorageName, SubstStorageContextTy,
+      /*IsCaptureList*/false, VD->getLoc(), StorageName,
       DC);
   Storage->setInterfaceType(SubstStorageInterfaceTy);
   Storage->setUserAccessible(false);
@@ -1461,8 +1444,7 @@ void TypeChecker::completePropertyBehaviorStorage(VarDecl *VD,
 void TypeChecker::completePropertyBehaviorParameter(VarDecl *VD,
                                  FuncDecl *BehaviorParameter,
                                  NormalProtocolConformance *BehaviorConformance,
-                                 SubstitutionMap interfaceMap,
-                                 SubstitutionMap contextMap) {
+                                 SubstitutionMap interfaceMap) {
   // Create a method to witness the requirement.
   auto DC = VD->getDeclContext();
   SmallString<64> NameBuf = VD->getName().str();
@@ -1514,8 +1496,6 @@ void TypeChecker::completePropertyBehaviorParameter(VarDecl *VD,
     auto declaredParamTy = declaredParam->getInterfaceType();
     auto interfaceTy = declaredParamTy.subst(interfaceMap);
     assert(interfaceTy);
-    auto contextTy = declaredParamTy.subst(contextMap);
-    assert(contextTy);
     auto declaredSpecifier = declaredParam->getSpecifier();
 
     SmallString<64> ParamNameBuf;
@@ -1525,7 +1505,7 @@ void TypeChecker::completePropertyBehaviorParameter(VarDecl *VD,
     }
     auto param = new (Context) ParamDecl(
         declaredSpecifier, SourceLoc(), SourceLoc(), Identifier(), SourceLoc(),
-        Context.getIdentifier(ParamNameBuf), contextTy, DC);
+        Context.getIdentifier(ParamNameBuf), DC);
     param->setInterfaceType(interfaceTy);
     param->setImplicit();
     Params.push_back(param);
@@ -1622,7 +1602,7 @@ void TypeChecker::completePropertyBehaviorAccessors(VarDecl *VD,
                                        VarDecl::Specifier::Var,
                                        /*IsCaptureList*/false, SourceLoc(),
                                        Context.getIdentifier("tempSelf"),
-                                       selfTy, fromAccessor);
+                                       fromAccessor);
       var->setInterfaceType(selfIfaceTy);
       var->setImplicit();
 
@@ -1726,7 +1706,7 @@ void TypeChecker::completeLazyVarImplementation(VarDecl *VD) {
 
   auto *Storage = new (Context) VarDecl(/*IsStatic*/false, VarDecl::Specifier::Var,
                                         /*IsCaptureList*/false, VD->getLoc(),
-                                        StorageName, StorageTy,
+                                        StorageName,
                                         VD->getDeclContext());
   Storage->setInterfaceType(StorageInterfaceTy);
   Storage->setUserAccessible(false);
@@ -2165,8 +2145,6 @@ ConstructorDecl *swift::createImplicitConstructor(TypeChecker &tc,
       
       accessLevel = std::min(accessLevel, var->getFormalAccess());
 
-      auto varType = var->getType()
-        ->getReferenceStorageReferent();
       auto varInterfaceType = var->getValueInterfaceType();
 
       // If var is a lazy property, its value is provided for the underlying
@@ -2174,15 +2152,13 @@ ConstructorDecl *swift::createImplicitConstructor(TypeChecker &tc,
       // need to do this because the implicit constructor is added before all
       // the properties are type checked.  Perhaps init() synth should be moved
       // later.
-      if (var->getAttrs().hasAttribute<LazyAttr>()) {
-        varType = OptionalType::get(varType);
+      if (var->getAttrs().hasAttribute<LazyAttr>())
         varInterfaceType = OptionalType::get(varInterfaceType);
-      }
 
       // Create the parameter.
       auto *arg = new (context)
           ParamDecl(VarDecl::Specifier::Default, SourceLoc(), Loc,
-                    var->getName(), Loc, var->getName(), varType, decl);
+                    var->getName(), Loc, var->getName(), decl);
       arg->setInterfaceType(varInterfaceType);
       arg->setImplicit();
       

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -456,7 +456,7 @@ static VarDecl *createKeyedContainer(ASTContext &C, DeclContext *DC,
   // let container : Keyed*Container<KeyType>
   auto *containerDecl = new (C) VarDecl(/*IsStatic=*/false, spec,
                                         /*IsCaptureList=*/false, SourceLoc(),
-                                        C.Id_container, containerType, DC);
+                                        C.Id_container, DC);
   containerDecl->setImplicit();
   containerDecl->setInterfaceType(containerType);
   return containerDecl;
@@ -481,7 +481,7 @@ static CallExpr *createContainerKeyedByCall(ASTContext &C, DeclContext *DC,
   // (keyedBy:)
   auto *keyedByDecl = new (C)
       ParamDecl(VarDecl::Specifier::Default, SourceLoc(), SourceLoc(),
-                C.Id_keyedBy, SourceLoc(), C.Id_keyedBy, returnType, DC);
+                C.Id_keyedBy, SourceLoc(), C.Id_keyedBy, DC);
   keyedByDecl->setImplicit();
   keyedByDecl->setInterfaceType(returnType);
 
@@ -711,7 +711,7 @@ static FuncDecl *deriveEncodable_encode(DerivedConformance &derived) {
   auto *selfDecl = ParamDecl::createSelf(SourceLoc(), conformanceDC);
   auto *encoderParam = new (C)
       ParamDecl(VarDecl::Specifier::Default, SourceLoc(), SourceLoc(), C.Id_to,
-                SourceLoc(), C.Id_encoder, encoderType, conformanceDC);
+                SourceLoc(), C.Id_encoder, conformanceDC);
   encoderParam->setInterfaceType(encoderType);
 
   ParameterList *params = ParameterList::createWithoutLoc(encoderParam);
@@ -1017,7 +1017,7 @@ static ValueDecl *deriveDecodable_init(DerivedConformance &derived) {
   auto decoderType = C.getDecoderDecl()->getDeclaredInterfaceType();
   auto *decoderParamDecl = new (C) ParamDecl(
       VarDecl::Specifier::Default, SourceLoc(), SourceLoc(), C.Id_from,
-      SourceLoc(), C.Id_decoder, decoderType, conformanceDC);
+      SourceLoc(), C.Id_decoder, conformanceDC);
   decoderParamDecl->setImplicit();
   decoderParamDecl->setInterfaceType(decoderType);
 

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -75,7 +75,7 @@ static void deriveRawValueInit(AbstractFunctionDecl *initDecl) {
   // rawValue param to init(rawValue:)
   auto *rawValueDecl = new (C) ParamDecl(
       VarDecl::Specifier::Default, SourceLoc(), SourceLoc(), C.Id_rawValue,
-      SourceLoc(), C.Id_rawValue, valueParam->getType(), parentDC);
+      SourceLoc(), C.Id_rawValue, parentDC);
   rawValueDecl->setInterfaceType(C.getIntDecl()->getDeclaredType());
   rawValueDecl->setImplicit();
   auto *paramList = ParameterList::createWithoutLoc(rawValueDecl);
@@ -117,7 +117,7 @@ static ValueDecl *deriveInitDecl(DerivedConformance &derived, Type paramType,
   // rawValue
   auto *rawDecl =
       new (C) ParamDecl(VarDecl::Specifier::Default, SourceLoc(), SourceLoc(),
-                        paramName, SourceLoc(), paramName, paramType, parentDC);
+                        paramName, SourceLoc(), paramName, parentDC);
   rawDecl->setInterfaceType(paramType);
   rawDecl->setImplicit();
 

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -123,8 +123,9 @@ static VarDecl *indexedVarDecl(char prefixChar, int index, Type type,
 
   auto varDecl = new (C) VarDecl(/*IsStatic*/false, VarDecl::Specifier::Let,
                                  /*IsCaptureList*/true, SourceLoc(),
-                                 C.getIdentifier(indexStrRef), type,
+                                 C.getIdentifier(indexStrRef),
                                  varContext);
+  varDecl->setType(type);
   varDecl->setHasNonPatternBindingInit(true);
   return varDecl;
 }
@@ -210,7 +211,7 @@ static DeclRefExpr *convertEnumToIndex(SmallVectorImpl<ASTNode> &stmts,
 
   auto indexVar = new (C) VarDecl(/*IsStatic*/false, VarDecl::Specifier::Var,
                                   /*IsCaptureList*/false, SourceLoc(),
-                                  C.getIdentifier(indexName), intType,
+                                  C.getIdentifier(indexName),
                                   funcDecl);
   indexVar->setInterfaceType(intType);
   indexVar->setImplicit();
@@ -590,13 +591,12 @@ deriveEquatable_eq(DerivedConformance &derived,
   ASTContext &C = derived.TC.Context;
 
   auto parentDC = derived.getConformanceContext();
-  auto selfTy = parentDC->getDeclaredTypeInContext();
   auto selfIfaceTy = parentDC->getDeclaredInterfaceType();
 
   auto getParamDecl = [&](StringRef s) -> ParamDecl * {
     auto *param = new (C) ParamDecl(VarDecl::Specifier::Default, SourceLoc(),
                                     SourceLoc(), Identifier(), SourceLoc(),
-                                    C.getIdentifier(s), selfTy, parentDC);
+                                    C.getIdentifier(s), parentDC);
     param->setInterfaceType(selfIfaceTy);
     return param;
   };
@@ -615,10 +615,10 @@ deriveEquatable_eq(DerivedConformance &derived,
   if (parentDC->getParentModule()->getResilienceStrategy() ==
       ResilienceStrategy::Resilient) {
     generatedIdentifier = C.Id_EqualsOperator;
-  } else if (selfTy->getEnumOrBoundGenericEnum()) {
+  } else if (selfIfaceTy->getEnumOrBoundGenericEnum()) {
     generatedIdentifier = C.Id_derived_enum_equals;
   } else {
-    assert(selfTy->getStructOrBoundGenericStruct());
+    assert(selfIfaceTy->getStructOrBoundGenericStruct());
     generatedIdentifier = C.Id_derived_struct_equals;
   }
 
@@ -759,7 +759,7 @@ deriveHashable_hashInto(DerivedConformance &derived,
   auto *hasherParamDecl = new (C) ParamDecl(VarDecl::Specifier::InOut,
                                             SourceLoc(),
                                             SourceLoc(), C.Id_into, SourceLoc(),
-                                            C.Id_hasher, hasherType, parentDC);
+                                            C.Id_hasher, parentDC);
   hasherParamDecl->setInterfaceType(hasherType);
 
   ParameterList *params = ParameterList::createWithoutLoc(hasherParamDecl);
@@ -1072,7 +1072,8 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
   VarDecl *hashValueDecl =
     new (C) VarDecl(/*IsStatic*/false, VarDecl::Specifier::Var,
                     /*IsCaptureList*/false, SourceLoc(),
-                    C.Id_hashValue, intType, parentDC);
+                    C.Id_hashValue, parentDC);
+  hashValueDecl->setType(intType);
 
   auto *selfDecl = ParamDecl::createSelf(SourceLoc(), parentDC);
   ParameterList *params = ParameterList::createEmpty(C);

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -323,7 +323,7 @@ deriveRawRepresentable_init(DerivedConformance &derived) {
 
   auto *rawDecl = new (C)
       ParamDecl(VarDecl::Specifier::Default, SourceLoc(), SourceLoc(),
-                C.Id_rawValue, SourceLoc(), C.Id_rawValue, rawType, parentDC);
+                C.Id_rawValue, SourceLoc(), C.Id_rawValue, parentDC);
   rawDecl->setInterfaceType(rawInterfaceType);
   rawDecl->setImplicit();
   auto paramList = ParameterList::createWithoutLoc(rawDecl);

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -331,7 +331,7 @@ DerivedConformance::declareDerivedProperty(Identifier name,
 
   VarDecl *propDecl = new (C) VarDecl(/*IsStatic*/isStatic, VarDecl::Specifier::Var,
                                       /*IsCaptureList*/false, SourceLoc(), name,
-                                      propertyContextType, parentDC);
+                                      parentDC);
   propDecl->setImplicit();
   propDecl->copyFormalAccessFrom(Nominal, /*sourceIsParentContext*/ true);
   propDecl->setInterfaceType(propertyInterfaceType);

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -482,8 +482,8 @@ public:
         new (Context) VarDecl(/*IsStatic*/false, VarDecl::Specifier::Let,
                               /*IsCaptureList*/false, SourceLoc(),
                               Context.getIdentifier(NameBuf),
-                              MaybeLoadInitExpr->getType(), TypeCheckDC);
-
+                              TypeCheckDC);
+    VD->setType(MaybeLoadInitExpr->getType());
     VD->setImplicit();
 
     NamedPattern *NP = new (Context) NamedPattern(VD, /*implicit*/ true);

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -749,8 +749,9 @@ public:
         new (Context) VarDecl(/*IsStatic*/false, VarDecl::Specifier::Let,
                               /*IsCaptureList*/false, SourceLoc(),
                               Context.getIdentifier(NameBuf),
-                              MaybeLoadInitExpr->getType(), TypeCheckDC);
-    VD->setInterfaceType(VD->getType()->mapTypeOutOfContext());
+                              TypeCheckDC);
+    VD->setType(MaybeLoadInitExpr->getType());
+    VD->setInterfaceType(MaybeLoadInitExpr->getType()->mapTypeOutOfContext());
     VD->setImplicit();
 
     NamedPattern *NP = new (Context) NamedPattern(VD, /*implicit*/ true);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1248,13 +1248,12 @@ bool PreCheckExpression::walkToClosureExprPre(ClosureExpr *closure) {
   options |= TypeResolutionFlags::AllowUnspecifiedTypes;
   options |= TypeResolutionFlags::AllowUnboundGenerics;
   options |= TypeResolutionFlags::InExpression;
+
   bool hadParameterError = false;
 
   GenericTypeToArchetypeResolver resolver(closure);
 
   if (TC.typeCheckParameterList(PL, DC, options, resolver)) {
-    closure->setType(ErrorType::get(TC.Context));
-
     // If we encounter an error validating the parameter list, don't bail.
     // Instead, go on to validate any potential result type, and bail
     // afterwards.  This allows for better diagnostics, and keeps the
@@ -1266,7 +1265,6 @@ bool PreCheckExpression::walkToClosureExprPre(ClosureExpr *closure) {
   if (closure->hasExplicitResultType() &&
       TC.validateType(closure->getExplicitResultTypeLoc(), DC,
                       TypeResolutionFlags::InExpression, &resolver)) {
-    closure->setType(ErrorType::get(TC.Context));
     return false;
   }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2882,8 +2882,8 @@ bool TypeChecker::typeCheckExprPattern(ExprPattern *EP, DeclContext *DC,
                                          /*IsCaptureList*/false,
                                          EP->getLoc(),
                                          Context.getIdentifier("$match"),
-                                         rhsType,
                                          DC);
+  matchVar->setType(rhsType);
   matchVar->setInterfaceType(rhsType->mapTypeOutOfContext());
 
   matchVar->setImplicit();

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1183,34 +1183,6 @@ static void configureImplicitSelf(TypeChecker &tc,
   selfDecl->setInterfaceType(selfParam.getPlainType());
 }
 
-static void recordParamContextTypes(AbstractFunctionDecl *func) {
-  auto *env = func->getGenericEnvironment();
-
-  if (auto *selfDecl = func->getImplicitSelfDecl()) {
-    if (!env)
-      selfDecl->setType(selfDecl->getInterfaceType());
-    else
-      selfDecl->setType(env->mapTypeIntoContext(selfDecl->getInterfaceType()));
-  }
-
-  for (auto param : *func->getParameters()) {
-    if (!env)
-      param->setType(param->getInterfaceType());
-    else
-      param->setType(env->mapTypeIntoContext(param->getInterfaceType()));
-  }
-}
-
-static void recordIndexContextTypes(SubscriptDecl *subscript) {
-  auto *env = subscript->getGenericEnvironment();
-  for (auto param : *subscript->getIndices()) {
-    if (!env)
-      param->setType(param->getInterfaceType());
-    else
-      param->setType(env->mapTypeIntoContext(param->getInterfaceType()));
-  }
-}
-
 /// Try to make the given declaration 'dynamic', checking any semantic
 /// constraints before doing so.
 ///
@@ -1862,8 +1834,7 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
         // Build the parameter witness method.
         TC.completePropertyBehaviorParameter(decl, func,
                                              conformance,
-                                             interfaceSubsMap,
-                                             contextSubsMap);
+                                             interfaceSubsMap);
         continue;
       }
     }
@@ -4127,14 +4098,12 @@ void TypeChecker::validateDecl(ValueDecl *D) {
       auto valueParams = accessor->getParameters();
 
       // Determine the value type.
-      Type valueIfaceTy, valueTy;
+      Type valueIfaceTy;
       if (auto VD = dyn_cast<VarDecl>(storage)) {
         valueIfaceTy = VD->getInterfaceType()->getReferenceStorageReferent();
-        valueTy = VD->getType()->getReferenceStorageReferent();
       } else {
         auto SD = cast<SubscriptDecl>(storage);
         valueIfaceTy = SD->getElementInterfaceType();
-        valueTy = SD->mapTypeIntoContext(valueIfaceTy);
 
         // Copy the index types instead of re-validating them.
         auto indices = SD->getIndices();
@@ -4144,10 +4113,8 @@ void TypeChecker::validateDecl(ValueDecl *D) {
             continue;
 
           Type paramIfaceTy = subscriptParam->getInterfaceType();
-          Type paramTy = SD->mapTypeIntoContext(paramIfaceTy);
 
           auto accessorParam = valueParams->get(valueParams->size() - e + i);
-          accessorParam->setType(paramTy);
           accessorParam->setInterfaceType(paramIfaceTy);
           accessorParam->getTypeLoc().setType(paramIfaceTy);
         }
@@ -4173,9 +4140,8 @@ void TypeChecker::validateDecl(ValueDecl *D) {
 
       case AccessorKind::Set: {
         auto newValueParam = valueParams->get(0);
-        newValueParam->setType(valueTy);
         newValueParam->setInterfaceType(valueIfaceTy);
-        newValueParam->getTypeLoc().setType(valueTy);
+        newValueParam->getTypeLoc().setType(valueIfaceTy);
         break;
       }
 
@@ -4204,7 +4170,6 @@ void TypeChecker::validateDecl(ValueDecl *D) {
     // If we have generic parameters, check the generic signature now.
     if (FD->getGenericParams() || !isa<AccessorDecl>(FD)) {
       validateGenericFuncSignature(FD);
-      recordParamContextTypes(FD);
     } else {
       // We've inherited all of the type information already.
       FD->setGenericEnvironment(
@@ -4331,7 +4296,6 @@ void TypeChecker::validateDecl(ValueDecl *D) {
     configureImplicitSelf(*this, CD);
 
     validateGenericFuncSignature(CD);
-    recordParamContextTypes(CD);
 
     // We want the constructor to be available for name lookup as soon
     // as it has a valid interface type.
@@ -4361,7 +4325,6 @@ void TypeChecker::validateDecl(ValueDecl *D) {
     configureImplicitSelf(*this, DD);
 
     validateGenericFuncSignature(DD);
-    recordParamContextTypes(DD);
 
     DD->setSignatureIsValidated();
 
@@ -4375,7 +4338,6 @@ void TypeChecker::validateDecl(ValueDecl *D) {
     DeclValidationRAII IBV(SD);
 
     validateGenericSubscriptSignature(SD);
-    recordIndexContextTypes(SD);
 
     SD->setSignatureIsValidated();
 

--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -231,7 +231,8 @@ void REPLChecker::generatePrintOfExpression(StringRef NameStr, Expr *E) {
   // Build function of type T->() which prints the operand.
   auto *Arg = new (Context) ParamDecl(
       VarDecl::Specifier::Default, SourceLoc(), SourceLoc(), Identifier(), Loc,
-      Context.getIdentifier("arg"), E->getType(), /*DC*/ newTopLevel);
+      Context.getIdentifier("arg"), /*DC*/ newTopLevel);
+  Arg->setType(E->getType());
   Arg->setInterfaceType(E->getType());
   auto params = ParameterList::createWithoutLoc(Arg);
 
@@ -310,7 +311,8 @@ void REPLChecker::processREPLTopLevelExpr(Expr *E) {
   VarDecl *vd = new (Context) VarDecl(/*IsStatic*/false,
                                       VarDecl::Specifier::Let,
                                       /*IsCaptureList*/false, E->getStartLoc(),
-                                      name, E->getType(), &SF);
+                                      name, &SF);
+  vd->setType(E->getType());
   vd->setInterfaceType(E->getType());
   SF.Decls.push_back(vd);
 
@@ -385,8 +387,8 @@ void REPLChecker::processREPLTopLevelPatternBinding(PatternBindingDecl *PBD) {
     VarDecl *vd = new (Context) VarDecl(/*IsStatic*/false,
                                         VarDecl::Specifier::Let,
                                         /*IsCaptureList*/false,
-                                        PBD->getStartLoc(), name,
-                                        pattern->getType(), &SF);
+                                        PBD->getStartLoc(), name, &SF);
+    vd->setType(pattern->getType());
     vd->setInterfaceType(pattern->getType());
     SF.Decls.push_back(vd);
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -707,7 +707,8 @@ public:
       name += "$generator";
       generator = new (TC.Context)
         VarDecl(/*IsStatic*/false, VarDecl::Specifier::Var, /*IsCaptureList*/false,
-                S->getInLoc(), TC.Context.getIdentifier(name), generatorTy, DC);
+                S->getInLoc(), TC.Context.getIdentifier(name), DC);
+      generator->setType(generatorTy);
       generator->setInterfaceType(generatorTy->mapTypeOutOfContext());
       generator->setImplicit();
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1475,8 +1475,7 @@ public:
   void completePropertyBehaviorParameter(VarDecl *VD,
                                FuncDecl *BehaviorParameter,
                                NormalProtocolConformance *BehaviorConformance,
-                               SubstitutionMap interfaceMap,
-                               SubstitutionMap contextMap);
+                               SubstitutionMap interfaceMap);
   
   /// Instantiate the accessor implementations for a behavior-backed
   /// property.

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2952,7 +2952,7 @@ ModuleFile::getDeclCheckedImpl(DeclID DID, Optional<DeclContext *> ForcedContext
 
     auto var = createDecl<VarDecl>(/*IsStatic*/ isStatic, *specifier,
                                    /*IsCaptureList*/ false, SourceLoc(), name,
-                                   Type(), DC);
+                                   DC);
     var->setHasNonPatternBindingInit(hasNonPatternBindingInit);
     var->setIsGetterMutating(isGetterMutating);
     var->setIsSetterMutating(isSetterMutating);
@@ -3021,7 +3021,7 @@ ModuleFile::getDeclCheckedImpl(DeclID DID, Optional<DeclContext *> ForcedContext
 
     auto param = createDecl<ParamDecl>(*specifier, SourceLoc(), SourceLoc(),
                                        getIdentifier(argNameID), SourceLoc(),
-                                       getIdentifier(paramNameID), Type(), DC);
+                                       getIdentifier(paramNameID), DC);
 
     declOrOffset = param;
 

--- a/test/Sema/circular_decl_checking.swift
+++ b/test/Sema/circular_decl_checking.swift
@@ -7,7 +7,7 @@ class HasFunc {
     return HasFunc()
   }
   func SomethingElse(_: SomethingElse) { // expected-error {{use of undeclared type 'SomethingElse'}}
-    return nil
+    return nil // expected-error {{unexpected non-void return value in void function}}
   }
   func SomethingElse() -> SomethingElse? { // expected-error {{use of undeclared type 'SomethingElse'}}
     return nil

--- a/test/decl/func/functions.swift
+++ b/test/decl/func/functions.swift
@@ -104,7 +104,7 @@ _ = nullaryClosure(0)
 // parameter labels, and they are thus not in scope in the body of the function.
 // expected-error@+1{{unnamed parameters must be written}} {{27-27=_: }}
 func destructureArgument( (result: Int, error: Bool) ) -> Int {
-  return result
+  return result  // expected-error {{use of unresolved identifier 'result'}}
 }
 
 // The former is the same as this:

--- a/unittests/AST/SourceLocTests.cpp
+++ b/unittests/AST/SourceLocTests.cpp
@@ -157,7 +157,6 @@ TEST(SourceLoc, StmtConditionElement) {
                                      /*IsCaptureList*/false,
                                      start.getAdvancedLoc(7)
                                     , C.Ctx.getIdentifier("x")
-                                    , Type()
                                     , nullptr);
   auto pattern = new (C.Ctx) NamedPattern(vardecl);
   auto init = new (C.Ctx) IntegerLiteralExpr( "1", start.getAdvancedLoc(25)


### PR DESCRIPTION
We're going through a lot of effort to set these types but its unnecessary because they're actually set for us automatically. Also, clean up some of the code for 'invalid' decls and be less eager about splatting random ErrorTypes everywhere.