### PR TITLE
[Name lookup] Use decl-based name lookup for protocol-related queries

### DIFF
--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -351,6 +351,24 @@ void lookupInModule(ModuleDecl *module, ModuleDecl::AccessPathTy accessPath,
                     ArrayRef<ModuleDecl::ImportedModule> extraImports = {});
 
 } // end namespace namelookup
+
+/// Retrieve the set of nominal type declarations that are directly
+/// "inherited" by the given declaration at a particular position in the
+/// list of "inherited" types.
+///
+/// Add anything we find to the
+void getDirectlyInheritedNominalTypeDecls(
+    llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
+    unsigned i,
+    llvm::SmallVectorImpl<std::pair<SourceLoc, NominalTypeDecl *>> &result);
+
+/// Retrieve the set of nominal type declarations that are directly
+/// "inherited" by the given declaration, looking through typealiases
+/// and splitting out the components of compositions.
+SmallVector<std::pair<SourceLoc, NominalTypeDecl *>, 4>
+getDirectlyInheritedNominalTypeDecls(
+                      llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl);
+
 } // end namespace swift
 
 #endif

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -356,18 +356,23 @@ void lookupInModule(ModuleDecl *module, ModuleDecl::AccessPathTy accessPath,
 /// "inherited" by the given declaration at a particular position in the
 /// list of "inherited" types.
 ///
-/// Add anything we find to the
+/// Add anything we find to the \c result vector. If we come across the
+/// AnyObject type, set \c anyObject true.
 void getDirectlyInheritedNominalTypeDecls(
     llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
     unsigned i,
-    llvm::SmallVectorImpl<std::pair<SourceLoc, NominalTypeDecl *>> &result);
+    llvm::SmallVectorImpl<std::pair<SourceLoc, NominalTypeDecl *>> &result,
+    bool &anyObject);
 
 /// Retrieve the set of nominal type declarations that are directly
 /// "inherited" by the given declaration, looking through typealiases
 /// and splitting out the components of compositions.
+///
+/// If we come across the AnyObject type, set \c anyObject true.
 SmallVector<std::pair<SourceLoc, NominalTypeDecl *>, 4>
 getDirectlyInheritedNominalTypeDecls(
-                      llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl);
+                      llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
+                      bool &anyObject);
 
 } // end namespace swift
 

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/NameLookup.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/ProtocolConformanceRef.h"
 #include "llvm/Support/SaveAndRestore.h"
