### PR TITLE
Removed the legacy code path for non-strict-DA from deabstraction

### DIFF
--- a/test/TensorFlow/optimization-disabled.swift
+++ b/test/TensorFlow/optimization-disabled.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Onone -emit-sil -Xllvm -tf-strict-deabstraction -Xllvm -tf-module-level-graph=false -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Onone -emit-sil -Xllvm -tf-module-level-graph=false -verify %s | %FileCheck %s
 import TensorFlow
 
 public func testArrayValues() -> Tensor<Float> {

--- a/test/TensorFlowRuntime/control_flow_1.swift
+++ b/test/TensorFlowRuntime/control_flow_1.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-strict-da-swift
+// RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/control_flow_objc.swift
+++ b/test/TensorFlowRuntime/control_flow_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-strict-da-swift
+// RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 // REQUIRES: OS=macosx

--- a/test/TensorFlowRuntime/dataset_1.swift
+++ b/test/TensorFlowRuntime/dataset_1.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-strict-da-swift
+// RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/loops.swift
+++ b/test/TensorFlowRuntime/loops.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-strict-da-swift
+// RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/models.swift
+++ b/test/TensorFlowRuntime/models.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-strict-da-swift
+// RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/raw_ops.swift
+++ b/test/TensorFlowRuntime/raw_ops.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-strict-da-swift
+// RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 // REQUIRES: tensorflow_swift_bindings

--- a/test/TensorFlowRuntime/retain_release_1.swift
+++ b/test/TensorFlowRuntime/retain_release_1.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-strict-da-swift
+// RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/sends_recvs_1.swift
+++ b/test/TensorFlowRuntime/sends_recvs_1.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-strict-da-swift
+// RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/shaped_array.swift
+++ b/test/TensorFlowRuntime/shaped_array.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-strict-da-swift
+// RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/sync_runtime.swift
+++ b/test/TensorFlowRuntime/sync_runtime.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-strict-da-swift
+// RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-strict-da-swift
+// RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-strict-da-swift
+// RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/tensor_debuglog.swift
+++ b/test/TensorFlowRuntime/tensor_debuglog.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-strict-da-swift
+// RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/tensor_xla_debuglog.swift
+++ b/test/TensorFlowRuntime/tensor_xla_debuglog.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-strict-da-swift
+// RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //

--- a/test/TensorFlowRuntime/top_level_1.swift
+++ b/test/TensorFlowRuntime/top_level_1.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-strict-da-swift
+// RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -709,9 +709,6 @@ if run_vendor == 'apple':
             config.target_run_simple_swift = (
                 "%s %%s" % (target_run_base))
             # SWIFT_ENABLE_TENSORFLOW
-            config.target_run_simple_swift_strict_da = (
-                "%s %%s -Xllvm -tf-strict-deabstraction" % (target_run_base))
-            # SWIFT_ENABLE_TENSORFLOW
             config.target_run_simple_swift_sese_loops = (
                 "%s %%s -Xllvm -tf-ensure-single-loop-exit" % (target_run_base))
             config.target_run_simple_swiftgyb = (
@@ -832,8 +829,6 @@ elif run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'wi
         config.target_run_simple_swift = (
             '%s %%s' % (target_run_base))
         # SWIFT_ENABLE_TENSORFLOW
-        config.target_run_simple_swift_strict_da = (
-            '%s %%s -Xllvm -tf-strict-deabstraction' % (target_run_base))
         config.target_run_simple_swift_sese_loops = (
             '%s %%s -Xllvm -tf-ensure-single-loop-exit' % (target_run_base))
         config.target_run_simple_swiftgyb = (
@@ -1013,13 +1008,6 @@ if not getattr(config, 'target_run_simple_swift', None):
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, swift_tensorflow_linker_options, config.target_codesign, config.target_run))
     # SWIFT_ENABLE_TENSORFLOW
-    config.target_run_simple_swift_strict_da = (
-        '%%empty-directory(%%t) && '
-        '%s %s %%s -Xllvm -tf-strict-deabstraction -o %%t/a.out -module-name main %s && '
-        '%s %%t/a.out &&'
-        '%s %%t/a.out'
-        % (config.target_build_swift, mcp_opt, swift_tensorflow_linker_options, config.target_codesign, config.target_run))
-    # SWIFT_ENABLE_TENSORFLOW
     config.target_run_simple_swift_sese_loops = (
         '%%empty-directory(%%t) && '
         '%s %s %%s -Xllvm -tf-ensure-single-loop-exit -o %%t/a.out -module-name main %s && '
@@ -1162,8 +1150,6 @@ config.substitutions.append(('%target-run-simple-swiftgyb-swift3', config.target
 config.substitutions.append(('%target-run-simple-swiftgyb', config.target_run_simple_swiftgyb))
 config.substitutions.append(('%target-run-simple-swift-swift3', config.target_run_simple_swift_swift3))
 config.substitutions.append(('%target-run-simple-swift', config.target_run_simple_swift))
-# SWIFT_ENABLE_TENSORFLOW
-config.substitutions.append(('%target-run-strict-da-swift', config.target_run_simple_swift_strict_da))
 # SWIFT_ENABLE_TENSORFLOW
 config.substitutions.append(('%target-run-sese-loops-swift', config.target_run_simple_swift_sese_loops))
 config.substitutions.append(('%target-run-simple-opt-O-swift', config.target_run_simple_opt_O_swift))


### PR DESCRIPTION
This is to facilitate bug fix work in that area (https://bugs.swift.org/browse/SR-8405).

Also removed the strict DA flag.
