### PR TITLE
[IRGen] Only emit conformances local to a nominal type along with its metadata

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -938,9 +938,11 @@ llvm::Constant *IRGenModule::getAddrOfAssociatedTypeGenericParamRef(
   return var;
 }
 
-void IRGenModule::addLazyConformances(NominalTypeDecl *Nominal) {
-  for (const ProtocolConformance *Conf : Nominal->getAllConformances()) {
-    IRGen.addLazyWitnessTable(Conf);
+void IRGenModule::addLazyConformances(DeclContext *dc) {
+  for (const ProtocolConformance *conf :
+         dc->getLocalConformances(ConformanceLookupKind::All,
+                                  nullptr, /*sorted=*/true)) {
+    IRGen.addLazyWitnessTable(conf);
   }
 }
 
@@ -3826,6 +3828,8 @@ static bool shouldEmitCategory(IRGenModule &IGM, ExtensionDecl *ext) {
 
 void IRGenModule::emitExtension(ExtensionDecl *ext) {
   emitNestedTypeDecls(ext->getMembers());
+
+  addLazyConformances(ext);
 
   // Generate a category if the extension either introduces a
   // conformance to an ObjC protocol or introduces a method

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1310,8 +1310,8 @@ private:
   void emitLazyPrivateDefinitions();
   void addRuntimeResolvableType(NominalTypeDecl *nominal);
 
-  /// Add all conformances of \p Nominal to LazyWitnessTables.
-  void addLazyConformances(NominalTypeDecl *Nominal);
+  /// Add all conformances of the given \c DeclContext LazyWitnessTables.
+  void addLazyConformances(DeclContext *dc);
 
 //--- Global context emission --------------------------------------------------
 public:

--- a/test/IRGen/conformance_multifile.swift
+++ b/test/IRGen/conformance_multifile.swift
@@ -2,7 +2,13 @@
 
 func g<U>(_ f : (E) throws -> (U)) {}
 
+// The extension E: P should not show up in this filel.
+// CHECK-NOT: $S21conformance_multifile1EOAA1PAAMc
+
 // CHECK: $S21conformance_multifile1tyyF
 func t() {
   g(E2.Filter)
 }
+
+// The extension E: P should not show up in this filel.
+// CHECK-NOT: $S21conformance_multifile1EOAA1PAAMc


### PR DESCRIPTION
Rather than using `getAllConformances()` to emit all conformances for a
nominal type whenever we emit its type metadata, use
`getLocalConformances()` consistently--on the nominal type and on any
extension--to emit the conformances in the appropriate source files.
