### PR TITLE
Fix constexpr crasher on invalid source location

### DIFF
--- a/lib/SIL/SILConstants.cpp
+++ b/lib/SIL/SILConstants.cpp
@@ -882,7 +882,12 @@ void SymbolicValue::emitUnknownDiagnosticNotes(SILLocation fallbackLoc) {
   bool emittedFirstNote =
       emitNoteDiagnostic(badInst, getUnknownReason(), fallbackLoc, error);
 
+  auto sourceLoc = fallbackLoc.getSourceLoc();
   auto &module = badInst->getModule();
+  if (sourceLoc.isInvalid()) {
+    diagnose(module.getASTContext(), sourceLoc, diag::constexpr_not_evaluable);
+    return;
+  }
   auto &SM = module.getASTContext().SourceMgr;
   unsigned originalDiagnosticLineNumber =
       SM.getLineNumber(fallbackLoc.getSourceLoc());


### PR DESCRIPTION
When const-folding a value inlined from another module, source locations are invalid and `SM.getLineNumber` triggers an assertion. This patch makes diagnostics be emitted just at the current location without going further, if the location is invalid.

Test cases are hard to construct for this simple fix, because it'll have to involve cross-module inlining.

Resolves [SR-8479](https://bugs.swift.org/browse/SR-8479).