### PR TITLE
[SIL] Clarify ownership in FunctionAnalysisBase w/ std::unique_ptr

### DIFF
--- a/include/swift/SILOptimizer/Analysis/DominanceAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/DominanceAnalysis.h
@@ -41,8 +41,8 @@ public:
     return S->getKind() == SILAnalysisKind::Dominance;
   }
 
-  DominanceInfo *newFunctionAnalysis(SILFunction *F) override {
-    return new DominanceInfo(F);
+  std::unique_ptr<DominanceInfo> newFunctionAnalysis(SILFunction *F) override {
+    return llvm::make_unique<DominanceInfo>(F);
   }
 
   virtual bool shouldInvalidate(SILAnalysis::InvalidationKind K) override {
@@ -70,8 +70,9 @@ public:
     return S->getKind() == SILAnalysisKind::PostDominance;
   }
 
-  PostDominanceInfo *newFunctionAnalysis(SILFunction *F) override {
-    return new PostDominanceInfo(F);
+  std::unique_ptr<PostDominanceInfo>
+  newFunctionAnalysis(SILFunction *F) override {
+    return llvm::make_unique<PostDominanceInfo>(F);
   }
 
   virtual bool shouldInvalidate(SILAnalysis::InvalidationKind K) override {

--- a/include/swift/SILOptimizer/Analysis/EpilogueARCAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EpilogueARCAnalysis.h
@@ -300,8 +300,9 @@ public:
 
   virtual void initialize(SILPassManager *PM) override;
   
-  virtual EpilogueARCFunctionInfo *newFunctionAnalysis(SILFunction *F) override {
-    return new EpilogueARCFunctionInfo(F, PO, AA, RC);
+  virtual std::unique_ptr<EpilogueARCFunctionInfo>
+  newFunctionAnalysis(SILFunction *F) override {
+    return llvm::make_unique<EpilogueARCFunctionInfo>(F, PO, AA, RC);
   }
 
   virtual bool shouldInvalidate(SILAnalysis::InvalidationKind K) override {

--- a/include/swift/SILOptimizer/Analysis/IVAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/IVAnalysis.h
@@ -90,8 +90,8 @@ public:
     return S->getKind() == SILAnalysisKind::InductionVariable;
   }
 
-  IVInfo *newFunctionAnalysis(SILFunction *F) override {
-    return new IVInfo(*F);
+  std::unique_ptr<IVInfo> newFunctionAnalysis(SILFunction *F) override {
+    return llvm::make_unique<IVInfo>(*F);
   }
 
   /// For now we always invalidate.

--- a/include/swift/SILOptimizer/Analysis/LoopAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/LoopAnalysis.h
@@ -44,7 +44,8 @@ public:
 
   // Computes loop information for the given function using dominance
   // information.
-  virtual SILLoopInfo *newFunctionAnalysis(SILFunction *F) override;
+  virtual std::unique_ptr<SILLoopInfo>
+  newFunctionAnalysis(SILFunction *F) override;
 
   virtual void initialize(SILPassManager *PM) override;
 };

--- a/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
@@ -1080,8 +1080,10 @@ public:
     return S->getKind() == SILAnalysisKind::LoopRegion;
   }
 
-  virtual LoopRegionFunctionInfo *newFunctionAnalysis(SILFunction *F) override {
-    return new LoopRegionFunctionInfo(F, POA->get(F), SLA->get(F));
+  virtual std::unique_ptr<LoopRegionFunctionInfo>
+  newFunctionAnalysis(SILFunction *F) override {
+    return llvm::make_unique<LoopRegionFunctionInfo>(F, POA->get(F),
+                                                     SLA->get(F));
   }
 
   virtual bool shouldInvalidate(SILAnalysis::InvalidationKind K) override {

--- a/include/swift/SILOptimizer/Analysis/PostOrderAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/PostOrderAnalysis.h
@@ -34,8 +34,9 @@ class SILFunction;
 /// reform the post order over and over again (it can be expensive).
 class PostOrderAnalysis : public FunctionAnalysisBase<PostOrderFunctionInfo> {
 protected:
-  virtual PostOrderFunctionInfo *newFunctionAnalysis(SILFunction *F) override {
-    return new PostOrderFunctionInfo(F);
+  virtual std::unique_ptr<PostOrderFunctionInfo>
+  newFunctionAnalysis(SILFunction *F) override {
+    return llvm::make_unique<PostOrderFunctionInfo>(F);
   }
 
   virtual bool shouldInvalidate(SILAnalysis::InvalidationKind K) override {

--- a/include/swift/SILOptimizer/Analysis/RCIdentityAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RCIdentityAnalysis.h
@@ -118,8 +118,9 @@ public:
 
   virtual void initialize(SILPassManager *PM) override;
   
-  virtual RCIdentityFunctionInfo *newFunctionAnalysis(SILFunction *F) override {
-    return new RCIdentityFunctionInfo(DA);
+  virtual std::unique_ptr<RCIdentityFunctionInfo>
+  newFunctionAnalysis(SILFunction *F) override {
+    return llvm::make_unique<RCIdentityFunctionInfo>(DA);
   }
 
   virtual bool shouldInvalidate(SILAnalysis::InvalidationKind K) override {

--- a/lib/SILOptimizer/Analysis/LoopAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/LoopAnalysis.cpp
@@ -18,11 +18,12 @@
 
 using namespace swift;
 
-SILLoopInfo *SILLoopAnalysis::newFunctionAnalysis(SILFunction *F) {
+std::unique_ptr<SILLoopInfo>
+SILLoopAnalysis::newFunctionAnalysis(SILFunction *F) {
   assert(DA != nullptr && "Expect a valid dominance analysis");
   DominanceInfo *DT = DA->get(F);
   assert(DT != nullptr && "Expect a valid dominance information");
-  return new SILLoopInfo(F, DT);
+  return llvm::make_unique<SILLoopInfo>(F, DT);
 }
 
 void SILLoopAnalysis::initialize(SILPassManager *PM) {


### PR DESCRIPTION
I also thought I was fixing a performance issue by changing invalidateFunction not to *insert* new entries into the map, but I guess those entries were present in practice. So this is just a cleanup to make ownership easier.