### PR TITLE
SIL: Lower the `self` argument of an @objc protocol class method requirement as an @objc_metatype.

### DIFF
--- a/lib/SIL/Bridging.cpp
+++ b/lib/SIL/Bridging.cpp
@@ -159,7 +159,9 @@ Type TypeConverter::getLoweredCBridgedType(AbstractionPattern pattern,
 
   // Class metatypes bridge to ObjC metatypes.
   if (auto metaTy = t->getAs<MetatypeType>()) {
-    if (metaTy->getInstanceType()->getClassOrBoundGenericClass()) {
+    if (metaTy->getInstanceType()->getClassOrBoundGenericClass()
+        // Self argument of an ObjC protocol
+        || metaTy->getInstanceType()->is<GenericTypeParamType>()) {
       return MetatypeType::get(metaTy->getInstanceType(),
                                MetatypeRepresentation::ObjC);
     }

--- a/test/SILGen/objc_protocols.swift
+++ b/test/SILGen/objc_protocols.swift
@@ -87,8 +87,9 @@ func objc_generic_partial_apply<T : NSRuncing>(_ x: T) {
 // CHECK: } // end sil function '[[THUNK2]]'
 
 // CHECK: sil shared [serializable] [thunk] @[[THUNK2_THUNK]] :
-// CHECK:      [[FN:%.*]] = objc_method %0 : $@thick Self.Type, #NSRuncing.mince!1.foreign
-// CHECK-NEXT: [[RESULT:%.*]] = apply [[FN]]<Self>(%0)
+// CHECK:      [[METATYPE:%.*]] = thick_to_objc_metatype %0
+// CHECK:      [[FN:%.*]] = objc_method [[METATYPE]] : $@objc_metatype Self.Type, #NSRuncing.mince!1.foreign
+// CHECK-NEXT: [[RESULT:%.*]] = apply [[FN]]<Self>([[METATYPE]])
 // CHECK-NEXT: return [[RESULT]]
 // CHECK: } // end sil function '[[THUNK2_THUNK]]'
 


### PR DESCRIPTION
Fixes rdar://problem/18921650.