### PR TITLE
[Diagnostics] Improve missing conformance diagnostics by using affect…

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1530,6 +1530,9 @@ ERROR(types_not_equal,none,
       (Type, Type, Type))
 ERROR(type_does_not_conform_owner,none,
       "%0 requires that %1 conform to %2", (Type, Type, Type))
+ERROR(type_does_not_conform_decl_owner,none,
+      "%0 %1 requires that %2 conform to %3 [with %2 = %4]",
+      (DescriptiveDeclKind, DeclName, Type, Type, Type))
 NOTE(requirement_implied_by_conditional_conformance,none,
      "requirement from conditional conformance of %0 to %1", (Type, Type))
 NOTE(candidate_types_equal_requirement,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1530,9 +1530,14 @@ ERROR(types_not_equal,none,
       (Type, Type, Type))
 ERROR(type_does_not_conform_owner,none,
       "%0 requires that %1 conform to %2", (Type, Type, Type))
-ERROR(type_does_not_conform_decl_owner,none,
-      "%0 %1 requires that %2 conform to %3 [with %2 = %4]",
+ERROR(type_does_not_conform_in_decl_ref,none,
+      "referencing %0 %1 on %2 requires that %3 conform to %4",
       (DescriptiveDeclKind, DeclName, Type, Type, Type))
+ERROR(type_does_not_conform_decl_owner,none,
+      "%0 %1 requires that %2 conform to %3",
+      (DescriptiveDeclKind, DeclName, Type, Type))
+NOTE(where_type_does_not_conform_type,none,
+     "where %0 = %1", (Type, Type))
 NOTE(requirement_implied_by_conditional_conformance,none,
      "requirement from conditional conformance of %0 to %1", (Type, Type))
 NOTE(candidate_types_equal_requirement,none,

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -147,8 +147,15 @@ bool MissingConformanceFailure::diagnose() {
                    diag::cannot_convert_argument_value_protocol, type,
                    protocolType);
   } else {
-    emitDiagnostic(anchor->getLoc(), diag::type_does_not_conform_owner,
-                   ownerType, type, protocolType);
+    const auto &req = getRequirement();
+    emitDiagnostic(anchor->getLoc(), diag::type_does_not_conform_decl_owner,
+                   AffectedDecl->getDescriptiveKind(),
+                   AffectedDecl->getFullName(), req.getFirstType(),
+                   protocolType, type);
+
+    if (!AffectedDecl->isImplicit())
+      emitDiagnostic(AffectedDecl, diag::decl_declared_here,
+                     AffectedDecl->getBaseName());
   }
   return true;
 }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -148,14 +148,35 @@ bool MissingConformanceFailure::diagnose() {
                    protocolType);
   } else {
     const auto &req = getRequirement();
-    emitDiagnostic(anchor->getLoc(), diag::type_does_not_conform_decl_owner,
-                   AffectedDecl->getDescriptiveKind(),
-                   AffectedDecl->getFullName(), req.getFirstType(),
-                   protocolType, type);
+    auto *genericCtx = AffectedDecl->getAsGenericContext();
 
-    if (!AffectedDecl->isImplicit())
-      emitDiagnostic(AffectedDecl, diag::decl_declared_here,
-                     AffectedDecl->getBaseName());
+    std::function<const DeclContext *(Type)> getAffectedCtx =
+        [&](Type type) -> const DeclContext * {
+      if (auto *DMT = type->getAs<DependentMemberType>())
+        return getAffectedCtx(DMT->getBase());
+
+      if (auto *GPT = type->getAs<GenericTypeParamType>())
+        return GPT->getDecl()->getDeclContext();
+
+      return genericCtx;
+    };
+
+    const auto *affected = getAffectedCtx(req.getFirstType());
+    if (affected != genericCtx) {
+      auto *NTD = affected->getAsNominalTypeOrNominalTypeExtensionContext();
+      emitDiagnostic(anchor->getLoc(), diag::type_does_not_conform_in_decl_ref,
+                     AffectedDecl->getDescriptiveKind(),
+                     AffectedDecl->getFullName(), NTD->getDeclaredType(), type,
+                     protocolType);
+    } else {
+      emitDiagnostic(anchor->getLoc(), diag::type_does_not_conform_decl_owner,
+                     AffectedDecl->getDescriptiveKind(),
+                     AffectedDecl->getFullName(), type, protocolType);
+    }
+
+    emitDiagnostic(affected->getAsDeclOrDeclExtensionContext(),
+                   diag::where_type_does_not_conform_type, req.getFirstType(),
+                   type);
   }
   return true;
 }

--- a/test/Constraints/conditionally_defined_types.swift
+++ b/test/Constraints/conditionally_defined_types.swift
@@ -54,14 +54,14 @@ let _ = SameType<Y>.T.self // expected-error {{'SameType<Y>.T.Type' (aka 'X.Type
 let _ = SameType<X>.T.self
 
 struct Conforms<T> {}
