### PR TITLE
IRGen: Use any field of fixed-layout structs for extra inhabitants.

### DIFF
--- a/lib/IRGen/FixedTypeInfo.h
+++ b/lib/IRGen/FixedTypeInfo.h
@@ -167,7 +167,8 @@ public:
   /// Map an extra inhabitant representation in memory to a unique 31-bit
   /// identifier, and map a valid representation of the type to -1.
   llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF,
-                                       Address src, SILType T) const override {
+                                       Address src, SILType T,
+                                       bool isOutlined) const override {
     return getSpareBitExtraInhabitantIndex(IGF, src);
   }
   
@@ -180,7 +181,8 @@ public:
   /// to memory.
   void storeExtraInhabitant(IRGenFunction &IGF,
                             llvm::Value *index,
-                            Address dest, SILType T) const override {
+                            Address dest, SILType T,
+                            bool isOutlined) const override {
     storeSpareBitExtraInhabitant(IGF, index, dest);
   }
   

--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -375,11 +375,13 @@ public:
 
   virtual llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF,
                                                Address src,
-                                               SILType T) const = 0;
+                                               SILType T,
+                                               bool isOutlined) const = 0;
   virtual void storeExtraInhabitant(IRGenFunction &IGF,
                                     llvm::Value *index,
                                     Address dest,
-                                    SILType T) const = 0;
+                                    SILType T,
+                                    bool isOutlined) const = 0;
   
   /// \group Delegated FixedTypeInfo operations
   

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -554,20 +554,21 @@ namespace {
     }
 
     llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF, Address src,
-                                         SILType T)
+                                         SILType T, bool isOutlined)
     const override {
       // NB: We assume that the witness table slots are zero if an extra
       // inhabitant is stored in the container.
       src = projectValue(IGF, src);
       return asDerived().getValueTypeInfoForExtraInhabitants(IGF.IGM)
-                        .getExtraInhabitantIndex(IGF, src, SILType());
+                      .getExtraInhabitantIndex(IGF, src, SILType(), isOutlined);
     }
 
     void storeExtraInhabitant(IRGenFunction &IGF, llvm::Value *index,
-                              Address dest, SILType T) const override {
+                              Address dest, SILType T, bool isOutlined)
+    const override {
       Address valueDest = projectValue(IGF, dest);
       asDerived().getValueTypeInfoForExtraInhabitants(IGF.IGM)
-                 .storeExtraInhabitant(IGF, index, valueDest, SILType());
+            .storeExtraInhabitant(IGF, index, valueDest, SILType(), isOutlined);
     }
 
     APInt getFixedExtraInhabitantMask(IRGenModule &IGM) const override {
@@ -615,23 +616,25 @@ namespace {
       } \
     } \
     llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF, Address src, \
-                                         SILType T) const override { \
+                                         SILType T, bool isOutlined) \
+    const override { \
       Address valueSrc = projectValue(IGF, src); \
       if (shouldStoreExtraInhabitantsInRef(IGF.IGM)) { \
         return IGF.getReferenceStorageExtraInhabitantIndex(valueSrc, \
                                        ReferenceOwnership::Name, Refcounting); \
       } else { \
-        return Super::getExtraInhabitantIndex(IGF, src, T); \
+        return Super::getExtraInhabitantIndex(IGF, src, T, isOutlined); \
       } \
     } \
     void storeExtraInhabitant(IRGenFunction &IGF, llvm::Value *index, \
-                              Address dest, SILType T) const override { \
+                              Address dest, SILType T, bool isOutlined) \
+    const override { \
       Address valueDest = projectValue(IGF, dest); \
       if (shouldStoreExtraInhabitantsInRef(IGF.IGM)) { \
         return IGF.storeReferenceStorageExtraInhabitant(index, valueDest, \
                                        ReferenceOwnership::Name, Refcounting); \
       } else { \
-        return Super::storeExtraInhabitant(IGF, index, dest, T); \
+        return Super::storeExtraInhabitant(IGF, index, dest, T, isOutlined); \
       } \
     } \
     APInt getFixedExtraInhabitantMask(IRGenModule &IGM) const override { \

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -165,13 +165,14 @@ namespace {
     }
 
     llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF, Address src,
-                                         SILType T)
+                                         SILType T, bool isOutlined)
     const override {
       return getFunctionPointerExtraInhabitantIndex(IGF, src);
     }
 
     void storeExtraInhabitant(IRGenFunction &IGF, llvm::Value *index,
-                              Address dest, SILType T) const override {
+                              Address dest, SILType T, bool isOutlined)
+    const override {
       return storeFunctionPointerExtraInhabitant(IGF, index, dest);
     }
   };
@@ -411,7 +412,8 @@ namespace {
     }
 
     llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF, Address src,
-                                         SILType T) const override {
+                                         SILType T, bool isOutlined)
+    const override {
       src = projectFunction(IGF, src);
       return getFunctionPointerExtraInhabitantIndex(IGF, src);
     }
@@ -425,7 +427,8 @@ namespace {
     }
 
     void storeExtraInhabitant(IRGenFunction &IGF, llvm::Value *index,
-                              Address dest, SILType T) const override {
+                              Address dest, SILType T, bool isOutlined)
+    const override {
       dest = projectFunction(IGF, dest);
       return storeFunctionPointerExtraInhabitant(IGF, index, dest);
     }

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -97,13 +97,15 @@ namespace {
                                       ReferenceCounting::Nativeness); \
     } \
     llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF, Address src, \
