### PR TITLE
[Sema] Warn for redundant access-level modifiers on setters or used in an extension.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1187,14 +1187,19 @@ ERROR(access_control_setter_more,none,
       "%select{variable|property|subscript}1 cannot have "
       "%select{%error|a fileprivate|an internal|a public|an open}2 setter",
       (AccessLevel, unsigned, AccessLevel))
+WARNING(access_control_setter_redundant,none,
+      "'%select{private|fileprivate|internal|public|open}0(set)' modifier is "
+      "redundant for %select{a private|a fileprivate|an internal|a public|an open}2 "
+      "%1",
+      (AccessLevel, DescriptiveDeclKind, AccessLevel))
 WARNING(access_control_ext_member_more,none,
     "declaring %select{%error|a fileprivate|an internal|a public|open}0 %1 in "
     "%select{a private|a fileprivate|an internal|a public|%error}2 extension",
     (AccessLevel, DescriptiveDeclKind, AccessLevel))
 WARNING(access_control_ext_member_redundant,none,
     "'%select{%error|fileprivate|internal|public|%error}0' modifier is redundant "
-    "for %1 declared in %select{%error|a fileprivate|an internal|a public|%error}2 "
-    "extension",
+    "for %1 declared in %select{a private (equivalent to fileprivate)|a fileprivate"
+    "|an internal|a public|%error}2 extension",
     (AccessLevel, DescriptiveDeclKind, AccessLevel))
 ERROR(access_control_ext_requirement_member_more,none,
     "cannot declare %select{%error|a fileprivate|an internal|a public|an open}0 %1 "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1189,7 +1189,12 @@ ERROR(access_control_setter_more,none,
       (AccessLevel, unsigned, AccessLevel))
 WARNING(access_control_ext_member_more,none,
     "declaring %select{%error|a fileprivate|an internal|a public|open}0 %1 in "
-    "%select{a private|a fileprivate|an internal|public|%error}2 extension",
+    "%select{a private|a fileprivate|an internal|a public|%error}2 extension",
+    (AccessLevel, DescriptiveDeclKind, AccessLevel))
+WARNING(access_control_ext_member_redundant,none,
+    "'%select{%error|fileprivate|internal|public|%error}0' modifier is redundant "
+    "for %1 declared in %select{%error|a fileprivate|an internal|a public|%error}2 "
+    "extension",
     (AccessLevel, DescriptiveDeclKind, AccessLevel))
 ERROR(access_control_ext_requirement_member_more,none,
     "cannot declare %select{%error|a fileprivate|an internal|a public|an open}0 %1 "

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3952,7 +3952,7 @@ void swift::performStmtDiagnostics(TypeChecker &TC, const Stmt *S) {
 
 void swift::fixItAccess(InFlightDiagnostic &diag, ValueDecl *VD,
                         AccessLevel desiredAccess, bool isForSetter,
-                        bool shouldNotReplace) {
+                        bool shouldUseDefaultAccess) {
   StringRef fixItString;
   switch (desiredAccess) {
   case AccessLevel::Private:      fixItString = "private ";      break;
@@ -3998,7 +3998,7 @@ void swift::fixItAccess(InFlightDiagnostic &diag, ValueDecl *VD,
     // this function is sometimes called to make access narrower, so assuming
     // that a broader scope is acceptable breaks some diagnostics.
     if (attr->getAccess() != desiredAccess) {
-      if (shouldNotReplace) {
+      if (shouldUseDefaultAccess) {
         // Remove the attribute if replacement is not preferred.
         diag.fixItRemove(attr->getRange());
       } else {

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3951,7 +3951,8 @@ void swift::performStmtDiagnostics(TypeChecker &TC, const Stmt *S) {
 //===----------------------------------------------------------------------===//
 
 void swift::fixItAccess(InFlightDiagnostic &diag, ValueDecl *VD,
-                        AccessLevel desiredAccess, bool isForSetter) {
+                        AccessLevel desiredAccess, bool isForSetter,
+                        bool shouldNotReplace) {
   StringRef fixItString;
   switch (desiredAccess) {
   case AccessLevel::Private:      fixItString = "private ";      break;
@@ -3997,9 +3998,14 @@ void swift::fixItAccess(InFlightDiagnostic &diag, ValueDecl *VD,
     // this function is sometimes called to make access narrower, so assuming
     // that a broader scope is acceptable breaks some diagnostics.
     if (attr->getAccess() != desiredAccess) {
-      // This uses getLocation() instead of getRange() because we don't want to
-      // replace the "(set)" part of a setter attribute.
-      diag.fixItReplace(attr->getLocation(), fixItString.drop_back());
+      if (shouldNotReplace) {
+        // Remove the attribute if replacement is not preferred.
+        diag.fixItRemove(attr->getRange());
+      } else {
+        // This uses getLocation() instead of getRange() because we don't want to
+        // replace the "(set)" part of a setter attribute.
+        diag.fixItReplace(attr->getLocation(), fixItString.drop_back());
+      }
       attr->setInvalid();
     }
 

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -51,8 +51,11 @@ void performTopLevelDeclDiagnostics(TypeChecker &TC, TopLevelCodeDecl *TLCD);
 /// Emit a fix-it to set the access of \p VD to \p desiredAccess.
 ///
 /// This actually updates \p VD as well.
-void fixItAccess(InFlightDiagnostic &diag, ValueDecl *VD,
-                 AccessLevel desiredAccess, bool isForSetter = false);
+void fixItAccess(InFlightDiagnostic &diag,
+                 ValueDecl *VD,
+                 AccessLevel desiredAccess,
+                 bool isForSetter = false,
+                 bool shouldNotReplace = false);
 
 /// Emit fix-its to correct the argument labels in \p expr, which is the
 /// argument tuple or single argument of a call.

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -55,7 +55,7 @@ void fixItAccess(InFlightDiagnostic &diag,
                  ValueDecl *VD,
                  AccessLevel desiredAccess,
                  bool isForSetter = false,
-                 bool shouldNotReplace = false);
+                 bool shouldUseDefaultAccess = false);
 
 /// Emit fix-its to correct the argument labels in \p expr, which is the
 /// argument tuple or single argument of a call.

--- a/stdlib/public/SDK/AppKit/AppKit_FoundationExtensions.swift
+++ b/stdlib/public/SDK/AppKit/AppKit_FoundationExtensions.swift
@@ -14,7 +14,7 @@ import Foundation
 @_exported import AppKit
 
 // NSCollectionView extensions
-public extension IndexPath {
+extension IndexPath {
     
     /// Initialize for use with `NSCollectionView`.
     public init(item: Int, section: Int) {
@@ -51,7 +51,7 @@ public extension IndexPath {
     
 }
 
-public extension URLResourceValues {
+extension URLResourceValues {
     /// Returns all thumbnails as a single NSImage.
     @available(macOS 10.10, *)
     public var thumbnail : NSImage? {

--- a/stdlib/public/SDK/CloudKit/NestedNames.swift
+++ b/stdlib/public/SDK/CloudKit/NestedNames.swift
@@ -16,7 +16,7 @@
 
 @nonobjc
 @available(macOS 10.10, iOS 8.0, watchOS 3.0, *)
-public extension CKContainer {
+extension CKContainer {
     @available(swift 4.2)
     public enum Application {
         public typealias Permissions = CKContainer_Application_Permissions

--- a/stdlib/public/SDK/CoreGraphics/CoreGraphics.swift
+++ b/stdlib/public/SDK/CoreGraphics/CoreGraphics.swift
@@ -429,10 +429,10 @@ public extension CGRect {
   }
 
   @available(*, unavailable, renamed: "minX")
-  public var x: CGFloat { return minX }
+  var x: CGFloat { return minX }
 
   @available(*, unavailable, renamed: "minY")
-  public var y: CGFloat { return minY }
+  var y: CGFloat { return minY }
 }
 
 extension CGRect : CustomReflectable {

--- a/stdlib/public/SDK/Dispatch/Dispatch.swift
+++ b/stdlib/public/SDK/Dispatch/Dispatch.swift
@@ -129,7 +129,7 @@ public enum DispatchTimeoutResult {
 
 /// dispatch_group
 
-public extension DispatchGroup {
+extension DispatchGroup {
 	public func notify(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], queue: DispatchQueue, execute work: @escaping @convention(block) () -> Void) {
 		if #available(macOS 10.10, iOS 8.0, *), qos != .unspecified || !flags.isEmpty {
 			let item = DispatchWorkItem(qos: qos, flags: flags, block: work)
@@ -159,7 +159,7 @@ public extension DispatchGroup {
 
 /// dispatch_semaphore
 
-public extension DispatchSemaphore {
+extension DispatchSemaphore {
 	@discardableResult
 	public func signal() -> Int {
 		return __dispatch_semaphore_signal(self)

--- a/stdlib/public/SDK/Dispatch/IO.swift
+++ b/stdlib/public/SDK/Dispatch/IO.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public extension DispatchIO {
+extension DispatchIO {
 
 	public enum StreamType : UInt  {
 		case stream = 0

--- a/stdlib/public/SDK/Dispatch/Queue.swift
+++ b/stdlib/public/SDK/Dispatch/Queue.swift
@@ -23,7 +23,7 @@ internal class _DispatchSpecificValue<T> {
 	internal init(value: T) { self.value = value }
 }
 
-public extension DispatchQueue {
+extension DispatchQueue {
 	public struct Attributes : OptionSet {
 		public let rawValue: UInt64
 		public init(rawValue: UInt64) { self.rawValue = rawValue }

--- a/stdlib/public/SDK/Dispatch/Source.swift
+++ b/stdlib/public/SDK/Dispatch/Source.swift
@@ -13,8 +13,8 @@
 // import Foundation
 import _SwiftDispatchOverlayShims
 
-public extension DispatchSourceProtocol {
-	typealias DispatchSourceHandler = @convention(block) () -> Void
+extension DispatchSourceProtocol {
+	public typealias DispatchSourceHandler = @convention(block) () -> Void
 
 	public func setEventHandler(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], handler: DispatchSourceHandler?) {
 		if #available(macOS 10.10, iOS 8.0, *),
@@ -98,7 +98,7 @@ public extension DispatchSourceProtocol {
 	}
 }
 
-public extension DispatchSource {
+extension DispatchSource {
 	public struct MachSendEvent : OptionSet, RawRepresentable {
 		public let rawValue: UInt
 		public init(rawValue: UInt) { self.rawValue = rawValue }
@@ -210,7 +210,7 @@ public extension DispatchSource {
 	}
 }
 
-public extension DispatchSourceMachSend {
+extension DispatchSourceMachSend {
 	public var handle: mach_port_t {
 		return mach_port_t(__dispatch_source_get_handle(self as! DispatchSource))
 	}
@@ -226,13 +226,13 @@ public extension DispatchSourceMachSend {
 	}
 }
 
-public extension DispatchSourceMachReceive {
+extension DispatchSourceMachReceive {
 	public var handle: mach_port_t {
 		return mach_port_t(__dispatch_source_get_handle(self as! DispatchSource))
 	}
 }
 
-public extension DispatchSourceMemoryPressure {
+extension DispatchSourceMemoryPressure {
 	public var data: DispatchSource.MemoryPressureEvent {
 		let data = __dispatch_source_get_data(self as! DispatchSource)
 		return DispatchSource.MemoryPressureEvent(rawValue: data)
@@ -244,7 +244,7 @@ public extension DispatchSourceMemoryPressure {
 	}
 }
 
-public extension DispatchSourceProcess {
+extension DispatchSourceProcess {
 	public var handle: pid_t {
 		return pid_t(__dispatch_source_get_handle(self as! DispatchSource))
 	}
@@ -260,7 +260,7 @@ public extension DispatchSourceProcess {
 	}
 }
 
-public extension DispatchSourceTimer {
+extension DispatchSourceTimer {
 	///
 	/// Sets the deadline and leeway for a timer event that fires once.
 	///
@@ -599,7 +599,7 @@ public extension DispatchSourceTimer {
 	}
 }
 
-public extension DispatchSourceFileSystemObject {
+extension DispatchSourceFileSystemObject {
 	public var handle: Int32 {
 		return Int32(__dispatch_source_get_handle(self as! DispatchSource))
 	}
@@ -615,7 +615,7 @@ public extension DispatchSourceFileSystemObject {
 	}
 }
 
-public extension DispatchSourceUserDataAdd {
+extension DispatchSourceUserDataAdd {
 	/// @function add
 	///
 	/// @abstract
@@ -630,7 +630,7 @@ public extension DispatchSourceUserDataAdd {
 	}
 }
 
-public extension DispatchSourceUserDataOr {
+extension DispatchSourceUserDataOr {
 	/// @function or
 	///
 	/// @abstract
@@ -645,7 +645,7 @@ public extension DispatchSourceUserDataOr {
 	}
 }
 
-public extension DispatchSourceUserDataReplace {
+extension DispatchSourceUserDataReplace {
 	/// @function replace
 	///
 	/// @abstract

--- a/stdlib/public/SDK/Foundation/Codable.swift
+++ b/stdlib/public/SDK/Foundation/Codable.swift
@@ -22,7 +22,7 @@ extension DecodingError : LocalizedError {}
 // Error Utilities
 //===----------------------------------------------------------------------===//
 
-internal extension DecodingError {
+extension DecodingError {
     /// Returns a `.typeMismatch` error describing the expected type.
     ///
     /// - parameter path: The path of `CodingKey`s taken to decode a value of this type.

--- a/stdlib/public/SDK/Foundation/JSONEncoder.swift
+++ b/stdlib/public/SDK/Foundation/JSONEncoder.swift
@@ -2432,7 +2432,7 @@ fileprivate var _iso8601Formatter: ISO8601DateFormatter = {
 // Error Utilities
 //===----------------------------------------------------------------------===//
 
-fileprivate extension EncodingError {
+extension EncodingError {
     /// Returns a `.invalidValue` error describing the given invalid floating-point value.
     ///
     ///

--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -463,7 +463,7 @@ extension _BridgedStoredNSError {
 }
 
 /// Implementation of _ObjectiveCBridgeableError for all _BridgedStoredNSErrors.
-public extension _BridgedStoredNSError {
+extension _BridgedStoredNSError {
   /// Default implementation of ``init(_bridgedNSError:)`` to provide
   /// bridging from NSError.
   public init?(_bridgedNSError error: NSError) {
@@ -617,7 +617,7 @@ public extension CocoaError {
   }
 }
 
-public extension CocoaError {
+extension CocoaError {
     public static func error(_ code: CocoaError.Code, userInfo: [AnyHashable : Any]? = nil, url: URL? = nil) -> Error {
         var info: [AnyHashable : Any] = userInfo ?? [:]
         if let url = url {
@@ -1821,7 +1821,7 @@ public struct URLError : _BridgedStoredNSError {
   }
 }
 
-public extension URLError.Code {
+extension URLError.Code {
   public static var unknown: URLError.Code {
     return URLError.Code(rawValue: -1)
   }
@@ -1984,7 +1984,7 @@ public extension URLError.Code {
   }
 }
 
-public extension URLError {
+extension URLError {
   private var _nsUserInfo: [AnyHashable : Any] {
     return (self as NSError).userInfo
   }
@@ -2009,7 +2009,7 @@ public extension URLError {
   }
 }
 
-public extension URLError {
+extension URLError {
   public static var unknown: URLError.Code {
     return .unknown
   }

--- a/stdlib/public/SDK/Foundation/NSObject.swift
+++ b/stdlib/public/SDK/Foundation/NSObject.swift
@@ -179,7 +179,7 @@ public class NSKeyValueObservation : NSObject {
     }
 }
 
-public extension _KeyValueCodingAndObserving {
+extension _KeyValueCodingAndObserving {
     
     ///when the returned NSKeyValueObservation is deinited or invalidated, it will stop observing
     public func observe<Value>(

--- a/stdlib/public/SDK/Foundation/Progress.swift
+++ b/stdlib/public/SDK/Foundation/Progress.swift
@@ -12,7 +12,7 @@
 
 @_exported import Foundation // Clang module
 
-public extension Progress {
+extension Progress {
     @available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *)
     public var estimatedTimeRemaining: TimeInterval? {
         get {

--- a/stdlib/public/SDK/Intents/INIntent.swift
+++ b/stdlib/public/SDK/Intents/INIntent.swift
@@ -17,7 +17,7 @@ import Foundation
 
 public protocol _INIntentSetImageKeyPath { }
 
-public extension _INIntentSetImageKeyPath {
+extension _INIntentSetImageKeyPath {
     
     @available(iOS 12.0, watchOS 5.0, macOS 10.14, *)
     public func setImage<Value>(_ image: INImage?, forParameterNamed parameterName: KeyPath<Self, Value>) {

--- a/stdlib/public/SDK/XCTest/XCTest.swift
+++ b/stdlib/public/SDK/XCTest/XCTest.swift
@@ -17,7 +17,7 @@ import _SwiftXCTestOverlayShims
 
 // --- XCTest API Swiftification ---
 
-public extension XCTContext {
+extension XCTContext {
 
   /// Create and run a new activity with provided name and block.
   public class func runActivity<Result>(named name: String, block: (XCTActivity) throws -> Result) rethrows -> Result {
@@ -40,7 +40,7 @@ public extension XCTContext {
 #if os(macOS)
 @available(swift 4.0)
 @available(macOS 10.11, *)
-public extension XCUIElement {
+extension XCUIElement {
   /// Types a single key from the XCUIKeyboardKey enumeration with the specified modifier flags.
   @nonobjc public func typeKey(_ key: XCUIKeyboardKey, modifierFlags: XCUIElement.KeyModifierFlags) {
     // Call the version of the method defined in XCTest.framework.

--- a/stdlib/public/core/Codable.swift.gyb
+++ b/stdlib/public/core/Codable.swift.gyb
@@ -1324,7 +1324,7 @@ internal struct _GenericIndexKey : CodingKey {
   }
 }
 
-public extension DecodingError {
+extension DecodingError {
   /// Returns a new `.dataCorrupted` error using a constructed coding path and
   /// the given debug description.
   ///
@@ -2058,7 +2058,7 @@ extension Dictionary : Decodable where Key : Decodable, Value : Decodable {
 
 // Default implementation of encodeConditional(_:forKey:) in terms of
 // encode(_:forKey:)
-public extension KeyedEncodingContainerProtocol {
+extension KeyedEncodingContainerProtocol {
   @inlinable // FIXME(sil-serialize-all)
   public mutating func encodeConditional<T : AnyObject & Encodable>(
     _ object: T, forKey key: Key) throws
@@ -2069,7 +2069,7 @@ public extension KeyedEncodingContainerProtocol {
 
 // Default implementation of encodeIfPresent(_:forKey:) in terms of
 // encode(_:forKey:)
-public extension KeyedEncodingContainerProtocol {
+extension KeyedEncodingContainerProtocol {
 % for type in codable_types:
   @inlinable // FIXME(sil-serialize-all)
   public mutating func encodeIfPresent(
@@ -2091,7 +2091,7 @@ public extension KeyedEncodingContainerProtocol {
 
 // Default implementation of decodeIfPresent(_:forKey:) in terms of
 // decode(_:forKey:) and decodeNil(forKey:)
-public extension KeyedDecodingContainerProtocol {
+extension KeyedDecodingContainerProtocol {
 % for type in codable_types:
   @inlinable // FIXME(sil-serialize-all)
   public func decodeIfPresent(
@@ -2115,7 +2115,7 @@ public extension KeyedDecodingContainerProtocol {
 
 // Default implementation of encodeConditional(_:) in terms of encode(_:),
 // and encode(contentsOf:) in terms of encode(_:) loop.
-public extension UnkeyedEncodingContainer {
+extension UnkeyedEncodingContainer {
   @inlinable // FIXME(sil-serialize-all)
   public mutating func encodeConditional<T : AnyObject & Encodable>(
     _ object: T) throws
@@ -2146,7 +2146,7 @@ public extension UnkeyedEncodingContainer {
 
 // Default implementation of decodeIfPresent(_:) in terms of decode(_:) and
 // decodeNil()
-public extension UnkeyedDecodingContainer {
+extension UnkeyedDecodingContainer {
 % for type in codable_types:
   @inlinable // FIXME(sil-serialize-all)
   public mutating func decodeIfPresent(

--- a/test/Compatibility/accessibility.swift
+++ b/test/Compatibility/accessibility.swift
@@ -74,18 +74,18 @@ extension PrivateStruct {
 }
 
 public extension PublicStruct {
-  public func extMemberPublic() {}
+  public func extMemberPublic() {} // expected-warning {{'public' modifier is redundant for instance method declared in a public extension}} {{3-10=}}
   fileprivate func extFuncPublic() {}
   private func extImplPublic() {}
 }
 internal extension PublicStruct {
-  public func extMemberInternal() {} // expected-warning {{declaring a public instance method in an internal extension}} {{3-9=internal}}
+  public func extMemberInternal() {} // expected-warning {{declaring a public instance method in an internal extension}} {{3-10=}}
   fileprivate func extFuncInternal() {}
   private func extImplInternal() {}
 }
 fileprivate extension PublicStruct {
-  public func extMemberFilePrivate() {} // expected-warning {{declaring a public instance method in a fileprivate extension}} {{3-9=fileprivate}}
-  fileprivate func extFuncFilePrivate() {}
+  public func extMemberFilePrivate() {} // expected-warning {{declaring a public instance method in a fileprivate extension}} {{3-10=}}
+  fileprivate func extFuncFilePrivate() {} // expected-warning {{'fileprivate' modifier is redundant for instance method declared in a fileprivate extension}} {{3-15=}}
   private func extImplFilePrivate() {}
 }
 private extension PublicStruct {
@@ -94,18 +94,18 @@ private extension PublicStruct {
   private func extImplPrivate() {}
 }
 public extension InternalStruct { // expected-error {{extension of internal struct cannot be declared public}} {{1-8=}}
-  public func extMemberPublic() {}
+  public func extMemberPublic() {} // expected-warning {{'public' modifier is redundant for instance method declared in a public extension}} {{3-10=}}
   fileprivate func extFuncPublic() {}
   private func extImplPublic() {}
 }
 internal extension InternalStruct {
-  public func extMemberInternal() {} // expected-warning {{declaring a public instance method in an internal extension}} {{3-9=internal}}
+  public func extMemberInternal() {} // expected-warning {{declaring a public instance method in an internal extension}} {{3-10=}}
   fileprivate func extFuncInternal() {}
   private func extImplInternal() {}
 }
 fileprivate extension InternalStruct {
-  public func extMemberFilePrivate() {} // expected-warning {{declaring a public instance method in a fileprivate extension}} {{3-9=fileprivate}}
-  fileprivate func extFuncFilePrivate() {}
+  public func extMemberFilePrivate() {} // expected-warning {{declaring a public instance method in a fileprivate extension}} {{3-10=}}
+  fileprivate func extFuncFilePrivate() {} // expected-warning {{'fileprivate' modifier is redundant for instance method declared in a fileprivate extension}} {{3-15=}}
   private func extImplFilePrivate() {}
 }
 private extension InternalStruct {
@@ -114,18 +114,18 @@ private extension InternalStruct {
   private func extImplPrivate() {}
 }
 public extension FilePrivateStruct { // expected-error {{extension of fileprivate struct cannot be declared public}} {{1-8=}}
-  public func extMemberPublic() {}
+  public func extMemberPublic() {} // expected-warning {{'public' modifier is redundant for instance method declared in a public extension}} {{3-10=}}
   fileprivate func extFuncPublic() {}
   private func extImplPublic() {}
 }
 internal extension FilePrivateStruct { // expected-error {{extension of fileprivate struct cannot be declared internal}} {{1-10=}}
-  public func extMemberInternal() {} // expected-warning {{declaring a public instance method in an internal extension}} {{3-9=internal}}
+  public func extMemberInternal() {} // expected-warning {{declaring a public instance method in an internal extension}} {{3-10=}}
   fileprivate func extFuncInternal() {}
   private func extImplInternal() {}
 }
 fileprivate extension FilePrivateStruct {
-  public func extMemberFilePrivate() {} // expected-warning {{declaring a public instance method in a fileprivate extension}} {{3-9=fileprivate}}
-  fileprivate func extFuncFilePrivate() {}
+  public func extMemberFilePrivate() {} // expected-warning {{declaring a public instance method in a fileprivate extension}} {{3-10=}}
+  fileprivate func extFuncFilePrivate() {} // expected-warning {{'fileprivate' modifier is redundant for instance method declared in a fileprivate extension}} {{3-15=}}
   private func extImplFilePrivate() {}
 }
 private extension FilePrivateStruct {
@@ -134,18 +134,18 @@ private extension FilePrivateStruct {
   private func extImplPrivate() {}
 }
 public extension PrivateStruct { // expected-error {{extension of private struct cannot be declared public}} {{1-8=}}
-  public func extMemberPublic() {}
+  public func extMemberPublic() {} // expected-warning {{'public' modifier is redundant for instance method declared in a public extension}} {{3-10=}}
   fileprivate func extFuncPublic() {}
   private func extImplPublic() {}
 }
 internal extension PrivateStruct { // expected-error {{extension of private struct cannot be declared internal}} {{1-10=}}
-  public func extMemberInternal() {} // expected-warning {{declaring a public instance method in an internal extension}} {{3-9=internal}}
+  public func extMemberInternal() {} // expected-warning {{declaring a public instance method in an internal extension}} {{3-10=}}
   fileprivate func extFuncInternal() {}
   private func extImplInternal() {}
 }
 fileprivate extension PrivateStruct { // expected-error {{extension of private struct cannot be declared fileprivate}} {{1-13=}}
-  public func extMemberFilePrivate() {} // expected-warning {{declaring a public instance method in a fileprivate extension}} {{3-9=fileprivate}}
-  fileprivate func extFuncFilePrivate() {}
+  public func extMemberFilePrivate() {} // expected-warning {{declaring a public instance method in a fileprivate extension}} {{3-10=}}
+  fileprivate func extFuncFilePrivate() {} // expected-warning {{'fileprivate' modifier is redundant for instance method declared in a fileprivate extension}} {{3-15=}}
   private func extImplFilePrivate() {}
 }
 private extension PrivateStruct {
@@ -174,7 +174,7 @@ public class Base {
 
 
 public extension Base {
-  open func extMemberPublic() {} // expected-warning {{declaring open instance method in public extension}}
+  open func extMemberPublic() {} // expected-warning {{declaring open instance method in a public extension}}
 }
 internal extension Base {
   open func extMemberInternal() {} // expected-warning {{declaring open instance method in an internal extension}}

--- a/test/Compatibility/accessibility.swift
+++ b/test/Compatibility/accessibility.swift
@@ -89,8 +89,8 @@ fileprivate extension PublicStruct {
   private func extImplFilePrivate() {}
 }
 private extension PublicStruct {
-  public func extMemberPrivate() {} // expected-warning {{declaring a public instance method in a private extension}} {{3-9=fileprivate}}
-  fileprivate func extFuncPrivate() {}
+  public func extMemberPrivate() {} // expected-warning {{declaring a public instance method in a private extension}} {{3-10=}}
+  fileprivate func extFuncPrivate() {} // expected-warning {{'fileprivate' modifier is redundant for instance method declared in a private (equivalent to fileprivate) extension}} {{3-15=}}
   private func extImplPrivate() {}
 }
 public extension InternalStruct { // expected-error {{extension of internal struct cannot be declared public}} {{1-8=}}
@@ -109,8 +109,8 @@ fileprivate extension InternalStruct {
   private func extImplFilePrivate() {}
 }
 private extension InternalStruct {
-  public func extMemberPrivate() {} // expected-warning {{declaring a public instance method in a private extension}} {{3-9=fileprivate}}
-  fileprivate func extFuncPrivate() {}
+  public func extMemberPrivate() {} // expected-warning {{declaring a public instance method in a private extension}} {{3-10=}}
+  fileprivate func extFuncPrivate() {} // expected-warning {{'fileprivate' modifier is redundant for instance method declared in a private (equivalent to fileprivate) extension}} {{3-15=}}
   private func extImplPrivate() {}
 }
 public extension FilePrivateStruct { // expected-error {{extension of fileprivate struct cannot be declared public}} {{1-8=}}
@@ -129,8 +129,8 @@ fileprivate extension FilePrivateStruct {
   private func extImplFilePrivate() {}
 }
 private extension FilePrivateStruct {
-  public func extMemberPrivate() {} // expected-warning {{declaring a public instance method in a private extension}} {{3-9=fileprivate}}
-  fileprivate func extFuncPrivate() {}
+  public func extMemberPrivate() {} // expected-warning {{declaring a public instance method in a private extension}} {{3-10=}}
+  fileprivate func extFuncPrivate() {} // expected-warning {{'fileprivate' modifier is redundant for instance method declared in a private (equivalent to fileprivate) extension}} {{3-15=}}
   private func extImplPrivate() {}
 }
 public extension PrivateStruct { // expected-error {{extension of private struct cannot be declared public}} {{1-8=}}
@@ -149,8 +149,8 @@ fileprivate extension PrivateStruct { // expected-error {{extension of private s
   private func extImplFilePrivate() {}
 }
 private extension PrivateStruct {
-  public func extMemberPrivate() {} // expected-warning {{declaring a public instance method in a private extension}} {{3-9=fileprivate}}
-  fileprivate func extFuncPrivate() {}
+  public func extMemberPrivate() {} // expected-warning {{declaring a public instance method in a private extension}} {{3-10=}}
+  fileprivate func extFuncPrivate() {} // expected-warning {{'fileprivate' modifier is redundant for instance method declared in a private (equivalent to fileprivate) extension}} {{3-15=}}
   private func extImplPrivate() {}
 }
 
@@ -716,3 +716,90 @@ public typealias BadPublicComposition2 = PublicClass & InternalProto // expected
 public typealias BadPublicComposition3<T> = InternalGenericClass<T> & PublicProto // expected-error {{type alias cannot be declared public because its underlying type uses an internal type}}
 public typealias BadPublicComposition4 = InternalGenericClass<Int> & PublicProto // expected-error {{type alias cannot be declared public because its underlying type uses an internal type}}
 public typealias BadPublicComposition5 = PublicGenericClass<InternalStruct> & PublicProto // expected-error {{type alias cannot be declared public because its underlying type uses an internal type}}
+
+
+open class ClassWithProperties {
+  open open(set) var openProp = 0 // expected-warning {{'open(set)' modifier is redundant for an open property}} {{8-18=}}
+  public public(set) var publicProp = 0 // expected-warning {{'public(set)' modifier is redundant for a public property}} {{10-22=}}
+  internal internal(set) var internalProp = 0 // expected-warning {{'internal(set)' modifier is redundant for an internal property}} {{12-26=}}
+  fileprivate fileprivate(set) var fileprivateProp = 0 // expected-warning {{'fileprivate(set)' modifier is redundant for a fileprivate property}} {{15-32=}}
+  private private(set) var privateProp = 0 // expected-warning {{'private(set)' modifier is redundant for a private property}} {{11-24=}}
+  internal(set) var defaultProp = 0 // expected-warning {{'internal(set)' modifier is redundant for an internal property}} {{3-17=}}
+}
+
+extension ClassWithProperties {
+  // expected-warning@+1 {{'internal(set)' modifier is redundant for an internal property}} {{12-26=}}
+  internal internal(set) var defaultExtProp: Int {
+    get { return 42 }
+    set {}
+  }
+  // expected-warning@+1 {{'internal(set)' modifier is redundant for an internal property}} {{3-17=}}
+  internal(set) var defaultExtProp2: Int {
+    get { return 42 }
+    set {}
+  }
+}
+
+public extension ClassWithProperties {
+  // expected-warning@+2 {{'public' modifier is redundant for property declared in a public extension}} {{3-10=}}
+  // expected-warning@+1 {{'public(set)' modifier is redundant for a public property}} {{10-22=}}
+  public public(set) var publicExtProp: Int {
+    get { return 42 }
+    set {}
+  }
+  // expected-warning@+1 {{'public(set)' modifier is redundant for a public property}} {{3-15=}}
+  public(set) var publicExtProp2: Int {
+    get { return 42 }
+    set {}
+  }
+}
+
+internal extension ClassWithProperties {
+  // expected-warning@+2 {{'internal' modifier is redundant for property declared in an internal extension}} {{3-12=}}
+  // expected-warning@+1 {{'internal(set)' modifier is redundant for an internal property}} {{12-26=}}
+  internal internal(set) var internalExtProp: Int {
+    get { return 42 }
+    set {}
+  }
+  // expected-warning@+1 {{'internal(set)' modifier is redundant for an internal property}} {{3-17=}}
+  internal(set) var internalExtProp2: Int {
+    get { return 42 }
+    set {}
+  }
+}
+
+fileprivate extension ClassWithProperties {
+  // expected-warning@+2 {{'fileprivate' modifier is redundant for property declared in a fileprivate extension}} {{3-15=}}
+  // expected-warning@+1 {{'fileprivate(set)' modifier is redundant for a fileprivate property}} {{15-32=}}
+  fileprivate fileprivate(set) var fileprivateExtProp: Int {
+    get { return 42 }
+    set {}
+  }
+  // expected-warning@+1 {{'fileprivate(set)' modifier is redundant for a fileprivate property}} {{3-20=}}
+  fileprivate(set) var fileprivateExtProp2: Int {
+    get { return 42 }
+    set {}
+  }
+  private(set) var fileprivateExtProp3: Int {
+    get { return 42 }
+    set {}
+  }
+}
+
+private extension ClassWithProperties {
+  // expected-warning@+2 {{'fileprivate' modifier is redundant for property declared in a private (equivalent to fileprivate) extension}} {{3-15=}}
+  // expected-warning@+1 {{'fileprivate(set)' modifier is redundant for a fileprivate property}} {{15-32=}}
+  fileprivate fileprivate(set) var privateExtProp: Int {
+    get { return 42 }
+    set {}
+  }
+  // expected-warning@+1 {{'fileprivate(set)' modifier is redundant for a fileprivate property}} {{3-20=}}
+  fileprivate(set) var privateExtProp2: Int {
+    get { return 42 }
+    set {}
+  }
+  private(set) var privateExtProp3: Int {
+    get { return 42 }
+    set {}
+  }
+}

--- a/test/Compatibility/tuple_arguments_4.swift
+++ b/test/Compatibility/tuple_arguments_4.swift
@@ -1631,15 +1631,13 @@ do {
 
 // https://bugs.swift.org/browse/SR-6509
 public extension Optional {
-  // expected-warning@+1 {{'public' modifier is redundant for instance method declared in a public extension}}
-  public func apply<Result>(_ transform: ((Wrapped) -> Result)?) -> Result? {
+  func apply<Result>(_ transform: ((Wrapped) -> Result)?) -> Result? {
     return self.flatMap { value in
       transform.map { $0(value) }
     }
   }
 
-  // expected-warning@+1 {{'public' modifier is redundant for instance method declared in a public extension}}
-  public func apply<Value, Result>(_ value: Value?) -> Result?
+  func apply<Value, Result>(_ value: Value?) -> Result?
     where Wrapped == (Value) -> Result {
     return value.apply(self)
   }

--- a/test/Compatibility/tuple_arguments_4.swift
+++ b/test/Compatibility/tuple_arguments_4.swift
@@ -1631,12 +1631,14 @@ do {
 
 // https://bugs.swift.org/browse/SR-6509
 public extension Optional {
+  // expected-warning@+1 {{'public' modifier is redundant for instance method declared in a public extension}}
   public func apply<Result>(_ transform: ((Wrapped) -> Result)?) -> Result? {
     return self.flatMap { value in
       transform.map { $0(value) }
     }
   }
 
+  // expected-warning@+1 {{'public' modifier is redundant for instance method declared in a public extension}}
   public func apply<Value, Result>(_ value: Value?) -> Result?
     where Wrapped == (Value) -> Result {
     return value.apply(self)

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1632,12 +1632,14 @@ do {
 
 // https://bugs.swift.org/browse/SR-6509
 public extension Optional {
+  // expected-warning@+1 {{'public' modifier is redundant for instance method declared in a public extension}}
   public func apply<Result>(_ transform: ((Wrapped) -> Result)?) -> Result? {
     return self.flatMap { value in
       transform.map { $0(value) }
     }
   }
 
+  // expected-warning@+1 {{'public' modifier is redundant for instance method declared in a public extension}}
   public func apply<Value, Result>(_ value: Value?) -> Result?
     where Wrapped == (Value) -> Result {
     return value.apply(self)

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1632,15 +1632,13 @@ do {
 
 // https://bugs.swift.org/browse/SR-6509
 public extension Optional {
-  // expected-warning@+1 {{'public' modifier is redundant for instance method declared in a public extension}}
-  public func apply<Result>(_ transform: ((Wrapped) -> Result)?) -> Result? {
+  func apply<Result>(_ transform: ((Wrapped) -> Result)?) -> Result? {
     return self.flatMap { value in
       transform.map { $0(value) }
     }
   }
 
-  // expected-warning@+1 {{'public' modifier is redundant for instance method declared in a public extension}}
-  public func apply<Value, Result>(_ value: Value?) -> Result?
+  func apply<Value, Result>(_ value: Value?) -> Result?
     where Wrapped == (Value) -> Result {
     return value.apply(self)
   }

--- a/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
@@ -312,7 +312,7 @@ public protocol _ErrorCodeProtocol {
 }
 
 public extension _BridgedStoredNSError {
-  public init?(_bridgedNSError error: NSError) {
+  init?(_bridgedNSError error: NSError) {
     self.init(_nsError: error)
   }
 }
@@ -321,13 +321,13 @@ public extension _BridgedStoredNSError {
 public extension _BridgedStoredNSError
     where Code: RawRepresentable, Code.RawValue: SignedInteger {
   // FIXME: Generalize to Integer.
-  public var code: Code {
+  var code: Code {
     return Code(rawValue: numericCast(_nsError.code))!
   }
 
   /// Initialize an error within this domain with the given ``code``
   /// and ``userInfo``.
-  public init(_ code: Code, userInfo: [String : Any] = [:]) {
+  init(_ code: Code, userInfo: [String : Any] = [:]) {
     self.init(_nsError: NSError(domain: "", code: 0, userInfo: [:]))
   }
 
@@ -340,13 +340,13 @@ public extension _BridgedStoredNSError
 public extension _BridgedStoredNSError
     where Code: RawRepresentable, Code.RawValue: UnsignedInteger {
   // FIXME: Generalize to Integer.
-  public var code: Code {
+  var code: Code {
     return Code(rawValue: numericCast(_nsError.code))!
   }
 
   /// Initialize an error within this domain with the given ``code``
   /// and ``userInfo``.
-  public init(_ code: Code, userInfo: [String : Any] = [:]) {
+  init(_ code: Code, userInfo: [String : Any] = [:]) {
     self.init(_nsError: NSError(domain: "", code: 0, userInfo: [:]))
   }
 }

--- a/test/SILGen/accessibility_warnings.swift
+++ b/test/SILGen/accessibility_warnings.swift
@@ -56,15 +56,9 @@ extension PrivateStruct {
   public var publicVarExtension: Int { get { return 0 } set {} }
 }
 
-public extension PublicStruct {
-  // CHECK-DAG: sil @$S22accessibility_warnings12PublicStructV09extMemberC0yyF
-  public func extMemberPublic() {}
-  // CHECK-DAG: sil private @$S22accessibility_warnings12PublicStructV07extImplC033_5D2F2E026754A901C0FF90C404896D02LLyyF
-  private func extImplPublic() {}
-}
 internal extension PublicStruct {
   // CHECK-DAG: sil hidden @$S22accessibility_warnings12PublicStructV17extMemberInternalyyF
-  public func extMemberInternal() {} // expected-warning {{declaring a public instance method in an internal extension}} {{3-9=internal}}
+  public func extMemberInternal() {} // expected-warning {{declaring a public instance method in an internal extension}} {{3-10=}}
   // CHECK-DAG: sil private @$S22accessibility_warnings12PublicStructV15extImplInternal33_5D2F2E026754A901C0FF90C404896D02LLyyF
   private func extImplInternal() {}
 }
@@ -77,7 +71,7 @@ private extension PublicStruct {
 
 internal extension InternalStruct {
   // CHECK-DAG: sil hidden @$S22accessibility_warnings14InternalStructV09extMemberC0yyF
-  public func extMemberInternal() {} // expected-warning {{declaring a public instance method in an internal extension}} {{3-9=internal}}
+  public func extMemberInternal() {} // expected-warning {{declaring a public instance method in an internal extension}} {{3-10=}}
   // CHECK-DAG: sil private @$S22accessibility_warnings14InternalStructV07extImplC033_5D2F2E026754A901C0FF90C404896D02LLyyF
   private func extImplInternal() {}
 }

--- a/test/SILGen/accessibility_warnings.swift
+++ b/test/SILGen/accessibility_warnings.swift
@@ -15,6 +15,7 @@ internal struct InternalStruct {
 
   public private(set) var publicVarPrivateSet = 0
 
+  // expected-warning@+1 {{'public(set)' modifier is redundant for a public property}} {{10-22=}}
   public public(set) var publicVarPublicSet = 0
 
   // CHECK-DAG: sil hidden @$S22accessibility_warnings14InternalStructV16publicVarGetOnlySivg
@@ -56,6 +57,13 @@ extension PrivateStruct {
   public var publicVarExtension: Int { get { return 0 } set {} }
 }
 
+public extension PublicStruct {
+  // CHECK-DAG: sil @$S22accessibility_warnings12PublicStructV09extMemberC0yyF
+  public func extMemberPublic() {} // expected-warning {{'public' modifier is redundant for instance method declared in a public extension}} {{3-10=}}
+  // CHECK-DAG: sil private @$S22accessibility_warnings12PublicStructV07extImplC033_5D2F2E026754A901C0FF90C404896D02LLyyF
+  private func extImplPublic() {}
+}
+
 internal extension PublicStruct {
   // CHECK-DAG: sil hidden @$S22accessibility_warnings12PublicStructV17extMemberInternalyyF
   public func extMemberInternal() {} // expected-warning {{declaring a public instance method in an internal extension}} {{3-10=}}
@@ -64,7 +72,7 @@ internal extension PublicStruct {
 }
 private extension PublicStruct {
   // CHECK-DAG: sil private @$S22accessibility_warnings12PublicStructV16extMemberPrivate33_5D2F2E026754A901C0FF90C404896D02LLyyF
-  public func extMemberPrivate() {} // expected-warning {{declaring a public instance method in a private extension}} {{3-9=fileprivate}}
+  public func extMemberPrivate() {} // expected-warning {{declaring a public instance method in a private extension}} {{3-10=}}
   // CHECK-DAG: sil private @$S22accessibility_warnings12PublicStructV14extImplPrivate33_5D2F2E026754A901C0FF90C404896D02LLyyF
   private func extImplPrivate() {}
 }
@@ -77,7 +85,7 @@ internal extension InternalStruct {
 }
 private extension InternalStruct {
   // CHECK-DAG: sil private @$S22accessibility_warnings14InternalStructV16extMemberPrivate33_5D2F2E026754A901C0FF90C404896D02LLyyF
-  public func extMemberPrivate() {} // expected-warning {{declaring a public instance method in a private extension}} {{3-9=fileprivate}}
+  public func extMemberPrivate() {} // expected-warning {{declaring a public instance method in a private extension}} {{3-10=}}
   // CHECK-DAG: sil private @$S22accessibility_warnings14InternalStructV14extImplPrivate33_5D2F2E026754A901C0FF90C404896D02LLyyF
   private func extImplPrivate() {}
 }
@@ -85,7 +93,7 @@ private extension InternalStruct {
 
 private extension PrivateStruct {
   // CHECK-DAG: sil private @$S22accessibility_warnings13PrivateStruct33_5D2F2E026754A901C0FF90C404896D02LLV09extMemberC0yyF
-  public func extMemberPrivate() {} // expected-warning {{declaring a public instance method in a private extension}} {{3-9=fileprivate}}
+  public func extMemberPrivate() {} // expected-warning {{declaring a public instance method in a private extension}} {{3-10=}}
   // CHECK-DAG: sil private @$S22accessibility_warnings13PrivateStruct33_5D2F2E026754A901C0FF90C404896D02LLV07extImplC0yyF
   private func extImplPrivate() {}
 }
@@ -120,6 +128,7 @@ internal class InternalClass {
   // CHECK-DAG: sil hidden [transparent] @$S22accessibility_warnings13InternalClassC19publicVarPrivateSetSivg
   public private(set) var publicVarPrivateSet = 0
 
+  // expected-warning@+1 {{'public(set)' modifier is redundant for a public property}} {{10-22=}}
   public public(set) var publicVarPublicSet = 0
 
   // CHECK-DAG: sil hidden @$S22accessibility_warnings13InternalClassC16publicVarGetOnlySivg

--- a/test/Sema/accessibility.swift
+++ b/test/Sema/accessibility.swift
@@ -74,18 +74,18 @@ extension PrivateStruct {
 }
 
 public extension PublicStruct {
-  public func extMemberPublic() {}
+  public func extMemberPublic() {} // expected-warning {{'public' modifier is redundant for instance method declared in a public extension}} {{3-10=}}
   fileprivate func extFuncPublic() {}
   private func extImplPublic() {}
 }
 internal extension PublicStruct {
-  public func extMemberInternal() {} // expected-warning {{declaring a public instance method in an internal extension}} {{3-9=internal}}
+  public func extMemberInternal() {} // expected-warning {{declaring a public instance method in an internal extension}} {{3-10=}}
   fileprivate func extFuncInternal() {}
   private func extImplInternal() {}
 }
 fileprivate extension PublicStruct {
-  public func extMemberFilePrivate() {} // expected-warning {{declaring a public instance method in a fileprivate extension}} {{3-9=fileprivate}}
-  fileprivate func extFuncFilePrivate() {}
+  public func extMemberFilePrivate() {} // expected-warning {{declaring a public instance method in a fileprivate extension}} {{3-10=}}
+  fileprivate func extFuncFilePrivate() {} // expected-warning {{'fileprivate' modifier is redundant for instance method declared in a fileprivate extension}} {{3-15=}}
   private func extImplFilePrivate() {}
 }
 private extension PublicStruct {
@@ -94,18 +94,18 @@ private extension PublicStruct {
   private func extImplPrivate() {}
 }
 public extension InternalStruct { // expected-error {{extension of internal struct cannot be declared public}} {{1-8=}}
-  public func extMemberPublic() {}
+  public func extMemberPublic() {} // expected-warning {{'public' modifier is redundant for instance method declared in a public extension}} {{3-10=}}
   fileprivate func extFuncPublic() {}
   private func extImplPublic() {}
 }
 internal extension InternalStruct {
-  public func extMemberInternal() {} // expected-warning {{declaring a public instance method in an internal extension}} {{3-9=internal}}
+  public func extMemberInternal() {} // expected-warning {{declaring a public instance method in an internal extension}} {{3-10=}}
   fileprivate func extFuncInternal() {}
   private func extImplInternal() {}
 }
 fileprivate extension InternalStruct {
-  public func extMemberFilePrivate() {} // expected-warning {{declaring a public instance method in a fileprivate extension}} {{3-9=fileprivate}}
-  fileprivate func extFuncFilePrivate() {}
+  public func extMemberFilePrivate() {} // expected-warning {{declaring a public instance method in a fileprivate extension}} {{3-10=}}
+  fileprivate func extFuncFilePrivate() {} // expected-warning {{'fileprivate' modifier is redundant for instance method declared in a fileprivate extension}} {{3-15=}}
   private func extImplFilePrivate() {}
 }
 private extension InternalStruct {
@@ -114,18 +114,18 @@ private extension InternalStruct {
   private func extImplPrivate() {}
 }
 public extension FilePrivateStruct { // expected-error {{extension of fileprivate struct cannot be declared public}} {{1-8=}}
-  public func extMemberPublic() {}
+  public func extMemberPublic() {} // expected-warning {{'public' modifier is redundant for instance method declared in a public extension}} {{3-10=}}
   fileprivate func extFuncPublic() {}
   private func extImplPublic() {}
 }
 internal extension FilePrivateStruct { // expected-error {{extension of fileprivate struct cannot be declared internal}} {{1-10=}}
-  public func extMemberInternal() {} // expected-warning {{declaring a public instance method in an internal extension}} {{3-9=internal}}
+  public func extMemberInternal() {} // expected-warning {{declaring a public instance method in an internal extension}} {{3-10=}}
   fileprivate func extFuncInternal() {}
   private func extImplInternal() {}
 }
 fileprivate extension FilePrivateStruct {
-  public func extMemberFilePrivate() {} // expected-warning {{declaring a public instance method in a fileprivate extension}} {{3-9=fileprivate}}
-  fileprivate func extFuncFilePrivate() {}
+  public func extMemberFilePrivate() {} // expected-warning {{declaring a public instance method in a fileprivate extension}} {{3-10=}}
+  fileprivate func extFuncFilePrivate() {} // expected-warning {{'fileprivate' modifier is redundant for instance method declared in a fileprivate extension}} {{3-15=}}
   private func extImplFilePrivate() {}
 }
 private extension FilePrivateStruct {
@@ -134,18 +134,18 @@ private extension FilePrivateStruct {
   private func extImplPrivate() {}
 }
 public extension PrivateStruct { // expected-error {{extension of private struct cannot be declared public}} {{1-8=}}
-  public func extMemberPublic() {}
+  public func extMemberPublic() {} // expected-warning {{'public' modifier is redundant for instance method declared in a public extension}} {{3-10=}}
   fileprivate func extFuncPublic() {}
   private func extImplPublic() {}
 }
 internal extension PrivateStruct { // expected-error {{extension of private struct cannot be declared internal}} {{1-10=}}
-  public func extMemberInternal() {} // expected-warning {{declaring a public instance method in an internal extension}} {{3-9=internal}}
+  public func extMemberInternal() {} // expected-warning {{declaring a public instance method in an internal extension}} {{3-10=}}
   fileprivate func extFuncInternal() {}
   private func extImplInternal() {}
 }
 fileprivate extension PrivateStruct { // expected-error {{extension of private struct cannot be declared fileprivate}} {{1-13=}}
-  public func extMemberFilePrivate() {} // expected-warning {{declaring a public instance method in a fileprivate extension}} {{3-9=fileprivate}}
-  fileprivate func extFuncFilePrivate() {}
+  public func extMemberFilePrivate() {} // expected-warning {{declaring a public instance method in a fileprivate extension}} {{3-10=}}
+  fileprivate func extFuncFilePrivate() {} // expected-warning {{'fileprivate' modifier is redundant for instance method declared in a fileprivate extension}} {{3-15=}}
   private func extImplFilePrivate() {}
 }
 private extension PrivateStruct {
@@ -174,7 +174,7 @@ public class Base {
 
 
 public extension Base {
-  open func extMemberPublic() {} // expected-warning {{declaring open instance method in public extension}}
+  open func extMemberPublic() {} // expected-warning {{declaring open instance method in a public extension}}
 }
 internal extension Base {
   open func extMemberInternal() {} // expected-warning {{declaring open instance method in an internal extension}}

--- a/test/Sema/accessibility.swift
+++ b/test/Sema/accessibility.swift
@@ -89,8 +89,8 @@ fileprivate extension PublicStruct {
   private func extImplFilePrivate() {}
 }
 private extension PublicStruct {
-  public func extMemberPrivate() {} // expected-warning {{declaring a public instance method in a private extension}} {{3-9=fileprivate}}
-  fileprivate func extFuncPrivate() {}
+  public func extMemberPrivate() {} // expected-warning {{declaring a public instance method in a private extension}} {{3-10=}}
+  fileprivate func extFuncPrivate() {} // expected-warning {{'fileprivate' modifier is redundant for instance method declared in a private (equivalent to fileprivate) extension}} {{3-15=}}
   private func extImplPrivate() {}
 }
 public extension InternalStruct { // expected-error {{extension of internal struct cannot be declared public}} {{1-8=}}
@@ -109,8 +109,8 @@ fileprivate extension InternalStruct {
   private func extImplFilePrivate() {}
 }
 private extension InternalStruct {
-  public func extMemberPrivate() {} // expected-warning {{declaring a public instance method in a private extension}} {{3-9=fileprivate}}
-  fileprivate func extFuncPrivate() {}
+  public func extMemberPrivate() {} // expected-warning {{declaring a public instance method in a private extension}} {{3-10=}}
+  fileprivate func extFuncPrivate() {} // expected-warning {{'fileprivate' modifier is redundant for instance method declared in a private (equivalent to fileprivate) extension}} {{3-15=}}
   private func extImplPrivate() {}
 }
 public extension FilePrivateStruct { // expected-error {{extension of fileprivate struct cannot be declared public}} {{1-8=}}
@@ -129,8 +129,8 @@ fileprivate extension FilePrivateStruct {
   private func extImplFilePrivate() {}
 }
 private extension FilePrivateStruct {
-  public func extMemberPrivate() {} // expected-warning {{declaring a public instance method in a private extension}} {{3-9=fileprivate}}
-  fileprivate func extFuncPrivate() {}
+  public func extMemberPrivate() {} // expected-warning {{declaring a public instance method in a private extension}} {{3-10=}}
+  fileprivate func extFuncPrivate() {} // expected-warning {{'fileprivate' modifier is redundant for instance method declared in a private (equivalent to fileprivate) extension}} {{3-15=}}
   private func extImplPrivate() {}
 }
 public extension PrivateStruct { // expected-error {{extension of private struct cannot be declared public}} {{1-8=}}
@@ -149,8 +149,8 @@ fileprivate extension PrivateStruct { // expected-error {{extension of private s
   private func extImplFilePrivate() {}
 }
 private extension PrivateStruct {
-  public func extMemberPrivate() {} // expected-warning {{declaring a public instance method in a private extension}} {{3-9=fileprivate}}
-  fileprivate func extFuncPrivate() {}
+  public func extMemberPrivate() {} // expected-warning {{declaring a public instance method in a private extension}} {{3-10=}}
+  fileprivate func extFuncPrivate() {} // expected-warning {{'fileprivate' modifier is redundant for instance method declared in a private (equivalent to fileprivate) extension}} {{3-15=}}
   private func extImplPrivate() {}
 }
 
@@ -724,3 +724,90 @@ public typealias BadPublicComposition2 = PublicClass & InternalProto // expected
 public typealias BadPublicComposition3<T> = InternalGenericClass<T> & PublicProto // expected-error {{type alias cannot be declared public because its underlying type uses an internal type}}
 public typealias BadPublicComposition4 = InternalGenericClass<Int> & PublicProto // expected-error {{type alias cannot be declared public because its underlying type uses an internal type}}
 public typealias BadPublicComposition5 = PublicGenericClass<InternalStruct> & PublicProto // expected-error {{type alias cannot be declared public because its underlying type uses an internal type}}
+
+
+open class ClassWithProperties {
+  open open(set) var openProp = 0 // expected-warning {{'open(set)' modifier is redundant for an open property}} {{8-18=}}
+  public public(set) var publicProp = 0 // expected-warning {{'public(set)' modifier is redundant for a public property}} {{10-22=}}
+  internal internal(set) var internalProp = 0 // expected-warning {{'internal(set)' modifier is redundant for an internal property}} {{12-26=}}
+  fileprivate fileprivate(set) var fileprivateProp = 0 // expected-warning {{'fileprivate(set)' modifier is redundant for a fileprivate property}} {{15-32=}}
+  private private(set) var privateProp = 0 // expected-warning {{'private(set)' modifier is redundant for a private property}} {{11-24=}}
+  internal(set) var defaultProp = 0 // expected-warning {{'internal(set)' modifier is redundant for an internal property}} {{3-17=}}
+}
+
+extension ClassWithProperties {
+  // expected-warning@+1 {{'internal(set)' modifier is redundant for an internal property}} {{12-26=}}
+  internal internal(set) var defaultExtProp: Int {
+    get { return 42 }
+    set {}
+  }
+  // expected-warning@+1 {{'internal(set)' modifier is redundant for an internal property}} {{3-17=}}
+  internal(set) var defaultExtProp2: Int {
+    get { return 42 }
+    set {}
+  }
+}
+
+public extension ClassWithProperties {
+  // expected-warning@+2 {{'public' modifier is redundant for property declared in a public extension}} {{3-10=}}
+  // expected-warning@+1 {{'public(set)' modifier is redundant for a public property}} {{10-22=}}
+  public public(set) var publicExtProp: Int {
+    get { return 42 }
+    set {}
+  }
+  // expected-warning@+1 {{'public(set)' modifier is redundant for a public property}} {{3-15=}}
+  public(set) var publicExtProp2: Int {
+    get { return 42 }
+    set {}
+  }
+}
+
+internal extension ClassWithProperties {
+  // expected-warning@+2 {{'internal' modifier is redundant for property declared in an internal extension}} {{3-12=}}
+  // expected-warning@+1 {{'internal(set)' modifier is redundant for an internal property}} {{12-26=}}
+  internal internal(set) var internalExtProp: Int {
+    get { return 42 }
+    set {}
+  }
+  // expected-warning@+1 {{'internal(set)' modifier is redundant for an internal property}} {{3-17=}}
+  internal(set) var internalExtProp2: Int {
+    get { return 42 }
+    set {}
+  }
+}
+
+fileprivate extension ClassWithProperties {
+  // expected-warning@+2 {{'fileprivate' modifier is redundant for property declared in a fileprivate extension}} {{3-15=}}
+  // expected-warning@+1 {{'fileprivate(set)' modifier is redundant for a fileprivate property}} {{15-32=}}
+  fileprivate fileprivate(set) var fileprivateExtProp: Int {
+    get { return 42 }
+    set {}
+  }
+  // expected-warning@+1 {{'fileprivate(set)' modifier is redundant for a fileprivate property}} {{3-20=}}
+  fileprivate(set) var fileprivateExtProp2: Int {
+    get { return 42 }
+    set {}
+  }
+  private(set) var fileprivateExtProp3: Int {
+    get { return 42 }
+    set {}
+  }
+}
+
+private extension ClassWithProperties {
+  // expected-warning@+2 {{'fileprivate' modifier is redundant for property declared in a private (equivalent to fileprivate) extension}} {{3-15=}}
+  // expected-warning@+1 {{'fileprivate(set)' modifier is redundant for a fileprivate property}} {{15-32=}}
+  fileprivate fileprivate(set) var privateExtProp: Int {
+    get { return 42 }
+    set {}
+  }
+  // expected-warning@+1 {{'fileprivate(set)' modifier is redundant for a fileprivate property}} {{3-20=}}
+  fileprivate(set) var privateExtProp2: Int {
+    get { return 42 }
+    set {}
+  }
+  private(set) var privateExtProp3: Int {
+    get { return 42 }
+    set {}
+  }
+}

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -910,6 +910,7 @@ public protocol ReallyRaw : RawRepresentable {
 }
 
 public extension ReallyRaw where RawValue: SignedInteger {
+  // expected-warning@+1 {{'public' modifier is redundant for initializer declared in a public extension}}
   public init?(rawValue: RawValue) {
     self = unsafeBitCast(rawValue, to: Self.self)
   }


### PR DESCRIPTION
~~This patch adds warning for redundant access-level modifiers used in an extension.~~

This patch adds warnings for redundant access-level modifiers for two aspects: (1) used on members declared in an extension, and (2) used on property setters.

(1) For the following example, it produces a warning - _**'public' modifier is redundant for instance method declared in a public extension**_.
```diff
 public extension SomeClass {
     public func foo() {}
+    ^~~~~~~
 }
```

(2) For instance below, it produces a warning - _**'public(set)' modifier is redundant for a public property**_.
```diff
 public SomeClass {
     public public(set) var x: Int = 0
+           ^~~~~~~~~~~~
 }
```

In addition, it refines the diagnostics of `access_control_ext_member_more` issues, in case the fixit
could suggest redundant modifiers. Consider the example below, the existing fixit suggests replacing `public` by `internal`, which is indeed a redundant modifier. This patch changes the fixit from replacement to removal.
```diff
 internal extension SomeClass {
     public func foo() {}
     ^~~~~~
-    internal
 }
```

Moreover, the corresponding redundancy warnings in the existing code of Swift projects are also fixed. These include:
- [x] stdlib in the main Swift repo as fixed by this patch
- [x] swift-corelibs-foundation repo [#1663](https://github.com/apple/swift-corelibs-foundation/pull/1663)
- [x] swift-corelibs-libdispatch repo [#390](https://github.com/apple/swift-corelibs-libdispatch/pull/390)
- [x] swift-corelibs-xctest repo [#218](https://github.com/apple/swift-corelibs-xctest/pull/218)
- [x] swiftpm repo [#1746](https://github.com/apple/swift-package-manager/pull/1746)

Resolves [SR-8453](https://bugs.swift.org/browse/SR-8453).