### PR TITLE
[4.2][stdlib]Remove deprecated TARGET_IPHONE_SIMULATOR reference

### DIFF
--- a/stdlib/public/stubs/Availability.mm
+++ b/stdlib/public/stubs/Availability.mm
@@ -30,7 +30,7 @@ using namespace swift;
 static NSDictionary *systemVersionDictionaryFromPlist() {
   NSString *plistPath = @"/System/Library/CoreServices/SystemVersion.plist";
 
-#if TARGET_IPHONE_SIMULATOR
+#if TARGET_OS_SIMULATOR
   // When targeting the iOS simulator, look in a special location so we do
   // not pick up the host OS version.
   const char *simulatorRoot = getenv("IPHONE_SIMULATOR_ROOT");


### PR DESCRIPTION
Cherry-picked from https://github.com/apple/swift/pull/17846

- **Explanation**: This replaces a use of the deprecated TARGET_IPHONE_SIMULATOR macro with TARGET_OS_SIMULATOR. The former has been deprecated a few SDK releases ago.
- **Scope**: NFC; modifies stdlib shims
- **Issue**: rdar://problem/35137355
- **Risk**: Minimal.
- **Testing**: PR testing.
- **Reviewed by**: @lorentey (authored by @lancep)