### PR TITLE
[build-script] Generate JUnit results from lit for LLDB

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2871,7 +2871,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     with_pushd ${lldb_build_dir} \
                      call ${NINJA_BIN} unittests/LLDBUnitTests
                     with_pushd ${results_dir} \
-                     call "${llvm_build_dir}/bin/llvm-lit" "${lldb_build_dir}/lit" -sv --param dotest-args="--build-dir ${lldb_build_dir}/lldb-test-build.noindex ${LLDB_TEST_SUBDIR_CLAUSE} ${LLDB_TEST_CATEGORIES} -E \"${DOTEST_EXTRA}\""
+                     call "${llvm_build_dir}/bin/llvm-lit" "${lldb_build_dir}/lit" -sv --xunit-xml-output=${results_dir}/results.xml --param dotest-args="--build-dir ${lldb_build_dir}/lldb-test-build.noindex ${LLDB_TEST_SUBDIR_CLAUSE} ${LLDB_TEST_CATEGORIES} -E \"${DOTEST_EXTRA}\""
 
                 else
                     with_pushd "${results_dir}" \


### PR DESCRIPTION
By switching to lit to run the LLDB tests we need to specify where to
generate the results.