### PR TITLE
Various cleanups for opaque accessors

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4263,6 +4263,13 @@ public:
     return {};
   }
 
+  /// Visit all the opaque accessors that this storage is expected to have.
+  void visitExpectedOpaqueAccessors(
+                            llvm::function_ref<void (AccessorKind)>) const;
+
+  /// Visit all the opaque accessors of this storage declaration.
+  void visitOpaqueAccessors(llvm::function_ref<void (AccessorDecl*)>) const;
+
   void setAccessors(StorageImplInfo storageImpl,
                     SourceLoc lbraceLoc, ArrayRef<AccessorDecl*> accessors,
                     SourceLoc rbraceLoc);
@@ -4283,6 +4290,9 @@ public:
 
   /// \brief Add a synthesized materializeForSet accessor.
   void setSynthesizedMaterializeForSet(AccessorDecl *materializeForSet);
+
+  /// Does this storage require a materializeForSet accessor?
+  bool requiresMaterializeForSet() const;
 
   SourceRange getBracesRange() const {
     if (auto info = Accessors.getPointer())

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6506,6 +6506,8 @@ AbstractStorageDecl::overwriteSetterAccess(AccessLevel accessLevel) {
     setter->overwriteAccess(accessLevel);
   if (auto materializeForSet = getMaterializeForSetFunc())
     materializeForSet->overwriteAccess(accessLevel);
+  if (auto modify = getModifyCoroutine())
+    modify->overwriteAccess(accessLevel);
   if (auto mutableAddressor = getMutableAddressor())
     mutableAddressor->overwriteAccess(accessLevel);
 }

--- a/include/swift/SIL/SILWitnessVisitor.h
+++ b/include/swift/SIL/SILWitnessVisitor.h
@@ -133,15 +133,9 @@ public:
   }
 
   void visitAbstractStorageDecl(AbstractStorageDecl *sd) {
-    asDerived().addMethod(SILDeclRef(sd->getGetter(),
-                                     SILDeclRef::Kind::Func));
-    if (sd->isSettable(sd->getDeclContext())) {
-      asDerived().addMethod(SILDeclRef(sd->getSetter(),
-                                       SILDeclRef::Kind::Func));
-      if (sd->getMaterializeForSetFunc())
-        asDerived().addMethod(SILDeclRef(sd->getMaterializeForSetFunc(),
-                                         SILDeclRef::Kind::Func));
-    }
+    sd->visitOpaqueAccessors([&](AccessorDecl *accessor) {
+      asDerived().addMethod(SILDeclRef(accessor, SILDeclRef::Kind::Func));
+    });
   }
 
   void visitConstructorDecl(ConstructorDecl *cd) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1624,6 +1624,56 @@ AbstractStorageDecl::getAccessStrategy(AccessSemantics semantics,
   llvm_unreachable("bad access semantics");
 }
 
