### PR TITLE
Run tests with `-tf-target-gpu` when `--enable-tensorflow-gpu` is enabled.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -263,7 +263,7 @@ foreach(SDK ${SWIFT_SDKS})
       endif()
       if(SWIFT_ENABLE_TENSORFLOW_GPU)
         list(APPEND LIT_ARGS
-            "--param" "swift_tensorflow_gpu")
+            "--param" "swift_tensorflow_gpu=true")
       endif()
 
       execute_process(COMMAND

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -131,7 +131,9 @@ normalize_boolean_spelling(SWIFT_STDLIB_ASSERTIONS)
 normalize_boolean_spelling(SWIFT_AST_VERIFIER)
 normalize_boolean_spelling(SWIFT_ASAN_BUILD)
 normalize_boolean_spelling(SWIFT_ENABLE_SOURCEKIT_TESTS)
+# SWIFT_ENABLE_TENSORFLOW
 normalize_boolean_spelling(SWIFT_ENABLE_TENSORFLOW)
+normalize_boolean_spelling(SWIFT_ENABLE_TENSORFLOW_GPU)
 is_build_type_optimized("${SWIFT_STDLIB_BUILD_TYPE}" SWIFT_OPTIMIZED)
 
 set(profdata_merge_worker
@@ -258,6 +260,10 @@ foreach(SDK ${SWIFT_SDKS})
       if(SWIFT_ENABLE_TENSORFLOW)
         list(APPEND LIT_ARGS
             "--param" "swift_tensorflow_path=${SWIFT_TENSORFLOW_TARGET_LIB_DIR}")
+      endif()
+      if(SWIFT_ENABLE_TENSORFLOW_GPU)
+        list(APPEND LIT_ARGS
+            "--param" "swift_tensorflow_gpu")
       endif()
 
       execute_process(COMMAND

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -324,10 +324,13 @@ lit_config.note('Compiling with -swift-version ' + swift_version)
 config.swift_test_options = '-swift-version ' + swift_version
 
 # SWIFT_ENABLE_TENSORFLOW
-swift_tensorflow_linker_options = ""
+swift_tensorflow_extra_options = ""
 swift_tensorflow_path = lit_config.params.get('swift_tensorflow_path', None)
 if swift_tensorflow_path:
-    swift_tensorflow_linker_options = ('-L%s -ltensorflow -ltensorflow_framework' % swift_tensorflow_path)
+    swift_tensorflow_extra_options += ('-L%s -ltensorflow -ltensorflow_framework' % swift_tensorflow_path)
+swift_tensorflow_gpu = lit_config.params.get('swift_tensorflow_gpu', None)
+if swift_tensorflow_gpu:
+    swift_tensorflow_extra_options += '-Xllvm -tf-target-gpu'
 
 test_options = os.environ.get('SWIFT_TEST_OPTIONS')
 if test_options:
@@ -628,7 +631,7 @@ if run_vendor == 'apple':
             "/tmp/swifttest-device/lib",
             sdk_overlay_linker_opt, config.swift_test_options,
             config.swift_driver_test_options,
-            swift_tensorflow_linker_options,
+            swift_tensorflow_extra_options,
             swift_execution_tests_extra_flags))
        config.target_run = "unsupported"
 
@@ -657,7 +660,7 @@ if run_vendor == 'apple':
              extra_frameworks_dir,
              sdk_overlay_linker_opt, config.swift_test_options,
              config.swift_driver_test_options,
-             swift_tensorflow_linker_options,
+             swift_tensorflow_extra_options,
              swift_execution_tests_extra_flags))
         # FIXME: allow specification of simulator and version
         #
@@ -692,7 +695,7 @@ if run_vendor == 'apple':
                extra_frameworks_dir, extra_frameworks_dir,
                sdk_overlay_linker_opt, config.swift_test_options,
                config.swift_driver_test_options,
-               swift_tensorflow_linker_options,
+               swift_tensorflow_extra_options,
                swift_execution_tests_extra_flags, sourcekitd_framework_dir,
                sourcekitd_framework_dir))
         config.target_run = ""
@@ -887,7 +890,7 @@ elif run_os == 'linux-androideabi':
            android_linker_opt, resource_dir_opt, mcp_opt,
            config.swift_test_options,
            config.swift_driver_test_options,
