### PR TITLE
[Batch Mode] Rdar 42314665 fix batch mode truncation bug

### DIFF
--- a/include/swift/AST/DiagnosticConsumer.h
+++ b/include/swift/AST/DiagnosticConsumer.h
@@ -251,7 +251,7 @@ private:
   /// This allows diagnostics to be emitted before files are actually opened,
   /// as long as they don't have source locations.
   ///
-  /// \see #consumerAndRangeForLocation
+  /// \see #subconsumerForLocation
   SmallVector<ConsumerAndRange, 4> ConsumersOrderedByRange;
 
   /// Indicates which consumer to send Note diagnostics too.
@@ -261,7 +261,7 @@ private:
   ///
   /// If None, Note diagnostics are sent to every consumer.
   /// If null, diagnostics are suppressed.
-  Optional<ConsumerAndRange *> ConsumerSpecificInfoForSubsequentNotes = None;
+  Optional<Subconsumer *> SubconsumerForSubsequentNotes = None;
 
   bool HasAnErrorBeenConsumed = false;
 
@@ -293,8 +293,8 @@ private:
   /// Returns nullptr if diagnostic is to be suppressed,
   /// None if diagnostic is to be distributed to every consumer,
   /// a particular consumer if diagnostic goes there.
-  Optional<ConsumerAndRange *> consumerAndRangeForLocation(SourceManager &SM,
-                                                           SourceLoc loc) const;
+  Optional<FileSpecificDiagnosticConsumer::Subconsumer *>
+  subconsumerForLocation(SourceManager &SM, SourceLoc loc);
 };
   
 } // end namespace swift

--- a/include/swift/AST/DiagnosticConsumer.h
+++ b/include/swift/AST/DiagnosticConsumer.h
@@ -210,12 +210,11 @@ public:
     /// Index into Subconsumers vector for this subconsumer.
     /// Should be const but then the sort won't compile.
     /*const*/ unsigned subconsumerIndex;
-    
+
   public:
     unsigned getSubconsumerIndex() const { return subconsumerIndex; }
-    
-    ConsumerAndRange(const CharSourceRange range,
-                                unsigned subconsumerIndex)
+
+    ConsumerAndRange(const CharSourceRange range, unsigned subconsumerIndex)
         : range(range), subconsumerIndex(subconsumerIndex) {}
 
     /// Compare according to range:
@@ -236,12 +235,12 @@ public:
       return compare(getRawLoc(range.getEnd()).getPointer(),
                      getRawLoc(loc).getPointer());
     }
- 
+
     bool contains(const SourceLoc loc) const { return range.contains(loc); }
   };
 
 private:
-  Subconsumer &operator[](const ConsumerAndRange& consumerAndRange) {
+  Subconsumer &operator[](const ConsumerAndRange &consumerAndRange) {
     return Subconsumers[consumerAndRange.getSubconsumerIndex()];
   }
   /// The consumers owned by this FileSpecificDiagnosticConsumer, sorted by
@@ -262,8 +261,7 @@ private:
   ///
   /// If None, Note diagnostics are sent to every consumer.
   /// If null, diagnostics are suppressed.
-  Optional<ConsumerAndRange *>
-      ConsumerSpecificInfoForSubsequentNotes = None;
+  Optional<ConsumerAndRange *> ConsumerSpecificInfoForSubsequentNotes = None;
 
   bool HasAnErrorBeenConsumed = false;
 
@@ -295,9 +293,8 @@ private:
   /// Returns nullptr if diagnostic is to be suppressed,
   /// None if diagnostic is to be distributed to every consumer,
   /// a particular consumer if diagnostic goes there.
-  Optional<ConsumerAndRange *>
-  consumerAndRangeForLocation(SourceManager &SM,
-                                         SourceLoc loc) const;
+  Optional<ConsumerAndRange *> consumerAndRangeForLocation(SourceManager &SM,
+                                                           SourceLoc loc) const;
 };
   
 } // end namespace swift

