### PR TITLE
[ConstraintSystem] Diagnose missing conformance requirements via "fixes"

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1508,8 +1508,8 @@ ERROR(use_of_equal_instead_of_equality,none,
 
 
 ERROR(protocol_does_not_conform_objc,none,
-      "using %0 as a concrete type conforming to protocol %1 is not supported",
-      (Type, Type))
+      "protocol type %0 cannot conform to %1 because only concrete "
+      "types can conform to protocols", (Type, Type))
 ERROR(protocol_does_not_conform_static,none,
       "%0 cannot be used as a type conforming to protocol %1 because %1 "
       "has static requirements",

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7971,7 +7971,7 @@ bool ConstraintSystem::applySolutionFix(
       (!resolved->getPath().empty() &&
        fix.first.getKind() != FixKind::ExplicitlyEscaping &&
        fix.first.getKind() != FixKind::ExplicitlyEscapingToAny &&
-       fix.first.getKind() != FixKind::AddConformace))
+       fix.first.getKind() != FixKind::AddConformance))
     return false;
   
   Expr *affected = resolved->getAnchor();
@@ -8150,7 +8150,7 @@ bool ConstraintSystem::applySolutionFix(
                                       isa<SubscriptExpr>(call->getFn()));
   }
 
-  case FixKind::AddConformace: {
+  case FixKind::AddConformance: {
     auto getMissingConformance = [&](ConstraintLocator *locator) {
       auto *anchor = locator->getAnchor();
       auto &requirement = locator->getPath().back();

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8162,7 +8162,7 @@ bool ConstraintSystem::applySolutionFix(
     auto conformance = getMissingConformance(locator);
 
     auto *anchor = locator->getAnchor();
-    auto owner = solution.simplifyType(getType(anchor));
+    auto owner = solution.simplifyType(getType(anchor))->getRValueInstanceType();
 
     auto type = conformance.first;
     auto protocolType = conformance.second->getDeclaredType();

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2783,7 +2783,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
       // diagnostics only care about anchor - to lookup type,
       // and what was the requirement# which is not satisfied.
       ConstraintLocatorBuilder requirement(getConstraintLocator(anchor));
-      if (!recordFix({FixKind::AddConformace},
+      if (!recordFix({FixKind::AddConformance},
                      requirement.withPathElement(typeRequirement)))
         return SolutionKind::Solved;
     }
@@ -5013,7 +5013,7 @@ ConstraintSystem::simplifyFixConstraint(Fix fix, Type type1, Type type2,
   case FixKind::ExplicitlyEscapingToAny:
   case FixKind::CoerceToCheckedCast:
   case FixKind::RelabelArguments:
-  case FixKind::AddConformace:
+  case FixKind::AddConformance:
     llvm_unreachable("handled elsewhere");
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2779,7 +2779,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
       auto typeRequirement = path.back();
       std::pair<Expr *, unsigned> reqLoc = {anchor, typeRequirement.getValue()};
       MissingConformances[reqLoc] = {type.getPointer(), protocol};
-      // Let's strip all of the uncessary information from locator,
+      // Let's strip all of the unnecessary information from locator,
       // diagnostics only care about anchor - to lookup type,
       // and what was the requirement# which is not satisfied.
       ConstraintLocatorBuilder requirement(getConstraintLocator(anchor));

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -542,7 +542,7 @@ StringRef Fix::getName(FixKind kind) {
     return "fix: add @escaping";
   case FixKind::RelabelArguments:
     return "fix: re-label argument(s)";
-  case FixKind::AddConformace:
+  case FixKind::AddConformance:
     return "fix: add missing protocol conformance";
   }
 

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -542,6 +542,8 @@ StringRef Fix::getName(FixKind kind) {
     return "fix: add @escaping";
   case FixKind::RelabelArguments:
     return "fix: re-label argument(s)";
+  case FixKind::AddConformace:
+    return "fix: add missing protocol conformance";
   }
 
   llvm_unreachable("Unhandled FixKind in switch.");

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -253,6 +253,9 @@ enum class FixKind : uint8_t {
   /// Arguments have labeling failures - missing/extraneous or incorrect
   /// labels attached to the, fix it by suggesting proper labels.
   RelabelArguments,
+
+  /// Add a new conformance to the type to satisfy a requirement.
+  AddConformace,
 };
 
 /// Describes a fix that can be applied to a constraint before visiting it.

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -255,7 +255,7 @@ enum class FixKind : uint8_t {
   RelabelArguments,
 
   /// Add a new conformance to the type to satisfy a requirement.
-  AddConformace,
+  AddConformance,
 };
 
 /// Describes a fix that can be applied to a constraint before visiting it.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1009,7 +1009,7 @@ private:
   /// Argument labels fixed by the constraint solver.
   SmallVector<std::vector<Identifier>, 4> FixedArgLabels;
 
-  /// Conformances which solver "fixed" to exist to help with
+  /// Conformances which solver "fixed" to help with
   /// diagnosing problems related to generic requirements.
   llvm::SmallDenseMap<std::pair<Expr *, unsigned>,
                       std::pair<TypeBase *, ProtocolDecl *>>

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -437,10 +437,10 @@ struct SelectedOverload {
 enum ScoreKind {
   // These values are used as indices into a Score value.
 
-  /// A reference to an @unavailable declaration.
-  SK_Unavailable,
   /// A fix needs to be applied to the source.
   SK_Fix,
+  /// A reference to an @unavailable declaration.
+  SK_Unavailable,
   /// An implicit force of an implicitly unwrapped optional value.
   SK_ForceUnchecked,
   /// A user-defined conversion.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1009,6 +1009,12 @@ private:
   /// Argument labels fixed by the constraint solver.
   SmallVector<std::vector<Identifier>, 4> FixedArgLabels;
 
+  /// Conformances which solver "fixed" to exist to help with
+  /// diagnosing problems related to generic requirements.
+  llvm::SmallDenseMap<std::pair<Expr *, unsigned>,
+                      std::pair<TypeBase *, ProtocolDecl *>>
+      MissingConformances;
+
   /// \brief The set of remembered disjunction choices used to reach
   /// the current constraint system.
   SmallVector<std::pair<ConstraintLocator*, unsigned>, 32>

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -709,6 +709,6 @@ extension Node {
         return item.key == key
         // expected-error@-1 {{binary operator '==' cannot be applied to operands of type '_' and 'Self.K'}}
         // expected-note@-2 {{overloads for '==' exist with these partially matching parameter lists:}}
-      })
+      })!
   }
 }

--- a/test/Constraints/conditionally_defined_types.swift
+++ b/test/Constraints/conditionally_defined_types.swift
@@ -75,18 +75,18 @@ let _ = Conforms<X>.Decl3.self
 let _ = Conforms<X>.Decl4<X>.self
 let _ = Conforms<X>.Decl5<X>.self
 
-let _ = Conforms<Y>.TypeAlias1.self // expected-error {{'Conforms<Y>.TypeAlias1.Type' (aka 'Y.Type') requires that 'Y' conform to 'P'}}
-let _ = Conforms<Y>.TypeAlias2.self // expected-error {{'Conforms<Y>.TypeAlias2.Type' (aka 'Y.Type') requires that 'Y' conform to 'P'}}
+let _ = Conforms<Y>.TypeAlias1.self // expected-error {{'Conforms<Y>.TypeAlias1' (aka 'Y') requires that 'Y' conform to 'P'}}
+let _ = Conforms<Y>.TypeAlias2.self // expected-error {{'Conforms<Y>.TypeAlias2' (aka 'Y') requires that 'Y' conform to 'P'}}
 let _ = Conforms<Y>.TypeAlias3<X>.self // expected-error {{type 'Y' does not conform to protocol 'P'}}
-let _ = Conforms<Y>.Decl1.self // expected-error {{'Conforms<Y>.Decl1.Type' requires that 'Y' conform to 'P'}}
-let _ = Conforms<Y>.Decl2.self // expected-error {{'Conforms<Y>.Decl2.Type' requires that 'Y' conform to 'P'}}
-let _ = Conforms<Y>.Decl3.self // expected-error {{'Conforms<Y>.Decl3.Type' requires that 'Y' conform to 'P'}}
+let _ = Conforms<Y>.Decl1.self // expected-error {{'Conforms<Y>.Decl1' requires that 'Y' conform to 'P'}}
+let _ = Conforms<Y>.Decl2.self // expected-error {{'Conforms<Y>.Decl2' requires that 'Y' conform to 'P'}}
+let _ = Conforms<Y>.Decl3.self // expected-error {{'Conforms<Y>.Decl3' requires that 'Y' conform to 'P'}}
 let _ = Conforms<Y>.Decl4<X>.self // expected-error {{type 'Y' does not conform to protocol 'P'}}
 let _ = Conforms<Y>.Decl5<X>.self // expected-error {{type 'Y' does not conform to protocol 'P'}}
 
 extension Conforms: AssociatedType where T: P {}
 
-let _ = Conforms<Y>.T.self // expected-error {{'Conforms<Y>.T.Type' (aka 'Y.Type') requires that 'Y' conform to 'P'}}
+let _ = Conforms<Y>.T.self // expected-error {{'Conforms<Y>.T' (aka 'Y') requires that 'Y' conform to 'P'}}
 
 let _ = Conforms<X>.T.self
 
@@ -197,34 +197,34 @@ let _ = Conforms<X>.Decl4<Z1>.Decl5<X>.self
 // Two different forms of badness, corresponding to the two requirements:
 
 let _ = Conforms<X>.Decl4<Y>.TypeAlias1.self
-// expected-error@-1 {{'Conforms<X>.Decl4<Y>.TypeAlias1.Type' (aka 'X.Type') requires that 'Y.T' conform to 'P'}}
-// expected-error@-2 {{'Conforms<X>.Decl4<Y>.TypeAlias1.Type' (aka 'X.Type') requires that 'Y' conform to 'AssociatedType'}}
+// expected-error@-1 {{'Conforms<X>.Decl4<Y>.TypeAlias1' (aka 'X') requires that 'Y.T' conform to 'P'}}
+// expected-error@-2 {{'Conforms<X>.Decl4<Y>.TypeAlias1' (aka 'X') requires that 'Y' conform to 'AssociatedType'}}
 
 let _ = Conforms<X>.Decl4<Y>.TypeAlias2.self
-// expected-error@-1 {{'Conforms<X>.Decl4<Y>.TypeAlias2.Type' (aka 'Y.Type') requires that 'Y.T' conform to 'P'}}
-// expected-error@-2 {{'Conforms<X>.Decl4<Y>.TypeAlias2.Type' (aka 'Y.Type') requires that 'Y' conform to 'AssociatedType'}}
+// expected-error@-1 {{'Conforms<X>.Decl4<Y>.TypeAlias2' (aka 'Y') requires that 'Y.T' conform to 'P'}}
+// expected-error@-2 {{'Conforms<X>.Decl4<Y>.TypeAlias2' (aka 'Y') requires that 'Y' conform to 'AssociatedType'}}
 
 let _ = Conforms<X>.Decl4<Y>.TypeAlias3<X>.self // expected-error {{type 'Y' does not conform to protocol 'AssociatedType'}}
 let _ = Conforms<X>.Decl4<Y>.Decl1.self
-// expected-error@-1 {{'Conforms<X>.Decl4<Y>.Decl1.Type' requires that 'Y.T' conform to 'P'}}
-// expected-error@-2 {{'Conforms<X>.Decl4<Y>.Decl1.Type' requires that 'Y' conform to 'AssociatedType'}}
+// expected-error@-1 {{'Conforms<X>.Decl4<Y>.Decl1' requires that 'Y.T' conform to 'P'}}
+// expected-error@-2 {{'Conforms<X>.Decl4<Y>.Decl1' requires that 'Y' conform to 'AssociatedType'}}
 
 let _ = Conforms<X>.Decl4<Y>.Decl2.self
-// expected-error@-1 {{'Conforms<X>.Decl4<Y>.Decl2.Type' requires that 'Y.T' conform to 'P'}}
-// expected-error@-2 {{'Conforms<X>.Decl4<Y>.Decl2.Type' requires that 'Y' conform to 'AssociatedType'}}
+// expected-error@-1 {{'Conforms<X>.Decl4<Y>.Decl2' requires that 'Y.T' conform to 'P'}}
+// expected-error@-2 {{'Conforms<X>.Decl4<Y>.Decl2' requires that 'Y' conform to 'AssociatedType'}}
 
 let _ = Conforms<X>.Decl4<Y>.Decl3.self
-// expected-error@-1 {{'Conforms<X>.Decl4<Y>.Decl3.Type' requires that 'Y.T' conform to 'P'}}
-// expected-error@-2 {{'Conforms<X>.Decl4<Y>.Decl3.Type' requires that 'Y' conform to 'AssociatedType'}}
+// expected-error@-1 {{'Conforms<X>.Decl4<Y>.Decl3' requires that 'Y.T' conform to 'P'}}
+// expected-error@-2 {{'Conforms<X>.Decl4<Y>.Decl3' requires that 'Y' conform to 'AssociatedType'}}
 
 let _ = Conforms<X>.Decl4<Y>.Decl4<X>.self // expected-error {{type 'Y' does not conform to protocol 'AssociatedType'}}
 let _ = Conforms<X>.Decl4<Y>.Decl5<X>.self // expected-error {{type 'Y' does not conform to protocol 'AssociatedType'}}
 
-let _ = Conforms<X>.Decl4<Z2>.TypeAlias1.self // expected-error {{'Conforms<X>.Decl4<Z2>.TypeAlias1.Type' (aka 'X.Type') requires that 'Z2.T' (aka 'Y') conform to 'P'}}
-let _ = Conforms<X>.Decl4<Z2>.TypeAlias2.self // expected-error {{'Conforms<X>.Decl4<Z2>.TypeAlias2.Type' (aka 'Y.Type') requires that 'Z2.T' (aka 'Y') conform to 'P'}}
+let _ = Conforms<X>.Decl4<Z2>.TypeAlias1.self // expected-error {{'Conforms<X>.Decl4<Z2>.TypeAlias1' (aka 'X') requires that 'Z2.T' (aka 'Y') conform to 'P'}}
+let _ = Conforms<X>.Decl4<Z2>.TypeAlias2.self // expected-error {{'Conforms<X>.Decl4<Z2>.TypeAlias2' (aka 'Y') requires that 'Z2.T' (aka 'Y') conform to 'P'}}
 let _ = Conforms<X>.Decl4<Z2>.TypeAlias3<X>.self // expected-error {{type 'Z2.T' (aka 'Y') does not conform to protocol 'P'}}
-let _ = Conforms<X>.Decl4<Z2>.Decl1.self // expected-error {{'Conforms<X>.Decl4<Z2>.Decl1.Type' requires that 'Z2.T' (aka 'Y') conform to 'P'}}
-let _ = Conforms<X>.Decl4<Z2>.Decl2.self // expected-error {{'Conforms<X>.Decl4<Z2>.Decl2.Type' requires that 'Z2.T' (aka 'Y') conform to 'P'}}
-let _ = Conforms<X>.Decl4<Z2>.Decl3.self // expected-error {{'Conforms<X>.Decl4<Z2>.Decl3.Type' requires that 'Z2.T' (aka 'Y') conform to 'P'}}
+let _ = Conforms<X>.Decl4<Z2>.Decl1.self // expected-error {{'Conforms<X>.Decl4<Z2>.Decl1' requires that 'Z2.T' (aka 'Y') conform to 'P'}}
+let _ = Conforms<X>.Decl4<Z2>.Decl2.self // expected-error {{'Conforms<X>.Decl4<Z2>.Decl2' requires that 'Z2.T' (aka 'Y') conform to 'P'}}
+let _ = Conforms<X>.Decl4<Z2>.Decl3.self // expected-error {{'Conforms<X>.Decl4<Z2>.Decl3' requires that 'Z2.T' (aka 'Y') conform to 'P'}}
 let _ = Conforms<X>.Decl4<Z2>.Decl4<X>.self // expected-error {{type 'Z2.T' (aka 'Y') does not conform to protocol 'P'}}
 let _ = Conforms<X>.Decl4<Z2>.Decl5<X>.self // expected-error {{type 'Z2.T' (aka 'Y') does not conform to protocol 'P'}}

--- a/test/Constraints/conditionally_defined_types.swift
+++ b/test/Constraints/conditionally_defined_types.swift
@@ -75,18 +75,18 @@ let _ = Conforms<X>.Decl3.self
 let _ = Conforms<X>.Decl4<X>.self
 let _ = Conforms<X>.Decl5<X>.self
 
-let _ = Conforms<Y>.TypeAlias1.self // expected-error {{type 'Y' does not conform to protocol 'P'}}
-let _ = Conforms<Y>.TypeAlias2.self // expected-error {{type 'Y' does not conform to protocol 'P'}}
+let _ = Conforms<Y>.TypeAlias1.self // expected-error {{'Conforms<Y>.TypeAlias1.Type' (aka 'Y.Type') requires that 'Y' conform to 'P'}}
+let _ = Conforms<Y>.TypeAlias2.self // expected-error {{'Conforms<Y>.TypeAlias2.Type' (aka 'Y.Type') requires that 'Y' conform to 'P'}}
 let _ = Conforms<Y>.TypeAlias3<X>.self // expected-error {{type 'Y' does not conform to protocol 'P'}}
-let _ = Conforms<Y>.Decl1.self // expected-error {{type 'Y' does not conform to protocol 'P'}}
-let _ = Conforms<Y>.Decl2.self // expected-error {{type 'Y' does not conform to protocol 'P'}}
-let _ = Conforms<Y>.Decl3.self // expected-error {{type 'Y' does not conform to protocol 'P'}}
+let _ = Conforms<Y>.Decl1.self // expected-error {{'Conforms<Y>.Decl1.Type' requires that 'Y' conform to 'P'}}
+let _ = Conforms<Y>.Decl2.self // expected-error {{'Conforms<Y>.Decl2.Type' requires that 'Y' conform to 'P'}}
+let _ = Conforms<Y>.Decl3.self // expected-error {{'Conforms<Y>.Decl3.Type' requires that 'Y' conform to 'P'}}
 let _ = Conforms<Y>.Decl4<X>.self // expected-error {{type 'Y' does not conform to protocol 'P'}}
 let _ = Conforms<Y>.Decl5<X>.self // expected-error {{type 'Y' does not conform to protocol 'P'}}
 
 extension Conforms: AssociatedType where T: P {}
 
-let _ = Conforms<Y>.T.self // expected-error {{type 'Y' does not conform to protocol 'P'}}
+let _ = Conforms<Y>.T.self // expected-error {{'Conforms<Y>.T.Type' (aka 'Y.Type') requires that 'Y' conform to 'P'}}
 
 let _ = Conforms<X>.T.self
 
@@ -196,20 +196,35 @@ let _ = Conforms<X>.Decl4<Z1>.Decl5<X>.self
 
 // Two different forms of badness, corresponding to the two requirements:
 
-let _ = Conforms<X>.Decl4<Y>.TypeAlias1.self // expected-error {{type 'Y' does not conform to protocol 'AssociatedType'}}
-let _ = Conforms<X>.Decl4<Y>.TypeAlias2.self // expected-error {{type 'Y' does not conform to protocol 'AssociatedType'}}
+let _ = Conforms<X>.Decl4<Y>.TypeAlias1.self
+// expected-error@-1 {{'Conforms<X>.Decl4<Y>.TypeAlias1.Type' (aka 'X.Type') requires that 'Y.T' conform to 'P'}}
+// expected-error@-2 {{'Conforms<X>.Decl4<Y>.TypeAlias1.Type' (aka 'X.Type') requires that 'Y' conform to 'AssociatedType'}}
+
+let _ = Conforms<X>.Decl4<Y>.TypeAlias2.self
+// expected-error@-1 {{'Conforms<X>.Decl4<Y>.TypeAlias2.Type' (aka 'Y.Type') requires that 'Y.T' conform to 'P'}}
+// expected-error@-2 {{'Conforms<X>.Decl4<Y>.TypeAlias2.Type' (aka 'Y.Type') requires that 'Y' conform to 'AssociatedType'}}
+
 let _ = Conforms<X>.Decl4<Y>.TypeAlias3<X>.self // expected-error {{type 'Y' does not conform to protocol 'AssociatedType'}}
-let _ = Conforms<X>.Decl4<Y>.Decl1.self // expected-error {{type 'Y' does not conform to protocol 'AssociatedType'}}
-let _ = Conforms<X>.Decl4<Y>.Decl2.self // expected-error {{type 'Y' does not conform to protocol 'AssociatedType'}}
-let _ = Conforms<X>.Decl4<Y>.Decl3.self // expected-error {{type 'Y' does not conform to protocol 'AssociatedType'}}
+let _ = Conforms<X>.Decl4<Y>.Decl1.self
+// expected-error@-1 {{'Conforms<X>.Decl4<Y>.Decl1.Type' requires that 'Y.T' conform to 'P'}}
+// expected-error@-2 {{'Conforms<X>.Decl4<Y>.Decl1.Type' requires that 'Y' conform to 'AssociatedType'}}
+
+let _ = Conforms<X>.Decl4<Y>.Decl2.self
+// expected-error@-1 {{'Conforms<X>.Decl4<Y>.Decl2.Type' requires that 'Y.T' conform to 'P'}}
+// expected-error@-2 {{'Conforms<X>.Decl4<Y>.Decl2.Type' requires that 'Y' conform to 'AssociatedType'}}
+
+let _ = Conforms<X>.Decl4<Y>.Decl3.self
+// expected-error@-1 {{'Conforms<X>.Decl4<Y>.Decl3.Type' requires that 'Y.T' conform to 'P'}}
+// expected-error@-2 {{'Conforms<X>.Decl4<Y>.Decl3.Type' requires that 'Y' conform to 'AssociatedType'}}
+
 let _ = Conforms<X>.Decl4<Y>.Decl4<X>.self // expected-error {{type 'Y' does not conform to protocol 'AssociatedType'}}
 let _ = Conforms<X>.Decl4<Y>.Decl5<X>.self // expected-error {{type 'Y' does not conform to protocol 'AssociatedType'}}
 
-let _ = Conforms<X>.Decl4<Z2>.TypeAlias1.self // expected-error {{type 'Z2.T' (aka 'Y') does not conform to protocol 'P'}}
-let _ = Conforms<X>.Decl4<Z2>.TypeAlias2.self // expected-error {{type 'Z2.T' (aka 'Y') does not conform to protocol 'P'}}
+let _ = Conforms<X>.Decl4<Z2>.TypeAlias1.self // expected-error {{'Conforms<X>.Decl4<Z2>.TypeAlias1.Type' (aka 'X.Type') requires that 'Z2.T' (aka 'Y') conform to 'P'}}
+let _ = Conforms<X>.Decl4<Z2>.TypeAlias2.self // expected-error {{'Conforms<X>.Decl4<Z2>.TypeAlias2.Type' (aka 'Y.Type') requires that 'Z2.T' (aka 'Y') conform to 'P'}}
 let _ = Conforms<X>.Decl4<Z2>.TypeAlias3<X>.self // expected-error {{type 'Z2.T' (aka 'Y') does not conform to protocol 'P'}}
-let _ = Conforms<X>.Decl4<Z2>.Decl1.self // expected-error {{type 'Z2.T' (aka 'Y') does not conform to protocol 'P'}}
-let _ = Conforms<X>.Decl4<Z2>.Decl2.self // expected-error {{type 'Z2.T' (aka 'Y') does not conform to protocol 'P'}}
-let _ = Conforms<X>.Decl4<Z2>.Decl3.self // expected-error {{type 'Z2.T' (aka 'Y') does not conform to protocol 'P'}}
+let _ = Conforms<X>.Decl4<Z2>.Decl1.self // expected-error {{'Conforms<X>.Decl4<Z2>.Decl1.Type' requires that 'Z2.T' (aka 'Y') conform to 'P'}}
+let _ = Conforms<X>.Decl4<Z2>.Decl2.self // expected-error {{'Conforms<X>.Decl4<Z2>.Decl2.Type' requires that 'Z2.T' (aka 'Y') conform to 'P'}}
+let _ = Conforms<X>.Decl4<Z2>.Decl3.self // expected-error {{'Conforms<X>.Decl4<Z2>.Decl3.Type' requires that 'Z2.T' (aka 'Y') conform to 'P'}}
 let _ = Conforms<X>.Decl4<Z2>.Decl4<X>.self // expected-error {{type 'Z2.T' (aka 'Y') does not conform to protocol 'P'}}
 let _ = Conforms<X>.Decl4<Z2>.Decl5<X>.self // expected-error {{type 'Z2.T' (aka 'Y') does not conform to protocol 'P'}}

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -94,10 +94,10 @@ func f7() -> (c: Int, v: A) {
 }
 
 func f8<T:P2>(_ n: T, _ f: @escaping (T) -> T) {}
-f8(3, f4) // expected-error {{in argument type '(Int) -> Int', 'Int' does not conform to expected type 'P2'}}
+f8(3, f4) // expected-error {{argument type 'Int' does not conform to expected type 'P2'}}
 typealias Tup = (Int, Double)
 func f9(_ x: Tup) -> Tup { return x }
-f8((1,2.0), f9) // expected-error {{in argument type '(Tup) -> Tup' (aka '((Int, Double)) -> (Int, Double)'), 'Tup' (aka '(Int, Double)') does not conform to expected type 'P2'}}
+f8((1,2.0), f9) // expected-error {{'(Tup, @escaping (Tup) -> Tup) -> ()' (aka '((Int, Double), @escaping ((Int, Double)) -> (Int, Double)) -> ()') requires that '(_, _)' conform to 'P2'}}
 
 // <rdar://problem/19658691> QoI: Incorrect diagnostic for calling nonexistent members on literals
 1.doesntExist(0)  // expected-error {{value of type 'Int' has no member 'doesntExist'}}
@@ -657,8 +657,7 @@ example21890157.property = "confusing"  // expected-error {{value of optional ty
 
 struct UnaryOp {}
 
-_ = -UnaryOp() // expected-error {{unary operator '-' cannot be applied to an operand of type 'UnaryOp'}}
-// expected-note @-1 {{overloads for '-' exist with these partially matching parameter lists: (Float), (Double)}}
+_ = -UnaryOp() // expected-error {{argument type 'UnaryOp' does not conform to expected type 'SignedNumeric'}}
 
 
 // <rdar://problem/23433271> Swift compiler segfault in failure diagnosis
@@ -1190,10 +1189,9 @@ func rdar17170728() {
 // https://bugs.swift.org/browse/SR-5934 - failure to emit diagnostic for bad
 // generic constraints
 func elephant<T, U>(_: T) where T : Collection, T.Element == U, T.Element : Hashable {}
-// expected-note@-1 {{in call to function 'elephant'}}
 
 func platypus<T>(a: [T]) {
-    _ = elephant(a) // expected-error {{generic parameter 'U' could not be inferred}}
+    _ = elephant(a) // expected-error {{'([T]) -> ()' requires that 'T' conform to 'Hashable'}}
 }
 
 // Another case of the above.

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -592,3 +592,19 @@ func sr8075() {
 
   let _: UIFont = .init(ofSize: switchOnCategory([0: 15.5, 1: 20.5]))
 }
+
+// rdar://problem/40537858 - Ambiguous diagnostic when type is missing conformance
+func rdar40537858() {
+  struct S {
+    struct Id {}
+    var id: Id
+  }
+
+  struct List<T: Collection, E: Hashable> {
+    typealias Data = T.Element
+    init(_: T, id: KeyPath<Data, E>) {}
+  }
+
+  var arr: [S] = []
+  _ = List(arr, id: \.id) // expected-error {{'List<[S], S.Id>' requires that 'S.Id' conform to 'Hashable'}}
+}

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -188,7 +188,7 @@ func r22459135() {
 
 // <rdar://problem/19710848> QoI: Friendlier error message for "[] as Set"
 // <rdar://problem/22326930> QoI: "argument for generic parameter 'Element' could not be inferred" lacks context
-_ = [] as Set  // expected-error {{generic parameter 'Element' could not be inferred in cast to 'Set'}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{14-14=<<#Element: Hashable#>>}}
+_ = [] as Set  // expected-error {{using 'Any' as a concrete type conforming to protocol 'Hashable' is not supported}}
 
 
 //<rdar://problem/22509125> QoI: Error when unable to infer generic archetype lacks greatness
@@ -285,10 +285,10 @@ struct ProtosBound3<Foo: SubProto> where Foo: NSCopyish {} // expected-note {{'F
 struct AnyClassAndProtoBound<Foo> where Foo: AnyObject, Foo: SubProto {} // expected-note {{'Foo' declared as parameter to type 'AnyClassAndProtoBound'}}
 struct AnyClassAndProtoBound2<Foo> where Foo: SubProto, Foo: AnyObject {} // expected-note {{'Foo' declared as parameter to type 'AnyClassAndProtoBound2'}}
 
-struct ClassAndProtoBound<Foo> where Foo: X, Foo: SubProto {} // expected-note {{'Foo' declared as parameter to type 'ClassAndProtoBound'}}
+struct ClassAndProtoBound<Foo> where Foo: X, Foo: SubProto {}
 
-struct ClassAndProtosBound<Foo> where Foo: X, Foo: SubProto, Foo: NSCopyish {} // expected-note {{'Foo' declared as parameter to type 'ClassAndProtosBound'}}
-struct ClassAndProtosBound2<Foo> where Foo: X, Foo: SubProto & NSCopyish {} // expected-note {{'Foo' declared as parameter to type 'ClassAndProtosBound2'}}
+struct ClassAndProtosBound<Foo> where Foo: X, Foo: SubProto, Foo: NSCopyish {}
+struct ClassAndProtosBound2<Foo> where Foo: X, Foo: SubProto & NSCopyish {}
 
 extension Pair {
   init(first: T) {}
@@ -331,10 +331,14 @@ func testFixIts() {
   _ = AnyClassAndProtoBound() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{28-28=<<#Foo: SubProto & AnyObject#>>}}
   _ = AnyClassAndProtoBound2() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{29-29=<<#Foo: SubProto & AnyObject#>>}}
 
-  _ = ClassAndProtoBound() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{25-25=<<#Foo: X & SubProto#>>}}
+  _ = ClassAndProtoBound() // expected-error {{'ClassAndProtoBound<X>' requires that 'X' conform to 'SubProto'}}
 
-  _ = ClassAndProtosBound() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{26-26=<<#Foo: X & NSCopyish & SubProto#>>}}
-  _ = ClassAndProtosBound2() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{27-27=<<#Foo: X & NSCopyish & SubProto#>>}}
+  _ = ClassAndProtosBound() 
+  // expected-error@-1 {{'ClassAndProtosBound<X>' requires that 'X' conform to 'SubProto'}}
+  // expected-error@-2 {{'ClassAndProtosBound<X>' requires that 'X' conform to 'NSCopyish'}}
+  _ = ClassAndProtosBound2()
+  // expected-error@-1 {{'ClassAndProtosBound2<X>' requires that 'X' conform to 'SubProto'}}
+  // expected-error@-2 {{'ClassAndProtosBound2<X>' requires that 'X' conform to 'NSCopyish'}}
 
   _ = Pair() // expected-error {{generic parameter 'T' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{11-11=<Any, Any>}}
   _ = Pair(first: S()) // expected-error {{generic parameter 'U' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{11-11=<S, Any>}}

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -611,4 +611,13 @@ func rdar40537858() {
 
   var arr: [S] = []
   _ = List(arr, id: \.id) // expected-error {{'List<[S], S.Id>' requires that 'S.Id' conform to 'Hashable'}}
+
+  enum E<T: P> {
+    case foo(T)
+    case bar([T])
+  }
+
+  var s = S(id: S.Id())
+  let _: E = .foo(s)   // expected-error {{'E<S>' requires that 'S' conform to 'P'}}
+  let _: E = .bar([s]) // expected-error {{'E<S>' requires that 'S' conform to 'P'}}
 }

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -188,7 +188,7 @@ func r22459135() {
 
 // <rdar://problem/19710848> QoI: Friendlier error message for "[] as Set"
 // <rdar://problem/22326930> QoI: "argument for generic parameter 'Element' could not be inferred" lacks context
-_ = [] as Set  // expected-error {{using 'Any' as a concrete type conforming to protocol 'Hashable' is not supported}}
+_ = [] as Set  // expected-error {{protocol type 'Any' cannot conform to 'Hashable' because only concrete types can conform to protocols}}
 
 
 //<rdar://problem/22509125> QoI: Error when unable to infer generic archetype lacks greatness

--- a/test/Constraints/rdar39931339.swift
+++ b/test/Constraints/rdar39931339.swift
@@ -29,16 +29,16 @@ class B<U> : A<[U], U> {}
 
 _ = B<C>.S1()          // Ok
 _ = B<Int>.S2()        // Ok
-_ = B<Float>.S1()      // expected-error {{type 'Float' does not conform to protocol 'P'}}
+_ = B<Float>.S1()      // expected-error {{'B<Float>.S1.Type' (aka 'Int.Type') requires that 'Float' conform to 'P'}}
 _ = B<String>.S2()     // expected-error {{'B<String>.S2.Type' (aka 'Int.Type') requires the types '[String]' and '[Int]' be equivalent}}
 
 _ = S<C>.A()           // Ok
-_ = S<Int>.A()         // expected-error {{type 'Int' does not conform to protocol 'P'}}
+_ = S<Int>.A()         // expected-error {{'S<Int>.A.Type' (aka 'Int.Type') requires that 'Int' conform to 'P'}}
 _ = S<String>.B<Int>() // expected-error {{type 'String' does not conform to protocol 'P'}}
 _ = S<Int>.C()         // expected-error {{'S<Int>.C.Type' (aka 'Int.Type') requires the types 'Int' and 'Float' be equivalent}}
 
 func foo<T>(_ s: S<T>.Type) {
-  _ = s.A() // expected-error {{type 'T' does not conform to protocol 'P'}}
+  _ = s.A() // expected-error {{'S<T>.A.Type' (aka 'Int.Type') requires that 'T' conform to 'P'}}
 }
 
 func bar<T: P>(_ s: S<T>.Type) {

--- a/test/Constraints/rdar39931339.swift
+++ b/test/Constraints/rdar39931339.swift
@@ -29,16 +29,16 @@ class B<U> : A<[U], U> {}
 
 _ = B<C>.S1()          // Ok
 _ = B<Int>.S2()        // Ok
-_ = B<Float>.S1()      // expected-error {{'B<Float>.S1.Type' (aka 'Int.Type') requires that 'Float' conform to 'P'}}
+_ = B<Float>.S1()      // expected-error {{'B<Float>.S1' (aka 'Int') requires that 'Float' conform to 'P'}}
 _ = B<String>.S2()     // expected-error {{'B<String>.S2.Type' (aka 'Int.Type') requires the types '[String]' and '[Int]' be equivalent}}
 
 _ = S<C>.A()           // Ok
-_ = S<Int>.A()         // expected-error {{'S<Int>.A.Type' (aka 'Int.Type') requires that 'Int' conform to 'P'}}
+_ = S<Int>.A()         // expected-error {{'S<Int>.A' (aka 'Int') requires that 'Int' conform to 'P'}}
 _ = S<String>.B<Int>() // expected-error {{type 'String' does not conform to protocol 'P'}}
 _ = S<Int>.C()         // expected-error {{'S<Int>.C.Type' (aka 'Int.Type') requires the types 'Int' and 'Float' be equivalent}}
 
 func foo<T>(_ s: S<T>.Type) {
-  _ = s.A() // expected-error {{'S<T>.A.Type' (aka 'Int.Type') requires that 'T' conform to 'P'}}
+  _ = s.A() // expected-error {{'S<T>.A' (aka 'Int') requires that 'T' conform to 'P'}}
 }
 
 func bar<T: P>(_ s: S<T>.Type) {

--- a/test/Generics/deduction.swift
+++ b/test/Generics/deduction.swift
@@ -214,7 +214,7 @@ func rangeOfIsBefore<R : IteratorProtocol>(_ range: R) where R.Element : IsBefor
 
 func callRangeOfIsBefore(_ ia: [Int], da: [Double]) {
   rangeOfIsBefore(ia.makeIterator())
-  rangeOfIsBefore(da.makeIterator()) // expected-error{{type 'Double' does not conform to protocol 'IsBefore'}}
+  rangeOfIsBefore(da.makeIterator()) // expected-error{{'(IndexingIterator<[Double]>) -> ()' requires that 'Double' conform to 'IsBefore'}}
 }
 
 func testEqualIterElementTypes<A: IteratorProtocol, B: IteratorProtocol>(_ a: A, _ b: B) where A.Element == B.Element {}

--- a/test/Generics/existential_restrictions.swift
+++ b/test/Generics/existential_restrictions.swift
@@ -17,7 +17,7 @@ func fAOE(_ t: AnyObject) { }
 func fT<T>(_ t: T) { }
 
 func testPassExistential(_ p: P, op: OP, opp: OP & P, cp: CP, sp: SP, any: Any, ao: AnyObject) {
-  fP(p) // expected-error{{using 'P' as a concrete type conforming to protocol 'P' is not supported}}
+  fP(p) // expected-error{{protocol type 'P' cannot conform to 'P' because only concrete types can conform to protocols}}
   fAO(p) // expected-error{{cannot invoke 'fAO' with an argument list of type '(P)'}} // expected-note{{expected an argument list of type '(T)'}}
   fAOE(p) // expected-error{{argument type 'P' does not conform to expected type 'AnyObject'}}
   fT(p)
@@ -31,8 +31,8 @@ func testPassExistential(_ p: P, op: OP, opp: OP & P, cp: CP, sp: SP, any: Any, 
   fAOE(cp)
   fT(cp)
 
-  fP(opp) // expected-error{{using 'OP & P' as a concrete type conforming to protocol 'P' is not supported}}
-  fOP(opp) // expected-error{{using 'OP & P' as a concrete type conforming to protocol 'OP' is not supported}}
+  fP(opp) // expected-error{{protocol type 'OP & P' cannot conform to 'P' because only concrete types can conform to protocols}}
+  fOP(opp) // expected-error{{protocol type 'OP & P' cannot conform to 'OP' because only concrete types can conform to protocols}}
   fAO(opp) // expected-error{{cannot invoke 'fAO' with an argument list of type '(OP & P)'}} // expected-note{{expected an argument list of type '(T)'}}
   fAOE(opp)
   fT(opp)
@@ -58,9 +58,9 @@ class GAO<T : AnyObject> {} // expected-note 2{{requirement specified as 'T' : '
 func blackHole(_ t: Any) {}
 
 func testBindExistential() {
-  blackHole(GP<P>()) // expected-error{{using 'P' as a concrete type conforming to protocol 'P' is not supported}}
+  blackHole(GP<P>()) // expected-error{{protocol type 'P' cannot conform to 'P' because only concrete types can conform to protocols}}
   blackHole(GOP<OP>())
-  blackHole(GCP<CP>()) // expected-error{{using 'CP' as a concrete type conforming to protocol 'CP' is not supported}}
+  blackHole(GCP<CP>()) // expected-error{{protocol type 'CP' cannot conform to 'CP' because only concrete types can conform to protocols}}
   blackHole(GAO<P>()) // expected-error{{'GAO' requires that 'P' be a class type}}
   blackHole(GAO<OP>())
   blackHole(GAO<CP>()) // expected-error{{'GAO' requires that 'CP' be a class type}}
@@ -85,5 +85,5 @@ func foo() {
   // generic no overloads error path. The error should actually talk
   // about the return type, and this can happen in other contexts as well;
   // <rdar://problem/21900971> tracks improving QoI here.
-  allMine.takeAll() // expected-error{{using 'Mine' as a concrete type conforming to protocol 'Mine' is not supported}}
+  allMine.takeAll() // expected-error{{protocol type 'Mine' cannot conform to 'Mine' because only concrete types can conform to protocols}}
 }

--- a/test/Generics/existential_restrictions.swift
+++ b/test/Generics/existential_restrictions.swift
@@ -17,7 +17,7 @@ func fAOE(_ t: AnyObject) { }
 func fT<T>(_ t: T) { }
 
 func testPassExistential(_ p: P, op: OP, opp: OP & P, cp: CP, sp: SP, any: Any, ao: AnyObject) {
-  fP(p) // expected-error{{cannot invoke 'fP' with an argument list of type '(P)'}} // expected-note{{expected an argument list of type '(T)'}}
+  fP(p) // expected-error{{using 'P' as a concrete type conforming to protocol 'P' is not supported}}
   fAO(p) // expected-error{{cannot invoke 'fAO' with an argument list of type '(P)'}} // expected-note{{expected an argument list of type '(T)'}}
   fAOE(p) // expected-error{{argument type 'P' does not conform to expected type 'AnyObject'}}
   fT(p)
@@ -31,14 +31,14 @@ func testPassExistential(_ p: P, op: OP, opp: OP & P, cp: CP, sp: SP, any: Any, 
   fAOE(cp)
   fT(cp)
 
-  fP(opp) // expected-error{{cannot invoke 'fP' with an argument list of type '(OP & P)'}} // expected-note{{expected an argument list of type '(T)'}}
-  fOP(opp) // expected-error{{cannot invoke 'fOP' with an argument list of type '(OP & P)'}} // expected-note{{expected an argument list of type '(T)'}}
+  fP(opp) // expected-error{{using 'OP & P' as a concrete type conforming to protocol 'P' is not supported}}
+  fOP(opp) // expected-error{{using 'OP & P' as a concrete type conforming to protocol 'OP' is not supported}}
   fAO(opp) // expected-error{{cannot invoke 'fAO' with an argument list of type '(OP & P)'}} // expected-note{{expected an argument list of type '(T)'}}
   fAOE(opp)
   fT(opp)
 
   fOP(sp)
-  fSP(sp) // expected-error{{cannot invoke 'fSP' with an argument list of type '(SP)'}} // expected-note{{expected an argument list of type '(T)'}}
+  fSP(sp) // expected-error{{'SP' cannot be used as a type conforming to protocol 'SP' because 'SP' has static requirements}}
   fAO(sp)
   fAOE(sp)
   fT(sp)

--- a/test/Generics/unbound.swift
+++ b/test/Generics/unbound.swift
@@ -59,13 +59,14 @@ class SomeClassWithInvalidMethod {
 // <rdar://problem/20792596> QoI: Cannot invoke with argument list (T), expected an argument list of (T)
 protocol r20792596P {}
 
-// expected-note @+1 {{in call to function 'foor20792596(x:)'}}
 func foor20792596<T: r20792596P>(x: T) -> T {
   return x
 }
 
 func callfoor20792596<T>(x: T) -> T {
-  return foor20792596(x) // expected-error {{generic parameter 'T' could not be inferred}}
+  return foor20792596(x)
+  // expected-error@-1 {{missing argument label 'x:' in call}}
+  // expected-error@-2 {{argument type 'T' does not conform to expected type 'r20792596P'}}
 }
 
 // <rdar://problem/31181895> parameter "not used in function signature" when part of a superclass constraint

--- a/test/IDE/annotation.swift
+++ b/test/IDE/annotation.swift
@@ -85,9 +85,9 @@ class SubCls : MyCls, Prot {
 func genFn<T : Prot where T.Blarg : Prot2>(_ p : T) -> Int {}
 
 func test(_ x: Int) {
-  // CHECK: <Func@[[@LINE-3]]:6>genFn</Func>(<Ctor@[[@LINE-11]]:28-Class@[[@LINE-11]]:7>SubCls</Ctor>())
+  // CHECK: <Func@[[@LINE-3]]:6>genFn</Func>(<Class@[[@LINE-11]]:7>SubCls</Class>())
   genFn(SubCls())
-  // CHECK: "This is string \(<Func@[[@LINE-5]]:6>genFn</Func>({(<Param>a</Param>:<iStruct@>Int</iStruct>) in <Ctor@[[@LINE-13]]:28-Class@[[@LINE-13]]:7>SubCls</Ctor>()}(<Param@[[@LINE-3]]:13>x</Param>))) interpolation"
+  // CHECK: "This is string \(<Func@[[@LINE-5]]:6>genFn</Func>({(<Param>a</Param>:<iStruct@>Int</iStruct>) in <Class@[[@LINE-13]]:7>SubCls</Class>()}(<Param@[[@LINE-3]]:13>x</Param>))) interpolation"
   "This is string \(genFn({(a:Int) in SubCls()}(x))) interpolation"
 }
 

--- a/test/Serialization/builtin.swift
+++ b/test/Serialization/builtin.swift
@@ -11,5 +11,4 @@ var a : TheBuiltinInt64
 
 // Check that it really is Builtin.Int64.
 var wrapped = Int64(a) // okay
-var badWrapped = Int32(a) // expected-error{{cannot invoke initializer for type 'Int32' with an argument list of type '(TheBuiltinInt64)'}}
-// expected-note @-1 {{overloads for 'Int32' exist with}}
+var badWrapped = Int32(a) // expected-error{{'Int32' requires that 'TheBuiltinInt64' conform to 'BinaryInteger'}}

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -180,7 +180,7 @@ extension S1 {
 // Protocol extensions with additional requirements
 // ----------------------------------------------------------------------------
 extension P4 where Self.AssocP4 : P1 {
-  func extP4a() {  // expected-note 2 {{found this candidate}}
+  func extP4a() {
     acceptsP1(reqP4a())
   }
 }
@@ -211,13 +211,13 @@ extension P4 where Self.AssocP4 == Int {
 }
 
 extension P4 where Self.AssocP4 == Bool {
-  func extP4a() -> Bool { return reqP4a() } // expected-note 2 {{found this candidate}}
+  func extP4a() -> Bool { return reqP4a() }
 }
 
 func testP4(_ s4a: S4a, s4b: S4b, s4c: S4c, s4d: S4d) {
-  s4a.extP4a() // expected-error{{ambiguous reference to member 'extP4a()'}}
+  s4a.extP4a() // expected-error{{'() -> ()' requires that 'S4aHelper' conform to 'P1'}}
   s4b.extP4a() // ok
-  s4c.extP4a() // expected-error{{ambiguous reference to member 'extP4a()'}}
+  s4c.extP4a() // expected-error{{'() -> ()' requires that 'Int' conform to 'P1'}}
   s4c.extP4Int() // okay
   var b1 = s4d.extP4a() // okay, "Bool" version
   b1 = true // checks type above

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -735,10 +735,9 @@ func invalidDictionaryLiteral() {
   var g = [1: "one", 2: ;] // expected-error {{expected value in dictionary literal}}
 }
 
-    
-// FIXME: The issue here is a type compatibility problem, there is no ambiguity.
-[4].joined(separator: [1]) // expected-error {{type of expression is ambiguous without more context}}
-[4].joined(separator: [[[1]]]) // expected-error {{type of expression is ambiguous without more context}}
+
+[4].joined(separator: [1]) // expected-error {{'() -> FlattenCollection<[Int]>' requires that 'Int' conform to 'Collection'}}
+[4].joined(separator: [[[1]]]) // expected-error {{'() -> FlattenCollection<[Int]>' requires that 'Int' conform to 'Collection'}}
 
 //===----------------------------------------------------------------------===//
 // nil/metatype comparisons

--- a/test/expr/unary/keypath/salvage-with-other-type-errors.swift
+++ b/test/expr/unary/keypath/salvage-with-other-type-errors.swift
@@ -27,7 +27,7 @@ struct A {
 }
 
 extension A: K {
-    static let j = S(\A.id + "id") // expected-error {{'+' cannot be applied}} expected-note {{}}
+    static let j = S(\A.id + "id") // expected-error {{'S' requires that 'String' conform to 'K'}}
 }
 
 // SR-5034

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -176,7 +176,7 @@ func testOptionalSequence() {
 
 // Crash with (invalid) for each over an existential
 func testExistentialSequence(s: Sequence) { // expected-error {{protocol 'Sequence' can only be used as a generic constraint because it has Self or associated type requirements}}
-  for x in s { // expected-error {{using 'Sequence' as a concrete type conforming to protocol 'Sequence' is not supported}}
+  for x in s { // expected-error {{protocol type 'Sequence' cannot conform to 'Sequence' because only concrete types can conform to protocols}}
     _ = x
   }
 }

--- a/test/type/subclass_composition.swift
+++ b/test/type/subclass_composition.swift
@@ -301,10 +301,8 @@ func conformsToAnyObject<T : AnyObject>(_: T) {}
 func conformsToP1<T : P1>(_: T) {}
 func conformsToP2<T : P2>(_: T) {}
 func conformsToBaseIntAndP2<T : Base<Int> & P2>(_: T) {}
-// expected-note@-1 4 {{in call to function 'conformsToBaseIntAndP2'}}
 
 func conformsToBaseIntAndP2WithWhereClause<T>(_: T) where T : Base<Int> & P2 {}
-// expected-note@-1 2 {{in call to function 'conformsToBaseIntAndP2WithWhereClause'}}
 
 class FakeDerived : Base<String>, P2 {
   required init(classInit: ()) {
@@ -409,26 +407,29 @@ func conformsTo<T1 : P2, T2 : Base<Int> & P2>(
   // expected-note@-2 {{expected an argument list of type '(T)'}}
 
   conformsToP1(p1)
-  // expected-error@-1 {{cannot invoke 'conformsToP1' with an argument list of type '(P1)'}}
-  // expected-note@-2 {{expected an argument list of type '(T)'}}
+  // expected-error@-1 {{using 'P1' as a concrete type conforming to protocol 'P1' is not supported}}
+
+  // FIXME: Following diagnostics are not great because when
+  // `conformsTo*` methods are re-typechecked, they loose information
+  // about `& P2` in generic parameter.
 
   conformsToBaseIntAndP2(base)
-  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+  // expected-error@-1 {{argument type 'Base<Int>' does not conform to expected type 'P2'}}
 
   conformsToBaseIntAndP2(badBase)
-  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+  // expected-error@-1 {{'(Base<Int>) -> ()' requires that 'Base<Int>' conform to 'P2'}}
 
   conformsToBaseIntAndP2(fakeDerived)
-  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+  // expected-error@-1 {{'(Base<Int>) -> ()' requires that 'Base<Int>' conform to 'P2'}}
 
   conformsToBaseIntAndP2WithWhereClause(fakeDerived)
-  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+  // expected-error@-1 {{'(Base<Int>) -> ()' requires that 'Base<Int>' conform to 'P2'}}
 
   conformsToBaseIntAndP2(p2Archetype)
-  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+  // expected-error@-1 {{'(Base<Int>) -> ()' requires that 'Base<Int>' conform to 'P2'}}
 
   conformsToBaseIntAndP2WithWhereClause(p2Archetype)
-  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+  // expected-error@-1 {{'(Base<Int>) -> ()' requires that 'Base<Int>' conform to 'P2'}}
 
   // Good
   conformsToAnyObject(anyObject)

--- a/test/type/subclass_composition.swift
+++ b/test/type/subclass_composition.swift
@@ -407,7 +407,7 @@ func conformsTo<T1 : P2, T2 : Base<Int> & P2>(
   // expected-note@-2 {{expected an argument list of type '(T)'}}
 
   conformsToP1(p1)
-  // expected-error@-1 {{using 'P1' as a concrete type conforming to protocol 'P1' is not supported}}
+  // expected-error@-1 {{protocol type 'P1' cannot conform to 'P1' because only concrete types can conform to protocols}}
 
   // FIXME: Following diagnostics are not great because when
   // `conformsTo*` methods are re-typechecked, they loose information

--- a/test/type/subclass_composition_objc.swift
+++ b/test/type/subclass_composition_objc.swift
@@ -27,7 +27,6 @@ class SomeMethods {
 func takesObjCClass<T : ObjCClass>(_: T) {}
 func takesObjCProtocol<T : ObjCProtocol>(_: T) {}
 func takesObjCClassAndProtocol<T : ObjCClass & ObjCProtocol>(_: T) {}
-// expected-note@-1 2 {{in call to function 'takesObjCClassAndProtocol'}}
 
 func testSelfConformance(c: ObjCClass, p: ObjCProtocol, cp: ObjCClass & ObjCProtocol) {
   takesObjCClass(c)
@@ -39,8 +38,8 @@ func testSelfConformance(c: ObjCClass, p: ObjCProtocol, cp: ObjCClass & ObjCProt
   takesObjCProtocol(cp)
 
   // FIXME: Bad diagnostics
-  takesObjCClassAndProtocol(c) // expected-error {{generic parameter 'T' could not be inferred}}
-  takesObjCClassAndProtocol(p) // expected-error {{generic parameter 'T' could not be inferred}}
+  takesObjCClassAndProtocol(c) // expected-error {{argument type 'ObjCClass' does not conform to expected type 'ObjCProtocol'}}
+  takesObjCClassAndProtocol(p) // expected-error {{'(ObjCClass) -> ()' requires that 'ObjCClass' conform to 'ObjCProtocol'}}
   takesObjCClassAndProtocol(cp)
 }
 
@@ -51,12 +50,8 @@ func testSelfConformance(c: ObjCClass, p: ObjCProtocol, cp: ObjCClass & ObjCProt
 func takesStaticObjCProtocol<T : StaticObjCProtocol>(_: T) {}
 
 func testSelfConformance(cp: ObjCClass & StaticObjCProtocol) {
-
-  // FIXME: Terrible diagnostic
   takesStaticObjCProtocol(cp)
-  // expected-error@-1 {{cannot invoke 'takesStaticObjCProtocol' with an argument list of type '(ObjCClass & StaticObjCProtocol)'}}
-  // expected-note@-2 {{expected an argument list of type '(T)'}}
-
+  // expected-error@-1 {{'ObjCClass & StaticObjCProtocol' cannot be used as a type conforming to protocol 'StaticObjCProtocol' because 'StaticObjCProtocol' has static requirements}}
 }
 
 func testMetatypeSelfConformance(m1: (ObjCClass & ObjCProtocol).Protocol,

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar27830834.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar27830834.swift
@@ -1,4 +1,4 @@
 // RUN: %target-swift-frontend %s -typecheck -verify
 
 var d = [String:String]()
-_ = "\(d.map{ [$0 : $0] })" // expected-error {{type of expression is ambiguous without more context}}
+_ = "\(d.map{ [$0 : $0] })" // expected-error {{'[(key: String, value: String) : (key: String, value: String)]' requires that '(key: String, value: String)' conform to 'Hashable'}}

--- a/validation-test/compiler_crashers_fixed/00017-llvm-foldingset-llvm-attributesetnode-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/00017-llvm-foldingset-llvm-attributesetnode-nodeequals.swift
@@ -19,4 +19,4 @@ extension Bool : BooleanProtocol {
 }
 func f<T : BooleanProtocol>(_ b: T) {
 }
-f(true as BooleanProtocol) // expected-error {{cannot invoke 'f' with an argument list of type '(BooleanProtocol)'}} // expected-note {{expected an argument list of type '(T)'}}
+f(true as BooleanProtocol) // expected-error {{using 'BooleanProtocol' as a concrete type conforming to protocol 'BooleanProtocol' is not supported}}

--- a/validation-test/compiler_crashers_fixed/00017-llvm-foldingset-llvm-attributesetnode-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/00017-llvm-foldingset-llvm-attributesetnode-nodeequals.swift
@@ -19,4 +19,4 @@ extension Bool : BooleanProtocol {
 }
 func f<T : BooleanProtocol>(_ b: T) {
 }
-f(true as BooleanProtocol) // expected-error {{using 'BooleanProtocol' as a concrete type conforming to protocol 'BooleanProtocol' is not supported}}
+f(true as BooleanProtocol) // expected-error {{protocol type 'BooleanProtocol' cannot conform to 'BooleanProtocol' because only concrete types can conform to protocols}}

--- a/validation-test/stdlib/FixedPointDiagnostics.swift.gyb
+++ b/validation-test/stdlib/FixedPointDiagnostics.swift.gyb
@@ -3,13 +3,13 @@
 // RUN: %line-directive %t/main.swift -- %target-swift-frontend -typecheck -verify -swift-version 3 %t/main.swift
 
 func testUnaryMinusInUnsigned() {
-  var a: UInt8 = -(1) // expected-error {{cannot convert value of type 'Int' to specified type 'UInt8'}} expected-note * {{}} expected-warning * {{}}
+  var a: UInt8 = -(1) // expected-error {{argument type 'UInt8' does not conform to expected type 'SignedNumeric'}} expected-note * {{}} expected-warning * {{}}
 
-  var b: UInt16 = -(1) // expected-error {{cannot convert value of type 'Int' to specified type 'UInt16'}} expected-note * {{}} expected-warning * {{}}
+  var b: UInt16 = -(1) // expected-error {{argument type 'UInt16' does not conform to expected type 'SignedNumeric'}} expected-note * {{}} expected-warning * {{}}
 
-  var c: UInt32 = -(1) // expected-error {{cannot convert value of type 'Int' to specified type 'UInt32'}} expected-note * {{}} expected-warning * {{}}
+  var c: UInt32 = -(1) // expected-error {{argument type 'UInt32' does not conform to expected type 'SignedNumeric'}} expected-note * {{}} expected-warning * {{}}
 
-  var d: UInt64 = -(1) // expected-error {{cannot convert value of type 'Int' to specified type 'UInt64'}} expected-note * {{}} expected-warning * {{}}
+  var d: UInt64 = -(1) // expected-error {{argument type 'UInt64' does not conform to expected type 'SignedNumeric'}} expected-note * {{}} expected-warning * {{}}
 }
 
 // Int and UInt are not identical to any fixed-size integer type


### PR DESCRIPTION
If fixes are allowed let solver record missing protocol conformance
requirements and assume that `conformsTo` constraint is successfully
solved, this helps to diagnose such errors without involving
heavy-weight expression based diagnostics.

Resolves: rdar://problem/40537858

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
