### PR TITLE
Add ceil/floor operations.

### DIFF
--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -171,6 +171,20 @@ func _adjointExp<T : BinaryFloatingPoint>(
 }
 
 @inlinable
+func _adjointCeil<T : BinaryFloatingPoint>(
+  _ x: Tensor<T>, originalValue: Tensor<T>, seed: Tensor<T>
+) -> Tensor<T> {
+  return Tensor(0).broadcast(like: x)
+}
+
+@inlinable
+func _adjointFloor<T : BinaryFloatingPoint>(
+  _ x: Tensor<T>, originalValue: Tensor<T>, seed: Tensor<T>
+) -> Tensor<T> {
+  return Tensor(0).broadcast(like: x)
+}
+
+@inlinable
 func _adjointSqrt<T : BinaryFloatingPoint>(
   _ x: Tensor<T>, originalValue: Tensor<T>, seed: Tensor<T>
 ) -> Tensor<T> {

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -627,6 +627,20 @@ public func exp<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
   return Raw.exp(x)
 }
 
+/// Computes the ceiling of the specified tensor element-wise.
+@inlinable @inline(__always)
+@differentiable(reverse, adjoint: _adjointCeil(_:originalValue:seed:))
+public func ceil<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+  return Raw.ceil(x)
+}
+
+/// Computes the floor of the specified tensor element-wise.
+@inlinable @inline(__always)
+@differentiable(reverse, adjoint: _adjointFloor(_:originalValue:seed:))
+public func floor<T : BinaryFloatingPoint>(_ x: Tensor<T>) -> Tensor<T> {
+  return Raw.floor(x)
+}
+
 /// Computes the power of the first tensor to the second tensor.
 @inlinable @inline(__always)
 @differentiable(reverse, adjoint: _adjointPow(_:_:originalValue:seed:))

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -245,6 +245,14 @@ TensorTests.testAllBackends("ArgMax") {
   expectEqual(5, scalarsArgmax)
 }
 
+TensorTests.testAllBackends("CeilFloor") {
+  let x = Tensor<Float>([-1.3, -0.4, 0.5, 1.6])
+  let xFloor = floor(x)
+  let xCeil = ceil(x)
+  expectEqual(ShapedArray(shape: [4], scalars: [-2, -1, 0, 1]), xFloor.array)
+  expectEqual(ShapedArray(shape: [4], scalars: [-1, 0, 1, 2]), xCeil.array)
+}
+
 TensorTests.testAllBackends("SimpleMath") {
   let x = Tensor<Float>([1.2, 1.2])
   let y = tanh(x)


### PR DESCRIPTION
Add ceil/floor and their adjoints.

The adjoints of ceil/floor are 0:
* TensorFlow gradients: [ceil](https://github.com/tensorflow/tensorflow/blob/a89726dea8d9005a5f9ca73ad14f28c32cd87e56/tensorflow/python/ops/math_grad.py#L1151), [floor](https://github.com/tensorflow/tensorflow/blob/a89726dea8d9005a5f9ca73ad14f28c32cd87e56/tensorflow/python/ops/math_grad.py#L1146)
* PyTorch derivatives: [ceil](https://github.com/pytorch/pytorch/blob/43b151224e5487eea00c7ce4e0efd442ee623715/tools/autograd/derivatives.yaml#L169), [floor](https://github.com/pytorch/pytorch/blob/43b151224e5487eea00c7ce4e0efd442ee623715/tools/autograd/derivatives.yaml#L270)