### PR TITLE
[upstream-update] Do not specify OpenFlags since it was removed upstr…

### DIFF
--- a/include/swift/Basic/FileSystem.h
+++ b/include/swift/Basic/FileSystem.h
@@ -45,7 +45,7 @@ namespace swift {
   /// As a special case, an output path of "-" is treated as referring to
   /// stdout.
   std::error_code atomicallyWritingToFile(
-      llvm::StringRef outputPath, bool binaryMode,
+      llvm::StringRef outputPath,
       llvm::function_ref<void(llvm::raw_pwrite_stream &)> action);
 
   /// Moves a file from \p source to \p destination, unless there is already

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -322,7 +322,7 @@ static bool atomicallyWritingToTextFile(
 
   bool actionFailed = false;
   std::error_code EC =
-      swift::atomicallyWritingToFile(outputPath, /*binary*/false,
+      swift::atomicallyWritingToFile(outputPath,
                                      [&](llvm::raw_pwrite_stream &out) {
     actionFailed = action(out);
   });

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5084,7 +5084,6 @@ static inline bool
 withOutputFile(ASTContext &ctx, StringRef outputPath,
                llvm::function_ref<void(raw_ostream &)> action){
   std::error_code EC = swift::atomicallyWritingToFile(outputPath,
-                                                      /*binary*/true,
                                                       action);
   if (!EC)
     return false;


### PR DESCRIPTION
…eam.

This was removed upstream in https://reviews.llvm.org/D47789 since the only
place this flag was used was in the windows implementation where the behavior
triggered by this could be hidden in the implementation instead of being an
argument. As such, this code doesn't compile on master-next.

Since this has an acceptable default argument given the current stable, we can
just fix this on master and everything will work.

rdar://42862352
