### PR TITLE
[CSRanking] Fix solution filtering not to erase everything when set i…

### DIFF
--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -1211,6 +1211,14 @@ ConstraintSystem::findBestSolution(SmallVectorImpl<Solution> &viable,
     return bestIdx;
   }
 
+  // If there is not a single "better" than others
+  // solution, which probably means that solutions
+  // were incomparable, let's just keep the original
+  // list instead of removing everything, even if we
+  // are asked to "minimize" the result.
+  if (losers.size() == viable.size())
+    return None;
+
   // The comparison was ambiguous. Identify any solutions that are worse than
   // any other solution.
   for (unsigned i = 0, n = viable.size(); i != n; ++i) {

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -374,10 +374,10 @@ func test8347() -> String {
       return ""
     }
 
-    func h() -> String {
+    func h() -> String { // expected-note {{found this candidate}}
       return ""
     }
-    func h() -> Double {
+    func h() -> Double { // expected-note {{found this candidate}}
       return 3.0
     }
     func h() -> Int? { //expected-note{{found this candidate}}

--- a/test/Constraints/rdar42678836.swift
+++ b/test/Constraints/rdar42678836.swift
@@ -1,0 +1,6 @@
+// RUN: %target-typecheck-verify-swift
+
+func foo(chr: Character) -> String {
+  return String(repeating: String(chr)) // expected-error {{argument labels '(repeating:)' do not match any available overloads}}
+  // expected-note@-1 {{overloads for 'String' exist with these partially matching parameter lists}}
+}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -550,8 +550,8 @@ struct SpecialPi {} // Type with no implicit construction.
 
 var pi_s: SpecialPi
 
-func getPi() -> Float {} // expected-note 3 {{found this candidate}}
-func getPi() -> Double {} // expected-note 3 {{found this candidate}}
+func getPi() -> Float {}
+func getPi() -> Double {}
 func getPi() -> SpecialPi {}
 
 enum Empty { }
@@ -573,12 +573,12 @@ func conversionTest(_ a: inout Double, b: inout Int) {
   var pi_d1 = Double(pi_d)
   var pi_s1 = SpecialPi(pi_s) // expected-error {{argument passed to call that takes no arguments}}
 
-  var pi_f2 = Float(getPi()) // expected-error {{ambiguous use of 'getPi()'}}
-  var pi_d2 = Double(getPi()) // expected-error {{ambiguous use of 'getPi()'}}
+  var pi_f2 = Float(getPi()) // expected-error {{ambiguous use of 'init'}}
+  var pi_d2 = Double(getPi()) // expected-error {{ambiguous use of 'init'}}
   var pi_s2: SpecialPi = getPi() // no-warning
   
   var float = Float.self
-  var pi_f3 = float.init(getPi()) // expected-error {{ambiguous use of 'getPi()'}}
+  var pi_f3 = float.init(getPi()) // expected-error {{ambiguous use of 'init'}}
   var pi_f4 = float.init(pi_f)
 
   var e = Empty(f)

--- a/validation-test/IDE/crashers_2_fixed/0022-rdar42678836.swift
+++ b/validation-test/IDE/crashers_2_fixed/0022-rdar42678836.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=COMPLETE -source-filename=%s
+
+public func * (lhs: Int, rhs: Character) -> String {
+  return String(repeating: String(rhs), count #^COMPLETE^#: lhs)
+}


### PR DESCRIPTION
…s completely ambiguous

Since constraint solver has been improved to diagnose more problems
via "fixes", sometimes applying fixes might lead to producing solutions
which are completely ambiguous when compared to each other, and/or are
incomparable, which leads to `findBestSolutions` erasing all of them
while trying to compute best "partial" solution, which is incorrect.

Resolves: [SR-8396](https://bugs.swift.org/browse/SR-8396)
Resolves: rdar://problem/42678836

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
