### PR TITLE
stdlib: mark the UTF8View iterator's next function as inline-always.

### DIFF
--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -517,6 +517,7 @@ extension String.UTF8View.Iterator : IteratorProtocol {
   }
 
   @inlinable // FIXME(sil-serialize-all)
+  @inline(__always)
   public mutating func next() -> Unicode.UTF8.CodeUnit? {
     if _slowPath(_nextOffset == _endOffset) {
       if _slowPath(_buffer.isEmpty) {


### PR DESCRIPTION
This speeds up C-String handling

rdar://problem/42247427
