### PR TITLE
[Parser] Remove custom diagnostic that relies on AST-level name lookup.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -223,8 +223,6 @@ ERROR(disallowed_init,none,
       "initial value is not allowed here", ())
 ERROR(var_init_self_referential,none,
       "variable used within its own initial value", ())
-ERROR(expected_self_before_reference,none,
-      "variable used within its own initial value; use 'self.' to refer to the %0", (DescriptiveDeclKind))
 
 ERROR(disallowed_enum_element,none,
       "enum 'case' is not allowed outside of an enum", ())

--- a/test/Sema/diag_variable_used_in_initial.swift
+++ b/test/Sema/diag_variable_used_in_initial.swift
@@ -3,7 +3,7 @@
 class A1 {
   func foo1() {}
   func foo2() {
-    var foo1 = foo1() // expected-error {{variable used within its own initial value; use 'self.' to refer to the instance method}}{{16-16=self.}}
+    var foo1 = foo1() // expected-error {{variable used within its own initial value}}
   }
 }
 
@@ -11,7 +11,7 @@ class A2 {
   var foo1 = 2
   func foo2() {
     // FIXME: "the var" doesn't sound right.
-    var foo1 = foo1 // expected-error {{variable used within its own initial value; use 'self.' to refer to the property}}{{16-16=self.}}
+    var foo1 = foo1 // expected-error {{variable used within its own initial value}}
   }
 }
 
@@ -33,13 +33,13 @@ func localContext() {
   class A5 {
     func foo1() {}
     func foo2() {
-      var foo1 = foo1() // expected-error {{variable used within its own initial value; use 'self.' to refer to the instance method}}{{18-18=self.}}
+      var foo1 = foo1() // expected-error {{variable used within its own initial value}}
     }
 
     class A6 {
       func foo1() {}
       func foo2() {
-        var foo1 = foo1() // expected-error {{variable used within its own initial value; use 'self.' to refer to the instance method}}{{20-20=self.}}
+        var foo1 = foo1() // expected-error {{variable used within its own initial value}}
       }
     }
 
@@ -47,7 +47,7 @@ func localContext() {
       class A7 {
         func foo1() {}
         func foo2() {
-          var foo1 = foo1() // expected-error {{variable used within its own initial value; use 'self.' to refer to the instance method}}{{22-22=self.}}
+          var foo1 = foo1() // expected-error {{variable used within its own initial value}}
         }
       }
     }


### PR DESCRIPTION
The parser was using an AST-level name lookup operation to provide a
slightly improved diagnostic (suggesting "self." if there was a member
of that name in the enclosing type context). This is a fairly unfortunate
layering violation: name lookup cannot produce correct results at this
point. Remove the custom diagnostic and the lookup; this can come back
when all lookup moves out of the parser.
