### PR TITLE
[AST] Remove stale comment from TypeAliasDecl::setUnderlyingType

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2696,8 +2696,6 @@ public:
     return UnderlyingTy;
   }
 
-  /// Set the underlying type, for deserialization and synthesized
-  /// aliases.
   void setUnderlyingType(Type type);
 
   /// For generic typealiases, return the unbound generic type.


### PR DESCRIPTION
This is used on all paths now.