### PR TITLE
Sema: Apply metatype-to-object conversions even without restriction hints.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6884,6 +6884,45 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
     }
   }
 
+  // Coercions from metadata to objects.
+  if (auto fromMeta = fromType->getAs<AnyMetatypeType>()) {
+    if (toType->isAnyObject()) {
+      assert(cs.getASTContext().LangOpts.EnableObjCInterop
+             && "metatype-to-object conversion requires objc interop");
+      if (fromMeta->is<MetatypeType>()) {
+        assert(fromMeta->getInstanceType()->mayHaveSuperclass()
+               && "metatype-to-object input should be a class metatype");
+        return cs.cacheType(
+          new (tc.Context) ClassMetatypeToObjectExpr(expr, toType));
+      }
+      
+      if (fromMeta->is<ExistentialMetatypeType>()) {
+        assert(fromMeta->getInstanceType()->getCanonicalType()
+                       ->getExistentialLayout().requiresClass()
+               && "metatype-to-object input should be a class metatype");
+        return cs.cacheType(
+          new (tc.Context) ExistentialMetatypeToObjectExpr(expr, toType));
+      }
+      
+      llvm_unreachable("unhandled metatype kind");
+    }
+    
+    if (auto toClass = toType->getClassOrBoundGenericClass()) {
+      if (toClass->getName() == cs.getASTContext().Id_Protocol
+          && toClass->getModuleContext()->getName()
+              == cs.getASTContext().Id_ObjectiveC) {
+        assert(cs.getASTContext().LangOpts.EnableObjCInterop
+               && "metatype-to-object conversion requires objc interop");
+        assert(fromMeta->is<MetatypeType>()
+               && fromMeta->getInstanceType()->is<ProtocolType>()
+               && "protocol-metatype-to-Protocol only works for single "
+                  "protocols");
+        return cs.cacheType(
+          new (tc.Context) ProtocolMetatypeToObjectExpr(expr, toType));
+      }
+    }
+  }
+
   // Coercions from a type to an existential type.
   if (toType->isAnyExistentialType()) {
     return coerceExistential(expr, toType, locator);

--- a/test/Constraints/class_to_object_in_collection.swift
+++ b/test/Constraints/class_to_object_in_collection.swift
@@ -1,0 +1,19 @@
+// RUN: %target-typecheck-verify-swift %clang-importer-sdk
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -verify %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+func f(_: [AnyObject]) {}
+func g(_: [Protocol]) {}
+
+f([NSString.self, NSObject.self])
+
+@objc protocol P: AnyObject {}
+@objc protocol Q: AnyObject {}
+
+func foo(p: P.Type, pq: (P & Q).Type) {
+  f([p, pq])
+}
+
+g([P.self, Q.self])


### PR DESCRIPTION
In some cases, such as when pushing a collection conversion down to per-element conversions, we'll coerce a subtype metatype to AnyObject, as in:

```
func f(_: [AnyObject]) {}
f([NSString.self, NSObject.self]) // Type checks as [NSObject.Type] converted to [AnyObject]
```

and only record the restriction kinds used in the indirect steps NSString -> NSObject and NSObject.Type -> AnyObject without recording the jump from NSString.Type to AnyObject. coerceToType ought to apply this subtyping rule even without such a hint, though, since the restriction kind is intended only as an optimization. Fixes rdar://problem/42666956 .