### PR TITLE
[TF API] Implement initial TensorFlow dataset API with bug workarounds

### DIFF
--- a/stdlib/public/TensorFlow/CMakeLists.txt
+++ b/stdlib/public/TensorFlow/CMakeLists.txt
@@ -37,6 +37,7 @@ list(APPEND swift_stdlib_compile_flags "-Onone")
 set(SOURCES
   CompilerRuntime.swift
   CompositeMath.swift
+  Dataset.swift
   DataTypes.swift
   Gradients.swift
   OpaqueHandles.swift

--- a/stdlib/public/TensorFlow/Dataset.swift
+++ b/stdlib/public/TensorFlow/Dataset.swift
@@ -1,0 +1,141 @@
+//===-- Dataset.swift -----------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// The dataset API.
+//
+//===----------------------------------------------------------------------===//
+
+/// Represents a potentially large set of elements.
+///
+/// A `SingleValueDataset` can be used to represent an input pipeline as a
+/// collection of element tensors.
+@_fixed_layout
+public struct SingleValueDataset {
+  // NOTE: SingleValueDataset is currently specialzed on `Float` to work around
+  // deabstraction bug SR-8463. This is to avoid indirect passing in SIL. When
+  // the bug gets resolved, `SingleValueDataset` will have generic parameter
+  // `Scalar`.
+  public typealias Scalar = Float
+  @usableFromInline let _handle: VariantHandle
+  public let elementShape: TensorShape
+
+  @usableFromInline @inline(__always)
+  internal init(_handle: VariantHandle, elementShape: TensorShape) {
+    self._handle = _handle
+    self.elementShape = elementShape
+  }
+}
+
+public extension SingleValueDataset {
+  /// Creates a dataset from a batch of elements as a tensor.
+  ///
+  /// - Parameter
+  ///   - elements: The batch of elements.
+  ///   - elementShape: The shape that the 
+  ///
+  // FIXME: Due to inability to perform shape inference during deabstraction,
+  // users must specify the element shape for today.
+  @inlinable @inline(__always)
+  public init(elements: Tensor<Scalar>, elementShape: TensorShape) {
+    self.init(
+      _handle: #tfop(
+        "TensorSliceDataset", [elements],
+        Toutput_types: [Scalar.self],
+        output_shapes: [elementShape]
+      ),
+      elementShape: elementShape
+    )
+  }
+}
+
+extension SingleValueDataset : Sequence {
+  public typealias Element = Tensor<Scalar>
+
+  public typealias Iterator = SingleValueDatasetIterator
+
+  /// Returns an iterator over the elements of this dataset.
+  @inlinable @inline(__always)
+  public func makeIterator() -> SingleValueDatasetIterator {
+    let resource: ResourceHandle = #tfop("AnonymousIterator",
+                                         output_types: [Scalar.self],
+                                         output_shapes: [elementShape])
+    #tfop("MakeIterator", _handle, resource) as Void
+    return SingleValueDatasetIterator(_handle: resource,
+                                      elementShape: elementShape)
+  }
+}
+
+public extension SingleValueDataset {
+  @inlinable @inline(__always)
+  func map<T>(
+    _ transform: @convention(tensorflow) (Tensor<Scalar>) -> Tensor<T>
+  ) -> SingleValueDataset {
+    return SingleValueDataset(
+      _handle: #tfop(
+        "MapDataset", _handle, [], f: transform, Targuments: [],
+        output_types: [Scalar.self], output_shapes: [elementShape]
+      ),
+      elementShape: elementShape
+    )
+  }
+
+  @inlinable @inline(__always)
+  func filter(
+    _ isIncluded: @convention(tensorflow) (Tensor<Scalar>) -> Tensor<Bool>
+  ) -> SingleValueDataset {
+    return SingleValueDataset(
+      _handle: #tfop(
+        "FilterDataset", _handle, [], predicate: isIncluded, Targuments: [],
+        output_types: [Scalar.self], output_shapes: [elementShape]
+      ),
+      elementShape: elementShape
+    )
+  }
+}
+
+/// Represents the state of iterating through a `SingleValueDataset`.
+@_fixed_layout
+public struct SingleValueDatasetIterator {
+  // NOTE: SingleValueDataset is currently specialzed on `Float` to work around
+  // deabstraction bug SR-8463. This is to avoid indirect passing in SIL. When
+  // the bug gets resolved, `SingleValueDataset` will have generic parameter
+  // `Scalar`.
+  public typealias Scalar = Float
+  @usableFromInline let handle: ResourceHandle
+  public let elementShape: TensorShape
+
+  @usableFromInline @inline(__always)
+  internal init(_handle: ResourceHandle, elementShape: TensorShape) {
+    self.handle = _handle
+    self.elementShape = elementShape
+  }
+}
+
+extension SingleValueDatasetIterator : IteratorProtocol {
+  public typealias Element = Tensor<Scalar>
+
+  // Advances to the next element and returns it, or nil if no next element
+  // exists.
+  @inlinable @inline(__always)
+  // FIXME: Make this `mutating` when SR-8463 is fixed.
+  public /*mutating*/ func next() -> Tensor<Scalar>? {
+    let optional: VariantHandle =
+      #tfop("IteratorGetNextAsOptional", handle,
+            output_types: [Scalar.self], output_shapes: [elementShape])
+    guard _TFGetScalarOrDie(#tfop("OptionalHasValue", optional)) else {
+      return nil
+    }
+    return Tensor(handle: #tfop("OptionalGetValue",optional,
+                                output_types: [Scalar.self],
+                                output_shapes: [elementShape]))
+  }
+}

