### PR TITLE
[sil-serialization] Create SILSerializationFunctionBuilder and use it…

### DIFF
--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -16,6 +16,7 @@
 #include "DeserializationErrors.h"
 #include "SILFormat.h"
 
+#include "SILSerializationFunctionBuilder.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/ProtocolConformance.h"
@@ -24,7 +25,6 @@
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILDebugScope.h"
-#include "swift/SIL/SILFunctionBuilder.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILUndef.h"
 #include "swift/Serialization/BCReadingExtras.h"
@@ -326,18 +326,6 @@ static SILType getSILType(Type Ty, SILValueCategory Category) {
                                    Category);
 }
 
-/// Helper function to create a bogus SILFunction to appease error paths.
-static SILFunction *createBogusSILFunction(SILModule &M,
-                                           StringRef name,
-                                           SILType type) {
-  SourceLoc loc;
-  SILFunctionBuilder builder(M);
-  return builder.createFunction(
-      SILLinkage::Private, name, type.castTo<SILFunctionType>(), nullptr,
-      RegularLocation(loc), IsNotBare, IsNotTransparent, IsNotSerialized,
-      ProfileCounter(), IsNotThunk, SubclassScope::NotApplicable);
-}
-
 /// Helper function to find a SILFunction, given its name and type.
 SILFunction *SILDeserializer::getFuncForReference(StringRef name,
                                                   SILType type) {
@@ -360,9 +348,16 @@ SILFunction *SILDeserializer::getFuncForReference(StringRef name,
 
   // FIXME: check for matching types.
 
-  // Always return something of the right type.
-  if (!fn) fn = createBogusSILFunction(SILMod, name, type);
-  return fn;
+  // At this point, if fn is set, we know that we have a good function to use.
+  if (fn)
+    return fn;
+
+  // Otherwise, create a function declaration with the right type and a bogus
+  // source location. This ensures that we can at least parse the rest of the
+  // SIL.
+  SourceLoc sourceLoc;
+  SILSerializationFunctionBuilder builder(SILMod);
+  return builder.createDeclaration(name, type, RegularLocation(sourceLoc));
 }
 
 /// Helper function to find a SILFunction, given its name and type.
@@ -550,18 +545,18 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
         linkage == SILLinkage::PublicNonABI) {
       fn->setLinkage(SILLinkage::SharedExternal);
     }
-
-  // Otherwise, create a new function.
   } else {
-    SILFunctionBuilder builder(SILMod);
-    fn = builder.createFunction(
-        linkage.getValue(), name, ty.castTo<SILFunctionType>(), nullptr, loc,
-        IsNotBare, IsTransparent_t(isTransparent == 1),
-        IsSerialized_t(isSerialized), ProfileCounter(), IsThunk_t(isThunk),
-        SubclassScope::NotApplicable, (Inline_t)inlineStrategy);
+    // Otherwise, create a new function.
+    SILSerializationFunctionBuilder builder(SILMod);
+    fn = builder.createDeclaration(name, ty, loc);
+    fn->setLinkage(linkage.getValue());
+    fn->setTransparent(IsTransparent_t(isTransparent == 1));
+    fn->setSerialized(IsSerialized_t(isSerialized));
+    fn->setThunk(IsThunk_t(isThunk));
+    fn->setInlineStrategy(Inline_t(inlineStrategy));
     fn->setGlobalInit(isGlobal == 1);
-    fn->setEffectsKind((EffectsKind)effect);
-    fn->setOptimizationMode((OptimizationMode)optimizationMode);
+    fn->setEffectsKind(EffectsKind(effect));
+    fn->setOptimizationMode(OptimizationMode(optimizationMode));
     fn->setWeakLinked(isWeakLinked);
     if (clangNodeOwner)
       fn->setClangNodeOwner(clangNodeOwner);

--- a/lib/Serialization/SILSerializationFunctionBuilder.h
+++ b/lib/Serialization/SILSerializationFunctionBuilder.h
@@ -1,0 +1,40 @@
+//===--- SerializationFunctionBuilder.h -----------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SERIALIZATION_SERIALIZATIONFUNCTIONBUILDER_H
+#define SWIFT_SERIALIZATION_SERIALIZATIONFUNCTIONBUILDER_H
+
+#include "swift/SIL/SILFunctionBuilder.h"
+
+namespace swift {
+
+class LLVM_LIBRARY_VISIBILITY SILSerializationFunctionBuilder {
+  SILFunctionBuilder builder;
+
+public:
+  SILSerializationFunctionBuilder(SILModule &mod) : builder(mod) {}
+
+  /// Create a SILFunction declaration for use either as a forward reference or
+  /// for the eventual deserialization of a function body.
+  SILFunction *createDeclaration(StringRef name, SILType type,
+                                 SILLocation loc) {
+    return builder.createFunction(
+        SILLinkage::Private, name, type.getAs<SILFunctionType>(), nullptr,
+        loc, IsNotBare, IsNotTransparent,
+        IsNotSerialized, ProfileCounter(), IsNotThunk,
+        SubclassScope::NotApplicable);
+  }
+};
+
+} // namespace swift
+
+#endif


### PR DESCRIPTION
… when deserializing.

This allowed me to fold all of the weird direct calls to createFunction into a
singular SILSerializationFunctionBuilder::createDeclaration. This is the only
API that is needed by the SILParser so only providing that gives us a
significantly cleaner API.

rdar://42301529
