### PR TITLE
Clean up IRGen class layout logic

### DIFF
--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -70,8 +70,7 @@ namespace {
   /// Layout information for class types.
   class ClassTypeInfo : public HeapTypeInfo<ClassTypeInfo> {
     ClassDecl *TheClass;
-    mutable StructLayout *Layout;
-    mutable ClassLayout FieldLayout;
+    mutable Optional<ClassLayout> FieldLayout;
 
     /// Can we use swift reference-counting, or do we have to use
     /// objc_retain/release?
@@ -84,26 +83,18 @@ namespace {
                   SpareBitVector spareBits, Alignment align,
                   ClassDecl *theClass, ReferenceCounting refcount)
       : HeapTypeInfo(irType, size, std::move(spareBits), align),
-        TheClass(theClass), Layout(nullptr), Refcount(refcount) {}
+        TheClass(theClass), Refcount(refcount) {}
 
     ReferenceCounting getReferenceCounting() const {
       return Refcount;
     }
 
-    ~ClassTypeInfo() override {
-      delete Layout;
-    }
-
     ClassDecl *getClass() const { return TheClass; }
 
-    const StructLayout &getLayout(IRGenModule &IGM, SILType classType) const;
     const ClassLayout &getClassLayout(IRGenModule &IGM, SILType type) const;
 
     Alignment getHeapAlignment(IRGenModule &IGM, SILType type) const {
-      return getLayout(IGM, type).getAlignment();
-    }
-    ArrayRef<ElementLayout> getElements(IRGenModule &IGM, SILType type) const {
-      return getLayout(IGM, type).getElements();
+      return getClassLayout(IGM, type).getAlignment();
     }
 
     StructLayout *createLayoutWithTailElems(IRGenModule &IGM,
@@ -160,7 +151,7 @@ namespace {
     // If not, we have to access stored properties either ivar offset globals,
     // or through the field offset vector, based on whether the layout has
     // dependent layout.
-    bool ClassHasFixedSize = true;
+    bool ClassIsFixedSize = true;
 
     // Does the class have identical layout under all generic substitutions?
     // If not, we can have to access stored properties through the field
@@ -221,17 +212,21 @@ namespace {
       return Elements;
     }
 
-    ClassLayout getClassLayout() const {
-      ClassLayout fieldLayout;
-      auto allStoredProps = IGM.Context.AllocateCopy(AllStoredProperties);
-      auto inheritedStoredProps = allStoredProps.slice(0, NumInherited);
-      fieldLayout.AllStoredProperties = allStoredProps;
-      fieldLayout.InheritedStoredProperties = inheritedStoredProps;
-      fieldLayout.AllFieldAccesses = IGM.Context.AllocateCopy(AllFieldAccesses);
-      fieldLayout.MetadataRequiresDynamicInitialization =
-        ClassMetadataRequiresDynamicInitialization;
-      fieldLayout.HasFixedSize = ClassHasFixedSize;
-      return fieldLayout;
+    ClassLayout getClassLayout(llvm::Type *classTy) const {
+      auto allStoredProps = IGM.Context.AllocateCopy(
+          ArrayRef<VarDecl *>(AllStoredProperties).slice(NumInherited));
+      auto allElements = IGM.Context.AllocateCopy(
+        ArrayRef<ElementLayout>(Elements).slice(NumInherited));
+      auto allFieldAccesses = IGM.Context.AllocateCopy(
+        ArrayRef<FieldAccess>(AllFieldAccesses).slice(NumInherited));
+
+      return ClassLayout(*this,
+                         ClassIsFixedSize,
+                         ClassMetadataRequiresDynamicInitialization,
+                         classTy,
+                         allStoredProps,
+                         allFieldAccesses,
+                         allElements);
     }
 
   private:
@@ -250,7 +245,7 @@ namespace {
         // the class object at compile time so we need to do runtime layout.
         if (classHasIncompleteLayout(IGM, superclass)) {
           ClassMetadataRequiresDynamicInitialization = true;
-          ClassHasFixedSize = false;
+          ClassIsFixedSize = false;
         }
 
         if (superclass->hasClangNode()) {
@@ -259,7 +254,7 @@ namespace {
           // vector only stores offsets of stored properties defined in
           // Swift, we don't have to worry about indirect indexing of
           // the field offset vector.
-          ClassHasFixedSize = false;
+          ClassIsFixedSize = false;
 
           // We can't use global offset variables if we are generic and layout
           // dependent on a generic parameter because the objective-c layout might
@@ -282,7 +277,7 @@ namespace {
             }
         } else if (IGM.isResilient(superclass, ResilienceExpansion::Maximal)) {
           ClassMetadataRequiresDynamicInitialization = true;
-          ClassHasFixedSize = false;
+          ClassIsFixedSize = false;
 
           // Furthermore, if the superclass is a generic context, we have to
           // assume that its layout depends on its generic parameters.
@@ -304,12 +299,12 @@ namespace {
       // not know its exact layout.
       if (classHasIncompleteLayout(IGM, theClass)) {
         ClassMetadataRequiresDynamicInitialization = true;
-        ClassHasFixedSize = false;
+        ClassIsFixedSize = false;
       }
 
       if (IGM.isResilient(theClass, ResilienceExpansion::Maximal)) {
         ClassMetadataRequiresDynamicInitialization = true;
-        ClassHasFixedSize = false;
+        ClassIsFixedSize = false;
       }
 
       // Access strategies should be set by the abstract class layout,
@@ -352,27 +347,23 @@ namespace {
 
         if (!eltTypeForLayout.isFixedSize()) {
           ClassMetadataRequiresDynamicInitialization = true;
-          ClassHasFixedSize = false;
+          ClassIsFixedSize = false;
 
           if (type.hasArchetype())
             ClassHasConcreteLayout = false;
         }
 
-        size_t fieldIndex = AllStoredProperties.size();
-        assert(!abstractLayout ||
-               abstractLayout->getFieldIndex(var) == fieldIndex);
-
         Elements.push_back(ElementLayout::getIncomplete(eltTypeForLayout,
                                                         eltTypeForAccess));
         AllStoredProperties.push_back(var);
-        AllFieldAccesses.push_back(getFieldAccess(abstractLayout, fieldIndex));
+        AllFieldAccesses.push_back(getFieldAccess(abstractLayout, var));
       }
     }
 
     FieldAccess getFieldAccess(const ClassLayout *abstractLayout,
-                               size_t abstractFieldIndex) {
+                               VarDecl *var) {
       // The class has fixed size, so the field offset is known statically.
-      if (ClassHasFixedSize) {
+      if (ClassIsFixedSize) {
         return FieldAccess::ConstantDirect;
       }
 
@@ -383,7 +374,7 @@ namespace {
       // The global will exist only if the abstract type has concrete layout,
       // so if we're not laying out the abstract type, use its access rule.
       if (abstractLayout) {
-        return abstractLayout->AllFieldAccesses[abstractFieldIndex];
+        return abstractLayout->getFieldAccessAndElement(var).first;
       }
 
       // If layout doesn't depend on any generic parameters, but it's
@@ -404,24 +395,21 @@ namespace {
 } // end anonymous namespace
 
 void ClassTypeInfo::generateLayout(IRGenModule &IGM, SILType classType) const {
-  assert(!Layout && FieldLayout.AllStoredProperties.empty() &&
-         "already generated layout");
+  assert(!FieldLayout && "already generated layout");
 
   // Add the heap header.
   ClassLayoutBuilder builder(IGM, classType, Refcount);
 
   // generateLayout should not call itself recursively.
-  assert(!Layout);
+  assert(!FieldLayout && "already generated layout re-entrantly");
 
   // Set the body of the class type.
   auto classTy =
     cast<llvm::StructType>(getStorageType()->getPointerElementType());
   builder.setAsBodyOfStruct(classTy);
-  
+
   // Record the layout.
-  Layout = new StructLayout(builder, classType.getASTType(), classTy,
-                            builder.getElements());
-  FieldLayout = builder.getClassLayout();
+  FieldLayout = builder.getClassLayout(classTy);
 }
 
 StructLayout *
@@ -455,24 +443,14 @@ ClassTypeInfo::createLayoutWithTailElems(IRGenModule &IGM,
                           builder.getElements());
 }
 
-const StructLayout &
-ClassTypeInfo::getLayout(IRGenModule &IGM, SILType classType) const {
-  // Return the cached layout if available.
-  if (Layout)
-    return *Layout;
-
-  generateLayout(IGM, classType);
-  return *Layout;
-}
-
 const ClassLayout &
 ClassTypeInfo::getClassLayout(IRGenModule &IGM, SILType classType) const {
   // Return the cached layout if available.
-  if (Layout)
-    return FieldLayout;
+  if (FieldLayout)
+    return *FieldLayout;
   
   generateLayout(IGM, classType);
-  return FieldLayout;
+  return *FieldLayout;
 }
 
 /// Cast the base to i8*, apply the given inbounds offset (in bytes,
@@ -524,11 +502,11 @@ irgen::tryEmitConstantClassFragilePhysicalMemberOffset(IRGenModule &IGM,
   auto &baseClassTI = IGM.getTypeInfo(baseType).as<ClassTypeInfo>();
 
   auto &classLayout = baseClassTI.getClassLayout(IGM, baseType);
-  unsigned fieldIndex = classLayout.getFieldIndex(field);
 
-  switch (classLayout.AllFieldAccesses[fieldIndex]) {
+  auto fieldInfo = classLayout.getFieldAccessAndElement(field);
+  switch (fieldInfo.first) {
   case FieldAccess::ConstantDirect: {
-    auto &element = baseClassTI.getElements(IGM, baseType)[fieldIndex];
+    auto element = fieldInfo.second;
     return llvm::ConstantInt::get(IGM.SizeTy,
                                   element.getByteOffset().getValue());
   }
@@ -542,18 +520,16 @@ FieldAccess
 irgen::getClassFieldAccess(IRGenModule &IGM, SILType baseType, VarDecl *field) {
   auto &baseClassTI = IGM.getTypeInfo(baseType).as<ClassTypeInfo>();
   auto &classLayout = baseClassTI.getClassLayout(IGM, baseType);
-  unsigned fieldIndex = classLayout.getFieldIndex(field);
-  return classLayout.AllFieldAccesses[fieldIndex];
+  return classLayout.getFieldAccessAndElement(field).first;
 }
 
 Size
 irgen::getClassFieldOffset(IRGenModule &IGM, SILType baseType, VarDecl *field) {
   auto &baseClassTI = IGM.getTypeInfo(baseType).as<ClassTypeInfo>();
   auto &classLayout = baseClassTI.getClassLayout(IGM, baseType);
-  auto &layout = baseClassTI.getLayout(IGM, baseType);
 
-  unsigned fieldIndex = classLayout.getFieldIndex(field);
-  auto &element = layout.getElement(fieldIndex);
+  auto fieldInfo = classLayout.getFieldAccessAndElement(field);
+  auto element = fieldInfo.second;
   assert(element.getKind() == ElementLayout::Kind::Fixed ||
          element.getKind() == ElementLayout::Kind::Empty);
   return element.getByteOffset();
@@ -581,12 +557,13 @@ OwnedAddress irgen::projectPhysicalClassMemberAddress(IRGenFunction &IGF,
   ClassDecl *baseClass = baseClassTI.getClass();
 
   auto &classLayout = baseClassTI.getClassLayout(IGF.IGM, baseType);
-  unsigned fieldIndex = classLayout.getFieldIndex(field);
 
-  switch (classLayout.AllFieldAccesses[fieldIndex]) {
+  auto fieldInfo = classLayout.getFieldAccessAndElement(field);
+
+  switch (fieldInfo.first) {
   case FieldAccess::ConstantDirect: {
     Address baseAddr(base, baseClassTI.getHeapAlignment(IGF.IGM, baseType));
-    auto &element = baseClassTI.getElements(IGF.IGM, baseType)[fieldIndex];
+    auto element = fieldInfo.second;
     Address memberAddr = element.project(IGF, baseAddr, None);
     // We may need to bitcast the address if the field is of a generic type.
     if (memberAddr.getType()->getElementType() != fieldTI.getStorageType())
@@ -619,11 +596,11 @@ irgen::getPhysicalClassMemberAccessStrategy(IRGenModule &IGM,
   ClassDecl *baseClass = baseType.getClassOrBoundGenericClass();
 
   auto &classLayout = baseClassTI.getClassLayout(IGM, baseType);
-  unsigned fieldIndex = classLayout.getFieldIndex(field);
+  auto fieldInfo = classLayout.getFieldAccessAndElement(field);
 
-  switch (classLayout.AllFieldAccesses[fieldIndex]) {
+  switch (fieldInfo.first) {
   case FieldAccess::ConstantDirect: {
-    auto &element = baseClassTI.getElements(IGM, baseType)[fieldIndex];
+    auto element = fieldInfo.second;
     return MemberAccessStrategy::getDirectFixed(element.getByteOffset());
   }
 
@@ -649,7 +626,7 @@ Address irgen::emitTailProjection(IRGenFunction &IGF, llvm::Value *Base,
   const ClassTypeInfo &classTI = IGF.getTypeInfo(ClassType).as<ClassTypeInfo>();
 
   llvm::Value *Offset = nullptr;
-  auto &layout = classTI.getLayout(IGF.IGM, ClassType);
+  auto &layout = classTI.getClassLayout(IGF.IGM, ClassType);
   Alignment HeapObjAlign = IGF.IGM.TargetInfo.HeapObjectAlignment;
   Alignment Align;
 
@@ -689,18 +666,18 @@ Address irgen::emitTailProjection(IRGenFunction &IGF, llvm::Value *Base,
 ///
 /// Returns the alloca if successful, or nullptr otherwise.
 static llvm::Value *stackPromote(IRGenFunction &IGF,
-                      const StructLayout &ClassLayout,
+                      const ClassLayout &FieldLayout,
                       int &StackAllocSize,
                       ArrayRef<std::pair<SILType, llvm::Value *>> TailArrays) {
   if (StackAllocSize < 0)
     return nullptr;
-  if (!ClassLayout.isFixedLayout())
+  if (!FieldLayout.isFixedLayout())
     return nullptr;
 
   // Calculate the total size needed.
   // The first part is the size of the class itself.
-  Alignment ClassAlign = ClassLayout.getAlignment();
-  Size TotalSize = ClassLayout.getSize();
+  Alignment ClassAlign = FieldLayout.getAlignment();
+  Size TotalSize = FieldLayout.getSize();
 
   // Add size for tail-allocated arrays.
   for (const auto &TailArray : TailArrays) {
@@ -730,9 +707,9 @@ static llvm::Value *stackPromote(IRGenFunction &IGF,
     return nullptr;
   StackAllocSize = TotalSize.getValue();
 
-  if (TotalSize == ClassLayout.getSize()) {
+  if (TotalSize == FieldLayout.getSize()) {
     // No tail-allocated arrays: we can use the llvm class type for alloca.
-    llvm::Type *ClassTy = ClassLayout.getType();
+    llvm::Type *ClassTy = FieldLayout.getType();
     Address Alloca = IGF.createAlloca(ClassTy, ClassAlign, "reference.raw");
     return Alloca.getAddress();
   }
@@ -793,15 +770,12 @@ llvm::Value *irgen::emitClassAllocation(IRGenFunction &IGF, SILType selfType,
     emitClassHeapMetadataRef(IGF, classType, MetadataValueType::TypeMetadata,
                              MetadataState::Complete);
 
-  const StructLayout &structLayout = classTI.getLayout(IGF.IGM, selfType);
   const ClassLayout &classLayout = classTI.getClassLayout(IGF.IGM, selfType);
 
   llvm::Value *size, *alignMask;
-  if (classLayout.HasFixedSize) {
-    assert(structLayout.isFixedLayout());
-
-    size = structLayout.emitSize(IGF.IGM);
-    alignMask = structLayout.emitAlignMask(IGF.IGM);
+  if (classLayout.isFixedSize()) {
+    size = IGF.IGM.getSize(classLayout.getSize());
+    alignMask = IGF.IGM.getSize(classLayout.getAlignMask());
   } else {
     std::tie(size, alignMask)
       = emitClassResilientInstanceSizeAndAlignMask(IGF,
@@ -809,9 +783,9 @@ llvm::Value *irgen::emitClassAllocation(IRGenFunction &IGF, SILType selfType,
                                      metadata);
   }
 
-  llvm::Type *destType = structLayout.getType()->getPointerTo();
+  llvm::Type *destType = classLayout.getType()->getPointerTo();
   llvm::Value *val = nullptr;
-  if (llvm::Value *Promoted = stackPromote(IGF, structLayout, StackAllocSize,
+  if (llvm::Value *Promoted = stackPromote(IGF, classLayout, StackAllocSize,
                                            TailArrays)) {
     val = IGF.Builder.CreateBitCast(Promoted, IGF.IGM.RefCountedPtrTy);
     val = IGF.emitInitStackObjectCall(metadata, val, "reference.new");
@@ -847,7 +821,7 @@ llvm::Value *irgen::emitClassAllocationDynamic(IRGenFunction &IGF,
   llvm::Value *val = IGF.emitAllocObjectCall(metadata, size, alignMask,
                                              "reference.new");
   auto &classTI = IGF.getTypeInfo(selfType).as<ClassTypeInfo>();
-  auto &layout = classTI.getLayout(IGF.IGM, selfType);
+  auto &layout = classTI.getClassLayout(IGF.IGM, selfType);
   llvm::Type *destType = layout.getType()->getPointerTo();
   return IGF.Builder.CreateBitCast(val, destType);
 }
@@ -862,12 +836,12 @@ static void getInstanceSizeAndAlignMask(IRGenFunction &IGF,
                                         llvm::Value *&alignMask) {
   // Try to determine the size of the object we're deallocating.
   auto &info = IGF.IGM.getTypeInfo(selfType).as<ClassTypeInfo>();
-  auto &layout = info.getLayout(IGF.IGM, selfType);
+  auto &layout = info.getClassLayout(IGF.IGM, selfType);
 
   // If it's fixed, emit the constant size and alignment mask.
   if (layout.isFixedLayout()) {
-    size = layout.emitSize(IGF.IGM);
-    alignMask = layout.emitAlignMask(IGF.IGM);
+    size = IGF.IGM.getSize(layout.getSize());
+    alignMask = IGF.IGM.getSize(layout.getAlignMask());
     return;
   }
 
@@ -927,9 +901,9 @@ llvm::Constant *irgen::tryEmitClassConstantFragileInstanceSize(
   auto selfType = getSelfType(Class);
   auto &classTI = IGM.getTypeInfo(selfType).as<ClassTypeInfo>();
 
-  auto &layout = classTI.getLayout(IGM, selfType);
+  auto &layout = classTI.getClassLayout(IGM, selfType);
   if (layout.isFixedLayout())
-    return layout.emitSize(IGM);
+    return IGM.getSize(layout.getSize());
   
   return nullptr;
 }
@@ -940,9 +914,9 @@ llvm::Constant *irgen::tryEmitClassConstantFragileInstanceAlignMask(
   auto selfType = getSelfType(Class);
   auto &classTI = IGM.getTypeInfo(selfType).as<ClassTypeInfo>();
   
-  auto &layout = classTI.getLayout(IGM, selfType);
+  auto &layout = classTI.getClassLayout(IGM, selfType);
   if (layout.isFixedLayout())
-    return layout.emitAlignMask(IGM);
+    return IGM.getSize(layout.getAlignMask());
   
   return nullptr;
 }
@@ -955,9 +929,7 @@ void IRGenModule::emitClassDecl(ClassDecl *D) {
   auto &classTI = getTypeInfo(selfType).as<ClassTypeInfo>();
 
   // Emit the class metadata.
-  emitClassMetadata(*this, D,
-                    classTI.getLayout(*this, selfType),
-                    classTI.getClassLayout(*this, selfType));
+  emitClassMetadata(*this, D, classTI.getClassLayout(*this, selfType));
 
   IRGen.addClassForEagerInitialization(D);
 
@@ -1010,7 +982,6 @@ namespace {
     IRGenModule &IGM;
     PointerUnion<ClassDecl *, ProtocolDecl *> TheEntity;
     ExtensionDecl *TheExtension;
-    const StructLayout *Layout;
     const ClassLayout *FieldLayout;
     
     ClassDecl *getClass() const {
@@ -1088,9 +1059,6 @@ namespace {
     SmallVector<VarDecl*, 8> ClassProperties;
     
     llvm::Constant *Name = nullptr;
-    /// Index of the first non-inherited field in the layout.
-    unsigned FirstFieldIndex;
-    unsigned NextFieldIndex;
 
     SmallVectorImpl<MethodDescriptor> &getMethodList(ValueDecl *decl) {
       if (decl->getAttrs().hasAttribute<OptionalAttr>()) {
@@ -1110,15 +1078,10 @@ namespace {
 
   public:
     ClassDataBuilder(IRGenModule &IGM, ClassDecl *theClass,
-                     const StructLayout &layout,
                      const ClassLayout &fieldLayout)
         : IGM(IGM), TheEntity(theClass), TheExtension(nullptr),
-          Layout(&layout),
           FieldLayout(&fieldLayout)
     {
-      FirstFieldIndex = fieldLayout.InheritedStoredProperties.size();
-      NextFieldIndex = FirstFieldIndex;
-
       visitConformances(theClass);
       visitMembers(theClass);
 
@@ -1131,11 +1094,8 @@ namespace {
     ClassDataBuilder(IRGenModule &IGM, ClassDecl *theClass,
                      ExtensionDecl *theExtension)
       : IGM(IGM), TheEntity(theClass), TheExtension(theExtension),
-        Layout(nullptr), FieldLayout(nullptr)
+        FieldLayout(nullptr)
     {
-      FirstFieldIndex = -1;
-      NextFieldIndex = -1;
-
       buildCategoryName(CategoryName);
 
       visitConformances(theExtension);
@@ -1209,7 +1169,7 @@ namespace {
     }
 
     void buildMetaclassStub() {
-      assert(Layout && "can't build a metaclass from a category");
+      assert(FieldLayout && "can't build a metaclass from a category");
       // The isa is the metaclass pointer for the root class.
       auto rootClass = getRootClassForMetaclass(IGM, TheEntity.get<ClassDecl *>());
       auto rootPtr = getMetaclassRefOrNull(rootClass);
@@ -1354,7 +1314,7 @@ namespace {
     }
 
     void emitRODataFields(ConstantStructBuilder &b, ForMetaClass_t forMeta) {
-      assert(Layout && "can't emit rodata for a category");
+      assert(FieldLayout && "can't emit rodata for a category");
 
       // struct _class_ro_t {
       //   uint32_t flags;
@@ -1375,19 +1335,8 @@ namespace {
         // historical nonsense
         instanceStart = instanceSize;
       } else {
-        instanceSize = Layout->getSize();
-        if (Layout->getElements().empty()
-            || Layout->getElements().size() == FirstFieldIndex) {
-          instanceStart = instanceSize;
-        } else if (Layout->getElement(FirstFieldIndex).getKind()
-                     == ElementLayout::Kind::Fixed ||
-                   Layout->getElement(FirstFieldIndex).getKind()
-                     == ElementLayout::Kind::Empty) {
-          // FIXME: assumes layout is always sequential!
-          instanceStart = Layout->getElement(FirstFieldIndex).getByteOffset();
-        } else {
-          instanceStart = Size(0);
-        }
+        instanceSize = FieldLayout->getSize();
+        instanceStart = FieldLayout->getInstanceStart();
       }
       b.addInt32(instanceStart.getValue());
       b.addInt32(instanceSize.getValue());
@@ -1724,7 +1673,7 @@ namespace {
     /// affect flags.
     void visitStoredVar(VarDecl *var) {
       // FIXME: how to handle ivar extensions in categories?
-      if (!Layout)
+      if (!FieldLayout)
         return;
 
       Ivars.push_back(var);
@@ -1752,11 +1701,11 @@ namespace {
                                  ->mapTypeIntoContext(ivar->getInterfaceType())
                                  ->getCanonicalType());
 
-      assert(Layout && "can't build ivar for category");
+      assert(FieldLayout && "can't build ivar for category");
       auto &ivarTI = IGM.getTypeInfo(fieldType);
 
       llvm::Constant *offsetPtr;
-      switch (FieldLayout->AllFieldAccesses[NextFieldIndex++]) {
+      switch (FieldLayout->getFieldAccessAndElement(ivar).first) {
       case FieldAccess::ConstantDirect:
       case FieldAccess::NonConstantDirect: {
         // If the field offset is fixed relative to the start of the superclass,
@@ -2083,9 +2032,8 @@ llvm::Constant *irgen::emitClassPrivateData(IRGenModule &IGM,
   assert(IGM.ObjCInterop && "emitting RO-data outside of interop mode");
   SILType selfType = getSelfType(cls);
   auto &classTI = IGM.getTypeInfo(selfType).as<ClassTypeInfo>();
-  auto &layout = classTI.getLayout(IGM, selfType);
   auto &fieldLayout = classTI.getClassLayout(IGM, selfType);
-  ClassDataBuilder builder(IGM, cls, layout, fieldLayout);
+  ClassDataBuilder builder(IGM, cls, fieldLayout);
 
   // First, build the metaclass object.
   builder.buildMetaclassStub();
@@ -2102,10 +2050,9 @@ irgen::emitClassPrivateDataFields(IRGenModule &IGM,
 
   SILType selfType = getSelfType(cls);
   auto &classTI = IGM.getTypeInfo(selfType).as<ClassTypeInfo>();
-  auto &layout = classTI.getLayout(IGM, selfType);
   auto &fieldLayout = classTI.getClassLayout(IGM, selfType);
 
-  ClassDataBuilder builder(IGM, cls, layout, fieldLayout);
+  ClassDataBuilder builder(IGM, cls, fieldLayout);
 
   Size startOfClassRO = init.getNextOffsetFromGlobal();
   assert(startOfClassRO.isMultipleOf(IGM.getPointerSize()));
@@ -2244,7 +2191,7 @@ bool irgen::doesClassMetadataRequireDynamicInitialization(IRGenModule &IGM,
   auto &selfTI = IGM.getTypeInfo(selfType).as<ClassTypeInfo>();
 
   auto &layout = selfTI.getClassLayout(IGM, selfType);
-  return layout.MetadataRequiresDynamicInitialization;
+  return layout.doesMetadataRequireDynamicInitialization();
 }
 
 bool irgen::hasKnownSwiftMetadata(IRGenModule &IGM, CanType type) {

--- a/lib/IRGen/GenClass.h
+++ b/lib/IRGen/GenClass.h
@@ -143,13 +143,13 @@ namespace irgen {
                                                   SILType baseType,
                                                   VarDecl *field);
                                                   
-  unsigned getClassFieldIndex(IRGenModule &IGM,
-                              SILType baseType,
-                              VarDecl *field);
-    
   FieldAccess getClassFieldAccess(IRGenModule &IGM,
                                   SILType baseType,
                                   VarDecl *field);
+
+  Size getClassFieldOffset(IRGenModule &IGM,
+                           SILType baseType,
+                           VarDecl *field);
 
   /// Creates a layout for the class \p classType with allocated tail elements
   /// \p tailTypes.

--- a/lib/IRGen/GenMeta.h
+++ b/lib/IRGen/GenMeta.h
@@ -45,14 +45,13 @@ namespace irgen {
   enum RequireMetadata_t : bool;
   class Size;
   class StructLayout;
-  struct ClassLayout;
+  class ClassLayout;
 
   bool requiresForeignTypeMetadata(CanType type);
   bool requiresForeignTypeMetadata(NominalTypeDecl *decl);
 
   /// Emit the metadata associated with the given class declaration.
   void emitClassMetadata(IRGenModule &IGM, ClassDecl *theClass,
-                         const StructLayout &layout,
                          const ClassLayout &fieldLayout);
 
   /// Emit the constant initializer of the type metadata candidate for

--- a/lib/IRGen/StructLayout.cpp
+++ b/lib/IRGen/StructLayout.cpp
@@ -177,6 +177,37 @@ Address ElementLayout::project(IRGenFunction &IGF, Address baseAddr,
   llvm_unreachable("bad element layout kind");
 }
 
+ClassLayout::ClassLayout(const StructLayoutBuilder &builder,
+                         bool isFixedSize,
+                         bool metadataRequiresDynamicInitialization,
+                         llvm::Type *classTy,
+                         ArrayRef<VarDecl *> allStoredProps,
+                         ArrayRef<FieldAccess> allFieldAccesses,
+                         ArrayRef<ElementLayout> allElements)
+  : MinimumAlign(builder.getAlignment()),
+    MinimumSize(builder.getSize()),
+    IsFixedLayout(builder.isFixedLayout()),
+    IsFixedSize(isFixedSize),
+    MetadataRequiresDynamicInitialization(metadataRequiresDynamicInitialization),
+    Ty(classTy),
+    AllStoredProperties(allStoredProps),
+    AllFieldAccesses(allFieldAccesses),
+    AllElements(allElements) { }
+
+Size ClassLayout::getInstanceStart() const {
+  if (AllElements.empty())
+    return getSize();
+
+  auto element = AllElements[0];
+  if (element.getKind() == ElementLayout::Kind::Fixed ||
+      element.getKind() == ElementLayout::Kind::Empty) {
+    // FIXME: assumes layout is always sequential!
+    return element.getByteOffset();
+  }
+
+  return Size(0);
+}
+
 void StructLayoutBuilder::addHeapHeader() {
   assert(StructFields.empty() && "adding heap header at a non-zero offset");
   CurSize = IGM.RefCountedStructSize;


### PR DESCRIPTION
Instead of building a StructLayout and ClassLayout and passing both around in various places, put all the relevant information in the ClassLayout, and make it support a richer set of operations. Also, change ClassLayout to only store information about the class's immediate stored properties, without including properties from any superclasses, since we can just get the layout for the superclass if we need it.