### PR TITLE
[AutoDiff] Add begin_access to various places and remove custom SIL loader

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -831,12 +831,8 @@ private:
     std::pair<SILFunction *, SILReverseAutoDiffIndices>,
     unsigned> enqueuedTaskIndices;
 
-  /// SIL loader.
-  ///
-  /// FIXME: Fix SILModule's deserialization so that we can drop the local
-  /// cache and use `SILModule::lookUpWitnessTable` directly.
-  const std::unique_ptr<SerializedSILLoader> silLoader =
-    SerializedSILLoader::create(astCtx, &module, nullptr);
+  /// The SIL loader owned by the module.
+  SerializedSILLoader *silLoader = module.getSILLoader();
 
   /// The VectorNumeric protocol in the standard library.
   ProtocolDecl *vectorNumericProtocol =
@@ -877,7 +873,7 @@ public:
     if (auto existingTable = module.lookUpWitnessTable(confRef))
       return existingTable;
     auto *decl =
-      conf->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
+        conf->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
     auto linkage = getSILLinkage(getDeclLinkage(decl), NotForDefinition);
     auto *newTable = module.createWitnessTableDeclaration(conf, linkage);
     newTable = silLoader->lookupWitnessTable(newTable);


### PR DESCRIPTION
- Add `begin_access` and `end_access` to various places.
- Remove custom SIL loader and use the module-associated one instead.
  - TODO: This is just a minor improvement on the existing hack. Need to switch to the devirtualizer if possible.