### PR TITLE
[ModuleInterface] Filter using access control and @usableFromInline

### DIFF
--- a/test/ModuleInterface/access-filter.swift
+++ b/test/ModuleInterface/access-filter.swift
@@ -1,0 +1,99 @@
+// RUN: %target-swift-frontend -emit-interface-path %t.swiftinterface -emit-module -o /dev/null %s
+// RUN: %FileCheck %s < %t.swiftinterface
+// RUN: %FileCheck -check-prefix NEGATIVE %s < %t.swiftinterface
+
+// NEGATIVE-NOT: BAD
+
+// CHECK: public func publicFn(){{$}}
+public func publicFn() {}
+internal func internalFn_BAD() {}
+private func privateFn_BAD() {}
+
+// CHECK: @usableFromInline
+// CHECK-NEXT: internal func ufiFn(){{$}}
+@usableFromInline internal func ufiFn() {}
+
+
+// CHECK: public struct PublicStruct {{[{]$}}
+public struct PublicStruct {
+  // CHECK: public func publicMethod(){{$}}
+  public func publicMethod() {}
+  internal func internalMethod_BAD() {}
+
+  // CHECK: @usableFromInline
+  // CHECK-NEXT: internal func ufiMethod(){{$}}
+  @usableFromInline internal func ufiMethod() {}
+} // CHECK: {{^[}]$}}
+
+internal struct InternalStruct_BAD {
+  public func publicMethod_BAD() {}
+  internal func internalMethod_BAD() {}
+  @usableFromInline internal func ufiMethod_BAD() {}
+}
+
+// CHECK: @usableFromInline
+// CHECK-NEXT: internal struct UFIStruct {{[{]$}}
+@usableFromInline
+internal struct UFIStruct {
+  // FIXME: Arguably this should be downgraded to "@usableFromInline internal".
+  // CHECK: public func publicMethod(){{$}}
+  public func publicMethod() {}
+  internal func internalMethod_BAD() {}
+
+  // CHECK: @usableFromInline
+  // CHECK-NEXT: internal func ufiMethod(){{$}}
+  @usableFromInline internal func ufiMethod() {}
+} // CHECK: {{^[}]$}}
+
+// CHECK: public protocol PublicProto {{[{]$}}
+public protocol PublicProto {
+} // CHECK: {{^[}]$}}
+
+// CHECK: extension PublicProto {{[{]$}}
+extension PublicProto {
+  // CHECK: public func publicMethod(){{$}}
+  public func publicMethod() {}
+  internal func internalMethod_BAD() {}
+
+  // CHECK: @usableFromInline
+  // CHECK-NEXT: internal func ufiMethod(){{$}}
+  @usableFromInline internal func ufiMethod() {}
+} // CHECK: {{^[}]$}}
+
+// FIXME: We shouldn't print access on extensions in textual interface files.
+// CHECK: {{^}}public extension PublicProto {{[{]$}}
+public extension PublicProto {
+  // CHECK: public func publicExtPublicMethod(){{$}}
+  func publicExtPublicMethod() {}
+  internal func publicExtInternalMethod_BAD() {}
+
+  // CHECK: @usableFromInline
+  // CHECK-NEXT: internal func publicExtUFIMethod(){{$}}
+  @usableFromInline internal func publicExtUFIMethod() {}
+}
+
+internal protocol InternalProto_BAD {
+}
+
+extension InternalProto_BAD {
+  public func publicMethod_BAD() {}
+  internal func internalMethod_BAD() {}
+  @usableFromInline internal func ufiMethod_BAD() {}
+}
+
+// CHECK: @usableFromInline
+// CHECK-NEXT: internal protocol UFIProto {{[{]$}}
+@usableFromInline
+internal protocol UFIProto {
+} // CHECK: {{^[}]$}}
+
+// CHECK: extension UFIProto {{[{]$}}
+extension UFIProto {
+  // CHECK: public func publicMethod(){{$}}
+  public func publicMethod() {}
+  internal func internalMethod_BAD() {}
+
+  // CHECK: @usableFromInline
+  // CHECK-NEXT: internal func ufiMethod(){{$}}
+  @usableFromInline internal func ufiMethod() {}
+} // CHECK: {{^[}]$}}

--- a/test/ModuleInterface/print-from-partial-modules.swift
+++ b/test/ModuleInterface/print-from-partial-modules.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -emit-module -o %t/other~partial.swiftmodule %s -primary-file %S/Inputs/other.swift -module-name main
 // RUN: %target-swift-frontend -merge-modules -emit-module -o /dev/null -emit-interface-path - %t/main~partial.swiftmodule -module-name main %t/other~partial.swiftmodule | %FileCheck %s
 
-// CHECK: {{^}}func verySimpleFunction(){{$}}
+// CHECK: {{^}}public func verySimpleFunction(){{$}}
 public func verySimpleFunction() {}
 
-// CHECK: {{^}}func otherFileFunction(){{$}}
+// CHECK: {{^}}public func otherFileFunction(){{$}}


### PR DESCRIPTION
These are the parts of a (resilient) module that affect the public interface and ABI; everything else is uninteresting. Or at least ought to be.