### PR TITLE
Use known instance size and alignment across module boundaries

### DIFF
--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -2289,36 +2289,6 @@ bool irgen::hasKnownSwiftMetadata(IRGenModule &IGM, ClassDecl *theClass) {
   return theClass->hasKnownSwiftImplementation();
 }
 
-/// Given a reference to class metadata of the given type,
-/// load the fragile instance size and alignment of the class.
-std::pair<llvm::Value *, llvm::Value *>
-irgen::emitClassFragileInstanceSizeAndAlignMask(IRGenFunction &IGF,
-                                                ClassDecl *theClass,
-                                                llvm::Value *metadata) {
-  // FIXME: The below checks should capture this property already, but
-  // resilient class metadata layout is not fully implemented yet.
-  auto superClass = theClass;
-  do {
-    if (superClass->getParentModule() != IGF.IGM.getSwiftModule()) {
-      return emitClassResilientInstanceSizeAndAlignMask(IGF, theClass,
-                                                        metadata);
-    }
-  } while ((superClass = superClass->getSuperclassDecl()));
-
-  // If the class has fragile fixed layout, return the constant size and
-  // alignment.
-  if (llvm::Constant *size
-        = tryEmitClassConstantFragileInstanceSize(IGF.IGM, theClass)) {
-    llvm::Constant *alignMask
-      = tryEmitClassConstantFragileInstanceAlignMask(IGF.IGM, theClass);
-    assert(alignMask && "static size without static align");
-    return {size, alignMask};
-  }
- 
-  // Otherwise, load it from the metadata.
-  return emitClassResilientInstanceSizeAndAlignMask(IGF, theClass, metadata);
-}
-
 std::pair<llvm::Value *, llvm::Value *>
 irgen::emitClassResilientInstanceSizeAndAlignMask(IRGenFunction &IGF,
                                                   ClassDecl *theClass,

--- a/lib/IRGen/GenClass.h
+++ b/lib/IRGen/GenClass.h
@@ -170,13 +170,6 @@ namespace irgen {
   /// the runtime?
   bool doesClassMetadataRequireDynamicInitialization(IRGenModule &IGM,
                                                      ClassDecl *theClass);
-    
-  /// If the superclass came from another module, we may have dropped
-  /// stored properties due to the Swift language version availability of
-  /// their types. In these cases we can't precisely lay out the ivars in
-  /// the class object at compile time so we need to do runtime layout.
-  bool classHasIncompleteLayout(IRGenModule &IGM,
-                                ClassDecl *theClass);
 
   /// Load the fragile instance size and alignment mask from a reference to
   /// class type metadata of the given type.

--- a/lib/IRGen/GenClass.h
+++ b/lib/IRGen/GenClass.h
@@ -171,13 +171,6 @@ namespace irgen {
   bool doesClassMetadataRequireDynamicInitialization(IRGenModule &IGM,
                                                      ClassDecl *theClass);
 
-  /// Load the fragile instance size and alignment mask from a reference to
-  /// class type metadata of the given type.
-  std::pair<llvm::Value *, llvm::Value *>
-  emitClassFragileInstanceSizeAndAlignMask(IRGenFunction &IGF,
-                                           ClassDecl *theClass,
-                                           llvm::Value *metadata);
-
   /// Load the instance size and alignment mask from a reference to
   /// class type metadata of the given type.
   std::pair<llvm::Value *, llvm::Value *>

--- a/lib/IRGen/StructLayout.h
+++ b/lib/IRGen/StructLayout.h
@@ -430,8 +430,14 @@ struct ClassLayout {
   ArrayRef<VarDecl*> InheritedStoredProperties;
   /// Lazily-initialized array of all field access methods.
   ArrayRef<FieldAccess> AllFieldAccesses;
-  /// Does the class metadata require dynamic initialization.
+  /// Does the class metadata require dynamic initialization?
   bool MetadataRequiresDynamicInitialization;
+  /// Do instances of this class have a size and layout known at compile time?
+  ///
+  /// Note: This is a stronger condition than the StructLayout of a class having
+  /// a fixed layout. The latter is true even when the class requires sliding
+  /// ivars by the Objective-C runtime.
+  bool HasFixedSize;
 
   unsigned getFieldIndex(VarDecl *field) const {
     // FIXME: This is algorithmically terrible.

--- a/test/IRGen/mixed_mode_class_with_unimportable_fields.sil
+++ b/test/IRGen/mixed_mode_class_with_unimportable_fields.sil
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/UsingObjCStuff.swiftmodule -module-name UsingObjCStuff -I %t -I %S/Inputs/mixed_mode -swift-version 5 %S/Inputs/mixed_mode/UsingObjCStuff.swift
-// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/mixed_mode -module-name main -swift-version 4 %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DWORD=i%target-ptrsize
-// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/mixed_mode -module-name main -swift-version 5 %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DWORD=i%target-ptrsize
+// RUN: %target-swift-frontend -emit-module -o %t/UsingObjCStuff.swiftmodule -module-name UsingObjCStuff -I %t -I %S/Inputs/mixed_mode -swift-version 4 %S/Inputs/mixed_mode/UsingObjCStuff.swift
+// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/mixed_mode -module-name main -swift-version 4 %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-V5 --check-prefix=CHECK-V5-%target-ptrsize  -DWORD=i%target-ptrsize
+// RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/mixed_mode -module-name main -swift-version 5 %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-V5 --check-prefix=CHECK-V5-%target-ptrsize -DWORD=i%target-ptrsize
 
 // REQUIRES: objc_interop
 
@@ -24,24 +24,45 @@ sil_vtable SubSubButtHolder {}
 // CHECK-LABEL: define {{.*}} @getHolder
 sil @getHolder: $@convention(thin) () -> @owned ButtHolder {
 entry:
-  // We should load the dimensions of the class instance from metadata, not try
-  // to hardcode constants.
-  // CHECK: [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S14UsingObjCStuff10ButtHolderCMa"([[WORD]] 0)
-  // CHECK: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
-  // CHECK-64: [[SIZE32:%.*]] = load i32
-  // CHECK-64: [[SIZE:%.*]] = zext i32 [[SIZE32]] to
-  // CHECK-32: [[SIZE:%.*]] = load i32
-  // CHECK: [[ALIGN16:%.*]] = load i16
-  // CHECK: [[ALIGN:%.*]] = zext i16 [[ALIGN16]] to [[WORD]]
-  // CHECK: call noalias %swift.refcounted* @swift_allocObject(%swift.type* [[METADATA]], [[WORD]] [[SIZE]], [[WORD]] [[ALIGN]])
+
+  // In Swift 4 mode, we don't know the size or alignment of ButtHolder
+  // instances, so we should load the dimensions of the class instance
+  // from metadata.
+  //
+  // In Swift 5 mode, it's okay to hardcode constants.
+
+  // CHECK-V4: [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S14UsingObjCStuff10ButtHolderCMa"([[WORD]] 0)
+  // CHECK-V4: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
+  // CHECK-V4-64: [[SIZE32:%.*]] = load i32
+  // CHECK-V4-64: [[SIZE:%.*]] = zext i32 [[SIZE32]] to
+  // CHECK-V4-32: [[SIZE:%.*]] = load i32
+  // CHECK-V4: [[ALIGN16:%.*]] = load i16
+  // CHECK-V4: [[ALIGN:%.*]] = zext i16 [[ALIGN16]] to [[WORD]]
+  // CHECK-V4: call noalias %swift.refcounted* @swift_allocObject(%swift.type* [[METADATA]], [[WORD]] [[SIZE]], [[WORD]] [[ALIGN]])
+
+  // CHECK-V5: [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S14UsingObjCStuff10ButtHolderCMa"([[WORD]] 0)
+  // CHECK-V5: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
+  // CHECK-V5-32: call noalias %swift.refcounted* @swift_allocObject(%swift.type* [[METADATA]], [[WORD]] 28, [[WORD]] 3)
+  // CHECK-V5-64: call noalias %swift.refcounted* @swift_allocObject(%swift.type* [[METADATA]], [[WORD]] 48, [[WORD]] 7)
+
   %x = alloc_ref $ButtHolder
-  // CHECK: [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S4main13SubButtHolderCMa"([[WORD]] 0)
-  // CHECK: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
-  // CHECK: call noalias %swift.refcounted* @swift_allocObject(%swift.type* [[METADATA]], [[WORD]] %{{.*}}, [[WORD]] %{{.*}})
+  // CHECK-V4: [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S4main13SubButtHolderCMa"([[WORD]] 0)
+  // CHECK-V4: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
+  // CHECK-V4: call noalias %swift.refcounted* @swift_allocObject(%swift.type* [[METADATA]], [[WORD]] %{{.*}}, [[WORD]] %{{.*}})
+
+  // CHECK-V5: [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S4main13SubButtHolderCMa"([[WORD]] 0)
+  // CHECK-V5: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
+  // CHECK-V5-32: call noalias %swift.refcounted* @swift_allocObject(%swift.type* [[METADATA]], [[WORD]] 40, [[WORD]] 7)
+  // CHECK-V5-64: call noalias %swift.refcounted* @swift_allocObject(%swift.type* [[METADATA]], [[WORD]] 56, [[WORD]] 7)
   %y = alloc_ref $SubButtHolder
-  // CHECK: [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S4main03SubB10ButtHolderCMa"([[WORD]] 0)
-  // CHECK: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
-  // CHECK: call noalias %swift.refcounted* @swift_allocObject(%swift.type* [[METADATA]], [[WORD]] %{{.*}}, [[WORD]] %{{.*}})
+  // CHECK-V4: [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S4main03SubB10ButtHolderCMa"([[WORD]] 0)
+  // CHECK-V4: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
+  // CHECK-V4: call noalias %swift.refcounted* @swift_allocObject(%swift.type* [[METADATA]], [[WORD]] %{{.*}}, [[WORD]] %{{.*}})
+
+  // CHECK-V5: [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S4main03SubB10ButtHolderCMa"([[WORD]] 0)
+  // CHECK-V5: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
+  // CHECK-V5-32: call noalias %swift.refcounted* @swift_allocObject(%swift.type* [[METADATA]], [[WORD]] 48, [[WORD]] 7)
+  // CHECK-V5-64: call noalias %swift.refcounted* @swift_allocObject(%swift.type* [[METADATA]], [[WORD]] 64, [[WORD]] 7)
   %z = alloc_ref $SubSubButtHolder
   return %x : $ButtHolder
 }


### PR DESCRIPTION
Follow-up to https://github.com/apple/swift/pull/18463. Removes another bogus case where we would fall back to the resilient pattern when a class came from a different module, after fixing the missing member case to do the right thing.