### PR TITLE
Fixed graph lowering code that threads ops based on side effects

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -2896,6 +2896,8 @@ GLStatus TFGraphFunctionLowering::lowerWhileLoopRegion(WhileLoopSESERegion *r) {
   if (buildGraphFunction(condFn, condFnName, condHasSideEffects,
                          /*inputTypes*/ nullptr, /*outputTypes*/ nullptr))
     return GLStatus::Error;
+  // This is needed for correctness, since we lower the header code again right
+  // after creating the While op towards the end of this function.
   assert(!condHasSideEffects && "The loop should have been canonicalized by "
                                 "now, where the cond has no side effects!");
 

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -318,9 +318,9 @@ public:
   /// function to wire up control dependence edges properly. In particular, the
   /// graph node that runs this function in the call-site is treated as a
   /// side-effecting node, and will be threaded via control edges with other
-  /// side-effecting nodes in the caller. This is unless we are building a top
-  /// level graph function, in which case we ignore `funcHasSideEffects`, as the
-  /// top level function gets called in a `TF_SessionRun()` call.
+  /// side-effecting nodes in the caller. This is true unless we are building a
+  /// top level graph function, in which case we ignore `funcHasSideEffects`, as
+  /// the top level function gets called in a `TF_SessionRun()` call.
   ///
   /// This emits an error and returns true on error.
   bool buildGraphFunction(const GraphFunctionBody &graphBody, StringRef name,

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -77,6 +77,7 @@ static void markNodeAsTPUReplicated(TF_OperationDescription *desc) {
                    strlen(TPU_CLUSTER_ATTR_VALUE));
 }
 
+// TODO: reformat the code below.
 namespace {
   /// Each op is represented by a single SILValue, but we then also have
   /// tuple_extract values that project multiple-result values out.  A
@@ -143,7 +144,7 @@ namespace {
     SmallVector<std::pair<SILArgument*, TF_Output>, 4> outputs;
 
     /// If this graph has any side-effecting operations, this is the most
-    /// recently emitted operation that had side effects, and that operation
+    /// recently emitted operation that had side effects, and this operation
     /// should get executed before the function returns.  Otherwise, it is null.
     TF_Operation *controlDependenceValue = nullptr;
 
@@ -194,7 +195,7 @@ namespace {
          controlDependenceValue = result;
 
        return result;
-     }
+    }
 
     // If there is a control dependence value, run it before producing an output
     // tensor in GraphFunctionBody.

--- a/test/TensorFlowRuntime/hangers.swift
+++ b/test/TensorFlowRuntime/hangers.swift
@@ -1,0 +1,48 @@
+// RUN: %target-run-strict-da-swift
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize
+//
+// Compiler-only testing for TPU graph lowering (e.g. shape requirements by XLA).
+// TODO: enable this after https://github.com/apple/swift/pull/18458 is submitted.
+// UN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -Xllvm -tf-target-tpu -O -emit-sil %s >/dev/null
+
+// Test cases that used to hang due to bugs (e.g. insufficient control
+// dependency edges in graph lowering).
+
+import TensorFlow
+#if TPU
+import TensorFlowUnittestTPU
+#else
+import TensorFlowUnittest
+#endif
+import StdlibUnittest
+
+var HangersTests = TestSuite("Hangers")
+
+// The top level graph function returns a result tensor `x` -- make sure we hook
+// up control dependency from that result value to the While/If node in the
+// body, so that the latter node gets run, producing the intended side effect of
+// enqueuing tensor `images` for swift host to dequeue from.
+//
+// An If node can be created instead of While because of swift compiler's code
+// transformation.
+@inline(never)
+public func SR8443(n: Int32) {
+  var i: Int32 = 0
+// expected-warning @+1 {{implicitly copied to the accelerator}}
+  while i < n { // expected-note {{value used here}}
+
+    // expected-warning @+1 {{implicitly copied to the host}}
+    let images = Tensor<Float>(0.0)
+    _hostOp(images)
+    i += 1
+  }
+
+  let x = Tensor<Float>(1.0)
+  _hostOp(x)
+}
+HangersTests.testAllBackends("SR8443") {
+  SR8443(n: 2)
+}
+
+runAllTests()


### PR DESCRIPTION
The TF runtime/grappler pruning behavior is:

1. When a graph function f() does not produce result tensors, it does not prune
- away any any ops marked as being stateful. When f() contains such an If op, we
  stopped If from being pruned away by marking it stateful in
  https://github.com/apple/swift/pull/18467.

2. [handled by this PR] When f() produces output tensor(s), it can prune away a
stateful op O, if O does not contribute to any output. To make sure that O gets
run (e.g. if O is run for its side effects like enqueuing/dequeuing tensors), we
need to wire up control dependency from some output tensor (a "ret val") of f()
to O, so that O gets run before f() is returned.

Notes on graph lowering code changes:
- Split a generic variable name `hasSideEffects` into `opHasSideEffects` and `funcHasSideEffects`. 
- When `buildGraphFunction()` is called with a graph function `f()`, and it returns with `funcHasSideEffects` set to true, caller of `f()` must run the `f()` node as a side-effecting node, threading it via control dependency with other side-effecting nodes in the caller. This is unless we are building a top level graph function, in which case we ignore `funcHasSideEffects`, as the top level function gets called in a `TF_SessionRun()` call.
- When lowering a while op condition function (header block of the WhileLoop SESE region), assert that it should not have side effects, as guaranteed by the CFG canonicalization before graph lowering. This is needed for correctness, as we lower the header code again right after creating the While op (http://google3/third_party/unsupported_toolchains/swift/src/swift/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp?l=2785&rcl=206048969).

Resolves [SR-8443](https://bugs.swift.org/browse/SR-8443).
