### PR TITLE
Revert "tests: disabled a clang importer test"

### DIFF
--- a/test/ClangImporter/CoreGraphics_test.swift
+++ b/test/ClangImporter/CoreGraphics_test.swift
@@ -1,7 +1,5 @@
 // RUN: %target-swift-frontend -module-name=cgtest -emit-ir -O %s | %FileCheck %s
 
-// REQUIRES: rdar42775178
-
 // Test some imported CG APIs
 import CoreGraphics
 


### PR DESCRIPTION
Reverts #18399, now that this test is working again (#18408).

rdar://problem/42775178