### PR TITLE
Make SILInstructionResultArray::begin() and end() inlinable

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -254,6 +254,36 @@ public:
   friend bool operator!=(iterator lhs, iterator rhs) { return !(lhs == rhs); }
 };
 
+inline SILInstructionResultArray::iterator
+SILInstructionResultArray::begin() const {
+  return iterator(*this, 0);
+}
+
+inline SILInstructionResultArray::iterator
+SILInstructionResultArray::end() const {
+  return iterator(*this, size());
+}
+
+inline SILInstructionResultArray::reverse_iterator
+SILInstructionResultArray::rbegin() const {
+  return llvm::make_reverse_iterator(end());
+}
+
+inline SILInstructionResultArray::reverse_iterator
+SILInstructionResultArray::rend() const {
+  return llvm::make_reverse_iterator(begin());
+}
+
+inline SILInstructionResultArray::range
+SILInstructionResultArray::getValues() const {
+  return {begin(), end()};
+}
+
+inline SILInstructionResultArray::reverse_range
+SILInstructionResultArray::getReversedValues() const {
+  return {rbegin(), rend()};
+}
+
 /// This is the root class for all instructions that can be used as the
 /// contents of a Swift SILBasicBlock.
 ///

--- a/lib/SIL/SILInstruction.cpp
+++ b/lib/SIL/SILInstruction.cpp
@@ -1358,33 +1358,6 @@ SILInstructionResultArray::getTypes() const {
   return {llvm::map_iterator(begin(), F), llvm::map_iterator(end(), F)};
 }
 
-SILInstructionResultArray::iterator SILInstructionResultArray::begin() const {
-  return iterator(*this, 0);
-}
-
-SILInstructionResultArray::iterator SILInstructionResultArray::end() const {
-  return iterator(*this, size());
-}
-
-SILInstructionResultArray::reverse_iterator
-SILInstructionResultArray::rbegin() const {
-  return llvm::make_reverse_iterator(end());
-}
-
-SILInstructionResultArray::reverse_iterator
-SILInstructionResultArray::rend() const {
-  return llvm::make_reverse_iterator(begin());
-}
-
-SILInstructionResultArray::range SILInstructionResultArray::getValues() const {
-  return {begin(), end()};
-}
-
-SILInstructionResultArray::reverse_range
-SILInstructionResultArray::getReversedValues() const {
-  return {rbegin(), rend()};
-}
-
 const ValueBase *SILInstructionResultArray::front() const {
   assert(size() && "Can not access front of an empty result array");
   return *begin();


### PR DESCRIPTION
These are trivial functions and should be inlined away; the only tricky bit is they need to be defined after the iterator type. This gives a slight speedup of stdlib compilation time (about 5% of the time spent generating the swiftmodule).