### PR TITLE
[ConstraintSystem] New FailureDiagnostic for rvalues that should be lvalues

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7765,6 +7765,8 @@ bool ConstraintSystem::applySolutionFixes(Expr *E, const Solution &solution) {
   llvm::SmallDenseMap<Expr *, SmallVector<const ConstraintFix *, 4>>
       fixesPerExpr;
 
+  applySolution(solution);
+
   for (auto *fix : solution.Fixes)
     fixesPerExpr[fix->getAnchor()].push_back(fix);
 

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -738,7 +738,7 @@ static void fixItChangeInoutArgType(const Expr * arg,
     .fixItReplaceChars(startLoc, endLoc, scratch);
 }
 
-static void diagnoseSubElementFailure(Expr *destExpr,
+void swift::diagnoseSubElementFailure(Expr *destExpr,
                                       SourceLoc loc,
                                       ConstraintSystem &CS,
                                       Diag<StringRef> diagID,
@@ -883,7 +883,8 @@ static void diagnoseSubElementFailure(Expr *destExpr,
     }
   }
 
-  TC.diagnose(loc, unknownDiagID, CS.getType(destExpr))
+  auto type = destExpr->getType() ?: CS.getType(destExpr);
+  TC.diagnose(loc, unknownDiagID, type)
       .highlight(immInfo.first->getSourceRange());
 }
 
@@ -6156,33 +6157,6 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
                                                 calleeInfo, TCC_ForceRecheck);
   if (!argExpr)
     return true; // already diagnosed.
-  
-  // A common error is to apply an operator that only has inout forms (e.g. +=)
-  // to non-lvalues (e.g. a local let).  Produce a nice diagnostic for this
-  // case.
-  if (calleeInfo.closeness == CC_NonLValueInOut) {
-    Diag<StringRef> subElementDiagID;
-    Diag<Type> rvalueDiagID;
-    Expr *diagExpr = nullptr;
-    
-    if (isa<PrefixUnaryExpr>(callExpr) || isa<PostfixUnaryExpr>(callExpr)) {
-      subElementDiagID = diag::cannot_apply_lvalue_unop_to_subelement;
-      rvalueDiagID = diag::cannot_apply_lvalue_unop_to_rvalue;
-      diagExpr = argExpr;
-    } else if (isa<BinaryExpr>(callExpr)) {
-      subElementDiagID = diag::cannot_apply_lvalue_binop_to_subelement;
-      rvalueDiagID = diag::cannot_apply_lvalue_binop_to_rvalue;
-      
-      if (auto argTuple = dyn_cast<TupleExpr>(argExpr))
-        diagExpr = argTuple->getElement(0);
-    }
-    
-    if (diagExpr) {
-      diagnoseSubElementFailure(diagExpr, callExpr->getFn()->getLoc(), CS,
-                                subElementDiagID, rvalueDiagID);
-      return true;
-    }
-  }
   
   // Handle argument label mismatches when we have multiple candidates.
   if (calleeInfo.closeness == CC_ArgumentLabelMismatch) {

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -883,7 +883,7 @@ void swift::diagnoseSubElementFailure(Expr *destExpr,
     }
   }
 
-  auto type = destExpr->getType() ?: CS.getType(destExpr);
+  auto type = destExpr->getType() ?: CS.simplifyType(CS.getType(destExpr));
   TC.diagnose(loc, unknownDiagID, type)
       .highlight(immInfo.first->getSourceRange());
 }

--- a/lib/Sema/CSDiag.h
+++ b/lib/Sema/CSDiag.h
@@ -26,7 +26,12 @@ namespace swift {
   /// UnresolvedType.
   Type replaceTypeParametersWithUnresolved(Type ty);
   Type replaceTypeVariablesWithUnresolved(Type ty);
-  
+
+  /// Diagnose lvalue expr error.
+  void diagnoseSubElementFailure(Expr *destExpr, SourceLoc loc,
+                                 constraints::ConstraintSystem &CS,
+                                 Diag<StringRef> diagID,
+                                 Diag<Type> unknownDiagID);
 };
 
 #endif /* SWIFT_SEMA_CSDIAG_H */

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -565,14 +565,6 @@ bool RValueTreatedAsLValueFailure::diagnose() {
       diagExpr = parens->getSubExpr();
   }
 
