### PR TITLE
[4.2] Fix a miscompile in the swift function merging pass.

### DIFF
--- a/lib/LLVMPasses/LLVMMergeFunctions.cpp
+++ b/lib/LLVMPasses/LLVMMergeFunctions.cpp
@@ -402,6 +402,8 @@ private:
 
   bool deriveParams(ParamInfos &Params, FunctionInfos &FInfos);
 
+  bool numOperandsDiffer(FunctionInfos &FInfos);
+
   bool constsDiffer(const FunctionInfos &FInfos, unsigned OpIdx);
 
   bool tryMapToParameter(FunctionInfos &FInfos, unsigned OpIdx,
@@ -762,6 +764,20 @@ bool SwiftMergeFunctions::deriveParams(ParamInfos &Params,
   // Iterate over all instructions synchronously in all functions.
   do {
     if (isEligibleForConstantSharing(FirstFI.CurrentInst)) {
+
+      // Here we handle a rare corner case which needs to be explained:
+      // Usually the number of operands match, because otherwise the functions
+      // in FInfos would not be in the same equivalence class. There is only one
+      // exception to that: If the current instruction is a call to a function,
+      // which was merged in the previous iteration (in tryMergeEquivalenceClass)
+      // then the call could be replaced and has more arguments than the
+      // original call.
+      if (numOperandsDiffer(FInfos)) {
+        assert(isa<CallInst>(FirstFI.CurrentInst) &&
+               "only calls are expected to differ in number of operands");
+        return false;
+      }
+
       for (unsigned OpIdx = 0, NumOps = FirstFI.CurrentInst->getNumOperands();
            OpIdx != NumOps; ++OpIdx) {
 
@@ -781,6 +797,16 @@ bool SwiftMergeFunctions::deriveParams(ParamInfos &Params,
   } while (FirstFI.CurrentInst);
 
   return true;
+}
+
+/// Returns true if the number of operands of the current instruction differs.
+bool SwiftMergeFunctions::numOperandsDiffer(FunctionInfos &FInfos) {
+  unsigned numOps = FInfos[0].CurrentInst->getNumOperands();
+  for (const FunctionInfo &FI : ArrayRef<FunctionInfo>(FInfos).drop_front(1)) {
+    if (FI.CurrentInst->getNumOperands() != numOps)
+      return true;
+  }
+  return false;
 }
 
 /// Returns true if the \p OpIdx's constant operand in the current instruction


### PR DESCRIPTION
In rare corner cases the pass merged two functions which contain incompatible call instructions.
See source comment in the change for details.

rdar://problem/43051718

* Explanation: With a very specific constellation of nearly identical functions, calling each other, a bug in Swift's function merging was exposed. It generated a wrong call to a merged function.
* Scope of Issue: It's impossible to narrow down the scope. The problem showed up with metadata access functions of deeply nested generic types.
* Origination: The bug was in the compiler since we added function merging a long time.
* Risk: Low. The change just adds a bail-out condition for this case.
* Reviewed By: @aschwaighofer
* Testing: There is a regression test for it