### PR TITLE
build: add top level option to control SwiftSyntax

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -398,14 +398,21 @@ endif()
 precondition(CMAKE_SYSTEM_NAME)
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
   set(SWIFT_BUILD_SOURCEKIT_default TRUE)
+  set(SWIFT_BUILD_SYNTAX_default FALSE)
 elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
   if(EXISTS ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE})
     set(SWIFT_BUILD_SOURCEKIT_default TRUE)
   else()
     set(SWIFT_BUILD_SOURCEKIT_default FALSE)
   endif()
+  if(EXISTS ${SWIFT_PATH_TO_FOUNDATION_SOURCE})
+    set(SWIFT_BUILD_SYNTAX_default TRUE)
+  else()
+    set(SWIFT_BUILD_SYNTAX_default FALSE)
+  endif()
 else()
     set(SWIFT_BUILD_SOURCEKIT_default FALSE)
+    set(SWIFT_BUILD_SYNTAX_default FALSE)
 endif()
 option(SWIFT_BUILD_SOURCEKIT
     "Build SourceKit"
@@ -413,6 +420,9 @@ option(SWIFT_BUILD_SOURCEKIT
 option(SWIFT_ENABLE_SOURCEKIT_TESTS
     "Enable running SourceKit tests"
     ${SWIFT_BUILD_SOURCEKIT_default})
+option(SWIFT_BUILD_SYNTAX
+       "Build SwiftSyntax"
+       ${SWIFT_BUILD_SYNTAX_default})
 
 #
 # Assume a new enough ar to generate the index at construction time. This avoids

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -49,17 +49,18 @@ endif()
 if(SWIFT_HOST_VARIANT STREQUAL "macosx")
   # Only build Darwin-specific tools when deploying to OS X.
   add_swift_tool_subdirectory(swift-stdlib-tool)
+endif()
 
-  # SwiftSyntax depends on both the standard library (because it's a
-  # Swift module), and the SDK overlays (because it depends on Foundation).
-  # Ensure we only build SwiftSyntax when we're building both.
+# SwiftSyntax depends on both the standard library (because it's a
+# Swift module), and the SDK overlays (because it depends on Foundation).
+if(SWIFT_BUILD_SYNTAX)
+  add_subdirectory(SwiftSyntax)
+  add_swift_tool_subdirectory(swift-swiftsyntax-test)
+endif()
+
+if(SWIFT_HOST_VARIANT STREQUAL "macosx")
   if(BUILD_FOUNDATION)
-    add_subdirectory(SwiftSyntax)
-    # We should build swift-swiftsyntax-test only when OSX SDK is built, aka,
-    # when SwiftSyntax is built.
-    if("OSX" IN_LIST SWIFT_SDKS)
-      add_swift_tool_subdirectory(swift-swiftsyntax-test)
-    endif()
+    add_subdirectory(swift-test-utils)
   endif()
 endif()
 

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2162,6 +2162,8 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DSWIFT_PATH_TO_CMARK_BUILD:PATH="$(build_directory ${host} cmark)"
                     -DSWIFT_PATH_TO_LIBDISPATCH_SOURCE:PATH="${LIBDISPATCH_SOURCE_DIR}"
                     -DSWIFT_PATH_TO_LIBDISPATCH_BUILD:PATH="$(build_directory ${host} libdispatch)"
+                    -DSWIFT_PATH_TO_FOUNDATION_SOURCE:PATH="${FOUNDATION_SOURCE_DIR}"
+                    -DSWIFT_PATH_TO_FOUNDATION_BUILD:PATH="$(build_directory ${host} foundation)"
                 )
 
                 if [[ ! "${SKIP_BUILD_LIBICU}" ]] ; then


### PR DESCRIPTION
SwiftSyntax requires Foundation which is not available by default on
Linux.  However, it should be possible to flesh out s-c-f and use that
to provide the dependency.  Add a top-level option to control whether
this component is built.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
