### PR TITLE
[Serialization] Don't walk into function bodies for doc comments

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4628,9 +4628,9 @@ static void writeDeclCommentTable(
         return true;
 
       RawComment Raw = VD->getRawComment();
-      // When building the stdlib we intend to
-      // serialize unusual comments.  This situation is represented by
-      // GroupContext.isEnable().  In that case, we perform fewer serialization checks.
+      // When building the stdlib we intend to serialize unusual comments.
+      // This situation is represented by GroupContext.isEnable().  In that
+      // case, we perform fewer serialization checks.
       if (!GroupContext.isEnable()) {
         // Skip the decl if it cannot have a comment.
         if (!VD->canHaveComment()) {
@@ -4641,11 +4641,11 @@ static void writeDeclCommentTable(
         if (Raw.Comments.empty())
           return true;
 
-        // Skip the decl if it's not visible to clients.
-        // The use of getEffectiveAccess is unusual here;
-        // we want to take the testability state into account
-        // and emit documentation if and only if they are visible to clients
-        // (which means public ordinarily, but public+internal when testing enabled).
+        // Skip the decl if it's not visible to clients. The use of
+        // getEffectiveAccess is unusual here; we want to take the testability
+        // state into account and emit documentation if and only if they are
+        // visible to clients (which means public ordinarily, but
+        // public+internal when testing enabled).
         if (VD->getEffectiveAccess() < swift::AccessLevel::Public)
           return true;
       }
@@ -4664,6 +4664,18 @@ static void writeDeclCommentTable(
                          SourceOrder++ });
       return true;
     }
+
+    std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
+      return { false, S };
+    }
+
+    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+      return { false, E };
+    }
+
+    bool walkToTypeLocPre(TypeLoc &TL) override { return false; }
+    bool walkToTypeReprPre(TypeRepr *T) override { return false; }
+    bool walkToParameterListPre(ParameterList *PL) override { return false; }
   };
 
   DeclCommentTableWriter Writer(GroupContext);

--- a/test/Serialization/Inputs/comments-params.json
+++ b/test/Serialization/Inputs/comments-params.json
@@ -1,0 +1,5 @@
+{
+  "Dummy": [
+    "comments-params.swift"
+  ]
+}

--- a/test/Serialization/comments-params.swift
+++ b/test/Serialization/comments-params.swift
@@ -1,0 +1,21 @@
+// Swiftdoc emission used to include entries for all the function parameters in
+// the file too if a group info file was provided.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -module-name comments -emit-module -emit-module-path %t/comments.swiftmodule -emit-module-doc -emit-module-doc-path %t/comments.swiftdoc -group-info-path %S/Inputs/comments-params.json %s
+// RUN: strings %t/comments.swiftdoc > %t.txt
+// RUN: %FileCheck %s < %t.txt
+// RUN: %FileCheck -check-prefix NEGATIVE %s < %t.txt
+
+// CHECK-DAG: s:8comments4good
+// CHECK-DAG: Good comment
+// NEGATIVE-NOT: BAD_PARAM_NAME
+// NEGATIVE-NOT: BAD_LOCAL_FUNC
+// NEGATIVE-NOT: Bad comment
+
+/// Good comment
+public func good<T>(_ BAD_PARAM_NAME: T) -> T {
+  /// Bad comment
+  func BAD_LOCAL_FUNC() {}
+  return BAD_PARAM_NAME
+}


### PR DESCRIPTION
Actually, the biggest win here seems to be not recording parameters, which were taking up a ridiculous amount of space in the generated swiftdoc. This change takes Swift.swiftdoc from 5MB to 3.5MB.