### PR TITLE
[SILGen] Forming transitive capture lists, need to unique on value not value+flags

### DIFF
--- a/include/swift/AST/CaptureInfo.h
+++ b/include/swift/AST/CaptureInfo.h
@@ -64,6 +64,12 @@ public:
 
   bool isDynamicSelfMetadata() const { return !Value.getPointer(); }
 
+  CapturedValue mergeFlags(CapturedValue cv) {
+    assert(Value.getPointer() == cv.Value.getPointer() &&
+           "merging flags on two different value decls");
+    return CapturedValue(Value.getPointer(), getFlags() & cv.getFlags());
+  }
+
   ValueDecl *getDecl() const {
     assert(Value.getPointer() && "dynamic Self metadata capture does not "
            "have a value");

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -2131,9 +2131,11 @@ TypeConverter::getLoweredLocalCaptures(AnyFunctionRef fn) {
 
           // We're capturing a 'self' value with dynamic 'Self' type;
           // handle it specially.
-          if (!selfCapture &&
-              captureType->getClassOrBoundGenericClass()) {
-            selfCapture = capture;
+          if (captureType->getClassOrBoundGenericClass()) {
+            if (selfCapture)
+              selfCapture = selfCapture->mergeFlags(capture);
+            else
+              selfCapture = capture;
             continue;
           }
         }
@@ -2146,9 +2148,7 @@ TypeConverter::getLoweredLocalCaptures(AnyFunctionRef fn) {
       if (capturedValues.count(value)) {
         for (auto it = captures.begin(); it != captures.end(); ++it) {
           if (it->getDecl() == value) {
-            // The value is already in the list, it needs to have the logical
-            // AND of each flag of all uses.
-            *it = CapturedValue(value, it->getFlags() & capture.getFlags());
+            *it = it->mergeFlags(capture);
             break;
           }
         }

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -2029,8 +2029,7 @@ TypeConverter::getLoweredLocalCaptures(AnyFunctionRef fn) {
   
   // Recursively collect transitive captures from captured local functions.
   llvm::DenseSet<AnyFunctionRef> visitedFunctions;
-  llvm::DenseSet<ValueDecl*> capturedValues;
-  llvm::SmallVector<CapturedValue, 4> captures;
+  llvm::MapVector<ValueDecl*,CapturedValue> captures;
 
   // If there is a capture of 'self' with dynamic 'Self' type, it goes last so
   // that IRGen can pass dynamic 'Self' metadata.
@@ -2145,29 +2144,29 @@ TypeConverter::getLoweredLocalCaptures(AnyFunctionRef fn) {
 
       // Collect non-function captures.
       ValueDecl *value = capture.getDecl();
-      if (capturedValues.count(value)) {
-        for (auto it = captures.begin(); it != captures.end(); ++it) {
-          if (it->getDecl() == value) {
-            *it = it->mergeFlags(capture);
-            break;
-          }
-        }
+      auto existing = captures.find(value);
+      if (existing != captures.end()) {
+        existing->second = existing->second.mergeFlags(capture);
       } else {
-        capturedValues.insert(value);
-        captures.push_back(capture);
+        captures.insert(std::pair<ValueDecl *, CapturedValue>(value, capture));
       }
     }
   };
   collectFunctionCaptures(fn);
 
+  SmallVector<CapturedValue, 4> resultingCaptures;
+  for (auto capturePair : captures) {
+    resultingCaptures.push_back(capturePair.second);
+  }
+
   // If we captured the dynamic 'Self' type and we have a 'self' value also,
   // add it as the final capture. Otherwise, add a fake hidden capture for
   // the dynamic 'Self' metatype.
   if (selfCapture.hasValue()) {
-    captures.push_back(*selfCapture);
+    resultingCaptures.push_back(*selfCapture);
   } else if (capturesDynamicSelf) {
     selfCapture = CapturedValue::getDynamicSelfMetadata();
-    captures.push_back(*selfCapture);
+    resultingCaptures.push_back(*selfCapture);
   }
 
   // Cache the uniqued set of transitive captures.
@@ -2176,7 +2175,7 @@ TypeConverter::getLoweredLocalCaptures(AnyFunctionRef fn) {
   auto &cachedCaptures = inserted.first->second;
   cachedCaptures.setGenericParamCaptures(capturesGenericParams);
   cachedCaptures.setDynamicSelfType(capturesDynamicSelf);
-  cachedCaptures.setCaptures(Context.AllocateCopy(captures));
+  cachedCaptures.setCaptures(Context.AllocateCopy(resultingCaptures));
   
   return cachedCaptures;
 }

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -2029,7 +2029,8 @@ TypeConverter::getLoweredLocalCaptures(AnyFunctionRef fn) {
   
   // Recursively collect transitive captures from captured local functions.
   llvm::DenseSet<AnyFunctionRef> visitedFunctions;
-  llvm::SetVector<CapturedValue> captures;
+  llvm::DenseSet<ValueDecl*> capturedValues;
+  llvm::SmallVector<CapturedValue, 4> captures;
 
   // If there is a capture of 'self' with dynamic 'Self' type, it goes last so
   // that IRGen can pass dynamic 'Self' metadata.
@@ -2139,9 +2140,22 @@ TypeConverter::getLoweredLocalCaptures(AnyFunctionRef fn) {
 
         // Fall through to capture the storage.
       }
-      
+
       // Collect non-function captures.
-      captures.insert(capture);
+      ValueDecl *value = capture.getDecl();
+      if (capturedValues.count(value)) {
+        for (auto it = captures.begin(); it != captures.end(); ++it) {
+          if (it->getDecl() == value) {
+            // The value is already in the list, it needs to have the logical
+            // AND of each flag of all uses.
+            *it = CapturedValue(value, it->getFlags() & capture.getFlags());
+            break;
+          }
+        }
+      } else {
+        capturedValues.insert(value);
+        captures.push_back(capture);
+      }
     }
   };
   collectFunctionCaptures(fn);
@@ -2150,10 +2164,10 @@ TypeConverter::getLoweredLocalCaptures(AnyFunctionRef fn) {
   // add it as the final capture. Otherwise, add a fake hidden capture for
   // the dynamic 'Self' metatype.
   if (selfCapture.hasValue()) {
-    captures.insert(*selfCapture);
+    captures.push_back(*selfCapture);
   } else if (capturesDynamicSelf) {
     selfCapture = CapturedValue::getDynamicSelfMetadata();
-    captures.insert(*selfCapture);
+    captures.push_back(*selfCapture);
   }
 
   // Cache the uniqued set of transitive captures.

--- a/test/SILGen/capture-transitive.swift
+++ b/test/SILGen/capture-transitive.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// SR-8398
+func fibonacci(_ n: Int) -> Int {
+  var cache: [Int: Int] = [:]
+
+  func recursive(_ m: Int) -> Int {
+    return cache[m] ?? {
+      // Make sure cache is only captured once in the closure
+      // CHECK: implicit closure #1 in recursive #1
+      // CHECK-LABEL: sil private [transparent] @{{.*}}9fibonacci{{.*}}9recursive{{.*}} : $@convention(thin) (Int, @guaranteed { var Dictionary<Int, Int> }) -> (Int, @error Error)
+      // CHECK: closure #1 in implicit closure #1 in recursive #1
+      // CHECK-LABEL: sil private @{{.*}}9fibonacci{{.*}}9recursive{{.*}} : $@convention(thin) (Int, @guaranteed { var Dictionary<Int, Int> }) -> Int
+      let output = m < 2 ? m : recursive(m - 1) + recursive(m - 2)
+      cache[m] = output
+      return output
+      }()
+  }
+  return recursive(n)
+}
+

--- a/test/SILGen/capture-transitive.swift
+++ b/test/SILGen/capture-transitive.swift
@@ -18,3 +18,24 @@ func fibonacci(_ n: Int) -> Int {
   return recursive(n)
 }
 
+class C {
+    required init() {}
+    func f() {}
+    // Make sure that we capture dynamic self type if an explicit self isn't guaranteed
+    func returnsSelf() -> Self {
+        return { self.f(); return .init() }()
+        // CHECK-LABEL: sil private @{{.*}}returnsSelf{{.*}} : $@convention(thin) (@guaranteed C) -> @owned C
+    }
+
+    func returnsSelf1() -> Self {
+        return { [weak self] in self?.f(); return .init() }()
+        // CHECK-LABEL: sil private @{{.*}}returnsSelf{{.*}}  : $@convention(thin) (@guaranteed { var @sil_weak Optional<C> }, @thick @dynamic_self C.Type) -> @owned C
+    }
+
+    func returnsSelf2() -> Self {
+        return { [unowned self] in self.f(); return .init() }()
+        // CHECK-LABEL: sil private @{{.*}}returnsSelf{{.*}}  : $@convention(thin) (@guaranteed @sil_unowned C, @thick @dynamic_self C.Type) -> @owned C
+    }
+}
+
+


### PR DESCRIPTION
Switch away from using a SetVector here because we want each ValueDecl to appear in the transitive capture list only once, not potentially repeated with different flags. Added logic to logical AND flags for same decls.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-8398](https://bugs.swift.org/browse/SR-8398) | rdar://problem/42742744.
