### PR TITLE
IRGen: Don't unconditionally use field offset globals for cross-module class field access

### DIFF
--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -302,13 +302,12 @@ namespace {
           NumInherited = Elements.size();
         }
       }
-      
+
       // If this class was imported from another module, assume that we may
       // not know its exact layout.
-      if (theClass->getModuleContext() != IGM.getSwiftModule()) {
+      if (classHasIncompleteLayout(IGM, theClass)) {
+        ClassMetadataRequiresDynamicInitialization = true;
         ClassHasFixedSize = false;
-        if (classHasIncompleteLayout(IGM, theClass))
-          ClassMetadataRequiresDynamicInitialization = true;
       }
 
       // Access strategies should be set by the abstract class layout,

--- a/test/IRGen/Inputs/mixed_mode/ObjCStuff.apinotes
+++ b/test/IRGen/Inputs/mixed_mode/ObjCStuff.apinotes
@@ -1,10 +1,10 @@
 Name: ObjCStuff
 SwiftVersions:
-- Version: 4
+- Version: 5
   Typedefs:
    - Name: OJCCloudButt
      SwiftName: OJCCloud.Butt
-- Version: 3
+- Version: 4
   Typedefs:
    - Name: OJCCloudButt
      SwiftWrapper: none

--- a/test/IRGen/Inputs/other_class.swift
+++ b/test/IRGen/Inputs/other_class.swift
@@ -1,0 +1,7 @@
+public class Other {
+  public final var x: Int32 = 0
+}
+
+public class Subclass : Other {
+  public final var y: Int32 = 0
+}

--- a/test/IRGen/class_field_other_module.swift
+++ b/test/IRGen/class_field_other_module.swift
@@ -1,0 +1,24 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module -emit-module-path=%t/other_class.swiftmodule %S/Inputs/other_class.swift
+// RUN: %target-swift-frontend -I %t -emit-ir -O %s | %FileCheck %s -DINT=i%target-ptrsize
+
+import other_class
+
+// CHECK-LABEL: define {{(protected )?}}{{(dllexport )?}}swiftcc i32 @"$S24class_field_other_module12getSubclassXys5Int32V0c1_A00F0CF"(%T11other_class8SubclassC* nocapture readonly)
+// CHECK-NEXT: entry:
+// CHECK-NEXT: %._value = getelementptr inbounds %T11other_class8SubclassC, %T11other_class8SubclassC* %0, [[INT]] 0, i32 1, i32 0
+// CHECK-NEXT: %1 = load i32, i32* %._value
+// CHECK-NEXT: ret i32 %1
+public func getSubclassX(_ o: Subclass) -> Int32 {
+  return o.x
+}
+
+// CHECK-LABEL: define {{(protected )?}}{{(dllexport )?}}swiftcc i32 @"$S24class_field_other_module12getSubclassYys5Int32V0c1_A00F0CF"(%T11other_class8SubclassC* nocapture readonly)
+// CHECK-NEXT: entry:
+// CHECK-NEXT: %._value = getelementptr inbounds %T11other_class8SubclassC, %T11other_class8SubclassC* %0, [[INT]] 0, i32 2, i32 0
+// CHECK-NEXT: %1 = load i32, i32* %._value
+// CHECK-NEXT: ret i32 %1
+public func getSubclassY(_ o: Subclass) -> Int32 {
+  return o.y
+}

--- a/test/IRGen/mixed_mode_class_with_unimportable_fields.sil
+++ b/test/IRGen/mixed_mode_class_with_unimportable_fields.sil
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/UsingObjCStuff.swiftmodule -module-name UsingObjCStuff -I %t -I %S/Inputs/mixed_mode -swift-version 4 %S/Inputs/mixed_mode/UsingObjCStuff.swift
-// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/mixed_mode -module-name main -swift-version 3 %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DWORD=i%target-ptrsize
+// RUN: %target-swift-frontend -emit-module -o %t/UsingObjCStuff.swiftmodule -module-name UsingObjCStuff -I %t -I %S/Inputs/mixed_mode -swift-version 5 %S/Inputs/mixed_mode/UsingObjCStuff.swift
 // RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/mixed_mode -module-name main -swift-version 4 %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DWORD=i%target-ptrsize
+// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/mixed_mode -module-name main -swift-version 5 %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DWORD=i%target-ptrsize
 
 // REQUIRES: objc_interop
 

--- a/test/IRGen/mixed_mode_class_with_unimportable_fields.swift
+++ b/test/IRGen/mixed_mode_class_with_unimportable_fields.swift
@@ -1,14 +1,14 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t/UsingObjCStuff.swiftmodule -module-name UsingObjCStuff -I %t -I %S/Inputs/mixed_mode -swift-version 4 %S/Inputs/mixed_mode/UsingObjCStuff.swift
-// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/mixed_mode -module-name main -swift-version 3 %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-V3
-// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/mixed_mode -module-name main -swift-version 4 %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-V4
+// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/mixed_mode -module-name main -swift-version 3 %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-V3 -DWORD=i%target-ptrsize
+// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/mixed_mode -module-name main -swift-version 4 %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-V4 -DWORD=i%target-ptrsize
 
 // REQUIRES: objc_interop
 
 import UsingObjCStuff
 
 public class SubButtHolder: ButtHolder {
-  final var w: Double = 0
+  final var w: Float = 0
 
   override public func virtual() {}
 
@@ -20,39 +20,64 @@ public class SubSubButtHolder: SubButtHolder {
   public override func subVirtual() {}
 }
 
-// CHECK-LABEL: define {{.*}} @{{.*}}accessFinalFields
+// CHECK-LABEL: define {{(protected )?}}{{(dllexport )?}}swiftcc void @"$S4main17accessFinalFields2ofyp_ypt14UsingObjCStuff10ButtHolderC_tF"
 public func accessFinalFields(of holder: ButtHolder) -> (Any, Any) {
-  // x and z came from the other module, so we should use their accessors.
-  // CHECK: [[OFFSET:%.*]] = load [[WORD:i[0-9]+]], [[WORD]]* @"$S14UsingObjCStuff10ButtHolderC1xSivpWvd"
-  // CHECK: [[INSTANCE_RAW:%.*]] = bitcast {{.*}} to i8*
-  // CHECK: getelementptr inbounds i8, i8* [[INSTANCE_RAW]], [[WORD]] [[OFFSET]]
 
-  // CHECK: [[OFFSET:%.*]] = load [[WORD]], [[WORD]]* @"$S14UsingObjCStuff10ButtHolderC1zSSvpWvd"
-  // CHECK: [[INSTANCE_RAW:%.*]] = bitcast {{.*}} to i8*
-  // CHECK: getelementptr inbounds i8, i8* [[INSTANCE_RAW]], [[WORD]] [[OFFSET]]
+  // ButtHolder.y cannot be imported in Swift 3 mode, so make sure we use field
+  // offset globals here.
+
+  // CHECK-V3: [[OFFSET:%.*]] = load [[WORD]], [[WORD]]* @"$S14UsingObjCStuff10ButtHolderC1xSivpWvd"
+  // CHECK-V3: [[INSTANCE_RAW:%.*]] = bitcast {{.*}} to i8*
+  // CHECK-V3: getelementptr inbounds i8, i8* [[INSTANCE_RAW]], [[WORD]] [[OFFSET]]
+
+  // CHECK-V3: [[OFFSET:%.*]] = load [[WORD]], [[WORD]]* @"$S14UsingObjCStuff10ButtHolderC1zSSvpWvd"
+  // CHECK-V3: [[INSTANCE_RAW:%.*]] = bitcast {{.*}} to i8*
+  // CHECK-V3: getelementptr inbounds i8, i8* [[INSTANCE_RAW]], [[WORD]] [[OFFSET]]
+
+  // ButtHolder.y is correctly imported in Swift 4 mode, so we can use fixed offsets.
+
+  // CHECK-V4: [[OFFSET:%.*]] = getelementptr inbounds %T14UsingObjCStuff10ButtHolderC, %T14UsingObjCStuff10ButtHolderC* %2, i32 0, i32 1
+
+  // CHECK-V4: [[OFFSET:%.*]] = getelementptr inbounds %T14UsingObjCStuff10ButtHolderC, %T14UsingObjCStuff10ButtHolderC* %2, i32 0, i32 3
+
   return (holder.x, holder.z)
 }
 
-// CHECK-LABEL: define {{.*}} @{{.*}}accessFinalFields
+// CHECK-LABEL: define {{(protected )?}}{{(dllexport )?}}swiftcc void @"$S4main17accessFinalFields5ofSubyp_ypyptAA0F10ButtHolderC_tF"
 public func accessFinalFields(ofSub holder: SubButtHolder) -> (Any, Any, Any) {
   // We should use the runtime-adjusted ivar offsets since we may not have
   // a full picture of the layout in mixed Swift language version modes.
-  // CHECK: [[OFFSET:%.*]] = load [[WORD]], [[WORD]]* @"$S14UsingObjCStuff10ButtHolderC1xSivpWvd"
-  // CHECK: [[INSTANCE_RAW:%.*]] = bitcast {{.*}} to i8*
-  // CHECK: getelementptr inbounds i8, i8* [[INSTANCE_RAW]], [[WORD]] [[OFFSET]]
 
-  // CHECK: [[OFFSET:%.*]] = load [[WORD]], [[WORD]]* @"$S14UsingObjCStuff10ButtHolderC1zSSvpWvd"
-  // CHECK: [[INSTANCE_RAW:%.*]] = bitcast {{.*}} to i8*
-  // CHECK: getelementptr inbounds i8, i8* [[INSTANCE_RAW]], [[WORD]] [[OFFSET]]
+  // ButtHolder.y cannot be imported in Swift 3 mode, so make sure we use field
+  // offset globals here.
 
-  // CHECK: [[OFFSET:%.*]] = load [[WORD]], [[WORD]]* @"$S4main13SubButtHolderC1wSdvpWvd"
+  // CHECK-V3: [[OFFSET:%.*]] = load [[WORD]], [[WORD]]* @"$S14UsingObjCStuff10ButtHolderC1xSivpWvd"
+  // CHECK-V3: [[INSTANCE_RAW:%.*]] = bitcast {{.*}} to i8*
+  // CHECK-V3: getelementptr inbounds i8, i8* [[INSTANCE_RAW]], [[WORD]] [[OFFSET]]
 
-  // CHECK: [[INSTANCE_RAW:%.*]] = bitcast {{.*}} to i8*
-  // CHECK: getelementptr inbounds i8, i8* [[INSTANCE_RAW]], [[WORD]] [[OFFSET]]
+  // CHECK-V3: [[OFFSET:%.*]] = load [[WORD]], [[WORD]]* @"$S14UsingObjCStuff10ButtHolderC1zSSvpWvd"
+  // CHECK-V3: [[INSTANCE_RAW:%.*]] = bitcast {{.*}} to i8*
+  // CHECK-V3: getelementptr inbounds i8, i8* [[INSTANCE_RAW]], [[WORD]] [[OFFSET]]
+
+  // CHECK-V3: [[OFFSET:%.*]] = load [[WORD]], [[WORD]]* @"$S4main13SubButtHolderC1wSfvpWvd"
+
+  // CHECK-V3: [[INSTANCE_RAW:%.*]] = bitcast {{.*}} to i8*
+  // CHECK-V3: getelementptr inbounds i8, i8* [[INSTANCE_RAW]], [[WORD]] [[OFFSET]]
+  
+  // ButtHolder.y is correctly imported in Swift 4 mode, so we can use fixed offsets.
+
+  // CHECK-V4: [[SELF:%.*]] = bitcast %T4main13SubButtHolderC* %3 to %T14UsingObjCStuff10ButtHolderC*
+  // CHECK-V4: [[OFFSET:%.*]] = getelementptr inbounds %T14UsingObjCStuff10ButtHolderC, %T14UsingObjCStuff10ButtHolderC* [[SELF]], i32 0, i32 1
+
+  // CHECK-V4: [[SELF:%.*]] = bitcast %T4main13SubButtHolderC* %3 to %T14UsingObjCStuff10ButtHolderC*
+  // CHECK-V4: [[OFFSET:%.*]] = getelementptr inbounds %T14UsingObjCStuff10ButtHolderC, %T14UsingObjCStuff10ButtHolderC* [[SELF]], i32 0, i32 3
+
+  // CHECK-V4: [[OFFSET:%.*]] = getelementptr inbounds %T4main13SubButtHolderC, %T4main13SubButtHolderC* %3, i32 0, i32 4
+
   return (holder.x, holder.z, holder.w)
 }
 
-// CHECK-LABEL: define {{.*}} @{{.*}}invokeMethod
+// CHECK-LABEL: define {{(protected )?}}{{(dllexport )?}}swiftcc void @"$S4main12invokeMethod2onyAA13SubButtHolderC_tF"
 public func invokeMethod(on holder: SubButtHolder) {
   // CHECK-64: [[IMPL_ADDR:%.*]] = getelementptr inbounds {{.*}}, [[WORD]] 10
   // CHECK-32: [[IMPL_ADDR:%.*]] = getelementptr inbounds {{.*}}, [[WORD]] 13

--- a/test/IRGen/mixed_mode_class_with_unimportable_fields.swift
+++ b/test/IRGen/mixed_mode_class_with_unimportable_fields.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/UsingObjCStuff.swiftmodule -module-name UsingObjCStuff -I %t -I %S/Inputs/mixed_mode -swift-version 4 %S/Inputs/mixed_mode/UsingObjCStuff.swift
-// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/mixed_mode -module-name main -swift-version 3 %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-V3 -DWORD=i%target-ptrsize
+// RUN: %target-swift-frontend -emit-module -o %t/UsingObjCStuff.swiftmodule -module-name UsingObjCStuff -I %t -I %S/Inputs/mixed_mode -swift-version 5 %S/Inputs/mixed_mode/UsingObjCStuff.swift
 // RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/mixed_mode -module-name main -swift-version 4 %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-V4 -DWORD=i%target-ptrsize
+// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/mixed_mode -module-name main -swift-version 5 %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-V5 -DWORD=i%target-ptrsize
 
 // REQUIRES: objc_interop
 
@@ -23,22 +23,22 @@ public class SubSubButtHolder: SubButtHolder {
 // CHECK-LABEL: define {{(protected )?}}{{(dllexport )?}}swiftcc void @"$S4main17accessFinalFields2ofyp_ypt14UsingObjCStuff10ButtHolderC_tF"
 public func accessFinalFields(of holder: ButtHolder) -> (Any, Any) {
 
-  // ButtHolder.y cannot be imported in Swift 3 mode, so make sure we use field
+  // ButtHolder.y cannot be imported in Swift 4 mode, so make sure we use field
   // offset globals here.
 
-  // CHECK-V3: [[OFFSET:%.*]] = load [[WORD]], [[WORD]]* @"$S14UsingObjCStuff10ButtHolderC1xSivpWvd"
-  // CHECK-V3: [[INSTANCE_RAW:%.*]] = bitcast {{.*}} to i8*
-  // CHECK-V3: getelementptr inbounds i8, i8* [[INSTANCE_RAW]], [[WORD]] [[OFFSET]]
+  // CHECK-V4: [[OFFSET:%.*]] = load [[WORD]], [[WORD]]* @"$S14UsingObjCStuff10ButtHolderC1xSivpWvd"
+  // CHECK-V4: [[INSTANCE_RAW:%.*]] = bitcast {{.*}} to i8*
+  // CHECK-V4: getelementptr inbounds i8, i8* [[INSTANCE_RAW]], [[WORD]] [[OFFSET]]
 
-  // CHECK-V3: [[OFFSET:%.*]] = load [[WORD]], [[WORD]]* @"$S14UsingObjCStuff10ButtHolderC1zSSvpWvd"
-  // CHECK-V3: [[INSTANCE_RAW:%.*]] = bitcast {{.*}} to i8*
-  // CHECK-V3: getelementptr inbounds i8, i8* [[INSTANCE_RAW]], [[WORD]] [[OFFSET]]
+  // CHECK-V4: [[OFFSET:%.*]] = load [[WORD]], [[WORD]]* @"$S14UsingObjCStuff10ButtHolderC1zSSvpWvd"
+  // CHECK-V4: [[INSTANCE_RAW:%.*]] = bitcast {{.*}} to i8*
+  // CHECK-V4: getelementptr inbounds i8, i8* [[INSTANCE_RAW]], [[WORD]] [[OFFSET]]
 
-  // ButtHolder.y is correctly imported in Swift 4 mode, so we can use fixed offsets.
+  // ButtHolder.y is correctly imported in Swift 5 mode, so we can use fixed offsets.
 
-  // CHECK-V4: [[OFFSET:%.*]] = getelementptr inbounds %T14UsingObjCStuff10ButtHolderC, %T14UsingObjCStuff10ButtHolderC* %2, i32 0, i32 1
+  // CHECK-V5: [[OFFSET:%.*]] = getelementptr inbounds %T14UsingObjCStuff10ButtHolderC, %T14UsingObjCStuff10ButtHolderC* %2, i32 0, i32 1
 
-  // CHECK-V4: [[OFFSET:%.*]] = getelementptr inbounds %T14UsingObjCStuff10ButtHolderC, %T14UsingObjCStuff10ButtHolderC* %2, i32 0, i32 3
+  // CHECK-V5: [[OFFSET:%.*]] = getelementptr inbounds %T14UsingObjCStuff10ButtHolderC, %T14UsingObjCStuff10ButtHolderC* %2, i32 0, i32 3
 
   return (holder.x, holder.z)
 }
@@ -48,31 +48,31 @@ public func accessFinalFields(ofSub holder: SubButtHolder) -> (Any, Any, Any) {
   // We should use the runtime-adjusted ivar offsets since we may not have
   // a full picture of the layout in mixed Swift language version modes.
 
-  // ButtHolder.y cannot be imported in Swift 3 mode, so make sure we use field
+  // ButtHolder.y cannot be imported in Swift 4 mode, so make sure we use field
   // offset globals here.
 
-  // CHECK-V3: [[OFFSET:%.*]] = load [[WORD]], [[WORD]]* @"$S14UsingObjCStuff10ButtHolderC1xSivpWvd"
-  // CHECK-V3: [[INSTANCE_RAW:%.*]] = bitcast {{.*}} to i8*
-  // CHECK-V3: getelementptr inbounds i8, i8* [[INSTANCE_RAW]], [[WORD]] [[OFFSET]]
+  // CHECK-V4: [[OFFSET:%.*]] = load [[WORD]], [[WORD]]* @"$S14UsingObjCStuff10ButtHolderC1xSivpWvd"
+  // CHECK-V4: [[INSTANCE_RAW:%.*]] = bitcast {{.*}} to i8*
+  // CHECK-V4: getelementptr inbounds i8, i8* [[INSTANCE_RAW]], [[WORD]] [[OFFSET]]
 
-  // CHECK-V3: [[OFFSET:%.*]] = load [[WORD]], [[WORD]]* @"$S14UsingObjCStuff10ButtHolderC1zSSvpWvd"
-  // CHECK-V3: [[INSTANCE_RAW:%.*]] = bitcast {{.*}} to i8*
-  // CHECK-V3: getelementptr inbounds i8, i8* [[INSTANCE_RAW]], [[WORD]] [[OFFSET]]
+  // CHECK-V4: [[OFFSET:%.*]] = load [[WORD]], [[WORD]]* @"$S14UsingObjCStuff10ButtHolderC1zSSvpWvd"
+  // CHECK-V4: [[INSTANCE_RAW:%.*]] = bitcast {{.*}} to i8*
+  // CHECK-V4: getelementptr inbounds i8, i8* [[INSTANCE_RAW]], [[WORD]] [[OFFSET]]
 
-  // CHECK-V3: [[OFFSET:%.*]] = load [[WORD]], [[WORD]]* @"$S4main13SubButtHolderC1wSfvpWvd"
+  // CHECK-V4: [[OFFSET:%.*]] = load [[WORD]], [[WORD]]* @"$S4main13SubButtHolderC1wSfvpWvd"
 
-  // CHECK-V3: [[INSTANCE_RAW:%.*]] = bitcast {{.*}} to i8*
-  // CHECK-V3: getelementptr inbounds i8, i8* [[INSTANCE_RAW]], [[WORD]] [[OFFSET]]
+  // CHECK-V4: [[INSTANCE_RAW:%.*]] = bitcast {{.*}} to i8*
+  // CHECK-V4: getelementptr inbounds i8, i8* [[INSTANCE_RAW]], [[WORD]] [[OFFSET]]
   
-  // ButtHolder.y is correctly imported in Swift 4 mode, so we can use fixed offsets.
+  // ButtHolder.y is correctly imported in Swift 5 mode, so we can use fixed offsets.
 
-  // CHECK-V4: [[SELF:%.*]] = bitcast %T4main13SubButtHolderC* %3 to %T14UsingObjCStuff10ButtHolderC*
-  // CHECK-V4: [[OFFSET:%.*]] = getelementptr inbounds %T14UsingObjCStuff10ButtHolderC, %T14UsingObjCStuff10ButtHolderC* [[SELF]], i32 0, i32 1
+  // CHECK-V5: [[SELF:%.*]] = bitcast %T4main13SubButtHolderC* %3 to %T14UsingObjCStuff10ButtHolderC*
+  // CHECK-V5: [[OFFSET:%.*]] = getelementptr inbounds %T14UsingObjCStuff10ButtHolderC, %T14UsingObjCStuff10ButtHolderC* [[SELF]], i32 0, i32 1
 
-  // CHECK-V4: [[SELF:%.*]] = bitcast %T4main13SubButtHolderC* %3 to %T14UsingObjCStuff10ButtHolderC*
-  // CHECK-V4: [[OFFSET:%.*]] = getelementptr inbounds %T14UsingObjCStuff10ButtHolderC, %T14UsingObjCStuff10ButtHolderC* [[SELF]], i32 0, i32 3
+  // CHECK-V5: [[SELF:%.*]] = bitcast %T4main13SubButtHolderC* %3 to %T14UsingObjCStuff10ButtHolderC*
+  // CHECK-V5: [[OFFSET:%.*]] = getelementptr inbounds %T14UsingObjCStuff10ButtHolderC, %T14UsingObjCStuff10ButtHolderC* [[SELF]], i32 0, i32 3
 
-  // CHECK-V4: [[OFFSET:%.*]] = getelementptr inbounds %T4main13SubButtHolderC, %T4main13SubButtHolderC* %3, i32 0, i32 4
+  // CHECK-V5: [[OFFSET:%.*]] = getelementptr inbounds %T4main13SubButtHolderC, %T4main13SubButtHolderC* %3, i32 0, i32 4
 
   return (holder.x, holder.z, holder.w)
 }
@@ -91,9 +91,9 @@ public func invokeMethod(on holder: SubButtHolder) {
   holder.subVirtual()
 }
 
-// CHECK-V3-LABEL: define private void @initialize_metadata_SubButtHolder
-// CHECK-V3:   call void @swift_initClassMetadata(
+// CHECK-V4-LABEL: define private void @initialize_metadata_SubButtHolder
+// CHECK-V4:   call void @swift_initClassMetadata(
 
-// CHECK-V3-LABEL: define private void @initialize_metadata_SubSubButtHolder
-// CHECK-V3:   call void @swift_initClassMetadata(
+// CHECK-V4-LABEL: define private void @initialize_metadata_SubSubButtHolder
+// CHECK-V4:   call void @swift_initClassMetadata(
 

--- a/test/Interpreter/SDK/Inputs/mixed_mode/ObjCStuff.apinotes
+++ b/test/Interpreter/SDK/Inputs/mixed_mode/ObjCStuff.apinotes
@@ -1,10 +1,10 @@
 Name: ObjCStuff
 SwiftVersions:
-- Version: 4
+- Version: 5
   Typedefs:
    - Name: OJCCloudButt
      SwiftName: OJCCloud.Butt
-- Version: 3
+- Version: 4
   Typedefs:
    - Name: OJCCloudButt
      SwiftWrapper: none

--- a/test/Interpreter/SDK/mixed_mode_class_with_missing_properties.swift
+++ b/test/Interpreter/SDK/mixed_mode_class_with_missing_properties.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -whole-module-optimization -emit-module-path %t/UsingObjCStuff.swiftmodule -c -o %t/UsingObjCStuff.o -module-name UsingObjCStuff -I %t -I %S/Inputs/mixed_mode -swift-version 4 -parse-as-library %S/Inputs/mixed_mode/UsingObjCStuff.swift
-// RUN: %target-build-swift -o %t/a.out.v3 -I %t -I %S/Inputs/mixed_mode -module-name main -swift-version 3 %t/main.swift %t/UsingObjCStuff.o
+// RUN: %target-build-swift -whole-module-optimization -emit-module-path %t/UsingObjCStuff.swiftmodule -c -o %t/UsingObjCStuff.o -module-name UsingObjCStuff -I %t -I %S/Inputs/mixed_mode -swift-version 5 -parse-as-library %S/Inputs/mixed_mode/UsingObjCStuff.swift
 // RUN: %target-build-swift -o %t/a.out.v4 -I %t -I %S/Inputs/mixed_mode -module-name main -swift-version 4 %t/main.swift %t/UsingObjCStuff.o
-// RUN: %target-run %t/a.out.v3 | %FileCheck %s
+// RUN: %target-build-swift -o %t/a.out.v5 -I %t -I %S/Inputs/mixed_mode -module-name main -swift-version 5 %t/main.swift %t/UsingObjCStuff.o
 // RUN: %target-run %t/a.out.v4 | %FileCheck %s
+// RUN: %target-run %t/a.out.v5 | %FileCheck %s
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test


### PR DESCRIPTION
While most class field accesses go through accessors, a special
case is if you have a final field (or class) in a non-resilient
module. Then, we were allowed to directly access the field.

However, an earlier hack made it so that this access always went
through a field offset global, which is unnecessary in the case
where the class layout is fully known.

One consequence of this is that 'Array.count' would compile down
to a load from a global followed by an indirect load, instead of
a single load from a constant offset.