### PR TITLE
Added a simple fix to reading global vars based on discussion with @lattner.

### DIFF
--- a/test/TensorFlow/top_level_code_1.swift
+++ b/test/TensorFlow/top_level_code_1.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-promote-global-variables -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s
+// RUN: %target-swift-frontend -Xllvm -tf-promote-global-variables -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s | %FileCheck %s
 import TensorFlow
 
 // This test is intended to verify that all of the operations end up in-graph:

--- a/test/TensorFlow/top_level_code_2.swift
+++ b/test/TensorFlow/top_level_code_2.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-promote-global-variables -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s
+// RUN: %target-swift-frontend -Xllvm -tf-promote-global-variables -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s | %FileCheck %s
 import TensorFlow
 
 // This test is intended to verify that all of the operations end up in-graph:

--- a/test/TensorFlowRuntime/top_level_2.swift
+++ b/test/TensorFlowRuntime/top_level_2.swift
@@ -1,0 +1,26 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize
+
+// This file contains stubs for functions that the playground transform in
+// lib/Sema/PlaygroundTransform.cpp generates calls into.
+
+import TensorFlow
+import TensorFlowUnittest
+import StdlibUnittest
+
+var TopLevelTests = TestSuite("TopLevel")
+
+let g = Tensor<Float>(1.0)
+
+// This function is not inlined into main(). Confirm that it 
+func SR8405() {
+  // _hostOp(g)
+  expectNearlyEqualWithScalarTensor(1.0, g)
+}
+
+TopLevelTests.testCPUOrGPU("TopLevel") {
+  SR8405()
+}
+
+runAllTests()

--- a/test/TensorFlowRuntime/top_level_2.swift
+++ b/test/TensorFlowRuntime/top_level_2.swift
@@ -13,9 +13,9 @@ var TopLevelTests = TestSuite("TopLevel")
 
 let g = Tensor<Float>(1.0)
 
-// This function is not inlined into main(). Confirm that it 
+// This function is not inlined into main(). Confirm that it can read the global
+// var properly and does not crash.
 func SR8405() {
-  // _hostOp(g)
   expectNearlyEqualWithScalarTensor(1.0, g)
 }
 


### PR DESCRIPTION

This is done by adding a new flag to protect the code that promotes global vars
to SSA values, as a performance optimization. It used to be required before we
support sends/recvs.

Resolves [SR-8405](https://bugs.swift.org/browse/SR-8405).

Filed [SR-8454](https://bugs.swift.org/browse/SR-8454) for possible future work.