-extension Conforms where T: P {
-    typealias TypeAlias1 = T // expected-note {{declared here}}
-    typealias TypeAlias2 = Y // expected-note {{declared here}}
+extension Conforms where T: P { // expected-note 5 {{where 'T' = 'Y'}}
+    typealias TypeAlias1 = T
+    typealias TypeAlias2 = Y
     typealias TypeAlias3<U> = (T, U)
 
-    struct Decl1 {} // expected-note {{declared here}}
-    enum Decl2 {}   // expected-note {{declared here}}
-    class Decl3 {}  // expected-note {{declared here}}
+    struct Decl1 {}
+    enum Decl2 {}
+    class Decl3 {}
     struct Decl4<U> {}
     enum Decl5<U: P> {}
 }
@@ -75,18 +75,18 @@ let _ = Conforms<X>.Decl3.self
 let _ = Conforms<X>.Decl4<X>.self
 let _ = Conforms<X>.Decl5<X>.self
 
-let _ = Conforms<Y>.TypeAlias1.self // expected-error {{type alias 'TypeAlias1' requires that 'T' conform to 'P' [with 'T' = 'Y']}}
-let _ = Conforms<Y>.TypeAlias2.self // expected-error {{type alias 'TypeAlias2' requires that 'T' conform to 'P' [with 'T' = 'Y']}}
+let _ = Conforms<Y>.TypeAlias1.self // expected-error {{referencing type alias 'TypeAlias1' on 'Conforms' requires that 'Y' conform to 'P'}}
+let _ = Conforms<Y>.TypeAlias2.self // expected-error {{referencing type alias 'TypeAlias2' on 'Conforms' requires that 'Y' conform to 'P'}}
 let _ = Conforms<Y>.TypeAlias3<X>.self // expected-error {{type 'Y' does not conform to protocol 'P'}}
-let _ = Conforms<Y>.Decl1.self // expected-error {{struct 'Decl1' requires that 'T' conform to 'P' [with 'T' = 'Y']}}
-let _ = Conforms<Y>.Decl2.self // expected-error {{enum 'Decl2' requires that 'T' conform to 'P' [with 'T' = 'Y']}}
-let _ = Conforms<Y>.Decl3.self // expected-error {{class 'Decl3' requires that 'T' conform to 'P' [with 'T' = 'Y']}}
+let _ = Conforms<Y>.Decl1.self // expected-error {{referencing struct 'Decl1' on 'Conforms' requires that 'Y' conform to 'P'}}
+let _ = Conforms<Y>.Decl2.self // expected-error {{referencing enum 'Decl2' on 'Conforms' requires that 'Y' conform to 'P'}}
+let _ = Conforms<Y>.Decl3.self // expected-error {{referencing class 'Decl3' on 'Conforms' requires that 'Y' conform to 'P'}}
 let _ = Conforms<Y>.Decl4<X>.self // expected-error {{type 'Y' does not conform to protocol 'P'}}
 let _ = Conforms<Y>.Decl5<X>.self // expected-error {{type 'Y' does not conform to protocol 'P'}}
 
-extension Conforms: AssociatedType where T: P {}
+extension Conforms: AssociatedType where T: P {} // expected-note {{where 'T' = 'Y'}}
 
-let _ = Conforms<Y>.T.self // expected-error {{type alias 'T' requires that 'T' conform to 'P' [with 'T' = 'Y']}}
+let _ = Conforms<Y>.T.self // expected-error {{referencing type alias 'T' on 'Conforms' requires that 'Y' conform to 'P'}}
 
 let _ = Conforms<X>.T.self
 
@@ -174,13 +174,16 @@ let _ = SameType<Y>.Decl4<Y>.Decl5<X>.self // expected-error {{'SameType<Y>.Decl
 
 // Finally, extra complicated:
 extension Conforms.Decl4 where U: AssociatedType, U.T: P {
-    typealias TypeAlias1 = T // expected-note 3 {{declared here}}
-    typealias TypeAlias2 = Y // expected-note 3 {{declared here}}
+// expected-note@-1 5 {{where 'U' = 'Y'}}
+// expected-note@-2 5 {{'U.T' = 'Z2.T' (aka 'Y')}}
+// expected-note@-3 5 {{'U.T' = 'Y.T'}}
+    typealias TypeAlias1 = T
+    typealias TypeAlias2 = Y
     typealias TypeAlias3<V> = (T, U, V)
 
-    struct Decl1 {} // expected-note 3 {{declared here}}
-    enum Decl2 {}   // expected-note 3 {{declared here}}
-    class Decl3 {}  // expected-note 3 {{declared here}}
+    struct Decl1 {}
+    enum Decl2 {}
+    class Decl3 {}
     struct Decl4<V> {}
     enum Decl5<V: P> {}
 }
@@ -197,34 +200,34 @@ let _ = Conforms<X>.Decl4<Z1>.Decl5<X>.self
 // Two different forms of badness, corresponding to the two requirements:
 
 let _ = Conforms<X>.Decl4<Y>.TypeAlias1.self
-// expected-error@-1 {{type alias 'TypeAlias1' requires that 'U.T' conform to 'P' [with 'U.T' = 'Y.T']}}
-// expected-error@-2 {{type alias 'TypeAlias1' requires that 'U' conform to 'AssociatedType' [with 'U' = 'Y']}}
+// expected-error@-1 {{referencing type alias 'TypeAlias1' on 'Conforms.Decl4' requires that 'Y.T' conform to 'P'}}
+// expected-error@-2 {{referencing type alias 'TypeAlias1' on 'Conforms.Decl4' requires that 'Y' conform to 'AssociatedType'}}
 
 let _ = Conforms<X>.Decl4<Y>.TypeAlias2.self
-// expected-error@-1 {{type alias 'TypeAlias2' requires that 'U.T' conform to 'P' [with 'U.T' = 'Y.T']}}
-// expected-error@-2 {{type alias 'TypeAlias2' requires that 'U' conform to 'AssociatedType' [with 'U' = 'Y']}}
+// expected-error@-1 {{referencing type alias 'TypeAlias2' on 'Conforms.Decl4' requires that 'Y.T' conform to 'P'}}
+// expected-error@-2 {{referencing type alias 'TypeAlias2' on 'Conforms.Decl4' requires that 'Y' conform to 'AssociatedType'}}
 
 let _ = Conforms<X>.Decl4<Y>.TypeAlias3<X>.self // expected-error {{type 'Y' does not conform to protocol 'AssociatedType'}}
 let _ = Conforms<X>.Decl4<Y>.Decl1.self
-// expected-error@-1 {{struct 'Decl1' requires that 'U.T' conform to 'P' [with 'U.T' = 'Y.T']}}
-// expected-error@-2 {{struct 'Decl1' requires that 'U' conform to 'AssociatedType' [with 'U' = 'Y']}}
+// expected-error@-1 {{referencing struct 'Decl1' on 'Conforms.Decl4' requires that 'Y.T' conform to 'P'}}
+// expected-error@-2 {{referencing struct 'Decl1' on 'Conforms.Decl4' requires that 'Y' conform to 'AssociatedType'}}
 
 let _ = Conforms<X>.Decl4<Y>.Decl2.self
-// expected-error@-1 {{enum 'Decl2' requires that 'U.T' conform to 'P' [with 'U.T' = 'Y.T']}}
-// expected-error@-2 {{enum 'Decl2' requires that 'U' conform to 'AssociatedType' [with 'U' = 'Y']}}
+// expected-error@-1 {{referencing enum 'Decl2' on 'Conforms.Decl4' requires that 'Y.T' conform to 'P'}}
+// expected-error@-2 {{referencing enum 'Decl2' on 'Conforms.Decl4' requires that 'Y' conform to 'AssociatedType'}}
 
 let _ = Conforms<X>.Decl4<Y>.Decl3.self
-// expected-error@-1 {{class 'Decl3' requires that 'U.T' conform to 'P' [with 'U.T' = 'Y.T']}}
-// expected-error@-2 {{class 'Decl3' requires that 'U' conform to 'AssociatedType' [with 'U' = 'Y']}}
+// expected-error@-1 {{referencing class 'Decl3' on 'Conforms.Decl4' requires that 'Y.T' conform to 'P'}}
+// expected-error@-2 {{referencing class 'Decl3' on 'Conforms.Decl4' requires that 'Y' conform to 'AssociatedType'}}
 
 let _ = Conforms<X>.Decl4<Y>.Decl4<X>.self // expected-error {{type 'Y' does not conform to protocol 'AssociatedType'}}
 let _ = Conforms<X>.Decl4<Y>.Decl5<X>.self // expected-error {{type 'Y' does not conform to protocol 'AssociatedType'}}
 
-let _ = Conforms<X>.Decl4<Z2>.TypeAlias1.self // expected-error {{type alias 'TypeAlias1' requires that 'U.T' conform to 'P' [with 'U.T' = 'Z2.T' (aka 'Y')]}}
-let _ = Conforms<X>.Decl4<Z2>.TypeAlias2.self // expected-error {{type alias 'TypeAlias2' requires that 'U.T' conform to 'P' [with 'U.T' = 'Z2.T' (aka 'Y')]}}
+let _ = Conforms<X>.Decl4<Z2>.TypeAlias1.self // expected-error {{referencing type alias 'TypeAlias1' on 'Conforms.Decl4' requires that 'Z2.T' (aka 'Y') conform to 'P'}}
+let _ = Conforms<X>.Decl4<Z2>.TypeAlias2.self // expected-error {{referencing type alias 'TypeAlias2' on 'Conforms.Decl4' requires that 'Z2.T' (aka 'Y') conform to 'P'}}
 let _ = Conforms<X>.Decl4<Z2>.TypeAlias3<X>.self // expected-error {{type 'Z2.T' (aka 'Y') does not conform to protocol 'P'}}
-let _ = Conforms<X>.Decl4<Z2>.Decl1.self // expected-error {{struct 'Decl1' requires that 'U.T' conform to 'P' [with 'U.T' = 'Z2.T' (aka 'Y')]}}
-let _ = Conforms<X>.Decl4<Z2>.Decl2.self // expected-error {{enum 'Decl2' requires that 'U.T' conform to 'P' [with 'U.T' = 'Z2.T' (aka 'Y')]}}
-let _ = Conforms<X>.Decl4<Z2>.Decl3.self // expected-error {{class 'Decl3' requires that 'U.T' conform to 'P' [with 'U.T' = 'Z2.T' (aka 'Y')]}}
+let _ = Conforms<X>.Decl4<Z2>.Decl1.self // expected-error {{referencing struct 'Decl1' on 'Conforms.Decl4' requires that 'Z2.T' (aka 'Y') conform to 'P'}}
+let _ = Conforms<X>.Decl4<Z2>.Decl2.self // expected-error {{referencing enum 'Decl2' on 'Conforms.Decl4' requires that 'Z2.T' (aka 'Y') conform to 'P'}}
+let _ = Conforms<X>.Decl4<Z2>.Decl3.self // expected-error {{referencing class 'Decl3' on 'Conforms.Decl4' requires that 'Z2.T' (aka 'Y') conform to 'P'}}
 let _ = Conforms<X>.Decl4<Z2>.Decl4<X>.self // expected-error {{type 'Z2.T' (aka 'Y') does not conform to protocol 'P'}}
 let _ = Conforms<X>.Decl4<Z2>.Decl5<X>.self // expected-error {{type 'Z2.T' (aka 'Y') does not conform to protocol 'P'}}

--- a/test/Constraints/conditionally_defined_types.swift
+++ b/test/Constraints/conditionally_defined_types.swift
@@ -55,13 +55,13 @@ let _ = SameType<X>.T.self
 
 struct Conforms<T> {}
 extension Conforms where T: P {
-    typealias TypeAlias1 = T
-    typealias TypeAlias2 = Y
+    typealias TypeAlias1 = T // expected-note {{declared here}}
+    typealias TypeAlias2 = Y // expected-note {{declared here}}
     typealias TypeAlias3<U> = (T, U)
 
-    struct Decl1 {}
-    enum Decl2 {}
-    class Decl3 {}
+    struct Decl1 {} // expected-note {{declared here}}
+    enum Decl2 {}   // expected-note {{declared here}}
+    class Decl3 {}  // expected-note {{declared here}}
     struct Decl4<U> {}
     enum Decl5<U: P> {}
 }
@@ -75,18 +75,18 @@ let _ = Conforms<X>.Decl3.self
 let _ = Conforms<X>.Decl4<X>.self
 let _ = Conforms<X>.Decl5<X>.self
 
-let _ = Conforms<Y>.TypeAlias1.self // expected-error {{'Conforms<Y>.TypeAlias1' (aka 'Y') requires that 'Y' conform to 'P'}}
-let _ = Conforms<Y>.TypeAlias2.self // expected-error {{'Conforms<Y>.TypeAlias2' (aka 'Y') requires that 'Y' conform to 'P'}}
+let _ = Conforms<Y>.TypeAlias1.self // expected-error {{type alias 'TypeAlias1' requires that 'T' conform to 'P' [with 'T' = 'Y']}}
+let _ = Conforms<Y>.TypeAlias2.self // expected-error {{type alias 'TypeAlias2' requires that 'T' conform to 'P' [with 'T' = 'Y']}}
 let _ = Conforms<Y>.TypeAlias3<X>.self // expected-error {{type 'Y' does not conform to protocol 'P'}}
-let _ = Conforms<Y>.Decl1.self // expected-error {{'Conforms<Y>.Decl1' requires that 'Y' conform to 'P'}}
-let _ = Conforms<Y>.Decl2.self // expected-error {{'Conforms<Y>.Decl2' requires that 'Y' conform to 'P'}}
-let _ = Conforms<Y>.Decl3.self // expected-error {{'Conforms<Y>.Decl3' requires that 'Y' conform to 'P'}}
+let _ = Conforms<Y>.Decl1.self // expected-error {{struct 'Decl1' requires that 'T' conform to 'P' [with 'T' = 'Y']}}
+let _ = Conforms<Y>.Decl2.self // expected-error {{enum 'Decl2' requires that 'T' conform to 'P' [with 'T' = 'Y']}}
+let _ = Conforms<Y>.Decl3.self // expected-error {{class 'Decl3' requires that 'T' conform to 'P' [with 'T' = 'Y']}}
 let _ = Conforms<Y>.Decl4<X>.self // expected-error {{type 'Y' does not conform to protocol 'P'}}
 let _ = Conforms<Y>.Decl5<X>.self // expected-error {{type 'Y' does not conform to protocol 'P'}}
 
 extension Conforms: AssociatedType where T: P {}
 
-let _ = Conforms<Y>.T.self // expected-error {{'Conforms<Y>.T' (aka 'Y') requires that 'Y' conform to 'P'}}
+let _ = Conforms<Y>.T.self // expected-error {{type alias 'T' requires that 'T' conform to 'P' [with 'T' = 'Y']}}
 
 let _ = Conforms<X>.T.self
 
@@ -174,13 +174,13 @@ let _ = SameType<Y>.Decl4<Y>.Decl5<X>.self // expected-error {{'SameType<Y>.Decl
 
 // Finally, extra complicated:
 extension Conforms.Decl4 where U: AssociatedType, U.T: P {
-    typealias TypeAlias1 = T
-    typealias TypeAlias2 = Y
+    typealias TypeAlias1 = T // expected-note 3 {{declared here}}
+    typealias TypeAlias2 = Y // expected-note 3 {{declared here}}
     typealias TypeAlias3<V> = (T, U, V)
 
-    struct Decl1 {}
-    enum Decl2 {}
-    class Decl3 {}
+    struct Decl1 {} // expected-note 3 {{declared here}}
+    enum Decl2 {}   // expected-note 3 {{declared here}}
+    class Decl3 {}  // expected-note 3 {{declared here}}
     struct Decl4<V> {}
     enum Decl5<V: P> {}
 }
@@ -197,34 +197,34 @@ let _ = Conforms<X>.Decl4<Z1>.Decl5<X>.self
 // Two different forms of badness, corresponding to the two requirements:
 
 let _ = Conforms<X>.Decl4<Y>.TypeAlias1.self
-// expected-error@-1 {{'Conforms<X>.Decl4<Y>.TypeAlias1' (aka 'X') requires that 'Y.T' conform to 'P'}}
-// expected-error@-2 {{'Conforms<X>.Decl4<Y>.TypeAlias1' (aka 'X') requires that 'Y' conform to 'AssociatedType'}}
+// expected-error@-1 {{type alias 'TypeAlias1' requires that 'U.T' conform to 'P' [with 'U.T' = 'Y.T']}}
+// expected-error@-2 {{type alias 'TypeAlias1' requires that 'U' conform to 'AssociatedType' [with 'U' = 'Y']}}
 
 let _ = Conforms<X>.Decl4<Y>.TypeAlias2.self
-// expected-error@-1 {{'Conforms<X>.Decl4<Y>.TypeAlias2' (aka 'Y') requires that 'Y.T' conform to 'P'}}
-// expected-error@-2 {{'Conforms<X>.Decl4<Y>.TypeAlias2' (aka 'Y') requires that 'Y' conform to 'AssociatedType'}}
+// expected-error@-1 {{type alias 'TypeAlias2' requires that 'U.T' conform to 'P' [with 'U.T' = 'Y.T']}}
+// expected-error@-2 {{type alias 'TypeAlias2' requires that 'U' conform to 'AssociatedType' [with 'U' = 'Y']}}
 
 let _ = Conforms<X>.Decl4<Y>.TypeAlias3<X>.self // expected-error {{type 'Y' does not conform to protocol 'AssociatedType'}}
 let _ = Conforms<X>.Decl4<Y>.Decl1.self
-// expected-error@-1 {{'Conforms<X>.Decl4<Y>.Decl1' requires that 'Y.T' conform to 'P'}}
-// expected-error@-2 {{'Conforms<X>.Decl4<Y>.Decl1' requires that 'Y' conform to 'AssociatedType'}}
+// expected-error@-1 {{struct 'Decl1' requires that 'U.T' conform to 'P' [with 'U.T' = 'Y.T']}}
+// expected-error@-2 {{struct 'Decl1' requires that 'U' conform to 'AssociatedType' [with 'U' = 'Y']}}
 
 let _ = Conforms<X>.Decl4<Y>.Decl2.self
-// expected-error@-1 {{'Conforms<X>.Decl4<Y>.Decl2' requires that 'Y.T' conform to 'P'}}
-// expected-error@-2 {{'Conforms<X>.Decl4<Y>.Decl2' requires that 'Y' conform to 'AssociatedType'}}
+// expected-error@-1 {{enum 'Decl2' requires that 'U.T' conform to 'P' [with 'U.T' = 'Y.T']}}
+// expected-error@-2 {{enum 'Decl2' requires that 'U' conform to 'AssociatedType' [with 'U' = 'Y']}}
 
 let _ = Conforms<X>.Decl4<Y>.Decl3.self
-// expected-error@-1 {{'Conforms<X>.Decl4<Y>.Decl3' requires that 'Y.T' conform to 'P'}}
-// expected-error@-2 {{'Conforms<X>.Decl4<Y>.Decl3' requires that 'Y' conform to 'AssociatedType'}}
+// expected-error@-1 {{class 'Decl3' requires that 'U.T' conform to 'P' [with 'U.T' = 'Y.T']}}
+// expected-error@-2 {{class 'Decl3' requires that 'U' conform to 'AssociatedType' [with 'U' = 'Y']}}
 
 let _ = Conforms<X>.Decl4<Y>.Decl4<X>.self // expected-error {{type 'Y' does not conform to protocol 'AssociatedType'}}
 let _ = Conforms<X>.Decl4<Y>.Decl5<X>.self // expected-error {{type 'Y' does not conform to protocol 'AssociatedType'}}
 
-let _ = Conforms<X>.Decl4<Z2>.TypeAlias1.self // expected-error {{'Conforms<X>.Decl4<Z2>.TypeAlias1' (aka 'X') requires that 'Z2.T' (aka 'Y') conform to 'P'}}
-let _ = Conforms<X>.Decl4<Z2>.TypeAlias2.self // expected-error {{'Conforms<X>.Decl4<Z2>.TypeAlias2' (aka 'Y') requires that 'Z2.T' (aka 'Y') conform to 'P'}}
+let _ = Conforms<X>.Decl4<Z2>.TypeAlias1.self // expected-error {{type alias 'TypeAlias1' requires that 'U.T' conform to 'P' [with 'U.T' = 'Z2.T' (aka 'Y')]}}
+let _ = Conforms<X>.Decl4<Z2>.TypeAlias2.self // expected-error {{type alias 'TypeAlias2' requires that 'U.T' conform to 'P' [with 'U.T' = 'Z2.T' (aka 'Y')]}}
 let _ = Conforms<X>.Decl4<Z2>.TypeAlias3<X>.self // expected-error {{type 'Z2.T' (aka 'Y') does not conform to protocol 'P'}}
-let _ = Conforms<X>.Decl4<Z2>.Decl1.self // expected-error {{'Conforms<X>.Decl4<Z2>.Decl1' requires that 'Z2.T' (aka 'Y') conform to 'P'}}
-let _ = Conforms<X>.Decl4<Z2>.Decl2.self // expected-error {{'Conforms<X>.Decl4<Z2>.Decl2' requires that 'Z2.T' (aka 'Y') conform to 'P'}}
-let _ = Conforms<X>.Decl4<Z2>.Decl3.self // expected-error {{'Conforms<X>.Decl4<Z2>.Decl3' requires that 'Z2.T' (aka 'Y') conform to 'P'}}
+let _ = Conforms<X>.Decl4<Z2>.Decl1.self // expected-error {{struct 'Decl1' requires that 'U.T' conform to 'P' [with 'U.T' = 'Z2.T' (aka 'Y')]}}
+let _ = Conforms<X>.Decl4<Z2>.Decl2.self // expected-error {{enum 'Decl2' requires that 'U.T' conform to 'P' [with 'U.T' = 'Z2.T' (aka 'Y')]}}
+let _ = Conforms<X>.Decl4<Z2>.Decl3.self // expected-error {{class 'Decl3' requires that 'U.T' conform to 'P' [with 'U.T' = 'Z2.T' (aka 'Y')]}}
 let _ = Conforms<X>.Decl4<Z2>.Decl4<X>.self // expected-error {{type 'Z2.T' (aka 'Y') does not conform to protocol 'P'}}
 let _ = Conforms<X>.Decl4<Z2>.Decl5<X>.self // expected-error {{type 'Z2.T' (aka 'Y') does not conform to protocol 'P'}}

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -93,11 +93,11 @@ func f7() -> (c: Int, v: A) {
   return f6(g) // expected-error {{cannot convert return expression of type '(c: Int, i: A)' to return type '(c: Int, v: A)'}}
 }
 
-func f8<T:P2>(_ n: T, _ f: @escaping (T) -> T) {} // expected-note {{declared here}}
+func f8<T:P2>(_ n: T, _ f: @escaping (T) -> T) {} // expected-note {{where 'T' = '(_, _)'}}
 f8(3, f4) // expected-error {{argument type 'Int' does not conform to expected type 'P2'}}
 typealias Tup = (Int, Double)
 func f9(_ x: Tup) -> Tup { return x }
-f8((1,2.0), f9) // expected-error {{global function 'f8' requires that 'T' conform to 'P2' [with 'T' = '(_, _)']}}
+f8((1,2.0), f9) // expected-error {{global function 'f8' requires that '(_, _)' conform to 'P2'}}
 
 // <rdar://problem/19658691> QoI: Incorrect diagnostic for calling nonexistent members on literals
 1.doesntExist(0)  // expected-error {{value of type 'Int' has no member 'doesntExist'}}
@@ -1188,10 +1188,10 @@ func rdar17170728() {
 
 // https://bugs.swift.org/browse/SR-5934 - failure to emit diagnostic for bad
 // generic constraints
-func elephant<T, U>(_: T) where T : Collection, T.Element == U, T.Element : Hashable {} // expected-note {{declared here}}
+func elephant<T, U>(_: T) where T : Collection, T.Element == U, T.Element : Hashable {} // expected-note {{where 'U' = 'T'}}
 
 func platypus<T>(a: [T]) {
-    _ = elephant(a) // expected-error {{global function 'elephant' requires that 'U' conform to 'Hashable' [with 'U' = 'T']}}
+    _ = elephant(a) // expected-error {{global function 'elephant' requires that 'T' conform to 'Hashable'}}
 }
 
 // Another case of the above.

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -93,11 +93,11 @@ func f7() -> (c: Int, v: A) {
   return f6(g) // expected-error {{cannot convert return expression of type '(c: Int, i: A)' to return type '(c: Int, v: A)'}}
 }
 
-func f8<T:P2>(_ n: T, _ f: @escaping (T) -> T) {}
+func f8<T:P2>(_ n: T, _ f: @escaping (T) -> T) {} // expected-note {{declared here}}
 f8(3, f4) // expected-error {{argument type 'Int' does not conform to expected type 'P2'}}
 typealias Tup = (Int, Double)
 func f9(_ x: Tup) -> Tup { return x }
-f8((1,2.0), f9) // expected-error {{'(Tup, @escaping (Tup) -> Tup) -> ()' (aka '((Int, Double), @escaping ((Int, Double)) -> (Int, Double)) -> ()') requires that '(_, _)' conform to 'P2'}}
+f8((1,2.0), f9) // expected-error {{global function 'f8' requires that 'T' conform to 'P2' [with 'T' = '(_, _)']}}
 
 // <rdar://problem/19658691> QoI: Incorrect diagnostic for calling nonexistent members on literals
 1.doesntExist(0)  // expected-error {{value of type 'Int' has no member 'doesntExist'}}
@@ -1188,10 +1188,10 @@ func rdar17170728() {
 
 // https://bugs.swift.org/browse/SR-5934 - failure to emit diagnostic for bad
 // generic constraints
-func elephant<T, U>(_: T) where T : Collection, T.Element == U, T.Element : Hashable {}
+func elephant<T, U>(_: T) where T : Collection, T.Element == U, T.Element : Hashable {} // expected-note {{declared here}}
 
 func platypus<T>(a: [T]) {
-    _ = elephant(a) // expected-error {{'([T]) -> ()' requires that 'T' conform to 'Hashable'}}
+    _ = elephant(a) // expected-error {{global function 'elephant' requires that 'U' conform to 'Hashable' [with 'U' = 'T']}}
 }
 
 // Another case of the above.

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -285,10 +285,10 @@ struct ProtosBound3<Foo: SubProto> where Foo: NSCopyish {} // expected-note {{'F
 struct AnyClassAndProtoBound<Foo> where Foo: AnyObject, Foo: SubProto {} // expected-note {{'Foo' declared as parameter to type 'AnyClassAndProtoBound'}}
 struct AnyClassAndProtoBound2<Foo> where Foo: SubProto, Foo: AnyObject {} // expected-note {{'Foo' declared as parameter to type 'AnyClassAndProtoBound2'}}
 
-struct ClassAndProtoBound<Foo> where Foo: X, Foo: SubProto {}
+struct ClassAndProtoBound<Foo> where Foo: X, Foo: SubProto {} // expected-note {{where 'Foo' = 'X'}}
 
-struct ClassAndProtosBound<Foo> where Foo: X, Foo: SubProto, Foo: NSCopyish {}
-struct ClassAndProtosBound2<Foo> where Foo: X, Foo: SubProto & NSCopyish {}
+struct ClassAndProtosBound<Foo> where Foo: X, Foo: SubProto, Foo: NSCopyish {} // expected-note 2 {{where 'Foo' = 'X'}}
+struct ClassAndProtosBound2<Foo> where Foo: X, Foo: SubProto & NSCopyish {} // expected-note 2 {{where 'Foo' = 'X'}}
 
 extension Pair {
   init(first: T) {}
@@ -331,14 +331,14 @@ func testFixIts() {
   _ = AnyClassAndProtoBound() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{28-28=<<#Foo: SubProto & AnyObject#>>}}
   _ = AnyClassAndProtoBound2() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{29-29=<<#Foo: SubProto & AnyObject#>>}}
 
-  _ = ClassAndProtoBound() // expected-error {{initializer 'init()' requires that 'Foo' conform to 'SubProto' [with 'Foo' = 'X']}}
+  _ = ClassAndProtoBound() // expected-error {{referencing initializer 'init()' on 'ClassAndProtoBound' requires that 'X' conform to 'SubProto'}}
 
   _ = ClassAndProtosBound() 
-  // expected-error@-1 {{initializer 'init()' requires that 'Foo' conform to 'NSCopyish' [with 'Foo' = 'X']}}
-  // expected-error@-2 {{initializer 'init()' requires that 'Foo' conform to 'SubProto' [with 'Foo' = 'X']}}
+  // expected-error@-1 {{referencing initializer 'init()' on 'ClassAndProtosBound' requires that 'X' conform to 'NSCopyish'}}
+  // expected-error@-2 {{referencing initializer 'init()' on 'ClassAndProtosBound' requires that 'X' conform to 'SubProto'}}
   _ = ClassAndProtosBound2()
-  // expected-error@-1 {{initializer 'init()' requires that 'Foo' conform to 'NSCopyish' [with 'Foo' = 'X']}}
-  // expected-error@-2 {{initializer 'init()' requires that 'Foo' conform to 'SubProto' [with 'Foo' = 'X']}}
+  // expected-error@-1 {{referencing initializer 'init()' on 'ClassAndProtosBound2' requires that 'X' conform to 'NSCopyish'}}
+  // expected-error@-2 {{referencing initializer 'init()' on 'ClassAndProtosBound2' requires that 'X' conform to 'SubProto'}}
 
   _ = Pair() // expected-error {{generic parameter 'T' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{11-11=<Any, Any>}}
   _ = Pair(first: S()) // expected-error {{generic parameter 'U' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{11-11=<S, Any>}}
@@ -604,20 +604,20 @@ func rdar40537858() {
     var id: Id
   }
 
-  struct List<T: Collection, E: Hashable> {
+  struct List<T: Collection, E: Hashable> { // expected-note {{where 'E' = 'S.Id'}}
     typealias Data = T.Element
-    init(_: T, id: KeyPath<Data, E>) {} // expected-note {{declared here}}
+    init(_: T, id: KeyPath<Data, E>) {}
   }
 
   var arr: [S] = []
-  _ = List(arr, id: \.id) // expected-error {{initializer 'init(_:id:)' requires that 'E' conform to 'Hashable' [with 'E' = 'S.Id']}}
+  _ = List(arr, id: \.id) // expected-error {{referencing initializer 'init(_:id:)' on 'List' requires that 'S.Id' conform to 'Hashable'}}
 
-  enum E<T: P> { // expected-note 2 {{declared here}}
+  enum E<T: P> { // expected-note 2 {{where 'T' = 'S'}}
     case foo(T)
     case bar([T])
   }
 
   var s = S(id: S.Id())
-  let _: E = .foo(s)   // expected-error {{generic enum 'E' requires that 'T' conform to 'P' [with 'T' = 'S']}}
-  let _: E = .bar([s]) // expected-error {{generic enum 'E' requires that 'T' conform to 'P' [with 'T' = 'S']}}
+  let _: E = .foo(s)   // expected-error {{generic enum 'E' requires that 'S' conform to 'P'}}
+  let _: E = .bar([s]) // expected-error {{generic enum 'E' requires that 'S' conform to 'P'}}
 }

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -331,14 +331,14 @@ func testFixIts() {
   _ = AnyClassAndProtoBound() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{28-28=<<#Foo: SubProto & AnyObject#>>}}
   _ = AnyClassAndProtoBound2() // expected-error {{generic parameter 'Foo' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{29-29=<<#Foo: SubProto & AnyObject#>>}}
 
-  _ = ClassAndProtoBound() // expected-error {{'ClassAndProtoBound<X>' requires that 'X' conform to 'SubProto'}}
+  _ = ClassAndProtoBound() // expected-error {{initializer 'init()' requires that 'Foo' conform to 'SubProto' [with 'Foo' = 'X']}}
 
   _ = ClassAndProtosBound() 
-  // expected-error@-1 {{'ClassAndProtosBound<X>' requires that 'X' conform to 'SubProto'}}
-  // expected-error@-2 {{'ClassAndProtosBound<X>' requires that 'X' conform to 'NSCopyish'}}
+  // expected-error@-1 {{initializer 'init()' requires that 'Foo' conform to 'NSCopyish' [with 'Foo' = 'X']}}
+  // expected-error@-2 {{initializer 'init()' requires that 'Foo' conform to 'SubProto' [with 'Foo' = 'X']}}
   _ = ClassAndProtosBound2()
-  // expected-error@-1 {{'ClassAndProtosBound2<X>' requires that 'X' conform to 'SubProto'}}
-  // expected-error@-2 {{'ClassAndProtosBound2<X>' requires that 'X' conform to 'NSCopyish'}}
+  // expected-error@-1 {{initializer 'init()' requires that 'Foo' conform to 'NSCopyish' [with 'Foo' = 'X']}}
+  // expected-error@-2 {{initializer 'init()' requires that 'Foo' conform to 'SubProto' [with 'Foo' = 'X']}}
 
   _ = Pair() // expected-error {{generic parameter 'T' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{11-11=<Any, Any>}}
   _ = Pair(first: S()) // expected-error {{generic parameter 'U' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}} {{11-11=<S, Any>}}
@@ -606,18 +606,18 @@ func rdar40537858() {
 
   struct List<T: Collection, E: Hashable> {
     typealias Data = T.Element
-    init(_: T, id: KeyPath<Data, E>) {}
+    init(_: T, id: KeyPath<Data, E>) {} // expected-note {{declared here}}
   }
 
   var arr: [S] = []
-  _ = List(arr, id: \.id) // expected-error {{'List<[S], S.Id>' requires that 'S.Id' conform to 'Hashable'}}
+  _ = List(arr, id: \.id) // expected-error {{initializer 'init(_:id:)' requires that 'E' conform to 'Hashable' [with 'E' = 'S.Id']}}
 
-  enum E<T: P> {
+  enum E<T: P> { // expected-note 2 {{declared here}}
     case foo(T)
     case bar([T])
   }
 
   var s = S(id: S.Id())
-  let _: E = .foo(s)   // expected-error {{'E<S>' requires that 'S' conform to 'P'}}
-  let _: E = .bar([s]) // expected-error {{'E<S>' requires that 'S' conform to 'P'}}
+  let _: E = .foo(s)   // expected-error {{generic enum 'E' requires that 'T' conform to 'P' [with 'T' = 'S']}}
+  let _: E = .bar([s]) // expected-error {{generic enum 'E' requires that 'T' conform to 'P' [with 'T' = 'S']}}
 }

--- a/test/Constraints/rdar39931339.swift
+++ b/test/Constraints/rdar39931339.swift
@@ -7,7 +7,7 @@ struct S<T> {}
 class C : P {}
 
 extension S where T : P {
-  typealias A = Int
+  typealias A = Int // expected-note 2 {{declared here}}
   typealias B<U> = S<U>
 }
 
@@ -18,7 +18,7 @@ extension S where T == Float {
 class A<T, U> {}
 
 extension A where T == [U], U: P {
-  typealias S1 = Int
+  typealias S1 = Int // expected-note {{declared here}}
 }
 
 extension A where T == [U], U == Int {
@@ -29,16 +29,16 @@ class B<U> : A<[U], U> {}
 
 _ = B<C>.S1()          // Ok
 _ = B<Int>.S2()        // Ok
-_ = B<Float>.S1()      // expected-error {{'B<Float>.S1' (aka 'Int') requires that 'Float' conform to 'P'}}
+_ = B<Float>.S1()      // expected-error {{type alias 'S1' requires that 'U' conform to 'P' [with 'U' = 'Float']}}
 _ = B<String>.S2()     // expected-error {{'B<String>.S2.Type' (aka 'Int.Type') requires the types '[String]' and '[Int]' be equivalent}}
 
 _ = S<C>.A()           // Ok
-_ = S<Int>.A()         // expected-error {{'S<Int>.A' (aka 'Int') requires that 'Int' conform to 'P'}}
+_ = S<Int>.A()         // expected-error {{type alias 'A' requires that 'T' conform to 'P' [with 'T' = 'Int']}}
 _ = S<String>.B<Int>() // expected-error {{type 'String' does not conform to protocol 'P'}}
 _ = S<Int>.C()         // expected-error {{'S<Int>.C.Type' (aka 'Int.Type') requires the types 'Int' and 'Float' be equivalent}}
 
 func foo<T>(_ s: S<T>.Type) {
-  _ = s.A() // expected-error {{'S<T>.A' (aka 'Int') requires that 'T' conform to 'P'}}
+  _ = s.A() // expected-error {{type alias 'A' requires that 'T' conform to 'P' [with 'T' = 'T']}}
 }
 
 func bar<T: P>(_ s: S<T>.Type) {

--- a/test/Constraints/rdar39931339.swift
+++ b/test/Constraints/rdar39931339.swift
@@ -7,7 +7,9 @@ struct S<T> {}
 class C : P {}
 
 extension S where T : P {
-  typealias A = Int // expected-note 2 {{declared here}}
+// expected-note@-1 {{where 'T' = 'T'}}
+// expected-note@-2 {{where 'T' = 'Int'}}
+  typealias A = Int
   typealias B<U> = S<U>
 }
 
@@ -17,8 +19,8 @@ extension S where T == Float {
 
 class A<T, U> {}
 
-extension A where T == [U], U: P {
-  typealias S1 = Int // expected-note {{declared here}}
+extension A where T == [U], U: P { // expected-note {{where 'U' = 'Float'}}
+  typealias S1 = Int
 }
 
 extension A where T == [U], U == Int {
@@ -29,16 +31,16 @@ class B<U> : A<[U], U> {}
 
 _ = B<C>.S1()          // Ok
 _ = B<Int>.S2()        // Ok
-_ = B<Float>.S1()      // expected-error {{type alias 'S1' requires that 'U' conform to 'P' [with 'U' = 'Float']}}
+_ = B<Float>.S1()      // expected-error {{referencing type alias 'S1' on 'A' requires that 'Float' conform to 'P'}}
 _ = B<String>.S2()     // expected-error {{'B<String>.S2.Type' (aka 'Int.Type') requires the types '[String]' and '[Int]' be equivalent}}
 
 _ = S<C>.A()           // Ok
-_ = S<Int>.A()         // expected-error {{type alias 'A' requires that 'T' conform to 'P' [with 'T' = 'Int']}}
+_ = S<Int>.A()         // expected-error {{referencing type alias 'A' on 'S' requires that 'Int' conform to 'P'}}
 _ = S<String>.B<Int>() // expected-error {{type 'String' does not conform to protocol 'P'}}
 _ = S<Int>.C()         // expected-error {{'S<Int>.C.Type' (aka 'Int.Type') requires the types 'Int' and 'Float' be equivalent}}
 
 func foo<T>(_ s: S<T>.Type) {
-  _ = s.A() // expected-error {{type alias 'A' requires that 'T' conform to 'P' [with 'T' = 'T']}}
+  _ = s.A() // expected-error {{referencing type alias 'A' on 'S' requires that 'T' conform to 'P'}}
 }
 
 func bar<T: P>(_ s: S<T>.Type) {

--- a/test/Generics/deduction.swift
+++ b/test/Generics/deduction.swift
@@ -210,11 +210,11 @@ func callMin(_ x: Int, y: Int, a: Float, b: Float) {
   min2(a, b) // expected-error{{argument type 'Float' does not conform to expected type 'IsBefore'}}
 }
 
-func rangeOfIsBefore<R : IteratorProtocol>(_ range: R) where R.Element : IsBefore {} // expected-note {{declared here}}
+func rangeOfIsBefore<R : IteratorProtocol>(_ range: R) where R.Element : IsBefore {} // expected-note {{'R.Element' = 'Double'}}
 
 func callRangeOfIsBefore(_ ia: [Int], da: [Double]) {
   rangeOfIsBefore(ia.makeIterator())
-  rangeOfIsBefore(da.makeIterator()) // expected-error{{global function 'rangeOfIsBefore' requires that 'R.Element' conform to 'IsBefore' [with 'R.Element' = 'Double']}}
+  rangeOfIsBefore(da.makeIterator()) // expected-error{{global function 'rangeOfIsBefore' requires that 'Double' conform to 'IsBefore'}}
 }
 
 func testEqualIterElementTypes<A: IteratorProtocol, B: IteratorProtocol>(_ a: A, _ b: B) where A.Element == B.Element {}

--- a/test/Generics/deduction.swift
+++ b/test/Generics/deduction.swift
@@ -210,11 +210,11 @@ func callMin(_ x: Int, y: Int, a: Float, b: Float) {
   min2(a, b) // expected-error{{argument type 'Float' does not conform to expected type 'IsBefore'}}
 }
 
-func rangeOfIsBefore<R : IteratorProtocol>(_ range: R) where R.Element : IsBefore {}
+func rangeOfIsBefore<R : IteratorProtocol>(_ range: R) where R.Element : IsBefore {} // expected-note {{declared here}}
 
 func callRangeOfIsBefore(_ ia: [Int], da: [Double]) {
   rangeOfIsBefore(ia.makeIterator())
-  rangeOfIsBefore(da.makeIterator()) // expected-error{{'(IndexingIterator<[Double]>) -> ()' requires that 'Double' conform to 'IsBefore'}}
+  rangeOfIsBefore(da.makeIterator()) // expected-error{{global function 'rangeOfIsBefore' requires that 'R.Element' conform to 'IsBefore' [with 'R.Element' = 'Double']}}
 }
 
 func testEqualIterElementTypes<A: IteratorProtocol, B: IteratorProtocol>(_ a: A, _ b: B) where A.Element == B.Element {}

--- a/test/Serialization/builtin.swift
+++ b/test/Serialization/builtin.swift
@@ -11,4 +11,4 @@ var a : TheBuiltinInt64
 
 // Check that it really is Builtin.Int64.
 var wrapped = Int64(a) // okay
-var badWrapped = Int32(a) // expected-error{{'Int32' requires that 'TheBuiltinInt64' conform to 'BinaryInteger'}}
+var badWrapped = Int32(a) // expected-error{{initializer 'init' requires that 'T' conform to 'BinaryInteger' [with 'T' = 'TheBuiltinInt64']}}

--- a/test/Serialization/builtin.swift
+++ b/test/Serialization/builtin.swift
@@ -11,4 +11,4 @@ var a : TheBuiltinInt64
 
 // Check that it really is Builtin.Int64.
 var wrapped = Int64(a) // okay
-var badWrapped = Int32(a) // expected-error{{initializer 'init' requires that 'T' conform to 'BinaryInteger' [with 'T' = 'TheBuiltinInt64']}}
+var badWrapped = Int32(a) // expected-error{{initializer 'init' requires that 'TheBuiltinInt64' conform to 'BinaryInteger'}}

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -180,7 +180,9 @@ extension S1 {
 // Protocol extensions with additional requirements
 // ----------------------------------------------------------------------------
 extension P4 where Self.AssocP4 : P1 {
-  func extP4a() { // expected-note 2 {{declared here}}
+// expected-note@-1 {{where 'Self.AssocP4' = 'S4aHelper'}}
+// expected-note@-2 {{'Self.AssocP4' = 'Int'}}
+  func extP4a() {
     acceptsP1(reqP4a())
   }
 }
@@ -215,9 +217,9 @@ extension P4 where Self.AssocP4 == Bool {
 }
 
 func testP4(_ s4a: S4a, s4b: S4b, s4c: S4c, s4d: S4d) {
-  s4a.extP4a() // expected-error{{instance method 'extP4a()' requires that 'Self.AssocP4' conform to 'P1' [with 'Self.AssocP4' = 'S4aHelper']}}
+  s4a.extP4a() // expected-error{{referencing instance method 'extP4a()' on 'P4' requires that 'S4aHelper' conform to 'P1'}}
   s4b.extP4a() // ok
-  s4c.extP4a() // expected-error{{instance method 'extP4a()' requires that 'Self.AssocP4' conform to 'P1' [with 'Self.AssocP4' = 'Int']}}
+  s4c.extP4a() // expected-error{{referencing instance method 'extP4a()' on 'P4' requires that 'Int' conform to 'P1'}}
   s4c.extP4Int() // okay
   var b1 = s4d.extP4a() // okay, "Bool" version
   b1 = true // checks type above

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -180,7 +180,7 @@ extension S1 {
 // Protocol extensions with additional requirements
 // ----------------------------------------------------------------------------
 extension P4 where Self.AssocP4 : P1 {
-  func extP4a() {
+  func extP4a() { // expected-note 2 {{declared here}}
     acceptsP1(reqP4a())
   }
 }
@@ -215,9 +215,9 @@ extension P4 where Self.AssocP4 == Bool {
 }
 
 func testP4(_ s4a: S4a, s4b: S4b, s4c: S4c, s4d: S4d) {
-  s4a.extP4a() // expected-error{{'() -> ()' requires that 'S4aHelper' conform to 'P1'}}
+  s4a.extP4a() // expected-error{{instance method 'extP4a()' requires that 'Self.AssocP4' conform to 'P1' [with 'Self.AssocP4' = 'S4aHelper']}}
   s4b.extP4a() // ok
-  s4c.extP4a() // expected-error{{'() -> ()' requires that 'Int' conform to 'P1'}}
+  s4c.extP4a() // expected-error{{instance method 'extP4a()' requires that 'Self.AssocP4' conform to 'P1' [with 'Self.AssocP4' = 'Int']}}
   s4c.extP4Int() // okay
   var b1 = s4d.extP4a() // okay, "Bool" version
   b1 = true // checks type above

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -736,8 +736,8 @@ func invalidDictionaryLiteral() {
 }
 
 
-[4].joined(separator: [1]) // expected-error {{'() -> FlattenCollection<[Int]>' requires that 'Int' conform to 'Collection'}}
-[4].joined(separator: [[[1]]]) // expected-error {{'() -> FlattenCollection<[Int]>' requires that 'Int' conform to 'Collection'}}
+[4].joined(separator: [1]) // expected-error {{instance method 'joined()' requires that 'Self.Element' conform to 'Collection' [with 'Self.Element' = 'Int']}}
+[4].joined(separator: [[[1]]]) // expected-error {{instance method 'joined()' requires that 'Self.Element' conform to 'Collection' [with 'Self.Element' = 'Int']}}
 
 //===----------------------------------------------------------------------===//
 // nil/metatype comparisons

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -736,8 +736,8 @@ func invalidDictionaryLiteral() {
 }
 
 
-[4].joined(separator: [1]) // expected-error {{instance method 'joined()' requires that 'Self.Element' conform to 'Collection' [with 'Self.Element' = 'Int']}}
-[4].joined(separator: [[[1]]]) // expected-error {{instance method 'joined()' requires that 'Self.Element' conform to 'Collection' [with 'Self.Element' = 'Int']}}
+[4].joined(separator: [1]) // expected-error {{referencing instance method 'joined()' on 'Collection' requires that 'Int' conform to 'Collection'}}
+[4].joined(separator: [[[1]]]) // expected-error {{referencing instance method 'joined()' on 'Collection' requires that 'Int' conform to 'Collection'}}
 
 //===----------------------------------------------------------------------===//
 // nil/metatype comparisons

--- a/test/expr/unary/keypath/salvage-with-other-type-errors.swift
+++ b/test/expr/unary/keypath/salvage-with-other-type-errors.swift
@@ -6,7 +6,7 @@
 struct P<T: K> { }
 
 struct S {
-    init<B>(_ a: P<B>) {
+    init<B>(_ a: P<B>) { // expected-note {{declared here}}
         fatalError()
     }
 }
@@ -27,7 +27,7 @@ struct A {
 }
 
 extension A: K {
-    static let j = S(\A.id + "id") // expected-error {{'S' requires that 'String' conform to 'K'}}
+    static let j = S(\A.id + "id") // expected-error {{initializer 'init' requires that 'B' conform to 'K' [with 'B' = 'String']}}
 }
 
 // SR-5034

--- a/test/expr/unary/keypath/salvage-with-other-type-errors.swift
+++ b/test/expr/unary/keypath/salvage-with-other-type-errors.swift
@@ -6,7 +6,7 @@
 struct P<T: K> { }
 
 struct S {
-    init<B>(_ a: P<B>) { // expected-note {{declared here}}
+    init<B>(_ a: P<B>) { // expected-note {{where 'B' = 'String'}}
         fatalError()
     }
 }
@@ -27,7 +27,7 @@ struct A {
 }
 
 extension A: K {
-    static let j = S(\A.id + "id") // expected-error {{initializer 'init' requires that 'B' conform to 'K' [with 'B' = 'String']}}
+    static let j = S(\A.id + "id") // expected-error {{initializer 'init' requires that 'String' conform to 'K'}}
 }
 
 // SR-5034

--- a/test/type/subclass_composition.swift
+++ b/test/type/subclass_composition.swift
@@ -300,9 +300,9 @@ func dependentMemberTypes<T : BaseIntAndP2>(
 func conformsToAnyObject<T : AnyObject>(_: T) {}
 func conformsToP1<T : P1>(_: T) {}
 func conformsToP2<T : P2>(_: T) {}
-func conformsToBaseIntAndP2<T : Base<Int> & P2>(_: T) {} // expected-note 3 {{declared here}}
+func conformsToBaseIntAndP2<T : Base<Int> & P2>(_: T) {} // expected-note 3 {{where 'T' = 'Base<Int>'}}
 
-func conformsToBaseIntAndP2WithWhereClause<T>(_: T) where T : Base<Int> & P2 {} // expected-note 2 {{declared here}}
+func conformsToBaseIntAndP2WithWhereClause<T>(_: T) where T : Base<Int> & P2 {} // expected-note 2 {{where 'T' = 'Base<Int>'}}
 
 class FakeDerived : Base<String>, P2 {
   required init(classInit: ()) {
@@ -417,19 +417,19 @@ func conformsTo<T1 : P2, T2 : Base<Int> & P2>(
   // expected-error@-1 {{argument type 'Base<Int>' does not conform to expected type 'P2'}}
 
   conformsToBaseIntAndP2(badBase)
-  // expected-error@-1 {{global function 'conformsToBaseIntAndP2' requires that 'T' conform to 'P2' [with 'T' = 'Base<Int>']}}
+  // expected-error@-1 {{global function 'conformsToBaseIntAndP2' requires that 'Base<Int>' conform to 'P2'}}
 
   conformsToBaseIntAndP2(fakeDerived)
-  // expected-error@-1 {{global function 'conformsToBaseIntAndP2' requires that 'T' conform to 'P2' [with 'T' = 'Base<Int>']}}
+  // expected-error@-1 {{global function 'conformsToBaseIntAndP2' requires that 'Base<Int>' conform to 'P2'}}
 
   conformsToBaseIntAndP2WithWhereClause(fakeDerived)
-  // expected-error@-1 {{global function 'conformsToBaseIntAndP2WithWhereClause' requires that 'T' conform to 'P2' [with 'T' = 'Base<Int>']}}
+  // expected-error@-1 {{global function 'conformsToBaseIntAndP2WithWhereClause' requires that 'Base<Int>' conform to 'P2'}}
 
   conformsToBaseIntAndP2(p2Archetype)
-  // expected-error@-1 {{global function 'conformsToBaseIntAndP2' requires that 'T' conform to 'P2' [with 'T' = 'Base<Int>']}}
+  // expected-error@-1 {{global function 'conformsToBaseIntAndP2' requires that 'Base<Int>' conform to 'P2'}}
 
   conformsToBaseIntAndP2WithWhereClause(p2Archetype)
-  // expected-error@-1 {{global function 'conformsToBaseIntAndP2WithWhereClause' requires that 'T' conform to 'P2' [with 'T' = 'Base<Int>']}}
+  // expected-error@-1 {{global function 'conformsToBaseIntAndP2WithWhereClause' requires that 'Base<Int>' conform to 'P2'}}
 
   // Good
   conformsToAnyObject(anyObject)

--- a/test/type/subclass_composition.swift
+++ b/test/type/subclass_composition.swift
@@ -300,9 +300,9 @@ func dependentMemberTypes<T : BaseIntAndP2>(
 func conformsToAnyObject<T : AnyObject>(_: T) {}
 func conformsToP1<T : P1>(_: T) {}
 func conformsToP2<T : P2>(_: T) {}
-func conformsToBaseIntAndP2<T : Base<Int> & P2>(_: T) {}
+func conformsToBaseIntAndP2<T : Base<Int> & P2>(_: T) {} // expected-note 3 {{declared here}}
 
-func conformsToBaseIntAndP2WithWhereClause<T>(_: T) where T : Base<Int> & P2 {}
+func conformsToBaseIntAndP2WithWhereClause<T>(_: T) where T : Base<Int> & P2 {} // expected-note 2 {{declared here}}
 
 class FakeDerived : Base<String>, P2 {
   required init(classInit: ()) {
@@ -417,19 +417,19 @@ func conformsTo<T1 : P2, T2 : Base<Int> & P2>(
   // expected-error@-1 {{argument type 'Base<Int>' does not conform to expected type 'P2'}}
 
   conformsToBaseIntAndP2(badBase)
-  // expected-error@-1 {{'(Base<Int>) -> ()' requires that 'Base<Int>' conform to 'P2'}}
+  // expected-error@-1 {{global function 'conformsToBaseIntAndP2' requires that 'T' conform to 'P2' [with 'T' = 'Base<Int>']}}
 
   conformsToBaseIntAndP2(fakeDerived)
-  // expected-error@-1 {{'(Base<Int>) -> ()' requires that 'Base<Int>' conform to 'P2'}}
+  // expected-error@-1 {{global function 'conformsToBaseIntAndP2' requires that 'T' conform to 'P2' [with 'T' = 'Base<Int>']}}
 
   conformsToBaseIntAndP2WithWhereClause(fakeDerived)
-  // expected-error@-1 {{'(Base<Int>) -> ()' requires that 'Base<Int>' conform to 'P2'}}
+  // expected-error@-1 {{global function 'conformsToBaseIntAndP2WithWhereClause' requires that 'T' conform to 'P2' [with 'T' = 'Base<Int>']}}
 
   conformsToBaseIntAndP2(p2Archetype)
-  // expected-error@-1 {{'(Base<Int>) -> ()' requires that 'Base<Int>' conform to 'P2'}}
+  // expected-error@-1 {{global function 'conformsToBaseIntAndP2' requires that 'T' conform to 'P2' [with 'T' = 'Base<Int>']}}
 
   conformsToBaseIntAndP2WithWhereClause(p2Archetype)
-  // expected-error@-1 {{'(Base<Int>) -> ()' requires that 'Base<Int>' conform to 'P2'}}
+  // expected-error@-1 {{global function 'conformsToBaseIntAndP2WithWhereClause' requires that 'T' conform to 'P2' [with 'T' = 'Base<Int>']}}
 
   // Good
   conformsToAnyObject(anyObject)

--- a/test/type/subclass_composition_objc.swift
+++ b/test/type/subclass_composition_objc.swift
@@ -26,7 +26,7 @@ class SomeMethods {
 
 func takesObjCClass<T : ObjCClass>(_: T) {}
 func takesObjCProtocol<T : ObjCProtocol>(_: T) {}
-func takesObjCClassAndProtocol<T : ObjCClass & ObjCProtocol>(_: T) {} // expected-note {{declared here}}
+func takesObjCClassAndProtocol<T : ObjCClass & ObjCProtocol>(_: T) {} // expected-note {{where 'T' = 'ObjCClass'}}
 
 func testSelfConformance(c: ObjCClass, p: ObjCProtocol, cp: ObjCClass & ObjCProtocol) {
   takesObjCClass(c)
@@ -39,7 +39,7 @@ func testSelfConformance(c: ObjCClass, p: ObjCProtocol, cp: ObjCClass & ObjCProt
 
   // FIXME: Bad diagnostics
   takesObjCClassAndProtocol(c) // expected-error {{argument type 'ObjCClass' does not conform to expected type 'ObjCProtocol'}}
-  takesObjCClassAndProtocol(p) // expected-error {{global function 'takesObjCClassAndProtocol' requires that 'T' conform to 'ObjCProtocol' [with 'T' = 'ObjCClass']}}
+  takesObjCClassAndProtocol(p) // expected-error {{global function 'takesObjCClassAndProtocol' requires that 'ObjCClass' conform to 'ObjCProtocol'}}
   takesObjCClassAndProtocol(cp)
 }
 

--- a/test/type/subclass_composition_objc.swift
+++ b/test/type/subclass_composition_objc.swift
@@ -26,7 +26,7 @@ class SomeMethods {
 
 func takesObjCClass<T : ObjCClass>(_: T) {}
 func takesObjCProtocol<T : ObjCProtocol>(_: T) {}
-func takesObjCClassAndProtocol<T : ObjCClass & ObjCProtocol>(_: T) {}
+func takesObjCClassAndProtocol<T : ObjCClass & ObjCProtocol>(_: T) {} // expected-note {{declared here}}
 
 func testSelfConformance(c: ObjCClass, p: ObjCProtocol, cp: ObjCClass & ObjCProtocol) {
   takesObjCClass(c)
@@ -39,7 +39,7 @@ func testSelfConformance(c: ObjCClass, p: ObjCProtocol, cp: ObjCClass & ObjCProt
 
   // FIXME: Bad diagnostics
   takesObjCClassAndProtocol(c) // expected-error {{argument type 'ObjCClass' does not conform to expected type 'ObjCProtocol'}}
-  takesObjCClassAndProtocol(p) // expected-error {{'(ObjCClass) -> ()' requires that 'ObjCClass' conform to 'ObjCProtocol'}}
+  takesObjCClassAndProtocol(p) // expected-error {{global function 'takesObjCClassAndProtocol' requires that 'T' conform to 'ObjCProtocol' [with 'T' = 'ObjCClass']}}
   takesObjCClassAndProtocol(cp)
 }
 

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar27830834.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar27830834.swift
@@ -1,4 +1,4 @@
 // RUN: %target-swift-frontend %s -typecheck -verify
 
 var d = [String:String]()
-_ = "\(d.map{ [$0 : $0] })" // expected-error {{generic struct 'Dictionary' requires that 'Key' conform to 'Hashable' [with 'Key' = '(key: String, value: String)']}}
+_ = "\(d.map{ [$0 : $0] })" // expected-error {{generic struct 'Dictionary' requires that '(key: String, value: String)' conform to 'Hashable'}}

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar27830834.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar27830834.swift
@@ -1,4 +1,4 @@
 // RUN: %target-swift-frontend %s -typecheck -verify
 
 var d = [String:String]()
-_ = "\(d.map{ [$0 : $0] })" // expected-error {{'[(key: String, value: String) : (key: String, value: String)]' requires that '(key: String, value: String)' conform to 'Hashable'}}
+_ = "\(d.map{ [$0 : $0] })" // expected-error {{generic struct 'Dictionary' requires that 'Key' conform to 'Hashable' [with 'Key' = '(key: String, value: String)']}}


### PR DESCRIPTION
…ed declaration

Instead of simply pointing out which type had conformance failures,
let's use affected declaration instead, which makes diagnostics much
richer e.g.

```
'List<[S], S.Id>' requires that 'S.Id' conform to 'Hashable'
```

versus

```
initializer 'init(_:id:)' requires that 'E' conform to 'Hashable' [with 'E' = 'S.Id']
```

Since latter message uses information about declaration, it can also
point to it in the source. That makes is much easier to understand when
problem is related to overloaded (function) declarations.


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
