### PR TITLE
[CodeCompletion] Improve context type analysis

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -687,19 +687,12 @@ public:
 /// can help us preserve the context of the code completion position.
 class CodeCompletionExpr : public Expr {
   SourceRange Range;
-  bool Activated;
 
 public:
-  CodeCompletionExpr(SourceRange Range, Type Ty = Type()) :
-      Expr(ExprKind::CodeCompletion, /*Implicit=*/true, Ty),
-      Range(Range) {
-    Activated = false;
-  }
+  CodeCompletionExpr(SourceRange Range, Type Ty = Type())
+      : Expr(ExprKind::CodeCompletion, /*Implicit=*/true, Ty), Range(Range) {}
 
   SourceRange getSourceRange() const { return Range; }
-
-  bool isActivated() const { return Activated; }
-  void setActivated() { Activated = true; }
 
   static bool classof(const Expr *E) {
     return E->getKind() == ExprKind::CodeCompletion;

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -1109,10 +1109,9 @@ ParserResult<Pattern> Parser::parseMatchingPattern(bool isExprBasic) {
   // disambiguate.
   ParserResult<Expr> subExpr =
     parseExprImpl(diag::expected_pattern, isExprBasic);
-  if (subExpr.hasCodeCompletion())
-    return makeParserCodeCompletionStatus();
+  ParserStatus status = subExpr;
   if (subExpr.isNull())
-    return nullptr;
+    return status;
 
   if (SyntaxContext->isEnabled()) {
     if (auto UPES = PatternCtx.popIf<UnresolvedPatternExprSyntax>()) {
@@ -1125,9 +1124,9 @@ ParserResult<Pattern> Parser::parseMatchingPattern(bool isExprBasic) {
   // obvious pattern, which will come back wrapped in an immediate
   // UnresolvedPatternExpr.  Transform this now to simplify later code.
   if (auto *UPE = dyn_cast<UnresolvedPatternExpr>(subExpr.get()))
-    return makeParserResult(UPE->getSubPattern());
+    return makeParserResult(status, UPE->getSubPattern());
   
-  return makeParserResult(new (Context) ExprPattern(subExpr.get()));
+  return makeParserResult(status, new (Context) ExprPattern(subExpr.get()));
 }
 
 ParserResult<Pattern> Parser::parseMatchingPatternAsLetOrVar(bool isLet,

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1190,9 +1190,6 @@ namespace {
     }
 
     virtual Type visitCodeCompletionExpr(CodeCompletionExpr *E) {
-      if (!E->isActivated())
-        return Type();
-
       CS.Options |= ConstraintSystemFlags::SuppressDiagnostics;
       return CS.createTypeVariable(CS.getConstraintLocator(E),
                                    TVO_CanBindToLValue);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2231,9 +2231,6 @@ bool TypeChecker::typeCheckCompletionSequence(Expr *&expr, DeclContext *DC) {
   // Ensure the output expression is up to date.
   assert(exprAsBinOp == expr && isa<BinaryExpr>(expr) && "found wrong expr?");
 
-  // Add type variable for the code-completion expression.
-  CCE->setActivated();
-
   if (auto generated = CS.generateConstraints(expr)) {
     expr = generated;
   } else {

--- a/test/IDE/complete_dynamic_lookup.swift
+++ b/test/IDE/complete_dynamic_lookup.swift
@@ -463,7 +463,7 @@ func testAnyObject11_(_ dl: AnyObject) {
   dl.returnsObjcClass!(#^DL_FUNC_NAME_PAREN_1^#
 }
 // DL_FUNC_NAME_PAREN_1: Begin completions
-// DL_FUNC_NAME_PAREN_1-DAG: Pattern/CurrModule: ['(']{#Int#}[')'][#TopLevelObjcClass#]{{; name=.+$}}
+// DL_FUNC_NAME_PAREN_1-DAG: Pattern/CurrModule: ['(']{#(i): Int#}[')'][#TopLevelObjcClass#]{{; name=.+$}}
 // DL_FUNC_NAME_PAREN_1: End completions
 
 func testAnyObject12(_ dl: AnyObject) {

--- a/test/IDE/complete_enum_elements.swift
+++ b/test/IDE/complete_enum_elements.swift
@@ -28,7 +28,7 @@
 // RUN: %FileCheck %s -check-prefix=FOO_ENUM_DOT < %t.enum.txt
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ENUM_SW_IN_PATTERN_1 > %t.enum.txt
-// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_RESULTS < %t.enum.txt
+// RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_RESULTS_INVALID < %t.enum.txt
 // RUN: %FileCheck %s -check-prefix=ENUM_SW_IN_PATTERN_1 < %t.enum.txt
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ENUM_SW_IN_PATTERN_2 > %t.enum.txt
@@ -279,6 +279,10 @@ func freeFunc() {}
 // WITH_GLOBAL_RESULTS: Begin completions
 // WITH_GLOBAL_RESULTS: Decl[FreeFunction]/CurrModule: freeFunc()[#Void#]{{; name=.+$}}
 // WITH_GLOBAL_RESULTS: End completions
+
+// WITH_GLOBAL_RESULTS_INVALID: Begin completions
+// WITH_GLOBAL_RESULTS_INVALID: Decl[FreeFunction]/CurrModule/NotRecommended/TypeRelation[Invalid]: freeFunc()[#Void#]{{; name=.+$}}
+// WITH_GLOBAL_RESULTS_INVALID: End completions
 
 //===--- Complete enum elements in 'switch'.
 

--- a/test/IDE/complete_expr_postfix_begin.swift
+++ b/test/IDE/complete_expr_postfix_begin.swift
@@ -58,7 +58,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_TYPEALIAS_2 | %FileCheck %s -check-prefix=MY_ALIAS_2
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_1 | %FileCheck %s -check-prefix=IN_FOR_EACH_1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_2 | %FileCheck %s -check-prefix=IN_FOR_EACH_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_2 | %FileCheck %s -check-prefix=IN_FOR_EACH_2
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_3 | %FileCheck %s -check-prefix=IN_FOR_EACH_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_4 | %FileCheck %s -check-prefix=IN_FOR_EACH_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_FOR_EACH_5 | %FileCheck %s -check-prefix=IN_FOR_EACH_1
@@ -443,6 +443,12 @@ func testInForEach2(arg: Int) {
     let inBody = 3
   }
   let after = 4
+// IN_FOR_EACH_2-NOT: Decl[LocalVar]
+// IN_FOR_EACH_2: Decl[LocalVar]/Local/TypeRelation[Identical]: local[#Int#];
+// FIXME: shouldn't show 'after' here.
+// IN_FOR_EACH_2: Decl[LocalVar]/Local/TypeRelation[Identical]: after[#Int#];
+// IN_FOR_EACH_2: Decl[LocalVar]/Local/TypeRelation[Identical]: arg[#Int#];
+// IN_FOR_EACH_2-NOT: Decl[LocalVar]
 }
 func testInForEach3(arg: Int) {
   let local = 2

--- a/test/IDE/complete_operator_operand.swift
+++ b/test/IDE/complete_operator_operand.swift
@@ -1,0 +1,33 @@
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=BINARY_RHS_1 | %FileCheck %s -check-prefix=BINARY_RHS_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=BINARY_RHS_2 | %FileCheck %s -check-prefix=BINARY_RHS_2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PREFIX_1 | %FileCheck %s -check-prefix=PREFIX_1
+
+infix operator <-->
+prefix operator -->
+
+class C1 {}
+class C2 {}
+func <--> (lhs: C1, rhs: C2) -> Bool {}
+func <--> (lhs: C2, rhs: C1) -> Bool {}
+
+func test_binary1(c1: C1, c2: C2) {
+  _ = c1 <--> #^BINARY_RHS_1^#
+// BINARY_RHS_1: Begin completion
+// BINARY_RHS_1-NOT: Decl[LocalVar]/Local/TypeRelation[Identical]: c1[#C1#]; name=c1
+// BINARY_RHS_1-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: c2[#C2#]; name=c2
+
+  _ = c2 <--> #^BINARY_RHS_2^#
+// BINARY_RHS_2: Begin completion
+// BINARY_RHS_2-NOT: Decl[LocalVar]/Local/TypeRelation[Identical]: c2[#C2#]; name=c2
+// BINARY_RHS_2-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: c1[#C1#]; name=c1
+}
+
+prefix func --> (operand: C1) -> Bool {}
+prefix func --> (operand: C2) -> Bool {}
+
+func test_prefix1(c1: C1, c2: C2) {
+  _ = -->#^PREFIX_1^#
+// PREFIX_1: Begin completion
+// PREFIX_1-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: c1[#C1#]; name=c1
+// PREFIX_1-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: c2[#C2#]; name=c2
+}

--- a/test/IDE/complete_pattern.swift
+++ b/test/IDE/complete_pattern.swift
@@ -55,6 +55,8 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=MULTI_PATTERN_3 | %FileCheck %s -check-prefix=MULTI_PATTERN_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=MULTI_PATTERN_4 | %FileCheck %s -check-prefix=MULTI_PATTERN_4
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CC_IN_PATTERN_1 | %FileCheck %s -check-prefix=CC_IN_PATTERN_1
+
 
 //===--- Helper types that are used in this test
 
@@ -261,3 +263,19 @@ func test_multiple_patterns4(x: Int) {
 // MULTI_PATTERN_4-DAG: Decl[LocalVar]/Local: x[#Int#]{{; name=.+$}}
 // MULTI_PATTERN_4: End completions
 
+enum IntHolder {
+  case hold(Int)
+}
+func ident(int: Int) -> Int { return int }
+func ident(double: Double) -> Int { return Double }
+
+func test_cc_in_pattern(subject: IntHolder, i1: Int) {
+  switch subject {
+  case .hold(#^CC_IN_PATTERN_1^#):
+    ()
+  }
+}
+
+// CC_IN_PATTERN_1: Begin completions
+// CC_IN_PATTERN_1-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: i1[#Int#]; name=i1
+// CC_IN_PATTERN_1: End completions

--- a/test/IDE/complete_return.swift
+++ b/test/IDE/complete_return.swift
@@ -7,6 +7,15 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RETURN_TR1 | %FileCheck %s -check-prefix=RETURN_TR1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RETURN_TR2 | %FileCheck %s -check-prefix=RETURN_TR2
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RETURN_TR3 | %FileCheck %s -check-prefix=RETURN_TR3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RETURN_TR1_METHOD | %FileCheck %s -check-prefix=RETURN_TR1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RETURN_TR2_METHOD | %FileCheck %s -check-prefix=RETURN_TR2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RETURN_TR3_METHOD | %FileCheck %s -check-prefix=RETURN_TR3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RETURN_TR1_STATICMETHOD | %FileCheck %s -check-prefix=RETURN_TR1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RETURN_TR2_STATICMETHOD | %FileCheck %s -check-prefix=RETURN_TR2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RETURN_TR3_STATICMETHOD | %FileCheck %s -check-prefix=RETURN_TR3
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RETURN_TR1_CLOSURE | %FileCheck %s -check-prefix=RETURN_TR1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RETURN_TR2_CLOSURE | %FileCheck %s -check-prefix=RETURN_TR2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RETURN_TR3_CLOSURE | %FileCheck %s -check-prefix=RETURN_TR3
 
 struct FooStruct {
   var instanceVar : Int
@@ -104,3 +113,47 @@ func testTR3(_ g : Gen) -> Int? {
 // RETURN_TR3-DAG: Decl[InstanceMethod]/CurrNominal:   InternalStringOpGen()[#String?#]{{; name=.+$}}
 // RETURN_TR3-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended/TypeRelation[Invalid]: InternalIntTaker({#(i1): Int#}, {#i2: Int#})[#Void#]{{; name=.+$}}
 // RETURN_TR3-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended/TypeRelation[Invalid]: InternalStringTaker({#(s1): String#}, {#s2: String#})[#Void#]{{; name=.+$}}
+
+struct TestStruct {
+  func testTR1_method() -> Int? {
+    var i : Int
+    var oi : Int?
+    var fs : FooStruct
+    return #^RETURN_TR1_METHOD^#
+  }
+  func testTR2_method(_ g : Gen) -> Int? {
+    return g.#^RETURN_TR2_METHOD^#
+  }
+  func testTR3_method(_ g : Gen) -> Int? {
+    return g.IG.#^RETURN_TR3_METHOD^#
+  }
+
+  static func testTR1_static() -> Int? {
+    var i : Int
+    var oi : Int?
+    var fs : FooStruct
+    return #^RETURN_TR1_STATICMETHOD^#
+  }
+  static func testTR2_static(_ g : Gen) -> Int? {
+    return g.#^RETURN_TR2_STATICMETHOD^#
+  }
+  static func testTR3_static(_ g : Gen) -> Int? {
+    return g.IG.#^RETURN_TR3_STATICMETHOD^#
+  }
+}
+
+func testClosures(_ g: Gen) {
+  var i : Int
+  var oi : Int?
+  var fs : FooStruct
+
+  _ = { () -> Int? in
+    return #^RETURN_TR1_CLOSURE^#
+  }
+  _ = { () -> Int? in
+    return g.#^RETURN_TR2_CLOSURE^#
+  }
+  _ = { () -> Int? in
+    return g.IG.#^RETURN_TR3_CLOSURE^#
+  }
+}


### PR DESCRIPTION
* Always activate `CodeCompletionExpr` so we don't interfere typechecking contexts.
* Improve inference of return type from context.
  * For methods, un-curry function interface type so we can get declared return type.
  * For closures, fall back to getting explicit result type in case we failed to retrieve it from the type of the closure itself.
* Handle binary/unary expression in context type analysis. This improves completion for RHS of operators.
* Handle `ExprPattern` in context type analysis. This improves completion in matching pattern.
* Small cleanups for `getPositionInArgs()` (https://github.com/apple/swift/pull/18535#discussion_r208281106)