-  // FIXME: Needed right now to apply correct overload choices to diagExpr for
-  // use by diagnoseSubElementFailure(). Once all callers are routed through
-  // here, that function can be rewritten to take the current Solution and use
-  // it for determining chosen decl bindings instead, making this extra
-  // typecheck unnecessary.
-  getConstraintSystem().TC.typeCheckExpression(diagExpr,
-                                               getConstraintSystem().DC);
-
   diagnoseSubElementFailure(diagExpr, loc, getConstraintSystem(),
                             subElementDiagID, rvalueDiagID);
   return true;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -16,6 +16,7 @@
 
 #include "CSDiagnostics.h"
 #include "ConstraintSystem.h"
+#include "CSDiag.h"
 #include "MiscDiagnostics.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/GenericSignature.h"
@@ -526,4 +527,45 @@ bool MissingOptionalUnwrapFailure::diagnose() {
   emitDiagnostic(tryExpr->getTryLoc(), diag::missing_unwrap_optional_try, type)
       .fixItReplace({tryExpr->getTryLoc(), tryExpr->getQuestionLoc()}, "try!");
   return true;
+}
+
+bool RValueTreatedAsLValueFailure::diagnose() {
+  if (auto callExpr = dyn_cast<ApplyExpr>(getAnchor())) {
+    Expr *argExpr = callExpr->getArg();
+
+    Diag<StringRef> subElementDiagID;
+    Diag<Type> rvalueDiagID;
+    Expr *diagExpr = nullptr;
+
+    if (isa<PrefixUnaryExpr>(callExpr) || isa<PostfixUnaryExpr>(callExpr)) {
+      subElementDiagID = diag::cannot_apply_lvalue_unop_to_subelement;
+      rvalueDiagID = diag::cannot_apply_lvalue_unop_to_rvalue;
+      diagExpr = argExpr;
+    } else if (isa<BinaryExpr>(callExpr)) {
+      subElementDiagID = diag::cannot_apply_lvalue_binop_to_subelement;
+      rvalueDiagID = diag::cannot_apply_lvalue_binop_to_rvalue;
+      auto argTuple = dyn_cast<TupleExpr>(argExpr);
+      diagExpr = argTuple->getElement(0);
+    } else {
+      auto lastPathElement = getLocator()->getPath().back();
+      assert(lastPathElement.getKind() == ConstraintLocator::PathElementKind::ApplyArgToParam);
+
+      subElementDiagID = diag::cannot_pass_rvalue_inout_subelement;
+      rvalueDiagID = diag::cannot_pass_rvalue_inout;
+      if (auto argTuple = dyn_cast<TupleExpr>(argExpr))
+        diagExpr = argTuple->getElement(lastPathElement.getValue());
+      else if (auto parens = dyn_cast<ParenExpr>(argExpr))
+        diagExpr = parens->getSubExpr();
+    }
+
+    // FIXME: Would like for this to be unnecessary.
+    getConstraintSystem().TC.typeCheckExpression(diagExpr, getConstraintSystem().DC);
+
+    diagnoseSubElementFailure(diagExpr, callExpr->getFn()->getLoc(),
+                              getConstraintSystem(),
+                              subElementDiagID, rvalueDiagID);
+    return true;
+  }
+  // These fixes are only being created for matching arg types right now, so this is unreachable.
+  return false;
 }

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -294,6 +294,17 @@ public:
   bool diagnose() override;
 };
 
