### PR TITLE
Extended graph lowering to use the stateless if/while ops when the if true/else body or while body funcs do not have stateful ops.

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -3169,9 +3169,9 @@ TFGraphFunctionLowering::lowerConditionalRegion(ConditionalSESERegion *r) {
   //   .Attr("Tin: list(type) >= 0")
   //   .Attr("Tout: list(type) >= 0")
   auto opLocString = getUniqueName(loc, "op");
-  bool usesideEffectingIf = trueFnHasSideEffects || falseFnHasSideEffects;
+  bool useSideEffectingIf = trueFnHasSideEffects || falseFnHasSideEffects;
   auto *op = TF_NewOperation(graphFn.getGraph(),
-                             usesideEffectingIf ? "If" : "StatelessIf",
+                             useSideEffectingIf ? "If" : "StatelessIf",
                              opLocString.c_str());
   TF_AddInput(op, condValue);
   TF_AddInputList(op, inputs.data(), inputs.size());
@@ -3181,7 +3181,7 @@ TFGraphFunctionLowering::lowerConditionalRegion(ConditionalSESERegion *r) {
   TF_SetAttrFuncName(op, "else_branch", falseFnName.c_str(),
                      falseFnName.size());
 
-  auto *result = graphFn.finishOp(op, usesideEffectingIf,
+  auto *result = graphFn.finishOp(op, useSideEffectingIf,
                                   /*isEligibleForTPU*/ true, status);
   if (checkStatus(getUserSourceLocation(loc)))
     return GLStatus::Error;

--- a/test/TensorFlow/control_flow.swift
+++ b/test/TensorFlow/control_flow.swift
@@ -100,11 +100,10 @@ public func testCondBranch(_ a: Bool) {
 // CHECK-LABEL: --- TFPartition GraphDef Proto:
 // CHECK:  op: "StatelessIf"
 
-public func testWhile(_ n: Int32) { // expected-warning {{'n' implicitly copied to the accelerator}}
+public func testWhile(_ n: Int32) {
   var i: Int32 = 0
   var a = Tensor<Float>(2.0)
-   // expected-warning @+1{{implicitly copied to the accelerator}}
-  while i < n { // expected-note {{value used here}}
+  while i < n {
     a += 1.0
     i += 1
   }

--- a/test/TensorFlow/control_flow.swift
+++ b/test/TensorFlow/control_flow.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -O -emit-sil %s -verify -enable-objc-interop -disable-objc-attr-requires-foundation-module | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -Xllvm -tf-dump-graph -Xllvm -tf-module-level-graph=false -O -emit-sil %s -verify -enable-objc-interop -disable-objc-attr-requires-foundation-module | %FileCheck %s
 
 import TensorFlow
 
@@ -95,6 +95,26 @@ public func testCondBranch(_ a: Bool) {
   b -= 1.0
   _hostOp(b)
 }
+
+// For testCondBranch(), we are generating a stateless if op.
+// CHECK-LABEL: --- TFPartition GraphDef Proto:
+// CHECK:  op: "StatelessIf"
+
+public func testWhile(_ n: Int32) { // expected-warning {{'n' implicitly copied to the accelerator}}
+  var i: Int32 = 0
+  var a = Tensor<Float>(2.0)
+   // expected-warning @+1{{implicitly copied to the accelerator}}
+  while i < n { // expected-note {{value used here}}
+    a += 1.0
+    i += 1
+  }
+  a += 0.0
+  _hostOp(a)
+}
+
+// For testWhile(), we are generating a stateless while op.
+// CHECK-LABEL: --- TFPartition GraphDef Proto:
+// CHECK:  op: "StatelessWhile"
 
 // CHECK-LABEL: ---- ANALYSIS STATE FOR FUNCTION {{.*}}testSwitchEnum
 // CHECK:       bb0:

--- a/test/TensorFlow/sends_recvs.swift
+++ b/test/TensorFlow/sends_recvs.swift
@@ -91,10 +91,9 @@ public func test2Sends() {
 
 // CHECK:      function_ref @_swift_tfc_FinishTensorComputation
 
- // expected-warning @+1{{implicitly copied to the accelerator}}
 public func testSendsInABranch(_ c: Bool) {
   var a = Tensor<Float>(1.0)
-  if c { // expected-note {{value used here}}
+  if c {
     a += a
     // One send.
     _hostOp(a.toHost())

--- a/utils/update-checkout-config.json
+++ b/utils/update-checkout-config.json
@@ -304,7 +304,7 @@
                 "swift-integration-tests": "swift-DEVELOPMENT-SNAPSHOT-2018-07-23-a",
                 "swift-xcode-playground-support": "swift-DEVELOPMENT-SNAPSHOT-2018-07-23-a",
                 "ninja": "253e94c1fa511704baeb61cf69995bbf09ba435e",
-                "tensorflow": "f9acd38eb687208dcee8622510b9a611e51d21a4",
+                "tensorflow": "8453e23a8b65423a4f2bfb2a98a928954771498f",
                 "tensorflow-swift-bindings": "489fcb7c4ca0ee11f3453ee7b0749a4f0742e780"
             }
         }


### PR DESCRIPTION
This is a potential performance optimization, where stateless ops can be pruned
away if TF-level graph compiler (e.g. grappler) can prove doing so is safe.

Updated TF repo commit hash to incorporate the new stateless if/while ops: https://github.com/tensorflow/tensorflow/commit/8453e23a8b65423a4f2bfb2a98a928954771498f.
