### PR TITLE
fix compile and test failures caused by merge

### DIFF
--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -557,10 +557,10 @@ static BuiltinGenericSignatureBuilder::LambdaGenerator
 makeBoundGeneric(NominalTypeDecl *decl, const P &parentGenerator,
                  const Gs & ...genericParamGenerators) {
   return {
-    [=](BuiltinGenericSignatureBuilder &builder, bool forBody) -> Type {
-      Type parent = parentGenerator.build(builder, forBody);
+    [=](BuiltinGenericSignatureBuilder &builder) -> Type {
+      Type parent = parentGenerator.build(builder);
       Type genParams[] = {
-        genericParamGenerators.build(builder, forBody)...
+        genericParamGenerators.build(builder)...
       };
       return BoundGenericType::get(decl, parent, genParams);
     }

--- a/lib/SILOptimizer/Mandatory/TFDevicePartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDevicePartition.cpp
@@ -22,6 +22,7 @@
 #include "swift/SIL/CFG.h"
 #include "swift/SIL/SILCloner.h"
 #include "swift/SIL/SILConstants.h"
+#include "swift/SIL/SILFunctionBuilder.h"
 #include "swift/SIL/SILVisitor.h"
 #include "swift/SILOptimizer/Utils/Local.h"
 #include "llvm/ADT/DepthFirstIterator.h"
@@ -651,7 +652,8 @@ public:
     std::string resultFnName = srcFn.getName().str() + "_" +
                                getDeviceShortName(deviceType) +
                                ".device_partition";
-    auto resultFn = srcFn.getModule().getOrCreateFunction(
+    SILFunctionBuilder FB(srcFn.getModule());
+    auto resultFn = FB.getOrCreateFunction(
         srcFn.getLocation(), resultFnName, SILLinkage::Private, newFnType,
         /*What's this*/ IsBare, IsNotTransparent, IsNotSerialized);
 

--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -35,6 +35,7 @@
 #include "swift/SIL/LoopInfo.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILCloner.h"
+#include "swift/SIL/SILFunctionBuilder.h"
 #include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
 #include "swift/SILOptimizer/Analysis/LoopAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
@@ -2379,13 +2380,14 @@ PrimalGen::createEmptyPrimal(DifferentiationTask *task) {
                                        results,
                                        originalTy->getOptionalErrorResult(),
                                        context.getASTContext());
-  auto *primal = module.getOrCreateFunction(original->getLocation(),
-                                            primalName,
-                                            original->getLinkage(),
-                                            primalTy,
-                                            original->isBare(),
-                                            original->isTransparent(),
-                                            original->isSerialized());
+  SILFunctionBuilder FB(module);
+  auto *primal = FB.getOrCreateFunction(original->getLocation(),
+                                        primalName,
+                                        original->getLinkage(),
+                                        primalTy,
+                                        original->isBare(),
+                                        original->isTransparent(),
+                                        original->isSerialized());
   primal->setUnqualifiedOwnership();
   LLVM_DEBUG(getADDebugStream() << "Primal function created \n" << *primal << '\n');
   task->setPrimal(primal);
@@ -2498,13 +2500,14 @@ AdjointGen::createEmptyAdjoint(DifferentiationTask *task) {
                                       origTy->getCalleeConvention(),
                                       adjParams, {}, adjResults, None,
                                       original->getASTContext());
-  auto *adjoint = module.createFunction(original->getLinkage(),
-                                        adjName, adjType,
-                                        original->getGenericEnvironment(),
-                                        original->getLocation(),
-                                        original->isBare(),
-                                        original->isTransparent(),
-                                        original->isSerialized());
+  SILFunctionBuilder FB(module);
+  auto *adjoint = FB.createFunction(original->getLinkage(),
+                                    adjName, adjType,
+                                    original->getGenericEnvironment(),
+                                    original->getLocation(),
+                                    original->isBare(),
+                                    original->isTransparent(),
+                                    original->isSerialized());
   adjoint->setUnqualifiedOwnership();
   adjoint->setDebugScope(
     new (module) SILDebugScope(original->getLocation(), adjoint));
@@ -3647,13 +3650,14 @@ static SILFunction *lookupOrSynthesizeGradient(
     std::string gradName =
       original->getName().str() + "__" + mangleADConfig(config);
     auto gradNameId = astCtx.getIdentifier(gradName);
-    auto *gradFn = module.createFunction(original->getLinkage(),
-                                         gradNameId.str(), gradType,
-                                         original->getGenericEnvironment(),
-                                         original->getLocation(),
-                                         original->isBare(),
-                                         original->isTransparent(),
-                                         original->isSerialized());
+    SILFunctionBuilder FB(module);
+    auto *gradFn = FB.createFunction(original->getLinkage(),
+                                     gradNameId.str(), gradType,
+                                     original->getGenericEnvironment(),
+                                     original->getLocation(),
+                                     original->isBare(),
+                                     original->isTransparent(),
+                                     original->isSerialized());
     gradFn->setUnqualifiedOwnership();
     gradFn->setDebugScope(
       new (module) SILDebugScope(original->getLocation(), gradFn));

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -28,6 +28,7 @@
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILCloner.h"
 #include "swift/SIL/SILConstants.h"
+#include "swift/SIL/SILFunctionBuilder.h"
 #include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
@@ -606,36 +607,6 @@ void BlocksReachingTensorCode::dump() { PDI.print(llvm::errs()); }
 //===----------------------------------------------------------------------===//
 //                             FunctionPartitioner
 //===----------------------------------------------------------------------===//
-
-namespace llvm {
-template <typename T> struct DenseMapInfo;
-
-// An alternative is to SourceManager::getLineAndColumn() as the
-// DenseMap/DenseSet key type instead of SourceRange. That would require that
-// the call-site translate a SILLocation / SourceRange to line and column
-// numbers first.
-template <> struct DenseMapInfo<SourceRange> {
-  static SourceRange getEmptyKey() { return SourceRange(); }
-
-  static SourceRange getTombstoneKey() {
-    // Make this different from empty key. See for context:
-    // http://lists.llvm.org/pipermail/llvm-dev/2015-July/088744.html
-    return SourceRange(SourceLoc(
-        SMLoc::getFromPointer(DenseMapInfo<const char *>::getTombstoneKey())));
-  }
-
-  static unsigned getHashValue(const SourceRange &Val) {
-    return hash_combine(DenseMapInfo<const void *>::getHashValue(
-                            Val.Start.getOpaquePointerValue()),
-                        DenseMapInfo<const void *>::getHashValue(
-                            Val.End.getOpaquePointerValue()));
-  }
-
-  static bool isEqual(const SourceRange &LHS, const SourceRange &RHS) {
-    return LHS == RHS;
-  }
-};
-} // namespace llvm
 
 namespace {
 /// Marking values in the host program need to either be moved, copied, or have
@@ -4283,7 +4254,8 @@ bool TFFunctionPartition::partition(bool isTest) {
       SILCoroutineKind::None, ParameterConvention::Direct_Owned, params,
       /*interfaceYields*/ {}, results, /*interfaceErrorResult*/ None,
       hostFn.getModule().getASTContext());
-  auto resultFn = hostFn.getModule().getOrCreateFunction(
+  SILFunctionBuilder FB(hostFn.getModule());
+  auto resultFn = FB.getOrCreateFunction(
       hostFn.getLocation(), hostFn.getName().str() + ".tf", SILLinkage::Private,
       newFnType,
       /*What's this*/ IsBare, IsNotTransparent, IsNotSerialized);

--- a/test/AutoDiff/autodiff_basic.sil
+++ b/test/AutoDiff/autodiff_basic.sil
@@ -6,17 +6,17 @@ import Swift
 sil_stage raw
 
 sil hidden @foo_adj : $@convention(thin) (Float, Float, Float) -> Float {
-bb0(%0 : $Float, %1 : $Float, %2 : $Float):
+bb0(%0 : @trivial $Float, %1 : @trivial $Float, %2 : @trivial $Float):
   return %2 : $Float
 }
 
 sil hidden [reverse_differentiable source 0 wrt 0 primal @foo adjoint @foo_adj] @foo : $@convention(thin) (Float) -> Float {
-bb0(%0 : $Float):
+bb0(%0 : @trivial $Float):
   return %0 : $Float
 }
 
 sil hidden @bar : $@convention(thin) (Float) -> (Float, Float) {
-bb0(%0 : $Float):
+bb0(%0 : @trivial $Float):
   %1 = function_ref @foo : $@convention(thin) (Float) -> Float
   %2 = gradient [source 0] [wrt 0] %1 : $@convention(thin) (Float) -> Float
   %3 = apply %2(%0) : $@convention(thin) (Float) -> Float

--- a/test/AutoDiff/gradient_inst.sil
+++ b/test/AutoDiff/gradient_inst.sil
@@ -5,17 +5,17 @@ sil_stage raw
 import Swift
 
 sil @foo : $@convention(thin) (Float, Float) -> Float {
-bb0(%0 : $Float, %1 : $Float):
+bb0(%0 : @trivial $Float, %1 : @trivial $Float):
   return undef : $Float
 }
 
 // CHECK-LABEL: sil @foo : $@convention(thin) (Float, Float) -> Float {
-// CHECK-NEXT: bb0(%0 : $Float, %1 : $Float):
+// CHECK-NEXT: bb0(%0 : @trivial $Float, %1 : @trivial $Float):
 // CHECK-NEXT:   return undef : $Float
 // CHECK-NEXT: }
 
 sil @dfoo : $@convention(thin) (Float, Float) -> (Float, Float) {
-bb0(%0 : $Float, %1 : $Float):
+bb0(%0 : @trivial $Float, %1 : @trivial $Float):
   %2 = function_ref @foo : $@convention(thin) (Float, Float) -> Float
   %3 = gradient [source 0] [wrt 0, 1] %2 : $@convention(thin) (Float, Float) -> Float
   %4 = apply %3(%0, %1) : $@convention(thin) (Float, Float) -> (Float, Float) 
@@ -23,7 +23,7 @@ bb0(%0 : $Float, %1 : $Float):
 }
 
 // CHECK-LABEL: sil @dfoo : $@convention(thin) (Float, Float) -> (Float, Float) {
-// CHECK: bb0(%0 : $Float, %1 : $Float):
+// CHECK: bb0(%0 : @trivial $Float, %1 : @trivial $Float):
 // CHECK:   %2 = function_ref @foo : $@convention(thin) (Float, Float) -> Float
 // CHECK-NEXT:   %3 = gradient [source 0] [wrt 0, 1] %2 : $@convention(thin) (Float, Float) -> Float
 // CHECK-NEXT:   %4 = apply %3(%0, %1) : $@convention(thin) (Float, Float) -> (Float, Float)
@@ -31,7 +31,7 @@ bb0(%0 : $Float, %1 : $Float):
 // CHECK-NEXT: }
 
 sil @dfoo_seedable : $@convention(thin) (Float, Float, Float) -> (Float, Float) {
-bb0(%0 : $Float, %1 : $Float, %2 : $Float):
+bb0(%0 : @trivial $Float, %1 : @trivial $Float, %2 : @trivial $Float):
   %3 = function_ref @foo : $@convention(thin) (Float, Float) -> Float
   %4 = gradient [source 0] [wrt 0, 1] [seedable] %3 : $@convention(thin) (Float, Float) -> Float
   %5 = apply %4(%0, %1, %2) : $@convention(thin) (Float, Float, Float) -> (Float, Float)
@@ -39,7 +39,7 @@ bb0(%0 : $Float, %1 : $Float, %2 : $Float):
 }
 
 // CHECK-LABEL: sil @dfoo_seedable : $@convention(thin) (Float, Float, Float) -> (Float, Float) {
-// CHECK: bb0(%0 : $Float, %1 : $Float, %2 : $Float):
+// CHECK: bb0(%0 : @trivial $Float, %1 : @trivial $Float, %2 : @trivial $Float):
 // CHECK:   %3 = function_ref @foo : $@convention(thin) (Float, Float) -> Float
 // CHECK-NEXT:   %4 = gradient [source 0] [wrt 0, 1] [seedable] %3 : $@convention(thin) (Float, Float) -> Float
 // CHECK-NEXT:   %5 = apply %4(%0, %1, %2) : $@convention(thin) (Float, Float, Float) -> (Float, Float)
@@ -47,7 +47,7 @@ bb0(%0 : $Float, %1 : $Float, %2 : $Float):
 // CHECK-NEXT: }
 
 sil @dfoo_preserving_result : $@convention(thin) (Float, Float) -> (Float, Float, Float) {
-bb0(%0 : $Float, %1 : $Float):
+bb0(%0 : @trivial $Float, %1 : @trivial $Float):
   %2 = function_ref @foo : $@convention(thin) (Float, Float) -> Float
   %3 = gradient [source 0] [wrt 0, 1] [preserving_result] %2 : $@convention(thin) (Float, Float) -> Float
   %4 = apply %3(%0, %1) : $@convention(thin) (Float, Float) -> (Float, Float, Float)
@@ -55,7 +55,7 @@ bb0(%0 : $Float, %1 : $Float):
 }
 
 // CHECK_LABEL: sil @dfoo_preserving_result : $@convention(thin) (Float, Float) -> (Float, Float, Float) {
-// CHECK: bb0(%0 : $Float, %1 : $Float):
+// CHECK: bb0(%0 : @trivial $Float, %1 : @trivial $Float):
 // CHECK:   %2 = function_ref @foo : $@convention(thin) (Float, Float) -> Float
 // CHECK-NEXT:   %3 = gradient [source 0] [wrt 0, 1] [preserving_result] %2 : $@convention(thin) (Float, Float) -> Float
 // CHECK-NEXT:   %4 = apply %3(%0, %1) : $@convention(thin) (Float, Float) -> (Float, Float, Float)

--- a/test/AutoDiff/tape_builtins.sil
+++ b/test/AutoDiff/tape_builtins.sil
@@ -6,7 +6,7 @@ import Swift
 import Builtin
 
 sil @foo : $@convention(thin) (Float, Float) -> Float {
-bb0(%0 : $Float, %1 : $Float):
+bb0(%0 : @trivial $Float, %1 : @trivial $Float):
   %tape = builtin "autodiffCreateTape"<Float>() : $_AutoDiffTape<Float>
   %id = integer_literal $Builtin.Word, 0
   builtin "autodiffPushToTape"<Float>(%tape : $_AutoDiffTape<Float>, %0 : $Float, %id : $Builtin.Word) : $()
@@ -16,7 +16,7 @@ bb0(%0 : $Float, %1 : $Float):
 }
 
 // CHECK-LABEL: @foo
-// CHECK: bb0(%0 : $Float, %1 : $Float):
+// CHECK: bb0(%0 : @trivial $Float, %1 : @trivial $Float):
 // CHECK:  [[tape:%.*]] = builtin "autodiffCreateTape"<Float>() : $_AutoDiffTape<Float>
 // CHECK:  [[id:%.*]] = integer_literal $Builtin.Word, 0
 // CHECK:  builtin "autodiffPushToTape"<Float>([[tape]] : $_AutoDiffTape<Float>, %0 : $Float, [[id]] : $Builtin.Word) : $()

--- a/test/AutoDiff/tape_builtins_irgen.sil
+++ b/test/AutoDiff/tape_builtins_irgen.sil
@@ -6,7 +6,7 @@ import Swift
 import Builtin
 
 sil @foo : $@convention(thin) (Float, Float) -> Float {
-bb0(%0 : $Float, %1 : $Float):
+bb0(%0 : @trivial $Float, %1 : @trivial $Float):
   %tape = builtin "autodiffCreateTape"<Float>() : $_AutoDiffTape<Float>
   %id = integer_literal $Builtin.Word, 0
   builtin "autodiffPushToTape"<Float>(%tape : $_AutoDiffTape<Float>, %0 : $Float, %id : $Builtin.Word) : $()

--- a/test/TensorFlow/deabstraction_finished.swift
+++ b/test/TensorFlow/deabstraction_finished.swift
@@ -13,7 +13,7 @@ CHECK-LABEL: --- INPUT FUNCTION {{.*}}trivialAdd
 CHECK: graph_op "Add,i,i"({{.*}} : $TensorHandle<Float>, {{.*}} : $TensorHandle<Float>) {T: $Float, __device: "/device:CPU:0"} : $TensorHandle<Float>
 
 CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}trivialAdd
-CHECK:      bb0(%0 : $TensorHandle<Float>):
+CHECK:      bb0(%0 : @unowned $TensorHandle<Float>):
 CHECK-NEXT:   %1 = graph_op "Add,i,i"(%0 : $TensorHandle<Float>, %0 : $TensorHandle<Float>) {T: $Float, __device: "/device:CPU:0"} : $TensorHandle<Float>
 CHECK-NEXT:   return %1 : $TensorHandle<Float>
 
@@ -77,7 +77,7 @@ public func inputListMultipleUses(a: TensorHandle<Float>)
 
 /*
 CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}inputListMultipleUses
-CHECK: bb0(%0 : $TensorHandle<Float>):
+CHECK: bb0(%0 : @unowned $TensorHandle<Float>):
 CHECK:   %1 = graph_op "Pack,L,e,e,e"(%0 : $TensorHandle<Float>, %0 : $TensorHandle<Float>, %0 : $TensorHandle<Float>)
 CHECK:   return %1 : $TensorHandle<Float>
 CHECK-LABEL: ----
@@ -118,7 +118,7 @@ public func test75407624() {
  * CHECK: [[CX2:%.*]] = graph_op "Const"() {dtype: $Float, value$tensor: f32 0x3F800000 /* 1 */
  * CHECK:  graph_op "Fill,i,i"([[C1X]] : $TensorHandle<Int32>, [[CX2]] : $TensorHandle<Float>)
  * CHECK: graph_op "Const"() {dtype: $Float, value$tensor: [$Float: (f32 0x3F800000 /* 1 */), (f32 0x40000000 /* 2 */), (f32 0x40400000 /* 3 */), (f32 0x40800000 /* 4 */)], value$shape: [$Int32: (i32 2), (i32 2)],
- * CHECK-LABEL: ---- END OF 
+ * CHECK-LABEL: ---- END OF
 */
 
 

--- a/test/TensorFlow/graph_op_inst.sil
+++ b/test/TensorFlow/graph_op_inst.sil
@@ -35,40 +35,40 @@ bb0:
 // CHECK-NEXT: }
 
 sil @chained_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> Tensor<Float> {
-bb0(%0 : $Tensor<Float>, %1 : $Tensor<Float>):
+bb0(%0 : @trivial $Tensor<Float>, %1 : @trivial $Tensor<Float>):
   %2 = graph_op "tf.Add"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) {T: $Float} : $Tensor<Float>
   %3 = graph_op "tf.Mul"(%2 : $Tensor<Float>, %2 : $Tensor<Float>) {T: $Float} : $Tensor<Float>
   return %3 : $Tensor<Float>
 }
 
 // CHECK-LABEL: sil @chained_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> Tensor<Float> {
-// CHECK: bb0(%0 : $Tensor<Float>, %1 : $Tensor<Float>):
+// CHECK: bb0(%0 : @trivial $Tensor<Float>, %1 : @trivial $Tensor<Float>):
 // CHECK-NEXT:   %2 = graph_op "tf.Add"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) {T: $Float} : $Tensor<Float>
 // CHECK-NEXT:   %3 = graph_op "tf.Mul"(%2 : $Tensor<Float>, %2 : $Tensor<Float>) {T: $Float} : $Tensor<Float>
 // CHECK-NEXT:   return %3 : $Tensor<Float>
 // CHECK-NEXT: }
 
 sil @single_result_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> Tensor<Float> {
-bb0(%0 : $Tensor<Float>, %1 : $Tensor<Float>):
+bb0(%0 : @trivial $Tensor<Float>, %1 : @trivial $Tensor<Float>):
   %2 = graph_op "tf.Add"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) {T: $Float} : $Tensor<Float>
   return %2 : $Tensor<Float>
 }
 
 // CHECK-LABEL: sil @single_result_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> Tensor<Float> {
-// CHECK: bb0(%0 : $Tensor<Float>, %1 : $Tensor<Float>):
+// CHECK: bb0(%0 : @trivial $Tensor<Float>, %1 : @trivial $Tensor<Float>):
 // CHECK-NEXT:   %2 = graph_op "tf.Add"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) {T: $Float} : $Tensor<Float>
 // CHECK-NEXT:   return %2 : $Tensor<Float>
 // CHECK-NEXT: }
 
 sil @multiple_result_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> (Tensor<Float>, Tensor<Float>) {
-bb0(%0 : $Tensor<Float>, %1 : $Tensor<Float>):
+bb0(%0 : @trivial $Tensor<Float>, %1 : @trivial $Tensor<Float>):
   (%2, %3) = graph_op "tf.Dummy"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) {T: $Float} : $Tensor<Float>, $Tensor<Float>
   %4 = tuple (%2 : $Tensor<Float>, %3 : $Tensor<Float>)
   return %4 : $(Tensor<Float>, Tensor<Float>)
 }
 
 // CHECK-LABEL: sil @multiple_result_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> (Tensor<Float>, Tensor<Float>) {
-// CHECK: bb0(%0 : $Tensor<Float>, %1 : $Tensor<Float>):
+// CHECK: bb0(%0 : @trivial $Tensor<Float>, %1 : @trivial $Tensor<Float>):
 // CHECK-NEXT:   (%2, %3) = graph_op "tf.Dummy"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) {T: $Float} : $Tensor<Float>, $Tensor<Float>
 // CHECK-NEXT:   %4 = tuple (%2 : $Tensor<Float>, %3 : $Tensor<Float>)
 // CHECK-NEXT:   return %4 : $(Tensor<Float>, Tensor<Float>)

--- a/test/TensorFlow/integration.swift
+++ b/test/TensorFlow/integration.swift
@@ -17,7 +17,7 @@ public func testTensor(a: Tensor<Float>, b: Tensor<Float>) {
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testTensor{{.*}}
 // CHECK:  sil private @{{.*}}testTensor{{.*}} : $@callee_owned (TensorHandle<Float>, TensorHandle<Float>) -> TensorHandle<Float> {
-// CHECK: bb0(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>):
+// CHECK: bb0(%0 : @unowned $TensorHandle<Float>, %1 : @unowned $TensorHandle<Float>):
 // CHECK-NEXT:   [[A:%.*]] = graph_op "Add,i,i"(%0 : $TensorHandle<Float>, %0 : $TensorHandle<Float>) {T: $Float, __device: "/device:CPU:0"} : $TensorHandle<Float>
 // CHECK-NEXT:   {{.*}} = graph_op "Sub,i,i"([[A]] : $TensorHandle<Float>, [[A]] : $TensorHandle<Float>) {T: $Float, __device: "/device:CPU:0"} : $TensorHandle<Float>
 // CHECK:        graph_op "tfc.SendToHost
@@ -53,7 +53,7 @@ public func testScalar(f: Float) { // expected-warning {{'f' implicitly copied t
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testScalar{{.*}}
 // CHECK: sil private @{{.*}}testScalar{{.*}} : $@callee_owned (TensorHandle<Builtin.FPIEEE32>) -> TensorHandle<Float> {
-// CHECK: bb0(%0 : $TensorHandle<Builtin.FPIEEE32>):
+// CHECK: bb0(%0 : @unowned $TensorHandle<Builtin.FPIEEE32>):
 // CHECK-NEXT:   %1 = unchecked_ref_cast %0 : $TensorHandle<Builtin.FPIEEE32> to $TensorHandle<Float>
 // CHECK:        [[CONST:%.*]] = graph_op "Const"() {dtype: $Float, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"} : $TensorHandle<Float>
 // CHECK:        [[ADD1:%.*]] = graph_op "Add,i,i"(%1 : $TensorHandle<Float>, [[CONST]] : $TensorHandle<Float>) {{.*}} : $TensorHandle<Float>
@@ -131,7 +131,7 @@ public func testExitBranch2(i: Int) {
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testExitBranch2{{.*}}
 // CHECK: sil private @{{.*}}testExitBranch2{{.*}} : $@callee_owned (TensorHandle<Builtin.Int1>) -> () {
-// CHECK: bb0(%0 : $TensorHandle<Builtin.Int1>):
+// CHECK: bb0(%0 : @unowned $TensorHandle<Builtin.Int1>):
 // CHECK:  graph_op "Const"()
 // CHECK:  cond_br {{.*}}, bb2, bb1
 
@@ -162,7 +162,7 @@ public func test_bool_param(cond: Bool, // expected-warning {{'cond' implicitly 
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}test_bool_param{{.*}}
 // CHECK: sil private @{{.*}}test_bool_param{{.*}} : $@callee_owned (TensorHandle<Builtin.Int1>, TensorHandle<Float>, TensorHandle<Float>) -> TensorHandle<Float>
-// CHECK: bb0(%0 : $TensorHandle<Builtin.Int1>, %1 : $TensorHandle<Float>, %2 : $TensorHandle<Float>):
+// CHECK: bb0(%0 : @unowned $TensorHandle<Builtin.Int1>, %1 : @unowned $TensorHandle<Float>, %2 : @unowned $TensorHandle<Float>):
 // CHECK: %3 = graph_op "tf_tensor_to_i1"(%0 : $TensorHandle<Builtin.Int1>) {{.*}} : $Builtin.Int1
 // CHECK: cond_br %3, bb2, bb1
 
@@ -195,7 +195,7 @@ public func test_bool_param2(cond: Bool, // expected-warning {{'cond' implicitly
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}test_bool_param2{{.*}}
 // CHECK: sil private @{{.*}}test_bool_param2{{.*}}
-// CHECK: bb0(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>, %2 : $TensorHandle<Builtin.Int1>):
+// CHECK: bb0(%0 : @unowned $TensorHandle<Float>, %1 : @unowned $TensorHandle<Float>, %2 : @unowned $TensorHandle<Builtin.Int1>):
 // CHECK:         graph_op "Add,i,i"(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>) {{.*}} : $TensorHandle<Float>
 // CHECK-NEXT:    [[BOOL:%.*]] = graph_op "tf_tensor_to_i1"(%2 : $TensorHandle<Builtin.Int1>) {{.*}} : $Builtin.Int1
 // CHECK-NEXT:    cond_br [[BOOL]]
@@ -260,13 +260,13 @@ public func test_while1(maxCount: Int,  // expected-warning {{'maxCount' implici
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}test_while1{{.*}}
 // CHECK: sil private @{{.*}}test_while1{{.*}}
-// CHECK: bb0(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>, %2 : $TensorHandle<Builtin.Int1>, %3 : $TensorHandle<Builtin.Int64>):
+// CHECK: bb0(%0 : @unowned $TensorHandle<Float>, %1 : @unowned $TensorHandle<Float>, %2 : @unowned $TensorHandle<Builtin.Int1>, %3 : @unowned $TensorHandle<Builtin.Int64>):
 // CHECK-NEXT: graph_op "Const"() {dtype$dtype: $Builtin.Int64, value$tensor: i64 0
 // CHECK:      graph_op "Add,i,i"(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>
 // CHECK-NEXT: graph_op "tf_tensor_to_i1"(
 // CHECK-NEXT: cond_br {{.*}}, bb2, bb1
 
-// CHECK: bb3([[A:%.*]] : $TensorHandle<Float>, [[COUNT:%.*]] : $TensorHandle<Builtin.Int64>):
+// CHECK: bb3([[A:%.*]] : @trivial $TensorHandle<Float>, [[COUNT:%.*]] : @trivial $TensorHandle<Builtin.Int64>):
 // CHECK:       [[NEXTA:%.*]] = graph_op "Sub,i,i"([[A]] : $TensorHandle<Float>, %1 : $TensorHandle<Float>) {{.*}} : $TensorHandle<Float>
 // CHECK:       [[NEXTCOUNT:%.*]] = graph_op "Add,i,i"([[COUNT]] : $TensorHandle<Builtin.Int64>
 // CHECK:       [[CONDT:%.*]] = graph_op "Less,i,i"([[NEXTCOUNT]] : $TensorHandle<Builtin.Int64>
@@ -306,7 +306,7 @@ public func scalar_manipulation(a : Float) -> Tensor<Float> {
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}scalar_manipulation{{.*}}
 // CHECK: sil private @{{.*}}scalar_manipulation{{.*}} : $@callee_owned (TensorHandle<Builtin.FPIEEE32>) -> TensorHandle<Float> {
-// CHECK: bb0(%0 : $TensorHandle<Builtin.FPIEEE32>):
+// CHECK: bb0(%0 : @unowned $TensorHandle<Builtin.FPIEEE32>):
 // CHECK-NEXT:  %1 = unchecked_ref_cast %0 : $TensorHandle<Builtin.FPIEEE32> to $TensorHandle<Float>
 // CHECK-NEXT:  [[CONST:%.*]] = graph_op "Const"() {dtype: $Float, value$tensor: f32 0x3F800000 /* 1 */, __device: "ALL_DEVICES"} : $TensorHandle<Float>
 // CHECK:       graph_op "Add,i,i"(%1 : $TensorHandle<Float>, [[CONST]] : $TensorHandle<Float>) {{.*}} : $TensorHandle<Float>
@@ -327,7 +327,7 @@ public func testCast(x: Tensor<Float>) -> Tensor<Int32> {
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testCast
 // CHECK: sil private @{{.*}}testCast{{.*}} : $@callee_owned (TensorHandle<Float>) -> TensorHandle<Int32> {
-// CHECK: bb0(%0 : $TensorHandle<Float>):
+// CHECK: bb0(%0 : @unowned $TensorHandle<Float>):
 // CHECK:   [[ADD:%.*]] = graph_op "Add,i,i"(%0 : $TensorHandle<Float>, %0 : $TensorHandle<Float>) {{.*}} : $TensorHandle<Float>
 // CHECK:   [[CAST:%.*]] = graph_op "Cast,i"([[ADD]] : $TensorHandle<Float>) {{.*}} : $TensorHandle<Int32>
 // CHECK:   return [[CAST]] : $TensorHandle<Int32>
@@ -344,7 +344,7 @@ public func testInputListArguments(a: TensorHandle<Float>, b: Tensor<Float>) -> 
 /*
  CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testInputListArguments
  CHECK: sil private @{{.*}}testInputListArguments{{.*}} : $@callee_owned (TensorHandle<Float>, TensorHandle<Float>) -> TensorHandle<Float> {
- CHECK: bb0(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>):
+ CHECK: bb0(%0 : @unowned $TensorHandle<Float>, %1 : @unowned $TensorHandle<Float>):
  CHECK:  [[PACK1:%.*]] = graph_op "Pack,L,e,e,e"(%0 : $TensorHandle<Float>, %0 : $TensorHandle<Float>, %0 : $TensorHandle<Float>) {{.*}} : $TensorHandle<Float>
  CHECK:  [[PACK2:%.*]] = graph_op "Pack,L,e,e,e"(%1 : $TensorHandle<Float>, %1 : $TensorHandle<Float>, %1 : $TensorHandle<Float>) {{.*}} : $TensorHandle<Float>
  CHECK:  [[RET:%.*]] = graph_op "Add,i,i"([[PACK1]] : $TensorHandle<Float>, [[PACK2]] : $TensorHandle<Float>) {{.*}} : $TensorHandle<Float>
@@ -365,7 +365,7 @@ public func liveOutTest(
 /*
 CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}liveOutTest
 CHECK: sil private @{{.*}}liveOutTest{{.*}} : $@callee_owned (TensorHandle<Float>, TensorHandle<Float>, TensorHandle<Float>) -> TensorHandle<Float> {
-CHECK: bb0(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>, %2 : $TensorHandle<Float>):
+CHECK: bb0(%0 : @unowned $TensorHandle<Float>, %1 : @unowned $TensorHandle<Float>, %2 : @unowned $TensorHandle<Float>):
 CHECK: return {{.*}} : $TensorHandle<Float>
 CHECK: }
 */
@@ -454,7 +454,7 @@ func shouldntInline(_ a: Tensor<Float>) -> Tensor<Float> {
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}shouldntInline
-// CHECK: bb0(%0 : $TensorHandle<Float>):
+// CHECK: bb0(%0 : @unowned $TensorHandle<Float>):
 // CHECK:  [[RET:%.*]] = graph_op "Mul,i,i"(%0 : $TensorHandle<Float>, %0 : $TensorHandle<Float>) {{.*}} : $TensorHandle<Float>
 // CHECK:  return [[RET]] : $TensorHandle<Float>
 // CHECK-LABEL: ----

--- a/test/TensorFlow/no_copy.swift
+++ b/test/TensorFlow/no_copy.swift
@@ -23,7 +23,7 @@ public func testSelect(conds1: Tensor<Bool>, x1: Tensor<Float>, y1: Tensor<Float
 /*
  CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testSelect
  CHECK: sil private @{{.*}}testSelect{{.*}} : $@callee_owned (TensorHandle<Float>, TensorHandle<Bool>, TensorHandle<Float>) -> TensorHandle<Float> {
- CHECK: bb0(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Bool>, %2 : $TensorHandle<Float>):
+ CHECK: bb0(%0 : @unowned $TensorHandle<Float>, %1 : @unowned $TensorHandle<Bool>, %2 : @unowned $TensorHandle<Float>):
  CHECK:       [[A:%.*]] = graph_op "Add,i,i"(%0 : $TensorHandle<Float>, %0 : $TensorHandle<Float>
  CHECK:       [[B:%.*]] = graph_op "Select,i,i,i"(%1 : $TensorHandle<Bool>, [[A]] : $TensorHandle<Float>, %2 : $TensorHandle<Float>
  CHECK:      [[C:%.*]] = graph_op "Mul,i,i"([[B]] : $TensorHandle<Float>, %2 : $TensorHandle<Float>
@@ -51,8 +51,8 @@ public func testConvolution(x: Tensor<Float>, filter: Tensor<Float>) -> Tensor<F
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testConvolution
 // CHECK: sil private @{{.*}}testConvolution{{.*}} : $@callee_owned (TensorHandle<Float>, TensorHandle<Float>) -> TensorHandle<Float> {
-// CHECK: bb0(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>):
-// CHECK: [[A:%.*]] = graph_op "Conv2D,i,i"(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>) {T: $Float, strides: [$Int32: (i32 1), (i32 2), (i32 3), (i32 4)], use_cudnn_on_gpu: i1 -1, padding: "SAME", data_format: "NHWC", dilations: [$Int32: (i32 1), (i32 1), (i32 1), (i32 1)], __device: "/device:CPU:0"} : $TensorHandle<Float> 
+// CHECK: bb0(%0 : @unowned $TensorHandle<Float>, %1 : @unowned $TensorHandle<Float>):
+// CHECK: [[A:%.*]] = graph_op "Conv2D,i,i"(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>) {T: $Float, strides: [$Int32: (i32 1), (i32 2), (i32 3), (i32 4)], use_cudnn_on_gpu: i1 -1, padding: "SAME", data_format: "NHWC", dilations: [$Int32: (i32 1), (i32 1), (i32 1), (i32 1)], __device: "/device:CPU:0"} : $TensorHandle<Float>
 // CHECK-NEXT:  return [[A]] : $TensorHandle<Float>
 // CHECK-NEXT:}
 
@@ -64,7 +64,7 @@ public func testConstantArray() -> TensorHandle<Float> {
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testConstantArray
 // CHECK: sil private @{{.*}}testConstantArray{{.*}} : $@callee_owned () -> TensorHandle<Float> {
 // CHECK: bb0:
-// CHECK:  %0 = graph_op "Const"() {dtype: $Float, value$tensor: [$Double: (f64 0x3FF0000000000000 /* 1 */), (f64 0x4000000000000000 /* 2 */)], value$shape: [$Int: (i64 2)], __device: "/device:CPU:0"} : $TensorHandle<Float> 
+// CHECK:  %0 = graph_op "Const"() {dtype: $Float, value$tensor: [$Double: (f64 0x3FF0000000000000 /* 1 */), (f64 0x4000000000000000 /* 2 */)], value$shape: [$Int: (i64 2)], __device: "/device:CPU:0"} : $TensorHandle<Float>
 // CHECK-NEXT:  return %0 : $TensorHandle<Float>
 
 // Sigmoid shouldn't cause copies.  This should compile with no copy warnings/errors.

--- a/test/TensorFlow/sends_recvs.swift
+++ b/test/TensorFlow/sends_recvs.swift
@@ -44,7 +44,7 @@ public func test1SendWithParam(x: Float) {
 
 // GPU function takes the input arg of x.
 // CHECK-LABEL: --- TFDevicePartition Per-Device Function Extraction Result: {{.*}}test1SendWithParam{{.*}}GPU{{.*}}
-// CHECK: bb0(%0 : $TensorHandle
+// CHECK: bb0(%0 : @unowned $TensorHandle
 // CHECK: graph_op "tfc.D2DTensorSend
 
 // The _Send node should be hooked up as a control dependency on the return


### PR DESCRIPTION
This fixes all compile and test failures caused by merging with `swift-DEVELOPMENT-SNAPSHOT-2018-08-06-a`, except for these two:
```
Sema/parameterized.swift
TensorFlowRuntime/parameter_update.swift
```
I will start a separate email thread asking for advice about those.