### PR TITLE
Add Lexer::IsHashbangAllowed, drop SourceManager::getHashbangBufferID

### DIFF
--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -30,9 +30,6 @@ class SourceManager {
   unsigned CodeCompletionBufferID = 0U;
   unsigned CodeCompletionOffset;
 
-  /// \brief The buffer ID where a hashbang line #! is allowed.
-  unsigned HashbangBufferID = 0U;
-
   /// Associates buffer identifiers to buffer IDs.
   llvm::StringMap<unsigned> BufIdentIDMap;
 
@@ -87,15 +84,6 @@ public:
   }
 
   SourceLoc getCodeCompletionLoc() const;
-
-  void setHashbangBufferID(unsigned BufferID) {
-    assert(HashbangBufferID == 0U && "Hashbang buffer ID already set");
-    HashbangBufferID = BufferID;
-  }
-
-  unsigned getHashbangBufferID() const {
-    return HashbangBufferID;
-  }
 
   /// Returns true if \c LHS is before \c RHS in the source buffer.
   bool isBeforeInBuffer(SourceLoc LHS, SourceLoc RHS) const {

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -51,6 +51,11 @@ enum class TriviaRetentionMode {
   WithTrivia,
 };
 
+enum class HashbangMode : bool {
+  Disallowed,
+  Allowed,
+};
+
 /// Kinds of conflict marker which the lexer might encounter.
 enum class ConflictMarkerKind {
   /// A normal or diff3 conflict marker, initiated by at least 7 "<"s,
@@ -98,6 +103,9 @@ class Lexer {
   /// file.  This enables the 'sil' keyword.
   const bool InSILMode;
 
+  /// True if we should skip past a `#!` line at the start of the file.
+  const bool IsHashbangAllowed;
+
   const CommentRetentionMode RetainComments;
 
   const TriviaRetentionMode TriviaRetention;
@@ -128,7 +136,7 @@ class Lexer {
   /// everything.
   Lexer(const PrincipalTag &, const LangOptions &LangOpts,
         const SourceManager &SourceMgr, unsigned BufferID,
-        DiagnosticEngine *Diags, bool InSILMode,
+        DiagnosticEngine *Diags, bool InSILMode, HashbangMode HashbangAllowed,
         CommentRetentionMode RetainComments,
         TriviaRetentionMode TriviaRetention);
 
@@ -151,13 +159,14 @@ public:
   Lexer(
       const LangOptions &Options, const SourceManager &SourceMgr,
       unsigned BufferID, DiagnosticEngine *Diags, bool InSILMode,
+      HashbangMode HashbangAllowed = HashbangMode::Disallowed,
       CommentRetentionMode RetainComments = CommentRetentionMode::None,
       TriviaRetentionMode TriviaRetention = TriviaRetentionMode::WithoutTrivia);
 
   /// \brief Create a lexer that scans a subrange of the source buffer.
   Lexer(const LangOptions &Options, const SourceManager &SourceMgr,
         unsigned BufferID, DiagnosticEngine *Diags, bool InSILMode,
-        CommentRetentionMode RetainComments,
+        HashbangMode HashbangAllowed, CommentRetentionMode RetainComments,
         TriviaRetentionMode TriviaRetention, unsigned Offset,
         unsigned EndOffset);
 

--- a/lib/AST/RawComment.cpp
+++ b/lib/AST/RawComment.cpp
@@ -109,6 +109,7 @@ static RawComment toRawComment(ASTContext &Context, CharSourceRange Range) {
   unsigned EndOffset = SourceMgr.getLocOffsetInBuffer(Range.getEnd(), BufferID);
   LangOptions FakeLangOpts;
   Lexer L(FakeLangOpts, SourceMgr, BufferID, nullptr, /*InSILMode=*/false,
+          HashbangMode::Disallowed,
           CommentRetentionMode::ReturnAsTokens,
           TriviaRetentionMode::WithoutTrivia,
           Offset, EndOffset);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -633,12 +633,6 @@ CompilerInstance::computeDelayedParsingCallback(bool isPrimary) {
 
 void CompilerInstance::addMainFileToModule(
     const ImplicitImports &implicitImports) {
-  const InputFileKind Kind = Invocation.getInputKind();
-  assert(Kind == InputFileKind::IFK_Swift || Kind == InputFileKind::IFK_SIL);
-
-  if (Kind == InputFileKind::IFK_Swift)
-    SourceMgr.setHashbangBufferID(MainBufferID);
-
   auto *MainFile = createSourceFileForMainModule(
       Invocation.getSourceFileKind(), implicitImports.kind, MainBufferID);
   addAdditionalInitialImportsTo(MainFile, implicitImports);
@@ -929,7 +923,6 @@ void CompilerInstance::performParseOnly(bool EvaluateConditionals) {
   // to match the parsing logic used when performing Sema.
   if (MainBufferID != NO_SUCH_BUFFER) {
     assert(Kind == InputFileKind::IFK_Swift);
-    SourceMgr.setHashbangBufferID(MainBufferID);
     createSourceFileForMainModule(Invocation.getSourceFileKind(),
                                   SourceFile::ImplicitModuleImportKind::None,
                                   MainBufferID);

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -673,7 +673,6 @@ public:
         Snapshot->getBuffer()->getText(), FilePath);
 
     BufferID = SM.addNewSourceBuffer(std::move(BufCopy));
-    SM.setHashbangBufferID(BufferID);
     DiagConsumer.setInputBufferIDs(BufferID);
 
     Parser.reset(

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -506,13 +506,7 @@ static StringRef getSourceToken(unsigned Offset,
                                                  MemBuf->getBufferIdentifier());
   auto BufId = SM.addNewSourceBuffer(std::move(MemBufRef));
   SourceLoc Loc = SM.getLocForOffset(BufId, Offset);
-
-  // Use fake language options; language options only affect validity
-  // and the exact token produced.
-  LangOptions FakeLangOpts;
-  Lexer L(FakeLangOpts, SM, BufId, nullptr, /*InSILMode=*/ false,
-          CommentRetentionMode::ReturnAsTokens);
-  return L.getTokenAt(Loc).getText();
+  return Lexer::getTokenAtLocation(SM, Loc).getText();
 }
 
 static llvm::Optional<unsigned>

--- a/unittests/Parse/LexerTests.cpp
+++ b/unittests/Parse/LexerTests.cpp
@@ -270,7 +270,8 @@ TEST_F(LexerTest, BOMNoCommentNoTrivia) {
   unsigned BufferID = SourceMgr.addMemBufferCopy(StringRef(Source));
   
   Lexer L(LangOpts, SourceMgr, BufferID, /*Diags=*/nullptr, /*InSILMode=*/false,
-          CommentRetentionMode::None, TriviaRetentionMode::WithoutTrivia);
+          HashbangMode::Disallowed, CommentRetentionMode::None,
+          TriviaRetentionMode::WithoutTrivia);
   
   Token Tok;
   syntax::Trivia LeadingTrivia, TrailingTrivia;
@@ -301,7 +302,8 @@ TEST_F(LexerTest, BOMTokenCommentNoTrivia) {
   unsigned BufferID = SourceMgr.addMemBufferCopy(StringRef(Source));
   
   Lexer L(LangOpts, SourceMgr, BufferID, /*Diags=*/nullptr, /*InSILMode=*/false,
-          CommentRetentionMode::ReturnAsTokens, TriviaRetentionMode::WithoutTrivia);
+          HashbangMode::Disallowed, CommentRetentionMode::ReturnAsTokens,
+          TriviaRetentionMode::WithoutTrivia);
   
   Token Tok;
   syntax::Trivia LeadingTrivia, TrailingTrivia;
@@ -359,7 +361,8 @@ TEST_F(LexerTest, BOMAttachCommentNoTrivia) {
   unsigned BufferID = SourceMgr.addMemBufferCopy(StringRef(Source));
   
   Lexer L(LangOpts, SourceMgr, BufferID, /*Diags=*/nullptr, /*InSILMode=*/false,
-          CommentRetentionMode::AttachToNextToken, TriviaRetentionMode::WithoutTrivia);
+          HashbangMode::Disallowed, CommentRetentionMode::AttachToNextToken,
+          TriviaRetentionMode::WithoutTrivia);
   
   Token Tok;
   syntax::Trivia LeadingTrivia, TrailingTrivia;
@@ -390,7 +393,8 @@ TEST_F(LexerTest, BOMNoCommentTrivia) {
   unsigned BufferID = SourceMgr.addMemBufferCopy(StringRef(Source));
   
   Lexer L(LangOpts, SourceMgr, BufferID, /*Diags=*/nullptr, /*InSILMode=*/false,
-          CommentRetentionMode::None, TriviaRetentionMode::WithTrivia);
+          HashbangMode::Disallowed, CommentRetentionMode::None,
+          TriviaRetentionMode::WithTrivia);
   
   Token Tok;
   syntax::Trivia LeadingTrivia, TrailingTrivia;
@@ -431,7 +435,8 @@ TEST_F(LexerTest, BOMAttachCommentTrivia) {
   unsigned BufferID = SourceMgr.addMemBufferCopy(StringRef(Source));
   
   Lexer L(LangOpts, SourceMgr, BufferID, /*Diags=*/nullptr, /*InSILMode=*/false,
-          CommentRetentionMode::AttachToNextToken, TriviaRetentionMode::WithTrivia);
+          HashbangMode::Disallowed, CommentRetentionMode::AttachToNextToken,
+          TriviaRetentionMode::WithTrivia);
   
   Token Tok;
   syntax::Trivia LeadingTrivia, TrailingTrivia;
@@ -747,8 +752,8 @@ TEST_F(LexerTest, DiagnoseEmbeddedNul) {
   Diags.addConsumer(DiagConsumer);
 
   Lexer L(LangOpts, SourceMgr, BufferID, &Diags,
-          /*InSILMode=*/false, CommentRetentionMode::None,
-          TriviaRetentionMode::WithTrivia);
+          /*InSILMode=*/false, HashbangMode::Disallowed,
+          CommentRetentionMode::None, TriviaRetentionMode::WithTrivia);
 
   ASSERT_TRUE(containsPrefix(DiagConsumer.messages,
                              "1, 2: nul character embedded in middle of file"));
@@ -769,8 +774,8 @@ TEST_F(LexerTest, DiagnoseEmbeddedNulOffset) {
   Diags.addConsumer(DiagConsumer);
 
   Lexer L(LangOpts, SourceMgr, BufferID, &Diags,
-          /*InSILMode=*/false, CommentRetentionMode::None,
-          TriviaRetentionMode::WithTrivia,
+          /*InSILMode=*/false, HashbangMode::Disallowed,
+          CommentRetentionMode::None, TriviaRetentionMode::WithTrivia,
           /*Offset=*/5, /*EndOffset=*/SourceLen);
 
   ASSERT_FALSE(containsPrefix(

--- a/unittests/Parse/LexerTriviaTests.cpp
+++ b/unittests/Parse/LexerTriviaTests.cpp
@@ -20,7 +20,7 @@ TEST_F(LexerTriviaTest, RestoreWithTrivia) {
   unsigned BufferID = SourceMgr.addMemBufferCopy(SourceStr);
 
   Lexer L(LangOpts, SourceMgr, BufferID, /*Diags=*/nullptr, /*InSILMode=*/false,
-          CommentRetentionMode::AttachToNextToken,
+          HashbangMode::Disallowed, CommentRetentionMode::AttachToNextToken,
           TriviaRetentionMode::WithTrivia);
 
   Token Tok;
@@ -68,7 +68,7 @@ TEST_F(LexerTriviaTest, TriviaHashbang) {
   unsigned BufferID = SourceMgr.addMemBufferCopy(SourceStr);
 
   Lexer L(LangOpts, SourceMgr, BufferID, /*Diags=*/nullptr, /*InSILMode=*/false,
-          CommentRetentionMode::AttachToNextToken,
+          HashbangMode::Disallowed, CommentRetentionMode::AttachToNextToken,
           TriviaRetentionMode::WithTrivia);
 
   Token Tok;
@@ -91,7 +91,7 @@ TEST_F(LexerTriviaTest, TriviaHashbangAfterBOM) {
   unsigned BufferID = SourceMgr.addMemBufferCopy(SourceStr);
 
   Lexer L(LangOpts, SourceMgr, BufferID, /*Diags=*/nullptr, /*InSILMode=*/false,
-          CommentRetentionMode::AttachToNextToken,
+          HashbangMode::Disallowed, CommentRetentionMode::AttachToNextToken,
           TriviaRetentionMode::WithTrivia);
 
   Token Tok;
@@ -124,7 +124,7 @@ TEST_F(LexerTriviaTest, TriviaConflictMarker) {
   unsigned BufferID = SourceMgr.addMemBufferCopy(SourceStr);
 
   Lexer L(LangOpts, SourceMgr, BufferID, /*Diags=*/nullptr, /*InSILMode=*/false,
-          CommentRetentionMode::AttachToNextToken,
+          HashbangMode::Disallowed, CommentRetentionMode::AttachToNextToken,
           TriviaRetentionMode::WithTrivia);
 
   Token Tok;
@@ -158,7 +158,7 @@ TEST_F(LexerTriviaTest, TriviaCarriageReturn) {
   unsigned BufferID = SourceMgr.addMemBufferCopy(SourceStr);
 
   Lexer L(LangOpts, SourceMgr, BufferID, /*Diags=*/nullptr, /*InSILMode=*/false,
-          CommentRetentionMode::AttachToNextToken,
+          HashbangMode::Disallowed, CommentRetentionMode::AttachToNextToken,
           TriviaRetentionMode::WithTrivia);
 
   Token Tok;
@@ -198,7 +198,7 @@ TEST_F(LexerTriviaTest, TriviaNewLines) {
   unsigned BufferID = SourceMgr.addMemBufferCopy(SourceStr);
 
   Lexer L(LangOpts, SourceMgr, BufferID, /*Diags=*/nullptr, /*InSILMode=*/false,
-          CommentRetentionMode::AttachToNextToken,
+          HashbangMode::Disallowed, CommentRetentionMode::AttachToNextToken,
           TriviaRetentionMode::WithTrivia);
 
   Token Tok;


### PR DESCRIPTION
Having this be a single buffer hardcoded in the SourceManager and set by all clients is silly. SourceFiles with the 'Main' kind are allowed to have hashbang lines (`#!`), other files are not. And anyone manually setting up a Lexer can decide for themselves.

No intended behavioral change.