### PR TITLE
[TF API] Comparison operator overhaul

### DIFF
--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -422,5 +422,5 @@ extension Tensor where Scalar : BinaryFloatingPoint {
 func _adjointRelu<T : BinaryFloatingPoint>(
   _ x: Tensor<T>, originalValue: Tensor<T>, seed: Tensor<T>
 ) -> Tensor<T> {
-  return Tensor(x > 0) * seed
+  return Tensor(x.elementsGreater(0)) * seed
 }

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -280,81 +280,83 @@ public extension Tensor where Scalar : Numeric {
 // Element-wise binary comparison
 //===----------------------------------------------------------------------===//
 
-public extension Tensor where Scalar : Numeric {
-  /// Computes `lhs < rhs` element-wise.
-  /// - Note: `<` supports broadcasting.
+public extension Tensor where Scalar : Numeric & Comparable {
+  /// Computes `self < other` element-wise.
   @inlinable @inline(__always)
-  static func < (lhs: Tensor, rhs: Tensor) -> Tensor<Bool> {
-    return Raw.less(lhs, rhs)
+  func elementsLess(_ other: Tensor) -> Tensor<Bool> {
+    return Raw.less(self, other)
   }
 
-  /// Computes `lhs < rhs`, broadcasting `rhs`.
+  /// Computes `self < other`, broadcasting `other`.
   @inlinable @inline(__always)
-  static func < (lhs: Tensor, rhs: Scalar) -> Tensor<Bool> {
-    return lhs < Tensor(rhs)
+  func elementsLess(_ other: Scalar) -> Tensor<Bool> {
+    return elementsLess(Tensor(other))
   }
 
-  /// Computes `lhs < rhs`, broadcasting `lhs`.
+  /// Computes `self <= other` element-wise.
   @inlinable @inline(__always)
-  static func < (lhs: Scalar, rhs: Tensor) -> Tensor<Bool> {
-    return Tensor(lhs) < rhs
+  func elementsLessOrEqual(_ other: Tensor) -> Tensor<Bool> {
+    return Raw.lessEqual(self, other)
   }
 
-  /// Computes `lhs <= rhs` element-wise.
-  /// - Note: `<=` supports broadcasting.
+  /// Computes `self <= other`, broadcasting `other`.
   @inlinable @inline(__always)
-  static func <= (lhs: Tensor, rhs: Tensor) -> Tensor<Bool> {
-    return Raw.lessEqual(lhs, rhs)
+  func elementsLessOrEqual(_ other: Scalar) -> Tensor<Bool> {
+    return elementsLessOrEqual(Tensor(other))
   }
 
-  /// Computes `lhs <= rhs`, broadcasting `rhs`.
+  /// Computes `self > other` element-wise.
   @inlinable @inline(__always)
-  static func <= (lhs: Tensor, rhs: Scalar) -> Tensor<Bool> {
-    return lhs <= Tensor(rhs)
+  func elementsGreater(_ other: Tensor) -> Tensor<Bool> {
+    return Raw.greater(self, other)
   }
 
-  /// Computes `lhs <= rhs`, broadcasting `rhs`.
+  /// Computes `self > other`, broadcasting `other`.
   @inlinable @inline(__always)
-  static func <= (lhs: Scalar, rhs: Tensor) -> Tensor<Bool> {
-    return Tensor(lhs) <= rhs
+  func elementsGreater(_ other: Scalar) -> Tensor<Bool> {
+    return elementsGreater(Tensor(other))
   }
 
-  /// Computes `lhs > rhs` element-wise.
-  /// - Note: `>` supports broadcasting.
+  /// Computes `self >= other` element-wise.
   @inlinable @inline(__always)
-  static func > (lhs: Tensor, rhs: Tensor) -> Tensor<Bool> {
-    return Raw.greater(lhs, rhs)
+  func elementsGreaterOrEqual(_ other: Tensor) -> Tensor<Bool> {
+    return Raw.greaterEqual(self, other)
   }
 
-  /// Computes `lhs <= rhs`, broadcasting `rhs`.
+  /// Computes `self >= other`, broadcasting `other`.
   @inlinable @inline(__always)
-  static func > (lhs: Tensor, rhs: Scalar) -> Tensor<Bool> {
-    return lhs > Tensor(rhs)
+  func elementsGreaterOrEqual(_ other: Scalar) -> Tensor<Bool> {
+    return elementsGreaterOrEqual(Tensor(other))
+  }
+}
+
+extension Tensor : Comparable where Scalar : Numeric & Comparable {
+  /// Returns a Boolean value indicating whether the value of the first argument
+  /// is lexicographically less than that of the second argument.
+  @inlinable @inline(__always)
+  public static func < (lhs: Tensor, rhs: Tensor) -> Bool {
+    return lhs.elementsLess(rhs).all()
   }
 
-  /// Computes `lhs <= rhs`, broadcasting `lhs`.
+  /// Returns a Boolean value indicating whether the value of the first argument
+  /// is lexicographically less than or equal to that of the second argument.
   @inlinable @inline(__always)
-  static func > (lhs: Scalar, rhs: Tensor) -> Tensor<Bool> {
-    return Tensor(lhs) > rhs
+  public static func <= (lhs: Tensor, rhs: Tensor) -> Bool {
+    return lhs.elementsLessOrEqual(rhs).all()
   }
 
-  /// Computes `lhs >= rhs` element-wise.
-  /// - Note: `>=` supports broadcasting.
+  /// Returns a Boolean value indicating whether the value of the first argument
+  /// is lexicographically greater than that of the second argument.
   @inlinable @inline(__always)
-  static func >= (lhs: Tensor, rhs: Tensor) -> Tensor<Bool> {
-    return Raw.greaterEqual(lhs, rhs)
+  public static func > (lhs: Tensor, rhs: Tensor) -> Bool {
+    return lhs.elementsGreater(rhs).all()
   }
 
-  /// Computes `lhs >= rhs`, broadcasting `rhs`.
+  /// Returns a Boolean value indicating whether the value of the first argument
+  /// is lexicographically greater than or equal to that of the second argument.
   @inlinable @inline(__always)
-  static func >= (lhs: Tensor, rhs: Scalar) -> Tensor<Bool> {
-    return lhs >= Tensor(rhs)
-  }
-
-  /// Computes `lhs >= rhs`, broadcasting `lhs`.
-  @inlinable @inline(__always)
-  static func >= (lhs: Scalar, rhs: Tensor) -> Tensor<Bool> {
-    return Tensor(lhs) >= rhs
+  public static func >= (lhs: Tensor, rhs: Tensor) -> Bool {
+    return lhs.elementsGreaterOrEqual(rhs).all()
   }
 }
 
@@ -386,49 +388,56 @@ public extension Tensor where Scalar : Equatable {
   }
 }
 
-public extension Tensor where Scalar == Bool {
-  /// Performs a logical NOT operation element-wise.
+infix operator ≈ : ComparisonPrecedence
+
+public extension Tensor where Scalar : BinaryFloatingPoint & Equatable {
+  /// Returns a `Tensor` of Boolean values indicating whether the elements of
+  /// `self` are approximately equal to those of `other`.
   @inlinable @inline(__always)
-  static prefix func ! (x: Tensor) -> Tensor {
-    return Raw.logicalNot(x)
+  func elementsApproximatelyEqual(_ other: Tensor,
+                                  tolerance: Double = 0.00001) -> Tensor<Bool> {
+    return Raw.approximateEqual(self, other, tolerance: tolerance)
   }
 
-  /// Performs a logical AND operation element-wise.
+  /// Returns a Boolean value indicating whether the value of the first argument
+  /// is lexicographically approximately equal to that of the second argument.
+  /// Errors no larger than `0.00001` are tolerated.
+  @inlinable @inline(__always)
+  static func ≈ (lhs: Tensor, rhs: Tensor) -> Bool {
+    return lhs.elementsApproximatelyEqual(rhs).all()
+  }
+}
+
+public extension Tensor where Scalar == Bool {
+  /// Computes `!self` element-wise.
+  @inlinable @inline(__always)
+  func elementsLogicalNot() -> Tensor {
+    return Raw.logicalNot(self)
+  }
+
+  /// Computes `self && other` element-wise.
   /// - Note: `&&` supports broadcasting.
   @inlinable @inline(__always)
-  static func && (lhs: Tensor, rhs: Tensor) -> Tensor {
-    return Raw.logicalAnd(lhs, rhs)
+  func elementsLogicalAnd(_ other: Tensor) -> Tensor {
+    return Raw.logicalAnd(self, other)
   }
 
-  /// Performs a logical AND operation element-wise, broadcasting `rhs`.
+  /// Computes `self && other` element-wise, broadcasting `other`.
   @inlinable @inline(__always)
-  static func && (lhs: Tensor, rhs: Scalar) -> Tensor {
-    return lhs && Tensor(rhs)
+  func elementsLogicalAnd(_ other: Scalar) -> Tensor {
+    return elementsLogicalAnd(Tensor(other))
   }
 
-  /// Performs a logical AND operation element-wise, broadcasting `lhs`.
+  /// Computes `self || other` element-wise.
   @inlinable @inline(__always)
-  static func && (lhs: Scalar, rhs: Tensor) -> Tensor {
-    return Tensor(lhs) && rhs
+  func elementsLogicalOr(_ other: Tensor) -> Tensor {
+    return Raw.logicalOr(self, other)
   }
 
-  /// Performs a logical OR operation element-wise.
-  /// - Note: `||` supports broadcasting.
+  /// Computes `self || other` element-wise, broadcasting `other`.
   @inlinable @inline(__always)
-  static func || (lhs: Tensor, rhs: Tensor) -> Tensor {
-    return Raw.logicalOr(lhs, rhs)
-  }
-
-  /// Performs a logical OR operation element-wise, broadcasting `rhs`.
-  @inlinable @inline(__always)
-  static func || (lhs: Tensor, rhs: Scalar) -> Tensor {
-    return lhs || Tensor(rhs)
-  }
-
-  /// Performs a logical OR operation element-wise, broadcasting `lhs`.
-  @inlinable @inline(__always)
-  static func || (lhs: Scalar, rhs: Tensor) -> Tensor {
-    return Tensor(lhs) || rhs
+  func elementsLogicalOr(_ other: Scalar) -> Tensor {
+    return elementsLogicalOr(Tensor(other))
   }
 }
 

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -360,6 +360,36 @@ extension Tensor : Comparable where Scalar : Numeric & Comparable {
   }
 }
 
+public extension Tensor where Scalar : Numeric & Comparable {
+  /// Returns a Boolean value indicating whether the value of the first argument
+  /// is lexicographically less than that of the second argument.
+  @inlinable @inline(__always)
+  public static func < (lhs: Tensor, rhs: Scalar) -> Bool {
+    return lhs.elementsLess(rhs).all()
+  }
+
+  /// Returns a Boolean value indicating whether the value of the first argument
+  /// is lexicographically less than or equal to that of the second argument.
+  @inlinable @inline(__always)
+  public static func <= (lhs: Tensor, rhs: Scalar) -> Bool {
+    return lhs.elementsLessOrEqual(rhs).all()
+  }
+
+  /// Returns a Boolean value indicating whether the value of the first argument
+  /// is lexicographically greater than that of the second argument.
+  @inlinable @inline(__always)
+  public static func > (lhs: Tensor, rhs: Scalar) -> Bool {
+    return lhs.elementsGreater(rhs).all()
+  }
+
+  /// Returns a Boolean value indicating whether the value of the first argument
+  /// is lexicographically greater than or equal to that of the second argument.
+  @inlinable @inline(__always)
+  public static func >= (lhs: Tensor, rhs: Scalar) -> Bool {
+    return lhs.elementsGreaterOrEqual(rhs).all()
+  }
+}
+
 public extension Tensor where Scalar : Equatable {
   /// Computes `self == other` element-wise.
   /// - Note: `elementsEqual` supports broadcasting.
@@ -397,14 +427,6 @@ public extension Tensor where Scalar : BinaryFloatingPoint & Equatable {
   func elementsApproximatelyEqual(_ other: Tensor,
                                   tolerance: Double = 0.00001) -> Tensor<Bool> {
     return Raw.approximateEqual(self, other, tolerance: tolerance)
-  }
-
-  /// Returns a Boolean value indicating whether the value of the first argument
-  /// is lexicographically approximately equal to that of the second argument.
-  /// Errors no larger than `0.00001` are tolerated.
-  @inlinable @inline(__always)
-  static func ≈ (lhs: Tensor, rhs: Tensor) -> Bool {
-    return lhs.elementsApproximatelyEqual(rhs).all()
   }
 }
 

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -234,6 +234,18 @@ TensorTests.testAllBackends("Concatenation") {
               concatenated1.array)
 }
 
+TensorTests.test("EwiseComparison") {
+  let x = Tensor<Float>([0, 1, 2])
+  let y = Tensor<Float>([2, 1, 3])
+  expectEqual(x.elementsLess(y).scalars, [true, false, true])
+}
+
+TensorTests.test("LexicographicalComparison") {
+  let x = Tensor<Float>([0, 1, 2, 3, 4])
+  let y = Tensor<Float>([2, 3, 4, 5, 6])
+  expectTrue(x < y)
+}
+
 TensorTests.testAllBackends("ArgMax") {
   // 2 x 3
   let x = Tensor<Float>([[0, 1, 2], [3, 4, 5]])


### PR DESCRIPTION
## Background

1. Operators like `Tensor.<=(_:_:)` today do not return `Bool`, but return `Tensor<Bool>` instead. Having comparison operators in Swift have element-wise semantics is highly inconsistent with 1) the mental model of comparison operators in Swift, 2) the established convention (see [C++ relational operators](http://www.cplusplus.com/reference/vector/vector/operators/)) and 3) the `Comparable` protocol that comparison operators should be associated with.

2. The existing `VectorNumeric` protocol overlaps with `Numeric` in that they both require arithmetic operators. The only reason `VectorNumeric` does not refine `Numeric` is the lack of `Comparable` conformance.

3. A couple of months ago, we changed `Tensor.==(_:_:)` from returning `Tensor<Bool>` to returning `Bool` and added a `elementsEqual(_:)` for element-wise comparison. `Tensor` was then made `Equatable`.

## Solution

As such, we do a three-step overhaul:
1. Rename existing element-wise comparison operators to well-named functions.
2. Make `Tensor` conform to `Comparable`. Comparison operators are lexicographical.
3. Make `VectorNumeric` refine `Numeric` and remove arithmetic operators with type `(Self, Self) -> Self` from `VectorNumeric`.

## This patch

* 1 and 2 described in "Solution" are included.
* Add API `elementsApproximatelyEqual(_:tolerance:)` for the corresponding TensorFlow op `ApproximateEqual`, since it is nice to have.