-                                         SILType T) const override { \
+                                         SILType T, bool isOutlined) \
+    const override { \
       return IGF.getReferenceStorageExtraInhabitantIndex(src, \
                                                ReferenceOwnership::Name, \
                                                ReferenceCounting::Nativeness); \
     } \
     void storeExtraInhabitant(IRGenFunction &IGF, llvm::Value *index, \
-                              Address dest, SILType T) const override { \
+                              Address dest, SILType T, bool isOutlined) \
+    const override { \
       return IGF.storeReferenceStorageExtraInhabitant(index, dest, \
                                                ReferenceOwnership::Name, \
                                                ReferenceCounting::Nativeness); \
@@ -166,13 +168,15 @@ namespace {
                                       ReferenceCounting::Nativeness); \
     } \
     llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF, Address src, \
-                                         SILType T) const override {     \
+                                         SILType T, bool isOutlined) \
+    const override {     \
       return IGF.getReferenceStorageExtraInhabitantIndex(src, \
                                                ReferenceOwnership::Name, \
                                                ReferenceCounting::Nativeness); \
     } \
     void storeExtraInhabitant(IRGenFunction &IGF, llvm::Value *index, \
-                              Address dest, SILType T) const override { \
+                              Address dest, SILType T, bool isOutlined) \
+    const override { \
       return IGF.storeReferenceStorageExtraInhabitant(index, dest, \
                                                ReferenceOwnership::Name, \
                                                ReferenceCounting::Nativeness); \
@@ -217,12 +221,13 @@ namespace {
                                                     index + IsOptional, 0); \
     } \
     llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF, Address src, \
-                                         SILType T) \
+                                         SILType T, bool isOutlined) \
     const override { \
       return getHeapObjectExtraInhabitantIndex(IGF, src); \
     } \
     void storeExtraInhabitant(IRGenFunction &IGF, llvm::Value *index, \
-                              Address dest, SILType T) const override { \
+                              Address dest, SILType T, bool isOutlined) \
+    const override { \
       return storeHeapObjectExtraInhabitant(IGF, index, dest); \
     } \
   };

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -278,7 +278,8 @@ namespace {
       return APInt(bits, 0);
     }
     llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF, Address src,