@@ -488,22 +489,10 @@ bool ConformanceLookupTable::addProtocol(ProtocolDecl *protocol, SourceLoc loc,
 void ConformanceLookupTable::addInheritedProtocols(
                           llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
                           ConformanceSource source) {
-  // Visit each of the types in the inheritance list to find
-  // protocols.
-  auto typeDecl = decl.dyn_cast<TypeDecl *>();
-  auto extDecl = decl.dyn_cast<ExtensionDecl *>();
-  unsigned numInherited = typeDecl ? typeDecl->getInherited().size()
-                                   : extDecl->getInherited().size();
-  for (auto index : range(numInherited)) {
-    Type inheritedType = typeDecl ? typeDecl->getInheritedType(index)
-                                  : extDecl->getInheritedType(index);
-    if (!inheritedType || !inheritedType->isExistentialType())
-      continue;
-    SourceLoc loc = typeDecl ? typeDecl->getInherited()[index].getLoc()
-                             : extDecl->getInherited()[index].getLoc();
-    auto layout = inheritedType->getExistentialLayout();
-    for (auto *proto : layout.getProtocols())
-      addProtocol(proto->getDecl(), loc, source);
+  // Find all of the protocols in the inheritance list.
+  for (const auto &found : getDirectlyInheritedNominalTypeDecls(decl)) {
+    if (auto proto = dyn_cast<ProtocolDecl>(found.second))
+      addProtocol(proto, found.first, source);
   }
 }
 

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -490,7 +490,9 @@ void ConformanceLookupTable::addInheritedProtocols(
                           llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
                           ConformanceSource source) {
   // Find all of the protocols in the inheritance list.
-  for (const auto &found : getDirectlyInheritedNominalTypeDecls(decl)) {
+  bool anyObject = false;
+  for (const auto &found :
+          getDirectlyInheritedNominalTypeDecls(decl, anyObject)) {
     if (auto proto = dyn_cast<ProtocolDecl>(found.second))
       addProtocol(proto, found.first, source);
   }

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -91,6 +91,16 @@ ProtocolDecl *DeclContext::getAsProtocolExtensionContext() const {
 GenericTypeParamType *DeclContext::getProtocolSelfType() const {
   assert(getAsProtocolOrProtocolExtensionContext() && "not a protocol");
 
+  auto genericParams = getGenericParamsOfContext();
+
+  if (!genericParams) {
+    if (auto proto = dyn_cast<ProtocolDecl>(this)) {
+      getASTContext().getLazyResolver()
+          ->resolveDeclSignature(const_cast<ProtocolDecl *>(proto));
+      genericParams = getGenericParamsOfContext();
+    }
+  }
+
   return getGenericParamsOfContext()->getParams().front()
       ->getDeclaredInterfaceType()
       ->castTo<GenericTypeParamType>();

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3016,6 +3016,11 @@ void ArchetypeType::resolveNestedType(
     builder.resolveEquivalenceClass(
                                   memberInterfaceType,
                                   ArchetypeResolutionKind::CompleteWellFormed);
+  if (!equivClass) {
+    nested.second = ErrorType::get(interfaceType);
+    return;
+  }
+
   auto result = equivClass->getTypeInContext(builder, genericEnv);
   assert(!nested.second ||
          nested.second->isEqual(result) ||

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -592,10 +592,6 @@ ModuleDecl::lookupConformance(Type type, ProtocolDecl *protocol) {
   // existential's list of conformances and the existential conforms to
   // itself.
   if (type->isExistentialType()) {
-    // FIXME: Recursion break.
-    if (!protocol->hasValidSignature())
-      return None;
-
     // If the existential type cannot be represented or the protocol does not
     // conform to itself, there's no point in looking further.
     if (!protocol->existentialConformsToSelf())

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5168,21 +5168,15 @@ Decl *SwiftDeclConverter::importCompatibilityTypeAlias(
 namespace {
   template<typename D>
   bool inheritanceListContainsProtocol(D decl, const ProtocolDecl *proto) {
-    return llvm::any_of(range(decl->getInherited().size()),
-                        [decl, proto](unsigned index) -> bool {
-      Type type = decl->getInheritedType(index);
-      if (!type || !type->isExistentialType())
-        return false;
-
-      auto layout = type->getExistentialLayout();
-      for (auto protoTy : layout.getProtocols()) {
-        auto *protoDecl = protoTy->getDecl();
+    bool anyObject = false;
+    for (const auto &found :
+            getDirectlyInheritedNominalTypeDecls(decl, anyObject)) {
+      if (auto protoDecl = dyn_cast<ProtocolDecl>(found.second))
         if (protoDecl == proto || protoDecl->inheritsFrom(proto))
           return true;
-      }
+    }
 
-      return false;
-    });
+    return false;
   }
 }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -560,16 +560,11 @@ getInheritedForCycleCheck(TypeChecker &tc,
                           ProtocolDecl **scratch) {
   TinyPtrVector<ProtocolDecl *> result;
 
-  for (unsigned index : indices(proto->getInherited())) {
-    if (auto type = proto->getInheritedType(index)) {
-      if (type->isExistentialType()) {
-        auto layout = type->getExistentialLayout();
-        for (auto protoTy : layout.getProtocols()) {
-          auto *protoDecl = protoTy->getDecl();
-          result.push_back(protoDecl);
-        }
-      }
-    }
+  bool anyObject = false;
+  for (const auto &found :
+         getDirectlyInheritedNominalTypeDecls(proto, anyObject)) {
+    if (auto protoDecl = dyn_cast<ProtocolDecl>(found.second))
+      result.push_back(protoDecl);
   }
 
   return result;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -233,12 +233,6 @@ void TypeChecker::validateWhereClauses(ProtocolDecl *protocol,
   }
 }
 
-void TypeChecker::resolveInheritedProtocols(ProtocolDecl *protocol) {
-  for (unsigned i : indices(protocol->getInherited()))
-    (void)protocol->getInheritedType(i);
-  resolveTrailingWhereClause(protocol);
-}
-
 /// check the inheritance clause of a type declaration or extension thereof.
 ///
 /// This routine validates all of the types in the parsed inheritance clause,
@@ -3966,8 +3960,6 @@ void TypeChecker::validateDecl(ValueDecl *D) {
       }
     }
 
-    // Record inherited protocols.
-    resolveInheritedProtocols(proto);
     resolveTrailingWhereClause(proto);
 
     validateAttributes(*this, D);
@@ -4513,8 +4505,6 @@ void TypeChecker::validateDeclForNameLookup(ValueDecl *D) {
 
     (void) proto->getFormalAccess();
 
-    // Record inherited protocols.
-    resolveInheritedProtocols(proto);
     resolveTrailingWhereClause(proto);
 
     for (auto ATD : proto->getAssociatedTypeMembers()) {
@@ -4734,6 +4724,7 @@ static void finalizeType(TypeChecker &TC, NominalTypeDecl *nominal) {
   // validation of protocols, but clients will assume that things
   // like the requirement signature have been set.
   if (auto PD = dyn_cast<ProtocolDecl>(nominal)) {
+    (void)PD->getInheritedProtocols();
     if (!PD->isRequirementSignatureComputed()) {
       TC.validateDecl(PD);
     }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1413,9 +1413,6 @@ public:
       GenericRequirementsCheckListener *listener = nullptr,
       SubstOptions options = None);
 
-  /// Resolve the inherited protocols of a given protocol.
-  void resolveInheritedProtocols(ProtocolDecl *protocol);
-
   /// Validate a protocol's where clause, along with the where clauses of
   /// its associated types.
   void validateWhereClauses(ProtocolDecl *protocol,

--- a/test/decl/inherit/inherit.swift
+++ b/test/decl/inherit/inherit.swift
@@ -46,7 +46,9 @@ struct S2 : struct { } // expected-error{{expected type}}
 struct S3 : P, P & Q { } // expected-error {{redundant conformance of 'S3' to protocol 'P'}}
                          // expected-error @-1 {{non-class type 'S3' cannot conform to class protocol 'Q'}}
                          // expected-note @-2 {{'S3' declares conformance to protocol 'P' here}}
-struct S4 : P, P { }     // expected-error {{duplicate inheritance from 'P'}}
+struct S4 : P, P { }     // FIXME: expected-error {{duplicate inheritance from 'P'}}
+// expected-error@-1{{redundant conformance of 'S4' to protocol 'P'}}
+// expected-note@-2{{'S4' declares conformance to protocol 'P' here}}
 struct S6 : P & { }      // expected-error {{expected identifier for type name}}
 struct S7 : protocol<P, Q> { }  // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}}
                                 // expected-error @-1 {{non-class type 'S7' cannot conform to class protocol 'Q'}}

--- a/test/decl/protocol/special/JSExport.swift
+++ b/test/decl/protocol/special/JSExport.swift
@@ -9,7 +9,7 @@ import Foundation
 
 @objc protocol RootJSExport : JSExport { }
 
-// CHECK: @_PROTOCOL_PROTOCOLS__TtP8JSExport4Sub1_ = private constant{{.*}}_PROTOCOL__TtP8JSExport12RootJSExport_{{.*}}_PROTOCOL__TtP8JSExport8JSExport_
+// CHECK: @_PROTOCOL_PROTOCOLS__TtP8JSExport4Sub1_ = private constant{{.*}}_PROTOCOL__TtP8JSExport8JSExport_{{.*}}_PROTOCOL__TtP8JSExport12RootJSExport_
 @objc protocol Sub1 : JSExport, RootJSExport { }
 
 // CHECK: @_PROTOCOL_PROTOCOLS__TtP8JSExport4Sub2_{{.*}}_PROTOCOL__TtP8JSExport4Sub1_{{.*}}_PROTOCOL__TtP8JSExport8JSExport_


### PR DESCRIPTION
Use the decl-base name lookup facilities (that don't recurse into the type checker) for various protocol-related queries, including:

* Construction of the "conformance lookup table", which is used to figure out which protocols a given nominal type conforms to.
* `ProtocolDecl::requiresClass()`, which determines whether a given protocol is class-bound
* `ProtocolDecl::getInheritedProtocols()`, which would bounce between using the requirement signature and using the type checker.