### PR TITLE
[stdlib][QoI] Replace recursion in sort  _siftDown with Iteration

### DIFF
--- a/stdlib/public/core/Sort.swift
+++ b/stdlib/public/core/Sort.swift
@@ -516,34 +516,34 @@ internal func _siftDown<C: MutableCollection & RandomAccessCollection>(
   subRange range: Range<C.Index>,
   by areInIncreasingOrder: (C.Element, C.Element) throws -> Bool
 ) rethrows {
-  var index = index
-  var countToIndex = elements.distance(from: range.lowerBound, to: index)
-  var countFromIndex = elements.distance(from: index, to: range.upperBound)
+  var i = index
+  var countToIndex = elements.distance(from: range.lowerBound, to: i)
+  var countFromIndex = elements.distance(from: i, to: range.upperBound)
   // Check if left child is within bounds. If not, stop iterating, because there are
   // no children of the given node in the heap.
   while countToIndex + 1 < countFromIndex {
-    let left = elements.index(index, offsetBy: countToIndex + 1)
-    var largest = index
-    if (try areInIncreasingOrder(elements[largest], elements[left])) {
+    let left = elements.index(i, offsetBy: countToIndex + 1)
+    var largest = i
+    if try areInIncreasingOrder(elements[largest], elements[left]) {
       largest = left
     }
     // Check if right child is also within bounds before trying to examine it.
     if countToIndex + 2 < countFromIndex {
       let right = elements.index(after: left)
-      if (try areInIncreasingOrder(elements[largest], elements[right])) {
+      if try areInIncreasingOrder(elements[largest], elements[right]) {
         largest = right
       }
     }
     // If a child is bigger than the current node, swap them and continue sifting
     // down.
-    if largest != index {
+    if largest != i {
       elements.swapAt(index, largest)
-      index = largest
+      i = largest
+      countToIndex = elements.distance(from: range.lowerBound, to: i)
+      countFromIndex = elements.distance(from: i, to: range.upperBound)
     } else {
       break
     }
-    countToIndex = elements.distance(from: range.lowerBound, to: index)
-    countFromIndex = elements.distance(from: index, to: range.upperBound)
   }
 }
 

--- a/stdlib/public/core/Sort.swift
+++ b/stdlib/public/core/Sort.swift
@@ -516,14 +516,12 @@ internal func _siftDown<C: MutableCollection & RandomAccessCollection>(
   subRange range: Range<C.Index>,
   by areInIncreasingOrder: (C.Element, C.Element) throws -> Bool
 ) rethrows {
-
-  let countToIndex = elements.distance(from: range.lowerBound, to: index)
-  let countFromIndex = elements.distance(from: index, to: range.upperBound)
-  // Check if left child is within bounds. If not, return, because there are
+  var index = index
+  var countToIndex = elements.distance(from: range.lowerBound, to: index)
+  var countFromIndex = elements.distance(from: index, to: range.upperBound)
+  // Check if left child is within bounds. If not, stop iterating, because there are
   // no children of the given node in the heap.
-  if countToIndex + 1 >= countFromIndex {
-    return
-  }
+  while countToIndex + 1 < countFromIndex {
   let left = elements.index(index, offsetBy: countToIndex + 1)
   var largest = index
   if (try areInIncreasingOrder(elements[largest], elements[left])) {
@@ -540,11 +538,12 @@ internal func _siftDown<C: MutableCollection & RandomAccessCollection>(
   // down.
   if largest != index {
     elements.swapAt(index, largest)
-    try _siftDown(
-      &elements,
-      index: largest,
-      subRange: range
-      , by: areInIncreasingOrder)
+    index = largest
+  } else {
+    break
+  }
+    countToIndex = elements.distance(from: range.lowerBound, to: index)
+    countFromIndex = elements.distance(from: index, to: range.upperBound)
   }
 }
 

--- a/stdlib/public/core/Sort.swift
+++ b/stdlib/public/core/Sort.swift
@@ -522,26 +522,26 @@ internal func _siftDown<C: MutableCollection & RandomAccessCollection>(
   // Check if left child is within bounds. If not, stop iterating, because there are
   // no children of the given node in the heap.
   while countToIndex + 1 < countFromIndex {
-  let left = elements.index(index, offsetBy: countToIndex + 1)
-  var largest = index
-  if (try areInIncreasingOrder(elements[largest], elements[left])) {
-    largest = left
-  }
-  // Check if right child is also within bounds before trying to examine it.
-  if countToIndex + 2 < countFromIndex {
-    let right = elements.index(after: left)
-    if (try areInIncreasingOrder(elements[largest], elements[right])) {
-      largest = right
+    let left = elements.index(index, offsetBy: countToIndex + 1)
+    var largest = index
+    if (try areInIncreasingOrder(elements[largest], elements[left])) {
+      largest = left
     }
-  }
-  // If a child is bigger than the current node, swap them and continue sifting
-  // down.
-  if largest != index {
-    elements.swapAt(index, largest)
-    index = largest
-  } else {
-    break
-  }
+    // Check if right child is also within bounds before trying to examine it.
+    if countToIndex + 2 < countFromIndex {
+      let right = elements.index(after: left)
+      if (try areInIncreasingOrder(elements[largest], elements[right])) {
+        largest = right
+      }
+    }
+    // If a child is bigger than the current node, swap them and continue sifting
+    // down.
+    if largest != index {
+      elements.swapAt(index, largest)
+      index = largest
+    } else {
+      break
+    }
     countToIndex = elements.distance(from: range.lowerBound, to: index)
     countFromIndex = elements.distance(from: index, to: range.upperBound)
   }


### PR DESCRIPTION
stdlib sorting function uses recursion in it's supporting function called siftDown. We can replace recursion with iteration and reduce overhead. 

@swift-ci please smoke benchmark