### PR TITLE
Added support for selectively disabling tests for GPU execution.

### DIFF
--- a/test/TensorFlowRuntime/control_flow_1.swift
+++ b/test/TensorFlowRuntime/control_flow_1.swift
@@ -48,12 +48,15 @@ public func weighPet(_ pet: Pet,
   let extra = Tensor<Float>(1.0)
   _hostOp(extra)
 }
+// TODO: fix the disabled GPU tests below.
+#if !CUDA
 ControlFlowTests.testAllBackends("weighPet") {
   weighPet(.bird, 2.0)
   weighPet(.cat, 6.0)
   weighPet(.dog, 11.0)
   weighPet(.fish, 1.0)
 }
+#endif // CUDA
 
 @inline(never)
 public func weighPetWithDefault(_ pet: Pet,
@@ -114,13 +117,14 @@ public func testEnumWithPayload(_ x: EnumWithPayload, _ expectedVal: Float) {
   val += 0.0
   expectNearlyEqualWithScalarTensor(expectedVal, val)
 }
+#if !CUDA
 ControlFlowTests.testAllBackends("testEnumWithPayload") {
   testEnumWithPayload(.a("Hello"), 3.0)
   testEnumWithPayload(.b(3.0), 5.0)
   testEnumWithPayload(.c(Tensor<Float>(1.0), Tensor<Float>(2.0)), 6.0)
   testEnumWithPayload(.d(.b(3.0)), 12.0)
 }
-
+#endif // CUDA
 
 @inline(never)
 public func testCondBranch(_ a: Bool,

--- a/test/TensorFlowRuntime/gpu_negative_tests.swift
+++ b/test/TensorFlowRuntime/gpu_negative_tests.swift
@@ -1,0 +1,32 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize
+// XFAIL: *
+
+// This test suite contains expected failure tests for GPU execution.
+
+import TensorFlow
+import TensorFlowUnittest
+import StdlibUnittest
+
+var GPUNegativeTests = TestSuite("GPUNegative")
+
+// Make sure this test suite would fail when running on any device.
+GPUNegativeTests.testAllBackends("dummy_failed_test") {
+  expectEqual(0, 1)
+}
+
+// This test would fail when running under GPU, because Assert does not have a
+// GPU kernel.
+#if CUDA
+public func noAssertOnGPU() {
+  let a = Tensor<Float>(1.0)
+  _hostOp(a)
+  #tfop("Assert", Tensor<Bool>(true), [a]) as Void
+  expectEqualWithScalarTensor(1, a)
+}
+GPUNegativeTests.testAllBackends("noAssertOnGPU", noAssertOnGPU)
+#endif // CUDA
+
+runAllTests()
+

--- a/test/TensorFlowRuntime/loops.swift
+++ b/test/TensorFlowRuntime/loops.swift
@@ -47,6 +47,8 @@ LoopsTests.testAllBackends("simpleCounterLoop_ab") {
   expectEqual(98, a.scalar)
 }
 
+// TODO: fix the disabled GPU tests below.
+#if !CUDA
 LoopsTests.testAllBackends("SR8164") {
   @inline(never)
   func SR8164(count: Int32, expectedVal: Int32) {
@@ -72,7 +74,9 @@ LoopsTests.testAllBackends("SR8164") {
   SR8164(count: 30, expectedVal: -30)
   SR8164(count: 70, expectedVal: 70)
 }
+#endif // CUDA
 
+#if !CUDA
 LoopsTests.testAllBackends("SR-8191") {
   let t = Tensor<Float>(1.0)
   var i = 0
@@ -86,6 +90,7 @@ LoopsTests.testAllBackends("SR-8191") {
   let extra = Tensor<Float>(1.0)
   _hostOp(extra)
 }
+#endif // CUDA
 
 // FIXME: Compiler bug (b/73607740)
 // error: internal error generating TensorFlow graph:

--- a/test/TensorFlowRuntime/sese_loop_canonicalization.swift
+++ b/test/TensorFlowRuntime/sese_loop_canonicalization.swift
@@ -8,6 +8,8 @@ import StdlibUnittest
 
 var ControlFlowTests = TestSuite("ControlFlow")
 
+// TODO: fix the disabled GPU tests below.
+#if !CUDA
 func powerOfTwo(_ N: Int32) -> Tensor<Float>{
   var a = Tensor<Float>(1.0)
   for _ in 0..<N {
@@ -87,5 +89,6 @@ ControlFlowTests.testAllBackends("sumOfProductsWithBound") {
   // Effectively no bound as natSum(3) * natSum(3) is 36.
   expectNearlyEqualWithScalarTensor(36, sumOfProductsWithBound(3, 3, 100))
 }
+#endif // CUDA
 
 runAllTests()

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -329,8 +329,9 @@ swift_tensorflow_path = lit_config.params.get('swift_tensorflow_path', None)
 if swift_tensorflow_path:
     swift_tensorflow_extra_options += ('-L%s -ltensorflow -ltensorflow_framework' % swift_tensorflow_path)
 swift_tensorflow_gpu = lit_config.params.get('swift_tensorflow_gpu', None)
+# Can use #if on CUDA to selectively disable tests for GPU.
 if swift_tensorflow_gpu:
-    swift_tensorflow_extra_options += ' -Xllvm -tf-target-gpu'
+    swift_tensorflow_extra_options += ' -Xllvm -tf-target-gpu -DCUDA'
 
 test_options = os.environ.get('SWIFT_TEST_OPTIONS')
 if test_options:


### PR DESCRIPTION
Such test infra code used to live in TensorFlowUnittest.swift under testCPU() vs
testGPU(), but I prefer to instead use "#if CUDA" in the test code directly, as
the latter syntax is more visible and serve as a reminder for those tests to be
fixed.

This is a step towards passing all runtime tests under GPU.

One way to build and run GPU tests is:
```
./utils/build-script --assertions --no-swift-stdlib-assertions --swift-enable-ast-verifier=0 --enable-tensorflow-gpu --release

../llvm/utils/lit/lit.py -sv --param swift_tensorflow_gpu=true --param swift_test_mode=optimize --param swift_tensorflow_path=../build/bazel-bin/tensorflow  ../build/${build_dir}/swift-linux-x86_64/test-linux-x86_64/TensorFlowRuntime
```
