### PR TITLE
[Serialization] Tweak deployment-target-too-new diagnostic

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -632,17 +632,21 @@ ERROR(serialization_name_mismatch,Fatal,
 ERROR(serialization_name_mismatch_repl,none,
       "cannot load module '%0' as %1", (StringRef, Identifier))
 ERROR(serialization_target_incompatible,Fatal,
-      "module file was created for incompatible target %0: %1",
-      (StringRef, StringRef))
+      "module %0 was created for incompatible target %1: %2",
+      (Identifier, StringRef, StringRef))
 ERROR(serialization_target_incompatible_repl,none,
-      "module file was created for incompatible target %0: %1",
-      (StringRef, StringRef))
+      "module %0 was created for incompatible target %1: %2",
+      (Identifier, StringRef, StringRef))
 ERROR(serialization_target_too_new,Fatal,
-      "module file's minimum deployment target is %0 v%1.%2%select{|.%3}3: %4",
-      (StringRef, unsigned, unsigned, unsigned, StringRef))
+      "compiling for %0 %1, but module %2 has a minimum "
+      "deployment target of %0 %3: %4",
+      (StringRef, clang::VersionTuple, Identifier, clang::VersionTuple,
+       StringRef))
 ERROR(serialization_target_too_new_repl,none,
-      "module file's minimum deployment target is %0 v%1.%2%select{|.%3}3: %4",
-      (StringRef, unsigned, unsigned, unsigned, StringRef))
+      "compiling for %0 %1, but module %2 has a minimum "
+      "deployment target of %0 %3: %4",
+      (StringRef, clang::VersionTuple, Identifier, clang::VersionTuple,
+       StringRef))
 
 ERROR(serialization_fatal,Fatal,
       "fatal error encountered while reading from module '%0'; "

--- a/test/Serialization/target-incompatible.swift
+++ b/test/Serialization/target-incompatible.swift
@@ -9,11 +9,11 @@
 // RUN: not %target-swift-frontend -I %t -typecheck -parse-stdlib %s -DSOLARIS 2>&1 | %FileCheck -check-prefix=CHECK-SOLARIS %s
 
 #if MIPS
-// CHECK-MIPS: :[[@LINE+1]]:8: error: module file was created for incompatible target mips64-unknown-darwin14: {{.*}}mips.swiftmodule{{$}}
+// CHECK-MIPS: :[[@LINE+1]]:8: error: module 'mips' was created for incompatible target mips64-unknown-darwin14: {{.*}}mips.swiftmodule{{$}}
 import mips
 
 #elseif SOLARIS
-// CHECK-SOLARIS: :[[@LINE+1]]:8: error: module file was created for incompatible target x86_64-unknown-solaris8: {{.*}}solaris.swiftmodule{{$}}
+// CHECK-SOLARIS: :[[@LINE+1]]:8: error: module 'solaris' was created for incompatible target x86_64-unknown-solaris8: {{.*}}solaris.swiftmodule{{$}}
 import solaris
 
 #endif

--- a/test/Serialization/target-too-new-ios.swift
+++ b/test/Serialization/target-too-new-ios.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -target x86_64-apple-ios50.50.1 -emit-module -parse-stdlib %S/../Inputs/empty.swift -o %t
+// RUN: not %target-swift-frontend -parse-stdlib -target x86_64-apple-ios12 -I %t -typecheck %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -parse-stdlib -target x86_64-apple-ios12 -I %t -typecheck %s -disable-target-os-checking
+// RUN: %target-swift-frontend -parse-stdlib -target x86_64-apple-ios50.50.1 -I %t -typecheck %s
+// RUN: %target-swift-frontend -parse-stdlib -target x86_64-apple-ios50.51 -I %t -typecheck %s
+
+// REQUIRES: OS=ios
+
+// CHECK: :[[@LINE+1]]:8: error: compiling for iOS 12.0, but module 'empty' has a minimum deployment target of iOS 50.50.1: {{.*}}empty.swiftmodule{{$}}
+import empty

--- a/test/Serialization/target-too-new.swift
+++ b/test/Serialization/target-too-new.swift
@@ -1,11 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -target x86_64-apple-macosx10.50 -emit-module -parse-stdlib %S/../Inputs/empty.swift -o %t
-// RUN: not %target-swift-frontend -I %t -typecheck %s 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -I %t -target x86_64-apple-macosx10.9 -typecheck %s 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -I %t -target x86_64-apple-darwin13 -typecheck %s 2>&1 | %FileCheck %s
 // RUN: %target-swift-frontend -I %t -typecheck %s -disable-target-os-checking
 // RUN: %target-swift-frontend -target x86_64-apple-macosx10.50 -I %t -typecheck %s
 // RUN: %target-swift-frontend -target x86_64-apple-macosx10.50.1 -I %t -typecheck %s
 
 // REQUIRES: OS=macosx
 
-// CHECK: :[[@LINE+1]]:8: error: module file's minimum deployment target is OS X v10.50: {{.*}}empty.swiftmodule{{$}}
+// CHECK: :[[@LINE+1]]:8: error: compiling for OS X 10.9, but module 'empty' has a minimum deployment target of OS X 10.50: {{.*}}empty.swiftmodule{{$}}
 import empty


### PR DESCRIPTION
Before:

> module file's minimum deployment target is iOS 12.0: /path/to/FooKit.swiftmodule

After:

> compiling for iOS 11.0, but module 'FooKit' has a minimum deployment target of iOS 12.0: /path/to/FooKit.swiftmodule

Also tweak the "incompatible target" error to include the module name.

rdar://problem/35546499