### PR TITLE
Add regression test for https://bugs.swift.org/browse/SR-5056

### DIFF
--- a/test/decl/inherit/initializer.swift
+++ b/test/decl/inherit/initializer.swift
@@ -110,3 +110,22 @@ func testClassInGenericFunc<T>(t: T) {
   _ = B(t: t)
 }
 
+
+// <https://bugs.swift.org/browse/SR-5056> Required convenience init inhibits inheritance
+
+class SR5056A {
+    required init(a: Int) {}
+}
+
+class SR5056B : SR5056A {
+    required convenience init(b: Int) {
+        self.init(a: b)
+    }
+}
+
+class SR5056C : SR5056B {}
+
+func useSR5056C() {
+  _ = SR5056C(a: 0)
+  _ = SR5056C(b: 0)
+}


### PR DESCRIPTION
This looks like a subtle issue. It was broken in 4.1 and got fixed in
4.2, perhaps by the decl checker cleanups or some other change.

I don't see many occurrences of 'required convenience' in the
non-executable tests, period, so it's good to have a bit more
coverage for this corner of the language.