+bool AbstractStorageDecl::requiresMaterializeForSet() const {
+  // Only for mutable storage.
+  if (!supportsMutation())
+    return false;
+
+  // We only need materializeForSet in type contexts.
+  // TODO: resilient global variables?
+  auto *dc = getDeclContext();
+  if (!dc->isTypeContext())
+    return false;
+
+  // Requirements of ObjC protocols don't need materializeForSet.
+  if (auto protoDecl = dyn_cast<ProtocolDecl>(dc))
+    if (protoDecl->isObjC())
+      return false;
+
+  // Members of structs imported by Clang don't need an eagerly-synthesized
+  // materializeForSet.
+  if (auto structDecl = dyn_cast<StructDecl>(dc))
+    if (structDecl->hasClangNode())
+      return false;
+
+  return true;
+}
+
+void AbstractStorageDecl::visitExpectedOpaqueAccessors(
+                        llvm::function_ref<void (AccessorKind)> visit) const {
+  // For now, always assume storage declarations should have getters
+  // instead of read accessors.
+  visit(AccessorKind::Get);
+
+  if (supportsMutation()) {
+    // All mutable storage should have a setter.
+    visit(AccessorKind::Set);
+
+    // Include materializeForSet if necessary.
+    if (requiresMaterializeForSet())
+      visit(AccessorKind::MaterializeForSet);
+  }
+}
+
+void AbstractStorageDecl::visitOpaqueAccessors(
+                        llvm::function_ref<void (AccessorDecl*)> visit) const {
+  visitExpectedOpaqueAccessors([&](AccessorKind kind) {
+    auto accessor = getAccessor(kind);
+    assert(accessor && "didn't have expected opaque accessor");
+    visit(accessor);
+  });
+}
+
 static bool hasPrivateOrFilePrivateFormalAccess(const ValueDecl *D) {
   return D->hasAccess() && D->getFormalAccess() <= AccessLevel::FilePrivate;
 }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1184,14 +1184,13 @@ void SILGenModule::visitVarDecl(VarDecl *vd) {
   if (vd->getImplInfo().isSimpleStored()) {
     // If the global variable has storage, it might also have synthesized
     // accessors. Emit them here, since they won't appear anywhere else.
-    if (auto getter = vd->getGetter())
-      emitFunction(getter);
-    if (auto setter = vd->getSetter())
-      emitFunction(setter);
-    if (auto materializeForSet = vd->getMaterializeForSetFunc())
-      emitFunction(materializeForSet);
+    vd->visitExpectedOpaqueAccessors([&](AccessorKind kind) {
+      auto accessor = vd->getAccessor(kind);
+      if (accessor)
+        emitFunction(accessor);
+    });
   }
-  
+
   tryEmitPropertyDescriptor(vd);
 }
 

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -888,30 +888,77 @@ static void addSetterToStorage(TypeChecker &TC, AbstractStorageDecl *storage) {
   storage->setSynthesizedSetter(setter);
 }
 
+/// Add a materializeForSet accessor to the given declaration.
+static void addMaterializeForSetToStorage(TypeChecker &TC,
+                                          AbstractStorageDecl *storage) {
+  if (TC.Context.getOptionalDecl() == nullptr) {
+    TC.diagnose(storage->getStartLoc(), diag::optional_intrinsics_not_found);
+    return;
+  }
+
+  auto materializeForSet = createMaterializeForSetPrototype(
+      storage, storage->getGetter(), storage->getSetter(), TC);
+
+  // Install the prototype.
+  storage->setSynthesizedMaterializeForSet(materializeForSet);
+}
+
+
+static void addOpaqueAccessorToStorage(TypeChecker &TC,
+                                       AbstractStorageDecl *storage,
+                                       AccessorKind kind) {
+  switch (kind) {
+  case AccessorKind::Get:
+    return addGetterToStorage(TC, storage);
+
+  case AccessorKind::Set:
+    return addSetterToStorage(TC, storage);
+
+  case AccessorKind::MaterializeForSet:
+    return addMaterializeForSetToStorage(TC, storage);
+
+#define OPAQUE_ACCESSOR(ID, KEYWORD)
+#define ACCESSOR(ID) \
+  case AccessorKind::ID:
+#include "swift/AST/AccessorKinds.def"
+    llvm_unreachable("not an opaque accessor");
+  }
+}
+
+static void addExpectedOpaqueAccessorsToStorage(TypeChecker &TC,
+                                                AbstractStorageDecl *storage) {
+  storage->visitExpectedOpaqueAccessors([&](AccessorKind kind) {
+    // If the accessor is already present, there's nothing to do.
+    if (storage->getAccessor(kind))
+      return;
+
+    addOpaqueAccessorToStorage(TC, storage, kind);
+  });
+}
+
 /// Add trivial accessors to a Stored or Addressed property.
 static void addTrivialAccessorsToStorage(AbstractStorageDecl *storage,
                                          TypeChecker &TC) {
   assert(!isSynthesizedComputedProperty(storage));
+  addExpectedOpaqueAccessorsToStorage(TC, storage);
+}
 
