### PR TITLE
XFAIL TestJSONEncoder.swift on armv7k

### DIFF
--- a/test/stdlib/TestJSONEncoder.swift
+++ b/test/stdlib/TestJSONEncoder.swift
@@ -10,6 +10,9 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
+// SR-8276
+// XFAIL: CPU=armv7k
+
 import Swift
 import Foundation
 


### PR DESCRIPTION
The workaround in #16238 does not seem to work for armv7k.

rdar://43145346
SR-8276