--- a/stdlib/public/TensorFlow/Dataset.swift
+++ b/stdlib/public/TensorFlow/Dataset.swift
@@ -134,7 +134,7 @@ extension SingleValueDatasetIterator : IteratorProtocol {
     guard _TFGetScalarOrDie(#tfop("OptionalHasValue", optional)) else {
       return nil
     }
-    return Tensor(handle: #tfop("OptionalGetValue",optional,
+    return Tensor(handle: #tfop("OptionalGetValue", optional,
                                 output_types: [Scalar.self],
                                 output_shapes: [elementShape]))
   }

--- a/stdlib/public/TensorFlow/OpaqueHandles.swift
+++ b/stdlib/public/TensorFlow/OpaqueHandles.swift
@@ -14,8 +14,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import CTensorFlow
-
 /// `ResourceHandle` is the type used by ops and the `#tfop()` syntax to
 /// represent TensorFlow "resource" values.  It exists only to represent edges
 /// in TensorFlow graphs, and has no host-side representation (and thus no

--- a/test/TensorFlowRuntime/dataset_api.swift
+++ b/test/TensorFlowRuntime/dataset_api.swift
@@ -1,0 +1,52 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize
+//
+// Dataset API tests.
+
+import TensorFlow
+
+#if TPU
+import TensorFlowUnittestTPU
+#else
+import TensorFlowUnittest
+#endif
+import StdlibUnittest
+
+var DatasetAPITests = TestSuite("DatasetAPI")
+
+DatasetAPITests.testAllBackends("SingleValueManualIterator") {
+  // [[1], [2], [3], [4], [5]]
+  let scalars = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1).reshaped(to: [5, 1])
+  let dataset = SingleValueDataset(elements: scalars, elementShape: [1])
+  var iterator = dataset.makeIterator()
+  var i: Int32 = 0
+  while let item = iterator.next() {
+    expectEqual(scalars[i].array, item.array)
+    i += 1
+  }
+}
+
+DatasetAPITests.testAllBackends("SingleValueDatasetIteration") {
+  // [[1], [2], [3], [4], [5]]
+  let scalars = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1).reshaped(to: [5, 1])
+  let dataset = SingleValueDataset(elements: scalars, elementShape: [1])
+  var i: Int32 = 0
+  for item in dataset {
+    expectEqual(scalars[i].array, item.array)
+    i += 1
+  }
+}
+
+// Higher-order operator tests are blocked by SR-8478.
+//
+// DatasetAPITests.testAllBackends("SingleValueDatasetMap") {
+//   let scalars = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1)
+//   let dataset = SingleValueDataset(elements: scalars, elementShape: [1])
+//   let evenDataset: SingleValueDataset = dataset.filter {
+//     x % 2 == Tensor<Float>(0) ? Tensor(true) : Tensor(false)
+//   }
+//   expectEqual(evenDataset.flatMap { $0.scalars }, [0, 2, 4])
+// }
+
+runAllTests()

