### PR TITLE
Cut down conformance checking time by reusing RequirementEnvironments

### DIFF
--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -333,14 +333,14 @@ public:
 /// \brief Describes a match between a requirement and a witness.
 struct RequirementMatch {
   RequirementMatch(ValueDecl *witness, MatchKind kind,
-                   Optional<RequirementEnvironment> &&env = None)
+                   Optional<RequirementEnvironment> env = None)
     : Witness(witness), Kind(kind), WitnessType(), ReqEnv(std::move(env)) {
     assert(!hasWitnessType() && "Should have witness type");
   }
 
   RequirementMatch(ValueDecl *witness, MatchKind kind,
                    Type witnessType,
-                   Optional<RequirementEnvironment> &&env = None,
+                   Optional<RequirementEnvironment> env = None,
                    ArrayRef<OptionalAdjustment> optionalAdjustments = {})
     : Witness(witness), Kind(kind), WitnessType(witnessType),
       ReqEnv(std::move(env)),
@@ -430,6 +430,12 @@ struct RequirementMatch {
 struct RequirementCheck;
 
 class WitnessChecker {
+public:
+  using RequirementEnvironmentCacheKey =
+      std::pair<const GenericSignature *, const ClassDecl *>;
+  using RequirementEnvironmentCache =
+      llvm::DenseMap<RequirementEnvironmentCacheKey, RequirementEnvironment>;
+
 protected:
   TypeChecker &TC;
   ProtocolDecl *Proto;
@@ -440,6 +446,8 @@ protected:
   // An auxiliary lookup table to be used for witnesses remapped via
   // @_implements(Protocol, DeclName)
   llvm::DenseMap<DeclName, llvm::TinyPtrVector<ValueDecl *>> ImplementsTable;
+
+  RequirementEnvironmentCache ReqEnvironmentCache;
 
   WitnessChecker(TypeChecker &tc, ProtocolDecl *proto,
                  Type adoptee, DeclContext *dc);
@@ -839,12 +847,11 @@ RequirementMatch matchWitness(
                      RequirementMatch(bool, ArrayRef<OptionalAdjustment>)
                    > finalize);
 
-RequirementMatch matchWitness(TypeChecker &tc,
-                              ProtocolDecl *proto,
-                              ProtocolConformance *conformance,
-                              DeclContext *dc,
-                              ValueDecl *req,
-                              ValueDecl *witness);
+RequirementMatch
+  matchWitness(TypeChecker &tc,
+               WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
+               ProtocolDecl *proto, ProtocolConformance *conformance,
+               DeclContext *dc, ValueDecl *req, ValueDecl *witness);
 
 /// If the given type is a direct reference to an associated type of
 /// the given protocol, return the referenced associated type.

--- a/test/SILGen/witnesses_class.swift
+++ b/test/SILGen/witnesses_class.swift
@@ -102,3 +102,17 @@ class UsesDefaults<X : Barable> : HasDefaults {}
 // CHECK: [[FN:%.*]] = function_ref @$S15witnesses_class11HasDefaultsPAAE23hasDefaultGenericTakesTyy1TQz_qd__tAA7FooableRd__lF : $@convention(method) <τ_0_0 where τ_0_0 : HasDefaults><τ_1_0 where τ_1_0 : Fooable> (@in_guaranteed τ_0_0.T, @guaranteed τ_1_0, @in_guaranteed τ_0_0) -> ()
 // CHECK: apply [[FN]]<UsesDefaults<τ_0_0>, τ_1_0>(
 // CHECK: return
+
+protocol ReturnsCovariantSelf {
+  func returnsCovariantSelf() -> Self
+}
+extension ReturnsCovariantSelf {
+  func returnsCovariantSelf() -> Self { return self }
+}
+
+class NonMatchingMember: ReturnsCovariantSelf {
+  func returnsCovariantSelf() {}
+}
+
+// CHECK-LABEL: sil private [transparent] [thunk] @$S15witnesses_class17NonMatchingMemberCAA20ReturnsCovariantSelfA2aDP07returnsgH0xyFTW : $@convention(witness_method: ReturnsCovariantSelf) <τ_0_0 where τ_0_0 : NonMatchingMember> (@in_guaranteed τ_0_0) -> @out τ_0_0 {
+


### PR DESCRIPTION
Trade an extra copy for saving the cost of reinitialization when there are a lot of witnesses to check. A small but measurable win when type-checking the standard library.