### PR TITLE
[TBDGen] Skip @_silgen_name functions with no body

### DIFF
--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -137,6 +137,12 @@ void TBDGenVisitor::addConformances(DeclContext *DC) {
 }
 
 void TBDGenVisitor::visitAbstractFunctionDecl(AbstractFunctionDecl *AFD) {
+  // A @_silgen_name("...") function without a body only exists
+  // to forward-declare a symbol from another library.
+  if (!AFD->hasBody() && AFD->getAttrs().hasAttribute<SILGenNameAttr>()) {
+    return;
+  }
+
   addSymbol(SILDeclRef(AFD));
 
   if (AFD->getAttrs().hasAttribute<CDeclAttr>()) {

--- a/test/TBD/function.swift
+++ b/test/TBD/function.swift
@@ -22,3 +22,9 @@ private func privateWithDefault(_: Int = 0) {}
 @_cdecl("c_internalNoArgs") internal func internalNoArgsCDecl() {}
 @_cdecl("c_internalSomeArgs") internal func internalSomeArgsCDecl(_: Int, x: Int) {}
 @_cdecl("c_internalWithDefault") internal func internalWithDefaultCDecl(_: Int = 0) {}
+
+@_silgen_name("silgen_publicNoArgs") public func publicNoArgsSilgenNameDecl()
+@_silgen_name("silgen_publicSomeArgs") public func publicSomeArgsSilgenNameDecl(_: Int, x: Int)
+
+@_silgen_name("silgen_internalNoArgs") internal func internalNoArgsSilgenNameDecl()
+@_silgen_name("silgen_internalSomeArgs") internal func internalSomeArgsSilgenNameDecl(_: Int, x: Int)


### PR DESCRIPTION
`@_silgen_name` functions with no body are forward-declarations of
existing symbols, only to appease the typechecker. They don't show up in
the IR, so don't add them to the TBD file.

Resolves rdar://32251501