### PR TITLE
[ReflectionContext] Remove dead code. NFCI.

### DIFF
--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -102,10 +102,6 @@ public:
     return sizeof(StoredPointer) * 2;
   }
 
-  void dumpAllSections(std::ostream &OS) {
-    getBuilder().dumpAllSections(OS);
-  }
-
 #if defined(__APPLE__) && defined(__MACH__)
   template <typename T> bool readMachOSections(RemoteAddress ImageStart) {
     auto Buf =


### PR DESCRIPTION
This is untested, and unused. I originally planned to use it
in the debugger, but I changed my mind.
