### PR TITLE
Fix test/TensorFlowRuntime/hangers.swift.

### DIFF
--- a/test/TensorFlowRuntime/hangers.swift
+++ b/test/TensorFlowRuntime/hangers.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-strict-da-swift
+// RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize
 //


### PR DESCRIPTION
`%target-run-strict-da-swift` has been removed, now that strict deabstraction
is the default.