### PR TITLE
Fixed a bug in device partitioning, where a tensor transfer is not generated  when a graph_op reads a func input arg on a different device.

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -1613,7 +1613,8 @@ void TFDeabstraction::checkAttributesAndFormGraphOps() {
       // TODO: remove this inst in the getForFunction() call above, once
       // the partition pass is folded into deabstraction.
       if (opInfo->opName == "tfc.configureTPU" ||
-          opInfo->opName == "tfc.configureGPU")
+          opInfo->opName == "tfc.configureGPU" ||
+          opInfo->opName == "tfc.configureCPU")
         continue;
       formGraphOp(*opInfo, constants, deviceInfo);
     }

--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -1612,6 +1612,7 @@ void TFDeabstraction::checkAttributesAndFormGraphOps() {
       // removed at the beginning of the partition pass.
       // TODO: remove this inst in the getForFunction() call above, once
       // the partition pass is folded into deabstraction.
+      // FIXME: consider defining constexpr strings for these literals.
       if (opInfo->opName == "tfc.configureTPU" ||
           opInfo->opName == "tfc.configureGPU" ||
           opInfo->opName == "tfc.configureCPU")

--- a/lib/SILOptimizer/Mandatory/TFDevicePartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDevicePartition.cpp
@@ -66,7 +66,8 @@ GraphFunctionDeviceInfo::getForFunction(SILFunction &fn,
       if (!tfopInfo)
         continue;
       bool isConfigOp = tfopInfo->opName == "tfc.configureTPU" ||
-                        tfopInfo->opName == "tfc.configureGPU";
+                        tfopInfo->opName == "tfc.configureGPU" ||
+                        tfopInfo->opName == "tfc.configureCPU";
       if (!isConfigOp)
         continue;
 
@@ -92,10 +93,12 @@ GraphFunctionDeviceInfo::getForFunction(SILFunction &fn,
         auto infeedEnabled =
             cast<IntegerLiteralInst>(tfopInfo->getAttrOperand(0));
         isTPUInfeedEnabled = !infeedEnabled->getValue().isNullValue();
-      } else {
-        assert(tfopInfo->opName == "tfc.configureGPU" &&
-               "unknown device configuration op");
+      } else if (tfopInfo->opName == "tfc.configureGPU") {
         deviceType = DeviceType::GPU;
+      } else {
+        assert(tfopInfo->opName == "tfc.configureCPU" &&
+               "unknown device configuration op");
+        deviceType = DeviceType::CPU;
       }
     }
   }
