### PR TITLE
[tensorflow] Reduce irrelevant messy SIL generated from tests.

### DIFF
--- a/stdlib/public/TensorFlow/Utilities.swift
+++ b/stdlib/public/TensorFlow/Utilities.swift
@@ -280,6 +280,11 @@ public struct RandomNumberSequence : Sequence {
 /// This is a generic host-only op that hides the details of its impl in the SIL
 /// code. This makes reading/writing SIL based compiler unit tests simple.
 @inline(never)
+public func _hostOp<T>(_ x: T) {
+  print(x)
+}
+
+@inline(never)
 public func _hostOp<Scalar>(_ x: Tensor<Scalar>) {
   print(x)
 }

--- a/test/TensorFlow/crashers.swift
+++ b/test/TensorFlow/crashers.swift
@@ -193,7 +193,7 @@ public func tensorEndPointComputation() -> Int {
 public func argumentCrash() {
   for i : Int8 in 1...10 {  // expected-warning {{implicitly copied to the accelerator}}
     let x = Tensor(i)  // expected-note {{value used here}}
-    print(x+x)
+    _hostOp(x+x)
   }
 }
 
@@ -276,7 +276,7 @@ public func SR8191() {
   var i = 0
   repeat {
     let y = t + t // expected-warning {{value implicitly copied to the host}}
-    print(y)
+    _hostOp(y)
     i += 1
   } while i < 10
 }
@@ -332,7 +332,7 @@ public func SR8222_cond_br_TensorHandle_Bool() {
   repeat {
     let y = t + t
     // expected-warning @-1{{implicitly copied to the host}}
-    print(y)
+    _hostOp(y)
     i += 1
   } while i != Tensor<Int32>(10)
   // expected-warning @-1{{implicitly copied to the host}}
@@ -352,7 +352,7 @@ func SR8316_main() {
 }
 
 func readDataset() -> (images: Tensor<Float>, labels: Tensor<Int32>)? {
-    print("Reading the data.")
+    _hostOp("Reading the data.")
     return (Tensor<Float>(1.0), Tensor<Int32>(1))
 }
 

--- a/test/TensorFlow/dataset_legacy.swift
+++ b/test/TensorFlow/dataset_legacy.swift
@@ -10,7 +10,7 @@ public func testDatasetWithFakeData() {
     batchSize: 1,
     outputShapes: [TensorShape()])
   let y = Tensor<Float>(handle: x) + 1
-  print(y.array.scalars[0])
+  _hostOp(y.array.scalars[0])
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testDatasetWithFakeData{{.*}}
@@ -32,8 +32,8 @@ public func testDatasetWithMNIST() {
   // Confirm we can add more nodes to the graph.
   let imagesMod = Tensor<Float>(handle: images) + 1
   let labelsMod = Tensor<Int32>(handle: labels) + 2
-  print(imagesMod.array.scalars[0])
-  print(labelsMod.array.scalars[0])
+  _hostOp(imagesMod.array.scalars[0])
+  _hostOp(labelsMod.array.scalars[0])
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testDatasetWithMNIST{{.*}}

--- a/test/TensorFlow/diagnostics_with_deabstraction_error.swift
+++ b/test/TensorFlow/diagnostics_with_deabstraction_error.swift
@@ -16,8 +16,8 @@ import TensorFlow
 public func nonConstantAttribute(x: Tensor<Float>, padding: Padding) {
   // expected-error @+1 {{attribute 'padding' requires a constant argument}}
   _hostOp(x.convolved2D(withFilter: Tensor<Float>(ones: [1, 3, 3, 1]),
-                      strides: (1, 1, 1, 1),
-                      padding: padding))
+                        strides: (1, 1, 1, 1),
+                        padding: padding))
 }
 
 public enum X {

--- a/test/TensorFlow/diagnostics_with_deabstraction_error.swift
+++ b/test/TensorFlow/diagnostics_with_deabstraction_error.swift
@@ -15,7 +15,7 @@ import TensorFlow
 // because both Swift/TensorFlow use the same name "padding".)
 public func nonConstantAttribute(x: Tensor<Float>, padding: Padding) {
   // expected-error @+1 {{attribute 'padding' requires a constant argument}}
-  print(x.convolved2D(withFilter: Tensor<Float>(ones: [1, 3, 3, 1]),
+  _hostOp(x.convolved2D(withFilter: Tensor<Float>(ones: [1, 3, 3, 1]),
                       strides: (1, 1, 1, 1),
                       padding: padding))
 }

--- a/test/TensorFlow/integration.swift
+++ b/test/TensorFlow/integration.swift
@@ -9,10 +9,10 @@ public func testTensor(a: Tensor<Float>, b: Tensor<Float>) {
 
   x -= x  // expected-warning {{value implicitly copied to the host, use .toHost() to make transfer explicit}}
 
-  print(x) // expected-note {{value used here}}
+  _hostOp(x) // expected-note {{value used here}}
   var y = b.toAccelerator()
   y += y
-  print(y)
+  _hostOp(y)
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testTensor{{.*}}
@@ -48,7 +48,7 @@ public func testScalar(f: Float) { // expected-warning {{'f' implicitly copied t
           +
           Tensor<Float>(1.0)
   x += x
-  print(x)
+  _hostOp(x)
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testScalar{{.*}}
@@ -86,7 +86,7 @@ public func testExitBranch1(i: Int) {
   }
 
   x += x
-  print(x)
+  _hostOp(x)
 }
 
 // The tensor program should have no branch.
@@ -126,7 +126,7 @@ public func testExitBranch2(i: Int) {
   }
 
   x += x    // expected-warning {{value implicitly copied to the host}}
-  print(x)  // expected-note {{value used here}}
+  _hostOp(x)  // expected-note {{value used here}}
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testExitBranch2{{.*}}
@@ -156,7 +156,7 @@ public func test_bool_param(cond: Bool, // expected-warning {{'cond' implicitly 
     a -= b
   }
   a += b
-  print(a.toHost())
+  _hostOp(a.toHost())
 }
 
 
@@ -190,7 +190,7 @@ public func test_bool_param2(cond: Bool, // expected-warning {{'cond' implicitly
     a -= b
   }
   a += b
-  print(a.toHost())
+  _hostOp(a.toHost())
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}test_bool_param2{{.*}}
@@ -255,7 +255,7 @@ public func test_while1(maxCount: Int,  // expected-warning {{'maxCount' implici
     count += 1
   }
   a += b
-  print(a.toHost())
+  _hostOp(a.toHost())
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}test_while1{{.*}}
@@ -471,7 +471,7 @@ public struct NonInlineMethodExample {
 // to retain these if there is a host use, because they may be retaining the value!
 @inline(never)
 func noInlineUser(_ x: Tensor<Float>) {
-  print(x)
+  _hostOp(x)
 }
 
 public func testNoInlineUser() {

--- a/test/TensorFlow/no_copy.swift
+++ b/test/TensorFlow/no_copy.swift
@@ -119,7 +119,7 @@ public func test75494462() {
     x += 1
     i += 1
   } while i < 5
-  _hostOp(x)
+  _hostOp(x.array)
 }
 
 public func paddingTuplesHoistable() {
@@ -191,7 +191,7 @@ public func mnist() {
   var classifier = Classifier()
   let loss = classifier.train(images: images, labels: labels,
                               learningRate: 0.3, epochCount: 100)
-  print(loss)
+  _hostOp(loss)
 }
 
 // A TF op that produces multiple outputs.

--- a/test/TensorFlow/sends_recvs.swift
+++ b/test/TensorFlow/sends_recvs.swift
@@ -174,7 +174,7 @@ public func testSendsInALoopWithNoResultTensor() {
   while count < maxCount {
     a += a
     // One send.
-    print(a.toHost())
+    _hostOp(a.toHost())
     count += 1
   }
 }
@@ -191,7 +191,7 @@ public func testCannotSendResource() {
   let iterator: ResourceHandle =
     #tfop("Iterator", shared_name: "foo", container: "bar")
 
-  print(iterator)
+  _hostOp(iterator)
   let _ = Tensor<Float>(1.0)
 }
 

--- a/test/TensorFlow/top_level_code_1.swift
+++ b/test/TensorFlow/top_level_code_1.swift
@@ -49,8 +49,8 @@ let y2 = y*y*y*y
 let a: Tensor<Float> = [1, 2, 3]
 let b: Tensor<Float> = [1, 2]
 
-print(x)
-print(y2)
+_hostOp(x)
+_hostOp(y2)
 
 
 // CHECK-LABEL: } // end sil function 'main'

--- a/test/TensorFlowRuntime/control_flow_1.swift
+++ b/test/TensorFlowRuntime/control_flow_1.swift
@@ -95,20 +95,21 @@ public func testEnumWithPayload(_ x: EnumWithPayload, _ expectedVal: Float) {
   case .a(let x):
     val += 1.0
     val = _scalarTensorWithShape(val)
-    print(x)
+    _hostOp(x)
   case .b(let x):
-    print(x)
+    _hostOp(x)
     let tx = Tensor<Float>(x).toAccelerator(shape: [])
     val += tx
     val = _scalarTensorWithShape(val)
   case .c(let x, let y):
     val *= x.toAccelerator(shape: []) + y.toAccelerator(shape: [])
     val = _scalarTensorWithShape(val)
-    print(x, y)
+    _hostOp(x)
+    _hostOp(y)
   case .d(let f):
     val += 10.0
     val = _scalarTensorWithShape(val)
-    print(f)
+    _hostOp(f)
   }
   val += 0.0
   expectNearlyEqualWithScalarTensor(expectedVal, val)

--- a/test/TensorFlowRuntime/sends_recvs_1.swift
+++ b/test/TensorFlowRuntime/sends_recvs_1.swift
@@ -94,7 +94,7 @@ func testSendsInALoopWithNoResultTensor() {
   while count < maxCount {
     a = _addScalarTensorsWithShape(a, a)
     // One send.
-    print(a.toHost())
+    _hostOp(a.toHost())
     count += 1
   }
 

--- a/test/TensorFlowRuntime/sync_runtime.swift
+++ b/test/TensorFlowRuntime/sync_runtime.swift
@@ -30,7 +30,7 @@ func expectNearlyEqual(_ outputTensor: CTensorHandle, _ expectedVal: Float) {
   TF_DeleteStatus(s)
   assert(TF_TensorByteSize(tensor) == MemoryLayout<Float>.stride)
   let actualValue = TF_TensorData(tensor).assumingMemoryBound(to: Float.self).pointee
-  print("The actual output float value is \(actualValue)")
+  _hostOp("The actual output float value is \(actualValue)")
   expectLT(abs(expectedVal - actualValue), 0.0001)
   TF_DeleteTensor(tensor)
 }


### PR DESCRIPTION
This patch overloads _hostOp to accept `Any`, and replaces all print by _hostOp in test files.  It helps keep SIL tidy.

For implementation details, we now have three overloads of `_hostOp` as shown below:
[1] `public func _hostOp<T>(_ x: T)`
[2] `public func _hostOp<Scalar>(_ x: Tensor<Scalar>)`
[3] `public func _hostOp<Scalar>(_ x: TensorHandle<Scalar>)`

[1] is the new one introduced by this patch, whose body is the same to [2] (i.e., `print(x)`). The reason why we add [1] while still keep [2] rather than replace [2] is not to have any effect on existing code. `Tensor<Scalar>` is a value type, but for [1] the underlying parameter passing is by reference. As a result, if we keep [2], the existing code would not be affected; otherwise if we remove [2], then the existing calls to [2] would switch to [1], switching from passing by value to passing by reference. Such changes may have impacts on some optimization passes (e.g., loop unroll), and consequently result in different SIL.