### PR TITLE
[Foundation][SR-3125] Fix Decimal init from (U)Int64

### DIFF
--- a/stdlib/public/SDK/Foundation/Decimal.swift
+++ b/stdlib/public/SDK/Foundation/Decimal.swift
@@ -370,8 +370,8 @@ extension Decimal {
         var compactValue = value
         var exponent: Int32 = 0
         while compactValue % 10 == 0 {
-            compactValue = compactValue / 10
-            exponent = exponent + 1
+            compactValue /= 10
+            exponent += 1
         }
         _isCompact = 1
         _exponent = exponent
@@ -385,11 +385,9 @@ extension Decimal {
     }
     
     public init(_ value: Int64) {
+        self.init(value.magnitude)
         if value < 0 {
-            self.init(value == Int64.min ? UInt64(Int64.max) + 1 : UInt64(abs(value)))
             _isNegative = 1
-        } else {
-            self.init(UInt64(value))
         }
     }
     

--- a/test/stdlib/TestDecimal.swift
+++ b/test/stdlib/TestDecimal.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -118,6 +118,10 @@ class TestDecimal : TestDecimalSuper {
         expectFalse(zero.isInfinite)
         expectFalse(zero.isNaN)
         expectFalse(zero.isSignaling)
+
+        let d1 = Decimal(1234567890123456789 as UInt64)
+        expectEqual(d1._exponent, 0)
+        expectEqual(d1._length, 4)
     }
     func test_Constants() {
         expectEqual(8, NSDecimalMaxSize)


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR synchronizes the Foundation overlay with the corresponding file in swift-corelibs-foundation by adding changes made in apple/swift-corelibs-foundation#1550 with respect to `Decimal` initialization from `UInt64` and `Int64`. (The remainder of that PR is unique to swift-corelibs-foundation.)

I was surveying outstanding bugs in `Decimal` and noticed that this one was fixed on Linux but not on Apple platforms. The actual changes here are not mine, and for the sake of synchrony <strike>no attempt is made to improve this code</strike> only minor changes are made because (for some unclear reason) ToT is rejecting the expression `UInt64(abs(value))`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-3125](https://bugs.swift.org/browse/SR-3125).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->