### PR TITLE
[update-checkout] Remove some old configs that are no longer used.

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -73,26 +73,6 @@
                 "ninja": "release"
             }
         },
-        "swift5-transition" : {
-            "aliases": ["swift5-transition", "llvm-swift5-transition",
-                        "master-llvm-swift5-transition"],
-            "repos": {
-                "llvm": "swift-5.0-branch",
-                "clang": "swift-5.0-branch",
-                "compiler-rt": "swift-5.0-branch",
-                "swift": "master-llvm-swift5-transition",
-                "lldb": "llvm-swift5-transition",
-                "cmark": "master",
-                "llbuild": "master",
-                "swiftpm": "master",
-                "swift-corelibs-xctest": "master",
-                "swift-corelibs-foundation": "master",
-                "swift-corelibs-libdispatch": "master",
-                "swift-integration-tests": "master",
-                "swift-xcode-playground-support": "master",
-                "ninja": "release"
-            }
-        },
         "swift-3.0-branch" : {
             "aliases": ["swift-3.0-branch"],
             "repos": {
@@ -131,25 +111,6 @@
                 "ninja": "release"
             }
         },
-        "swift-4.1-branch" : {
-            "aliases": ["swift-4.1-branch"],
-            "repos": {
-                "llvm": "swift-4.1-branch",
-                "clang": "swift-4.1-branch",
-                "swift": "swift-4.1-branch",
-                "lldb": "swift-4.1-branch",
-                "cmark": "swift-4.1-branch",
-                "llbuild": "swift-4.1-branch",
-                "swiftpm": "swift-4.1-branch",
-                "compiler-rt": "swift-4.1-branch",
-                "swift-corelibs-xctest": "swift-4.1-branch",
-                "swift-corelibs-foundation": "swift-4.1-branch",
-                "swift-corelibs-libdispatch": "swift-4.1-branch",
-                "swift-integration-tests": "swift-4.1-branch",
-                "swift-xcode-playground-support": "swift-4.1-branch",
-                "ninja": "release"
-            }
-        },
         "swift-4.0-branch" : {
             "aliases": ["swift-4.0-branch"],
             "repos": {
@@ -169,22 +130,22 @@
                 "ninja": "release"
             }
         },
-         "swift-4.0-branch-07-11-2017" : {
-            "aliases": ["swift-4.0-branch-07-11-2017"],
+        "swift-4.1-branch" : {
+            "aliases": ["swift-4.1-branch"],
             "repos": {
-                "llvm": "swift-4.0-branch-07-11-2017",
-                "clang": "swift-4.0-branch-07-11-2017",
-                "swift": "swift-4.0-branch-07-11-2017",
-                "lldb": "swift-4.0-branch-07-11-2017",
-                "cmark": "swift-4.0-branch",
-                "llbuild": "swift-4.0-branch",
-                "swiftpm": "swift-4.0-branch",
-                "compiler-rt": "swift-4.0-branch-07-11-2017",
-                "swift-corelibs-xctest": "swift-4.0-branch",
-                "swift-corelibs-foundation": "swift-4.0-branch",
-                "swift-corelibs-libdispatch": "swift-4.0-branch",
-                "swift-integration-tests": "swift-4.0-branch",
-                "swift-xcode-playground-support": "swift-4.0-branch",
+                "llvm": "swift-4.1-branch",
+                "clang": "swift-4.1-branch",
+                "swift": "swift-4.1-branch",
+                "lldb": "swift-4.1-branch",
+                "cmark": "swift-4.1-branch",
+                "llbuild": "swift-4.1-branch",
+                "swiftpm": "swift-4.1-branch",
+                "compiler-rt": "swift-4.1-branch",
+                "swift-corelibs-xctest": "swift-4.1-branch",
+                "swift-corelibs-foundation": "swift-4.1-branch",
+                "swift-corelibs-libdispatch": "swift-4.1-branch",
+                "swift-integration-tests": "swift-4.1-branch",
+                "swift-xcode-playground-support": "swift-4.1-branch",
                 "ninja": "release"
             }
         },
@@ -194,63 +155,6 @@
                 "llvm": "swift-4.2-branch",
                 "clang": "swift-4.2-branch",
                 "swift": "swift-4.2-branch",
-                "lldb": "swift-4.2-branch",
-                "cmark": "swift-4.2-branch",
-                "llbuild": "swift-4.2-branch",
-                "swiftpm": "swift-4.2-branch",
-                "compiler-rt": "swift-4.2-branch",
-                "swift-corelibs-xctest": "swift-4.2-branch",
-                "swift-corelibs-foundation": "swift-4.2-branch",
-                "swift-corelibs-libdispatch": "swift-4.2-branch",
-                "swift-integration-tests": "swift-4.2-branch",
-                "swift-xcode-playground-support": "swift-4.2-branch",
-                "ninja": "release"
-            }
-        },
-        "swift-4.2-branch-03-26-2018" : {
-            "aliases": ["swift-4.2-branch-03-26-2018"],
-            "repos": {
-                "llvm": "swift-4.2-branch-03-26-2018",
-                "clang": "swift-4.2-branch-03-26-2018",
-                "swift": "swift-4.2-branch-03-26-2018",
-                "lldb": "swift-4.2-branch-03-26-2018",
-                "cmark": "master",
-                "llbuild": "master",
-                "swiftpm": "master",
-                "compiler-rt": "swift-4.2-branch-03-26-2018",
-                "swift-corelibs-xctest": "swift-4.2-branch",
-                "swift-corelibs-foundation": "swift-4.2-branch",
-                "swift-corelibs-libdispatch": "swift-4.2-branch",
-                "swift-integration-tests": "master",
-                "swift-xcode-playground-support": "master",
-                "ninja": "release"
-            }
-        },
-        "swift-4.2-branch-04-20-2018" : {
-            "aliases": ["swift-4.2-branch-04-20-2018"],
-            "repos": {
-                "llvm": "swift-4.2-branch-04-20-2018",
-                "clang": "swift-4.2-branch-04-20-2018",
-                "swift": "swift-4.2-branch-04-20-2018",
-                "lldb": "swift-4.2-branch-04-20-2018",
-                "cmark": "master",
-                "llbuild": "master",
-                "swiftpm": "master",
-                "compiler-rt": "swift-4.2-branch-04-20-2018",
-                "swift-corelibs-xctest": "swift-4.2-branch-04-20-2018",
-                "swift-corelibs-foundation": "swift-4.2-branch-04-20-2018",
-                "swift-corelibs-libdispatch": "swift-4.2-branch-04-20-2018",
-                "swift-integration-tests": "swift-4.2-branch",
-                "swift-xcode-playground-support": "swift-4.2-branch",
-                "ninja": "release"
-            }
-        },
-        "swift-4.2-branch-06-11-2018" : {
-            "aliases": ["swift-4.2-branch-06-11-2018"],
-            "repos": {
-                "llvm": "swift-4.2-branch",
-                "clang": "swift-4.2-branch",
-                "swift": "swift-4.2-branch-06-11-2018",
                 "lldb": "swift-4.2-branch",
                 "cmark": "swift-4.2-branch",
                 "llbuild": "swift-4.2-branch",


### PR DESCRIPTION
The checkout configs included some old dated branches that are no longer
used. They are unlikely to work well anyway because the corresponding
Clang/LLVM branches moved forward independently. Remove those config entries.
Also re-order the 4.0 and 4.1 configs to be consistent.