### PR TITLE
Make compiler not reject @convention(tf) -> @convention(tf) argument passing

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6308,10 +6308,13 @@ maybeDiagnoseUnsupportedFunctionConversion(ConstraintSystem &cs, Expr *expr,
   auto fromFnType = fromType->getAs<AnyFunctionType>();
 
   // SWIFT_ENABLE_TENSORFLOW
-  if (toType->getRepresentation()
-        == AnyFunctionType::Representation::TensorFlow ||
-      fromFnType->getRepresentation()
-        == AnyFunctionType::Representation::TensorFlow) {
+  // If function types have different representations and one of them is
+  // @convention(tensorflow), reject it.
+  auto toTypeRepr = toType->getRepresentation();
+  auto fromTypeRepr = fromFnType->getRepresentation();
+  if (toTypeRepr != fromTypeRepr &&
+      (toTypeRepr == AnyFunctionType::Representation::TensorFlow ||
+       fromTypeRepr == AnyFunctionType::Representation::TensorFlow)) {
     tc.diagnose(expr->getLoc(),
                 diag::invalid_tensorflow_fn_conversion);
     return;

--- a/test/TensorFlow/attr_tensorflow_graph_sema.swift
+++ b/test/TensorFlow/attr_tensorflow_graph_sema.swift
@@ -47,3 +47,19 @@ enum SomeType {
 
 let f: @convention(tensorflow) (Tensor<Float>) -> Tensor<Int32> = tensors(_:) // okay
 let g: (Tensor<Float>) -> Tensor<Int32> = tensors(_:) // expected-error {{TensorFlow functions cannot be converted to other function types}}
+
+func hof(_ f: @convention(tensorflow) (Tensor<Float>) -> Tensor<Int32>) -> Tensor<Float> {}
+_ = hof(tensors) // okay
+
+// Enable these tests when SR-8487 is fixed.
+//
+// let closure: @convention(tensorflow) (Tensor<Float>) -> Tensor<Int32> = {
+//   return Tensor<Int32>($0)
+// } // okay
+//
+// hof {
+//   return Tensor<Int32>($0)
+// } // okay
+
+func hofHost(_ f: (Tensor<Float>) -> Tensor<Int32>) -> Tensor<Float> {}
+_ = hofHost(tensors) // expected-error {{TensorFlow functions cannot be converted to other function types}}


### PR DESCRIPTION
The following function has `@convention(tensorflow)`. 

```swift
@TensorFlowGraph
func tensors(_ x: Tensor<Float>) -> Tensor<Int32> {}
```

When it's being passed to a higher-order function with an identical `@convention(tensorflow)` type, the type checker thinks it's an unsupported conversion.

```swift
func hof(_ f: @convention(tensorflow) (Tensor<Float>) -> Tensor<Int32>) -> Tensor<Float> {}
```

This patch supports passing `@convention(tensorflow)` function values as `@convention(tensorflow)` parameters and only disallow conversion to `@convention(tensorflow)` from a non-TF function type and vice versa.

Resolves [SR-8478](https://bugs.swift.org/browse/SR-8478).