### PR TITLE
Fix `ShapedArray` code example.

### DIFF
--- a/stdlib/public/TensorFlow/ShapedArray.swift
+++ b/stdlib/public/TensorFlow/ShapedArray.swift
@@ -596,7 +596,7 @@ extension ShapedArray : CustomReflectable {
 ///
 /// For example:
 ///
-///     let matrix = ShapedArray(shape: [2, 2], scalars: [0, 1, 2, 3])
+///     var matrix = ShapedArray(shape: [2, 2], scalars: [0, 1, 2, 3])
 ///     // `matrix` represents [[0, 1], [2, 3]].
 ///
 ///     let element = matrix[0]


### PR DESCRIPTION
`matrix` must be a mutable variable for subscript setter to work.
Doc comment code example is (sans explanatory comments):
```swift
// Originally `let matrix` on line below.
var matrix = ShapedArray(shape: [2, 2], scalars: [0, 1, 2, 3])
let element = matrix[0]
// `let matrix` causes line below to fail.
matrix[1] = ShapedArraySlice(shape: [2], scalars: [4, 8])
```