### PR TITLE
[Sema] Fix a crash in use-before-declaration case

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -469,6 +469,9 @@ static bool findNonMembers(TypeChecker &TC,
     }
 
     ValueDecl *D = Result.getValueDecl();
+    if (!isValid(D))
+      return false;
+
     if (!D->hasInterfaceType())
       TC.validateDecl(D);
 
@@ -477,9 +480,6 @@ static bool findNonMembers(TypeChecker &TC,
       AllDeclRefs = false;
       continue;
     }
-
-    if (!isValid(D))
-      return false;
 
     if (matchesDeclRefKind(D, refKind))
       ResultValues.push_back(D);

--- a/test/Sema/diag_use_before_declaration.swift
+++ b/test/Sema/diag_use_before_declaration.swift
@@ -18,7 +18,7 @@ func test() {
   guard let bar = foo else {
     return
   }
-  let foo = String(bar)
+  let foo = String(bar) // expected-warning {{initialization of immutable value 'foo' was never used; consider replacing with assignment to '_' or removing it}}
 }
 
 // SR-7660
@@ -28,6 +28,18 @@ class C {
     guard let _ = variable else { return }
     let variable = 1 // expected-warning {{initialization of immutable value 'variable' was never used; consider replacing with assignment to '_' or removing it}}
   }
+}
+
+// SR-7517
+func testExample() {
+  let app = app2 // expected-error {{use of local variable 'app2' before its declaration}}
+  let app2 = app // expected-note {{'app2' declared here}}
+}
+
+// SR-8447
+func test_circular() {
+  let obj = sr8447 // expected-error {{use of local variable 'sr8447' before its declaration}}
+  let _ = obj.prop, sr8447 // expected-note {{'sr8447' declared here}} expected-error {{type annotation missing in pattern}}
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Check "use-before-declaration" early so we don't typecheck referenced decl which might depends on the reference.

https://bugs.swift.org/browse/SR-7517
https://bugs.swift.org/browse/SR-8447
rdar://problem/39782719