### PR TITLE
Extended const eval engine to const-evaluate a chain of tuple_element_addr insts

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
@@ -197,8 +197,7 @@ SymbolicValue ConstExprFunctionState::computeConstantValue(SILValue value) {
   // single store value.  Since this is a very different computation, split it
   // out to its own path.
   if (!fn && value->getType().isAddress() && isa<AllocStackInst>(value)) {
-    SymbolicValue result = getSingleWriterAddressValue(value);
-    return result;
+    return getSingleWriterAddressValue(value);
   }
 
   // If this a trivial constant instruction that we can handle, then fold it

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
@@ -1723,7 +1723,7 @@ bool ConstExprEvaluator::decodeAllocUninitializedArray(
         use = iai->getSingleUse();
         if (!use)
           return true;
-        user = use ? use->getUser() : nullptr;
+        user = use->getUser();
       }
 
       // We handle the cases that the element is either set by a store or

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
@@ -840,10 +840,9 @@ ConstExprFunctionState::computeCallResult(ApplyInst *apply) {
       // Okay, we were able to decode the array.  See if we can fold all of the
       // elements we found.
       for (auto *use : elementsAtInit) {
-        SymbolicValue eltCst;
         auto addrValue = use->get();
         assert(addrValue->getType().isAddress());
-        eltCst = computeLoadResult(addrValue);
+        SymbolicValue eltCst = computeLoadResult(addrValue);
         if (!eltCst.isConstant())
           return eltCst;
         elementConstants.push_back(eltCst);

--- a/test/TensorFlow/no_copy.swift
+++ b/test/TensorFlow/no_copy.swift
@@ -236,3 +236,10 @@ public func SR8399_2() {
   let y = x.reshaped(toShape: Tensor<Int32>([4, Int32(1 * 1)]))
   _hostOp(y)
 }
+
+public func SR8413() {
+  let x = Tensor<Float>(ones: [17, 17, 17, 17])
+  let _ = x.maxPooled(
+    kernelSize: (64, 65, 66, 67), strides: (64, 65, 66, 67), padding: .same
+  )
+}


### PR DESCRIPTION
One use case is to deabstract a const tuple used in the `kernelSize` and `strides` attrs of the TF `maxPoolV2` op.

One example is given by the SIL snippet below. There we set
`elementsAtInit[index]` to %178 with `index` being 3. To const-evaluate the last
copy_addr below, we first const-evaluate %191, which const-evaluates %179, which
involves const-evaluating %183, where the writer to that tuple elt address is
"copy_addr %114". Eventually it const-evaluates %101 to fill in the vlaue for
%183. The continues until the writer insts of all the other tuple elements of
%179 are const-evaluated, yielding a const tuple for %179. This finally gives us
the const value at address %178.

```
%101 = tuple_extract %96 : $(Int32, Int32, Int32, Int32), 3
%108 = alloc_stack $Int32
store %101 to %108 : $*Int32
%114 = tuple_element_addr %110 : $*(Int32, Int32, Int32, Int32), 3
%121 = tuple_element_addr %110 : $*(Int32, Int32, Int32, Int32), 3
copy_addr [take] %108 to [initialization] %121 : $*Int32
copy_addr %114 to [initialization] %183 : $*Int32
%177 = integer_literal $Builtin.Word, 3
%178 = index_addr %130 : $*Int32, %177
%179 = alloc_stack $(Int32, Int32, Int32, Int32)
%183 = tuple_element_addr %179 : $*(Int32, Int32, Int32, Int32), 3
%191 = tuple_element_addr %179 : $*(Int32, Int32, Int32, Int32), 3
copy_addr [take] %191 to [initialization] %178 : $*Int32
```

Also refactored the code as follows:
- Renamed computeXXX() methods to getXXX(), when such methods use the
  cache (`calculatedValues`).

- Wrote comments to contrast `getSingleWriterAddressValue()` with
  `getConstAddrAndLoadResult()`, and corrected `decodeAllocUninitializedArray()`
  logic to call `getSingleWriterAddressValue()` instead of
  `getConstAddrAndLoadResult()`.

- Moved more code from `getConstantValue()` to `computeConstantValue()`, so that the
  former becomes a thin wrapper for the latter, and the wrapper only handles
  caching.


<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-8413](https://bugs.swift.org/browse/SR-8413).
