### PR TITLE
Sema: Fix ConstraintSystem::getTypeOfMemberReference() for protocol typealiases

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1268,7 +1268,7 @@ ConstraintSystem::getTypeOfMemberReference(
   // protocols.
   if (auto *alias = dyn_cast<TypeAliasDecl>(value)) {
     if (baseObjTy->isExistentialType()) {
-      auto memberTy = alias->getDeclaredInterfaceType();
+      auto memberTy = alias->getInterfaceType();
       // If we end up with a protocol typealias here, it's underlying
       // type must be fully concrete.
       assert(!memberTy->hasTypeParameter());

--- a/test/Sema/typo_correction.swift
+++ b/test/Sema/typo_correction.swift
@@ -119,7 +119,7 @@ protocol P { // expected-note {{'P' previously declared here}}
 protocol P {} // expected-error {{invalid redeclaration of 'P'}}
 
 func hasTypo() {
-  _ = P.a.a // expected-error {{value of type 'Generic' has no member 'a'}}
+  _ = P.a.a // expected-error {{type 'Generic' has no member 'a'}}
 }
 
 // Typo correction with AnyObject.

--- a/test/decl/typealias/protocol.swift
+++ b/test/decl/typealias/protocol.swift
@@ -299,3 +299,19 @@ struct SomeConformingType : UnboundGenericAliasProto {
 protocol UnboundGenericAliasProto {
   typealias G = X
 }
+
+// If pre-checking cannot resolve a member type due to ambiguity,
+// we go down the usual member access path. Make sure its correct
+// for protocol typealiases.
+protocol Amb1 {
+  typealias T = Int
+}
+
+protocol Amb2 {
+  typealias T = String
+}
+
+typealias Amb = Amb1 & Amb2
+
+let _: Int.Type = Amb.T.self
+let _: String.Type = Amb.T.self


### PR DESCRIPTION
Reported in https://forums.swift.org/t/reconsider-how-type-aliases-are-used-within-protocols-and-their-extensions/11965/18?u=slava_pestov