### PR TITLE
[TF API] Avoid using Tensor.scalarized() in op definitions.

### DIFF
--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -281,7 +281,8 @@ extension Tensor where Scalar : BinaryFloatingPoint {
     let dim = Tensor(Tensor<Int32>(shapeTensor[axis]))
     let tmp = (dNorm * inv) + (dVariance * 2 * dMean / dim)
     let dSelf = tmp + (dMean / dim)
-    return (dSelf, dOffset.scalarized(), dScale.scalarized())
+    return (dSelf, _TFGetScalarOrDie(dOffset.handle),  
+            _TFGetScalarOrDie(dScale.handle))
   }
 }
 

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -818,7 +818,7 @@ public extension Tensor where Scalar == Bool {
   @inlinable @inline(__always)
   func all() -> Bool {
     let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
-    return _TFGetScalarOrDie(Raw.all(self, reductionIndices: axes))
+    return _TFGetScalarOrDie(Raw.all(self, reductionIndices: axes).handle)
   }
 
   /// Returns `true` if any scalars are equal to `true`. Otherwise, returns
@@ -828,7 +828,7 @@ public extension Tensor where Scalar == Bool {
   @inlinable @inline(__always)
   func any() -> Bool {
     let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
-    return _TFGetScalarOrDie(Raw.any(self, reductionIndices: axes))
+    return _TFGetScalarOrDie(Raw.any(self, reductionIndices: axes).handle)
   }
 
   /// Performs a logical AND operation along the specified axes. The reduced
@@ -874,7 +874,7 @@ public extension Tensor where Scalar : Numeric & Comparable {
   @inlinable @inline(__always)
   func min() -> Scalar {
     let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
-    return _TFGetScalarOrDie(Raw.min(self, reductionIndices: axes))
+    return _TFGetScalarOrDie(Raw.min(self, reductionIndices: axes).handle)
   }
 
   // NOTE: This overload is necessary, otherwise `max()` would refer
@@ -882,7 +882,7 @@ public extension Tensor where Scalar : Numeric & Comparable {
   @inlinable @inline(__always)
   func max() -> Scalar {
     let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
-    return _TFGetScalarOrDie(Raw.max(self, reductionIndices: axes))
+    return _TFGetScalarOrDie(Raw.max(self, reductionIndices: axes).handle)
   }
 
   /// Returns the maximum values along the specified axes. The reduced

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -818,7 +818,7 @@ public extension Tensor where Scalar == Bool {
   @inlinable @inline(__always)
   func all() -> Bool {
     let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
-    return Raw.all(self, reductionIndices: axes).scalarized()
+    return _TFGetScalarOrDie(Raw.all(self, reductionIndices: axes))
   }
 
   /// Returns `true` if any scalars are equal to `true`. Otherwise, returns
@@ -828,7 +828,7 @@ public extension Tensor where Scalar == Bool {
   @inlinable @inline(__always)
   func any() -> Bool {
     let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
-    return Raw.any(self, reductionIndices: axes).scalarized()
+    return _TFGetScalarOrDie(Raw.any(self, reductionIndices: axes))
   }
 
   /// Performs a logical AND operation along the specified axes. The reduced
@@ -874,7 +874,7 @@ public extension Tensor where Scalar : Numeric & Comparable {
   @inlinable @inline(__always)
   func min() -> Scalar {
     let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
-    return Raw.min(self, reductionIndices: axes).scalarized()
+    return _TFGetScalarOrDie(Raw.min(self, reductionIndices: axes))
   }
 
   // NOTE: This overload is necessary, otherwise `max()` would refer
@@ -882,7 +882,7 @@ public extension Tensor where Scalar : Numeric & Comparable {
   @inlinable @inline(__always)
   func max() -> Scalar {
     let axes = Tensor<Int32>(rangeFrom: 0, to: rank, stride: 1)
-    return Raw.max(self, reductionIndices: axes).scalarized()
+    return _TFGetScalarOrDie(Raw.max(self, reductionIndices: axes))
   }
 
   /// Returns the maximum values along the specified axes. The reduced


### PR DESCRIPTION
In `all()`, `any()`, `min()` and `max()`, the resultant tensor is guaranteed to be a scalar. In these cases, we should use `_TFGetScalarOrDie(_:)` in the op implementation to avoid unnecessary graph ops.