### PR TITLE
[TBDGen] Set tbd files to two-level namespace and explicitly set dylib compatibility version to 1

### DIFF
--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -422,6 +422,8 @@ static void enumeratePublicSymbolsAndWrite(ModuleDecl *M, FileUnit *singleFile,
   tapi::internal::InterfaceFile file;
   file.setFileType(tapi::internal::FileType::TBD_V3);
   file.setInstallName(opts.InstallName);
+  file.setCompatibilityVersion(tapi::internal::PackedVersion(1, 0, 0));
+  file.setTwoLevelNamespace();
   // FIXME: proper version
   file.setCurrentVersion(tapi::internal::PackedVersion(1, 0, 0));
   file.setSwiftABIVersion(TAPI_SWIFT_ABI_VERSION);


### PR DESCRIPTION
Fixes rdar://43151135