-           swift_tensorflow_linker_options,
+           swift_tensorflow_extra_options,
            swift_execution_tests_extra_flags))
     config.target_codesign = "echo"
     config.target_build_swift_dylib = (
@@ -1006,47 +1009,47 @@ if not getattr(config, 'target_run_simple_swift', None):
         '%s %s %%s -o %%t/a.out -module-name main %s && '
         '%s %%t/a.out &&'
         '%s %%t/a.out'
-        % (config.target_build_swift, mcp_opt, swift_tensorflow_linker_options, config.target_codesign, config.target_run))
+        % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
     # SWIFT_ENABLE_TENSORFLOW
     config.target_run_simple_swift_sese_loops = (
         '%%empty-directory(%%t) && '
         '%s %s %%s -Xllvm -tf-ensure-single-loop-exit -o %%t/a.out -module-name main %s && '
         '%s %%t/a.out &&'
         '%s %%t/a.out'
-        % (config.target_build_swift, mcp_opt, swift_tensorflow_linker_options, config.target_codesign, config.target_run))
+        % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
 
     config.target_run_simple_opt_O_swift = (
         '%%empty-directory(%%t) && '
         '%s %s -O %%s -o %%t/a.out -module-name main %s && '
         '%s %%t/a.out &&'
         '%s %%t/a.out'
-        % (config.target_build_swift, mcp_opt, swift_tensorflow_linker_options, config.target_codesign, config.target_run))
+        % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
     config.target_run_simple_opt_Osize_swift = (
         '%%empty-directory(%%t) && '
         '%s %s -Osize %%s -o %%t/a.out -module-name main %s && '
         '%s %%t/a.out &&'
         '%s %%t/a.out'
-        % (config.target_build_swift, mcp_opt, swift_tensorflow_linker_options, config.target_codesign, config.target_run))
+        % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
     config.target_run_simple_swift_swift3 = (
         '%%empty-directory(%%t) && '
         '%s %s %%s -o %%t/a.out -module-name main -swift-version 3 %s && '
         '%s %%t/a.out &&'
         '%s %%t/a.out'
-        % (config.target_build_swift, mcp_opt, swift_tensorflow_linker_options, config.target_codesign, config.target_run))
+        % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
     config.target_run_stdlib_swift = (
         '%%empty-directory(%%t) && '
         '%s %s %%s -o %%t/a.out -module-name main '
         '-Xfrontend -disable-access-control %s && '
         '%s %%t/a.out &&'
         '%s %%t/a.out'
-        % (config.target_build_swift, mcp_opt, swift_tensorflow_linker_options, config.target_codesign, config.target_run))
+        % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
     config.target_run_stdlib_swift_swift3 = (
         '%%empty-directory(%%t) && '
         '%s %s %%s -o %%t/a.out -module-name main '
         '-Xfrontend -disable-access-control -swift-version 3 %s && '
         '%s %%t/a.out &&'
         '%s %%t/a.out'
-        % (config.target_build_swift, mcp_opt, swift_tensorflow_linker_options, config.target_codesign, config.target_run))
+        % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
     config.target_run_simple_swiftgyb = (
         '%%empty-directory(%%t) && '
         '%%gyb %%s -o %%t/main.swift && '
@@ -1055,7 +1058,7 @@ if not getattr(config, 'target_run_simple_swift', None):
         '%s %%t/a.out &&'
         '%%line-directive %%t/main.swift -- '
         '%s %%t/a.out'
-        % (config.target_build_swift, mcp_opt, swift_tensorflow_linker_options, config.target_codesign, config.target_run))
+        % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
     config.target_run_simple_swiftgyb_swift3 = (
         '%%empty-directory(%%t) && '
         '%%gyb %%s -o %%t/main.swift && '
@@ -1064,7 +1067,7 @@ if not getattr(config, 'target_run_simple_swift', None):
         '%s %%t/a.out &&'
         '%%line-directive %%t/main.swift -- '
         '%s %%t/a.out'
-        % (config.target_build_swift, mcp_opt, swift_tensorflow_linker_options, config.target_codesign, config.target_run))
+        % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
     config.target_run_stdlib_swiftgyb = (
         '%%empty-directory(%%t) && '
         '%%gyb %%s -o %%t/main.swift && '
@@ -1074,7 +1077,7 @@ if not getattr(config, 'target_run_simple_swift', None):
         '%s %%t/a.out &&'
         '%%line-directive %%t/main.swift -- '
         '%s %%t/a.out'
-        % (config.target_build_swift, mcp_opt, swift_tensorflow_linker_options, config.target_codesign, config.target_run))
+        % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
     config.target_run_stdlib_swiftgyb_swift3 = (
         '%%empty-directory(%%t) && '
         '%%gyb %%s -o %%t/main.swift && '
@@ -1084,7 +1087,7 @@ if not getattr(config, 'target_run_simple_swift', None):
         '%s %%t/a.out &&'
         '%%line-directive %%t/main.swift -- '
         '%s %%t/a.out'
-        % (config.target_build_swift, mcp_opt, swift_tensorflow_linker_options, config.target_codesign, config.target_run))
+        % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
 
 subst_target_jit_run = ""
 if 'swift_interpreter' in config.available_features:

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -330,7 +330,7 @@ if swift_tensorflow_path:
     swift_tensorflow_extra_options += ('-L%s -ltensorflow -ltensorflow_framework' % swift_tensorflow_path)
 swift_tensorflow_gpu = lit_config.params.get('swift_tensorflow_gpu', None)
 if swift_tensorflow_gpu:
-    swift_tensorflow_extra_options += '-Xllvm -tf-target-gpu'
+    swift_tensorflow_extra_options += ' -Xllvm -tf-target-gpu'
 
 test_options = os.environ.get('SWIFT_TEST_OPTIONS')
 if test_options:

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2340,8 +2340,6 @@ for host in "${ALL_HOSTS[@]}"; do
                     )
 
                     # Propagate TensorFlow GPU support flag to CMake.
-                    # Note: the 'SWIFT_ENABLE_TENSORFLOW_GPU' flag is not
-                    # currently used in CMake but may be useful in the future.
                     if [[ "${ENABLE_TENSORFLOW_GPU}" ]] ; then
                         cmake_options=(
                             "${cmake_options[@]}"


### PR DESCRIPTION
This patch should make GPU tests pass, which is important for a future GPU CI machine. Run the following:
```
swift/utils/build-script --preset tensorflow_test,gpu
```

Thanks to @mhong for verifying that tests pass locally.