### PR TITLE
[overlay] The AssetsLibrary APIs have been deprecated since iOS 9

### DIFF
--- a/stdlib/public/SDK/AssetsLibrary/ALAssetsLibrary.swift
+++ b/stdlib/public/SDK/AssetsLibrary/ALAssetsLibrary.swift
@@ -13,6 +13,7 @@
 @_exported import AssetsLibrary // Clang module
 
 extension ALAssetsLibrary { 
+  @available(iOS, deprecated: 9.0)
   @nonobjc
   public func enumerateGroupsWithTypes(_ types: UInt32,
       usingBlock enumerationBlock: ALAssetsLibraryGroupsEnumerationResultsBlock!,


### PR DESCRIPTION
Addresses: <rdar://problem/39029315>