### PR TITLE
[sil] Add a template parameter to TypeSubstCloner so that subclasses …

### DIFF
--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -30,8 +30,13 @@
 
 namespace swift {
 
-/// TypeSubstCloner - a utility class for cloning code while remapping types.
-template<typename ImplClass>
+/// \brief A utility class for cloning code while remapping types.
+///
+/// \tparam FunctionBuilderTy Function builder type injected by
+/// subclasses. Used to break a circular dependency from SIL <=>
+/// SILOptimizer that would be caused by us needing to use
+/// SILOptFunctionBuilder here.
+template<typename ImplClass, typename FunctionBuilderTy>
 class TypeSubstCloner : public SILClonerWithScopes<ImplClass> {
   friend class SILInstructionVisitor<ImplClass>;
   friend class SILCloner<ImplClass>;
@@ -157,7 +162,6 @@ public:
       Original(From),
       Inlining(Inlining) {
   }
-
 
 protected:
   SILType remapType(SILType Ty) {
@@ -309,7 +313,8 @@ protected:
   /// necessary when inlining said function into a new generic context.
   /// \param SubsMap - the substitutions of the inlining/specialization process.
   /// \param RemappedSig - the generic signature.
-  static SILFunction *remapParentFunction(SILModule &M,
+  static SILFunction *remapParentFunction(FunctionBuilderTy &FuncBuilder,
+					  SILModule &M,
                                           SILFunction *ParentFunction,
                                           SubstitutionMap SubsMap,
                                           GenericSignature *RemappedSig,
@@ -344,8 +349,7 @@ protected:
       // Create a new function with this mangled name with an empty
       // body. There won't be any IR generated for it (hence the linkage),
       // but the symbol will be refered to by the debug info metadata.
-      SILFunctionBuilder B(M);
-      ParentFunction = B.getOrCreateFunction(
+      ParentFunction = FuncBuilder.getOrCreateFunction(
           ParentFunction->getLocation(), MangledName, SILLinkage::Shared,
           ParentFunction->getLoweredFunctionType(), ParentFunction->isBare(),
           ParentFunction->isTransparent(), ParentFunction->isSerialized(), 0,
@@ -375,7 +379,7 @@ protected:
   SILFunction &Original;
   /// True, if used for inlining.
   bool Inlining;
-  };
+};
 
 } // end namespace swift
 

--- a/include/swift/SILOptimizer/Utils/GenericCloner.h
+++ b/include/swift/SILOptimizer/Utils/GenericCloner.h
@@ -30,7 +30,11 @@
 
 namespace swift {
 
-class GenericCloner : public TypeSubstCloner<GenericCloner> {
+class GenericCloner
+  : public TypeSubstCloner<GenericCloner, SILOptFunctionBuilder> {
+  using SuperTy = TypeSubstCloner<GenericCloner, SILOptFunctionBuilder>;
+
+  SILOptFunctionBuilder &FuncBuilder;
   IsSerialized_t Serialized;
   const ReabstractionInfo &ReInfo;
   CloneCollector::CallbackType Callback;
@@ -47,8 +51,8 @@ public:
                 SubstitutionMap ParamSubs,
                 StringRef NewName,
                 CloneCollector::CallbackType Callback)
-    : TypeSubstCloner(*initCloned(FuncBuilder, F, Serialized, ReInfo, NewName), *F,
-                    ParamSubs), ReInfo(ReInfo), Callback(Callback) {
+    : SuperTy(*initCloned(FuncBuilder, F, Serialized, ReInfo, NewName), *F,
+	      ParamSubs), FuncBuilder(FuncBuilder), ReInfo(ReInfo), Callback(Callback) {
     assert(F->getDebugScope()->Parent != getCloned()->getDebugScope()->Parent);
   }
   /// Clone and remap the types in \p F according to the substitution

--- a/include/swift/SILOptimizer/Utils/SILInliner.h
+++ b/include/swift/SILOptimizer/Utils/SILInliner.h
@@ -20,6 +20,7 @@
 
 #include "llvm/ADT/DenseMap.h"
 #include "swift/SIL/TypeSubstCloner.h"
+#include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
 #include <functional>
 
 namespace swift {
@@ -35,9 +36,10 @@ enum class InlineCost : unsigned {
 /// disappear at the LLVM IR level are assigned a cost of 'Free'.
 InlineCost instructionInlineCost(SILInstruction &I);
 
-class SILInliner : public TypeSubstCloner<SILInliner> {
+class SILInliner : public TypeSubstCloner<SILInliner, SILOptFunctionBuilder> {
   friend class SILInstructionVisitor<SILInliner>;
   friend class SILCloner<SILInliner>;
+  using SuperTy = TypeSubstCloner<SILInliner, SILOptFunctionBuilder>;
 
 public:
   enum class InlineKind { MandatoryInline, PerformanceInline };
@@ -62,15 +64,17 @@ private:
   llvm::SmallDenseMap<const SILDebugScope *, const SILDebugScope *, 8>
       InlinedScopeCache;
   CloneCollector::CallbackType Callback;
+  SILOptFunctionBuilder &FuncBuilder;
 
 public:
-  SILInliner(SILFunction &To, SILFunction &From, InlineKind IKind,
+  SILInliner(SILOptFunctionBuilder &FuncBuilder,
+	     SILFunction &To, SILFunction &From, InlineKind IKind,
              SubstitutionMap ApplySubs,
              SILOpenedArchetypesTracker &OpenedArchetypesTracker,
              CloneCollector::CallbackType Callback = nullptr)
-      : TypeSubstCloner<SILInliner>(To, From, ApplySubs,
-                                    OpenedArchetypesTracker, true),
-        IKind(IKind), CalleeFunction(&Original), Callback(Callback) {
+      : SuperTy(To, From, ApplySubs, OpenedArchetypesTracker, true),
+        IKind(IKind), CalleeFunction(&Original), Callback(Callback),
+	FuncBuilder(FuncBuilder) {
     // CalleeEntryBB is initialized later in case the callee is modified.
   }
 

--- a/lib/SILOptimizer/IPO/CapturePropagation.cpp
+++ b/lib/SILOptimizer/IPO/CapturePropagation.cpp
@@ -93,8 +93,9 @@ namespace {
 /// caller, so the cloned function will have a mix of locations from different
 /// functions.
 class CapturePropagationCloner
-  : public TypeSubstCloner<CapturePropagationCloner> {
-  using SuperTy = TypeSubstCloner<CapturePropagationCloner>;
+  : public TypeSubstCloner<CapturePropagationCloner, SILOptFunctionBuilder> {
+  using SuperTy =
+    TypeSubstCloner<CapturePropagationCloner, SILOptFunctionBuilder>;
   friend class SILInstructionVisitor<CapturePropagationCloner>;
   friend class SILCloner<CapturePropagationCloner>;
 

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -19,6 +19,7 @@
 #include "swift/SILOptimizer/Utils/CFG.h"
 #include "swift/SILOptimizer/Utils/Devirtualize.h"
 #include "swift/SILOptimizer/Utils/Local.h"
+#include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
 #include "swift/SILOptimizer/Utils/SILInliner.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/ImmutableSet.h"
@@ -462,7 +463,8 @@ tryDevirtualizeApplyHelper(FullApplySite InnerAI, SILBasicBlock::iterator I,
 ///
 /// \returns true if successful, false if failed due to circular inlining.
 static bool
-runOnFunctionRecursively(SILFunction *F, FullApplySite AI,
+runOnFunctionRecursively(SILOptFunctionBuilder &FuncBuilder,
+			 SILFunction *F, FullApplySite AI,
                          DenseFunctionSet &FullyInlinedSet,
                          ImmutableFunctionSet::Factory &SetFactory,
                          ImmutableFunctionSet CurrentInliningSet,
@@ -516,7 +518,7 @@ runOnFunctionRecursively(SILFunction *F, FullApplySite AI,
         continue;
 
       // Then recursively process it first before trying to inline it.
-      if (!runOnFunctionRecursively(CalleeFunction, InnerAI,
+      if (!runOnFunctionRecursively(FuncBuilder, CalleeFunction, InnerAI,
                                     FullyInlinedSet, SetFactory,
                                     CurrentInliningSet, CHA)) {
         // If we failed due to circular inlining, then emit some notes to
@@ -549,7 +551,7 @@ runOnFunctionRecursively(SILFunction *F, FullApplySite AI,
         OpenedArchetypesTracker.registerUsedOpenedArchetypes(PAI);
       }
 
-      SILInliner Inliner(*F, *CalleeFunction,
+      SILInliner Inliner(FuncBuilder, *F, *CalleeFunction,
                          SILInliner::InlineKind::MandatoryInline, Subs,
                          OpenedArchetypesTracker);
       if (!Inliner.canInlineFunction(InnerAI)) {
@@ -629,6 +631,7 @@ class MandatoryInlining : public SILModuleTransform {
     DenseFunctionSet FullyInlinedSet;
     ImmutableFunctionSet::Factory SetFactory;
 
+    SILOptFunctionBuilder FuncBuilder(*getPassManager());
     for (auto &F : *M) {
       // Don't inline into thunks, even transparent callees.
       if (F.isThunk())
@@ -638,7 +641,7 @@ class MandatoryInlining : public SILModuleTransform {
       if (F.wasDeserializedCanonical())
         continue;
 
-      runOnFunctionRecursively(&F,
+      runOnFunctionRecursively(FuncBuilder, &F,
                                FullApplySite(), FullyInlinedSet, SetFactory,
                                SetFactory.getEmptySet(), CHA);
     }

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -19,6 +19,7 @@
 #include "swift/SILOptimizer/Utils/Devirtualize.h"
 #include "swift/SILOptimizer/Utils/Generics.h"
 #include "swift/SILOptimizer/Utils/PerformanceInlinerUtils.h"
+#include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
 #include "swift/Strings.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/CommandLine.h"
@@ -45,6 +46,8 @@ namespace {
 using Weight = ShortestPathAnalysis::Weight;
 
 class SILPerformanceInliner {
+  SILOptFunctionBuilder &FuncBuilder;
+
   /// Specifies which functions not to inline, based on @_semantics and
   /// global_init attributes.
   InlineSelection WhatToInline;
@@ -164,11 +167,12 @@ class SILPerformanceInliner {
                               SmallVectorImpl<FullApplySite> &Applies);
 
 public:
-  SILPerformanceInliner(InlineSelection WhatToInline, DominanceAnalysis *DA,
+  SILPerformanceInliner(SILOptFunctionBuilder &FuncBuilder,
+			InlineSelection WhatToInline, DominanceAnalysis *DA,
                         SILLoopAnalysis *LA, SideEffectAnalysis *SEA,
                         OptimizationMode OptMode, OptRemark::Emitter &ORE)
-      : WhatToInline(WhatToInline), DA(DA), LA(LA), SEA(SEA), CBI(DA), ORE(ORE),
-        OptMode(OptMode) {}
+      : FuncBuilder(FuncBuilder), WhatToInline(WhatToInline), DA(DA), LA(LA),
+	SEA(SEA), CBI(DA), ORE(ORE), OptMode(OptMode) {}
 
   bool inlineCallsIntoFunction(SILFunction *F);
 };
@@ -826,7 +830,7 @@ bool SILPerformanceInliner::inlineCallsIntoFunction(SILFunction *Caller) {
     // the substitution list.
     OpenedArchetypesTracker.registerUsedOpenedArchetypes(AI.getInstruction());
 
-    SILInliner Inliner(*Caller, *Callee,
+    SILInliner Inliner(FuncBuilder, *Caller, *Callee,
                        SILInliner::InlineKind::PerformanceInline,
                        AI.getSubstitutionMap(),
                        OpenedArchetypesTracker);
@@ -896,7 +900,9 @@ public:
 
     auto OptMode = getFunction()->getEffectiveOptimizationMode();
 
-    SILPerformanceInliner Inliner(WhatToInline, DA, LA, SEA, OptMode, ORE);
+    SILOptFunctionBuilder FuncBuilder(*getPassManager());
+    SILPerformanceInliner Inliner(FuncBuilder, WhatToInline, DA, LA, SEA,
+				  OptMode, ORE);
 
     assert(getFunction()->isDefinition() &&
            "Expected only functions with bodies!");

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -182,7 +182,7 @@ const SILDebugScope *GenericCloner::remapScope(const SILDebugScope *DS) {
     ParentFunction = getCloned();
   else if (ParentFunction)
     ParentFunction = remapParentFunction(
-        M, ParentFunction, SubsMap,
+        FuncBuilder, M, ParentFunction, SubsMap,
         Original.getLoweredFunctionType()->getGenericSignature());
 
   auto *ParentScope = DS->Parent.dyn_cast<const SILDebugScope *>();

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -11,7 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "sil-inliner"
+
 #include "swift/SILOptimizer/Utils/SILInliner.h"
+#include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
 #include "swift/SIL/SILDebugScope.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
@@ -445,7 +447,7 @@ SILInliner::getOrCreateInlineScope(const SILDebugScope *CalleeScope) {
   auto *ParentFunction = CalleeScope->Parent.dyn_cast<SILFunction *>();
   if (ParentFunction)
     ParentFunction = remapParentFunction(
-        M, ParentFunction, SubsMap,
+        FuncBuilder, M, ParentFunction, SubsMap,
         CalleeFunction->getLoweredFunctionType()->getGenericSignature(),
         ForInlining);
 


### PR DESCRIPTION
…can inject a SILFunctionBuilder composition class.

This works around a potential circular dependence issue where TypeSubstCloner
needs access to SILOptFunctionBuilder but is in libswiftSIL.

rdar://42301529
