### PR TITLE
Revert "Temporarily change to build master-next against swift-5.0-branch of LLVM"

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -57,9 +57,9 @@
                         "stable-next", "upstream",
                         "next-upstream", "upstream-with-swift"],
             "repos": {
-                "llvm": "swift-5.0-branch",
-                "clang": "swift-5.0-branch",
-                "compiler-rt": "swift-5.0-branch",
+                "llvm": "upstream-with-swift",
+                "clang": "upstream-with-swift",
+                "compiler-rt": "upstream-with-swift",
                 "swift": "master-next",
                 "lldb": "upstream-with-swift",
                 "cmark": "master",


### PR DESCRIPTION
While preparing for the stable branch update, we had temporarily been using the master-next bots to test that. Now it is time to go back to testing master-next with the Clang/LLVM upstream-with-swift branches.

This reverts commit 563292998bece91592750ee837ac0b6b68dc80ad.