-  if (!storage->getGetter())
-    addGetterToStorage(TC, storage);
-
-  if (storage->supportsMutation()) {
-    if (!storage->getSetter())
-      addSetterToStorage(TC, storage);
-
-    if (!storage->getMaterializeForSetFunc())
-      maybeAddMaterializeForSet(storage, TC);
+static StorageImplInfo getProtocolStorageImpl(AbstractStorageDecl *storage) {
+  auto protocol = cast<ProtocolDecl>(storage->getDeclContext());
+  if (protocol->isObjC()) {
+    return StorageImplInfo::getComputed(storage->supportsMutation());
+  } else {
+    return StorageImplInfo::getOpaque(storage->supportsMutation());
   }
 }
 
-static void convertStoredVarInProtocolToComputed(VarDecl *VD, TypeChecker &TC) {
-  if (!VD->getGetter()) {
-    addGetterToStorage(TC, VD);
-  }
+/// Given a storage declaration in a protocol, set it up with the right
+/// StorageImpl and add the right set of opaque accessors.
+static void setProtocolStorageImpl(TypeChecker &TC,
+                                   AbstractStorageDecl *storage) {
+  addExpectedOpaqueAccessorsToStorage(TC, storage);
 
-  // Okay, we have the getter; make the VD computed.
-  VD->overwriteImplInfo(StorageImplInfo::getImmutableComputed());
+  storage->overwriteImplInfo(getProtocolStorageImpl(storage));
 }
 
 /// Synthesize the body of a setter which just delegates to a mutable
@@ -930,23 +977,6 @@ static void synthesizeModifyCoroutineSetterBody(TypeChecker &TC,
   // This should call the modify coroutine.
   synthesizeTrivialSetterBodyWithStorage(TC, setter, TargetImpl::Implementation,
                                          setter->getStorage());
-}
-
-/// Add a materializeForSet accessor to the given declaration.
-static FuncDecl *addMaterializeForSet(AbstractStorageDecl *storage,
-                                      TypeChecker &TC) {
-  if (TC.Context.getOptionalDecl() == nullptr) {
-    TC.diagnose(storage->getStartLoc(), diag::optional_intrinsics_not_found);
-    return nullptr;
-  }
-
-  auto materializeForSet = createMaterializeForSetPrototype(
-      storage, storage->getGetter(), storage->getSetter(), TC);
-
-  // Install the prototype.
-  storage->setSynthesizedMaterializeForSet(materializeForSet);
-
-  return materializeForSet;
 }
 
 static void convertNSManagedStoredVarToComputed(VarDecl *VD, TypeChecker &TC) {
@@ -974,7 +1004,7 @@ static void convertNSManagedStoredVarToComputed(VarDecl *VD, TypeChecker &TC) {
   // Okay, we have both a getter and setter; overwrite the impl info.
   VD->overwriteImplInfo(StorageImplInfo::getMutableComputed());
 
-  maybeAddMaterializeForSet(VD, TC);
+  addExpectedOpaqueAccessorsToStorage(TC, VD);
 }
 
 /// The specified AbstractStorageDecl was just found to satisfy a
@@ -984,42 +1014,45 @@ void TypeChecker::synthesizeWitnessAccessorsForStorage(
                                              AbstractStorageDecl *requirement,
                                              AbstractStorageDecl *storage) {
   bool addedAccessor = false;
-  auto flagAddedAccessor = [&](AccessorDecl *accessor,
-                               Optional<SynthesizedFunction::Kind> kind) {
+
+  requirement->visitExpectedOpaqueAccessors([&](AccessorKind kind) {
+    // If the accessor already exists, we have nothing to do.
+    if (storage->getAccessor(kind))
+      return;
+
+    // Otherwise, synthesize it.
+    addOpaqueAccessorToStorage(*this, storage, kind);
+
+    // Flag that we've added an accessor.
     addedAccessor = true;
 
-    // Synthesize a trivial body when we create an on-demand accessor.
-    if (kind && isOnDemandAccessor(accessor->getStorage(),
-                                   accessor->getAccessorKind())) {
-      triggerSynthesis(*this, accessor, *kind);
+    // Trigger synthesize of the accessor body if it's created on-demand.
+    SynthesizedFunction::Kind synthKind;
+    switch (kind) {
+    case AccessorKind::MaterializeForSet:
+      // No need to do this for materializeForSet, which we always synthesize
+      // in SILGen.
+      return;
+
+    case AccessorKind::Get:
+      synthKind = SynthesizedFunction::Getter;
+      break;
+
+    case AccessorKind::Set:
+      synthKind = SynthesizedFunction::Setter;
+      break;
+
+#define OPAQUE_ACCESSOR(ID, KEYWORD)
+#define ACCESSOR(ID) \
+    case AccessorKind::ID:
+#include "swift/AST/AccessorKinds.def"
+      llvm_unreachable("unexpected synthesized accessor");
     }
-  };
 
-  // Synthesize a getter.
-  if (!storage->getGetter()) {
-    addGetterToStorage(*this, storage);
-    flagAddedAccessor(storage->getGetter(), SynthesizedFunction::Getter);
-  }
-
-  // Synthesize a setter if the storage is mutable and the requirement
-  // needs it.
-  if (!storage->getSetter() &&
-      storage->supportsMutation() &&
-      requirement->supportsMutation()) {
-    addSetterToStorage(*this, storage);
-    flagAddedAccessor(storage->getSetter(), SynthesizedFunction::Setter);
-  }
-
-  // @objc protocols don't need a materializeForSet since ObjC doesn't
-  // have that concept.
-  bool wantMaterializeForSet =
-    !requirement->isObjC() && requirement->getSetter();
-
-  // If we want wantMaterializeForSet, create it now.
-  if (wantMaterializeForSet && !storage->getMaterializeForSetFunc()) {
-    addMaterializeForSet(storage, *this);
-    flagAddedAccessor(storage->getMaterializeForSetFunc(), None);
-  }
+    if (isOnDemandAccessor(storage, kind)) {
+      triggerSynthesis(*this, storage->getAccessor(kind), synthKind);
+    }
+  });
 
   // Cue (delayed) validation of any accessors we just added, just
   // in case this is coming after the normal delayed validation finished.
@@ -1728,38 +1761,6 @@ void TypeChecker::completeLazyVarImplementation(VarDecl *VD) {
   Storage->overwriteSetterAccess(AccessLevel::Private);
 }
 
-/// Consider add a materializeForSet accessor to the given storage
-/// decl (which has accessors).
-void swift::maybeAddMaterializeForSet(AbstractStorageDecl *storage,
-                                      TypeChecker &TC) {
-  assert(storage->getGetter());
-
-  // Be idempotent.  There are a bunch of places where we want to
-  // ensure that there's a materializeForSet accessor.
-  if (storage->getMaterializeForSetFunc()) return;
-
-  // Never add materializeForSet to readonly declarations.
-  if (!storage->getSetter()) return;
-
-  // We only need materializeForSet in type contexts.
-  auto *dc = storage->getDeclContext();
-  if (!dc->isTypeContext())
-    return;
-
-  // Requirements of ObjC protocols don't need this.
-  if (auto protoDecl = dyn_cast<ProtocolDecl>(dc))
-    if (protoDecl->isObjC())
-      return;
-
-  // Members of structs imported by Clang don't need this, because we can
-  // synthesize it later.
-  if (auto structDecl = dyn_cast<StructDecl>(dc))
-    if (structDecl->hasClangNode())
-      return;
-
-  addMaterializeForSet(storage, TC);
-}
-
 void swift::triggerAccessorSynthesis(TypeChecker &TC,
                                      AbstractStorageDecl *storage) {
   auto VD = dyn_cast<VarDecl>(storage);
@@ -1959,7 +1960,7 @@ static void maybeAddAccessorsToLazyVariable(TypeChecker &TC, VarDecl *var) {
 
   var->overwriteImplInfo(StorageImplInfo::getMutableComputed());
 
-  maybeAddMaterializeForSet(var, TC);
+  addExpectedOpaqueAccessorsToStorage(TC, var);
 }
 
 /// Try to add the appropriate accessors required a storage declaration.
@@ -2008,11 +2009,9 @@ void swift::maybeAddAccessorsToStorage(TypeChecker &TC,
                     diag::protocol_property_must_be_computed_var);
       else
         TC.diagnose(var->getLoc(), diag::protocol_property_must_be_computed);
-
-      convertStoredVarInProtocolToComputed(var, TC);
     }
 
-    maybeAddMaterializeForSet(storage, TC);
+    setProtocolStorageImpl(TC, storage);
     return;
 
   // NSManaged properties on classes require special handling.
@@ -2034,7 +2033,7 @@ void swift::maybeAddAccessorsToStorage(TypeChecker &TC,
   if (auto sourceFile = dc->getParentSourceFile())
     if (sourceFile->Kind == SourceFileKind::SIL) {
       if (storage->getGetter() && storage->getSetter()) {
-        maybeAddMaterializeForSet(storage, TC);
+        addExpectedOpaqueAccessorsToStorage(TC, storage);
       }
       return;
     }

--- a/lib/Sema/CodeSynthesis.h
+++ b/lib/Sema/CodeSynthesis.h
@@ -100,8 +100,6 @@ void makeFinal(ASTContext &ctx, ValueDecl *D);
 bool checkOverrides(ValueDecl *decl);
 
 // These are implemented in CodeSynthesis.cpp.
-void maybeAddMaterializeForSet(AbstractStorageDecl *storage,
-                               TypeChecker &TC);
 void maybeAddAccessorsToStorage(TypeChecker &TC, AbstractStorageDecl *storage);
 
 void triggerAccessorSynthesis(TypeChecker &TC, AbstractStorageDecl *storage);

--- a/lib/Serialization/DeserializationErrors.h
+++ b/lib/Serialization/DeserializationErrors.h
@@ -131,6 +131,12 @@ class XRefTracePath {
         case DidSet:
           os << "(didSet)";
           break;
+        case Read:
+          os << "(read)";
+          break;
+        case Modify:
+          os << "(modify)";
+          break;
         default:
           os << "(unknown accessor kind)";
           break;

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -125,13 +125,12 @@ void TBDGenVisitor::addConformances(DeclContext *DC) {
             addSymbolIfNecessary(valueReq, witnessDecl);
           } else if (auto *storage = dyn_cast<AbstractStorageDecl>(valueReq)) {
             auto witnessStorage = cast<AbstractStorageDecl>(witnessDecl);
-            if (auto *getter = storage->getGetter())
-              addSymbolIfNecessary(getter, witnessStorage->getGetter());
-            if (auto *setter = storage->getSetter())
-              addSymbolIfNecessary(setter, witnessStorage->getSetter());
-            if (auto *materializeForSet = storage->getMaterializeForSetFunc())
-              addSymbolIfNecessary(materializeForSet,
-                                   witnessStorage->getMaterializeForSetFunc());
+            storage->visitOpaqueAccessors([&](AccessorDecl *reqtAccessor) {
+              auto witnessAccessor =
+                witnessStorage->getAccessor(reqtAccessor->getAccessorKind());
+              assert(witnessAccessor && "no corresponding witness accessor?");
+              addSymbolIfNecessary(reqtAccessor, witnessAccessor);
+            });
           }
         });
   }


### PR DESCRIPTION
In preparation for replacing `materializeForSet` with `modify`, clean up a few things involve opaque accessors.