### PR TITLE
Check for deterministic compilation in the tools=R,stdlib=RD job.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -214,6 +214,7 @@ dash-dash
 skip-test-ios-host
 skip-test-tvos-host
 skip-test-watchos-host
+check-incremental-compilation
 
 
 [preset: buildbot,tools=RA,stdlib=RDA]


### PR DESCRIPTION
This option causes the stdlib core to compile multiple times and check if the generated llvm IR is the same for all compilations.
