### PR TITLE
[4.2] SILGen: Handle reabstraction in attempted +0 argument peephole.

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1270,15 +1270,20 @@ RValue SILGenFunction::emitRValueForStorageLoad(
   }
 
   // If the base is a reference type, just handle this as loading the lvalue.
+  ManagedValue result;
   if (baseFormalType->hasReferenceSemantics()) {
     LValue LV = emitPropertyLValue(loc, base, baseFormalType, field,
                                    LValueOptions(), AccessKind::Read,
                                    AccessSemantics::DirectToStorage);
-    return emitLoadOfLValue(loc, std::move(LV), C, isBaseGuaranteed);
-  }
-
-  ManagedValue result;
-  if (!base.getType().isAddress()) {
+    auto loaded = emitLoadOfLValue(loc, std::move(LV), C, isBaseGuaranteed);
+    // If we don't have to reabstract, the load is sufficient.
+    if (!hasAbstractionChange)
+      return loaded;
+    
+    // Otherwise, bring the component up to +1 so we can reabstract it.
+    result = std::move(loaded).getAsSingleValue(*this, loc)
+                              .copyUnmanaged(*this, loc);
+  } else if (!base.getType().isAddress()) {
     // For non-address-only structs, we emit a struct_extract sequence.
     result = B.createStructExtract(loc, base, field);
 
@@ -2511,7 +2516,7 @@ private:
     // If the field is not a let, bail. We need to use the lvalue logic.
     if (!Field->isLet())
       return None;
-
+    
     // If we are emitting a delegating init super and we have begun the
     // super.init call, since self has been exclusively borrowed, we need to be
     // conservative and use the lvalue machinery. This ensures that we properly

--- a/test/SILGen/guaranteed-let-peephole-reabstraction.swift
+++ b/test/SILGen/guaranteed-let-peephole-reabstraction.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -verify %s 
+class BlockBox<T> {
+  let block: (T) -> Void = { _ in }
+
+  var computedBlock: (T) -> Void { return { _ in } }
+}
+
+struct BlockStruct<T> {
+  let block: (T) -> Void = { _ in }
+  var computedBlock: (T) -> Void { return { _ in } }
+}
+
+func escapingCompletion(completion: @escaping (String) -> Void) {}
+
+func foo(box: BlockBox<String>) {
+  escapingCompletion(completion: box.block)
+  escapingCompletion(completion: box.computedBlock)
+}
+func foo(struc: BlockStruct<String>) {
+  escapingCompletion(completion: struc.block)
+  escapingCompletion(completion: struc.computedBlock)
+}


### PR DESCRIPTION
Explanation: A peephole in SILGen for class let properties would fail in the case where a reabstraction was necessary.

Scope: Regression from 4.1

Issue: rdar://problem/41056468

Risk: Low, small bug fix.

Testing: Swift CI, test case from radar, compatibility suite

Reviewed by: @gottesmm 