### PR TITLE
[Diagnostics] NFC: Port the rest of "fix" diagnostics to new abstraction

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7845,19 +7845,8 @@ bool ConstraintSystem::applySolutionFix(
     
   switch (fix.first.getKind()) {
   case FixKind::ForceOptional: {
-    Expr *unwrapped = affected->getValueProvidingExpr();
-    auto type = solution.simplifyType(getType(affected))->getRValueType();
-
-    if (auto tryExpr = dyn_cast<OptionalTryExpr>(unwrapped)) {
-      TC.diagnose(tryExpr->getTryLoc(), diag::missing_unwrap_optional_try,
-                  type)
-        .fixItReplace({tryExpr->getTryLoc(), tryExpr->getQuestionLoc()},
-                      "try!");
-
-    } else {
-      return diagnoseUnwrap(TC, DC, unwrapped, type);
-    }
-    return true;
+    MissingOptionalUnwrapFailure failure(expr, solution, locator);
+    return failure.diagnose();
   }
           
   case FixKind::UnwrapOptionalBase: {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8000,27 +8000,14 @@ bool ConstraintSystem::applySolutionFix(
   }
 
   case FixKind::ExplicitlyEscaping: {
-    auto path = locator->getPath();
-    auto *anchor = locator->getAnchor();
-
-    if (path.empty())
-      return false;
-
-    auto &last = path.back();
-    if (last.getKind() == ConstraintLocator::Archetype) {
-      auto *archetype = last.getArchetype();
-      TC.diagnose(anchor->getLoc(), diag::converting_noescape_to_type,
-                  archetype);
-      return true;
-    }
-    break;
+    NoEscapeFuncToTypeConversionFailure failure(expr, solution, locator);
+    return failure.diagnose();
   }
 
   case FixKind::ExplicitlyEscapingToAny: {
-    auto *anchor = locator->getAnchor();
-    TC.diagnose(anchor->getLoc(), diag::converting_noescape_to_type,
-                getASTContext().TheAnyType);
-    return true;
+    NoEscapeFuncToTypeConversionFailure failure(expr, solution, locator,
+                                                getASTContext().TheAnyType);
+    return failure.diagnose();
   }
 
   case FixKind::RelabelArguments: {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7957,10 +7957,8 @@ bool ConstraintSystem::applySolutionFix(
   }
 
   case FixKind::AddressOf: {
-    auto type = solution.simplifyType(getType(affected))->getRValueType();
-    TC.diagnose(affected->getLoc(), diag::missing_address_of, type)
-      .fixItInsert(affected->getStartLoc(), "&");
-    return true;
+    MissingAddressOfFailure failure(expr, solution, locator);
+    return failure.diagnose();
   }
 
   case FixKind::CoerceToCheckedCast: {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7818,31 +7818,6 @@ bool ConstraintSystem::applySolutionFix(
   if (!locator)
     return false;
 
-  // Resolve the locator to a specific expression.
-  SourceRange range;
-  bool isSubscriptMember =
-    (!locator->getPath().empty() &&
-     locator->getPath().back().getKind() == ConstraintLocator::SubscriptMember);
-  ConstraintLocator *resolved = simplifyLocator(*this, locator, range);
-
-  // If we didn't manage to resolve directly to an expression, we don't
-  // have a great diagnostic to give, so bail.
-  if (!resolved || !resolved->getAnchor() ||
-      (!resolved->getPath().empty() &&
-       fix.first.getKind() != FixKind::ExplicitlyEscaping &&
-       fix.first.getKind() != FixKind::ExplicitlyEscapingToAny &&
-       fix.first.getKind() != FixKind::AddConformance))
-    return false;
-  
-  Expr *affected = resolved->getAnchor();
-
-  // FIXME: Work around an odd locator representation that doesn't separate the
-  // base of a subscript member from the member access.
-  if (isSubscriptMember) {
-    if (auto subscript = dyn_cast<SubscriptExpr>(affected))
-      affected = subscript->getBase();
-  }
-    
   switch (fix.first.getKind()) {
   case FixKind::ForceOptional: {
     MissingOptionalUnwrapFailure failure(expr, solution, locator);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7861,26 +7861,12 @@ bool ConstraintSystem::applySolutionFix(
   }
           
   case FixKind::UnwrapOptionalBase: {
-    auto type = solution.simplifyType(getType(affected))->getRValueType();
-    bool resultOptional = fix.first.isUnwrapOptionalBaseByOptionalChaining(*this);
-
-    // If we've resolved the member overload to one that returns an optional
-    // type, then the result of the expression is optional (and we want to offer
-    // only a '?' fixit) even though the constraint system didn't need to add any
-    // additional optionality.
-    auto resolvedOverload = getResolvedOverloadSets();
-    while (resolvedOverload) {
-      if (resolvedOverload->Locator == fix.second) {
-        if (resolvedOverload->ImpliedType->getOptionalObjectType())
-          resultOptional = true;
-        break;
-      }
-      resolvedOverload = resolvedOverload->Previous;
-    }
-
-    DeclName memberName = fix.first.getDeclNameArgument(*this);
-    return diagnoseBaseUnwrapForMemberAccess(affected, type, memberName,
-                                             resultOptional, SourceRange());
+    auto memberName = fix.first.getDeclNameArgument(*this);
+    bool resultIsOptional =
+        fix.first.isUnwrapOptionalBaseByOptionalChaining(*this);
+    MemberAccessOnOptionalBaseFailure failure(expr, solution, locator,
+                                              memberName, resultIsOptional);
+    return failure.diagnose();
   }
 
   case FixKind::ForceDowncast: {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -275,3 +275,11 @@ bool MissingForcedDowncastFailure::diagnose() {
     return true;
   }
 }
+
+bool MissingAddressOfFailure::diagnose() {
+  auto *anchor = getAnchor();
+  auto type = getType(anchor)->getRValueType();
+  emitDiagnostic(anchor->getLoc(), diag::missing_address_of, type)
+      .fixItInsert(anchor->getStartLoc(), "&");
+  return true;
+}

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -354,3 +354,17 @@ bool MemberAccessOnOptionalBaseFailure::diagnose() {
   return diagnoseBaseUnwrapForMemberAccess(anchor, type, Member,
                                            resultIsOptional, SourceRange());
 }
+
+bool MissingOptionalUnwrapFailure::diagnose() {
+  auto *anchor = getAnchor();
+  auto *unwrapped = anchor->getValueProvidingExpr();
+  auto type = getType(anchor)->getRValueType();
+
+  auto *tryExpr = dyn_cast<OptionalTryExpr>(unwrapped);
+  if (!tryExpr)
+    return diagnoseUnwrap(getTypeChecker(), getDC(), unwrapped, type);
+
+  emitDiagnostic(tryExpr->getTryLoc(), diag::missing_unwrap_optional_try, type)
+      .fixItReplace({tryExpr->getTryLoc(), tryExpr->getQuestionLoc()}, "try!");
+  return true;
+}

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -188,3 +188,26 @@ bool LabelingFailure::diagnose() {
                                     CorrectLabels,
                                     isa<SubscriptExpr>(call->getFn()));
 }
+
+bool NoEscapeFuncToTypeConversionFailure::diagnose() {
+  auto *anchor = getAnchor();
+
+  if (ConvertTo) {
+    emitDiagnostic(anchor->getLoc(), diag::converting_noescape_to_type,
+                   ConvertTo);
+    return true;
+  }
+
+  auto path = getLocator()->getPath();
+  if (path.empty())
+    return false;
+
+  auto &last = path.back();
+  if (last.getKind() != ConstraintLocator::Archetype)
+    return false;
+
+  auto *archetype = last.getArchetype();
+  emitDiagnostic(anchor->getLoc(), diag::converting_noescape_to_type,
+                 archetype);
+  return true;
+}

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -34,10 +34,13 @@ class FailureDiagnostic {
   const Solution &solution;
   ConstraintLocator *Locator;
 
+  Expr *Anchor;
+
 public:
   FailureDiagnostic(Expr *expr, const Solution &solution,
                     ConstraintLocator *locator)
-      : E(expr), solution(solution), Locator(locator) {}
+      : E(expr), solution(solution), Locator(locator), Anchor(computeAnchor()) {
+  }
 
   virtual ~FailureDiagnostic();
 
@@ -55,7 +58,7 @@ public:
 
   Expr *getParentExpr() const { return E; }
 
-  Expr *getAnchor() const { return Locator->getAnchor(); }
+  Expr *getAnchor() const { return Anchor; }
 
   ConstraintLocator *getLocator() const { return Locator; }
 
@@ -78,6 +81,10 @@ protected:
   getOverloadChoiceIfAvailable(ConstraintLocator *locator) const {
     return solution.getOverloadChoiceIfAvailable(locator);
   }
+
+private:
+  /// Compute anchor expression associated with current diagnostic.
+  Expr *computeAnchor() const;
 };
 
 /// Base class for all of the diagnostics related to generic requirement

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -61,10 +61,19 @@ public:
 
   Type getType(Expr *expr) const;
 
+  /// Resolve type variables present in the raw type, if any.
+  Type resolveType(Type rawType) const {
+    return solution.simplifyType(rawType);
+  }
+
   template <typename... ArgTypes>
   InFlightDiagnostic emitDiagnostic(ArgTypes &&... Args) const;
 
 protected:
+  TypeChecker &getTypeChecker() const { return getConstraintSystem().TC; }
+
+  DeclContext *getDC() const { return getConstraintSystem().DC; }
+
   Optional<SelectedOverload>
   getOverloadChoiceIfAvailable(ConstraintLocator *locator) const {
     return solution.getOverloadChoiceIfAvailable(locator);
@@ -164,6 +173,15 @@ public:
                                       ConstraintLocator *locator,
                                       Type toType = Type())
       : FailureDiagnostic(expr, solution, locator), ConvertTo(toType) {}
+
+  bool diagnose() override;
+};
+
+class MissingForcedDowncastFailure final : public FailureDiagnostic {
+public:
+  MissingForcedDowncastFailure(Expr *expr, const Solution &solution,
+                               ConstraintLocator *locator)
+      : FailureDiagnostic(expr, solution, locator) {}
 
   bool diagnose() override;
 };

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -154,6 +154,20 @@ public:
   bool diagnose() override;
 };
 
+/// Diagnose errors related to converting function type which
+/// isn't explicitly '@escaping' to some other type.
+class NoEscapeFuncToTypeConversionFailure final : public FailureDiagnostic {
+  Type ConvertTo;
+
+public:
+  NoEscapeFuncToTypeConversionFailure(Expr *expr, const Solution &solution,
+                                      ConstraintLocator *locator,
+                                      Type toType = Type())
+      : FailureDiagnostic(expr, solution, locator), ConvertTo(toType) {}
+
+  bool diagnose() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -193,6 +193,17 @@ public:
   bool diagnose() override;
 };
 
+/// Diagnose failures related to passing value of some type
+/// to `inout` parameter, without explicitly specifying `&`.
+class MissingAddressOfFailure final : public FailureDiagnostic {
+public:
+  MissingAddressOfFailure(Expr *expr, const Solution &solution,
+                          ConstraintLocator *locator)
+      : FailureDiagnostic(expr, solution, locator) {}
+
+  bool diagnose() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -271,6 +271,17 @@ public:
   bool diagnose() override;
 };
 
+/// Diagnose failures related to use of the unwrapped optional types,
+/// which require some type of force-unwrap e.g. "!" or "try!".
+class MissingOptionalUnwrapFailure final : public FailureDiagnostic {
+public:
+  MissingOptionalUnwrapFailure(Expr *expr, const Solution &solution,
+                               ConstraintLocator *locator)
+      : FailureDiagnostic(expr, solution, locator) {}
+
+  bool diagnose() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -35,11 +35,15 @@ class FailureDiagnostic {
   ConstraintLocator *Locator;
 
   Expr *Anchor;
+  /// Indicates whether locator could be simplified
+  /// down to anchor expression.
+  bool HasComplexLocator;
 
 public:
   FailureDiagnostic(Expr *expr, const Solution &solution,
                     ConstraintLocator *locator)
-      : E(expr), solution(solution), Locator(locator), Anchor(computeAnchor()) {
+      : E(expr), solution(solution), Locator(locator) {
+    std::tie(Anchor, HasComplexLocator) = computeAnchor();
   }
 
   virtual ~FailureDiagnostic();
@@ -94,9 +98,12 @@ protected:
     return nullptr;
   }
 
+  /// \returns true is locator hasn't been simplified down to expression.
+  bool hasComplexLocator() const { return HasComplexLocator; }
+
 private:
   /// Compute anchor expression associated with current diagnostic.
-  Expr *computeAnchor() const;
+  std::pair<Expr *, bool> computeAnchor() const;
 };
 
 /// Base class for all of the diagnostics related to generic requirement

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3611,6 +3611,21 @@ bool exprNeedsParensAfterAddingNilCoalescing(TypeChecker &TC,
                                              Expr *expr,
                                              Expr *rootExpr);
 
+/// Return true if, when replacing "<expr>" with "<expr> op <something>",
+/// parentheses must be added around "<expr>" to allow the new operator
+/// to bind correctly.
+bool exprNeedsParensInsideFollowingOperator(TypeChecker &TC, DeclContext *DC,
+                                            Expr *expr,
+                                            PrecedenceGroupDecl *followingPG);
+
+/// Return true if, when replacing "<expr>" with "<expr> op <something>"
+/// within the given root expression, parentheses must be added around
+/// the new operator to prevent it from binding incorrectly in the
+/// surrounding context.
+bool exprNeedsParensOutsideFollowingOperator(
+    TypeChecker &TC, DeclContext *DC, Expr *expr, Expr *rootExpr,
+    PrecedenceGroupDecl *followingPG);
+
 } // end namespace swift
 
 #endif // LLVM_SWIFT_SEMA_CONSTRAINT_SYSTEM_H


### PR DESCRIPTION
This cleans up `applySolutionFix` and its support functions in `CSApply`.

Next step is to expect Fix to support storing data and attaching diagnostics to it,
so we can get rid of `applySolutionFix` altogether.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
