### PR TITLE
Revert "Fix several incorrect uses of ApplySite::getArgumentConvention."

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1937,6 +1937,11 @@ public:
     return OperandValueArrayRef(opsWithoutSelf);
   }
 
+  /// Return the SILArgumentConvention for the given applied argument index.
+  SILArgumentConvention getArgumentConvention(unsigned index) const {
+    return getSubstCalleeConv().getSILArgumentConvention(index);
+  }
+
   Optional<SILResultInfo> getSingleResult() const {
     auto SubstCallee = getSubstCalleeType();
     if (SubstCallee->getNumAllResults() != 1)
@@ -7675,7 +7680,7 @@ public:
   }
 
   /// Return the applied argument index for the given operand.
-  unsigned getAppliedArgIndex(const Operand &oper) const {
+  unsigned getArgumentIndex(const Operand &oper) const {
     assert(oper.getUser() == Inst);
     assert(isArgumentOperand(oper));
 
@@ -7714,14 +7719,19 @@ public:
   /// Note: Passing an applied argument index into SILFunctionConvention, as
   /// opposed to a function argument index, is incorrect.
   unsigned getCalleeArgIndex(const Operand &oper) const {
-    return getCalleeArgIndexOfFirstAppliedArg() + getAppliedArgIndex(oper);
+    return getCalleeArgIndexOfFirstAppliedArg() + getArgumentIndex(oper);
   }
 
   /// Return the SILArgumentConvention for the given applied argument operand.
   SILArgumentConvention getArgumentConvention(Operand &oper) const {
     unsigned calleeArgIdx =
-        getCalleeArgIndexOfFirstAppliedArg() + getAppliedArgIndex(oper);
+      getCalleeArgIndexOfFirstAppliedArg() + getArgumentIndex(oper);
     return getSubstCalleeConv().getSILArgumentConvention(calleeArgIdx);
+  }
+
+  // FIXME: This is incorrect. It will be removed in the next commit.
+  SILArgumentConvention getArgumentConvention(unsigned index) const {
+    return getSubstCalleeConv().getSILArgumentConvention(index);
   }
 
   /// Return true if 'self' is an applied argument.

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -2709,7 +2709,7 @@ public:
     auto isConsumingOrMutatingApplyUse = [](Operand *use) -> bool {
       ApplySite apply(use->getUser());
       assert(apply && "Not an apply instruction kind");
-      auto conv = apply.getArgumentConvention(*use);
+      auto conv = apply.getArgumentConvention(use->getOperandNumber() - 1);
       switch (conv) {
       case SILArgumentConvention::Indirect_In_Guaranteed:
         return false;

--- a/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
+++ b/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
@@ -339,7 +339,8 @@ static SILInstruction *getOnlyDestroy(CopyBlockWithoutEscapingInst *CB) {
 
     // If this an apply use, only handle unowned parameters.
     if (auto Apply = FullApplySite::isa(Inst)) {
-      SILArgumentConvention Conv = Apply.getArgumentConvention(*Use);
+      SILArgumentConvention Conv =
+          Apply.getArgumentConvention(Apply.getCalleeArgIndex(*Use));
       if (Conv != SILArgumentConvention::Direct_Unowned)
         return nullptr;
       continue;

--- a/lib/SILOptimizer/Transforms/CopyForwarding.cpp
+++ b/lib/SILOptimizer/Transforms/CopyForwarding.cpp
@@ -152,10 +152,12 @@ static SILArgumentConvention getAddressArgConvention(ApplyInst *Apply,
                                                      Operand *&Oper) {
   Oper = nullptr;
   auto Args = Apply->getArgumentOperands();
+  llvm::Optional<unsigned> FoundArgIdx;
   for (auto ArgIdx : indices(Args)) {
     if (Args[ArgIdx].get() != Address)
       continue;
 
+    FoundArgIdx = ArgIdx;
     assert(!Oper && "Address can only be passed once as an indirection.");
     Oper = &Args[ArgIdx];
 #ifdef NDEBUG
@@ -163,7 +165,7 @@ static SILArgumentConvention getAddressArgConvention(ApplyInst *Apply,
 #endif
   }
   assert(Oper && "Address value not passed as an argument to this call.");
-  return ApplySite(Apply).getArgumentConvention(*Oper);
+  return Apply->getArgumentConvention(FoundArgIdx.getValue());
 }
 
 /// If the given instruction is a store, return the stored value.
@@ -1631,10 +1633,10 @@ bool TempRValueOptPass::collectLoads(
     return false;
 
   case SILInstructionKind::ApplyInst: {
-    ApplySite apply(user);
-    auto Convention = apply.getArgumentConvention(*userOp);
+    auto *AI = cast<ApplyInst>(user);
+    auto Convention = AI->getArgumentConvention(userOp->getOperandNumber() - 1);
     if (Convention.isGuaranteedConvention()) {
-      loadInsts.insert(user);
+      loadInsts.insert(AI);
       return true;
     }
     LLVM_DEBUG(llvm::dbgs() << "  Temp consuming use may write/destroy "

--- a/lib/SILOptimizer/Utils/Existential.cpp
+++ b/lib/SILOptimizer/Utils/Existential.cpp
@@ -152,7 +152,9 @@ SILValue swift::getAddressOfStackInit(AllocStackInst *ASI,
     }
     if (isa<ApplyInst>(User) || isa<TryApplyInst>(User)) {
       // Ignore function calls which do not write to the stack location.
-      auto Conv = FullApplySite(User).getArgumentConvention(*Use);
+      auto Idx =
+          Use->getOperandNumber() - ApplyInst::getArgumentOperandNumber();
+      auto Conv = FullApplySite(User).getArgumentConvention(Idx);
       if (Conv != SILArgumentConvention::Indirect_In &&
           Conv != SILArgumentConvention::Indirect_In_Guaranteed)
         return SILValue();


### PR DESCRIPTION
Reverts apple/swift#18315

https://ci.swift.org/view/Source%20Compatibility/job/swift-master-source-compat-suite/2251/artifact/swift-source-compat-suite/

https://ci.swift.org/view/Source%20Compatibility/job/swift-master-source-compat-suite/2251/artifact/swift-source-compat-suite/FAIL_Kitura_4.0_BuildSwiftPackage.log

