### PR TITLE
 Runtime: Don't attempt to round-trip mangled names for private types.

### DIFF
--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -226,8 +226,8 @@ swift::_buildDemanglingForContext(const ContextDescriptor *context,
       // no richer runtime information available about it (such as an anonymous
       // context). Use an unstable mangling to represent the context by its
       // pointer identity.
-      char addressBuf[sizeof(void*) * 2 + 2 + 1];
-      snprintf(addressBuf, sizeof(addressBuf), "0x%" PRIxPTR, (uintptr_t)component);
+      char addressBuf[sizeof(void*) * 2 + 1 + 1];
+      snprintf(addressBuf, sizeof(addressBuf), "$%" PRIxPTR, (uintptr_t)component);
       
       auto anonNode = Dem.createNode(Node::Kind::AnonymousContext);
       CharVector addressStr;


### PR DESCRIPTION
By design, we don't want private or function-nested types to be accessible by mangled name, since they don't have stable identities, and they could inadvertently become ABI if someone serialized a mangled string and expected to deserialize it into a type. Fixes rdar://problem/39826794 .