### PR TITLE
Add a new SourceFileKind and InputFileKind for textual interfaces

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -100,7 +100,8 @@ enum class SourceFileKind {
   Library,  ///< A normal .swift file.
   Main,     ///< A .swift file that can have top-level code.
   REPL,     ///< A virtual file that holds the user's input in the REPL.
-  SIL       ///< Came from a .sil file.
+  SIL,      ///< Came from a .sil file.
+  Interface ///< Came from a .swiftinterface file, representing another module.
 };
 
 /// Discriminator for resilience strategy.
@@ -1021,6 +1022,7 @@ public:
       return true;
       
     case SourceFileKind::Library:
+    case SourceFileKind::Interface:
     case SourceFileKind::SIL:
       return false;
     }

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -293,7 +293,7 @@ public:
   std::string getPCHHash() const;
 
   SourceFile::ImplicitModuleImportKind getImplicitModuleImportKind() {
-    if (getInputKind() == InputFileKind::IFK_SIL) {
+    if (getInputKind() == InputFileKind::SIL) {
       return SourceFile::ImplicitModuleImportKind::None;
     }
     if (getParseStdlib()) {
@@ -310,7 +310,7 @@ public:
                        bool alwaysSetModuleToMain, bool bePrimary,
                        serialization::ExtendedValidationInfo &extendedInfo);
   bool hasSerializedAST() {
-    return FrontendOpts.InputKind == InputFileKind::IFK_Swift_Library;
+    return FrontendOpts.InputKind == InputFileKind::SwiftLibrary;
   }
 
   const PrimarySpecificPaths &
@@ -507,10 +507,10 @@ private:
   void setUpDiagnosticOptions();
   bool setUpModuleLoaders();
   bool isInputSwift() {
-    return Invocation.getInputKind() == InputFileKind::IFK_Swift;
+    return Invocation.getInputKind() == InputFileKind::Swift;
   }
   bool isInSILMode() {
-    return Invocation.getInputKind() == InputFileKind::IFK_SIL;
+    return Invocation.getInputKind() == InputFileKind::SIL;
   }
 
   bool setUpInputs();

--- a/include/swift/Frontend/FrontendInputsAndOutputs.h
+++ b/include/swift/Frontend/FrontendInputsAndOutputs.h
@@ -152,6 +152,7 @@ public:
   // treat the input as LLVM_IR.
   bool shouldTreatAsLLVM() const;
   bool shouldTreatAsSIL() const;
+  bool shouldTreatAsModuleInterface() const;
 
   bool areAllNonPrimariesSIB() const;
 

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -36,7 +36,7 @@ public:
   FrontendInputsAndOutputs InputsAndOutputs;
 
   /// The kind of input on which the frontend should operate.
-  InputFileKind InputKind = InputFileKind::IFK_Swift;
+  InputFileKind InputKind = InputFileKind::Swift;
 
   void forAllOutputPaths(const InputFile &input,
                          llvm::function_ref<void(StringRef)> fn) const;
@@ -291,7 +291,7 @@ public:
   StringRef determineFallbackModuleName() const;
 
   bool isCompilingExactlyOneSwiftFile() const {
-    return InputKind == InputFileKind::IFK_Swift &&
+    return InputKind == InputFileKind::Swift &&
            InputsAndOutputs.hasSingleInput();
   }
 

--- a/include/swift/Frontend/InputFile.h
+++ b/include/swift/Frontend/InputFile.h
@@ -26,6 +26,7 @@ enum class InputFileKind {
   Swift,
   SwiftLibrary,
   SwiftREPL,
+  SwiftModuleInterface,
   SIL,
   LLVM
 };

--- a/include/swift/Frontend/InputFile.h
+++ b/include/swift/Frontend/InputFile.h
@@ -22,12 +22,12 @@
 namespace swift {
 
 enum class InputFileKind {
-  IFK_None,
-  IFK_Swift,
-  IFK_Swift_Library,
-  IFK_Swift_REPL,
-  IFK_SIL,
-  IFK_LLVM_IR
+  None,
+  Swift,
+  SwiftLibrary,
+  SwiftREPL,
+  SIL,
+  LLVM
 };
 
 // Inputs may include buffers that override contents, and eventually should

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1379,6 +1379,7 @@ bool SourceFile::shouldCollectToken() const {
   switch (Kind) {
   case SourceFileKind::Library:
   case SourceFileKind::Main:
+  case SourceFileKind::Interface:
     return (bool)AllCorrectedTokens;
   case SourceFileKind::REPL:
   case SourceFileKind::SIL:
@@ -1390,6 +1391,7 @@ bool SourceFile::shouldBuildSyntaxTree() const {
   switch (Kind) {
   case SourceFileKind::Library:
   case SourceFileKind::Main:
+  case SourceFileKind::Interface:
     return SyntaxInfo.Enable;
   case SourceFileKind::REPL:
   case SourceFileKind::SIL:

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -378,15 +378,15 @@ bool ArgsToFrontendOptionsConverter::setUpForSILOrLLVM() {
   }
 
   if (treatAsSIL)
-    Opts.InputKind = InputFileKind::IFK_SIL;
+    Opts.InputKind = InputFileKind::SIL;
   else if (treatAsLLVM)
-    Opts.InputKind = InputFileKind::IFK_LLVM_IR;
+    Opts.InputKind = InputFileKind::LLVM;
   else if (Args.hasArg(OPT_parse_as_library))
-    Opts.InputKind = InputFileKind::IFK_Swift_Library;
+    Opts.InputKind = InputFileKind::SwiftLibrary;
   else if (Opts.RequestedAction == FrontendOptions::ActionType::REPL)
-    Opts.InputKind = InputFileKind::IFK_Swift_REPL;
+    Opts.InputKind = InputFileKind::SwiftREPL;
   else
-    Opts.InputKind = InputFileKind::IFK_Swift;
+    Opts.InputKind = InputFileKind::Swift;
 
   return false;
 }

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -118,7 +118,7 @@ bool ArgsToFrontendOptionsConverter::convert(
     return true;
   }
 
-  if (setUpForSILOrLLVM())
+  if (setUpInputKindAndImmediateArgs())
     return true;
 
   if (computeModuleName())
@@ -355,11 +355,10 @@ ArgsToFrontendOptionsConverter::determineRequestedAction(const ArgList &args) {
   llvm_unreachable("Unhandled mode option");
 }
 
-bool ArgsToFrontendOptionsConverter::setUpForSILOrLLVM() {
+bool ArgsToFrontendOptionsConverter::setUpInputKindAndImmediateArgs() {
   using namespace options;
   bool treatAsSIL =
       Args.hasArg(OPT_parse_sil) || Opts.InputsAndOutputs.shouldTreatAsSIL();
-  bool treatAsLLVM = Opts.InputsAndOutputs.shouldTreatAsLLVM();
 
   if (Opts.InputsAndOutputs.verifyInputs(
           Diags, treatAsSIL,
@@ -379,8 +378,10 @@ bool ArgsToFrontendOptionsConverter::setUpForSILOrLLVM() {
 
   if (treatAsSIL)
     Opts.InputKind = InputFileKind::SIL;
-  else if (treatAsLLVM)
+  else if (Opts.InputsAndOutputs.shouldTreatAsLLVM())
     Opts.InputKind = InputFileKind::LLVM;
+  else if (Opts.InputsAndOutputs.shouldTreatAsModuleInterface())
+    Opts.InputKind = InputFileKind::SwiftModuleInterface;
   else if (Args.hasArg(OPT_parse_as_library))
     Opts.InputKind = InputFileKind::SwiftLibrary;
   else if (Opts.RequestedAction == FrontendOptions::ActionType::REPL)

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.h
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.h
@@ -50,7 +50,7 @@ private:
   void setUnsignedIntegerArgument(options::ID optionID, unsigned radix,
                                   unsigned &valueToSet);
 
-  bool setUpForSILOrLLVM();
+  bool setUpInputKindAndImmediateArgs();
 
   bool checkUnusedSupplementaryOutputPaths() const;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -65,16 +65,16 @@ void CompilerInvocation::setTargetTriple(StringRef Triple) {
 
 SourceFileKind CompilerInvocation::getSourceFileKind() const {
   switch (getInputKind()) {
-  case InputFileKind::IFK_Swift:
+  case InputFileKind::Swift:
     return SourceFileKind::Main;
-  case InputFileKind::IFK_Swift_Library:
+  case InputFileKind::SwiftLibrary:
     return SourceFileKind::Library;
-  case InputFileKind::IFK_Swift_REPL:
+  case InputFileKind::SwiftREPL:
     return SourceFileKind::REPL;
-  case InputFileKind::IFK_SIL:
+  case InputFileKind::SIL:
     return SourceFileKind::SIL;
-  case InputFileKind::IFK_None:
-  case InputFileKind::IFK_LLVM_IR:
+  case InputFileKind::None:
+  case InputFileKind::LLVM:
     llvm_unreachable("Trying to convert from unsupported InputFileKind");
   }
 
@@ -171,7 +171,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.DisableTsanInoutInstrumentation |=
       Args.hasArg(OPT_disable_tsan_inout_instrumentation);
 
-  if (FrontendOpts.InputKind == InputFileKind::IFK_SIL)
+  if (FrontendOpts.InputKind == InputFileKind::SIL)
     Opts.DisableAvailabilityChecking = true;
   
   if (auto A = Args.getLastArg(OPT_enable_access_control,
@@ -1204,13 +1204,13 @@ CompilerInvocation::setUpInputForSILTool(
                                ? moduleNameArg
                                : llvm::sys::path::stem(inputFilename);
     setModuleName(stem);
-    setInputKind(InputFileKind::IFK_Swift_Library);
+    setInputKind(InputFileKind::SwiftLibrary);
   } else {
     const StringRef name = (alwaysSetModuleToMain || moduleNameArg.empty())
                                ? "main"
                                : moduleNameArg;
     setModuleName(name);
-    setInputKind(InputFileKind::IFK_SIL);
+    setInputKind(InputFileKind::SIL);
   }
   return fileBufOrErr;
 }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -71,6 +71,8 @@ SourceFileKind CompilerInvocation::getSourceFileKind() const {
     return SourceFileKind::Library;
   case InputFileKind::SwiftREPL:
     return SourceFileKind::REPL;
+  case InputFileKind::SwiftModuleInterface:
+    return SourceFileKind::Interface;
   case InputFileKind::SIL:
     return SourceFileKind::SIL;
   case InputFileKind::None:

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -498,7 +498,7 @@ void CompilerInstance::performSemaUpTo(SourceFile::ASTStage_t LimitStage) {
   FrontendStatsTracer tracer(Context->Stats, "perform-sema");
   Context->LoadedModules[MainModule->getName()] = getMainModule();
 
-  if (Invocation.getInputKind() == InputFileKind::IFK_SIL) {
+  if (Invocation.getInputKind() == InputFileKind::SIL) {
     assert(!InputSourceCodeBufferIDs.empty());
     assert(InputSourceCodeBufferIDs.size() == 1);
     assert(MainBufferID != NO_SUCH_BUFFER);
@@ -517,7 +517,7 @@ void CompilerInstance::performSemaUpTo(SourceFile::ASTStage_t LimitStage) {
 
   const ImplicitImports implicitImports(*this);
 
-  if (Invocation.getInputKind() == InputFileKind::IFK_Swift_REPL) {
+  if (Invocation.getInputKind() == InputFileKind::SwiftREPL) {
     createREPLFile(implicitImports);
     return;
   }
@@ -914,15 +914,15 @@ void CompilerInstance::performParseOnly(bool EvaluateConditionals) {
   ModuleDecl *const MainModule = getMainModule();
   Context->LoadedModules[MainModule->getName()] = MainModule;
 
-  assert((Kind == InputFileKind::IFK_Swift ||
-          Kind == InputFileKind::IFK_Swift_Library) &&
+  assert((Kind == InputFileKind::Swift ||
+          Kind == InputFileKind::SwiftLibrary) &&
          "only supports parsing .swift files");
   (void)Kind;
 
   // Make sure the main file is the first file in the module but parse it last,
   // to match the parsing logic used when performing Sema.
   if (MainBufferID != NO_SUCH_BUFFER) {
-    assert(Kind == InputFileKind::IFK_Swift);
+    assert(Kind == InputFileKind::Swift);
     createSourceFileForMainModule(Invocation.getSourceFileKind(),
                                   SourceFile::ImplicitModuleImportKind::None,
                                   MainBufferID);

--- a/lib/Frontend/FrontendInputsAndOutputs.cpp
+++ b/lib/Frontend/FrontendInputsAndOutputs.cpp
@@ -168,6 +168,15 @@ bool FrontendInputsAndOutputs::shouldTreatAsLLVM() const {
   return false;
 }
 
+bool FrontendInputsAndOutputs::shouldTreatAsModuleInterface() const {
+  if (!hasSingleInput())
+    return false;
+
+  StringRef InputExt = llvm::sys::path::extension(getFilenameOfFirstInput());
+  file_types::ID InputType = file_types::lookupTypeForExtension(InputExt);
+  return InputType == file_types::TY_SwiftModuleInterfaceFile;
+}
+
 bool FrontendInputsAndOutputs::shouldTreatAsSIL() const {
   if (hasSingleInput()) {
     // If we have exactly one input filename, and its extension is "sil",

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -912,7 +912,7 @@ static bool performCompile(CompilerInstance &Instance,
   if (Action == FrontendOptions::ActionType::EmitPCH)
     return precompileBridgingHeader(Invocation, Instance);
 
-  if (Invocation.getInputKind() == InputFileKind::IFK_LLVM_IR)
+  if (Invocation.getInputKind() == InputFileKind::LLVM)
     return compileLLVMIR(Invocation, Instance, Stats);
 
   if (FrontendOptions::shouldActionOnlyParse(Action)) {

--- a/lib/FrontendTool/TBD.cpp
+++ b/lib/FrontendTool/TBD.cpp
@@ -57,13 +57,13 @@ bool swift::inputFileKindCanHaveTBDValidated(InputFileKind kind) {
   // Only things that involve an AST can have a TBD file computed, at the
   // moment.
   switch (kind) {
-  case InputFileKind::IFK_Swift:
-  case InputFileKind::IFK_Swift_Library:
+  case InputFileKind::Swift:
+  case InputFileKind::SwiftLibrary:
     return true;
-  case InputFileKind::IFK_None:
-  case InputFileKind::IFK_Swift_REPL:
-  case InputFileKind::IFK_SIL:
-  case InputFileKind::IFK_LLVM_IR:
+  case InputFileKind::None:
+  case InputFileKind::SwiftREPL:
+  case InputFileKind::SIL:
+  case InputFileKind::LLVM:
     return false;
   }
 }

--- a/lib/FrontendTool/TBD.cpp
+++ b/lib/FrontendTool/TBD.cpp
@@ -60,6 +60,9 @@ bool swift::inputFileKindCanHaveTBDValidated(InputFileKind kind) {
   case InputFileKind::Swift:
   case InputFileKind::SwiftLibrary:
     return true;
+  case InputFileKind::SwiftModuleInterface:
+    // FIXME: This would be a good test of the interface format.
+    return false;
   case InputFileKind::None:
   case InputFileKind::SwiftREPL:
   case InputFileKind::SIL:

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3105,10 +3105,18 @@ public:
         return false;
     }
 
-    // Declarations in SIL don't require definitions.
+    // Declarations in SIL and textual interface files don't require
+    // definitions.
     if (auto sourceFile = decl->getDeclContext()->getParentSourceFile()) {
-      if (sourceFile->Kind == SourceFileKind::SIL)
+      switch (sourceFile->Kind) {
+      case SourceFileKind::SIL:
+      case SourceFileKind::Interface:
         return false;
+      case SourceFileKind::Library:
+      case SourceFileKind::Main:
+      case SourceFileKind::REPL:
+        break;
+      }
     }
 
     // Everything else requires a definition.

--- a/test/ModuleInterface/SmokeTest.swiftinterface
+++ b/test/ModuleInterface/SmokeTest.swiftinterface
@@ -1,0 +1,10 @@
+// Make sure parse-only works...
+// RUN: %target-swift-frontend -parse %s
+
+// ...and then make sure parse-and-typecheck-and-serialize works.
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t/SmokeTest.swiftmodule %s
+// RUN: %target-swift-ide-test -print-module -module-to-print SmokeTest -I %t -source-filename x -print-access | %FileCheck %s
+
+// CHECK: public func verySimpleFunction(){{$}}
+public func verySimpleFunction()

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -165,7 +165,8 @@ if platform.system() == 'Darwin':
 config.test_format = swift_test.SwiftTest(coverage_mode=config.coverage_mode)
 
 # suffixes: A list of file extensions to treat as test files.
-config.suffixes = ['.swift', '.ll', '.sil', '.gyb', '.m', '.test-sh']
+config.suffixes = ['.swift', '.ll', '.sil', '.gyb', '.m', '.swiftinterface',
+                   '.test-sh']
 
 # excludes: A list of directories to exclude from the testsuite. The 'Inputs'
 # subdirectories contain auxiliary inputs for various tests in their parent

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -776,7 +776,7 @@ static bool makeParserAST(CompilerInstance &CI, StringRef Text,
                           CompilerInvocation Invocation) {
   Invocation.getFrontendOptions().InputsAndOutputs.clearInputs();
   Invocation.setModuleName("main");
-  Invocation.setInputKind(InputFileKind::IFK_Swift);
+  Invocation.setInputKind(InputFileKind::Swift);
 
   std::unique_ptr<llvm::MemoryBuffer> Buf;
   Buf = llvm::MemoryBuffer::getMemBuffer(Text, "<module-interface>");
@@ -1361,7 +1361,7 @@ SourceFile *SwiftLangSupport::getSyntacticSourceFile(
     Error = "Compiler invocation init failed";
     return nullptr;
   }
-  Invocation.setInputKind(InputFileKind::IFK_Swift);
+  Invocation.setInputKind(InputFileKind::Swift);
   Invocation.getFrontendOptions().InputsAndOutputs.addInput(
       InputFile(InputBuf->getBufferIdentifier(), false, InputBuf));
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -231,7 +231,7 @@ static bool makeParserAST(CompilerInstance &CI, StringRef Text,
                           CompilerInvocation Invocation) {
   Invocation.getFrontendOptions().InputsAndOutputs.clearInputs();
   Invocation.setModuleName("main");
-  Invocation.setInputKind(InputFileKind::IFK_Swift);
+  Invocation.setInputKind(InputFileKind::Swift);
 
   std::unique_ptr<llvm::MemoryBuffer> Buf;
   Buf = llvm::MemoryBuffer::getMemBuffer(Text, "<module-interface>");

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -761,7 +761,7 @@ static int doREPLCodeCompletion(const CompilerInvocation &InitInvok,
     BufferText = BufferText.drop_back(1);
 
   CompilerInvocation Invocation(InitInvok);
-  Invocation.setInputKind(InputFileKind::IFK_Swift_REPL);
+  Invocation.setInputKind(InputFileKind::SwiftREPL);
 
   CompilerInstance CI;
 
@@ -3037,7 +3037,7 @@ int main(int argc, char *argv[]) {
   for (auto &File : options::InputFilenames)
     InitInvok.getFrontendOptions().InputsAndOutputs.addInputFile(File);
   if (!options::InputFilenames.empty())
-    InitInvok.setInputKind(InputFileKind::IFK_Swift_Library);
+    InitInvok.setInputKind(InputFileKind::SwiftLibrary);
 
   InitInvok.setMainExecutablePath(
       llvm::sys::fs::getMainExecutable(argv[0],


### PR DESCRIPTION
And test this by tweaking the rules to allow functions without definitions, like SIL files.