### PR TITLE
[SourceKit] Syntax parsing performance improvements

### DIFF
--- a/include/swift/Parse/SyntaxParsingCache.h
+++ b/include/swift/Parse/SyntaxParsingCache.h
@@ -90,10 +90,10 @@ public:
   getReusedRegions(const SourceFileSyntax &SyntaxTree) const;
 
 private:
-  llvm::Optional<Syntax> lookUpFrom(const Syntax &Node, size_t Position,
-                                    SyntaxKind Kind);
+  llvm::Optional<Syntax> lookUpFrom(const Syntax &Node, size_t NodeStart,
+                                    size_t Position, SyntaxKind Kind);
 
-  bool nodeCanBeReused(const Syntax &Node, size_t Position,
+  bool nodeCanBeReused(const Syntax &Node, size_t Position, size_t NodeStart,
                        SyntaxKind Kind) const;
 };
 

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -265,7 +265,7 @@ public:
 
   virtual void
   handleSyntaxTree(const swift::syntax::SourceFileSyntax &SyntaxTree,
-                   std::unordered_set<unsigned> ReusedNodeIds) = 0;
+                   std::unordered_set<unsigned> &ReusedNodeIds) = 0;
   virtual bool syntaxTreeEnabled() {
     return syntaxTreeTransferMode() != SyntaxTreeTransferMode::Off;
   }

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1796,12 +1796,6 @@ void SwiftEditorDocument::readSyntaxInfo(EditorConsumer &Consumer) {
 
   Impl.ParserDiagnostics = Impl.SyntaxInfo->getDiagnostics();
 
-  if (Consumer.syntaxTreeEnabled()) {
-    std::unordered_set<unsigned> ReusedNodeIds;
-    Consumer.handleSyntaxTree(Impl.SyntaxInfo->getSourceFile().getSyntaxRoot(),
-                              ReusedNodeIds);
-  }
-
   SwiftSyntaxMap NewMap = SwiftSyntaxMap(Impl.SyntaxMap.Tokens.size() + 16);
 
   if (Consumer.syntaxTreeEnabled()) {
@@ -2107,6 +2101,12 @@ void SwiftLangSupport::editorOpen(StringRef Name, llvm::MemoryBuffer *Buf,
 
   EditorDoc->readSyntaxInfo(Consumer);
   EditorDoc->readSemanticInfo(Snapshot, Consumer);
+
+  if (Consumer.syntaxTreeEnabled()) {
+    assert(EditorDoc->getSyntaxTree().hasValue());
+    Consumer.handleSyntaxTree(EditorDoc->getSyntaxTree().getValue(),
+                              /*ReusedNodeIds=*/{});
+  }
 }
 
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -2104,8 +2104,9 @@ void SwiftLangSupport::editorOpen(StringRef Name, llvm::MemoryBuffer *Buf,
 
   if (Consumer.syntaxTreeEnabled()) {
     assert(EditorDoc->getSyntaxTree().hasValue());
-    Consumer.handleSyntaxTree(EditorDoc->getSyntaxTree().getValue(),
-                              /*ReusedNodeIds=*/{});
+    std::unordered_set<unsigned> ReusedNodeIds;
+    Consumer.handleSyntaxTree(EditorDoc->getSyntaxTree().getValue(), 
+                              ReusedNodeIds);
   }
 }
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -2423,9 +2423,14 @@ void serializeSyntaxTreeAsJson(
     const swift::syntax::SourceFileSyntax &SyntaxTree,
     std::unordered_set<unsigned> ReusedNodeIds,
     ResponseBuilder::Dictionary &Dict) {
+  // 4096 is a heuristic buffer size that appears to usually be able to fit an
+  // incremental syntax tree
+  size_t ReserveBufferSize = 4096;
   std::string SyntaxTreeString;
+  SyntaxTreeString.reserve(ReserveBufferSize);
   {
     llvm::raw_string_ostream SyntaxTreeStream(SyntaxTreeString);
+    SyntaxTreeStream.SetBufferSize(ReserveBufferSize);
     swift::json::Output::UserInfoMap JsonUserInfo;
     JsonUserInfo[swift::json::OmitNodesUserInfoKey] = &ReusedNodeIds;
     swift::json::Output SyntaxTreeOutput(SyntaxTreeStream, JsonUserInfo,

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -2089,7 +2089,7 @@ public:
   void handleSourceText(StringRef Text) override;
 
   void handleSyntaxTree(const swift::syntax::SourceFileSyntax &SyntaxTree,
-                        std::unordered_set<unsigned> ReusedNodeIds) override;
+                        std::unordered_set<unsigned> &ReusedNodeIds) override;
 
   bool syntaxReuseInfoEnabled() override { return Opts.EnableSyntaxReuseInfo; }
   void
@@ -2422,7 +2422,7 @@ void SKEditorConsumer::handleSourceText(StringRef Text) {
 
 void serializeSyntaxTreeAsJson(
     const swift::syntax::SourceFileSyntax &SyntaxTree,
-    std::unordered_set<unsigned> ReusedNodeIds,
+    std::unordered_set<unsigned> &ReusedNodeIds,
     ResponseBuilder::Dictionary &Dict) {
   auto StartClock = clock();
   // 4096 is a heuristic buffer size that appears to usually be able to fit an
@@ -2453,7 +2453,7 @@ void serializeSyntaxTreeAsJson(
 
 void SKEditorConsumer::handleSyntaxTree(
     const swift::syntax::SourceFileSyntax &SyntaxTree,
-    std::unordered_set<unsigned> ReusedNodeIds) {
+    std::unordered_set<unsigned> &ReusedNodeIds) {
   if (Opts.SyntaxTransferMode == SyntaxTreeTransferMode::Off)
     return;
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -2419,12 +2419,10 @@ void SKEditorConsumer::handleSourceText(StringRef Text) {
   Dict.set(KeySourceText, Text);
 }
 
-void SKEditorConsumer::handleSyntaxTree(
+void serializeSyntaxTreeAsJson(
     const swift::syntax::SourceFileSyntax &SyntaxTree,
-    std::unordered_set<unsigned> ReusedNodeIds) {
-  if (Opts.SyntaxTransferMode == SyntaxTreeTransferMode::Off)
-    return;
-
+    std::unordered_set<unsigned> ReusedNodeIds,
+    ResponseBuilder::Dictionary &Dict) {
   std::string SyntaxTreeString;
   {
     llvm::raw_string_ostream SyntaxTreeStream(SyntaxTreeString);
@@ -2435,6 +2433,15 @@ void SKEditorConsumer::handleSyntaxTree(
     SyntaxTreeOutput << *SyntaxTree.getRaw();
   }
   Dict.set(KeySerializedSyntaxTree, SyntaxTreeString);
+}
+
+void SKEditorConsumer::handleSyntaxTree(
+    const swift::syntax::SourceFileSyntax &SyntaxTree,
+    std::unordered_set<unsigned> ReusedNodeIds) {
+  if (Opts.SyntaxTransferMode == SyntaxTreeTransferMode::Off)
+    return;
+
+  serializeSyntaxTreeAsJson(SyntaxTree, ReusedNodeIds, Dict);
 }
 
 void SKEditorConsumer::handleSyntaxReuseRegions(

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -37,6 +37,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/NativeFormatting.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/Support/raw_ostream.h"
@@ -2423,6 +2424,7 @@ void serializeSyntaxTreeAsJson(
     const swift::syntax::SourceFileSyntax &SyntaxTree,
     std::unordered_set<unsigned> ReusedNodeIds,
     ResponseBuilder::Dictionary &Dict) {
+  auto StartClock = clock();
   // 4096 is a heuristic buffer size that appears to usually be able to fit an
   // incremental syntax tree
   size_t ReserveBufferSize = 4096;
@@ -2438,6 +2440,15 @@ void serializeSyntaxTreeAsJson(
     SyntaxTreeOutput << *SyntaxTree.getRaw();
   }
   Dict.set(KeySerializedSyntaxTree, SyntaxTreeString);
+
+  auto EndClock = clock();
+  LOG_SECTION("incrParse Performance", InfoLowPrio) {
+    Log->getOS() << "Serialized " << SyntaxTreeString.size() << " bytes in ";
+    llvm::write_double(Log->getOS(),
+                       (double)(EndClock - StartClock) * 1000 / CLOCKS_PER_SEC,
+                       llvm::FloatStyle::Fixed, 2);
+    Log->getOS() << "ms";
+  }
 }
 
 void SKEditorConsumer::handleSyntaxTree(

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -79,7 +79,7 @@ class NullEditorConsumer : public EditorConsumer {
 
   void handleSourceText(StringRef Text) override {}
   void handleSyntaxTree(const swift::syntax::SourceFileSyntax &SyntaxTree,
-                        std::unordered_set<unsigned> ReusedNodeIds) override {}
+                        std::unordered_set<unsigned> &ReusedNodeIds) override {}
 
   SyntaxTreeTransferMode syntaxTreeTransferMode() override {
     return SyntaxTreeTransferMode::Off;

--- a/unittests/SourceKit/SwiftLang/EditingTest.cpp
+++ b/unittests/SourceKit/SwiftLang/EditingTest.cpp
@@ -87,7 +87,7 @@ private:
 
   void handleSourceText(StringRef Text) override {}
   void handleSyntaxTree(const swift::syntax::SourceFileSyntax &SyntaxTree,
-                        std::unordered_set<unsigned> ReusedNodeIds) override {}
+                        std::unordered_set<unsigned> &ReusedNodeIds) override {}
 
   SyntaxTreeTransferMode syntaxTreeTransferMode() override {
     return SyntaxTreeTransferMode::Off;


### PR DESCRIPTION
This PR bundles a bunch of small performance improvements for parsing a syntax tree from a Swift file using SourceKit.

The separate improvements are described in the respective commit messages.