### PR TITLE
Temporarily disable the stdlib/ErrorBridgedStatic.swift test

### DIFF
--- a/test/stdlib/ErrorBridgedStatic.swift
+++ b/test/stdlib/ErrorBridgedStatic.swift
@@ -7,6 +7,7 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 // REQUIRES: static_stdlib
+// REQUIRES: rdar42789939
 
 import StdlibUnittest
 


### PR DESCRIPTION
This test has been failing on the oss-swift_tools-RA_stdlib-DA_test-simulator
bot for more than a week. I finally managed to reproduce the failure
locally, so I am now disabling the test to get the bot passing again.
rdar://problem/42789939