--- a/include/swift/AST/DiagnosticConsumer.h
+++ b/include/swift/AST/DiagnosticConsumer.h
@@ -136,18 +136,34 @@ public:
 /// current file.
 class FileSpecificDiagnosticConsumer : public DiagnosticConsumer {
 public:
+  
   /// A diagnostic consumer, along with the name of the buffer that it should
-  /// be associated with. An empty string means that a consumer is not
-  /// associated with any particular buffer, and should only receive diagnostics
-  /// that are not in any of the other consumers' files.
-  /// A null pointer for the DiagnosticConsumer means that diagnostics for this
-  /// file should not be emitted.
-  using Subconsumer =
-      std::pair<std::string, std::unique_ptr<DiagnosticConsumer>>;
+  /// be associated with.
+  class Subconsumer {
+  public:
+    /// The name of the buffer that a consumer should
+    /// be associated with. An empty string means that a consumer is not
+    /// associated with any particular buffer, and should only receive diagnostics
+    /// that are not in any of the other consumers' files.
+    std::string bufferName;
+    
+    /// A null pointer for the DiagnosticConsumer means that diagnostics for this
+    /// file should not be emitted.
+    std::unique_ptr<DiagnosticConsumer> consumer;
+    
+  private:
+    
+    // Has this subconsumer ever handled a diagnostic that is an error?
+    bool handledError = false;
+    
+  public:
+    Subconsumer(std::string bufferName, std::unique_ptr<DiagnosticConsumer> consumer)
+    : bufferName(bufferName), consumer(std::move(consumer)) {}
+  };
 
 private:
   /// All consumers owned by this FileSpecificDiagnosticConsumer.
-  const SmallVector<Subconsumer, 4> SubConsumers;
+  const SmallVector<Subconsumer, 4> Subconsumers;
 
 public:
   // The commented-out consts are there because the data does not change

--- a/include/swift/AST/DiagnosticConsumer.h
+++ b/include/swift/AST/DiagnosticConsumer.h
@@ -136,29 +136,28 @@ public:
 /// current file.
 class FileSpecificDiagnosticConsumer : public DiagnosticConsumer {
 public:
-  
   /// A diagnostic consumer, along with the name of the buffer that it should
   /// be associated with.
   class Subconsumer {
   public:
     /// The name of the buffer that a consumer should
     /// be associated with. An empty string means that a consumer is not
-    /// associated with any particular buffer, and should only receive diagnostics
-    /// that are not in any of the other consumers' files.
+    /// associated with any particular buffer, and should only receive
+    /// diagnostics that are not in any of the other consumers' files.
     std::string bufferName;
-    
-    /// A null pointer for the DiagnosticConsumer means that diagnostics for this
-    /// file should not be emitted.
+
+    /// A null pointer for the DiagnosticConsumer means that diagnostics for
+    /// this file should not be emitted.
     std::unique_ptr<DiagnosticConsumer> consumer;
-    
+
   private:
-    
     // Has this subconsumer ever handled a diagnostic that is an error?
     bool handledError = false;
-    
+
   public:
-    Subconsumer(std::string bufferName, std::unique_ptr<DiagnosticConsumer> consumer)
-    : bufferName(bufferName), consumer(std::move(consumer)) {}
+    Subconsumer(std::string bufferName,
+                std::unique_ptr<DiagnosticConsumer> consumer)
+        : bufferName(bufferName), consumer(std::move(consumer)) {}
   };
 
 private:

--- a/include/swift/AST/DiagnosticConsumer.h
+++ b/include/swift/AST/DiagnosticConsumer.h
@@ -142,12 +142,12 @@ public:
   /// that are not in any of the other consumers' files.
   /// A null pointer for the DiagnosticConsumer means that diagnostics for this
   /// file should not be emitted.
-  using ConsumerPair =
+  using Subconsumer =
       std::pair<std::string, std::unique_ptr<DiagnosticConsumer>>;
 
 private:
   /// All consumers owned by this FileSpecificDiagnosticConsumer.
-  const SmallVector<ConsumerPair, 4> SubConsumers;
+  const SmallVector<Subconsumer, 4> SubConsumers;
 
 public:
   // The commented-out consts are there because the data does not change
@@ -194,7 +194,7 @@ public:
   /// There must not be two consumers for the same file (i.e., having the same
   /// buffer name).
   explicit FileSpecificDiagnosticConsumer(
-      SmallVectorImpl<ConsumerPair> &consumers);
+      SmallVectorImpl<Subconsumer> &consumers);
 
   void handleDiagnostic(SourceManager &SM, SourceLoc Loc,
                         DiagnosticKind Kind,

--- a/lib/AST/DiagnosticConsumer.cpp
+++ b/lib/AST/DiagnosticConsumer.cpp
@@ -35,7 +35,7 @@ llvm::SMLoc DiagnosticConsumer::getRawLoc(SourceLoc loc) {
 
 LLVM_ATTRIBUTE_UNUSED
 static bool hasDuplicateFileNames(
-    ArrayRef<FileSpecificDiagnosticConsumer::ConsumerPair> consumers) {
+    ArrayRef<FileSpecificDiagnosticConsumer::Subconsumer> consumers) {
   llvm::StringSet<> seenFiles;
   for (const auto &consumerPair : consumers) {
     if (consumerPair.first.empty()) {
@@ -54,8 +54,8 @@ static bool hasDuplicateFileNames(
 }
 
 FileSpecificDiagnosticConsumer::FileSpecificDiagnosticConsumer(
-    SmallVectorImpl<ConsumerPair> &consumers)
-  : SubConsumers(std::move(consumers)) {
+    SmallVectorImpl<Subconsumer> &consumers)
+    : SubConsumers(std::move(consumers)) {
   assert(!SubConsumers.empty() &&
          "don't waste time handling diagnostics that will never get emitted");
   assert(!hasDuplicateFileNames(SubConsumers) &&
@@ -65,7 +65,7 @@ FileSpecificDiagnosticConsumer::FileSpecificDiagnosticConsumer(
 void FileSpecificDiagnosticConsumer::computeConsumersOrderedByRange(
     SourceManager &SM) {
   // Look up each file's source range and add it to the "map" (to be sorted).
-  for (const ConsumerPair &pair : SubConsumers) {
+  for (const Subconsumer &pair : SubConsumers) {
     if (pair.first.empty())
       continue;
 
@@ -121,9 +121,9 @@ FileSpecificDiagnosticConsumer::consumerSpecificInformationForLocation(
     // can't find buffers for the inputs).
     assert(!SubConsumers.empty());
     if (!SM.getIDForBufferIdentifier(SubConsumers.begin()->first).hasValue()) {
-      assert(llvm::none_of(SubConsumers, [&](const ConsumerPair &pair) {
-            return SM.getIDForBufferIdentifier(pair.first).hasValue();
-          }));
+      assert(llvm::none_of(SubConsumers, [&](const Subconsumer &pair) {
+        return SM.getIDForBufferIdentifier(pair.first).hasValue();
+      }));
       return None;
     }
     auto *mutableThis = const_cast<FileSpecificDiagnosticConsumer*>(this);

--- a/lib/AST/DiagnosticConsumer.cpp
+++ b/lib/AST/DiagnosticConsumer.cpp
@@ -146,17 +146,15 @@ FileSpecificDiagnosticConsumer::consumerAndRangeForLocation(
   // that /might/ contain 'loc'. Specifically, since the ranges are sorted
   // by end location, it's looking for the first range where the end location
   // is greater than or equal to 'loc'.
-  const ConsumerAndRange *possiblyContainingRangeIter =
-      std::lower_bound(
-          ConsumersOrderedByRange.begin(), ConsumersOrderedByRange.end(), loc,
-          [](const ConsumerAndRange &entry, SourceLoc loc) -> bool {
-            return entry.endsAfter(loc);
-          });
+  const ConsumerAndRange *possiblyContainingRangeIter = std::lower_bound(
+      ConsumersOrderedByRange.begin(), ConsumersOrderedByRange.end(), loc,
+      [](const ConsumerAndRange &entry, SourceLoc loc) -> bool {
+        return entry.endsAfter(loc);
+      });
 
   if (possiblyContainingRangeIter != ConsumersOrderedByRange.end() &&
       possiblyContainingRangeIter->contains(loc)) {
-    return const_cast<ConsumerAndRange *>(
-        possiblyContainingRangeIter);
+    return const_cast<ConsumerAndRange *>(possiblyContainingRangeIter);
   }
 
   return None;
@@ -182,7 +180,8 @@ void FileSpecificDiagnosticConsumer::handleDiagnostic(
     break;
   }
   if (consumerAndRange.hasValue()) {
-    (*this)[*consumerAndRange.getValue()].handleDiagnostic(SM,Loc, Kind, FormatString, FormatArgs, Info);
+    (*this)[*consumerAndRange.getValue()].handleDiagnostic(
+        SM, Loc, Kind, FormatString, FormatArgs, Info);
     return;
   }
   for (auto &subconsumer : Subconsumers)

--- a/lib/AST/DiagnosticConsumer.cpp
+++ b/lib/AST/DiagnosticConsumer.cpp
@@ -53,15 +53,18 @@ static bool hasDuplicateFileNames(
   return false;
 }
 
-std::unique_ptr<DiagnosticConsumer> FileSpecificDiagnosticConsumer::
-consolidateSubconsumers(SmallVectorImpl<Subconsumer> &subconsumers) {
+std::unique_ptr<DiagnosticConsumer>
+FileSpecificDiagnosticConsumer::consolidateSubconsumers(
+    SmallVectorImpl<Subconsumer> &subconsumers) {
   if (subconsumers.empty())
     return nullptr;
   if (subconsumers.size() == 1)
     return std::move(subconsumers.front()).consumer;
-  // Cannot use return llvm::make_unique<FileSpecificDiagnosticConsumer>(subconsumers);
-  // because the constructor is private.
-  return std::unique_ptr<DiagnosticConsumer>(new FileSpecificDiagnosticConsumer(subconsumers));
+  // Cannot use return
+  // llvm::make_unique<FileSpecificDiagnosticConsumer>(subconsumers); because
+  // the constructor is private.
+  return std::unique_ptr<DiagnosticConsumer>(
+      new FileSpecificDiagnosticConsumer(subconsumers));
 }
 
 FileSpecificDiagnosticConsumer::FileSpecificDiagnosticConsumer(
@@ -134,7 +137,8 @@ FileSpecificDiagnosticConsumer::consumerSpecificInformationForLocation(
     if (!SM.getIDForBufferIdentifier(Subconsumers.begin()->getInputFileName())
              .hasValue()) {
       assert(llvm::none_of(Subconsumers, [&](const Subconsumer &subconsumer) {
-        return SM.getIDForBufferIdentifier(subconsumer.getInputFileName()).hasValue();
+        return SM.getIDForBufferIdentifier(subconsumer.getInputFileName())
+            .hasValue();
       }));
       return None;
     }
@@ -197,8 +201,8 @@ bool FileSpecificDiagnosticConsumer::finishProcessing() {
 
   bool hadError = false;
   for (auto &subconsumer : Subconsumers)
-    hadError |=
-        subconsumer.getConsumer() && subconsumer.getConsumer()->finishProcessing();
+    hadError |= subconsumer.getConsumer() &&
+                subconsumer.getConsumer()->finishProcessing();
   return hadError;
 }
 

--- a/lib/AST/DiagnosticConsumer.cpp
+++ b/lib/AST/DiagnosticConsumer.cpp
@@ -39,10 +39,10 @@ static bool hasDuplicateFileNames(
   llvm::StringSet<> seenFiles;
   for (const auto &subconsumer : subconsumers) {
     if (subconsumer.bufferName.empty()) {
-      // We can handle multiple subconsumers that aren't associated with any file,
-      // because they only collect diagnostics that aren't in any of the special
-      // files. This isn't an important use case to support, but also SmallSet
-      // doesn't handle empty strings anyway!
+      // We can handle multiple subconsumers that aren't associated with any
+      // file, because they only collect diagnostics that aren't in any of the
+      // special files. This isn't an important use case to support, but also
+      // SmallSet doesn't handle empty strings anyway!
       continue;
     }
 
@@ -69,7 +69,8 @@ void FileSpecificDiagnosticConsumer::computeConsumersOrderedByRange(
     if (subconsumer.bufferName.empty())
       continue;
 
-    Optional<unsigned> bufferID = SM.getIDForBufferIdentifier(subconsumer.bufferName);
+    Optional<unsigned> bufferID =
+        SM.getIDForBufferIdentifier(subconsumer.bufferName);
     assert(bufferID.hasValue() && "consumer registered for unknown file");
     CharSourceRange range = SM.getRangeForBuffer(bufferID.getValue());
     ConsumersOrderedByRange.emplace_back(
@@ -120,7 +121,8 @@ FileSpecificDiagnosticConsumer::consumerSpecificInformationForLocation(
     // than trying to build a nonsensical map (and actually crashing since we
     // can't find buffers for the inputs).
     assert(!Subconsumers.empty());
-    if (!SM.getIDForBufferIdentifier(Subconsumers.begin()->bufferName).hasValue()) {
+    if (!SM.getIDForBufferIdentifier(Subconsumers.begin()->bufferName)
+             .hasValue()) {
       assert(llvm::none_of(Subconsumers, [&](const Subconsumer &subconsumer) {
         return SM.getIDForBufferIdentifier(subconsumer.bufferName).hasValue();
       }));
@@ -175,7 +177,7 @@ void FileSpecificDiagnosticConsumer::handleDiagnostic(
     for (auto &subconsumer : Subconsumers) {
       if (subconsumer.consumer) {
         subconsumer.consumer->handleDiagnostic(SM, Loc, Kind, FormatString,
-                                             FormatArgs, Info);
+                                               FormatArgs, Info);
       }
     }
     return;
@@ -197,7 +199,8 @@ bool FileSpecificDiagnosticConsumer::finishProcessing() {
 
   bool hadError = false;
   for (auto &subconsumer : Subconsumers)
-    hadError |= subconsumer.consumer && subconsumer.consumer->finishProcessing();
+    hadError |=
+        subconsumer.consumer && subconsumer.consumer->finishProcessing();
   return hadError;
 }
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1586,7 +1586,7 @@ static std::unique_ptr<DiagnosticConsumer>
 createDispatchingDiagnosticConsumerIfNeeded(
     const FrontendInputsAndOutputs &inputsAndOutputs,
     llvm::function_ref<std::unique_ptr<DiagnosticConsumer>(const InputFile &)>
-      maybeCreateConsumerForDiagnosticsFrom) {
+        maybeCreateConsumerForDiagnosticsFrom) {
 
   // The "4" here is somewhat arbitrary. In practice we're going to have one
   // sub-consumer for each diagnostic file we're trying to output, which (again

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1600,10 +1600,11 @@ createDispatchingDiagnosticConsumerIfNeeded(
 
   inputsAndOutputs.forEachInputProducingSupplementaryOutput(
       [&](const InputFile &input) -> bool {
-    if (auto subconsumer = maybeCreateSingleConsumer(input))
-      subconsumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer(input.file(), std::move(subconsumer)));
-    return false;
-  });
+        if (auto subconsumer = maybeCreateSingleConsumer(input))
+          subconsumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer(
+              input.file(), std::move(subconsumer)));
+        return false;
+      });
   // For batch mode, the compiler must swallow diagnostics pertaining to
   // non-primary files in order to avoid Xcode showing the same diagnostic
   // multiple times. So, create a diagnostic "eater" for those non-primary

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1586,7 +1586,7 @@ static std::unique_ptr<DiagnosticConsumer>
 createDispatchingDiagnosticConsumerIfNeeded(
     const FrontendInputsAndOutputs &inputsAndOutputs,
     llvm::function_ref<std::unique_ptr<DiagnosticConsumer>(const InputFile &)>
-      maybeCreateSingleConsumer) {
+      maybeCreateConsumerForDiagnosticsFrom) {
 
   // The "4" here is somewhat arbitrary. In practice we're going to have one
   // sub-consumer for each diagnostic file we're trying to output, which (again
@@ -1600,9 +1600,8 @@ createDispatchingDiagnosticConsumerIfNeeded(
 
   inputsAndOutputs.forEachInputProducingSupplementaryOutput(
       [&](const InputFile &input) -> bool {
-        if (auto subconsumer = maybeCreateSingleConsumer(input))
-          subconsumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer(
-              input.file(), std::move(subconsumer)));
+        if (auto subconsumer = maybeCreateConsumerForDiagnosticsFrom(input))
+          subconsumers.emplace_back(input.file(), std::move(subconsumer));
         return false;
       });
   // For batch mode, the compiler must swallow diagnostics pertaining to

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1618,7 +1618,7 @@ createDispatchingDiagnosticConsumerIfNeeded(
           return false;
         });
   }
-  
+
   return FileSpecificDiagnosticConsumer::consolidateSubconsumers(subconsumers);
 }
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1618,12 +1618,8 @@ createDispatchingDiagnosticConsumerIfNeeded(
           return false;
         });
   }
-
-  if (subconsumers.empty())
-    return nullptr;
-  if (subconsumers.size() == 1)
-    return std::move(subconsumers.front()).consumer;
-  return llvm::make_unique<FileSpecificDiagnosticConsumer>(subconsumers);
+  
+  return FileSpecificDiagnosticConsumer::consolidateSubconsumers(subconsumers);
 }
 
 /// Creates a diagnostic consumer that handles serializing diagnostics, based on

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1596,7 +1596,7 @@ createDispatchingDiagnosticConsumerIfNeeded(
   // So a value of "4" here means that there would be no heap allocation on a
   // clean build of a module with up to 32 files on an 8-core machine, if the
   // user doesn't customize anything.
-  SmallVector<FileSpecificDiagnosticConsumer::ConsumerPair, 4> subConsumers;
+  SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 4> subConsumers;
 
   inputsAndOutputs.forEachInputProducingSupplementaryOutput(
       [&](const InputFile &input) -> bool {

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1600,8 +1600,8 @@ createDispatchingDiagnosticConsumerIfNeeded(
 
   inputsAndOutputs.forEachInputProducingSupplementaryOutput(
       [&](const InputFile &input) -> bool {
-        if (auto subconsumer = maybeCreateConsumerForDiagnosticsFrom(input))
-          subconsumers.emplace_back(input.file(), std::move(subconsumer));
+        if (auto consumer = maybeCreateConsumerForDiagnosticsFrom(input))
+          subconsumers.emplace_back(input.file(), std::move(consumer));
         return false;
       });
   // For batch mode, the compiler must swallow diagnostics pertaining to

--- a/unittests/AST/DiagnosticConsumerTests.cpp
+++ b/unittests/AST/DiagnosticConsumerTests.cpp
@@ -63,7 +63,7 @@ TEST(FileSpecificDiagnosticConsumer, SubConsumersFinishInOrder) {
   auto consumerUnaffiliated = llvm::make_unique<ExpectationDiagnosticConsumer>(
       consumerA.get(), None);
 
-  SmallVector<FileSpecificDiagnosticConsumer::ConsumerPair, 2> consumers;
+  SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
   consumers.emplace_back("A", std::move(consumerA));
   consumers.emplace_back("", std::move(consumerUnaffiliated));
 
@@ -82,7 +82,7 @@ TEST(FileSpecificDiagnosticConsumer, InvalidLocDiagsGoToEveryConsumer) {
   auto consumerUnaffiliated = llvm::make_unique<ExpectationDiagnosticConsumer>(
       consumerA.get(), expected);
 
-  SmallVector<FileSpecificDiagnosticConsumer::ConsumerPair, 2> consumers;
+  SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
   consumers.emplace_back("A", std::move(consumerA));
   consumers.emplace_back("", std::move(consumerUnaffiliated));
 
@@ -122,7 +122,7 @@ TEST(FileSpecificDiagnosticConsumer, ErrorsWithLocationsGoToExpectedConsumers) {
   auto consumerB = llvm::make_unique<ExpectationDiagnosticConsumer>(
       consumerA.get(), expectedB);
 
-  SmallVector<FileSpecificDiagnosticConsumer::ConsumerPair, 2> consumers;
+  SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
   consumers.emplace_back("A", std::move(consumerA));
   consumers.emplace_back("B", std::move(consumerB));
 
@@ -176,7 +176,7 @@ TEST(FileSpecificDiagnosticConsumer,
   auto consumerUnaffiliated = llvm::make_unique<ExpectationDiagnosticConsumer>(
       consumerA.get(), expectedUnaffiliated);
 
-  SmallVector<FileSpecificDiagnosticConsumer::ConsumerPair, 2> consumers;
+  SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
   consumers.emplace_back("A", std::move(consumerA));
   consumers.emplace_back("", std::move(consumerUnaffiliated));
 
@@ -221,7 +221,7 @@ TEST(FileSpecificDiagnosticConsumer, WarningsAndRemarksAreTreatedLikeErrors) {
   auto consumerUnaffiliated = llvm::make_unique<ExpectationDiagnosticConsumer>(
       consumerA.get(), expectedUnaffiliated);
 
-  SmallVector<FileSpecificDiagnosticConsumer::ConsumerPair, 2> consumers;
+  SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
   consumers.emplace_back("A", std::move(consumerA));
   consumers.emplace_back("", std::move(consumerUnaffiliated));
 
@@ -273,7 +273,7 @@ TEST(FileSpecificDiagnosticConsumer, NotesAreAttachedToErrors) {
   auto consumerUnaffiliated = llvm::make_unique<ExpectationDiagnosticConsumer>(
       consumerA.get(), expectedUnaffiliated);
 
-  SmallVector<FileSpecificDiagnosticConsumer::ConsumerPair, 2> consumers;
+  SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
   consumers.emplace_back("A", std::move(consumerA));
   consumers.emplace_back("", std::move(consumerUnaffiliated));
 
@@ -335,7 +335,7 @@ TEST(FileSpecificDiagnosticConsumer, NotesAreAttachedToWarningsAndRemarks) {
   auto consumerUnaffiliated = llvm::make_unique<ExpectationDiagnosticConsumer>(
       consumerA.get(), expectedUnaffiliated);
 
-  SmallVector<FileSpecificDiagnosticConsumer::ConsumerPair, 2> consumers;
+  SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
   consumers.emplace_back("A", std::move(consumerA));
   consumers.emplace_back("", std::move(consumerUnaffiliated));
 
@@ -394,7 +394,7 @@ TEST(FileSpecificDiagnosticConsumer, NotesAreAttachedToErrorsEvenAcrossFiles) {
   auto consumerB = llvm::make_unique<ExpectationDiagnosticConsumer>(
       consumerA.get(), expectedB);
 
-  SmallVector<FileSpecificDiagnosticConsumer::ConsumerPair, 2> consumers;
+  SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
   consumers.emplace_back("A", std::move(consumerA));
   consumers.emplace_back("B", std::move(consumerB));
 
@@ -457,7 +457,7 @@ TEST(FileSpecificDiagnosticConsumer,
   auto consumerUnaffiliated = llvm::make_unique<ExpectationDiagnosticConsumer>(
       consumerA.get(), expectedUnaffiliated);
 
-  SmallVector<FileSpecificDiagnosticConsumer::ConsumerPair, 2> consumers;
+  SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
   consumers.emplace_back("A", std::move(consumerA));
   consumers.emplace_back("", std::move(consumerUnaffiliated));
 
@@ -512,7 +512,7 @@ TEST(FileSpecificDiagnosticConsumer,
   auto consumerUnaffiliated = llvm::make_unique<ExpectationDiagnosticConsumer>(
       consumerA.get(), expectedUnaffiliated);
 
-  SmallVector<FileSpecificDiagnosticConsumer::ConsumerPair, 2> consumers;
+  SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
   consumers.emplace_back("A", std::move(consumerA));
   consumers.emplace_back("", std::move(consumerUnaffiliated));
 

--- a/unittests/AST/DiagnosticConsumerTests.cpp
+++ b/unittests/AST/DiagnosticConsumerTests.cpp
@@ -64,8 +64,10 @@ TEST(FileSpecificDiagnosticConsumer, SubconsumersFinishInOrder) {
       consumerA.get(), None);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
-  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("", std::move(consumerUnaffiliated)));
+  consumers.emplace_back(
+      FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
+  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer(
+      "", std::move(consumerUnaffiliated)));
 
   FileSpecificDiagnosticConsumer topConsumer(consumers);
   topConsumer.finishProcessing();
@@ -83,8 +85,10 @@ TEST(FileSpecificDiagnosticConsumer, InvalidLocDiagsGoToEveryConsumer) {
       consumerA.get(), expected);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
-  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("", std::move(consumerUnaffiliated)));
+  consumers.emplace_back(
+      FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
+  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer(
+      "", std::move(consumerUnaffiliated)));
 
   FileSpecificDiagnosticConsumer topConsumer(consumers);
   topConsumer.handleDiagnostic(sourceMgr, SourceLoc(), DiagnosticKind::Error,
@@ -123,8 +127,10 @@ TEST(FileSpecificDiagnosticConsumer, ErrorsWithLocationsGoToExpectedConsumers) {
       consumerA.get(), expectedB);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
-  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("B", std::move(consumerB)));
+  consumers.emplace_back(
+      FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
+  consumers.emplace_back(
+      FileSpecificDiagnosticConsumer::Subconsumer("B", std::move(consumerB)));
 
   FileSpecificDiagnosticConsumer topConsumer(consumers);
   topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
@@ -177,8 +183,10 @@ TEST(FileSpecificDiagnosticConsumer,
       consumerA.get(), expectedUnaffiliated);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
-  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("", std::move(consumerUnaffiliated)));
+  consumers.emplace_back(
+      FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
+  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer(
+      "", std::move(consumerUnaffiliated)));
 
   FileSpecificDiagnosticConsumer topConsumer(consumers);
   topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
@@ -222,8 +230,10 @@ TEST(FileSpecificDiagnosticConsumer, WarningsAndRemarksAreTreatedLikeErrors) {
       consumerA.get(), expectedUnaffiliated);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
-  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("", std::move(consumerUnaffiliated)));
+  consumers.emplace_back(
+      FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
+  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer(
+      "", std::move(consumerUnaffiliated)));
 
   FileSpecificDiagnosticConsumer topConsumer(consumers);
   topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Warning,
@@ -274,8 +284,10 @@ TEST(FileSpecificDiagnosticConsumer, NotesAreAttachedToErrors) {
       consumerA.get(), expectedUnaffiliated);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
-  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("", std::move(consumerUnaffiliated)));
+  consumers.emplace_back(
+      FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
+  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer(
+      "", std::move(consumerUnaffiliated)));
 
   FileSpecificDiagnosticConsumer topConsumer(consumers);
   topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
@@ -336,8 +348,10 @@ TEST(FileSpecificDiagnosticConsumer, NotesAreAttachedToWarningsAndRemarks) {
       consumerA.get(), expectedUnaffiliated);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
-  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("", std::move(consumerUnaffiliated)));
+  consumers.emplace_back(
+      FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
+  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer(
+      "", std::move(consumerUnaffiliated)));
 
   FileSpecificDiagnosticConsumer topConsumer(consumers);
   topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Warning,
@@ -395,8 +409,10 @@ TEST(FileSpecificDiagnosticConsumer, NotesAreAttachedToErrorsEvenAcrossFiles) {
       consumerA.get(), expectedB);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
-  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("B", std::move(consumerB)));
+  consumers.emplace_back(
+      FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
+  consumers.emplace_back(
+      FileSpecificDiagnosticConsumer::Subconsumer("B", std::move(consumerB)));
 
   FileSpecificDiagnosticConsumer topConsumer(consumers);
   topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
@@ -458,8 +474,10 @@ TEST(FileSpecificDiagnosticConsumer,
       consumerA.get(), expectedUnaffiliated);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
-  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("", std::move(consumerUnaffiliated)));
+  consumers.emplace_back(
+      FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
+  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer(
+      "", std::move(consumerUnaffiliated)));
 
   FileSpecificDiagnosticConsumer topConsumer(consumers);
   topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
@@ -513,8 +531,10 @@ TEST(FileSpecificDiagnosticConsumer,
       consumerA.get(), expectedUnaffiliated);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
-  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("", std::move(consumerUnaffiliated)));
+  consumers.emplace_back(
+      FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
+  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer(
+      "", std::move(consumerUnaffiliated)));
 
   FileSpecificDiagnosticConsumer topConsumer(consumers);
   topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,

--- a/unittests/AST/DiagnosticConsumerTests.cpp
+++ b/unittests/AST/DiagnosticConsumerTests.cpp
@@ -64,10 +64,8 @@ TEST(FileSpecificDiagnosticConsumer, SubconsumersFinishInOrder) {
       consumerA.get(), None);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back(
-      FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
-  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer(
-      "", std::move(consumerUnaffiliated)));
+  consumers.emplace_back("A", std::move(consumerA));
+  consumers.emplace_back("", std::move(consumerUnaffiliated));
 
   auto topConsumer =
       FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);
@@ -86,10 +84,8 @@ TEST(FileSpecificDiagnosticConsumer, InvalidLocDiagsGoToEveryConsumer) {
       consumerA.get(), expected);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back(
-      FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
-  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer(
-      "", std::move(consumerUnaffiliated)));
+  consumers.emplace_back("A", std::move(consumerA));
+  consumers.emplace_back("", std::move(consumerUnaffiliated));
 
   auto topConsumer =
       FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);
@@ -129,10 +125,8 @@ TEST(FileSpecificDiagnosticConsumer, ErrorsWithLocationsGoToExpectedConsumers) {
       consumerA.get(), expectedB);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back(
-      FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
-  consumers.emplace_back(
-      FileSpecificDiagnosticConsumer::Subconsumer("B", std::move(consumerB)));
+  consumers.emplace_back("A", std::move(consumerA));
+  consumers.emplace_back("B", std::move(consumerB));
 
   auto topConsumer =
       FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);
@@ -186,10 +180,8 @@ TEST(FileSpecificDiagnosticConsumer,
       consumerA.get(), expectedUnaffiliated);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back(
-      FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
-  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer(
-      "", std::move(consumerUnaffiliated)));
+  consumers.emplace_back("A", std::move(consumerA));
+  consumers.emplace_back("", std::move(consumerUnaffiliated));
 
   auto topConsumer =
       FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);
@@ -234,10 +226,8 @@ TEST(FileSpecificDiagnosticConsumer, WarningsAndRemarksAreTreatedLikeErrors) {
       consumerA.get(), expectedUnaffiliated);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back(
-      FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
-  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer(
-      "", std::move(consumerUnaffiliated)));
+  consumers.emplace_back("A", std::move(consumerA));
+  consumers.emplace_back("", std::move(consumerUnaffiliated));
 
   auto topConsumer =
       FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);
@@ -289,10 +279,8 @@ TEST(FileSpecificDiagnosticConsumer, NotesAreAttachedToErrors) {
       consumerA.get(), expectedUnaffiliated);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back(
-      FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
-  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer(
-      "", std::move(consumerUnaffiliated)));
+  consumers.emplace_back("A", std::move(consumerA));
+  consumers.emplace_back("", std::move(consumerUnaffiliated));
 
   auto topConsumer =
       FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);
@@ -354,10 +342,8 @@ TEST(FileSpecificDiagnosticConsumer, NotesAreAttachedToWarningsAndRemarks) {
       consumerA.get(), expectedUnaffiliated);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back(
-      FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
-  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer(
-      "", std::move(consumerUnaffiliated)));
+  consumers.emplace_back("A", std::move(consumerA));
+  consumers.emplace_back("", std::move(consumerUnaffiliated));
 
   auto topConsumer =
       FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);
@@ -416,10 +402,8 @@ TEST(FileSpecificDiagnosticConsumer, NotesAreAttachedToErrorsEvenAcrossFiles) {
       consumerA.get(), expectedB);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back(
-      FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
-  consumers.emplace_back(
-      FileSpecificDiagnosticConsumer::Subconsumer("B", std::move(consumerB)));
+  consumers.emplace_back("A", std::move(consumerA));
+  consumers.emplace_back("B", std::move(consumerB));
 
   auto topConsumer =
       FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);
@@ -482,10 +466,8 @@ TEST(FileSpecificDiagnosticConsumer,
       consumerA.get(), expectedUnaffiliated);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back(
-      FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
-  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer(
-      "", std::move(consumerUnaffiliated)));
+  consumers.emplace_back("A", std::move(consumerA));
+  consumers.emplace_back("", std::move(consumerUnaffiliated));
 
   auto topConsumer =
       FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);
@@ -540,10 +522,8 @@ TEST(FileSpecificDiagnosticConsumer,
       consumerA.get(), expectedUnaffiliated);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back(
-      FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
-  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer(
-      "", std::move(consumerUnaffiliated)));
+  consumers.emplace_back("A", std::move(consumerA));
+  consumers.emplace_back("", std::move(consumerUnaffiliated));
 
   auto topConsumer =
       FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);

--- a/unittests/AST/DiagnosticConsumerTests.cpp
+++ b/unittests/AST/DiagnosticConsumerTests.cpp
@@ -53,7 +53,7 @@ namespace {
   };
 } // end anonymous namespace
 
-TEST(FileSpecificDiagnosticConsumer, SubConsumersFinishInOrder) {
+TEST(FileSpecificDiagnosticConsumer, SubconsumersFinishInOrder) {
   SourceManager sourceMgr;
   (void)sourceMgr.addMemBufferCopy("abcde", "A");
   (void)sourceMgr.addMemBufferCopy("vwxyz", "B");
@@ -64,8 +64,8 @@ TEST(FileSpecificDiagnosticConsumer, SubConsumersFinishInOrder) {
       consumerA.get(), None);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back("A", std::move(consumerA));
-  consumers.emplace_back("", std::move(consumerUnaffiliated));
+  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
+  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("", std::move(consumerUnaffiliated)));
 
   FileSpecificDiagnosticConsumer topConsumer(consumers);
   topConsumer.finishProcessing();
@@ -83,8 +83,8 @@ TEST(FileSpecificDiagnosticConsumer, InvalidLocDiagsGoToEveryConsumer) {
       consumerA.get(), expected);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back("A", std::move(consumerA));
-  consumers.emplace_back("", std::move(consumerUnaffiliated));
+  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
+  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("", std::move(consumerUnaffiliated)));
 
   FileSpecificDiagnosticConsumer topConsumer(consumers);
   topConsumer.handleDiagnostic(sourceMgr, SourceLoc(), DiagnosticKind::Error,
@@ -123,8 +123,8 @@ TEST(FileSpecificDiagnosticConsumer, ErrorsWithLocationsGoToExpectedConsumers) {
       consumerA.get(), expectedB);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back("A", std::move(consumerA));
-  consumers.emplace_back("B", std::move(consumerB));
+  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
+  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("B", std::move(consumerB)));
 
   FileSpecificDiagnosticConsumer topConsumer(consumers);
   topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
@@ -177,8 +177,8 @@ TEST(FileSpecificDiagnosticConsumer,
       consumerA.get(), expectedUnaffiliated);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back("A", std::move(consumerA));
-  consumers.emplace_back("", std::move(consumerUnaffiliated));
+  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
+  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("", std::move(consumerUnaffiliated)));
 
   FileSpecificDiagnosticConsumer topConsumer(consumers);
   topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
@@ -222,8 +222,8 @@ TEST(FileSpecificDiagnosticConsumer, WarningsAndRemarksAreTreatedLikeErrors) {
       consumerA.get(), expectedUnaffiliated);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back("A", std::move(consumerA));
-  consumers.emplace_back("", std::move(consumerUnaffiliated));
+  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
+  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("", std::move(consumerUnaffiliated)));
 
   FileSpecificDiagnosticConsumer topConsumer(consumers);
   topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Warning,
@@ -274,8 +274,8 @@ TEST(FileSpecificDiagnosticConsumer, NotesAreAttachedToErrors) {
       consumerA.get(), expectedUnaffiliated);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back("A", std::move(consumerA));
-  consumers.emplace_back("", std::move(consumerUnaffiliated));
+  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
+  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("", std::move(consumerUnaffiliated)));
 
   FileSpecificDiagnosticConsumer topConsumer(consumers);
   topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
@@ -336,8 +336,8 @@ TEST(FileSpecificDiagnosticConsumer, NotesAreAttachedToWarningsAndRemarks) {
       consumerA.get(), expectedUnaffiliated);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back("A", std::move(consumerA));
-  consumers.emplace_back("", std::move(consumerUnaffiliated));
+  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
+  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("", std::move(consumerUnaffiliated)));
 
   FileSpecificDiagnosticConsumer topConsumer(consumers);
   topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Warning,
@@ -395,8 +395,8 @@ TEST(FileSpecificDiagnosticConsumer, NotesAreAttachedToErrorsEvenAcrossFiles) {
       consumerA.get(), expectedB);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back("A", std::move(consumerA));
-  consumers.emplace_back("B", std::move(consumerB));
+  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
+  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("B", std::move(consumerB)));
 
   FileSpecificDiagnosticConsumer topConsumer(consumers);
   topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
@@ -458,8 +458,8 @@ TEST(FileSpecificDiagnosticConsumer,
       consumerA.get(), expectedUnaffiliated);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back("A", std::move(consumerA));
-  consumers.emplace_back("", std::move(consumerUnaffiliated));
+  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
+  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("", std::move(consumerUnaffiliated)));
 
   FileSpecificDiagnosticConsumer topConsumer(consumers);
   topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
@@ -513,8 +513,8 @@ TEST(FileSpecificDiagnosticConsumer,
       consumerA.get(), expectedUnaffiliated);
 
   SmallVector<FileSpecificDiagnosticConsumer::Subconsumer, 2> consumers;
-  consumers.emplace_back("A", std::move(consumerA));
-  consumers.emplace_back("", std::move(consumerUnaffiliated));
+  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("A", std::move(consumerA)));
+  consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer("", std::move(consumerUnaffiliated)));
 
   FileSpecificDiagnosticConsumer topConsumer(consumers);
   topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,

--- a/unittests/AST/DiagnosticConsumerTests.cpp
+++ b/unittests/AST/DiagnosticConsumerTests.cpp
@@ -69,8 +69,9 @@ TEST(FileSpecificDiagnosticConsumer, SubconsumersFinishInOrder) {
   consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer(
       "", std::move(consumerUnaffiliated)));
 
-  FileSpecificDiagnosticConsumer topConsumer(consumers);
-  topConsumer.finishProcessing();
+  auto topConsumer =
+      FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);
+  topConsumer->finishProcessing();
 }
 
 TEST(FileSpecificDiagnosticConsumer, InvalidLocDiagsGoToEveryConsumer) {
@@ -90,10 +91,11 @@ TEST(FileSpecificDiagnosticConsumer, InvalidLocDiagsGoToEveryConsumer) {
   consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer(
       "", std::move(consumerUnaffiliated)));
 
-  FileSpecificDiagnosticConsumer topConsumer(consumers);
-  topConsumer.handleDiagnostic(sourceMgr, SourceLoc(), DiagnosticKind::Error,
-                               "dummy", {}, DiagnosticInfo());
-  topConsumer.finishProcessing();
+  auto topConsumer =
+      FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);
+  topConsumer->handleDiagnostic(sourceMgr, SourceLoc(), DiagnosticKind::Error,
+                                "dummy", {}, DiagnosticInfo());
+  topConsumer->finishProcessing();
 }
 
 TEST(FileSpecificDiagnosticConsumer, ErrorsWithLocationsGoToExpectedConsumers) {
@@ -132,20 +134,21 @@ TEST(FileSpecificDiagnosticConsumer, ErrorsWithLocationsGoToExpectedConsumers) {
   consumers.emplace_back(
       FileSpecificDiagnosticConsumer::Subconsumer("B", std::move(consumerB)));
 
-  FileSpecificDiagnosticConsumer topConsumer(consumers);
-  topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
-                               "front", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Error,
-                               "front", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Error,
-                               "middle", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Error,
-                               "middle", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Error,
-                               "back", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, backOfB, DiagnosticKind::Error,
-                               "back", {}, DiagnosticInfo());
-  topConsumer.finishProcessing();
+  auto topConsumer =
+      FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);
+  topConsumer->handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
+                                "front", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Error,
+                                "front", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Error,
+                                "middle", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Error,
+                                "middle", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Error,
+                                "back", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, backOfB, DiagnosticKind::Error,
+                                "back", {}, DiagnosticInfo());
+  topConsumer->finishProcessing();
 }
 
 TEST(FileSpecificDiagnosticConsumer,
@@ -188,20 +191,21 @@ TEST(FileSpecificDiagnosticConsumer,
   consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer(
       "", std::move(consumerUnaffiliated)));
 
-  FileSpecificDiagnosticConsumer topConsumer(consumers);
-  topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
-                               "front", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Error,
-                               "front", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Error,
-                               "middle", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Error,
-                               "middle", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Error,
-                               "back", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, backOfB, DiagnosticKind::Error,
-                               "back", {}, DiagnosticInfo());
-  topConsumer.finishProcessing();
+  auto topConsumer =
+      FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);
+  topConsumer->handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
+                                "front", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Error,
+                                "front", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Error,
+                                "middle", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Error,
+                                "middle", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Error,
+                                "back", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, backOfB, DiagnosticKind::Error,
+                                "back", {}, DiagnosticInfo());
+  topConsumer->finishProcessing();
 }
 
 TEST(FileSpecificDiagnosticConsumer, WarningsAndRemarksAreTreatedLikeErrors) {
@@ -235,16 +239,17 @@ TEST(FileSpecificDiagnosticConsumer, WarningsAndRemarksAreTreatedLikeErrors) {
   consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer(
       "", std::move(consumerUnaffiliated)));
 
-  FileSpecificDiagnosticConsumer topConsumer(consumers);
-  topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Warning,
-                               "warning", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Warning,
-                               "warning", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Remark,
-                               "remark", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Remark,
-                               "remark", {}, DiagnosticInfo());
-  topConsumer.finishProcessing();
+  auto topConsumer =
+      FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);
+  topConsumer->handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Warning,
+                                "warning", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Warning,
+                                "warning", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Remark,
+                                "remark", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Remark,
+                                "remark", {}, DiagnosticInfo());
+  topConsumer->finishProcessing();
 }
 
 TEST(FileSpecificDiagnosticConsumer, NotesAreAttachedToErrors) {
@@ -289,26 +294,27 @@ TEST(FileSpecificDiagnosticConsumer, NotesAreAttachedToErrors) {
   consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer(
       "", std::move(consumerUnaffiliated)));
 
-  FileSpecificDiagnosticConsumer topConsumer(consumers);
-  topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
-                               "error", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Note,
-                               "note", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
-                               "note", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Error,
-                               "error", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Note,
-                               "note", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, backOfB, DiagnosticKind::Note,
-                               "note", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
-                               "error", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Note,
-                               "note", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
-                               "note", {}, DiagnosticInfo());
-  topConsumer.finishProcessing();
+  auto topConsumer =
+      FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);
+  topConsumer->handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
+                                "error", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Note,
+                                "note", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
+                                "note", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Error,
+                                "error", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Note,
+                                "note", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, backOfB, DiagnosticKind::Note,
+                                "note", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
+                                "error", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Note,
+                                "note", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
+                                "note", {}, DiagnosticInfo());
+  topConsumer->finishProcessing();
 }
 
 TEST(FileSpecificDiagnosticConsumer, NotesAreAttachedToWarningsAndRemarks) {
@@ -353,26 +359,27 @@ TEST(FileSpecificDiagnosticConsumer, NotesAreAttachedToWarningsAndRemarks) {
   consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer(
       "", std::move(consumerUnaffiliated)));
 
-  FileSpecificDiagnosticConsumer topConsumer(consumers);
-  topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Warning,
-                               "warning", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Note,
-                               "note", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
-                               "note", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Warning,
-                               "warning", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Note,
-                               "note", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, backOfB, DiagnosticKind::Note,
-                               "note", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Remark,
-                               "remark", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Note,
-                               "note", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
-                               "note", {}, DiagnosticInfo());
-  topConsumer.finishProcessing();
+  auto topConsumer =
+      FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);
+  topConsumer->handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Warning,
+                                "warning", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Note,
+                                "note", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
+                                "note", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Warning,
+                                "warning", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Note,
+                                "note", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, backOfB, DiagnosticKind::Note,
+                                "note", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Remark,
+                                "remark", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Note,
+                                "note", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
+                                "note", {}, DiagnosticInfo());
+  topConsumer->finishProcessing();
 }
 
 TEST(FileSpecificDiagnosticConsumer, NotesAreAttachedToErrorsEvenAcrossFiles) {
@@ -414,26 +421,27 @@ TEST(FileSpecificDiagnosticConsumer, NotesAreAttachedToErrorsEvenAcrossFiles) {
   consumers.emplace_back(
       FileSpecificDiagnosticConsumer::Subconsumer("B", std::move(consumerB)));
 
-  FileSpecificDiagnosticConsumer topConsumer(consumers);
-  topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
-                               "error", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Note,
-                               "note", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
-                               "note", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Error,
-                               "error", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Note,
-                               "note", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, backOfB, DiagnosticKind::Note,
-                               "note", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
-                               "error", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Note,
-                               "note", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
-                               "note", {}, DiagnosticInfo());
-  topConsumer.finishProcessing();
+  auto topConsumer =
+      FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);
+  topConsumer->handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
+                                "error", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Note,
+                                "note", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
+                                "note", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Error,
+                                "error", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Note,
+                                "note", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, backOfB, DiagnosticKind::Note,
+                                "note", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
+                                "error", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Note,
+                                "note", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
+                                "note", {}, DiagnosticInfo());
+  topConsumer->finishProcessing();
 }
 
 TEST(FileSpecificDiagnosticConsumer,
@@ -479,26 +487,27 @@ TEST(FileSpecificDiagnosticConsumer,
   consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer(
       "", std::move(consumerUnaffiliated)));
 
-  FileSpecificDiagnosticConsumer topConsumer(consumers);
-  topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
-                               "error", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Note,
-                               "note", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
-                               "note", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Error,
-                               "error", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Note,
-                               "note", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, backOfB, DiagnosticKind::Note,
-                               "note", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
-                               "error", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Note,
-                               "note", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
-                               "note", {}, DiagnosticInfo());
-  topConsumer.finishProcessing();
+  auto topConsumer =
+      FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);
+  topConsumer->handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
+                                "error", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Note,
+                                "note", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
+                                "note", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Error,
+                                "error", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Note,
+                                "note", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, backOfB, DiagnosticKind::Note,
+                                "note", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
+                                "error", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Note,
+                                "note", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
+                                "note", {}, DiagnosticInfo());
+  topConsumer->finishProcessing();
 }
 
 
