### PR TITLE
[4.2] Sema: Apply metatype-to-object conversions even without restriction hints.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6992,6 +6992,45 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
     }
   }
 
+  // Coercions from metadata to objects.
+  if (auto fromMeta = fromType->getAs<AnyMetatypeType>()) {
+    if (toType->isAnyObject()) {
+      assert(cs.getASTContext().LangOpts.EnableObjCInterop
+             && "metatype-to-object conversion requires objc interop");
+      if (fromMeta->is<MetatypeType>()) {
+        assert(fromMeta->getInstanceType()->mayHaveSuperclass()
+               && "metatype-to-object input should be a class metatype");
+        return cs.cacheType(
+          new (tc.Context) ClassMetatypeToObjectExpr(expr, toType));
+      }
+      
+      if (fromMeta->is<ExistentialMetatypeType>()) {
+        assert(fromMeta->getInstanceType()->getCanonicalType()
+                       ->getExistentialLayout().requiresClass()
+               && "metatype-to-object input should be a class metatype");
+        return cs.cacheType(
+          new (tc.Context) ExistentialMetatypeToObjectExpr(expr, toType));
+      }
+      
+      llvm_unreachable("unhandled metatype kind");
+    }
+    
+    if (auto toClass = toType->getClassOrBoundGenericClass()) {
+      if (toClass->getName() == cs.getASTContext().Id_Protocol
+          && toClass->getModuleContext()->getName()
+              == cs.getASTContext().Id_ObjectiveC) {
+        assert(cs.getASTContext().LangOpts.EnableObjCInterop
+               && "metatype-to-object conversion requires objc interop");
+        assert(fromMeta->is<MetatypeType>()
+               && fromMeta->getInstanceType()->is<ProtocolType>()
+               && "protocol-metatype-to-Protocol only works for single "
+                  "protocols");
+        return cs.cacheType(
+          new (tc.Context) ProtocolMetatypeToObjectExpr(expr, toType));
+      }
+    }
+  }
+
   // Coercions from a type to an existential type.
   if (toType->isAnyExistentialType()) {
     return coerceExistential(expr, toType, locator);

--- a/test/Constraints/class_to_object_in_collection.swift
+++ b/test/Constraints/class_to_object_in_collection.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -verify %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+func f(_: [AnyObject]) {}
+func g(_: [Protocol]) {}
+
+f([NSString.self, NSObject.self])
+
+@objc protocol P: AnyObject {}
+@objc protocol Q: AnyObject {}
+
+func foo(p: P.Type, pq: (P & Q).Type) {
+  f([p, pq])
+}
+
+g([P.self, Q.self])


### PR DESCRIPTION
Explanation: The compiler would crash or miscompile when arrays of class objects were bridged to an array of `[AnyObject]`.

Scope: Regression from 4.1

Issue: rdar://problem/42666956

Risk: Low, small bug fix.

Testing: Test case from Radar, Swift CI, compatibility suite

Reviewed by: @rudkx, @xedin 