@@ -309,11 +312,6 @@ class DevicePartitionCloner
 }  // end anonymous namespace
 
 void DevicePartitionCloner::visitGraphOperationInst(GraphOperationInst *inst) {
-  if (inst->getName().str() == "tf_tensor_to_i1") {
-    SILClonerWithScopes::visitGraphOperationInst(inst);
-    return;
-  }
-
   GraphOperationInfo decoder(inst);
   SmallVector<GraphOperationInfo::InputMarker, 4> inputInfos;
   auto opName = decoder.decodeName(inputInfos);
@@ -828,14 +826,58 @@ public:
                         unsigned operIdx) {
     auto opValue = inst->getOperand(operIdx);
 
-    // BB args are replicated on all devices, so no transfer is needed.
-    if (isa<SILArgument>(opValue)) return;
     // Undefs will be handled later.
     if (isa<SILUndef>(opValue)) return;
+    if (isa<SILArgument>(opValue)) {
+      // BB args that are not func input args are replicated on all devices, so
+      // no transfer is needed.
+      auto *funcArg = dyn_cast<SILFunctionArgument>(opValue);
+      if (!funcArg)
+        return;
+
+      // Otherwise, `inst` can look like like:
+      //   %3 = graph_op "tf_tensor_to_i1"(%0 : $TensorHandle<Builtin.Int1>)
+      //     {__device: "ALL_DEVICES"} : $Builtin.Int1
+      // Here we need to transfer %0 to the device that runs the graph_op. To
+      // keep the remaining code in this function simple (the code assumes
+      // `opValue` is produced by a graph_op inst), we synthesize an identity op
+      // that reads the func input arg at the primary device. If it turns out
+      // reading the func arg need no tensor transfer (i.e., if the graph_op %3
+      // above is placed on the primary device), we rely on the backend graph
+      // compiler (e.g. grappler) to optimize away this extraneous identity op.
+      std::string identityOpName = "Identity";
+      identityOpName +=
+          GraphOperationInfo::getInputMarker(GraphOperationInfo::IM_Normal);
+
+      // insert this new inst at the beginning of the function.
+      SILBuilder B(&srcFn.front().front());
+      auto &ctx = B.getModule().getASTContext();
+      GraphOperationAttribute deviceAttr = {
+          ctx.getIdentifier(DEVICE_ATTR),
+          SymbolicValue::getString(
+              getDeviceString(deviceInfo.primaryDeviceType),
+              ctx.getAllocator())};
+      auto *identityOpInst = B.createGraphOperation(
+          srcFn.getLocation(), ctx.getIdentifier(identityOpName),
+          /*operands*/ {opValue}, /*attributes*/ {deviceAttr},
+          {opValue->getType()});
+      identityOpInst->dump(); // see if this crashes.
+      markInstForDevice(deviceInfo.primaryDeviceType, identityOpInst);
+
+      auto newValue = getSingleValueResult(identityOpInst);
+      // Replace all users with the value produced by the new identity op inst,
+      // except for the identity inst itself.
+      for (auto *use : opValue->getUses()) {
+        auto *user = use->getUser();
+        if (user != identityOpInst)
+          use->set(newValue);
+      }
+      opValue = newValue;
+    }
 
     auto *operandInst = opValue->getDefiningInstruction();
     assert(operandInst && "value must be defined by an instruction");
-    
+
     DeviceType operandDeviceType = getSomeDevicePlacement(operandInst);
     // Already on this device -- we are done.
     if (operandDeviceType == DeviceType::ALL ||
@@ -848,7 +890,7 @@ public:
 
     assert(operandDeviceType != DeviceType::ALL);
     assert(operandDeviceType != deviceType);
-    // See if we have previously emitted a TransorTransfer from
+    // See if we have previously emitted a TensorTransfer from
     // `operandDeviceType` to `deviceType`.
     // FIXME: If we earlier sent the value to GPU device, and later lookup the
     // same value with dest device set to ALL, we will be generating another

--- a/lib/SILOptimizer/Mandatory/TFDevicePartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDevicePartition.cpp
@@ -861,7 +861,6 @@ public:
           srcFn.getLocation(), ctx.getIdentifier(identityOpName),
           /*operands*/ {opValue}, /*attributes*/ {deviceAttr},
           {opValue->getType()});
-      identityOpInst->dump(); // see if this crashes.
       markInstForDevice(deviceInfo.primaryDeviceType, identityOpInst);
 
       auto newValue = getSingleValueResult(identityOpInst);

--- a/lib/SILOptimizer/Mandatory/TFDeviceSupport.h
+++ b/lib/SILOptimizer/Mandatory/TFDeviceSupport.h
@@ -279,6 +279,11 @@ private:
     if (opType == "tfc.RecvFromHost" || opType == "tfc.SendToHost")
       return DeviceType::CPU;
 
+    // Dataset / iterator related ops.
+    if (opType == "OneShotIterator" || opType == "IteratorGetNext" ||
+        opType == "TensorSliceDataset")
+      return DeviceType::CPU;
+
     // Place this inst on the device given by this deviceInfo.
     // FIXME: Use the op kernel device availability info to select a device for
     // `opType` -- if that op has no available kernel on `primaryDeviceType`, a

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -57,6 +57,11 @@ public func enableGPU() {
   #tfop("tfc.configureGPU") as Void
 }
 
+@_transparent
+public func enableCPU() {
+  #tfop("tfc.configureCPU") as Void
+}
+
 @_frozen
 public enum _ExecutionMode : Equatable {
   /// CPU or GPU execution.

--- a/test/TensorFlowRuntime/string.swift
+++ b/test/TensorFlowRuntime/string.swift
@@ -10,7 +10,8 @@ import StdlibUnittest
 var StringTensorTests = TestSuite("String")
 
 StringTensorTests.test("StringComparison") {
-
+  // Const op over a String tensor cannot live on GPU.
+  TensorFlow.enableCPU()
   let t1 = Tensor("foo")
   let result1 = t1.elementsEqual(t1)
   expectEqual(ShapedArray(shape: [], scalars: [true]), result1.array)


### PR DESCRIPTION
One such test case is running `HangersTests.testAllBackends("SR8443")` with GPU as
the primary device. In the accelerator function SIL snippet below,
`tf_tensor_to_i1` running on CPU (this test case involves printing a tensor
value, where the tensor is first transferred from GPU to CPU, before being sent
to Swift host) cannot read %0 on GPU directly (recall func input args are always
placed on the primary device partition function, GPU in this case; also recall
that we are replicating control flow on all device partition functions for now,
hence `tf_tensor_to_i1` runs on ALL devices).

```
--- TFPartition Accelerator Result: $S7hangers6SR84431nys5Int32V_tF.tf
// SR8443(n:)
sil private @$S7hangers6SR84431nys5Int32V_tF.tf : $@callee_owned (TensorHandle<Builtin.Int1>, TensorHandle<Builtin.Int32>) -> TensorHandle<Float> {
// %0                                             // user: %3
// %1                                             // user: %11
bb0(%0 : $TensorHandle<Builtin.Int1>, %1 : $TensorHandle<Builtin.Int32>):
  %2 = graph_op "Const"() {dtype$dtype: $Builtin.Int32, value$tensor: i32 0, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int32> // user: %6
  %3 = graph_op "tf_tensor_to_i1"(%0 : $TensorHandle<Builtin.Int1>) {__device: "ALL_DEVICES"} : $Builtin.Int1 // user: %4
```

For code simplicity, the fix involves creating an identity op on the primary device first, and then
transferring its output to the device running `tf_tensor_to_i1`. The resulting
SIL code (after handling the transfers of both %0 and %1) is:

```
// %0                                             // user: %3
// %1                                             // user: %2
bb0(%0 : $TensorHandle<Builtin.Int1>, %1 : $TensorHandle<Builtin.Int32>):
  %2 = graph_op "Identity,i"(%1 : $TensorHandle<Builtin.Int32>) {__device: "/device:GPU:0"} : $TensorHandle<Builtin.Int32> // user: %16
  %3 = graph_op "Identity,i"(%0 : $TensorHandle<Builtin.Int1>) {__device: "/device:GPU:0"} : $TensorHandle<Builtin.Int1> // user: %4
  %4 = graph_op "tfc.TensorTransfer,i"(%3 : $TensorHandle<Builtin.Int1>) {transferId: i32 0, srcDevice: "/device:GPU:0", destDevice: "ALL_DEVICES"} : $TensorHandle<Builtin.Int1> // user: %6
  %5 = graph_op "Const"() {dtype$dtype: $Builtin.Int32, value$tensor: i32 0, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int32> // user: %12
  %6 = graph_op "tf_tensor_to_i1"(%4 : $TensorHandle<Builtin.Int1>) {__device: "ALL_DEVICES"} : $Builtin.Int1 // user: %7
```

Also added `TensorFlow.enableCPU()`. Once use case is to mark a swift function
for dataset creation to run on CPU (see the test case in `dataset_1.swift`).