@@ -536,18 +545,19 @@ TEST(FileSpecificDiagnosticConsumer,
   consumers.emplace_back(FileSpecificDiagnosticConsumer::Subconsumer(
       "", std::move(consumerUnaffiliated)));
 
-  FileSpecificDiagnosticConsumer topConsumer(consumers);
-  topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
-                               "error", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, SourceLoc(), DiagnosticKind::Note,
-                               "note", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Error,
-                               "error", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, SourceLoc(), DiagnosticKind::Note,
-                               "note", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
-                               "error", {}, DiagnosticInfo());
-  topConsumer.handleDiagnostic(sourceMgr, SourceLoc(), DiagnosticKind::Note,
-                               "note", {}, DiagnosticInfo());
-  topConsumer.finishProcessing();
+  auto topConsumer =
+      FileSpecificDiagnosticConsumer::consolidateSubconsumers(consumers);
+  topConsumer->handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
+                                "error", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, SourceLoc(), DiagnosticKind::Note,
+                                "note", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Error,
+                                "error", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, SourceLoc(), DiagnosticKind::Note,
+                                "note", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
+                                "error", {}, DiagnosticInfo());
+  topConsumer->handleDiagnostic(sourceMgr, SourceLoc(), DiagnosticKind::Note,
+                                "note", {}, DiagnosticInfo());
+  topConsumer->finishProcessing();
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Batch mode must truncate the serialized diagnostics file of any primary which does not have errors specifically attached to it. However, some errors are not specific to any primary, and these must count as attached to every primary. This PR fixes the code to do the latter. It also refactors the FileSpecificDiagnosticConsumer to avoid future bugs.

It also includes tests for same, courtesy of @jrose-apple .

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://43033749

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
