### PR TITLE
 prototype for SE-0174

### DIFF
--- a/stdlib/public/core/ArrayType.swift
+++ b/stdlib/public/core/ArrayType.swift
@@ -14,6 +14,7 @@
 internal protocol ArrayProtocol
   : RangeReplaceableCollection,
     ExpressibleByArrayLiteral
+  where Filtered == [Element]
 {
   //===--- public interface -----------------------------------------------===//
   /// The number of elements the Array stores.
@@ -79,7 +80,7 @@ extension ArrayProtocol {
   @inlinable
   public func filter(
     _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> [Element] {
+  ) rethrows -> Filtered {
     return try _filter(isIncluded)
   }
 }

--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -45,6 +45,9 @@ where SubSequence: BidirectionalCollection, Indices: BidirectionalCollection {
 
   // FIXME(ABI): Associated type inference requires this.
   associatedtype SubSequence
+  
+  // FIXME(ABI): Associated type inference (probably) requires this.
+  associatedtype Filtered
 
   // FIXME(ABI): Associated type inference requires this.
   associatedtype Indices

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -124,6 +124,7 @@ extension ClosedRange: Sequence
 where Bound: Strideable, Bound.Stride: SignedInteger {
   public typealias Element = Bound
   public typealias Iterator = IndexingIterator<ClosedRange<Bound>>
+  public typealias Filtered = [Bound]
 }
 
 extension ClosedRange where Bound : Strideable, Bound.Stride : SignedInteger {

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -392,7 +392,7 @@ public protocol Collection: Sequence where SubSequence: Collection {
   /// collection, the subsequence should also conform to `Collection`.
   associatedtype SubSequence = Slice<Self> where SubSequence.Index == Index
 
-  /// A type that represents a collection composed of an arbatrary
+  /// A type that represents a collection composed of an arbitrary
   /// assortment of the collection's elements.
   ///
   /// This associated type appears as a requirement in the `Sequence`

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -392,6 +392,14 @@ public protocol Collection: Sequence where SubSequence: Collection {
   /// collection, the subsequence should also conform to `Collection`.
   associatedtype SubSequence = Slice<Self> where SubSequence.Index == Index
 
+  /// A type that represents a collection composed of an arbatrary
+  /// assortment of the collection's elements.
+  ///
+  /// This associated type appears as a requirement in the `Sequence`
+  /// protocol, but it is restated here with stricter constraints. A
+  /// filtered collection should also conform to `Collection`.
+  associatedtype Filtered : Collection = Array<Element>
+  
   /// Accesses the element at the specified position.
   ///
   /// The following example accesses an element of an array through its

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -75,6 +75,9 @@ extension CollectionOfOne: RandomAccessCollection, MutableCollection {
   public typealias Index = Int
   public typealias Indices = Range<Int>
   public typealias SubSequence = Slice<CollectionOfOne<Element>>
+  // FIXME: do we want a special type for this?
+  // a `CollectionOfZeroOrOne`?
+  public typealias Filtered = [Element]
 
   /// The position of the first element.
   ///

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -61,6 +61,11 @@ extension ContiguousArray: RandomAccessCollection, MutableCollection {
   /// The type that allows iteration over an array's elements.
   public typealias Iterator = IndexingIterator<ContiguousArray>
 
+  // FIXME: do we want this?
+  // public typealias Filtered = ContiguousArray<Element>
+  // or this:
+  public typealias Filtered = [Element]
+  
   /// The position of the first element in a nonempty array.
   ///
   /// For an instance of `ContiguousArray`, `startIndex` is always zero. If the array

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -393,6 +393,8 @@ public struct Dictionary<Key: Hashable, Value> {
   /// key-value pair.
   public typealias Element = (key: Key, value: Value)
 
+  public typealias Filtered = [Key: Value]
+  
   @usableFromInline
   internal var _variantBuffer: _VariantBuffer
 
@@ -587,7 +589,6 @@ extension Dictionary: Sequence {
   }
 }
 
-// This is not quite Sequence.filter, because that returns [Element], not Self
 extension Dictionary {
   /// Returns a new dictionary containing the key-value pairs of the dictionary
   /// that satisfy the given predicate.

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -47,6 +47,22 @@ extension EmptyCollection.Iterator: IteratorProtocol, Sequence {
   public mutating func next() -> Element? {
     return nil
   }
+  
+  /// Returns a sequence containing, in order, the elements of the sequence
+  /// that satisfy the given predicate.
+  ///
+  /// - Parameter isIncluded: A closure that takes an element of the
+  ///   sequence as its argument and returns a Boolean value indicating
+  ///   whether the element should be included in the returned array.
+  /// - Returns: An collection of the elements that `isIncluded` allowed.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  public func filter(
+    _ isIncluded: (Element) throws -> Bool
+    ) rethrows -> Filtered {
+    return self
+  }
 }
 
 extension EmptyCollection: Sequence {
@@ -144,6 +160,22 @@ extension EmptyCollection: RandomAccessCollection, MutableCollection {
     return n == 0 ? i : nil
   }
 
+  /// Returns a collection containing, in order, the elements of the sequence
+  /// that satisfy the given predicate.
+  ///
+  /// - Parameter isIncluded: A closure that takes an element of the
+  ///   sequence as its argument and returns a Boolean value indicating
+  ///   whether the element should be included in the returned array.
+  /// - Returns: An collection of the elements that `isIncluded` allowed.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  public func filter(
+    _ isIncluded: (Element) throws -> Bool
+    ) rethrows -> Filtered {
+    return self
+  }
+  
   /// The distance between two indexes (always zero).
   @inlinable // FIXME(sil-serialize-all)
   public func distance(from start: Index, to end: Index) -> Int {

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -60,7 +60,7 @@ extension EmptyCollection.Iterator: IteratorProtocol, Sequence {
   @inlinable
   public func filter(
     _ isIncluded: (Element) throws -> Bool
-    ) rethrows -> Filtered {
+  ) rethrows -> Filtered {
     return self
   }
 }
@@ -172,7 +172,7 @@ extension EmptyCollection: RandomAccessCollection, MutableCollection {
   @inlinable
   public func filter(
     _ isIncluded: (Element) throws -> Bool
-    ) rethrows -> Filtered {
+  ) rethrows -> Filtered {
     return self
   }
   

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -40,6 +40,8 @@ extension EmptyCollection {
 }
 
 extension EmptyCollection.Iterator: IteratorProtocol, Sequence {
+  public typealias Filtered = EmptyCollection.Iterator
+  
   /// Returns `nil`, indicating that there are no more elements.
   @inlinable // FIXME(sil-serialize-all)
   public mutating func next() -> Element? {
@@ -63,6 +65,7 @@ extension EmptyCollection: RandomAccessCollection, MutableCollection {
   public typealias Index = Int
   public typealias Indices = Range<Int>
   public typealias SubSequence = EmptyCollection<Element>
+  public typealias Filtered = EmptyCollection<Element>
 
   /// Always zero, just like `endIndex`.
   @inlinable // FIXME(sil-serialize-all)

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -202,7 +202,7 @@ internal class _AnyRandomAccessCollectionBox<Element>
   @inlinable
   internal func _filter(
     _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> [Element] {
+  ) rethrows -> Filtered {
     _abstract()
   }
 
@@ -432,7 +432,7 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Element>
   @inlinable
   internal override func _filter(
     _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> [Element] {
+  ) rethrows -> Filtered {
     return try _base.filter(isIncluded)
   }
   @inlinable
@@ -733,7 +733,7 @@ extension Any${Kind} {
   @inlinable
   public func filter(
     _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> [Element] {
+  ) rethrows -> Filtered {
     return try _box._filter(isIncluded)
   }
 

--- a/stdlib/public/core/Indices.swift
+++ b/stdlib/public/core/Indices.swift
@@ -38,6 +38,7 @@ extension DefaultIndices: Collection {
   public typealias Element = Elements.Index
   public typealias Indices = DefaultIndices<Elements>
   public typealias SubSequence = DefaultIndices<Elements>
+  public typealias Filtered = [Elements.Index]
   public typealias Iterator = IndexingIterator<DefaultIndices<Elements>>
 
   @inlinable

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -3500,6 +3500,8 @@ ${assignmentOperatorComment(x.operator, True)}
   public struct Words : BidirectionalCollection {
     public typealias Indices = Range<Int>
     public typealias SubSequence = Slice<${Self}.Words>
+    // FIXME: do we want a special type for this?
+    public typealias Filtered = [UInt]
 
     @usableFromInline // FIXME(sil-serialize-all)
     internal var _value: ${Self}

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -68,6 +68,9 @@ where SubSequence: MutableCollection
 
   // FIXME(ABI): Associated type inference requires this.
   associatedtype SubSequence
+  
+  // FIXME(ABI): Associated type inference (probably) requires this.
+  associatedtype Filtered
 
   /// Accesses the element at the specified position.
   ///

--- a/stdlib/public/core/RandomAccessCollection.swift
+++ b/stdlib/public/core/RandomAccessCollection.swift
@@ -155,9 +155,7 @@ where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection
   ///   is the same value as the result of `abs(distance)` calls to
   ///   `index(before:)`.
   ///
-  /// - Complexity: O(1) if the collection conforms to
-  ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is the absolute
-  ///   value of `distance`.
+  /// - Complexity: O(1)
   func index(_ i: Index, offsetBy distance: Int) -> Index
 
   /// Returns an index that is the specified distance from the given index,
@@ -199,9 +197,7 @@ where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection
   ///   index would be beyond `limit` in the direction of movement. In that
   ///   case, the method returns `nil`.
   ///
-  /// - Complexity: O(1) if the collection conforms to
-  ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is the absolute
-  ///   value of `distance`.
+  /// - Complexity: O(1)
   func index(
     _ i: Index, offsetBy distance: Int, limitedBy limit: Index
   ) -> Index?
@@ -219,9 +215,7 @@ where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection
   ///   negative only if the collection conforms to the
   ///   `BidirectionalCollection` protocol.
   ///
-  /// - Complexity: O(1) if the collection conforms to
-  ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is the
-  ///   resulting distance.
+  /// - Complexity: O(1)
   func distance(from start: Index, to end: Index) -> Int
 }
 

--- a/stdlib/public/core/RandomAccessCollection.swift
+++ b/stdlib/public/core/RandomAccessCollection.swift
@@ -42,6 +42,9 @@ where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection
   // FIXME(ABI): Associated type inference requires this.
   associatedtype SubSequence
 
+  // FIXME(ABI): Associated type inference (probably) requires this.
+  associatedtype Filtered
+  
   // FIXME(ABI): Associated type inference requires this.
   associatedtype Indices
 
@@ -152,7 +155,9 @@ where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection
   ///   is the same value as the result of `abs(distance)` calls to
   ///   `index(before:)`.
   ///
-  /// - Complexity: O(1)
+  /// - Complexity: O(1) if the collection conforms to
+  ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is the absolute
+  ///   value of `distance`.
   func index(_ i: Index, offsetBy distance: Int) -> Index
 
   /// Returns an index that is the specified distance from the given index,
@@ -194,7 +199,9 @@ where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection
   ///   index would be beyond `limit` in the direction of movement. In that
   ///   case, the method returns `nil`.
   ///
-  /// - Complexity: O(1)
+  /// - Complexity: O(1) if the collection conforms to
+  ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is the absolute
+  ///   value of `distance`.
   func index(
     _ i: Index, offsetBy distance: Int, limitedBy limit: Index
   ) -> Index?
@@ -212,7 +219,9 @@ where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection
   ///   negative only if the collection conforms to the
   ///   `BidirectionalCollection` protocol.
   ///
-  /// - Complexity: O(1)
+  /// - Complexity: O(1) if the collection conforms to
+  ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is the
+  ///   resulting distance.
   func distance(from start: Index, to end: Index) -> Int
 }
 

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -184,6 +184,7 @@ extension Range: Sequence
 where Bound: Strideable, Bound.Stride : SignedInteger {
   public typealias Element = Bound
   public typealias Iterator = IndexingIterator<Range<Bound>>
+  public typealias Filtered = [Bound]
 }
 
 extension Range: Collection, BidirectionalCollection, RandomAccessCollection

--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -66,7 +66,7 @@ public protocol RangeReplaceableCollection : Collection
   // FIXME(ABI): Associated type inference requires this.
   associatedtype SubSequence
   
-  /// A type that represents a collection composed of an arbatrary
+  /// A type that represents a collection composed of an arbitrary
   /// assortment of the collection's elements.
   ///
   /// This associated type appears as a requirement in the `Sequence`

--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -65,6 +65,15 @@ public protocol RangeReplaceableCollection : Collection
   where SubSequence : RangeReplaceableCollection {
   // FIXME(ABI): Associated type inference requires this.
   associatedtype SubSequence
+  
+  /// A type that represents a collection composed of an arbatrary
+  /// assortment of the collection's elements.
+  ///
+  /// This associated type appears as a requirement in the `Sequence`
+  /// protocol, but it is restated here with stricter constraints. A
+  /// filtered `RangeReplaceableCollection` should also conform
+  /// to `RangeReplaceableCollection`.
+  associatedtype Filtered: RangeReplaceableCollection = Self
 
   //===--- Fundamental Requirements ---------------------------------------===//
 
@@ -1074,8 +1083,8 @@ extension RangeReplaceableCollection {
   @available(swift, introduced: 4.0)
   public func filter(
     _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> Self {
-    return try Self(self.lazy.filter(isIncluded))
+  ) rethrows -> Filtered {
+    return try Filtered(self.lazy.filter(isIncluded))
   }
 }
 

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -335,7 +335,7 @@ public protocol Sequence {
     where Element == SubSequence.Element,
           SubSequence.SubSequence == SubSequence
   
-  /// A type that represents a sequence composed of an arbatrary
+  /// A type that represents a sequence composed of an arbitrary
   /// assortment of this sequence's elements.
   associatedtype Filtered : Sequence = Array<Element>
     where Element == Filtered.Element
@@ -391,7 +391,7 @@ public protocol Sequence {
   /// - Parameter isIncluded: A closure that takes an element of the
   ///   sequence as its argument and returns a Boolean value indicating
   ///   whether the element should be included in the returned array.
-  /// - Returns: An sequence of the elements that `isIncluded` allowed.
+  /// - Returns: A sequence of the elements that `isIncluded` allowed.
   ///
   /// - Complexity: O(*n*), where *n* is the length of the sequence.
   __consuming func filter(
@@ -1037,14 +1037,14 @@ extension Sequence where Filtered: RangeReplaceableCollection {
   @inlinable
   public func filter(
     _ isIncluded: (Element) throws -> Bool
-    ) rethrows -> Filtered {
+  ) rethrows -> Filtered {
     return try _filter(isIncluded)
   }
   
   @_transparent
   public func _filter(
     _ isIncluded: (Element) throws -> Bool
-    ) rethrows -> Filtered {
+  ) rethrows -> Filtered {
     
     // FIXME: should we directly do this 2-pass like this?
     // or filter directly into `Filtered`?
@@ -1085,14 +1085,14 @@ extension Sequence where Filtered == Array<Element> {
   @inlinable
   public func filter(
     _ isIncluded: (Element) throws -> Bool
-    ) rethrows -> [Element] {
+  ) rethrows -> [Element] {
     return try _filter(isIncluded)
   }
   
   @_transparent
   public func _filter(
     _ isIncluded: (Element) throws -> Bool
-    ) rethrows -> [Element] {
+  ) rethrows -> [Element] {
     
     var result = ContiguousArray<Element>()
     

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -1017,7 +1017,7 @@ extension Sequence where Element : Equatable {
 
 extension Sequence where Filtered: RangeReplaceableCollection {
   
-  /// Returns an array containing, in order, the elements of the sequence
+  /// Returns a collection containing, in order, the elements of the sequence
   /// that satisfy the given predicate.
   ///
   /// In this example, `filter(_:)` is used to include only names shorter than

--- a/stdlib/public/core/SequenceWrapper.swift
+++ b/stdlib/public/core/SequenceWrapper.swift
@@ -18,11 +18,10 @@
 /// A type that is just a wrapper over some base Sequence
 @_show_in_interface
 public // @testable
-protocol _SequenceWrapper : Sequence {
+protocol _SequenceWrapper : Sequence where Filtered == Base.Filtered {
   associatedtype Base : Sequence where Base.Element == Element
   associatedtype Iterator = Base.Iterator
   associatedtype SubSequence = Base.SubSequence
-  associatedtype Filtered = Base.Filtered
   
   var _base: Base { get }
 }

--- a/stdlib/public/core/SequenceWrapper.swift
+++ b/stdlib/public/core/SequenceWrapper.swift
@@ -22,6 +22,7 @@ protocol _SequenceWrapper : Sequence {
   associatedtype Base : Sequence where Base.Element == Element
   associatedtype Iterator = Base.Iterator
   associatedtype SubSequence = Base.SubSequence
+  associatedtype Filtered = Base.Filtered
   
   var _base: Base { get }
 }
@@ -66,7 +67,7 @@ extension _SequenceWrapper {
   @inlinable // FIXME(sil-serialize-all)
   public func filter(
     _ isIncluded: (Element) throws -> Bool
-  ) rethrows -> [Element] {
+  ) rethrows -> Filtered {
     return try _base.filter(isIncluded)
   }
 

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -245,7 +245,7 @@ extension Set: Sequence {
     return _variantBuffer.makeIterator()
   }
 
-  typealias Filtered = Set<Element>
+  public typealias Filtered = Set<Element>
   
   /// Returns a Boolean value that indicates whether the given element exists
   /// in the set.

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -245,6 +245,8 @@ extension Set: Sequence {
     return _variantBuffer.makeIterator()
   }
 
+  typealias Filtered = Set<Element>
+  
   /// Returns a Boolean value that indicates whether the given element exists
   /// in the set.
   ///
@@ -275,8 +277,6 @@ extension Set: Sequence {
   }
 }
 
-// This is not quite Sequence.filter, because that returns [Element], not Self
-// (RangeReplaceableCollection.filter returns Self, but Set isn't an RRC)
 extension Set {
   /// Returns a new set containing the elements of the set that satisfy the
   /// given predicate.

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -20,6 +20,8 @@ extension String: BidirectionalCollection {
   public typealias IndexDistance = Int
 
   public typealias SubSequence = Substring
+  
+  public typealias Filtered = String
 
   /// The position of the first character in a nonempty string.
   ///

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -96,6 +96,7 @@ extension String {
 public struct Substring : StringProtocol {
   public typealias Index = String.Index
   public typealias SubSequence = Substring
+  public typealias Filtered = String
 
   @usableFromInline // FIXME(sil-serialize-all)
   internal var _slice: Slice<String>


### PR DESCRIPTION
<!-- What's in this pull request? -->
I noticed that despite being accepted since May 6, 2017, over a year ago, there is not even a PR to implement SE-0174, so it being a completely standard library change, I made a prototype.

Note this does not include:
* tests
* source compatibility aids
And also includes:
* custom `Filtered`s for 'obvious' types.
* `where` clauses not specified by the proposal (because it was accepted before `where` clauses)

Due to the age of SE-0174, I believe this certainly needs core team approval, but I do not believe it needs a re-review.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -→
Implements half of [SR-3444](https://bugs.swift.org/browse/SR-3444).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->