### PR TITLE
[Sema] Omit recording some conversion restrictions in constraint solutions

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4879,6 +4879,19 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
   llvm_unreachable("bad conversion restriction");
 }
 
+// Restrictions where CSApply can figure out the correct action from the shape of
+// the types, rather than needing a record of the choice made.
+static bool recordRestriction(ConversionRestrictionKind restriction) {
+  switch(restriction) {
+    case ConversionRestrictionKind::TupleToTuple:
+    case ConversionRestrictionKind::ScalarToTuple:
+    case ConversionRestrictionKind::LValueToRValue:
+      return false;
+    default:
+      return true;
+  }
+}
+
 ConstraintSystem::SolutionKind
 ConstraintSystem::simplifyRestrictedConstraint(
                                        ConversionRestrictionKind restriction,
@@ -4889,8 +4902,8 @@ ConstraintSystem::simplifyRestrictedConstraint(
   switch (simplifyRestrictedConstraintImpl(restriction, type1, type2,
                                            matchKind, flags, locator)) {
   case SolutionKind::Solved:
-    ConstraintRestrictions.push_back(
-      std::make_tuple(type1, type2, restriction));
+    if (recordRestriction(restriction))
+      ConstraintRestrictions.push_back(std::make_tuple(type1, type2, restriction));
     return SolutionKind::Solved;
 
   case SolutionKind::Unsolved:


### PR DESCRIPTION
Omit recording conversion restrictions in a solution that apply can just as easily figure out itself from the shape of the types. This is an implementation discussed in <https://github.com/apple/swift/pull/18345>. 

Helps resolve [SR-8314](https://bugs.swift.org/browse/SR-8314).

Recording and simplifying these types of restrictions takes almost 75% of the total compilation time in the test file in SR-8314, and by inspection, the coercion code executed in CSApply is exactly the same with or without.
