### PR TITLE
Force teh deployment target of LLDB to 10.13

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1762,6 +1762,7 @@ function set_lldb_xcodebuild_options() {
         OBJROOT="${lldb_build_dir}"
         -UseNewBuildSystem=NO
         ${LLDB_EXTRA_XCODEBUILD_ARGS}
+        MACOSX_DEPLOYMENT_TARGET=10.13
     )
     if [[ "${LLDB_NO_DEBUGSERVER}" ]] ; then
         lldb_xcodebuild_options=(


### PR DESCRIPTION
instead of infering 10.14 from the used SDK.

rdar://43011380
