### PR TITLE
[Parse] Set ErrorType to invalid ParamDecl

### DIFF
--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -431,6 +431,14 @@ mapParsedParameters(Parser &parser,
                                      paramNameLoc, paramName, Type(),
                                      parser.CurDeclContext);
     param->getAttrs() = paramInfo.Attrs;
+
+    auto setInvalid = [&]{
+      if (param->isInvalid())
+        return;
+      param->getTypeLoc().setInvalidType(ctx);
+      param->setInvalid();
+    };
+
     bool parsingEnumElt
       = (paramContext == Parser::ParameterContextKind::EnumElement);
     // If we're not parsing an enum case, lack of a SourceLoc for both
@@ -440,7 +448,7 @@ mapParsedParameters(Parser &parser,
     
     // If we diagnosed this parameter as a parse error, propagate to the decl.
     if (paramInfo.isInvalid)
-      param->setInvalid();
+      setInvalid();
     
     // If a type was provided, create the type for the parameter.
     if (auto type = paramInfo.Type) {
@@ -464,8 +472,7 @@ mapParsedParameters(Parser &parser,
       if (!param->isInvalid())
         parser.diagnose(param->getLoc(), diag::missing_parameter_type);
       
-      param->getTypeLoc() = TypeLoc::withoutLoc(ErrorType::get(ctx));
-      param->setInvalid();
+      setInvalid();
     } else if (paramInfo.SpecifierLoc.isValid()) {
       StringRef specifier;
       switch (paramInfo.SpecifierKind) {

--- a/validation-test/compiler_crashers_2_fixed/0170-sr8475.swift
+++ b/validation-test/compiler_crashers_2_fixed/0170-sr8475.swift
@@ -1,0 +1,8 @@
+// RUN: not %target-swift-frontend -typecheck %s
+
+func receive() {}
+func test() {
+  receive { (dat: Container<>) in
+    dat
+  }
+}


### PR DESCRIPTION
TypeChecker assumes invalid decl has valid (error) type.

https://bugs.swift.org/browse/SR-8475
rdar://problem/43057057
