### PR TITLE
Incorporated the TF fix on running an If op for its side effects only, and adapted unit tests for it.

### DIFF
--- a/test/TensorFlow/control_flow.swift
+++ b/test/TensorFlow/control_flow.swift
@@ -15,9 +15,10 @@ public func weighPet(pet: Pet) {
   case .dog: weight += 10.0
   case .fish: break // no tensor code here
   }
-  // This is needed to work-around the current TF limitation where the `If` op
-  // must produce some output tensors.
-  // FIXME: lift this restriction.
+  // This is used to avoid noisy send/recv warnings, where in each case above,
+  // the computed tensor value is sent to host due to the branch inst that's not
+  // marked for accelerator.
+  // FIXME: Revisit sends/recvs warnings design and remove this statement.
   weight += 0.0
   _hostOp(weight)
 }

--- a/test/TensorFlowRuntime/control_flow_1.swift
+++ b/test/TensorFlowRuntime/control_flow_1.swift
@@ -42,11 +42,11 @@ public func weighPet(_ pet: Pet,
     weight = _scalarTensorWithShape(weight)
   case .fish: break // no tensor code here
   }
-  // This is needed to work-around the current TF limitation where the `If` op
-  // must produce some output tensors.
-  // FIXME: lift this restriction.
-  weight += 0.0
   expectNearlyEqualWithScalarTensor(expectedVal, weight)
+  // TODO: remove the extra code below once TPU execution supports 0 output
+  // tensors (b/111123797)
+  let extra = Tensor<Float>(1.0)
+  _hostOp(extra)
 }
 ControlFlowTests.testAllBackends("weighPet") {
   weighPet(.bird, 2.0)
@@ -67,11 +67,11 @@ public func weighPetWithDefault(_ pet: Pet,
     weight += 3.0
     weight = _scalarTensorWithShape(weight)
   }
-  // This is needed to work-around the current TF limitation where the `If` op
-  // must produce some output tensors.
-  // FIXME: lift this restriction.
-  weight += 0.0
   expectNearlyEqualWithScalarTensor(expectedVal, weight)
+  // TODO: remove the extra code below once TPU execution supports 0 output
+  // tensors (b/111123797)
+  let extra = Tensor<Float>(1.0)
+  _hostOp(extra)
 }
 ControlFlowTests.testAllBackends("weighPetWithDefault") {
   weighPetWithDefault(.cat, 6.0)

--- a/utils/update-checkout-config.json
+++ b/utils/update-checkout-config.json
@@ -304,7 +304,7 @@
                 "swift-integration-tests": "swift-DEVELOPMENT-SNAPSHOT-2018-07-23-a",
                 "swift-xcode-playground-support": "swift-DEVELOPMENT-SNAPSHOT-2018-07-23-a",
                 "ninja": "253e94c1fa511704baeb61cf69995bbf09ba435e",
-                "tensorflow": "f943f0c2012e3820ddfe0fa86f002a80998e1faf",
+                "tensorflow": "72691c24e222aaff5681a718cbe96eb1436e4971",
                 "tensorflow-swift-bindings": "489fcb7c4ca0ee11f3453ee7b0749a4f0742e780"
             }
         }


### PR DESCRIPTION
The TF fix is https://github.com/tensorflow/tensorflow/commit/9354ab24b9760382b6e0fcd5f3276191fd27f233. This resolves a few runtime hanging bugs.

When an If op is only executed for its side effects (e.g. enqueue/dequeue tensors), it needs to be marked stateful, so that it does not get pruned away in a graph function. Note when the graph function itself does not produce output, there is no way to run the If op by setting up a control dependency edge. One example graph named.pbtxt attached to https://bugs.swift.org/browse/SR-8405.
 
Resolves [SR-8405](https://bugs.swift.org/browse/SR-8405).
Resolves [SR-8214](https://bugs.swift.org/browse/SR-8214).
