### PR TITLE
[GPE] Improve diagnostics for invalid use of opaque handles for send/receive or as tensor program arguments

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -234,6 +234,8 @@ ERROR(tfop_invalid_tfop, none,
 ERROR(tfop_incorrect_definition, none,
       "tfop function doesn't align with TensorFlow op definition:\n%0",
       (StringRef))
+ERROR(tfop_value_no_send_receive, none,
+      "value cannot be used by non-TensorFlow API", ())
 ERROR(tf_multiple_device, none,
       "device configuration specified multiple times", ())
 NOTE(tf_multiple_device_prev, none,

--- a/include/swift/AST/TensorFlow.h
+++ b/include/swift/AST/TensorFlow.h
@@ -44,8 +44,12 @@ namespace tf {
   /// if so, which one it is.
   TFValueKind classifyTensorFlowValue(Type ty);
 
-  /// Return true if the specified type is a TensorHandle<T>.
+  /// Return true if the specified type is an opaque handle such as
+  /// VariantHandle and ResourceHandle.
   bool isTensorHandle(Type ty);
+  
+  /// Return true if the specified type is a TensorHandle<T>.
+  bool isOpaqueHandle(Type ty);
 
   /// Return true if the specified type is TensorHandle<T>, ResourceHandle, or
   /// VariantHandle.

--- a/include/swift/AST/TensorFlow.h
+++ b/include/swift/AST/TensorFlow.h
@@ -44,11 +44,11 @@ namespace tf {
   /// if so, which one it is.
   TFValueKind classifyTensorFlowValue(Type ty);
 
-  /// Return true if the specified type is an opaque handle such as
-  /// VariantHandle and ResourceHandle.
+  /// Return true if the specified type is a TensorHandle<T>.
   bool isTensorHandle(Type ty);
   
-  /// Return true if the specified type is a TensorHandle<T>.
+  /// Return true if the specified type is an opaque handle such as
+  /// VariantHandle and ResourceHandle.
   bool isOpaqueHandle(Type ty);
 
   /// Return true if the specified type is TensorHandle<T>, ResourceHandle, or

--- a/lib/AST/TensorFlow.cpp
+++ b/lib/AST/TensorFlow.cpp
@@ -57,6 +57,13 @@ bool tf::isTensorHandle(Type ty) {
   return classifyTensorFlowValue(ty) == TFValueKind::TensorHandle;
 }
 
+/// Return true if the specified type is an opaque handle, such as
+/// VariantHandle and ResourceHandle.
+bool tf::isOpaqueHandle(Type ty) {
+  auto kind = classifyTensorFlowValue(ty);
+  return kind != TFValueKind::Nope && kind != TFValueKind::TensorHandle;
+}
+
 /// Return true if the specified type is TensorHandle<T>, ResourceHandle, or
 /// VariantHandle.
 bool tf::isTensorFlowValue(Type ty) {

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -4266,9 +4266,8 @@ bool TFFunctionPartition::partition(bool isTest) {
           // If it's an opaque handle such as VariantHandle or ResourceHandle,
           // it cannot be a result except when it's being returned in an
           // accelerator-only function.
-          if (isOpaqueHandle(result->getType())) {
-            if (isAcceleratorOnly(hostFn) && isReturning(user))
-              continue;
+          if (isOpaqueHandle(result->getType()) &&
+              !(isAcceleratorOnly(hostFn) && isReturning(user))) {
             diagnoseOpaqueHandleCopy(result, user);
             return true;
           }

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -943,7 +943,8 @@ void TFFunctionPartition::diagnoseCopyToAccelerator(
   auto loc = getUserSourceLocation(value);
   
   // Opaque handles can never be sent or passed as tensor program arguments.
-  // Deabstraction must have rejected this earlier.
+  // Type checking must have rejected host functions that are either a)
+  // public with private ABI or b) marked @inline(never).
   assert(!isOpaqueHandle(value->getType()) &&
          "Opaque handles should never have been on the host");
 

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -73,11 +73,15 @@ static InFlightDiagnostic diagnose(ASTContext &Context, SourceLoc loc,
 static bool isUserIgnoredByPartitioning(SILInstruction *inst) {
   auto optMode = inst->getFunction()->getEffectiveOptimizationMode();
   // `debug_value` instructions are used for value inspection during debugging.
-  // For optimized builds, we ignored these instructions so that no send/receive
-  // will be emitted.
-  if (isa<DebugValueInst>(inst) &&
-      optMode != OptimizationMode::NoOptimization) {
-    return true;
+  if (auto *DVI = dyn_cast<DebugValueInst>(inst)) {
+    // Ignore all debug_value instructions for an optimized build so that no
+    // send/receive will be triggered.
+    if (optMode != OptimizationMode::NoOptimization)
+      return true;
+    // Ignore opaque handle because they cannot be sent/received.
+    if (isOpaqueHandle(DVI->getOperand()->getType()))
+      return true;
+    return false;
   }
   // Reference counting instructions are always ignored.
   return isa<RefCountingInst>(inst);
@@ -305,7 +309,7 @@ classifyPromotedScalarOp(SILInstruction *inst) {
   }
 }
 
-/// Returns true when this function must be entirely lowered to a TF graph
+/// Return true when this function must be entirely lowered to a TF graph
 /// function, with no host-side logic remaining (i.e., no sends/recvs, and no
 /// start/stop tensor computation on the host side). In other words, this
 /// function uses the tensorflow calling convention.
@@ -315,6 +319,15 @@ classifyPromotedScalarOp(SILInstruction *inst) {
 static bool isAcceleratorOnly(const SILFunction &hostFn) {
   return hostFn.getRepresentation() ==
          SILFunctionType::Representation::TensorFlow; // @convention(tensorflow)
+}
+
+/// Return true if a user instruction is returning or forming a return value.
+static bool isReturning(SILInstruction *user) {
+  if (isa<ReturnInst>(user)) return true;
+  if (auto *TI = dyn_cast<TupleInst>(user))
+    return llvm::all_of(
+      TI->getUses(), [&](Operand *use) { return isReturning(user); });
+  return false;
 }
 
 //===----------------------------------------------------------------------===//
@@ -813,6 +826,7 @@ public:
   void diagnoseUsesFromHost(SILValue value, SILLocation loc);
   void diagnoseCopyToHost(SILValue value, SILInstruction *user,
                           SILLocation loc);
+  void diagnoseOpaqueHandleCopy(SILValue value, SILInstruction *user);
 
 private:
   // Marking.
@@ -938,6 +952,11 @@ void TFFunctionPartition::diagnoseCopyToAccelerator(
 
   // Try to determine a good source location to report.
   auto loc = getUserSourceLocation(value);
+  
+  // Opaque handles can never be sent or passed as tenosr program arguments.
+  // Deabstraction must have rejected this earlier.
+  assert(!isOpaqueHandle(value->getType()) &&
+         "Opaque handles should never have been on the host");
 
   // Try to make a useful description of the value being copied to help
   // disambiguate.
@@ -1039,6 +1058,12 @@ void TFFunctionPartition::diagnoseUsesFromHost(SILValue value,
     // here.  It won't be very useful.
     if (isUserIgnoredByPartitioning(user))
       continue;
+    
+    // If the value is a non-copyable opaque handle, emit an error.
+    if (isOpaqueHandle(value->getType())) {
+      diagnoseOpaqueHandleCopy(value, user);
+      continue;
+    }
 
     // If we are running this in the context of an expression run in the REPL or
     // playgrounds, or script mode, then we should never emit a warning: we know
@@ -1097,6 +1122,19 @@ void TFFunctionPartition::diagnoseCopyToHost(SILValue value,
              diag::tf_value_implicitly_copied_to_host_computed_used_here)
         .highlight(userLoc.getSourceRange());
   }
+}
+
+/// Emit an error for invalid send/receive of opaque handles.
+void TFFunctionPartition::diagnoseOpaqueHandleCopy(SILValue value,
+                                                   SILInstruction *user) {
+  assert(isOpaqueHandle(value->getType()) &&
+         "Shouldn't emit an error for opaque handle copy when the value is not "
+         "an opaque handle");
+  auto &ctx = value->getFunction()->getASTContext();
+  diagnose(ctx, getUserSourceLocation(value).getSourceLoc(),
+           diag::tfop_value_no_send_receive);
+  diagnose(ctx, getUserSourceLocation(user).getSourceLoc(),
+           diag::tf_value_implicitly_copied_to_host_computed_used_here);
 }
 
 /// Some instruction in the specified block needs to be split out to the
@@ -3014,11 +3052,8 @@ SILFunction *PartitionCloner::lookupSendReceiveFunction(StringRef fnName,
   auto nominal = tensorValueTy.getASTType()->getAnyNominal();
   auto lookup =
       nominal->lookupConformance(&tensorFlowModule, proto, conformances);
-  if (!lookup) {
-    diagnose(ctx, loc.getSourceLoc(), diag::tfop_incorrect_definition,
-             "This value type cannot be sent/received");
-    return nullptr;
-  }
+  assert(lookup && "No conformance to TensorSendableReceivable found. "
+         "Is it a sendable/receivable TensorFlow value?");
   assert(conformances.size() == 1 && "Found multiple conformance candidates.");
   DeclName fnDeclName(ctx.getIdentifier(fnName));
   auto *fn = findSILFunctionForRequiredProtocolMember(
@@ -4227,6 +4262,16 @@ bool TFFunctionPartition::partition(bool isTest) {
                 (argInfo->second.first == Marking::Move ||
                  argInfo->second.first == Marking::Delete))
               continue;
+          }
+          
+          // If it's an opaque handle such as VariantHandle or ResourceHandle,
+          // it cannot be a result except when it's being returned in an
+          // accelerator-only function.
+          if (isOpaqueHandle(result->getType())) {
+            if (isAcceleratorOnly(hostFn) && isReturning(user))
+              continue;
+            diagnoseOpaqueHandleCopy(result, user);
+            return true;
           }
 
           // Remember if the instruction has any use.  If not, then it never

--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -96,7 +96,11 @@ VarDecl *tf::getFieldIfContainsSingleField(NominalTypeDecl *decl) {
 }
 
 bool tf::isTensorHandle(SILType ty) {
-  return (bool)isTensorHandle(ty.getASTType());
+  return isTensorHandle(ty.getASTType());
+}
+
+bool tf::isOpaqueHandle(SILType ty) {
+  return isOpaqueHandle(ty.getASTType());
 }
 
 /// Determine whether the specified type is one of our well-known types, and

--- a/lib/SILOptimizer/Mandatory/TFUtilities.h
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.h
@@ -40,10 +40,10 @@ llvm::raw_ostream *getTFDumpIntermediateStream();
 /// return null.
 VarDecl *getFieldIfContainsSingleField(NominalTypeDecl *decl);
 
-/// Returns true if the specified type is the well-known TensorHandle<T> type.
+/// Return true if the specified type is the well-known TensorHandle<T> type.
 bool isTensorHandle(SILType ty);
   
-/// Returns true if the specified type is the well-known opaque handle type such
+/// Return true if the specified type is the well-known opaque handle type such
 /// as VariantHandle and ResourceHandle.
 bool isOpaqueHandle(SILType ty);
 

--- a/lib/SILOptimizer/Mandatory/TFUtilities.h
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.h
@@ -40,9 +40,12 @@ llvm::raw_ostream *getTFDumpIntermediateStream();
 /// return null.
 VarDecl *getFieldIfContainsSingleField(NominalTypeDecl *decl);
 
-/// If the specified type is the well-known TensorHandle<T> type, then return
-/// "T".  If not, return a null type.
+/// Returns true if the specified type is the well-known TensorHandle<T> type.
 bool isTensorHandle(SILType ty);
+  
+/// Returns true if the specified type is the well-known opaque handle type such
+/// as VariantHandle and ResourceHandle.
+bool isOpaqueHandle(SILType ty);
 
 /// Determine whether the specified type is one of our well-known types, and
 /// if so, which one it is.

--- a/test/TensorFlow/debugging.swift
+++ b/test/TensorFlow/debugging.swift
@@ -47,8 +47,6 @@ public func noCopyForOpaqueHandles() {
 // CHECK:   br bb1
 
 
-// CHECK-LABEL: ---- ANALYSIS STATE FOR FUNCTION ${{.*}}noCopyForOpaqueHandle
-// CHECK: [Move]    %28 = graph_op "TensorSliceDataset,L,e"(%4 : $TensorHandle<Float>)
 // CHECK-LABEL: ---- PARTITION STATE FOR FUNCTION ${{.*}}noCopyForOpaqueHandle
 // CHECK: result values:
 // CHECK-NOT: graph_op "TensorSliceDataset,L,e"(%4 : $TensorHandle<Float>)

--- a/test/TensorFlow/debugging.swift
+++ b/test/TensorFlow/debugging.swift
@@ -15,14 +15,23 @@ public func debugValuesInLoop(_ x: Tensor<Float>) {
   }
 }
 
-// CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}basicDebugValues{{.*}}
+// Opaque handles should not trigger send/receive even at -Onone, so we won't
+// expect their `debug_value` to work.
+public func noCopyForOpaqueHandles() {
+  let values = Tensor<Float>([1.0])
+  let dataset: VariantHandle =
+    #tfop("TensorSliceDataset", [values],
+          Toutput_types: [Float.self], output_shapes: [TensorShape()])
+}
+
+// CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}basicDebugValues
 // CHECK: @{{.*}}basicDebugValues{{.*}}.tf
 // CHECK: [[ONE:%.*]] = graph_op "Const"
 // CHECK: [[ADD_RESULT:%.*]] = graph_op "Add,i,i"
 // CHECK: graph_op "Square,i"([[ADD_RESULT]] : $TensorHandle<Float>) {T: $Float, __device: "/device:CPU:0"} : $TensorHandle<Float>
 
 
-// CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}debugValuesInLoop{{.*}}
+// CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}debugValuesInLoop
 // CHECK: bb0
 // CHECK:   [[SQUARED:%.*]] = graph_op "Square,i"
 // CHECK-NEXT:   graph_op "tfc.SendToHost,i"([[SQUARED]] : $TensorHandle<Float>)
@@ -38,7 +47,14 @@ public func debugValuesInLoop(_ x: Tensor<Float>) {
 // CHECK:   br bb1
 
 
-// CHECK-LABEL: --- TFPartition Host Result: {{.*}}basicDebugValues{{.*}}
+// CHECK-LABEL: ---- ANALYSIS STATE FOR FUNCTION ${{.*}}noCopyForOpaqueHandle
+// CHECK: [Move]    %28 = graph_op "TensorSliceDataset,L,e"(%4 : $TensorHandle<Float>)
+// CHECK-LABEL: ---- PARTITION STATE FOR FUNCTION ${{.*}}noCopyForOpaqueHandle
+// CHECK: result values:
+// CHECK-NOT: graph_op "TensorSliceDataset,L,e"(%4 : $TensorHandle<Float>)
+
+
+// CHECK-LABEL: --- TFPartition Host Result: {{.*}}basicDebugValues
 // CHECK: debug_value %{{.*}} : $Tensor<Float>, let, name "x", argno 1
 // CHECK: debug_value %{{.*}} : $Tensor<Float>, let, name "y"
 // CHECK: debug_value %{{.*}} : $Tensor<Float>, let, name "z"

--- a/test/TensorFlow/diagnostics.swift
+++ b/test/TensorFlow/diagnostics.swift
@@ -101,3 +101,20 @@ public func scalarToHost() {
 public func inoutArgumentToAccelerator(t: inout Tensor<Float>) {
   t += 1  // expected-note {{value used here}}
 }
+
+// Opaque handles should not be sent or received.
+public func opaqueHandlesCannotBeSentOrReceived() {
+  // expected-error @+2 {{value cannot be used by non-TensorFlow API}}
+  let iterator: ResourceHandle =
+    #tfop("Iterator", shared_name: "foo", container: "bar")
+  _hostOp(iterator) // expected-note {{value used here}}
+  let _ = Tensor<Float>(1.0)
+}
+
+// SR-8498: Opaque handles should not be tensor program results.
+public func opaqueHandlesCannotBeResults() {
+  // expected-error @+2 {{value cannot be used by non-TensorFlow API}}
+  let iterator: ResourceHandle =
+    #tfop("Iterator", shared_name: "foo", container: "bar")
+  _hostOp(iterator) // expected-note {{value used here}}
+}

--- a/test/TensorFlow/diagnostics.swift
+++ b/test/TensorFlow/diagnostics.swift
@@ -118,3 +118,11 @@ public func opaqueHandlesCannotBeResults() {
     #tfop("Iterator", shared_name: "foo", container: "bar")
   _hostOp(iterator) // expected-note {{value used here}}
 }
+
+// Accelerator-only functions can return multiple opaque handles.
+@TensorFlowGraph
+public func graphFuncReturningOpaqueHandles() -> (ResourceHandle, ResourceHandle) {
+  let iterator: ResourceHandle =
+    #tfop("Iterator", shared_name: "foo", container: "bar")
+  return (iterator, iterator)
+}

--- a/test/TensorFlow/diagnostics.swift
+++ b/test/TensorFlow/diagnostics.swift
@@ -118,11 +118,3 @@ public func opaqueHandlesCannotBeResults() {
     #tfop("Iterator", shared_name: "foo", container: "bar")
   _hostOp(iterator) // expected-note {{value used here}}
 }
-
-// Accelerator-only functions can return multiple opaque handles.
-@TensorFlowGraph
-public func graphFuncReturningOpaqueHandles() -> (ResourceHandle, ResourceHandle) {
-  let iterator: ResourceHandle =
-    #tfop("Iterator", shared_name: "foo", container: "bar")
-  return (iterator, iterator)
-}

--- a/test/TensorFlow/sends_recvs.swift
+++ b/test/TensorFlow/sends_recvs.swift
@@ -185,15 +185,6 @@ public func testSendsInALoopWithNoResultTensor() {
 // CHECK:        return {{.*}} : $()
 // CHECK-NEXT: } // end sil function {{.*}}testSendsInALoopWithNoResultTensor{{.*}}
 
-public func testCannotSendResource() {
-  // expected-error @+2 {{This value type cannot be sent/received}}
-  let iterator: ResourceHandle =
-    #tfop("Iterator", shared_name: "foo", container: "bar")
-
-  _hostOp(iterator)
-  let _ = Tensor<Float>(1.0)
-}
-
 // FIXME: Eliminate the sends/receives in this case, since host does not use the
 // value x.scalar! in any interesting way other than sending it back to device.
 // On the other hand, this likely will not happen in a real use case.


### PR DESCRIPTION
Opaque handles such as `VariantHandle` and `ResourceHandle` only reside in the TensorFlow graph. They cannot be sent, received, or returned from a tensor program. The diagnostics logic previously only handled cases where an opaque handle is being sent/received, but not when the opaque handle is classified as a result from the tensor program.

- Diagnostics are now handled at places where they should occur, i.e., `TFFunctionPartition::diagnoseUsesFromHost` and `TFFunctionPartition::diagnoseCopyToHost`.

- Method `TFFunctionPartition::diagnoseOpaqueHandleCopy` is added to generalize opaque handle diagnostics.

    Given

    ```swift
    let dataset: SingleValueDataset = ...
    _hostOp(dataset)
    ```

    Diagnostics will show
    ```swift
    let dataset: SingleValueDataset = ...
        ^ value cannot be used by non-TensorFlow API
    _hostOp(dataset)
            ^ value used here
    ```

- When the function being partitioned is an accelerator-only function, it is fine to make the function return an opaque handle. In these cases, we allow `return` of opaque handles by checking whether `hostFn` is `isAcceleratorOnly()`. The `isReturning` helper function helps determine whether an instruction is returning its operand or preparing a tuple for the operand to be returned.

- Extended `isUserIgnoredByPartitioning` to ignore `debug_value` consuming opaque handles even for `-Onone` builds. Since they do not have a host-side representation, they cannot be transferred to the host for debugging. More exploration for debugging opaque handles will come later.

- Minor fixes for incorrect comments.

This patch resolves [SR-8498](https://bugs.swift.org/browse/SR-8498), and partially resolves [SR-8496](https://bugs.swift.org/browse/SR-8496).