### PR TITLE
[Sema] NFC: Refactor most TypeResolutionFlags into a traditional enum

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1194,8 +1194,7 @@ void ConstraintSystem::shrink(Expr *expr) {
             // instead of cloning representative.
             auto coercionRepr = typeRepr->clone(CS.getASTContext());
             // Let's try to resolve coercion type from cloned representative.
-            auto coercionType = CS.TC.resolveType(coercionRepr, CS.DC,
-                                                  TypeResolutionOptions());
+            auto coercionType = CS.TC.resolveType(coercionRepr, CS.DC, None);
 
             // Looks like coercion type is invalid, let's skip this sub-tree.
             if (coercionType->hasError())

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1846,8 +1846,7 @@ static void maybeAddAccessorsToBehaviorStorage(TypeChecker &TC, VarDecl *var) {
   };
 
   // Try to resolve the behavior to a protocol.
-  auto behaviorType = TC.resolveType(behavior->ProtocolName, dc,
-                                     TypeResolutionOptions());
+  auto behaviorType = TC.resolveType(behavior->ProtocolName, dc, None);
   if (!behaviorType) {
     return makeBehaviorAccessors();
   }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -981,7 +981,7 @@ ConstraintSystem::getTypeOfReference(ValueDecl *value,
   if (auto typeDecl = dyn_cast<TypeDecl>(value)) {
     // Resolve the reference to this type declaration in our current context.
     auto type = TC.resolveTypeInContext(typeDecl, nullptr, useDC,
-                                        TypeResolutionFlags::InExpression,
+                                        TypeResolverContext::InExpression,
                                         /*isSpecialized=*/false);
 
     // Open the type.

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1773,10 +1773,6 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
   SmallVector<Requirement, 4> convertedRequirements;
   SmallVector<RequirementRepr, 4> resolvedRequirements;
 
-  // Add all requirements from the "where" clause to the old signature
-  // to check if there are any inconsistencies.
-  auto options = TypeResolutionOptions();
-
   // Set of generic parameters being constrained. It is used to
   // determine if a full specialization misses requirements for
   // some of the generic parameters.
@@ -1785,8 +1781,8 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
   // Go over the set of requirements and resolve their types.
   for (auto &req : trailingWhereClause->getRequirements()) {
     if (req.getKind() == RequirementReprKind::SameType) {
-      auto firstType = TC.resolveType(req.getFirstTypeRepr(), FD, options);
-      auto secondType = TC.resolveType(req.getSecondTypeRepr(), FD, options);
+      auto firstType = TC.resolveType(req.getFirstTypeRepr(), FD, None);
+      auto secondType = TC.resolveType(req.getSecondTypeRepr(), FD, None);
       Type interfaceFirstType;
       Type interfaceSecondType;
 
@@ -1836,7 +1832,7 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
     }
 
     if (req.getKind() == RequirementReprKind::LayoutConstraint) {
-      auto subjectType = TC.resolveType(req.getSubjectRepr(), FD, options);
+      auto subjectType = TC.resolveType(req.getSubjectRepr(), FD, None);
       Type interfaceSubjectType;
 
       // Map types to their interface types.
@@ -1872,9 +1868,9 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
     }
 
     if (req.getKind() == RequirementReprKind::TypeConstraint) {
-      auto subjectType = TC.resolveType(req.getSubjectRepr(), FD, options);
+      auto subjectType = TC.resolveType(req.getSubjectRepr(), FD, None);
       auto constraint = TC.resolveType(
-          req.getConstraintLoc().getTypeRepr(), FD, options);
+          req.getConstraintLoc().getTypeRepr(), FD, None);
 
       Type interfaceSubjectType;
 
@@ -2038,11 +2034,11 @@ void AttributeChecker::visitDiscardableResultAttr(DiscardableResultAttr *attr) {
 
 void AttributeChecker::visitImplementsAttr(ImplementsAttr *attr) {
   TypeLoc &ProtoTypeLoc = attr->getProtocolType();
-  auto options = TypeResolutionFlags::AllowUnboundGenerics;
+  TypeResolutionOptions options = None;
+  options |= TypeResolutionFlags::AllowUnboundGenerics;
 
   DeclContext *DC = D->getDeclContext();
-  Type T = TC.resolveType(ProtoTypeLoc.getTypeRepr(),
-                          DC, options);
+  Type T = TC.resolveType(ProtoTypeLoc.getTypeRepr(), DC, options);
   ProtoTypeLoc.setType(T);
 
   // Definite error-types were already diagnosed in resolveType.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -214,9 +214,7 @@ void TypeChecker::resolveTrailingWhereClause(ProtocolDecl *proto) {
 
 void TypeChecker::validateWhereClauses(ProtocolDecl *protocol,
                                        GenericTypeResolver *resolver) {
-  TypeResolutionOptions options;
-
-  options |= TypeResolutionFlags::ProtocolWhereClause;
+  TypeResolutionOptions options(TypeResolverContext::ProtocolWhereClause);
 
   if (auto whereClause = protocol->getTrailingWhereClause()) {
     revertGenericRequirements(whereClause->getRequirements());
@@ -242,17 +240,17 @@ void TypeChecker::validateWhereClauses(ProtocolDecl *protocol,
 /// to which this type declaration conforms.
 void TypeChecker::checkInheritanceClause(Decl *decl,
                                          GenericTypeResolver *resolver) {
-  TypeResolutionOptions options;
+  TypeResolutionOptions options = None;
   DeclContext *DC;
   if (auto nominal = dyn_cast<NominalTypeDecl>(decl)) {
     DC = nominal;
-    options |= TypeResolutionFlags::GenericSignature;
-    options |= TypeResolutionFlags::InheritanceClause;
+    options = TypeResolutionOptions(TypeResolverContext::GenericSignature);
+    options.setContext(TypeResolverContext::InheritanceClause);
     options |= TypeResolutionFlags::AllowUnavailableProtocol;
   } else if (auto ext = dyn_cast<ExtensionDecl>(decl)) {
     DC = ext;
-    options |= TypeResolutionFlags::GenericSignature;
-    options |= TypeResolutionFlags::InheritanceClause;
+    options = TypeResolutionOptions(TypeResolverContext::GenericSignature);
+    options.setContext(TypeResolverContext::InheritanceClause);
     options |= TypeResolutionFlags::AllowUnavailableProtocol;
   } else if (isa<GenericTypeParamDecl>(decl)) {
     // For generic parameters, we want name lookup to look at just the
@@ -260,13 +258,13 @@ void TypeChecker::checkInheritanceClause(Decl *decl,
     DC = decl->getDeclContext();
     if (auto nominal = dyn_cast<NominalTypeDecl>(DC)) {
       DC = nominal;
-      options |= TypeResolutionFlags::GenericSignature;
+      options = TypeResolutionOptions(TypeResolverContext::GenericSignature);
     } else if (auto ext = dyn_cast<ExtensionDecl>(DC)) {
       DC = ext;
-      options |= TypeResolutionFlags::GenericSignature;
+      options = TypeResolutionOptions(TypeResolverContext::GenericSignature);
     } else if (auto func = dyn_cast<AbstractFunctionDecl>(DC)) {
       DC = func;
-      options |= TypeResolutionFlags::GenericSignature;
+      options = TypeResolutionOptions(TypeResolverContext::GenericSignature);
     } else if (!DC->isModuleScopeContext()) {
       // Skip the generic parameter's context entirely.
       DC = DC->getParent();
@@ -1036,9 +1034,7 @@ static void validatePatternBindingEntry(TypeChecker &tc,
   // In particular, it's /not/ correct to check the PBD's DeclContext because
   // top-level variables in a script file are accessible from other files,
   // even though the PBD is inside a TopLevelCodeDecl.
-  TypeResolutionOptions options = TypeResolutionFlags::PatternBindingEntry;
-  options |= TypeResolutionFlags::InExpression;
-  options |= TypeResolutionFlags::Direct;
+  TypeResolutionOptions options(TypeResolverContext::PatternBindingDecl);
 
   if (binding->getInit(entryNumber)) {
     // If we have an initializer, we can also have unknown types.
@@ -3418,7 +3414,7 @@ void TypeChecker::typeCheckDecl(Decl *D) {
 
 /// Validate the underlying type of the given typealias.
 static void validateTypealiasType(TypeChecker &tc, TypeAliasDecl *typeAlias) {
-  TypeResolutionOptions options = TypeResolutionFlags::TypeAliasUnderlyingType;
+  TypeResolutionOptions options(TypeResolverContext::TypeAliasDecl);
   if (!typeAlias->getDeclContext()->isCascadingContextForLookup(
         /*functionsAreNonCascading*/true)) {
      options |= TypeResolutionFlags::KnownNonCascadingDependency;
@@ -4376,7 +4372,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
       CompleteGenericTypeResolver resolver(*this, ED->getGenericSignature());
 
       typeCheckParameterList(PL, EED->getParentEnum(),
-                             TypeResolutionFlags::EnumCase, resolver);
+                             TypeResolverContext::EnumElementDecl, resolver);
       checkDefaultArguments(PL, EED);
     }
 
@@ -4482,8 +4478,7 @@ void TypeChecker::validateDeclForNameLookup(ValueDecl *D) {
           (void) typealias->getFormalAccess();
 
           ProtocolRequirementTypeResolver resolver;
-          TypeResolutionOptions options =
-            TypeResolutionFlags::TypeAliasUnderlyingType;
+          TypeResolutionOptions options(TypeResolverContext::TypeAliasDecl);
           if (validateType(typealias->getUnderlyingTypeLoc(),
                            typealias, options, &resolver)) {
             typealias->setInvalid();

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -245,12 +245,10 @@ void TypeChecker::checkInheritanceClause(Decl *decl,
   if (auto nominal = dyn_cast<NominalTypeDecl>(decl)) {
     DC = nominal;
     options = TypeResolutionOptions(TypeResolverContext::GenericSignature);
-    options.setContext(TypeResolverContext::InheritanceClause);
     options |= TypeResolutionFlags::AllowUnavailableProtocol;
   } else if (auto ext = dyn_cast<ExtensionDecl>(decl)) {
     DC = ext;
     options = TypeResolutionOptions(TypeResolverContext::GenericSignature);
-    options.setContext(TypeResolverContext::InheritanceClause);
     options |= TypeResolutionFlags::AllowUnavailableProtocol;
   } else if (isa<GenericTypeParamDecl>(decl)) {
     // For generic parameters, we want name lookup to look at just the

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -25,13 +25,13 @@ Type InheritedTypeRequest::evaluate(
                         llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
                         unsigned index) const {
   // Figure out how to resolve types.
-  TypeResolutionOptions options;
+  TypeResolutionOptions options = None;
   DeclContext *dc;
   if (auto typeDecl = decl.dyn_cast<TypeDecl *>()) {
     if (auto nominal = dyn_cast<NominalTypeDecl>(typeDecl)) {
       dc = nominal;
-      options |= TypeResolutionFlags::GenericSignature;
-      options |= TypeResolutionFlags::InheritanceClause;
+      options = TypeResolutionOptions(TypeResolverContext::GenericSignature);
+      options.setContext(TypeResolverContext::InheritanceClause);
       options |= TypeResolutionFlags::AllowUnavailableProtocol;
     } else {
       dc = typeDecl->getDeclContext();
@@ -41,13 +41,13 @@ Type InheritedTypeRequest::evaluate(
         // signature of the enclosing entity.
         if (auto nominal = dyn_cast<NominalTypeDecl>(dc)) {
           dc = nominal;
-          options |= TypeResolutionFlags::GenericSignature;
+          options = TypeResolutionOptions(TypeResolverContext::GenericSignature);
         } else if (auto ext = dyn_cast<ExtensionDecl>(dc)) {
           dc = ext;
-          options |= TypeResolutionFlags::GenericSignature;
+          options = TypeResolutionOptions(TypeResolverContext::GenericSignature);
         } else if (auto func = dyn_cast<AbstractFunctionDecl>(dc)) {
           dc = func;
-          options |= TypeResolutionFlags::GenericSignature;
+          options = TypeResolutionOptions(TypeResolverContext::GenericSignature);
         } else if (!dc->isModuleScopeContext()) {
           // Skip the generic parameter's context entirely.
           dc = dc->getParent();
@@ -57,8 +57,8 @@ Type InheritedTypeRequest::evaluate(
   } else {
     auto ext = decl.get<ExtensionDecl *>();
     dc = ext;
-    options |= TypeResolutionFlags::GenericSignature;
-    options |= TypeResolutionFlags::InheritanceClause;
+    options = TypeResolutionOptions(TypeResolverContext::GenericSignature);
+    options.setContext(TypeResolverContext::InheritanceClause);
     options |= TypeResolutionFlags::AllowUnavailableProtocol;
   }
 

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -31,7 +31,6 @@ Type InheritedTypeRequest::evaluate(
     if (auto nominal = dyn_cast<NominalTypeDecl>(typeDecl)) {
       dc = nominal;
       options = TypeResolutionOptions(TypeResolverContext::GenericSignature);
-      options.setContext(TypeResolverContext::InheritanceClause);
       options |= TypeResolutionFlags::AllowUnavailableProtocol;
     } else {
       dc = typeDecl->getDeclContext();
@@ -58,7 +57,6 @@ Type InheritedTypeRequest::evaluate(
     auto ext = decl.get<ExtensionDecl *>();
     dc = ext;
     options = TypeResolutionOptions(TypeResolverContext::GenericSignature);
-    options.setContext(TypeResolverContext::InheritanceClause);
     options |= TypeResolutionFlags::AllowUnavailableProtocol;
   }
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -629,10 +629,9 @@ public:
   }
   
   Stmt *visitForEachStmt(ForEachStmt *S) {
-    TypeResolutionOptions options;
+    TypeResolutionOptions options(TypeResolverContext::InExpression);
     options |= TypeResolutionFlags::AllowUnspecifiedTypes;
     options |= TypeResolutionFlags::AllowUnboundGenerics;
-    options |= TypeResolutionFlags::InExpression;
     
     if (auto *P = TC.resolvePattern(S->getPattern(), DC,
                                     /*isStmtCondition*/false)) {
@@ -926,8 +925,9 @@ public:
                                                  /*isStmtCondition*/false)) {
           pattern = newPattern;
           // Coerce the pattern to the subject's type.
+          TypeResolutionOptions patternOptions(TypeResolverContext::InExpression);
           if (!subjectType || TC.coercePatternToType(pattern, DC, subjectType,
-                                     TypeResolutionFlags::InExpression)) {
+                                     patternOptions)) {
             limitExhaustivityChecks = true;
 
             // If that failed, mark any variables binding pieces of the pattern
@@ -1132,9 +1132,8 @@ bool TypeChecker::typeCheckCatchPattern(CatchStmt *S, DeclContext *DC) {
     pattern = newPattern;
 
     // Coerce the pattern to the exception type.
-    if (!exnType ||
-        coercePatternToType(pattern, DC, exnType,
-                            TypeResolutionFlags::InExpression)) {
+    TypeResolutionOptions patternOptions(TypeResolverContext::InExpression);
+    if (!exnType || coercePatternToType(pattern, DC, exnType, patternOptions)) {
       // If that failed, be sure to give the variables error types
       // before we type-check the guard.  (This will probably kill
       // most of the type-checking, but maybe not.)

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1236,9 +1236,7 @@ static Type resolveNestedIdentTypeComponent(
   NameLookupOptions lookupOptions = defaultMemberLookupOptions;
   if (isKnownNonCascading)
     lookupOptions |= NameLookupFlags::KnownPrivate;
-  // FIXME: Lift the restriction for TypeResolutionFlags::InheritanceClause
-  if (options.is(TypeResolverContext::ExtensionBinding) ||
-      options.is(TypeResolverContext::InheritanceClause))
+  if (options.is(TypeResolverContext::ExtensionBinding))
     lookupOptions -= NameLookupFlags::ProtocolMembers;
   LookupTypeResult memberTypes;
   if (parentTy->mayHaveMembers())
@@ -2711,7 +2709,6 @@ Type TypeResolver::resolveImplicitlyUnwrappedOptionalType(
   case TypeResolverContext::ForEachStmt:
   case TypeResolverContext::ExtensionBinding:
   case TypeResolverContext::ExplicitCastExpr:
-  case TypeResolverContext::InheritanceClause:
   case TypeResolverContext::SubscriptDecl:
   case TypeResolverContext::EnumElementDecl:
   case TypeResolverContext::EnumPatternPayload:

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -315,9 +315,8 @@ Type TypeChecker::resolveTypeInContext(
 
 static TypeResolutionOptions
 adjustOptionsForGenericArgs(TypeResolutionOptions options) {
+  options.setContext(None);
   options -= TypeResolutionFlags::SILType;
-  options -= TypeResolutionFlags::FunctionInput;
-  options -= TypeResolutionFlags::TypeAliasUnderlyingType;
   options -= TypeResolutionFlags::AllowUnavailableProtocol;
 
   return options;
@@ -401,7 +400,7 @@ Type TypeChecker::applyGenericArguments(Type type,
       if (nominal->isOptionalDecl()) {
         // Validate the generic argument.
         TypeLoc arg = genericArgs[0];
-        if (validateType(arg, dc, withoutContext(options, true), resolver))
+        if (validateType(arg, dc, options.withoutContext(true), resolver))
           return nullptr;
 
         Type objectType = arg.getType();
@@ -414,7 +413,7 @@ Type TypeChecker::applyGenericArguments(Type type,
   }
 
   // Cannot extend a bound generic type.
-  if (options.contains(TypeResolutionFlags::ExtensionBinding)) {
+  if (options.is(TypeResolverContext::ExtensionBinding)) {
     if (!options.contains(TypeResolutionFlags::SilenceErrors)) {
       diagnose(loc, diag::extension_specialization,
                genericDecl->getName())
@@ -641,7 +640,7 @@ static Type resolveTypeDecl(TypeChecker &TC, TypeDecl *typeDecl, SourceLoc loc,
   assert(fromDC && "No declaration context for type resolution?");
 
   // Don't validate nominal type declarations during extension binding.
-  if (!options.contains(TypeResolutionFlags::ExtensionBinding) ||
+  if (!options.is(TypeResolverContext::ExtensionBinding) ||
       !isa<NominalTypeDecl>(typeDecl)) {
     // Validate the declaration.
     TC.validateDeclForNameLookup(typeDecl);
@@ -663,8 +662,8 @@ static Type resolveTypeDecl(TypeChecker &TC, TypeDecl *typeDecl, SourceLoc loc,
                             generic, resolver);
 
   if (type->is<UnboundGenericType>() && !generic &&
+      !options.is(TypeResolverContext::TypeAliasDecl) &&
       !options.contains(TypeResolutionFlags::AllowUnboundGenerics) &&
-      !options.contains(TypeResolutionFlags::TypeAliasUnderlyingType) &&
       !options.contains(TypeResolutionFlags::ResolveStructure)) {
     diagnoseUnboundGenericType(TC, type, loc);
     return ErrorType::get(TC.Context);
@@ -756,7 +755,7 @@ static Type diagnoseUnknownType(TypeChecker &tc, DeclContext *dc,
         // If this is a requirement, replacing 'Self' with a valid type will
         // result in additional unnecessary diagnostics (does not refer to a
         // generic parameter or associated type). Simply return an error type.
-        if (options.contains(TypeResolutionFlags::GenericRequirement))
+        if (options.is(TypeResolverContext::GenericRequirement))
           return ErrorType::get(tc.Context);
 
         auto type = resolver->mapTypeIntoContext(
@@ -775,7 +774,7 @@ static Type diagnoseUnknownType(TypeChecker &tc, DeclContext *dc,
 
     // Try ignoring access control.
     DeclContext *lookupDC = dc;
-    if (options.contains(TypeResolutionFlags::GenericSignature))
+    if (options.getBaseContext() == TypeResolverContext::GenericSignature)
       lookupDC = dc->getParentForLookup();
 
     NameLookupOptions relookupOptions = lookupOptions;
@@ -1008,7 +1007,7 @@ resolveTopLevelIdentTypeComponent(TypeChecker &TC, DeclContext *DC,
   DeclContext *lookupDC = DC;
 
   // Dynamic 'Self' in the result type of a function body.
-  if (options.contains(TypeResolutionFlags::DynamicSelfResult) &&
+  if (options.getBaseContext() == TypeResolverContext::DynamicSelfResult &&
       comp->getIdentifier() == TC.Context.Id_Self) {
     auto func = cast<FuncDecl>(DC);
     assert(func->hasDynamicSelf() && "Not marked as having dynamic Self?");
@@ -1024,7 +1023,7 @@ resolveTopLevelIdentTypeComponent(TypeChecker &TC, DeclContext *DC,
 
   // For lookups within the generic signature, look at the generic
   // parameters (only), then move up to the enclosing context.
-  if (options.contains(TypeResolutionFlags::GenericSignature)) {
+  if (options.getBaseContext() == TypeResolverContext::GenericSignature) {
     Type type = resolveGenericSignatureComponent(
       TC, DC, comp, options, resolver);
     if (type)
@@ -1135,8 +1134,8 @@ static Type resolveNestedIdentTypeComponent(
     }
 
     if (memberType->is<UnboundGenericType>() &&
+        !options.is(TypeResolverContext::TypeAliasDecl) &&
         !options.contains(TypeResolutionFlags::AllowUnboundGenerics) &&
-        !options.contains(TypeResolutionFlags::TypeAliasUnderlyingType) &&
         !options.contains(TypeResolutionFlags::ResolveStructure)) {
       diagnoseUnboundGenericType(TC, memberType, comp->getLoc());
       return ErrorType::get(TC.Context);
@@ -1168,7 +1167,7 @@ static Type resolveNestedIdentTypeComponent(
 
     // Only the last component of the underlying type of a type alias may
     // be an unbound generic.
-    if (options & TypeResolutionFlags::TypeAliasUnderlyingType) {
+    if (options.is(TypeResolverContext::TypeAliasDecl)) {
       if (parentTy->is<UnboundGenericType>()) {
         if (!options.contains(TypeResolutionFlags::SilenceErrors))
           diagnoseUnboundGenericType(TC, parentTy, parentRange.End);
@@ -1229,7 +1228,7 @@ static Type resolveNestedIdentTypeComponent(
 
   // Look for member types with the given name.
   bool isKnownNonCascading = options.contains(TypeResolutionFlags::KnownNonCascadingDependency);
-  if (!isKnownNonCascading && options.contains(TypeResolutionFlags::InExpression)) {
+  if (!isKnownNonCascading && options.isAnyExpr()) {
     // Expressions cannot affect a function's signature.
     isKnownNonCascading = isa<AbstractFunctionDecl>(DC);
   }
@@ -1238,8 +1237,8 @@ static Type resolveNestedIdentTypeComponent(
   if (isKnownNonCascading)
     lookupOptions |= NameLookupFlags::KnownPrivate;
   // FIXME: Lift the restriction for TypeResolutionFlags::InheritanceClause
-  if (options.contains(TypeResolutionFlags::ExtensionBinding) ||
-      options.contains(TypeResolutionFlags::InheritanceClause))
+  if (options.is(TypeResolverContext::ExtensionBinding) ||
+      options.is(TypeResolverContext::InheritanceClause))
     lookupOptions -= NameLookupFlags::ProtocolMembers;
   LookupTypeResult memberTypes;
   if (parentTy->mayHaveMembers())
@@ -1340,9 +1339,8 @@ static Type applyNonEscapingFromContext(DeclContext *DC,
                                         Type ty,
                                         TypeResolutionOptions options) {
   // Remember whether this is a function parameter.
-  bool defaultNoEscape =
-    !options.contains(TypeResolutionFlags::EnumCase) &&
-    options.contains(TypeResolutionFlags::FunctionInput);
+  bool defaultNoEscape = options.is(TypeResolverContext::FunctionInput) &&
+                         !options.hasBase(TypeResolverContext::EnumElementDecl);
 
   // Desugar here
   auto *funcTy = ty->castTo<FunctionType>();
@@ -1569,9 +1567,9 @@ Type TypeResolver::resolveType(TypeRepr *repr, TypeResolutionOptions options) {
       !isa<AttributedTypeRepr>(repr) && !isa<FunctionTypeRepr>(repr) &&
       !isa<IdentTypeRepr>(repr) &&
       !isa<ImplicitlyUnwrappedOptionalTypeRepr>(repr)) {
-    options -= TypeResolutionFlags::FunctionInput;
-    options -= TypeResolutionFlags::TypeAliasUnderlyingType;
+    options.setContext(None);
   }
+
 
   if (Context.LangOpts.DisableAvailabilityChecking)
     options |= TypeResolutionFlags::AllowUnavailable;
@@ -1679,11 +1677,11 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
   };
 
   // Remember whether this is a function parameter.
-  bool isParam = options.contains(TypeResolutionFlags::FunctionInput);
+  bool isParam = options.is(TypeResolverContext::FunctionInput);
 
   bool isVariadicFunctionParam =
-    !options.contains(TypeResolutionFlags::EnumCase) &&
-    options.contains(TypeResolutionFlags::VariadicFunctionInput);
+    options.is(TypeResolverContext::VariadicFunctionInput) &&
+    !options.hasBase(TypeResolverContext::EnumElementDecl);
 
   // The type we're working with, in case we want to build it differently
   // based on the attributes we see.
@@ -1708,9 +1706,8 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
           Optional<MetatypeRepresentation> storedRepr;
           // The instance type is not a SIL type.
           auto instanceOptions = options;
+          instanceOptions.setContext(None);
           instanceOptions -= TypeResolutionFlags::SILType;
-          instanceOptions -= TypeResolutionFlags::FunctionInput;
-          instanceOptions -= TypeResolutionFlags::TypeAliasUnderlyingType;
 
           auto instanceTy = resolveType(base, instanceOptions);
           if (!instanceTy || instanceTy->hasError())
@@ -1925,8 +1922,7 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
   }
 
   auto instanceOptions = options;
-  instanceOptions -= TypeResolutionFlags::FunctionInput;
-  instanceOptions -= TypeResolutionFlags::TypeAliasUnderlyingType;
+  instanceOptions.setContext(None);
 
   // If we didn't build the type differently above, we might have
   // a typealias pointing at a function type with the @escaping
@@ -1938,9 +1934,8 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
   // Handle @escaping
   if (hasFunctionAttr && ty->is<FunctionType>()) {
     if (attrs.has(TAK_escaping)) {
-      // The attribute is meaningless except on parameter types.
-      bool isEnum = options.contains(TypeResolutionFlags::EnumCase);
-      if (isEnum || !isParam) {
+      // The attribute is meaningless except on non-variadic parameter types.
+      if (!isParam || options.getBaseContext() == TypeResolverContext::EnumElementDecl) {
         auto loc = attrs.getLoc(TAK_escaping);
         auto attrRange = getTypeAttrRangeWithAt(TC, loc);
 
@@ -1948,7 +1943,7 @@ Type TypeResolver::resolveAttributedType(TypeAttributes &attrs,
             .fixItRemove(attrRange);
 
         // Try to find a helpful note based on how the type is being used
-        if (options.contains(TypeResolutionFlags::ImmediateOptionalTypeArgument)) {
+        if (options.is(TypeResolverContext::ImmediateOptionalTypeArgument)) {
           TC.diagnose(repr->getLoc(), diag::escaping_optional_type_argument);
         }
       }
@@ -2050,8 +2045,8 @@ bool TypeResolver::resolveASTFunctionTypeParams(
     SmallVectorImpl<AnyFunctionType::Param> &elements) {
   elements.reserve(inputRepr->getNumElements());
 
-  const auto elementOptions = withoutContext(options, true)
-                            | TypeResolutionFlags::FunctionInput;
+  auto elementOptions = options.withoutContext(true);
+  elementOptions.setContext(TypeResolverContext::FunctionInput);
   for (unsigned i = 0, end = inputRepr->getNumElements(); i != end; ++i) {
     auto *eltTypeRepr = inputRepr->getElementType(i);
 
@@ -2062,8 +2057,8 @@ bool TypeResolver::resolveASTFunctionTypeParams(
     bool variadic = false;
     if (inputRepr->hasEllipsis() &&
         elements.size() == inputRepr->getEllipsisIndex()) {
-      thisElementOptions = withoutContext(elementOptions);
-      thisElementOptions |= TypeResolutionFlags::VariadicFunctionInput;
+      thisElementOptions = elementOptions.withoutContext();
+      thisElementOptions.setContext(TypeResolverContext::VariadicFunctionInput);
       variadic = true;
     }
 
@@ -2116,12 +2111,10 @@ bool TypeResolver::resolveASTFunctionTypeParams(
 }
 
 Type TypeResolver::resolveASTFunctionType(FunctionTypeRepr *repr,
-                                          TypeResolutionOptions options,
+                                          TypeResolutionOptions parentOptions,
                                           FunctionType::ExtInfo extInfo) {
-  options -= TypeResolutionFlags::Direct;
-  options -= TypeResolutionFlags::FunctionInput;
-  options -= TypeResolutionFlags::FunctionResult;
-  options -= TypeResolutionFlags::TypeAliasUnderlyingType;
+  TypeResolutionOptions options = None;
+  options |= parentOptions.withoutContext().getFlags();
 
   SmallVector<AnyFunctionType::Param, 8> params;
   if (resolveASTFunctionTypeParams(repr->getArgsTypeRepr(), options,
@@ -2268,8 +2261,7 @@ Type TypeResolver::resolveSILFunctionType(FunctionTypeRepr *repr,
                                           SILFunctionType::ExtInfo extInfo,
                                           ParameterConvention callee,
                                           TypeRepr *witnessMethodProtocol) {
-  options -= TypeResolutionFlags::FunctionInput;
-  options -= TypeResolutionFlags::TypeAliasUnderlyingType;
+  options.setContext(None);
 
   bool hasError = false;
 
@@ -2305,8 +2297,9 @@ Type TypeResolver::resolveSILFunctionType(FunctionTypeRepr *repr,
     }
 
     for (auto elt : argsTuple->getElements()) {
-      auto param = resolveSILParameter(elt.Type,
-                       options | TypeResolutionFlags::FunctionInput);
+      auto elementOptions = options;
+      elementOptions.setContext(TypeResolverContext::FunctionInput);
+      auto param = resolveSILParameter(elt.Type, elementOptions);
       params.push_back(param);
       if (!param.getType()) return nullptr;
 
@@ -2409,17 +2402,16 @@ SILYieldInfo TypeResolver::resolveSILYield(TypeAttributes &attrs,
                                            TypeRepr *repr,
                                            TypeResolutionOptions options) {
   AttributedTypeRepr attrRepr(attrs, repr);
-  SILParameterInfo paramInfo =
-    resolveSILParameter(&attrRepr,
-                        options | TypeResolutionFlags::FunctionInput);
+  options.setContext(TypeResolverContext::FunctionInput);
+  SILParameterInfo paramInfo = resolveSILParameter(&attrRepr, options);
   return SILYieldInfo(paramInfo.getType(), paramInfo.getConvention());
 }
 
 SILParameterInfo TypeResolver::resolveSILParameter(
                                  TypeRepr *repr,
                                  TypeResolutionOptions options) {
-  assert(options.contains(TypeResolutionFlags::FunctionInput)
-         && "Parameters should be marked as inputs");
+  assert(options.is(TypeResolverContext::FunctionInput) &&
+         "Parameters should be marked as inputs");
   auto convention = DefaultParameterConvention;
   Type type;
   bool hadError = false;
@@ -2585,14 +2577,14 @@ Type TypeResolver::resolveSpecifierTypeRepr(SpecifierTypeRepr *repr,
                                             TypeResolutionOptions options) {
   // inout is only valid for (non-Subscript and non-EnumCaseDecl)
   // function parameters.
-  if ((options & TypeResolutionFlags::SubscriptParameters) ||
-      (options & TypeResolutionFlags::EnumCase) ||
-        (!(options & TypeResolutionFlags::FunctionInput))) {
+  if (!options.is(TypeResolverContext::FunctionInput) ||
+      options.hasBase(TypeResolverContext::SubscriptDecl) ||
+      options.hasBase(TypeResolverContext::EnumElementDecl)) {
 
     decltype(diag::attr_only_on_parameters) diagID;
-    if (options & TypeResolutionFlags::SubscriptParameters) {
+    if (options.getBaseContext() == TypeResolverContext::SubscriptDecl) {
       diagID = diag::attr_not_on_subscript_parameters;
-    } else if (options & TypeResolutionFlags::VariadicFunctionInput) {
+    } else if (options.is(TypeResolverContext::VariadicFunctionInput)) {
       diagID = diag::attr_not_on_variadic_parameters;
     } else {
       diagID = diag::attr_only_on_parameters;
@@ -2618,8 +2610,7 @@ Type TypeResolver::resolveSpecifierTypeRepr(SpecifierTypeRepr *repr,
 
   if (!isa<ImplicitlyUnwrappedOptionalTypeRepr>(repr->getBase())) {
     // Anything within the inout isn't a parameter anymore.
-    options -= TypeResolutionFlags::FunctionInput;
-    options -= TypeResolutionFlags::TypeAliasUnderlyingType;
+    options.setContext(None);
   }
 
   return resolveType(repr->getBase(), options);
@@ -2628,7 +2619,7 @@ Type TypeResolver::resolveSpecifierTypeRepr(SpecifierTypeRepr *repr,
 
 Type TypeResolver::resolveArrayType(ArrayTypeRepr *repr,
                                     TypeResolutionOptions options) {
-  Type baseTy = resolveType(repr->getBase(), withoutContext(options));
+  Type baseTy = resolveType(repr->getBase(), options.withoutContext());
   if (!baseTy || baseTy->hasError()) return baseTy;
 
   auto sliceTy = TC.getArraySliceType(repr->getBrackets().Start, baseTy);
@@ -2647,10 +2638,10 @@ Type TypeResolver::resolveDictionaryType(DictionaryTypeRepr *repr,
                                          TypeResolutionOptions options) {
   options = adjustOptionsForGenericArgs(options);
 
-  Type keyTy = resolveType(repr->getKey(), withoutContext(options));
+  Type keyTy = resolveType(repr->getKey(), options.withoutContext());
   if (!keyTy || keyTy->hasError()) return keyTy;
 
-  Type valueTy = resolveType(repr->getValue(), withoutContext(options));
+  Type valueTy = resolveType(repr->getValue(), options.withoutContext());
   if (!valueTy || valueTy->hasError()) return valueTy;
 
   auto dictDecl = TC.Context.getDictionaryDecl();
@@ -2683,8 +2674,8 @@ Type TypeResolver::resolveDictionaryType(DictionaryTypeRepr *repr,
 
 Type TypeResolver::resolveOptionalType(OptionalTypeRepr *repr,
                                        TypeResolutionOptions options) {
-  auto elementOptions = withoutContext(options, true);
-  elementOptions |= TypeResolutionFlags::ImmediateOptionalTypeArgument;
+  TypeResolutionOptions elementOptions = options.withoutContext(true);
+  elementOptions.setContext(TypeResolverContext::ImmediateOptionalTypeArgument);
 
   // The T in T? is a generic type argument and therefore always an AST type.
   // FIXME: diagnose non-materializability of element type!
@@ -2701,18 +2692,48 @@ Type TypeResolver::resolveImplicitlyUnwrappedOptionalType(
       ImplicitlyUnwrappedOptionalTypeRepr *repr,
       TypeResolutionOptions options,
       bool isDirect) {
-  TypeResolutionOptions allowIUO = TypeResolutionFlags::SILType;
-  allowIUO |= TypeResolutionFlags::FunctionInput;
-  allowIUO |= TypeResolutionFlags::FunctionResult;
-  allowIUO |= TypeResolutionFlags::PatternBindingEntry;
+  TypeResolutionFlags allowIUO = TypeResolutionFlags::SILType;
 
-  if (!isDirect || !(options & allowIUO)) {
+  bool doDiag = false;
+  switch (options.getContext()) {
+  case TypeResolverContext::None:
+    if (!isDirect || !(options & allowIUO))
+      doDiag = true;
+    break;
+  case TypeResolverContext::FunctionInput:
+  case TypeResolverContext::FunctionResult:
+  case TypeResolverContext::DynamicSelfResult:
+  case TypeResolverContext::PatternBindingDecl:
+    doDiag = !isDirect;
+    break;
+  case TypeResolverContext::VariadicFunctionInput:
+  case TypeResolverContext::ProtocolWhereClause:
+  case TypeResolverContext::ForEachStmt:
+  case TypeResolverContext::ExtensionBinding:
+  case TypeResolverContext::ExplicitCastExpr:
+  case TypeResolverContext::InheritanceClause:
+  case TypeResolverContext::SubscriptDecl:
+  case TypeResolverContext::EnumElementDecl:
+  case TypeResolverContext::EnumPatternPayload:
+  case TypeResolverContext::TypeAliasDecl:
+  case TypeResolverContext::GenericRequirement:
+  case TypeResolverContext::GenericSignature:
+  case TypeResolverContext::ImmediateOptionalTypeArgument:
+  case TypeResolverContext::InExpression:
+  case TypeResolverContext::EditorPlaceholderExpr:
+  case TypeResolverContext::AbstractFunctionDecl:
+  case TypeResolverContext::ClosureExpr:
+    doDiag = true;
+    break;
+  }
+
+  if (doDiag) {
     // Prior to Swift 5, we allow 'as T!' and turn it into a disjunction.
     if (TC.Context.isSwiftVersionAtLeast(5)) {
       TC.diagnose(repr->getStartLoc(),
                   diag::implicitly_unwrapped_optional_in_illegal_position)
           .fixItReplace(repr->getExclamationLoc(), "?");
-    } else if (options.contains(TypeResolutionFlags::InCastOrCoercionExpression)) {
+    } else if (options.is(TypeResolverContext::ExplicitCastExpr)) {
       TC.diagnose(
           repr->getStartLoc(),
           diag::implicitly_unwrapped_optional_deprecated_in_this_position);
@@ -2724,8 +2745,8 @@ Type TypeResolver::resolveImplicitlyUnwrappedOptionalType(
     }
   }
 
-  auto elementOptions = withoutContext(options, true);
-  elementOptions |= TypeResolutionFlags::ImmediateOptionalTypeArgument;
+  TypeResolutionOptions elementOptions = options.withoutContext(true);
+  elementOptions.setContext(TypeResolverContext::ImmediateOptionalTypeArgument);
 
   // The T in T! is a generic type argument and therefore always an AST type.
   // FIXME: diagnose non-materializability of element type!
@@ -2747,10 +2768,8 @@ Type TypeResolver::resolveTupleType(TupleTypeRepr *repr,
   elements.reserve(repr->getNumElements());
   
   auto elementOptions = options;
-  if (repr->isParenType()) {
-    elementOptions -= TypeResolutionFlags::Direct;
-  } else {
-    elementOptions = withoutContext(elementOptions, true);
+  if (!repr->isParenType()) {
+    elementOptions = elementOptions.withoutContext(true);
   }
 
   // Variadic tuples are not permitted.
@@ -2814,7 +2833,7 @@ Type TypeResolver::resolveCompositionType(CompositionTypeRepr *repr,
   };
 
   for (auto tyR : repr->getTypes()) {
-    Type ty = resolveType(tyR, withoutContext(options));
+    Type ty = resolveType(tyR, options.withoutContext());
     if (!ty || ty->hasError()) return ty;
 
     auto nominalDecl = ty->getAnyNominal();
@@ -2858,7 +2877,7 @@ Type TypeResolver::resolveCompositionType(CompositionTypeRepr *repr,
 Type TypeResolver::resolveMetatypeType(MetatypeTypeRepr *repr,
                                        TypeResolutionOptions options) {
   // The instance type of a metatype is always abstract, not SIL-lowered.
-  Type ty = resolveType(repr->getBase(), withoutContext(options));
+  Type ty = resolveType(repr->getBase(), options.withoutContext());
   if (!ty || ty->hasError()) return ty;
 
   Optional<MetatypeRepresentation> storedRepr;
@@ -2889,7 +2908,7 @@ Type TypeResolver::buildMetatypeType(
 Type TypeResolver::resolveProtocolType(ProtocolTypeRepr *repr,
                                        TypeResolutionOptions options) {
   // The instance type of a metatype is always abstract, not SIL-lowered.
-  Type ty = resolveType(repr->getBase(), withoutContext(options));
+  Type ty = resolveType(repr->getBase(), options.withoutContext());
   if (!ty || ty->hasError()) return ty;
 
   Optional<MetatypeRepresentation> storedRepr;

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -355,9 +355,8 @@ static void bindExtensionDecl(ExtensionDecl *ED, TypeChecker &TC) {
 
   // Validate the representation.
   // FIXME: Perform some kind of "shallow" validation here?
-  TypeResolutionOptions options;
+  TypeResolutionOptions options(TypeResolverContext::ExtensionBinding);
   options |= TypeResolutionFlags::AllowUnboundGenerics;
-  options |= TypeResolutionFlags::ExtensionBinding;
   if (TC.validateType(ED->getExtendedTypeLoc(), dc, options)) {
     ED->setInvalid();
     ED->getExtendedTypeLoc().setInvalidType(TC.Context);
@@ -476,8 +475,8 @@ void TypeChecker::resolveExtensionForConformanceConstruction(
     SmallVectorImpl<ConformanceConstructionInfo> &protocols) {
   // and the protocols which it inherits from:
   DependentGenericTypeResolver resolver;
-  TypeResolutionOptions options = TypeResolutionFlags::GenericSignature;
-  options |= TypeResolutionFlags::InheritanceClause;
+  TypeResolutionOptions options(TypeResolverContext::GenericSignature);
+  options.setContext(TypeResolverContext::InheritanceClause);
   options |= TypeResolutionFlags::AllowUnavailableProtocol;
   options |= TypeResolutionFlags::ResolveStructure;
   for (auto &inherited : ext->getInherited()) {
@@ -841,7 +840,7 @@ bool swift::performTypeLocChecking(ASTContext &Ctx, TypeLoc &T,
                                    GenericEnvironment *GenericEnv,
                                    DeclContext *DC,
                                    bool ProduceDiagnostics) {
-  TypeResolutionOptions options;
+  TypeResolutionOptions options = None;
 
   // Fine to have unbound generic types.
   options |= TypeResolutionFlags::AllowUnboundGenerics;

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -476,7 +476,6 @@ void TypeChecker::resolveExtensionForConformanceConstruction(
   // and the protocols which it inherits from:
   DependentGenericTypeResolver resolver;
   TypeResolutionOptions options(TypeResolverContext::GenericSignature);
-  options.setContext(TypeResolverContext::InheritanceClause);
   options |= TypeResolutionFlags::AllowUnavailableProtocol;
   options |= TypeResolutionFlags::ResolveStructure;
   for (auto &inherited : ext->getInherited()) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -552,10 +552,6 @@ enum class TypeResolverContext : uint8_t {
   /// Whether this type is being used in a cast or coercion expression.
   ExplicitCastExpr,
 
-  /// Whether we are in the inheritance clause of a nominal type declaration
-  /// or extension.
-  InheritanceClause,
-
   /// Whether this type is the value carried in an enum case.
   EnumElementDecl,
 
@@ -650,7 +646,6 @@ public:
     case Context::DynamicSelfResult:
     case Context::ProtocolWhereClause:
     case Context::ExtensionBinding:
-    case Context::InheritanceClause:
     case Context::SubscriptDecl:
     case Context::EnumElementDecl:
     case Context::EnumPatternPayload:

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -457,133 +457,256 @@ enum class RequirementCheckResult {
   Success, Failure, SubstitutionFailure
 };
 
-
 /// Flags that describe the context of type checking a pattern or
 /// type.
-enum class TypeResolutionFlags : unsigned {
+enum class TypeResolutionFlags : uint16_t {
   /// Whether to allow unspecified types within a pattern.
   AllowUnspecifiedTypes = 1 << 0,
 
-  /// Whether the given type can override the type of a typed pattern.
-  OverrideType = 1 << 1,
-
   /// Whether to allow unbound generic types.
-  AllowUnboundGenerics = 1 << 2,
+  AllowUnboundGenerics = 1 << 1,
+
+  /// Whether an unavailable protocol can be referenced.
+  AllowUnavailableProtocol = 1 << 2,
+
+  /// Whether we should allow references to unavailable types.
+  AllowUnavailable = 1 << 3,
+
+  /// Whether the given type can override the type of a typed pattern.
+  OverrideType = 1 << 4,
 
   /// Whether we are validating the type for SIL.
-  SILType = 1 << 3,
+  // FIXME: Move this flag to TypeResolverContext.
+  SILType = 1 << 5,
 
   /// Whether we are parsing a SIL file.  Not the same as SILType,
   /// because the latter is not set if we're parsing an AST type.
-  SILMode = 1 << 4,
+  SILMode = 1 << 6,
+
+  /// Whether this is a resolution based on a non-inferred type pattern.
+  FromNonInferredPattern = 1 << 7,
+
+  /// Whether this type resolution is guaranteed not to affect downstream files.
+  KnownNonCascadingDependency = 1 << 8,
+
+  /// Whether we should resolve only the structure of the resulting
+  /// type rather than its complete semantic properties.
+  ResolveStructure = 1 << 9,
+
+  /// Whether we are at the direct base of a type expression.
+  Direct = 1 << 10,
+
+  /// Whether we should not produce diagnostics if the type is invalid.
+  SilenceErrors = 1 << 11,
+};
+
+/// Type resolution contexts that require special handling.
+enum class TypeResolverContext : uint8_t {
+  /// No special type handling is required.
+  None,
+
+  /// Whether we are checking the parameter list of a function.
+  AbstractFunctionDecl,
+
+  /// Whether we are checking the parameter list of a subscript.
+  SubscriptDecl,
+
+  /// Whether we are checking the parameter list of a closure.
+  ClosureExpr,
 
   /// Whether we are in the input type of a function, or under one level of
   /// tuple type.  This is not set for multi-level tuple arguments.
   /// See also: TypeResolutionFlags::Direct
-  FunctionInput = 1 << 5,
+  FunctionInput,
 
   /// Whether this is a variadic function input.
-  VariadicFunctionInput = 1 << 6,
+  VariadicFunctionInput,
+
+  /// Whether we are in the result type of a function, including multi-level
+  /// tuple return values. See also: TypeResolutionFlags::Direct
+  FunctionResult,
 
   /// Whether we are in the result type of a function body that is
   /// known to produce dynamic Self.
-  DynamicSelfResult = 1 << 7,
+  DynamicSelfResult,
 
-  /// Whether this is a resolution based on a non-inferred type pattern.
-  FromNonInferredPattern = 1 << 8,
+  /// Whether we are in a protocol's where clause
+  ProtocolWhereClause,
+
+  /// Whether this is a pattern binding entry.
+  PatternBindingDecl,
 
   /// Whether we are the variable type in a for/in statement.
-  EnumerationVariable = 1 << 9,
+  ForEachStmt,
 
-  /// Whether we are looking only in the generic signature of the context
-  /// we're searching, rather than the entire context.
-  GenericSignature = 1 << 10,
-
-  /// Whether an unavailable protocol can be referenced.
-  AllowUnavailableProtocol = 1 << 11,
-
-  /// Whether this type is the value carried in an enum case.
-  EnumCase = 1 << 12,
+  /// Whether we are binding an extension declaration, which limits
+  /// the lookup.
+  ExtensionBinding,
 
   /// Whether this type is being used in an expression or local declaration.
   ///
   /// This affects what sort of dependencies are recorded when resolving the
   /// type.
-  InExpression = 1 << 13,
+  InExpression,
 
-  /// Whether this type resolution is guaranteed not to affect downstream files.
-  KnownNonCascadingDependency = 1 << 14,
-
-  /// Whether we should allow references to unavailable types.
-  AllowUnavailable = 1 << 15,
-
-  /// Whether this is the payload subpattern of an enum pattern.
-  EnumPatternPayload = 1 << 16,
-
-  /// Whether we are binding an extension declaration, which limits
-  /// the lookup.
-  ExtensionBinding = 1 << 17,
+  /// Whether this type is being used in a cast or coercion expression.
+  ExplicitCastExpr,
 
   /// Whether we are in the inheritance clause of a nominal type declaration
   /// or extension.
-  InheritanceClause = 1 << 18,
+  InheritanceClause,
 
-  /// Whether we should resolve only the structure of the resulting
-  /// type rather than its complete semantic properties.
-  ResolveStructure = 1 << 19,
+  /// Whether this type is the value carried in an enum case.
+  EnumElementDecl,
 
-  /// Whether this is the type of an editor placeholder.
-  EditorPlaceholder = 1 << 20,
-
-  /// Whether we are in a type argument for an optional
-  ImmediateOptionalTypeArgument = 1 << 21,
+  /// Whether this is the payload subpattern of an enum pattern.
+  EnumPatternPayload,
 
   /// Whether we are checking the underlying type of a typealias.
-  TypeAliasUnderlyingType = 1 << 22,
+  TypeAliasDecl,
 
-  /// Whether we are checking the parameter list of a subscript.
-  SubscriptParameters = 1 << 23,
-
-  /// Whether we are at the direct base of a type expression.
-  Direct = 1 << 24,
-
-  /// Whether this type is being used in a cast or coercion expression.
-  InCastOrCoercionExpression = 1 << 25,
+  /// Whether we are looking only in the generic signature of the context
+  /// we're searching, rather than the entire context.
+  GenericSignature,
 
   /// Whether we are in a requirement of a generic declaration
-  GenericRequirement = 1 << 26,
+  GenericRequirement,
 
-  /// Whether we are in a protocol's where clause
-  ProtocolWhereClause = 1 << 27,
+  /// Whether we are in a type argument for an optional
+  ImmediateOptionalTypeArgument,
 
-  /// Whether we should not produce diagnostics if the type is invalid.
-  SilenceErrors = 1 << 28,
-
-  /// Whether we are in the result type of a function, including multi-level
-  /// tuple return values. See also: TypeResolutionFlags::Direct
-  FunctionResult = 1 << 29,
-
-  /// Whether this is a pattern binding entry.
-  PatternBindingEntry = 1 << 30,
+  /// Whether this is the type of an editor placeholder.
+  EditorPlaceholderExpr,
 };
 
-/// Option set describing how type resolution should work.
-using TypeResolutionOptions = OptionSet<TypeResolutionFlags>;
+/// Options that determine how type resolution should work.
+class TypeResolutionOptions {
+  using Context = TypeResolverContext;
 
-/// Strip the contextual options from the given type resolution options.
-static inline TypeResolutionOptions
-withoutContext(TypeResolutionOptions options, bool preserveSIL = false) {
-  options -= TypeResolutionFlags::Direct;
-  options -= TypeResolutionFlags::FunctionInput;
-  options -= TypeResolutionFlags::VariadicFunctionInput;
-  options -= TypeResolutionFlags::FunctionResult;
-  options -= TypeResolutionFlags::EnumCase;
-  options -= TypeResolutionFlags::SubscriptParameters;
-  options -= TypeResolutionFlags::ImmediateOptionalTypeArgument;
-  options -= TypeResolutionFlags::PatternBindingEntry;
-  if (!preserveSIL) options -= TypeResolutionFlags::SILType;
-  return options;
-}
+  // The "base" type resolution context. This never changes.
+  Context base = Context::None;
+  // The current type resolution context.
+  Context context = Context::None;
+  // TypeResolutionFlags
+  uint16_t flags = 0;
+  static_assert(sizeof(flags) == sizeof(TypeResolutionFlags),
+      "Flags size error");
+
+public:
+  ~TypeResolutionOptions() = default;
+  TypeResolutionOptions(const TypeResolutionOptions &) = default;
+  TypeResolutionOptions(TypeResolutionOptions &&) = default;
+  TypeResolutionOptions &operator =(const TypeResolutionOptions &) = default;
+  TypeResolutionOptions &operator =(TypeResolutionOptions &&) = default;
+
+  // NOTE: Use either setContext() or explicit construction and assignment.
+  void operator =(const Context &) = delete;
+  void operator =(Context &&) = delete;
+
+  // NOTE: "None" might be more permissive than one wants, therefore no
+  // reasonable default context is possible.
+  TypeResolutionOptions() = delete;
+
+  TypeResolutionOptions(Context context) : base(context), context(context),
+      flags(unsigned(TypeResolutionFlags::Direct)) {}
+  // Helper forwarding constructors:
+  TypeResolutionOptions(llvm::NoneType) : TypeResolutionOptions(Context::None){}
+
+  /// Test the current type resolution base context.
+  bool hasBase(Context context) const { return base == context; }
+
+  /// Get the base type resolution context.
+  Context getBaseContext() const { return base; }
+
+  /// Test the current type resolution context.
+  bool is(Context context) const { return this->context == context; }
+
+  /// Get the current type resolution context.
+  Context getContext() const { return context; }
+  /// Set the current type resolution context.
+  void setContext(Context newContext) {
+    context = newContext;
+    flags &= ~unsigned(TypeResolutionFlags::Direct);
+  }
+  void setContext(llvm::NoneType) { setContext(Context::None); }
+
+  /// Get the current flags.
+  TypeResolutionFlags getFlags() const { return TypeResolutionFlags(flags); }
+
+  /// Is this type resolution context an expression.
+  bool isAnyExpr() const {
+    switch (base) {
+    case Context::InExpression:
+    case Context::ExplicitCastExpr:
+    case Context::ForEachStmt:
+    case Context::PatternBindingDecl:
+    case Context::EditorPlaceholderExpr:
+    case Context::ClosureExpr:
+      return true;
+    case Context::None:
+    case Context::FunctionInput:
+    case Context::VariadicFunctionInput:
+    case Context::FunctionResult:
+    case Context::DynamicSelfResult:
+    case Context::ProtocolWhereClause:
+    case Context::ExtensionBinding:
+    case Context::InheritanceClause:
+    case Context::SubscriptDecl:
+    case Context::EnumElementDecl:
+    case Context::EnumPatternPayload:
+    case Context::TypeAliasDecl:
+    case Context::GenericSignature:
+    case Context::GenericRequirement:
+    case Context::ImmediateOptionalTypeArgument:
+    case Context::AbstractFunctionDecl:
+      return false;
+    }
+  }
+
+  /// Determine whether all of the given options are set.
+  bool contains(TypeResolutionFlags set) const {
+    return !static_cast<bool>(unsigned(set) & ~unsigned(flags));
+  }
+
+  /// Produce type resolution options with additional flags.
+  friend TypeResolutionOptions operator|(TypeResolutionOptions lhs,
+                                         TypeResolutionFlags rhs) {
+    return lhs |= rhs;
+  }
+
+  /// Merge additional flags into type resolution options.
+  friend TypeResolutionOptions &operator|=(TypeResolutionOptions &lhs,
+                                           TypeResolutionFlags rhs) {
+    lhs.flags |= unsigned(rhs);
+    return lhs;
+  }
+
+  /// Test whether any given flag is set in the type resolution options.
+  friend bool operator&(TypeResolutionOptions lhs, TypeResolutionFlags rhs) {
+    return lhs.flags & unsigned(rhs);
+  }
+
+  /// Produce type resolution options with removed flags.
+  friend TypeResolutionOptions operator-(TypeResolutionOptions lhs,
+                                         TypeResolutionFlags rhs) {
+    return lhs -= rhs;
+  }
+
+  /// Remove the flags from the type resolution options.
+  friend TypeResolutionOptions &operator-=(TypeResolutionOptions &lhs,
+                                           TypeResolutionFlags rhs) {
+    lhs.flags &= ~unsigned(rhs);
+    return lhs;
+  }
+  /// Strip the contextual options from the given type resolution options.
+  inline TypeResolutionOptions withoutContext(bool preserveSIL = false) const {
+    auto copy = *this;
+    copy.setContext(None);
+    // FIXME: Move SILType to TypeResolverContext.
+    if (!preserveSIL) copy -= TypeResolutionFlags::SILType;
+    return copy;
+  }
+};
 
 /// Flags that control protocol conformance checking.
 enum class ConformanceCheckFlags {


### PR DESCRIPTION
`TypeResolutionFlags` is overly complicated at the moment because the vast majority of flag combinations are impossible and nonsensical. With this patch, we create a new `TypeResolverContext` type that is a classic enum and far easier to reason about. It also enables "exhaustive enum" checking, unlike the "flags" based approach.