-                                         SILType T) const override {
+                                         SILType T,
+                                         bool isOutlined) const override {
       src = IGF.Builder.CreateBitCast(src, IGF.IGM.SizeTy->getPointerTo());
       auto val = IGF.Builder.CreateLoad(src);
       auto isNonzero = IGF.Builder.CreateICmpNE(val,
@@ -288,7 +289,8 @@ namespace {
       return IGF.Builder.CreateSExt(isNonzero, IGF.IGM.Int32Ty);
     }
     void storeExtraInhabitant(IRGenFunction &IGF, llvm::Value *index,
-                              Address dest, SILType T) const override {
+                              Address dest, SILType T, bool isOutlined)
+    const override {
       // There's only one extra inhabitant, 0.
       dest = IGF.Builder.CreateBitCast(dest, IGF.IGM.SizeTy->getPointerTo());
       IGF.Builder.CreateStore(llvm::ConstantInt::get(IGF.IGM.SizeTy, 0), dest);

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -108,7 +108,8 @@ namespace {
   class StructTypeInfoBase :
      public RecordTypeInfo<Impl, Base, FieldInfoType> {
     using super = RecordTypeInfo<Impl, Base, FieldInfoType>;
-
+   mutable Optional<const FieldInfoType *> ExtraInhabitantProvidingField;
+   mutable Optional<bool> MayHaveExtraInhabitants;
   protected:
     template <class... As>
     StructTypeInfoBase(StructTypeInfoKind kind, As &&...args)
@@ -201,37 +202,48 @@ namespace {
       return fieldInfo.getStructIndex();
     }
 
-    // For now, just use extra inhabitants from the first field.
-    // FIXME: generalize
     bool mayHaveExtraInhabitants(IRGenModule &IGM) const override {
-      if (asImpl().getFields().empty()) return false;
-      return asImpl().getFields()[0].getTypeInfo().mayHaveExtraInhabitants(IGM);
+      if (!MayHaveExtraInhabitants.hasValue()) {
+        MayHaveExtraInhabitants = false;
+        for (auto &field : asImpl().getFields())
+          if (field.getTypeInfo().mayHaveExtraInhabitants(IGM)) {
+            MayHaveExtraInhabitants = true;
+            break;
+          }
+      }
+      return *MayHaveExtraInhabitants;
     }
 
     // This is dead code in NonFixedStructTypeInfo.
     unsigned getFixedExtraInhabitantCount(IRGenModule &IGM) const {
-      if (asImpl().getFields().empty()) return 0;
-      auto &fieldTI = cast<FixedTypeInfo>(asImpl().getFields()[0].getTypeInfo());
-      return fieldTI.getFixedExtraInhabitantCount(IGM);
+      if (auto field = asImpl().getFixedExtraInhabitantProvidingField(IGM)) {
+        auto &fieldTI = cast<FixedTypeInfo>(field->getTypeInfo());
+        return fieldTI.getFixedExtraInhabitantCount(IGM);
+      }
+      
+      return 0;
     }
 
     // This is dead code in NonFixedStructTypeInfo.
     APInt getFixedExtraInhabitantValue(IRGenModule &IGM,
                                        unsigned bits,
                                        unsigned index) const {
-      auto &fieldTI = cast<FixedTypeInfo>(asImpl().getFields()[0].getTypeInfo());
-      return fieldTI.getFixedExtraInhabitantValue(IGM, bits, index);
+      // We are only called if the type is known statically to have extra
+      // inhabitants.
+      auto &field = *asImpl().getFixedExtraInhabitantProvidingField(IGM);
+      auto &fieldTI = cast<FixedTypeInfo>(field.getTypeInfo());
+      APInt fieldValue = fieldTI.getFixedExtraInhabitantValue(IGM, bits, index);
+      return fieldValue.shl(field.getFixedByteOffset().getValueInBits());
     }
 
     // This is dead code in NonFixedStructTypeInfo.
     APInt getFixedExtraInhabitantMask(IRGenModule &IGM) const {
-      if (asImpl().getFields().empty())
+      auto field = asImpl().getFixedExtraInhabitantProvidingField(IGM);
+      if (!field)
         return APInt();
       
-      // Currently we only use the first field's extra inhabitants. The other
-      // fields can be ignored.
       const FixedTypeInfo &fieldTI
-        = cast<FixedTypeInfo>(asImpl().getFields()[0].getTypeInfo());
+        = cast<FixedTypeInfo>(field->getTypeInfo());
       auto targetSize = asImpl().getFixedSize().getValueInBits();
       
       if (fieldTI.isKnownEmpty(ResilienceExpansion::Maximal))
@@ -240,28 +252,164 @@ namespace {
       APInt fieldMask = fieldTI.getFixedExtraInhabitantMask(IGM);
       if (targetSize > fieldMask.getBitWidth())
         fieldMask = fieldMask.zext(targetSize);
+      fieldMask = fieldMask.shl(field->getFixedByteOffset().getValueInBits());
       return fieldMask;
+    }
+    
+    // Perform an operation using the field that provides extra inhabitants for
+    // the aggregate, whether that field is known statically or dynamically.
+    llvm::Value *withExtraInhabitantProvidingField(IRGenFunction &IGF,
+           Address structAddr,
+           SILType structType,
+           bool isOutlined,
+           llvm::Type *resultTy,
+           llvm::function_ref<llvm::Value* (const FieldInfoType &field)> body,
+           llvm::function_ref<llvm::Value* ()> outline) const {
+      // If we know one field consistently provides extra inhabitants, delegate
+      // to that field.
+      if (auto field = asImpl().getFixedExtraInhabitantProvidingField(IGF.IGM)){
+        return body(*field);
+      }
+      
+      // Otherwise, we have to figure out which field at runtime.
+      // The decision tree could be rather large, so invoke the value witness
+      // unless we're emitting the value witness.
+      if (!isOutlined)
+        return outline();
+
+      // The number of extra inhabitants the instantiated type has can be used
+      // to figure out which field the runtime chose. The runtime uses the same
+      // algorithm as above--use the field with the most extra inhabitants,
+      // favoring the earliest field in a tie. If we test the number of extra
+      // inhabitants in the struct against each field type's, then the first
+      // match should indicate which field we chose.
+      //
+      // We can reduce the decision space somewhat if there are fixed-layout
+      // fields, since we know the only possible runtime choices are
+      // either the fixed field with the most extra inhabitants (if any), or
+      // one of the unknown-layout fields.
+      //
+      // See whether we have a fixed candidate.
+      const FieldInfoType *fixedCandidate = nullptr;
+      unsigned fixedCount = 0;
+      for (auto &field : asImpl().getFields()) {
+        if (!field.getTypeInfo().mayHaveExtraInhabitants(IGF.IGM))
+          continue;
+        
+        if (const FixedTypeInfo *fixed =
+              dyn_cast<FixedTypeInfo>(&field.getTypeInfo())) {
+          auto fieldCount = fixed->getFixedExtraInhabitantCount(IGF.IGM);
+          if (fieldCount > fixedCount) {
+            fixedCandidate = &field;
+            fixedCount = fieldCount;
+          }
+        }
+      }
+      
+      // Loop through checking to see whether we picked the fixed candidate
+      // (if any) or one of the unknown-layout fields.
+      llvm::Value *instantiatedCount
+        = emitLoadOfExtraInhabitantCount(IGF, structType);
+      
+      auto contBB = IGF.createBasicBlock("chose_field_for_xi");
+      llvm::PHINode *contPhi = nullptr;
+      if (resultTy != IGF.IGM.VoidTy)
+        contPhi = llvm::PHINode::Create(resultTy,
+                                        asImpl().getFields().size());
+      
+      // If two fields have the same type, they have the same extra inhabitant
+      // count, and we'll pick the first. We don't have to check both.
+      SmallPtrSet<SILType, 4> visitedTypes;
+      
+      for (auto &field : asImpl().getFields()) {
+        if (!field.getTypeInfo().mayHaveExtraInhabitants(IGF.IGM))
+          continue;
+
+        ConditionalDominanceScope condition(IGF);
+
+        llvm::Value *fieldCount;
+        if (isa<FixedTypeInfo>(field.getTypeInfo())) {
+          // Skip fixed fields except for the candidate with the most known
+          // extra inhabitants we picked above.
+          if (&field != fixedCandidate)
+            continue;
+          
+          fieldCount = llvm::ConstantInt::get(IGF.IGM.SizeTy, fixedCount);
+        } else {
+          auto fieldTy = field.getType(IGF.IGM, structType);
+          // If this field has the same type as a field we already tested,
+          // we'll never pick this one, since they both have the same count.
+          if (!visitedTypes.insert(fieldTy).second)
+            continue;
+        
+          fieldCount = emitLoadOfExtraInhabitantCount(IGF, fieldTy);
+        }
+        auto equalsCount = IGF.Builder.CreateICmpEQ(instantiatedCount,
+                                                    fieldCount);
+        
+        auto yesBB = IGF.createBasicBlock("");
+        auto noBB = IGF.createBasicBlock("");
+        
+        IGF.Builder.CreateCondBr(equalsCount, yesBB, noBB);
+        
+        IGF.Builder.emitBlock(yesBB);
+        auto value = body(field);
+        if (contPhi)
+          contPhi->addIncoming(value, IGF.Builder.GetInsertBlock());
+        IGF.Builder.CreateBr(contBB);
+        
+        IGF.Builder.emitBlock(noBB);
+      }
+      
+      // We shouldn't have picked a number of extra inhabitants inconsistent
+      // with any individual field.
+      IGF.Builder.CreateUnreachable();
+      
+      IGF.Builder.emitBlock(contBB);
+      if (contPhi)
+        IGF.Builder.Insert(contPhi);
+     
+      return contPhi;
     }
 
     llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF,
                                          Address structAddr,
-                                         SILType structType) const override {
-      auto &field = asImpl().getFields()[0];
-      Address fieldAddr =
-        asImpl().projectFieldAddress(IGF, structAddr, structType, field.Field);
-      return field.getTypeInfo().getExtraInhabitantIndex(IGF, fieldAddr,
-                                          field.getType(IGF.IGM, structType));
+                                         SILType structType,
+                                         bool isOutlined) const override {
+      return withExtraInhabitantProvidingField(IGF, structAddr, structType,
+                                               isOutlined,
+                                               IGF.IGM.Int32Ty,
+        [&](const FieldInfoType &field) -> llvm::Value* {
+          Address fieldAddr = asImpl().projectFieldAddress(
+                                     IGF, structAddr, structType, field.Field);
+          return field.getTypeInfo().getExtraInhabitantIndex(IGF, fieldAddr,
+                                           field.getType(IGF.IGM, structType),
+                                           false /*not outlined for field*/);
+        },
+        [&]() -> llvm::Value * {
+          return emitGetExtraInhabitantIndexCall(IGF, structType, structAddr);
+        });
     }
 
     void storeExtraInhabitant(IRGenFunction &IGF,
                               llvm::Value *index,
                               Address structAddr,
-                              SILType structType) const override {
-      auto &field = asImpl().getFields()[0];
-      Address fieldAddr =
-        asImpl().projectFieldAddress(IGF, structAddr, structType, field.Field);
-      field.getTypeInfo().storeExtraInhabitant(IGF, index, fieldAddr,
-                                          field.getType(IGF.IGM, structType));
+                              SILType structType,
+                              bool isOutlined) const override {
+      withExtraInhabitantProvidingField(IGF, structAddr, structType, isOutlined,
+                                        IGF.IGM.VoidTy,
+        [&](const FieldInfoType &field) -> llvm::Value* {
+          Address fieldAddr = asImpl().projectFieldAddress(
+                                     IGF, structAddr, structType, field.Field);
+          field.getTypeInfo().storeExtraInhabitant(IGF, index, fieldAddr,
+                                           field.getType(IGF.IGM, structType),
+                                           false /*not outlined for field*/);
+          return nullptr;
+        },
+        [&]() -> llvm::Value * {
+          emitStoreExtraInhabitantCall(IGF, structType, index, structAddr);
+          return nullptr;
+        });
     }
        
     bool isSingleRetainablePointer(ResilienceExpansion expansion,
@@ -285,12 +433,17 @@ namespace {
             : public StructMetadataScanner<FindOffsetOfFieldOffsetVector> {
           public:
             VarDecl *FieldToFind;
+            Size AddressPoint = Size::invalid();
             Size FieldOffset = Size::invalid();
 
             FindOffsetOfFieldOffsetVector(IRGenModule &IGM, VarDecl *Field)
                 : StructMetadataScanner<FindOffsetOfFieldOffsetVector>(
                       IGM, cast<StructDecl>(Field->getDeclContext())),
                   FieldToFind(Field) {}
+
+            void noteAddressPoint() {
+              AddressPoint = this->NextOffset;
+            }
 
             void addFieldOffset(VarDecl *Field) {
               if (Field == FieldToFind) {
@@ -304,7 +457,8 @@ namespace {
           FindOffsetOfFieldOffsetVector scanner(IGF.IGM, field.Field);
           scanner.layout();
           
-          if (scanner.FieldOffset == Size::invalid())
+          if (scanner.FieldOffset == Size::invalid()
+              || scanner.AddressPoint == Size::invalid())
             continue;
           
           // Load the offset from the field offset vector and ensure it matches
@@ -313,13 +467,14 @@ namespace {
             IGF.Builder.CreateBitCast(metadata, IGF.IGM.Int8PtrTy);
           auto fieldOffsetPtr =
             IGF.Builder.CreateInBoundsGEP(metadataBytes,
-                                          IGF.IGM.getSize(scanner.FieldOffset));
+                  IGF.IGM.getSize(scanner.FieldOffset - scanner.AddressPoint));
           fieldOffsetPtr =
             IGF.Builder.CreateBitCast(fieldOffsetPtr,
-                                      IGF.IGM.SizeTy->getPointerTo());
-          auto fieldOffset =
-            IGF.Builder.CreateLoad(fieldOffsetPtr,
-                                   IGF.IGM.getPointerAlignment());
+                                      IGF.IGM.Int32Ty->getPointerTo());
+          llvm::Value *fieldOffset =
+            IGF.Builder.CreateLoad(fieldOffsetPtr, Alignment(4));
+          fieldOffset = IGF.Builder.CreateZExtOrBitCast(fieldOffset,
+                                                        IGF.IGM.SizeTy);
           
           IGF.verifyValues(metadata, fieldOffset,
                        IGF.IGM.getSize(field.getFixedByteOffset()),
@@ -333,8 +488,70 @@ namespace {
         }
       }
     }
-  };
+       
+    const FieldInfoType *
+    getFixedExtraInhabitantProvidingField(IRGenModule &IGM) const {
+      if (!ExtraInhabitantProvidingField.hasValue()) {
+        unsigned mostExtraInhabitants = 0;
+        const FieldInfoType *fieldWithMost = nullptr;
+        const FieldInfoType *singleNonFixedField = nullptr;
 
+        // TODO: If two fields have the same type, they have the same extra
+        // inhabitant count, and we'll pick the first. We don't have to check
+        // both. However, we don't always have access to the substituted struct
+        // type from this context, which would be necessary to make that
+        // judgment reliably.
+        
+        for (auto &field : asImpl().getFields()) {
+          auto &ti = field.getTypeInfo();
+          if (!ti.mayHaveExtraInhabitants(IGM))
+            continue;
+          
+          auto *fixed = dyn_cast<FixedTypeInfo>(&field.getTypeInfo());
+          // If any field is non-fixed, we can't definitively pick a best one,
+          // unless it happens to be the only non-fixed field and none of the
+          // other fields have extra inhabitants.
+          if (!fixed) {
+            // If we already saw a non-fixed field, then we can't pick one
+            // at compile time.
+            if (singleNonFixedField) {
+              singleNonFixedField = fieldWithMost = nullptr;
+              break;
+            }
+            
+            // Otherwise, note this field for later. If we have no fixed
+            // candidates, it may be the only choice for extra inhabitants.
+            singleNonFixedField = &field;
+            continue;
+          }
+          
+          unsigned count = fixed->getFixedExtraInhabitantCount(IGM);
+          if (count > mostExtraInhabitants) {
+            mostExtraInhabitants = count;
+            fieldWithMost = &field;
+          }
+        }
+        
+        if (fieldWithMost) {
+          if (singleNonFixedField) {
+            // If we have a non-fixed and fixed candidate, we can't know for
+            // sure now.
+            ExtraInhabitantProvidingField = nullptr;
+          } else {
+            // If we had all fixed fields, pick the one with the most extra
+            // inhabitants.
+            ExtraInhabitantProvidingField = fieldWithMost;
+          }
+        } else {
+          // If there were no fixed candidates, but we had a single non-fixed
+          // field with potential extra inhabitants, then it's our only choice.
+          ExtraInhabitantProvidingField = singleNonFixedField;
+        }
+      }
+      return *ExtraInhabitantProvidingField;
+    }
+  };
+  
   /// A type implementation for loadable record types imported from Clang.
   class ClangRecordTypeInfo final :
     public StructTypeInfoBase<ClangRecordTypeInfo, LoadableTypeInfo,
@@ -350,7 +567,8 @@ namespace {
                            fields, explosionSize,
                            storageType, size, std::move(spareBits),
                            align, IsPOD, IsFixedSize),
-        ClangDecl(clangDecl) {
+        ClangDecl(clangDecl)
+    {
     }
 
     void initializeFromParams(IRGenFunction &IGF, Explosion &params,
@@ -381,7 +599,6 @@ namespace {
   class LoadableStructTypeInfo final
       : public StructTypeInfoBase<LoadableStructTypeInfo, LoadableTypeInfo> {
   public:
-    // FIXME: Spare bits between struct members.
     LoadableStructTypeInfo(ArrayRef<StructFieldInfo> fields,
                            unsigned explosionSize,
                            llvm::Type *storageType, Size size,
@@ -893,7 +1110,7 @@ TypeConverter::convertResilientStruct(IsABIAccessible_t abiAccessible) {
 }
 
 const TypeInfo *TypeConverter::convertStructType(TypeBase *key, CanType type,
-                                                 StructDecl *D) {
+                                                 StructDecl *D){
   // All resilient structs have the same opaque lowering, since they are
   // indistinguishable as values --- except that we have to track
   // ABI-accessibility.

--- a/lib/IRGen/GenTuple.cpp
+++ b/lib/IRGen/GenTuple.cpp
@@ -204,23 +204,27 @@ namespace {
 
     llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF,
                                          Address tupleAddr,
-                                         SILType tupleType) const override {
+                                         SILType tupleType,
+                                         bool isOutlined) const override {
       Address eltAddr =
         asImpl().projectElementAddress(IGF, tupleAddr, tupleType, 0);
       auto &elt = asImpl().getFields()[0];
       return elt.getTypeInfo().getExtraInhabitantIndex(IGF, eltAddr,
-                                               elt.getType(IGF.IGM, tupleType));
+                                             elt.getType(IGF.IGM, tupleType),
+                                             false /*not outlined for field*/);
     }
   
     void storeExtraInhabitant(IRGenFunction &IGF,
                               llvm::Value *index,
                               Address tupleAddr,
-                              SILType tupleType) const override {
+                              SILType tupleType,
+                              bool isOutlined) const override {
       Address eltAddr =
         asImpl().projectElementAddress(IGF, tupleAddr, tupleType, 0);
       auto &elt = asImpl().getFields()[0];
       elt.getTypeInfo().storeExtraInhabitant(IGF, index, eltAddr,
-                                             elt.getType(IGF.IGM, tupleType));
+                                             elt.getType(IGF.IGM, tupleType),
+                                             false /*not outlined for field*/);
     }
     
     void verify(IRGenTypeVerifierFunction &IGF,

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -510,7 +510,7 @@ llvm::Value *FixedTypeInfo::getEnumTagSinglePayload(IRGenFunction &IGF,
   // If there are extra inhabitants, see whether the payload is valid.
   llvm::Value *result0;
   if (mayHaveExtraInhabitants(IGM)) {
-    result0 = getExtraInhabitantIndex(IGF, enumAddr, T);
+    result0 = getExtraInhabitantIndex(IGF, enumAddr, T, false);
     noExtraTagBitsBB = Builder.GetInsertBlock();
   } else {
     result0 = llvm::ConstantInt::getSigned(IGM.Int32Ty, -1);
@@ -665,7 +665,8 @@ void FixedTypeInfo::storeEnumTagSinglePayload(IRGenFunction &IGF,
   if (mayHaveExtraInhabitants(IGM)) {
     // Store an index in the range [0..ElementsWithNoPayload-1].
     auto *nonPayloadElementIndex = Builder.CreateSub(whichCase, one);
-    storeExtraInhabitant(IGF, nonPayloadElementIndex, enumAddr, T);
+    storeExtraInhabitant(IGF, nonPayloadElementIndex, enumAddr, T,
+                         /*outlined*/ false);
   }
   Builder.CreateBr(returnBB);
 
@@ -868,7 +869,8 @@ namespace {
 
     llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF,
                                          Address src,
-                                         SILType T) const override {
+                                         SILType T,
+                                         bool isOutlined) const override {
       // Copied from BridgeObjectTypeInfo.
       src = IGF.Builder.CreateBitCast(src, IGF.IGM.IntPtrTy->getPointerTo());
       auto val = IGF.Builder.CreateLoad(src);
@@ -880,7 +882,8 @@ namespace {
     }
 
     void storeExtraInhabitant(IRGenFunction &IGF, llvm::Value *index,
-                              Address dest, SILType T) const override {
+                              Address dest, SILType T,
+                              bool isOutlined) const override {
       // Copied from BridgeObjectTypeInfo.
       // There's only one extra inhabitant, 0.
       dest = IGF.Builder.CreateBitCast(dest, IGF.IGM.IntPtrTy->getPointerTo());

--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -515,7 +515,8 @@ static void buildValueWitnessFunction(IRGenModule &IGM,
     llvm::Value *index = getArg(argv, "index");
     getArgAsLocalSelfTypeMetadata(IGF, argv, abstractType);
 
-    type.storeExtraInhabitant(IGF, index, dest, concreteType);
+    type.storeExtraInhabitant(IGF, index, dest, concreteType,
+                              /*outlined*/ true);
     IGF.Builder.CreateRetVoid();
     return;
   }
@@ -524,7 +525,8 @@ static void buildValueWitnessFunction(IRGenModule &IGM,
     Address src = getArgAs(IGF, argv, type, "src");
     getArgAsLocalSelfTypeMetadata(IGF, argv, abstractType);
 
-    llvm::Value *idx = type.getExtraInhabitantIndex(IGF, src, concreteType);
+    llvm::Value *idx = type.getExtraInhabitantIndex(IGF, src, concreteType,
+                                                    /*outlined*/ true);
     IGF.Builder.CreateRet(idx);
     return;
   }

--- a/lib/IRGen/HeapTypeInfo.h
+++ b/lib/IRGen/HeapTypeInfo.h
@@ -237,13 +237,14 @@ public:
   }
 
   llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF, Address src,
-                                       SILType T)
+                                       SILType T, bool isOutlined)
   const override {
     return getHeapObjectExtraInhabitantIndex(IGF, src);
   }
 
   void storeExtraInhabitant(IRGenFunction &IGF, llvm::Value *index,
-                            Address dest, SILType T) const override {
+                            Address dest, SILType T, bool isOutlined)
+  const override {
     return storeHeapObjectExtraInhabitant(IGF, index, dest);
   }
 };

--- a/lib/IRGen/NonFixedTypeInfo.h
+++ b/lib/IRGen/NonFixedTypeInfo.h
@@ -118,12 +118,14 @@ public:
   /// FIXME: Dynamic extra inhabitant lookup.
   bool mayHaveExtraInhabitants(IRGenModule &) const override { return false; }
   llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF,
-                                       Address src, SILType T) const override {
+                                       Address src, SILType T,
+                                       bool isOutlined) const override {
     llvm_unreachable("dynamic extra inhabitants not supported");
   }
   void storeExtraInhabitant(IRGenFunction &IGF,
                             llvm::Value *index,
-                            Address dest, SILType T) const override {
+                            Address dest, SILType T,
+                            bool isOutlined) const override {
     llvm_unreachable("dynamic extra inhabitants not supported");
   }
 

--- a/lib/IRGen/ResilientTypeInfo.h
+++ b/lib/IRGen/ResilientTypeInfo.h
@@ -139,13 +139,15 @@ public:
   }
   llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF,
                                        Address src,
-                                       SILType T) const override {
+                                       SILType T,
+                                       bool isOutlined) const override {
     return emitGetExtraInhabitantIndexCall(IGF, T, src);
   }
   void storeExtraInhabitant(IRGenFunction &IGF,
                             llvm::Value *index,
                             Address dest,
-                            SILType T) const override {
+                            SILType T,
+                            bool isOutlined) const override {
     emitStoreExtraInhabitantCall(IGF, T, index, dest);
   }
 

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -409,7 +409,8 @@ public:
   /// has extra inhabitants.
   virtual llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF,
                                                Address src,
-                                               SILType T) const = 0;
+                                               SILType T,
+                                               bool isOutlined) const = 0;
   
   /// Store the extra inhabitant representation indexed by a 31-bit identifier
   /// to memory.
@@ -419,7 +420,8 @@ public:
   virtual void storeExtraInhabitant(IRGenFunction &IGF,
                                     llvm::Value *index,
                                     Address dest,
-                                    SILType T) const = 0;
+                                    SILType T,
+                                    bool isOutlined) const = 0;
   
   /// Get the tag of a single payload enum with a payload of this type (\p T) e.g
   /// Optional<T>.

--- a/test/Interpreter/Inputs/struct_extra_inhabitants_ExtraInhabitantResilientTypes.swift
+++ b/test/Interpreter/Inputs/struct_extra_inhabitants_ExtraInhabitantResilientTypes.swift
@@ -1,0 +1,7 @@
+public struct ResilientXI {
+  var x: AnyObject
+}
+
+public struct ResilientNoXI {
+  var x: Int
+}

--- a/test/Interpreter/struct_extra_inhabitants.swift
+++ b/test/Interpreter/struct_extra_inhabitants.swift
@@ -1,0 +1,169 @@
+// RUN: %empty-directory(%t)
+
+// -- build resilient library
+// RUN: %target-build-swift -force-single-frontend-invocation -Xfrontend -enable-resilience -module-name ExtraInhabitantResilientTypes -emit-module-path %t/ExtraInhabitantResilientTypes.swiftmodule -parse-as-library -c -o %t/ExtraInhabitantResilientTypes.o %S/Inputs/struct_extra_inhabitants_ExtraInhabitantResilientTypes.swift
+
+// -- run tests
+// RUN: %target-build-swift -parse-stdlib -Xfrontend -verify-type-layout -Xfrontend PairWithPointerFirst -Xfrontend -verify-type-layout -Xfrontend PairWithPointerSecond -Xfrontend -verify-type-layout -Xfrontend PairWithPointerSecondAndPhantomParam_Int -Xfrontend -verify-type-layout -Xfrontend GenericPairWithPointerFirst_Int -Xfrontend -verify-type-layout -Xfrontend GenericPairWithPointerFirst_AnyObject -Xfrontend -verify-type-layout -Xfrontend GenericPairWithPointerSecond_Int -Xfrontend -verify-type-layout -Xfrontend GenericPairWithPointerSecond_AnyObject -Xfrontend -verify-type-layout -Xfrontend StringAlike32 -Xfrontend -verify-type-layout -Xfrontend StringAlike64 -I %t -o %t/a.out.tests %s %t/ExtraInhabitantResilientTypes.o
+// RUN: %target-run %t/a.out.tests 2>&1
+
+// Type layout verifier is only compiled into the runtime in asserts builds.
+// REQUIRES: swift_stdlib_asserts
+
+// CHECK-NOT: Type verification
+
+import Swift
+import ExtraInhabitantResilientTypes
+import StdlibUnittest
+
+// Enum layout should use extra inhabitants from any struct field
+// for fixed-layout types.
+struct PairWithPointerFirst {
+  var a: AnyObject
+  var b: Int
+}
+
+struct PairWithPointerSecond {
+  var a: Int
+  var b: AnyObject
+}
+
+struct PairWithPointerSecondAndPhantomParam<X> {
+  var a: Int
+  var b: AnyObject
+}
+
+struct StringAlike64 {
+  var a: Int
+  var b: Builtin.BridgeObject
+}
+struct StringAlike32 {
+  var a,b,c: Int
+  var d: Builtin.BridgeObject
+}
+
+// TODO: Runtime struct instantiation still only considers the first argument
+
+struct GenericPair<T, U> {
+  var a: T
+  var b: U
+}
+
+struct GenericSamePair<T> {
+  var a: T
+  var b: T
+}
+
+struct GenericPairPlusPointer<T, U> {
+  var a: T
+  var b: U
+  var c: UnsafeRawPointer
+}
+
+struct GenericSamePairPlusPointer<T> {
+  var a: T
+  var b: T
+  var c: UnsafeRawPointer
+}
+
+struct GenericPairWithPointerFirst<T> {
+  var a: AnyObject
+  var b: T
+}
+
+struct GenericPairWithPointerSecond<T> {
+  var a: T
+  var b: AnyObject
+}
+
+struct GenericFullHouse<T, U> {
+  var a, b, c: T
+  var d, e: U
+}
+
+struct ResilientPairWithXIFirst {
+  var a: ResilientXI
+  var b: ResilientNoXI
+}
+
+struct ResilientPairWithXISecond {
+  var a: ResilientNoXI
+  var b: ResilientXI
+}
+
+// Typealiases for the type layout verifier
+
+typealias PairWithPointerSecondAndPhantomParam_Int
+ = PairWithPointerSecondAndPhantomParam<Int>
+
+typealias GenericPairWithPointerFirst_Int
+ = GenericPairWithPointerFirst<Int>
+
+typealias GenericPairWithPointerFirst_AnyObject
+ = GenericPairWithPointerFirst<AnyObject>
+
+typealias GenericPairWithPointerSecond_Int
+ = GenericPairWithPointerSecond<Int>
+
+typealias GenericPairWithPointerSecond_AnyObject
+ = GenericPairWithPointerSecond<AnyObject>
+
+var tests = TestSuite("extra inhabitants of structs")
+
+@inline(never)
+func expectHasExtraInhabitant<T>(_: T.Type, nil: T?,
+                                 file: String = #file, line: UInt = #line) {
+  expectEqual(MemoryLayout<T>.size, MemoryLayout<T?>.size,
+              "\(T.self) has extra inhabitant",
+              file: file, line: line)
+
+  expectNil(Optional<T>.none,
+            "\(T.self) extra inhabitant should agree in generic and concrete " +
+            "context")
+}
+
+func expectHasNoExtraInhabitant<T>(_: T.Type,
+                                   file: String = #file, line: UInt = #line) {
+  expectNotEqual(MemoryLayout<T>.size, MemoryLayout<T?>.size,
+                 "\(T.self) does not have extra inhabitant",
+                 file: file, line: line)
+}
+
+tests.test("types that have extra inhabitants") {
+  expectHasExtraInhabitant(PairWithPointerFirst.self, nil: nil)
+  expectHasExtraInhabitant(PairWithPointerSecond.self, nil: nil)
+  expectHasExtraInhabitant(PairWithPointerSecondAndPhantomParam<Int>.self, nil: nil)
+  expectHasExtraInhabitant(PairWithPointerSecondAndPhantomParam<AnyObject>.self, nil: nil)
+  expectHasExtraInhabitant(GenericPairWithPointerFirst<Int>.self, nil: nil)
+  expectHasExtraInhabitant(GenericPairWithPointerFirst<AnyObject>.self, nil: nil)
+  expectHasExtraInhabitant(GenericPairWithPointerSecond<Int>.self, nil: nil)
+  expectHasExtraInhabitant(GenericPairWithPointerSecond<AnyObject>.self, nil: nil)
+  expectHasExtraInhabitant(ResilientPairWithXIFirst.self, nil: nil)
+  expectHasExtraInhabitant(ResilientPairWithXISecond.self, nil: nil)
+  expectHasExtraInhabitant(StringAlike64.self, nil: nil)
+  expectHasExtraInhabitant(StringAlike32.self, nil: nil)
+  expectHasExtraInhabitant(GenericPair<AnyObject, Int>.self, nil: nil)
+  expectHasExtraInhabitant(GenericPair<Int, AnyObject>.self, nil: nil)
+  expectHasExtraInhabitant(GenericPair<AnyObject, AnyObject>.self, nil: nil)
+  expectHasExtraInhabitant(GenericPair<AnyObject, UnsafeRawPointer>.self, nil: nil)
+  expectHasExtraInhabitant(GenericPair<UnsafeRawPointer, AnyObject>.self, nil: nil)
+  expectHasExtraInhabitant(GenericPair<UnsafeRawPointer, UnsafeRawPointer>.self, nil: nil)
+  expectHasExtraInhabitant(GenericPairPlusPointer<Int, Int>.self, nil: nil)
+  expectHasExtraInhabitant(GenericPairPlusPointer<AnyObject, Int>.self, nil: nil)
+  expectHasExtraInhabitant(GenericPairPlusPointer<Int, AnyObject>.self, nil: nil)
+  expectHasExtraInhabitant(GenericPairPlusPointer<AnyObject, AnyObject>.self, nil: nil)
+  expectHasExtraInhabitant(GenericSamePair<UnsafeRawPointer>.self, nil: nil)
+  expectHasExtraInhabitant(GenericSamePair<AnyObject>.self, nil: nil)
+  expectHasExtraInhabitant(GenericSamePairPlusPointer<UnsafeRawPointer>.self, nil: nil)
+  expectHasExtraInhabitant(GenericSamePairPlusPointer<AnyObject>.self, nil: nil)
+  expectHasExtraInhabitant(GenericSamePairPlusPointer<Int>.self, nil: nil)
+  expectHasExtraInhabitant(GenericFullHouse<AnyObject, Int>.self, nil: nil)
+  expectHasExtraInhabitant(GenericFullHouse<Int, AnyObject>.self, nil: nil)
+  expectHasExtraInhabitant(GenericFullHouse<AnyObject, AnyObject>.self, nil: nil)
+  expectHasExtraInhabitant(GenericFullHouse<AnyObject, UnsafeRawPointer>.self, nil: nil)
+  expectHasExtraInhabitant(GenericFullHouse<UnsafeRawPointer, AnyObject>.self, nil: nil)
+  expectHasExtraInhabitant(GenericFullHouse<UnsafeRawPointer, UnsafeRawPointer>.self, nil: nil)
+}
+
+runAllTests()
+


### PR DESCRIPTION
This allows us to layout-optimize Optional<T> when T is a struct with an extra-inhabitant-bearing field anywhere in its definition, not only at the beginning. Since runtime struct layout instantiation does not yet handle this, limit the effect only to structs whose layout is always completely known at compile time independent of their type parameters. rdar://problem/19690160