### PR TITLE
use lldb commit hash instead of branch name

### DIFF
--- a/utils/update-checkout-config.json
+++ b/utils/update-checkout-config.json
@@ -293,7 +293,7 @@
                 "llvm": "swift-DEVELOPMENT-SNAPSHOT-2018-07-23-a",
                 "clang": "swift-DEVELOPMENT-SNAPSHOT-2018-07-23-a",
                 "swift": "tensorflow",
-                "lldb": "tensorflow",
+                "lldb": "7b71714e6b6ffb745d7f4c113a08eaf81755e943",
                 "cmark": "swift-DEVELOPMENT-SNAPSHOT-2018-07-23-a",
                 "llbuild": "swift-DEVELOPMENT-SNAPSHOT-2018-07-23-a",
                 "swiftpm": "swift-DEVELOPMENT-SNAPSHOT-2018-07-23-a",


### PR DESCRIPTION
This will make `update-checkout` always checkout the correct version of `lldb` rather than the latest version. This will make it safe to push updates to `lldb` before you push updates to `swift`, which will make the merge workflow safer and easier.

As I run through the merge process this week, I'll update the script and doc to set this hash.