### PR TITLE
[stdlib] Simplify concrete floating-point-to-integer conversion

### DIFF
--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1589,15 +1589,14 @@ extension ${Self} {
 %   ThatBuiltinName = self_ty.builtin_name
 %   sign = 's' if self_ty.is_signed else 'u'
 %   srcBits = self_ty.bits
-%   maxExponent = (1 << (ExponentBitCount - 1)) - 1
-%   maxBitLength = SignificandBitCount + 1 # implicit leading one
-%   if self_ty.is_signed:
-%     # The magnitude of the minimum value of a signed integer type is always
-%     # representable in floating point (assuming a large enough exponent)
-%     # because only one bit is set. All other possible magnitudes can be
-%     # represented using one bit less than the original source type.
-%     maxBitLength += 1
-%   end
+%
+%   max_required_exponent = srcBits - 1
+%   max_available_exponent = (1 << (ExponentBitCount - 1)) - 1
+%   max_required_precision = srcBits - 1 if self_ty.is_signed else srcBits
+%   max_available_precision = SignificandBitCount + 1
+%   is_always_represented_exactly = \
+%     (max_required_exponent <= max_available_exponent and \
+%       max_required_precision <= max_available_precision)
 
   /// Creates the closest representable value to the given integer.
   ///
@@ -1613,28 +1612,18 @@ extension ${Self} {
   /// can't be represented exactly, the result is `nil`.
   ///
   /// - Parameter value: The integer to represent as a floating-point value.
-%   if srcBits <= maxBitLength and srcBits - 1 <= maxExponent:
+%   if is_always_represented_exactly:
   @available(*, message: "Converting ${That} to ${Self} will always succeed.")
 %   end
   @inlinable // FIXME(sil-serialize-all)
   @inline(__always)
   public init?(exactly value: ${That}) {
-%   if srcBits - 1 > maxExponent:
-    // Check that the exponent will be in range.
-    guard value.magnitude >> ${maxExponent} <= 1 else {
-      return nil
-    }
-%   end
-%   if srcBits > maxBitLength:
-    // The magnitude of the integer must be representable by the significand.
-    // Omit trailing zeros that can be encoded by the exponent.
-    let mask: ${That}.Magnitude = ~((1 << (${SignificandBitCount} + 1)) - 1)
-    let absolute = value.magnitude
-    guard (absolute >> absolute.trailingZeroBitCount) & mask == 0 else {
-      return nil
-    }
-%   end
     _value = Builtin.${sign}itofp_${ThatBuiltinName}_FPIEEE${bits}(value._value)
+%   if not is_always_represented_exactly:
+    guard let roundTrip = ${That}(exactly: self), roundTrip == value else {
+      return nil
+    }
+%   end
   }
 % end # all_integer_types
 }

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -3297,10 +3297,10 @@ public struct ${Self}
     guard source > ${str(lower)}.0 && source < ${str(upper)}.0 else {
       return nil
     }
-    self._value = Builtin.fpto${u}i_FPIEEE${FloatBits}_${BuiltinName}(source._value)
-    if ${FloatType}(self) != source {
+    guard source == source.rounded(.towardZero) else {
       return nil
     }
+    self._value = Builtin.fpto${u}i_FPIEEE${FloatBits}_${BuiltinName}(source._value)
   }
 
 %     if FloatType == 'Float80':

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -3291,15 +3291,16 @@ public struct ${Self}
   /// - Parameter source: A floating-point value to convert to an integer.
   @_transparent
   public init?(exactly source: ${FloatType}) {
+    // The value passed as `source` must not be infinite, NaN, or exceed the
+    // bounds of the integer type; the result of `fptosi` or `fptoui` is
+    // undefined if it overflows.
     guard source > ${str(lower)}.0 && source < ${str(upper)}.0 else {
-      // The source is out of bounds (including infinities).
-      return nil
-    }
-    guard source == source.rounded(.towardZero) else {
-      // The source is a fraction or NaN.
       return nil
     }
     self._value = Builtin.fpto${u}i_FPIEEE${FloatBits}_${BuiltinName}(source._value)
+    if ${FloatType}(self) != source {
+      return nil
+    }
   }
 
 %     if FloatType == 'Float80':


### PR DESCRIPTION
This PR is a minor simplification of concrete floating-point conversions to integers. Specifically:

* It preserves the GYB logic improved in #16960 that more robustly checks when FP-to-integer conversion is always exact for two given types, but refactors the logic in one place so that subsequent tests can use a single Boolean value `is_always_represented_exactly`.

* It restores the use of roundtripping as the test for exactness, which is the notional litmus test. This will avoid the scenario where any future changes could cause roundtripping and manually implemented tests of exactness to fall out of sync, it eliminates an untestable branch without changing behavior, and it improves ease of understanding of the code particularly now that the function bodies are greatly simplified.

For FP-to-integer conversions, this PR preserves the `guard` condition implemented in #16960 that prevents undefined results, but corrects the comment to note that it is the initial guard condition that guards against NaN source values, and expands on that comment to explain that we are guarding against undefined results.