+/// Diagnose errors associated with rvalues in positions
+/// where an lvalue is required, such as inout arguments.
+class RValueTreatedAsLValueFailure final : public FailureDiagnostic {
+
+public:
+  RValueTreatedAsLValueFailure(const Solution &solution, ConstraintLocator *locator)
+    : FailureDiagnostic(nullptr, solution, locator) {}
+
+  bool diagnose() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -104,6 +104,17 @@ AddAddressOf *AddAddressOf::create(ConstraintSystem &cs,
   return new (cs.getAllocator()) AddAddressOf(locator);
 }
 
+bool TreatRValueAsLValue::diagnose(Expr *root, const Solution &solution) const {
+  RValueTreatedAsLValueFailure failure(solution, getLocator());
+  return failure.diagnose();
+}
+
+TreatRValueAsLValue *TreatRValueAsLValue::create(ConstraintSystem &cs,
+                                   ConstraintLocator *locator) {
+  return new (cs.getAllocator()) TreatRValueAsLValue(locator);
+}
+
+
 bool CoerceToCheckedCast::diagnose(Expr *root, const Solution &solution) const {
   MissingForcedDowncastFailure failure(root, solution, getLocator());
   return failure.diagnose();

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -68,6 +68,9 @@ enum class FixKind : uint8_t {
 
   /// Add a new conformance to the type to satisfy a requirement.
   AddConformance,
+
+  /// Treat rvalue as lvalue
+  TreatRValueAsLValue,
 };
 
 class ConstraintFix {
@@ -167,6 +170,20 @@ public:
 
   static AddAddressOf *create(ConstraintSystem &cs, ConstraintLocator *locator);
 };
+
+// Treat rvalue as if it was an lvalue
+class TreatRValueAsLValue final : public ConstraintFix {
+  TreatRValueAsLValue(ConstraintLocator *locator)
+    : ConstraintFix(FixKind::TreatRValueAsLValue, locator) {}
+
+public:
+  std::string getName() const override { return "treat rvalue as lvalue"; }
+
+  bool diagnose(Expr *root, const Solution &solution) const override;
+
+  static TreatRValueAsLValue *create(ConstraintSystem &cs, ConstraintLocator *locator);
+};
+
 
 /// Replace a coercion ('as') with a forced checked cast ('as!').
 class CoerceToCheckedCast final : public ConstraintFix {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2446,7 +2446,8 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
           AddAddressOf::create(*this, getConstraintLocator(locator)));
       } else if (!isTypeVarOrMember1) {
         // If we have a concrete type that's an rvalue, "fix" it.
-        conversionsOrFixes.push_back(FixKind::TreatRValueAsLValue);
+        conversionsOrFixes.push_back(
+          TreatRValueAsLValue::create(*this, getConstraintLocator(locator)));
       }
     }
   }
@@ -4990,7 +4991,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
     auto result = matchTypes(LValueType::get(type1), type2,
                              matchKind, subflags, locator);
     if (result == SolutionKind::Solved)
-      if (recordFix(fix, locator))
+      if (recordFix(fix))
         return SolutionKind::Error;
 
     return result;

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -343,7 +343,7 @@ public:
       return PathElement(NamedTupleElement, position);
     }
 
