### PR TITLE
Request evaluator: Cut down on the cost of AnyRequest in two ways

### DIFF
--- a/include/swift/AST/AnyRequest.h
+++ b/include/swift/AST/AnyRequest.h
@@ -50,6 +50,12 @@ class DiagnosticEngine;
 ///       void noteCycleStep(DiagnosticEngine &diags) const;
 ///
 class AnyRequest {
+  friend llvm::DenseMapInfo<swift::AnyRequest>;
+
+  static hash_code hashForHolder(uint64_t typeID, hash_code requestHash) {
+    return hash_combine(hash_value(typeID), requestHash);
+  }
+
   /// Abstract base class used to hold the specific request kind.
   class HolderBase : public llvm::RefCountedBase<HolderBase> {
   public:
@@ -62,7 +68,7 @@ class AnyRequest {
   protected:
     /// Initialize base with type ID and hash code.
     HolderBase(uint64_t typeID, hash_code hash)
-      : typeID(typeID), hash(hash_combine(hash_value(typeID), hash)) { }
+      : typeID(typeID), hash(AnyRequest::hashForHolder(typeID, hash)) { }
 
   public:
     virtual ~HolderBase();
@@ -160,7 +166,7 @@ public:
 
   /// Construct a new instance with the given value.
   template<typename T>
-  AnyRequest(T&& value) : storageKind(StorageKind::Normal) {
+  explicit AnyRequest(T&& value) : storageKind(StorageKind::Normal) {
     using ValueType =
         typename std::remove_cv<typename std::remove_reference<T>::type>::type;
     stored = llvm::IntrusiveRefCntPtr<HolderBase>(
@@ -171,7 +177,7 @@ public:
   template<typename Request>
   const Request &castTo() const {
     assert(stored->typeID == TypeID<Request>::value && "wrong type in cast");
-    return static_cast<const Holder<Request> *>(stored.get())->value;
+    return static_cast<const Holder<Request> *>(stored.get())->request;
   }
 
   /// Try casting to a specific (known) type, returning \c nullptr on
@@ -181,7 +187,7 @@ public:
     if (stored->typeID != TypeID<Request>::value)
       return nullptr;
 
-    return &static_cast<const Holder<Request> *>(stored.get())->value;
+    return &static_cast<const Holder<Request> *>(stored.get())->request;
   }
 
   /// Diagnose a cycle detected for this request.
@@ -250,9 +256,24 @@ namespace llvm {
     static unsigned getHashValue(const swift::AnyRequest &request) {
       return hash_value(request);
     }
+    template <typename Request>
+    static unsigned getHashValue(const Request &request) {
+      return swift::AnyRequest::hashForHolder(swift::TypeID<Request>::value,
+                                              hash_value(request));
+    }
     static bool isEqual(const swift::AnyRequest &lhs,
                         const swift::AnyRequest &rhs) {
       return lhs == rhs;
+    }
+    template <typename Request>
+    static bool isEqual(const Request &lhs,
+                        const swift::AnyRequest &rhs) {
+      if (rhs == getEmptyKey() || rhs == getTombstoneKey())
+        return false;
+      const Request *rhsRequest = rhs.getAs<Request>();
+      if (!rhsRequest)
+        return false;
+      return lhs == *rhsRequest;
     }
   };
 

--- a/lib/AST/Evaluator.cpp
+++ b/lib/AST/Evaluator.cpp
@@ -191,15 +191,6 @@ void Evaluator::printDependencies(
   }
 }
 
-void Evaluator::printDependencies(const AnyRequest &request,
-                                  llvm::raw_ostream &out) const {
-  std::string prefixStr;
-  llvm::DenseSet<AnyRequest> visitedAnywhere;
-  llvm::SmallVector<AnyRequest, 4> visitedAlongPath;
-  printDependencies(request, out, visitedAnywhere, visitedAlongPath, { },
-                    prefixStr, /*lastChild=*/true);
-}
-
 void Evaluator::dumpDependencies(const AnyRequest &request) const {
   printDependencies(request, llvm::dbgs());
 }


### PR DESCRIPTION
- Use a non-thread-safe llvm::IntrusiveRefCntPtr instead of std::shared_ptr.

- Use DenseMap::find_as when we just need to look up a Request and not store it, to avoid copying the Request into an AnyRequest heap box.

This shaves about a second off of the 11s of time spent type-checking the standard library.