### PR TITLE
[IRGen] Use a more precise computation for the kind of reference count.

### DIFF
--- a/include/swift/AST/ReferenceCounting.h
+++ b/include/swift/AST/ReferenceCounting.h
@@ -1,0 +1,63 @@
+//===--- ReferenceCounting.h ------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_REFERENCE_COUNTING_H
+#define SWIFT_AST_REFERENCE_COUNTING_H
+
+namespace swift {
+
+/// The kind of reference counting implementation a heap object uses.
+enum class ReferenceCounting : uint8_t {
+  /// The object uses native Swift reference counting.
+  Native,
+
+  /// The object uses ObjC reference counting.
+  ///
+  /// When ObjC interop is enabled, native Swift class objects are also ObjC
+  /// reference counting compatible. Swift non-class heap objects are never
+  /// ObjC reference counting compatible.
+  ///
+  /// Blocks are always ObjC reference counting compatible.
+  ObjC,
+
+  /// The object uses _Block_copy/_Block_release reference counting.
+  ///
+  /// This is a strict subset of ObjC; all blocks are also ObjC reference
+  /// counting compatible. The block is assumed to have already been moved to
+  /// the heap so that _Block_copy returns the same object back.
+  Block,
+
+  /// The object has an unknown reference counting implementation.
+  ///
+  /// This uses maximally-compatible reference counting entry points in the
+  /// runtime.
+  Unknown,
+
+  /// Cases prior to this one are binary-compatible with Unknown reference
+  /// counting.
+  LastUnknownCompatible = Unknown,
+
+  /// The object has an unknown reference counting implementation and
+  /// the reference value may contain extra bits that need to be masked.
+  ///
+  /// This uses maximally-compatible reference counting entry points in the
+  /// runtime, with a masking layer on top. A bit inside the pointer is used
+  /// to signal native Swift refcounting.
+  Bridge,
+
+  /// The object uses ErrorType's reference counting entry points.
+  Error,
+};
+
+} // end namespace swift
+
+#endif

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -54,6 +54,7 @@ namespace swift {
   class GenericParamList;
   class GenericSignature;
   class Identifier;
+  enum class ReferenceCounting : uint8_t;
   enum class ResilienceExpansion : unsigned;
   class SILModule;
   class SILType;
@@ -842,6 +843,10 @@ public:
   /// \brief Given that this type is a reference type, is it known to use
   /// Swift-native reference counting?
   bool usesNativeReferenceCounting(ResilienceExpansion resilience);
+
+  /// Given that this type is a reference type, which kind of reference
+  /// counting does it use?
+  ReferenceCounting getReferenceCounting(ResilienceExpansion resilience);
 
   /// Determines whether this type has a bridgeable object
   /// representation, i.e., whether it is always represented as a single

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -63,22 +63,7 @@ using namespace irgen;
 /// What reference counting mechanism does a class-like type have?
 ReferenceCounting irgen::getReferenceCountingForType(IRGenModule &IGM,
                                                      CanType type) {
-  // If ObjC interop is disabled, we have a Swift refcount.
-  if (!IGM.ObjCInterop)
-    return ReferenceCounting::Native;
-
-  if (type->usesNativeReferenceCounting(ResilienceExpansion::Maximal))
-    return ReferenceCounting::Native;
-
-  // Class-constrained archetypes and existentials that don't use
-  // native reference counting and yet have a superclass must be
-  // using ObjC reference counting.
-  auto superclass = type->getSuperclass();
-  if (superclass)
-    return ReferenceCounting::ObjC;
-
-  // Otherwise, it could be either one.
-  return ReferenceCounting::Unknown;
+  return type->getReferenceCounting(ResilienceExpansion::Maximal);
 }
 
 namespace {

--- a/lib/IRGen/GenClass.h
+++ b/lib/IRGen/GenClass.h
@@ -48,7 +48,6 @@ namespace irgen {
   class StructLayout;
   class TypeInfo;
   
-  enum class ReferenceCounting : unsigned char;
   enum class ClassDeallocationKind : unsigned char;
   enum class FieldAccess : uint8_t;
   

--- a/lib/IRGen/IRGen.h
+++ b/lib/IRGen/IRGen.h
@@ -82,49 +82,6 @@ enum IsABIAccessible_t : bool {
   IsABIAccessible = true  
 };
 
-/// The kind of reference counting implementation a heap object uses.
-enum class ReferenceCounting : uint8_t {
-  /// The object uses native Swift reference counting.
-  Native,
-
-  /// The object uses ObjC reference counting.
-  ///
-  /// When ObjC interop is enabled, native Swift class objects are also ObjC
-  /// reference counting compatible. Swift non-class heap objects are never
-  /// ObjC reference counting compatible.
-  ///
-  /// Blocks are always ObjC reference counting compatible.
-  ObjC,
-
-  /// The object uses _Block_copy/_Block_release reference counting.
-  ///
-  /// This is a strict subset of ObjC; all blocks are also ObjC reference
-  /// counting compatible. The block is assumed to have already been moved to
-  /// the heap so that _Block_copy returns the same object back.
-  Block,
-
-  /// The object has an unknown reference counting implementation.
-  ///
-  /// This uses maximally-compatible reference counting entry points in the
-  /// runtime.
-  Unknown,
-
-  /// Cases prior to this one are binary-compatible with Unknown reference
-  /// counting.
-  LastUnknownCompatible = Unknown,
-
-  /// The object has an unknown reference counting implementation and
-  /// the reference value may contain extra bits that need to be masked.
-  ///
-  /// This uses maximally-compatible reference counting entry points in the
-  /// runtime, with a masking layer on top. A bit inside the pointer is used
-  /// to signal native Swift refcounting.
-  Bridge,
-
-  /// The object uses ErrorType's reference counting entry points.
-  Error,
-};
-
 /// The atomicity of a reference counting operation to be used.
 enum class Atomicity : bool {
   /// Atomic reference counting operations should be used.

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -60,7 +60,6 @@ namespace irgen {
   class Scope;
   class TypeInfo;
   enum class ValueWitness : unsigned;
-  enum class ReferenceCounting : unsigned char;
 
 /// IRGenFunction - Primary class for emitting LLVM instructions for a
 /// specific function.

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -22,6 +22,7 @@
 #include "SwiftTargetInfo.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/ReferenceCounting.h"
 #include "swift/Basic/ClusteredBitVector.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/OptimizationMode.h"
@@ -133,7 +134,6 @@ namespace irgen {
   class TypeConverter;
   class TypeInfo;
   enum class ValueWitness : unsigned;
-  enum class ReferenceCounting : unsigned char;
 
 class IRGenModule;
 

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -26,6 +26,7 @@
 #define SWIFT_IRGEN_TYPEINFO_H
 
 #include "IRGen.h"
+#include "swift/AST/ReferenceCounting.h"
 #include "llvm/ADT/MapVector.h"
 
 namespace llvm {

--- a/test/IRGen/Inputs/objc_layout_other.swift
+++ b/test/IRGen/Inputs/objc_layout_other.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+@objc class Bar : NSObject { }

--- a/test/IRGen/objc_layout_multifile.swift
+++ b/test/IRGen/objc_layout_multifile.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+// RUN: %build-irgen-test-overlays
+
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s %S/Inputs/objc_layout_other.swift -emit-ir | %FileCheck %s
+
+// REQUIRES: CPU=x86_64
+// REQUIRES: objc_interop
+
+class Foo {
+  // CHECK-LABEL: define hidden swiftcc void @"$S21objc_layout_multifile3FooC3barAA3BarCSgvs"
+  // CHECK-NOT: ret
+  // CHECK: @objc_retain
+  var bar: Bar?
+}

--- a/test/IRGen/objc_pointers.swift
+++ b/test/IRGen/objc_pointers.swift
@@ -18,3 +18,10 @@ import Foundation
   @objc func pointerMetatypeArguments(x: AutoreleasingUnsafeMutablePointer<AnyClass>,
                                       y: AutoreleasingUnsafeMutablePointer<AnyClass?>) {}
 }
+
+// CHECK-LABEL: S13objc_pointers14returnNSObject3objSo0D0CAE_tF
+func returnNSObject(obj: NSObject) -> NSObject {
+  // CHECK-NOT: return
+  // CHECK: @objc_retain
+  return obj
+}


### PR DESCRIPTION
TypeBase::usesNativeReferenceCounting() was doing a lot of work to
find the class that a type refers to, then determine whether it
would use the native reference-counting scheme. Its primary caller
in IRGen would use an overly-conservative approximation to decide
between the “Objective-C” and “unknown” cases, which resulted in
uses of “unknown” reference counting for some obviously-ObjC cases
(e.g., values of “NSObject”).

Moreover, the approximation would try to call into the type checker
(because it relied unnecessarily on the superclass *type* of a class
declaration), causing an assertion.

Fixes rdar://problem/42828798.
