### PR TITLE
Add subscript setter for Tensor

### DIFF
--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -192,6 +192,15 @@ TensorTests.testAllBackends("SliceIndexing") {
   expectEqual(Array(stride(from: 3.0, to: 5, by: 1)), array1D.scalars)
 }
 
+TensorTests.testAllBackends("SliceUpdate") {
+  var t1 = Tensor<Float>([[1, 2, 3],[4, 5, 6]])
+  t1[0] = Tensor(zeros: [3])
+  var t2 = t1
+  t2[0][2] = Tensor(3)
+  expectEqual(ShapedArray(shape:[2, 3], scalars: [0, 0, 0, 4, 5, 6]), t1.array)
+  expectEqual(ShapedArray(shape:[2, 3], scalars: [0, 0, 3, 4, 5, 6]), t2.array)
+}
+
 TensorTests.test("WholeTensorSlicing") {
   let t: Tensor<Int32> = [[[1, 1, 1], [2, 2, 2]],
                           [[3, 3, 3], [4, 4, 4]],


### PR DESCRIPTION
This patch adds a subscript setter for `Tensor`. Since TensorFlow doesn't have a non-in-place slice updating operator, I made a hack using numeric arithmetic and `scatterNd`. It is not fully type-safe (it doesn't work for `Tensor<Bool>`) but it is a workaround for today's situation.