### PR TITLE
master-next: Disable LLVM ABI breaking check enforcement in the demangler

### DIFF
--- a/lib/Demangling/CMakeLists.txt
+++ b/lib/Demangling/CMakeLists.txt
@@ -1,3 +1,11 @@
+# Do not enforce checks for LLVM's ABI-breaking build settings.
+# The demangler uses some header-only code from LLVM's ADT classes,
+# but we do not want to link libSupport into the demangler. These checks rely
+# on the presence of symbols in libSupport to identify how the code was
+# built and cause link failures for mismatches. Without linking that library,
+# we get link failures regardless, so instead, this just disables the checks.
+append("-DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+
 add_swift_library(swiftDemangling STATIC
   Demangler.cpp
   Context.cpp

--- a/lib/SwiftDemangle/CMakeLists.txt
+++ b/lib/SwiftDemangle/CMakeLists.txt
@@ -3,6 +3,14 @@ add_swift_library(swiftDemangle SHARED
   MangleHack.cpp
   LINK_LIBRARIES swiftDemangling)
 
+# Do not enforce checks for LLVM's ABI-breaking build settings.
+# The demangler uses some header-only code from LLVM's ADT classes,
+# but we do not want to link libSupport into the demangler. These checks rely
+# on the presence of symbols in libSupport to identify how the code was
+# built and cause link failures for mismatches. Without linking that library,
+# we get link failures regardless, so instead, this just disables the checks.
+append("-DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+
 swift_install_in_component(compiler
     TARGETS swiftDemangle
     LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}"


### PR DESCRIPTION
LLVM r338955 added an include of "llvm/Config/abi-breaking.h" in
the llvm/ADT/STLExtras.h header so that the Swift demangler's use of
header-only ADT code runs afoul of the ABI breaking check enforcement.
Disable those checks for the demangler in the same way that we already
do for the Swift runtime.