-    /// Retrieve a patch element for an argument/parameter comparison in a
+    /// Retrieve a path element for an argument/parameter comparison in a
     /// function application.
     static PathElement getApplyArgToParam(unsigned argIdx, unsigned paramIdx) {
       return PathElement(ApplyArgToParam, argIdx, paramIdx);

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -719,14 +719,13 @@ func overloadSetResultType(_ a : Int, b : Int) -> Int {
 }
 
 postfix operator +++
-postfix func +++ <T>(_: inout T) -> T { fatalError() } // expected-note {{in call to operator '+++'}}
+postfix func +++ <T>(_: inout T) -> T { fatalError() }
 
 // <rdar://problem/21523291> compiler error message for mutating immutable field is incorrect
 func r21523291(_ bytes : UnsafeMutablePointer<UInt8>) {
-  let i = 42
+  let i = 42 // expected-note {{change 'let' to 'var' to make it mutable}}
 
-  // FIXME: rdar://41416382
-  _ = bytes[i+++]  // expected-error {{generic parameter 'T' could not be inferred}}
+  _ = bytes[i+++]  // expected-error {{cannot pass immutable value to mutating operator: 'i' is a 'let' constant}}
 }
 
 

--- a/test/Constraints/lvalues.swift
+++ b/test/Constraints/lvalues.swift
@@ -76,14 +76,14 @@ f2(&non_settable_x) // expected-error{{cannot pass immutable value as inout argu
 f1(&non_settable_x) // expected-error{{cannot pass immutable value as inout argument: 'non_settable_x' is a get-only property}}
 // - inout assignment
 non_settable_x += x // expected-error{{left side of mutating operator isn't mutable: 'non_settable_x' is a get-only property}}
-+++non_settable_x // expected-error{{cannot pass immutable value as inout argument: 'non_settable_x' is a get-only property}}
++++non_settable_x // expected-error{{cannot pass immutable value to mutating operator: 'non_settable_x' is a get-only property}}
 
 // non-settable property is non-settable:
 z.non_settable_x = x // expected-error{{cannot assign to property: 'non_settable_x' is a get-only property}}
 f2(&z.non_settable_x) // expected-error{{cannot pass immutable value as inout argument: 'non_settable_x' is a get-only property}}
 f1(&z.non_settable_x) // expected-error{{cannot pass immutable value as inout argument: 'non_settable_x' is a get-only property}}
 z.non_settable_x += x // expected-error{{left side of mutating operator isn't mutable: 'non_settable_x' is a get-only property}}
-+++z.non_settable_x // expected-error{{cannot pass immutable value as inout argument: 'non_settable_x' is a get-only property}}
++++z.non_settable_x // expected-error{{cannot pass immutable value to mutating operator: 'non_settable_x' is a get-only property}}
 
 // non-settable subscript is non-settable:
 z[0] = 0.0 // expected-error{{cannot assign through subscript: subscript is get-only}}
@@ -97,7 +97,7 @@ fz().settable_x = x // expected-error{{cannot assign to property: 'fz' returns i
 f2(&fz().settable_x) // expected-error{{cannot pass immutable value as inout argument: 'fz' returns immutable value}}
 f1(&fz().settable_x) // expected-error{{cannot pass immutable value as inout argument: 'fz' returns immutable value}}
 fz().settable_x += x // expected-error{{left side of mutating operator isn't mutable: 'fz' returns immutable value}}
-+++fz().settable_x // expected-error{{cannot pass immutable value as inout argument: 'fz' returns immutable value}}
++++fz().settable_x // expected-error{{cannot pass immutable value to mutating operator: 'fz' returns immutable value}}
 
 // settable property of an rvalue reference type IS SETTABLE:
 fref().property = 0.0

--- a/test/expr/cast/array_iteration.swift
+++ b/test/expr/cast/array_iteration.swift
@@ -16,9 +16,7 @@ for view in rootView.subviews as! [View] { // expected-warning{{immutable value 
   doFoo()
 }
 
-// FIXME: Diagnostic below should be "'AnyObject' is not convertible to
-// 'View'", but IUO type gets in the way of proper diagnosis.
-for view:View in rootView.subviews { // expected-error{{type 'Array<AnyObject>?' does not conform to protocol 'Sequence'}}
+for view:View in rootView.subviews { // expected-error{{'AnyObject' is not convertible to 'View'}}
   doFoo()
 }
 

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -614,7 +614,7 @@ func unaryOps(_ i8: inout Int8, i64: inout Int64) {
   i64 += 1
   i8 -= 1
 
-  Int64(5) += 1 // expected-error{{left side of mutating operator isn't mutable: function call returns immutable value}}
+  Int64(5) += 1 // expected-error{{left side of mutating operator has immutable type 'Int64'}}
   
   // <rdar://problem/17691565> attempt to modify a 'let' variable with ++ results in typecheck error not being able to apply ++ to Float
   let a = i8 // expected-note {{change 'let' to 'var' to make it mutable}} {{3-6=var}}

--- a/validation-test/stdlib/FixedPointDiagnostics.swift.gyb
+++ b/validation-test/stdlib/FixedPointDiagnostics.swift.gyb
@@ -95,7 +95,8 @@ func testMixedSignArithmetic() {
     x += Stride(1) // expected-error {{'+=' is unavailable: Please use explicit type conversions or Strideable methods for mixed-type arithmetics.}}
     x -= Stride(1) // expected-error {{'-=' is unavailable: Please use explicit type conversions or Strideable methods for mixed-type arithmetics.}}
 
-    _ = (x - x) as Stride // expected-error {{ambiguous reference to member '-'}}
+    // Terrible over-specific error, but at least disabled
+    _ = (x - x) as Stride // expected-error {{'(@lvalue ${T}, @lvalue ${T}) -> ${T}' is not convertible to '(${T}, ${T}) -> ${T}'}}
 
     //===------------------------------------------------------------------===//
     // The following errors are different because they're not being


### PR DESCRIPTION
Start changing over rvalue-vs-lvalue errors to be done via constraint system fixes. For this first commit, just handling inout parameter problems.

Improves several diagnoses along the way, including apparently rdar://41416382 
