### PR TITLE
[TF] Emit error for @TensorFlowGraph functions that capture variables.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2668,7 +2668,7 @@ ERROR(tf_graph_attr_function_tensorflow_value_only,none,
 ERROR(tf_graph_attr_no_generic_functions,none,
       "@TensorFlowGraph cannot be applied to generic functions", ())
 ERROR(tf_graph_attr_no_functions_with_captures,none,
-      "@TensorFlowGraph cannot be applied to functions that capture variables",
+      "@TensorFlowGraph cannot be applied to functions that capture values",
       ())
 
 // @TFParameter attribute

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2667,6 +2667,9 @@ ERROR(tf_graph_attr_function_tensorflow_value_only,none,
       "values", ())
 ERROR(tf_graph_attr_no_generic_functions,none,
       "@TensorFlowGraph cannot be applied to generic functions", ())
+ERROR(tf_graph_attr_no_functions_with_captures,none,
+      "@TensorFlowGraph cannot be applied to functions that capture variables",
+      ())
 
 // @TFParameter attribute
 ERROR(tfparameter_attr_tensorflow_not_imported,none,

--- a/test/TensorFlow/tf_graph_func_decls.swift
+++ b/test/TensorFlow/tf_graph_func_decls.swift
@@ -30,7 +30,7 @@ public func usingHostCode(_ x: Tensor<Float>) -> Tensor<Float> {
 public func outer() {
   let x = Tensor<Float>([1, 2, 3])
 
-  @TensorFlowGraph // expected-error {{@TensorFlowGraph cannot be applied to functions that capture variables}}
+  @TensorFlowGraph // expected-error {{@TensorFlowGraph cannot be applied to functions that capture values}}
   func inner() -> Tensor<Float> {
     return x
   }

--- a/test/TensorFlow/tf_graph_func_decls.swift
+++ b/test/TensorFlow/tf_graph_func_decls.swift
@@ -26,3 +26,12 @@ public func usingHostCode(_ x: Tensor<Float>) -> Tensor<Float> {
   let z = hostCode(y).toAccelerator()
   return z + z
 }
+
+public func outer() {
+  let x = Tensor<Float>([1, 2, 3])
+
+  @TensorFlowGraph // expected-error {{@TensorFlowGraph cannot be applied to functions that capture variables}}
+  func inner() -> Tensor<Float> {
+    return x
+  }
+}


### PR DESCRIPTION
Functions declared with `@TensorFlowGraph` cannot capture variables.
Addresses [SR-8442](https://bugs.swift.org/browse/SR-8442).