### PR TITLE
[tensorflow] Fix a crash caused by tf::skipInternalLocations.

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -1554,17 +1554,15 @@ SILDebugLocation tf::skipInternalLocations(SILDebugLocation loc) {
   // implementation guts of the tensor library.  We want to report the
   // message inside the user's code, not in the guts we inlined through.
   for (; auto ics = ds->InlinedCallSite; ds = ics) {
-    // If we found a valid inlined-into location, then we are good.
-    if (ds->Loc.getSourceLoc().isValid())
-      return SILDebugLocation(ds->Loc, ds);
+    // Stop if ds is already inside a valid function location.
     if (SILFunction *F = ds->getInlinedFunction()) {
       if (F->getLocation().getSourceLoc().isValid())
         break;
     }
+    // If we found a valid inlined-into location, then we are good.
+    if (ics->Loc.getSourceLoc().isValid())
+      return SILDebugLocation(ics->Loc, ics);
   }
-
-  if (ds->Loc.getSourceLoc().isValid())
-    return SILDebugLocation(ds->Loc, ds);
 
   return loc;
 }

--- a/test/TensorFlow/crashers.swift
+++ b/test/TensorFlow/crashers.swift
@@ -353,3 +353,17 @@ public func constFoldingBug() {
     return
   }
 }
+
+public func SR8419(iterationCount: Int) {
+  let images = Tensor<Float>(ones: [1000, 784])
+  let batchSize = Float(images.shape[0])
+
+  _hostOp("Begin training for \(iterationCount) iterations.")
+
+  for _ in 0...iterationCount {
+    let bound = Int32(batchSize)/25
+    for _ in 0..<bound {
+      let _ = Tensor(1)
+    }
+  }
+}

--- a/test/TensorFlow/crashers.swift
+++ b/test/TensorFlow/crashers.swift
@@ -354,6 +354,7 @@ public func constFoldingBug() {
   }
 }
 
+// This function failed SIL verification due to a non-inlined SILDebugLocation.
 public func SR8419(iterationCount: Int) {
   let images = Tensor<Float>(ones: [1000, 784])
   let batchSize = Float(images.shape[0])


### PR DESCRIPTION
This patch improves `tf::skipInternalLocations` to correctly handle non-inlined SILDebugScope input. It returns the input `loc` in this case, instead of a new `SILDebugLocation(ds->Loc, ds)` which may lead to crashes in SIL verification.

Resolves [SR-8419](https://bugs.swift.org/browse/SR-8419).
