### PR TITLE
[ConstraintSystem] Remove disjunction number as we're not currently

### DIFF
--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -823,7 +823,6 @@ Constraint *Constraint::createDisjunction(ConstraintSystem &cs,
   auto disjunction =  new (mem) Constraint(ConstraintKind::Disjunction,
                               cs.allocateCopy(constraints), locator, typeVars);
   disjunction->RememberChoice = (bool) rememberChoice;
-  cs.noteNewDisjunction(disjunction);
   return disjunction;
 }
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -912,10 +912,6 @@ public:
   /// \brief The total number of disjunctions created.
   unsigned CountDisjunctions = 0;
 
-  /// \brief Map from disjunction to the number indicating the order it
-  //         was created in.
-  llvm::DenseMap<Constraint *, unsigned> DisjunctionNumber;
-
 private:
 
   /// \brief Allocator used for all of the related constraint systems.
@@ -1894,11 +1890,6 @@ public:
   void addExplicitConversionConstraint(Type fromType, Type toType,
                                        bool allowFixes,
                                        ConstraintLocatorBuilder locator);
-
-  void noteNewDisjunction(Constraint *constraint) {
-    assert(constraint->getKind() == ConstraintKind::Disjunction);
-    DisjunctionNumber[constraint] = CountDisjunctions++;
-  }
 
   /// \brief Add a disjunction constraint.
   void addDisjunctionConstraint(ArrayRef<Constraint *> constraints,


### PR DESCRIPTION
using it.

It was added to use for selecting the order we visit disjunctions, but
this order turned out to not be great (and I don't think there are
simple variations on the creation order, like reverse order), that
will work well either.
