### PR TITLE
disable send/recv warnings for scalars

### DIFF
--- a/test/TensorFlow/control_flow.swift
+++ b/test/TensorFlow/control_flow.swift
@@ -87,9 +87,9 @@ public func weighPetOnlyDefault(pet: Pet) {
 // CHECK:           return
 // CHECK-NEXT:  ---- END OF ANALYSIS STATE FOR FUNCTION
 
-public func testCondBranch(_ a: Bool) { // expected-warning {{'a' implicitly copied to the accelerator}}
+public func testCondBranch(_ a: Bool) {
   var b = Tensor<Float>(2.0)
-  if a { // expected-note {{value used here}}
+  if a {
     b += 1.0
   }
   b -= 1.0
@@ -320,12 +320,9 @@ public func testCriticalEdges() {
 
 // TODO: fix the noisy sends/recvs warning diagnostics.
 @inline(never)
-// expected-warning @+1 {{implicitly copied to the accelerator}}
 public func SR8443(n: Int32) {
   var i: Int32 = 0
-// expected-warning @+1 {{implicitly copied to the accelerator}}
-  while i < n { // expected-note {{value used here}}
-
+  while i < n {
     // expected-warning @+1 {{implicitly copied to the host}}
     let images = Tensor<Float>(0.0)
     _hostOp(images)

--- a/test/TensorFlow/control_flow.swift
+++ b/test/TensorFlow/control_flow.swift
@@ -318,7 +318,6 @@ public func testCriticalEdges() {
 }
 
 
-// TODO: fix the noisy sends/recvs warning diagnostics.
 @inline(never)
 public func SR8443(n: Int32) {
   var i: Int32 = 0

--- a/test/TensorFlow/crashers.swift
+++ b/test/TensorFlow/crashers.swift
@@ -237,7 +237,6 @@ public func testMultiResultOp_rawop(x: Tensor<Float>, y: Tensor<Float>) {
   _hostOp(results.backprop)
 }
 
-// TODO: The sends/recvs diagnostics are not very good. Fix them.
 public func testMultiResultOp_send_recv() {
   var x = Tensor<Float>([[1.0]])  // expected-warning {{implicitly copied to the host}}
   // Accelerator -> Host

--- a/test/TensorFlow/diagnostics.swift
+++ b/test/TensorFlow/diagnostics.swift
@@ -2,7 +2,6 @@
 
 import TensorFlow
 
-
 // Show inference of the tensor element type based on context.  This also
 // exposed a SILGen bug handling cleanup generation when emitting into let
 // declarations.
@@ -56,13 +55,44 @@ public func SR8412_CopyToHost() {
 }
 
 @inline(never)
-public func hostFunc() -> Tensor<Float> {
+public func hostScalarTensor() -> Tensor<Float> {
   return Tensor<Float>(1.0)
+}
+
+@inline(never)
+public func hostNonScalarTensor() -> Tensor<Float> {
+  return Tensor<Float>([1.0, 2.0])
 }
 
 public func SR8412_CopyToAccel(a: Int32) {
   let x = Tensor<Float>(1.0)
   for _ in 0...10 {
-    let _ = hostFunc() + x  // expected-warning {{value implicitly copied to the accelerator}}
+    let _ = hostScalarTensor() + x  // expected-warning {{value implicitly copied to the accelerator}}
+  }
+}
+
+public func copyScalarTensorToAccel() -> Tensor<Float> {
+  return hostScalarTensor() + 1  // expected-warning {{value implicitly copied to the accelerator}}
+}
+
+public func copyNonScalarTensorToAccel() -> Tensor<Float> {
+  return hostNonScalarTensor() + 1  // expected-warning {{value implicitly copied to the accelerator}}
+}
+
+// Test that we do not diagnose a scalar transfer to the accelerator. There is a parallel test in
+// diagnostics_scalar_transfers.swift that tests that we do diagnose when
+// tf-warn-scalar-transfer=true.
+public func scalarToAccelerator(x: Float) -> Tensor<Float> {
+  return Tensor(x) + 1
+}
+
+// Test that we do not diagnose a scalar transfer to the host. There is a parallel test in
+// diagnostics_scalar_transfers.swift that tests that we do diagnose when
+// tf-warn-scalar-transfer=true.
+public func scalarToHost() {
+  var i = Tensor(0)
+  while i < 10 {
+    print("Running loop body")
+    i += 1
   }
 }

--- a/test/TensorFlow/diagnostics_scalar_transfers.swift
+++ b/test/TensorFlow/diagnostics_scalar_transfers.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -Xllvm -tf-warn-scalar-transfer=true -O -emit-sil -verify %s
+
+// Tests that we diagnose scalar transfers when tf-warn-scalar-transfer=true. There are parallel
+// tests in diagnostics.swift ensuring that we do not diagnost the transfers when
+// tf-warn-scalar-transfer=false.
+
+import TensorFlow
+
+// expected-warning @+1 {{'x' implicitly copied to the accelerator}}
+public func scalarToAccelerator(x: Float) -> Tensor<Float> {
+  return Tensor(x) + 1  // expected-note {{value used here}}
+}
+
+public func scalarToHost() {
+  var i = Tensor(0)
+  while i < 10 {  // expected-warning {{value implicitly copied to the host}}
+    print("Running loop body")
+    i += 1
+  }
+}

--- a/test/TensorFlow/integration.swift
+++ b/test/TensorFlow/integration.swift
@@ -44,9 +44,7 @@ public func testTensor(a: Tensor<Float>, b: Tensor<Float>) {
 
 
 public func testScalar(f: Float) {
-  var x = Tensor<Float>(f)
-          +
-          Tensor<Float>(1.0)
+  var x = Tensor<Float>(f) + Tensor<Float>(1.0)
   x += x
   _hostOp(x)
 }
@@ -146,8 +144,7 @@ public func testExitBranch2(i: Int) {
 
 
 // This program results in a boolean parameter being passed in.
-public func test_bool_param(cond: Bool,
-                            x: Tensor<Float>, y: Tensor<Float>) {
+public func test_bool_param(cond: Bool, x: Tensor<Float>, y: Tensor<Float>) {
   var a = x.toAccelerator()
   let b = y.toAccelerator()
 
@@ -178,8 +175,7 @@ public func test_bool_param(cond: Bool,
 // CHECK-NEXT:  end_access
 // CHECK-NEXT:  dealloc_stack
 
-public func test_bool_param2(cond: Bool,
-                             x: Tensor<Float>, y: Tensor<Float>) {
+public func test_bool_param2(cond: Bool, x: Tensor<Float>, y: Tensor<Float>) {
   var a = x.toAccelerator()
   let b = y.toAccelerator()
 
@@ -238,8 +234,7 @@ public func test_multiple_ifs(status: Bool) {
 // CHECK-NEXT:     block bb4}
 // CHECK-NEXT:   block bb6]
 
-public func test_while1(maxCount: Int,
-                        arg1: Tensor<Float>, arg2: Tensor<Float>) {
+public func test_while1(maxCount: Int, arg1: Tensor<Float>, arg2: Tensor<Float>) {
   var a = arg1.toAccelerator()
   let b = arg2.toAccelerator()
 
@@ -291,7 +286,6 @@ public func test_while1(maxCount: Int,
 public func scalar_manipulation(a : Float) -> Tensor<Float> {
   let x = Tensor<Float>(a) + Tensor<Float>(1.0) // expected-warning {{value implicitly copied to the host}}
   let y = x.scalar! + 2.0 // expected-note {{value used here}}
-
   let z = Tensor<Float>(y)
   return z+z
 }

--- a/test/TensorFlow/integration.swift
+++ b/test/TensorFlow/integration.swift
@@ -43,8 +43,8 @@ public func testTensor(a: Tensor<Float>, b: Tensor<Float>) {
 // CHECK-NEXT: apply [[FINISHFN]]([[PROGRAM]],
 
 
-public func testScalar(f: Float) { // expected-warning {{'f' implicitly copied to the accelerator}}
-  var x = Tensor<Float>(f) // expected-note {{value used here}}
+public func testScalar(f: Float) {
+  var x = Tensor<Float>(f)
           +
           Tensor<Float>(1.0)
   x += x
@@ -120,7 +120,6 @@ public func testExitBranch1(i: Int) {
 public func testExitBranch2(i: Int) {
   var x = Tensor<Float>(1.0)
 
-  // expected-warning @+1 {{implicitly copied to the accelerator}}
   if i == 0 {
     return
   }
@@ -147,12 +146,12 @@ public func testExitBranch2(i: Int) {
 
 
 // This program results in a boolean parameter being passed in.
-public func test_bool_param(cond: Bool, // expected-warning {{'cond' implicitly copied to the accelerator}}
+public func test_bool_param(cond: Bool,
                             x: Tensor<Float>, y: Tensor<Float>) {
   var a = x.toAccelerator()
   let b = y.toAccelerator()
 
-  if cond {  // expected-note {{value used here}}
+  if cond {
     a -= b
   }
   a += b
@@ -179,14 +178,14 @@ public func test_bool_param(cond: Bool, // expected-warning {{'cond' implicitly 
 // CHECK-NEXT:  end_access
 // CHECK-NEXT:  dealloc_stack
 
-public func test_bool_param2(cond: Bool, // expected-warning {{'cond' implicitly copied to the accelerator}}
+public func test_bool_param2(cond: Bool,
                              x: Tensor<Float>, y: Tensor<Float>) {
   var a = x.toAccelerator()
   let b = y.toAccelerator()
 
   a += b
 
-  if cond { // expected-note {{value used here}}
+  if cond {
     a -= b
   }
   a += b
@@ -213,15 +212,13 @@ public func test_bool_param2(cond: Bool, // expected-warning {{'cond' implicitly
 // CHECK: cond_br [[BOOLVAL]],
 
 
-// expected-warning @+1 {{'status' implicitly copied to the accelerator}}
 public func test_multiple_ifs(status: Bool) {
   var a = Tensor<Int32>(0)
   let b = a
-  if status { // expected-note {{value used here}}
+  if status {
     a += b
   }
   a += b
-  // expected-warning @+1 {{value implicitly copied to the host, use .toHost() to make transfer explicit}}
   if a.scalarized() > 10 {
     a += b
   }
@@ -241,7 +238,7 @@ public func test_multiple_ifs(status: Bool) {
 // CHECK-NEXT:     block bb4}
 // CHECK-NEXT:   block bb6]
 
-public func test_while1(maxCount: Int,  // expected-warning {{'maxCount' implicitly copied to the accelerator}}
+public func test_while1(maxCount: Int,
                         arg1: Tensor<Float>, arg2: Tensor<Float>) {
   var a = arg1.toAccelerator()
   let b = arg2.toAccelerator()
@@ -249,8 +246,7 @@ public func test_while1(maxCount: Int,  // expected-warning {{'maxCount' implici
   a += b
 
   var count = 0
-  // expected-warning @+1 {{implicitly copied to the accelerator}}
-  while count < maxCount { // expected-note {{value used here}}
+  while count < maxCount {
     a -= b
     count += 1
   }
@@ -293,12 +289,8 @@ public func test_while1(maxCount: Int,  // expected-warning {{'maxCount' implici
 // disprove away the optional check, so we'll need to send a bit back to the
 // host.
 public func scalar_manipulation(a : Float) -> Tensor<Float> {
-  // expected-warning @-1 {{'a' implicitly copied to the accelerator, use .toAccelerator() to make transfer explicit}}
-
-  // expected-note @+1 {{value used here}}
   let x = Tensor<Float>(a) + Tensor<Float>(1.0) // expected-warning {{value implicitly copied to the host}}
   let y = x.scalar! + 2.0 // expected-note {{value used here}}
-  // expected-warning @-1 {{value implicitly copied to the accelerator}}
 
   let z = Tensor<Float>(y)
   return z+z
@@ -417,7 +409,7 @@ public func testResourceAndVariants() {
 // CHECK:  [[VALUES:%.*]] = graph_op "Const"() {dtype: $Float, value$tensor: [$Float: (f32 0x3F800000 /* 1 */), (f32 0x40000000 /* 2 */),
 // CHECK:  [[DATASET:%.*]] = graph_op "TensorDataSet,i"([[VALUES]] : $TensorHandle<Float>
 // CHECK:  [[ITERATOR:%.*]] = graph_op "Iterator"()
-// CHECK:  graph_op "MakeIterator,i,i"([[DATASET]] : $VariantHandle, [[ITERATOR]] : $ResourceHandle) {{.*}} 
+// CHECK:  graph_op "MakeIterator,i,i"([[DATASET]] : $VariantHandle, [[ITERATOR]] : $ResourceHandle) {{.*}}
 // CHECK-LABEL: ----
 
 
@@ -493,9 +485,9 @@ public func testNoInlineUser() {
 
 // b/77437755
 public func test77437755(_ hiddenSize: Float) {
-  let stddev = 1.0 / hiddenSize  // expected-warning {{method result implicitly copied to the accelerator}}
+  let stddev = 1.0 / hiddenSize
   let t1 = Tensor<Float>(shape: [5], scalars: [1.0, 2.0, 3.0, 4.0, 5.0])
-  _ = t1 * stddev  // expected-note {{value used here}}
+  _ = t1 * stddev
 }
 
 // CHECK-LABEL: ---- INPUT FUNCTION {{.*}}test77437755{{.*}} ----------

--- a/test/TensorFlow/optimization-disabled.swift
+++ b/test/TensorFlow/optimization-disabled.swift
@@ -22,7 +22,6 @@ public func testSendsInALoopGPU() {
   var a = Tensor<Float>(1)
   var count = 1
 
-  // expected-warning @+1 {{result implicitly copied to the accelerator}}
   while count < maxCount {
     // expected-warning @+2 {{implicitly copied to the accelerator}}
     // expected-warning @+1 {{implicitly copied to the accelerator}}

--- a/test/TensorFlow/sends_recvs.swift
+++ b/test/TensorFlow/sends_recvs.swift
@@ -26,10 +26,9 @@ public func test1Send() {
 // CHECK:      function_ref @_swift_tfc_FinishTensorComputation
 
 
-// expected-warning@+1 {{'x' implicitly copied to the accelerator}}
 public func test1SendWithParam(x: Float) {
   TensorFlow.enableGPU()
-  var a = Tensor<Float>(x) // expected-note {{value used here}}
+  var a = Tensor<Float>(x)
   // One send.
   _hostOp(a.toHost())
   a += 1
@@ -201,7 +200,6 @@ public func testCannotSendResource() {
 public func test1RecvScalarCPU() {
   let x = Tensor<Float>(1.0) // expected-warning {{value implicitly copied to the host}}
   let y = x.scalar! + 2.0 // expected-note {{value used here}}
-  // expected-warning @-1 {{value implicitly copied to the accelerator}}
 
   let z = Tensor<Float>(y)
   let result = z+z
@@ -242,8 +240,6 @@ public func test1RecvScalarGPU() {
   TensorFlow.enableGPU()
   let x = Tensor<Float>(1.0) // expected-warning {{value implicitly copied to the host}}
   let y = x.scalar! + 2.0 // expected-note {{value used here}}
-  // expected-warning @-1 {{value implicitly copied to the accelerator}}
-
   let z = Tensor<Float>(y)
   let result = z+z
   let _ = result.scalar
@@ -265,8 +261,6 @@ public func test1RecvScalarTPU() {
   TensorFlow.enableTPU()
   let x = Tensor<Float>(1.0) // expected-warning {{value implicitly copied to the host}}
   let y = x.scalar! + 2 // expected-note {{value used here}}
-  // expected-warning @-1 {{value implicitly copied to the accelerator}}
-
   let z = Tensor<Float>(y)
   let result = z + z
   _hostOp(result.toHost())


### PR DESCRIPTION
Based on a discussion with @mhong, this disables send/recv warnings for values that are definitely scalar.

This cleans up the warning output (e.g. removes warnings about sends/recvs for outer loop indices), making it easier to focus on more interesting warnings.

At some point we might want to re-enable some scalar warnings based on some cost model (e.g. warn for scalar transfers in inner loops), but that's a lot more complicated and this is a good starting point.