### PR TITLE
[unittests] Stop linking to swiftSIL for SwiftASTTests

### DIFF
--- a/unittests/AST/CMakeLists.txt
+++ b/unittests/AST/CMakeLists.txt
@@ -13,5 +13,4 @@ target_link_libraries(SwiftASTTests
    # FIXME: Circular dependencies.
    swiftParse
    swiftSema
-   swiftSIL
 )


### PR DESCRIPTION
AST still circularly depends on Parse (and Sema), but Parse no longer depends on SIL. That's up in ParseSIL now.