### PR TITLE
Temoprarily revert AllocBoxToStack change to handle general applies.

### DIFF
--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -301,7 +301,9 @@ static bool partialApplyEscapes(SILValue V, bool examineApply) {
       continue;
     }
 
-    if (auto Apply = FullApplySite::isa(User)) {
+    if (auto AI = dyn_cast<ApplyInst>(User)) {
+      ApplySite Apply(AI);
+
       // Applying a function does not cause the function to escape.
       if (!Apply.isArgumentOperand(*Op))
         continue;


### PR DESCRIPTION
Fixes <rdar://problem/42815224> Swift CI: 2. Swift Source Compatibility Suite (master):
Kitura project fails with compiler crash

This will be properly fixed by rewriting the AllocBoxToStack utilities
in a follow up commit.
