### PR TITLE
fix stack promotion location

### DIFF
--- a/test/TensorFlow/diagnostics.swift
+++ b/test/TensorFlow/diagnostics.swift
@@ -96,3 +96,8 @@ public func scalarToHost() {
     i += 1
   }
 }
+
+// expected-warning @+1 {{'t' implicitly copied to the accelerator}}
+public func inoutArgumentToAccelerator(t: inout Tensor<Float>) {
+  t += 1  // expected-note {{value used here}}
+}

--- a/test/TensorFlow/integration.swift
+++ b/test/TensorFlow/integration.swift
@@ -467,7 +467,7 @@ public struct NonInlineMethodExample {
   var b = Tensor<Float>(2.0)
 
   @inline(never)
-  public mutating func mutatingMethod() {  // expected-warning {{value implicitly copied}}
+  public mutating func mutatingMethod() {  // expected-warning {{'self' implicitly copied}}
     a += b   // expected-note {{value used here}}
     b += a
   }


### PR DESCRIPTION
Points all the stack promotion instructions at the location of the address that they are promoting.

This improves the warnings for inout arguments. Warnings used to look like this:
```
workspace/testcase.swift:3:13: warning: value implicitly copied to the accelerator, use .toAccelerator() to make transfer explicit
public func inoutArgumentToAccelerator(t: inout Tensor<Float>) {
       ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
workspace/testcase.swift:4:5: note: value used here
  t += 1
  ~~^~~~
```

Now they look like this:
```
workspace/testcase.swift:3:40: warning: 't' implicitly copied to the accelerator, use .toAccelerator() to make transfer explicit
public func inoutArgumentToAccelerator(t: inout Tensor<Float>) {
                                       ^~~~~~~~~~~~~~~~~~~~~~
workspace/testcase.swift:4:5: note: value used here
  t += 1
  ~~^~~~
```