### PR TITLE
Revert "Check for deterministic compilation in the tools=R,stdlib=RD job."

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -214,7 +214,6 @@ dash-dash
 skip-test-ios-host
 skip-test-tvos-host
 skip-test-watchos-host
-check-incremental-compilation
 
 
 [preset: buildbot,tools=RA,stdlib=RDA]


### PR DESCRIPTION
Reverts apple/swift#18524

Unfortunately we are not there yet. The compiler is still not deterministic (for some reason I could not reproduce it locally). I'm reverting this check for now and investigate the non-determinism problem locally.

rdar://problem/43032497