--- a/utils/update-checkout-config.json
+++ b/utils/update-checkout-config.json
@@ -305,7 +305,7 @@
                 "swift-xcode-playground-support": "swift-DEVELOPMENT-SNAPSHOT-2018-07-23-a",
                 "ninja": "253e94c1fa511704baeb61cf69995bbf09ba435e",
                 "tensorflow": "72691c24e222aaff5681a718cbe96eb1436e4971",
-                "tensorflow-swift-bindings": "489fcb7c4ca0ee11f3453ee7b0749a4f0742e780"
+                "tensorflow-swift-bindings": "f9acd38eb687208dcee8622510b9a611e51d21a4"
             }
         }
     }

--- a/utils/update-checkout-config.json
+++ b/utils/update-checkout-config.json
@@ -304,8 +304,8 @@
                 "swift-integration-tests": "swift-DEVELOPMENT-SNAPSHOT-2018-07-23-a",
                 "swift-xcode-playground-support": "swift-DEVELOPMENT-SNAPSHOT-2018-07-23-a",
                 "ninja": "253e94c1fa511704baeb61cf69995bbf09ba435e",
-                "tensorflow": "ff8f6371d9670101b5dfc5eb8cef118547d78dcc",
-                "tensorflow-swift-bindings": "f9acd38eb687208dcee8622510b9a611e51d21a4"
+                "tensorflow": "f9acd38eb687208dcee8622510b9a611e51d21a4",
+                "tensorflow-swift-bindings": "489fcb7c4ca0ee11f3453ee7b0749a4f0742e780"
             }
         }
     }

--- a/utils/update-checkout-config.json
+++ b/utils/update-checkout-config.json
@@ -304,7 +304,7 @@
                 "swift-integration-tests": "swift-DEVELOPMENT-SNAPSHOT-2018-07-23-a",
                 "swift-xcode-playground-support": "swift-DEVELOPMENT-SNAPSHOT-2018-07-23-a",
                 "ninja": "253e94c1fa511704baeb61cf69995bbf09ba435e",
-                "tensorflow": "72691c24e222aaff5681a718cbe96eb1436e4971",
+                "tensorflow": "ff8f6371d9670101b5dfc5eb8cef118547d78dcc",
                 "tensorflow-swift-bindings": "f9acd38eb687208dcee8622510b9a611e51d21a4"
             }
         }


### PR DESCRIPTION
## Introduction

TensorFlow's [data API](https://www.tensorflow.org/api_docs/python/tf/data/Dataset) represents a potentially large set of elements and is to be used as an input pipeline for training. Transformation operators like `MapDataset`(https://github.com/tensorflow/tensorflow/blob/aed8f42bafabf11c5d92ce4109a5e0408b31f9c5/tensorflow/core/ops/dataset_ops.cc#L189) correspond exactly to Swift's `Sequence` methods. Iterator operator `IteratorGetNextAsOptional` corresponds exactly to Swift's `IteratorProtocol.next()`.

This patch adds `SingleValueDataset` type that implements `Sequence` and a `SingleValueDatasetIterator` type that implements `IteratorProtocol`. Both types use bare-form `#tfop` to wire up the dataset ops.

Kickstarts [SR-8438](https://bugs.swift.org/browse/SR-8438).

## Brief design rationale

Due to multiple language limitations, e.g. variadic generics and variadic tuples, we cannot have a single `Dataset` type that works for any nest-like structure. Using arrays or other dynamic data structures on the other hand would fail to fulfill efficient Graph Program Extraction. We start with this simple model and specialize dataset types for different common result types, e.g. `DoubleValueDataset`, `TripleValueDataset`, and `QuadrupleValueDataset`. Whenever the type system is good enough to generalize, we replace them with a type alias.

This API is going to unblock demos and tutorials instead of pursing full generality of nest-like APIs. I'll write a holistic design document on Swift dataset API design later down the road.

## Known issues

- [SR-8463](https://bugs.swift.org/browse/SR-8463) blocks any API that would result into indirect passing, so `SingleValueDataset` is intentionally specialized on `Float` and will be made generic once the bug is fixed.

- As documented in [SR-8478](https://bugs.swift.org/browse/SR-8478) `@convention(tensorflow)` parameters won't accept functions of the same type. Until this is fixed, we cannot test higher order operators.