### PR TITLE
Serialization: Remove an old hack concerning GenericParamLists in SILFunctions

### DIFF
--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -506,8 +506,7 @@ private:
 
   /// Main logic of getDeclChecked.
   llvm::Expected<Decl *>
-  getDeclCheckedImpl(serialization::DeclID DID,
-                     Optional<DeclContext *> ForcedContext = None);
+  getDeclCheckedImpl(serialization::DeclID DID);
 
   /// Reads the index block, which contains global tables.
   ///
@@ -796,23 +795,15 @@ public:
   /// Returns the decl with the given ID, deserializing it if needed.
   ///
   /// \param DID The ID for the decl within this module.
-  /// \param ForcedContext Optional override for the decl context of certain
-  ///                      kinds of decls, used to avoid re-entrant
-  ///                      deserialization.
-  ///
+
   /// \sa getDeclChecked
-  Decl *getDecl(serialization::DeclID DID,
-                Optional<DeclContext *> ForcedContext = None);
+  Decl *getDecl(serialization::DeclID DID);
 
   /// Returns the decl with the given ID, deserializing it if needed.
   ///
   /// \param DID The ID for the decl within this module.
-  /// \param ForcedContext Optional override for the decl context of certain
-  ///                      kinds of decls, used to avoid re-entrant
-  ///                      deserialization.
   llvm::Expected<Decl *>
-  getDeclChecked(serialization::DeclID DID,
-                 Optional<DeclContext *> ForcedContext = None);
+  getDeclChecked(serialization::DeclID DID);
 
   /// Returns the decl context with the given ID, deserializing it if needed.
   DeclContext *getDeclContext(serialization::DeclContextID DID);

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t VERSION_MINOR = 432; // Last change: default argument text
+const uint16_t VERSION_MINOR = 433; // Last change: GenericTypeParamDecl doesn't need a DC
 
 using DeclIDField = BCFixed<31>;
 
@@ -871,7 +871,6 @@ namespace decls_block {
   using GenericTypeParamDeclLayout = BCRecordLayout<
     GENERIC_TYPE_PARAM_DECL,
     IdentifierIDField,  // name
-    DeclContextIDField, // context decl
     BCFixed<1>,         // implicit flag
     BCVBR<4>,           // depth
     BCVBR<4>            // index

--- a/lib/ClangImporter/ClangAdapter.h
+++ b/lib/ClangImporter/ClangAdapter.h
@@ -19,7 +19,6 @@
 #define CLANG_ADAPTER_H
 
 #include "swift/Basic/StringExtras.h"
-#include "swift/Serialization/ModuleFormat.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "clang/Basic/Specifiers.h"

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2918,12 +2918,9 @@ void Serializer::writeDecl(const Decl *D) {
     auto genericParam = cast<GenericTypeParamDecl>(D);
     verifyAttrSerializable(genericParam);
 
-    auto contextID = addDeclContextRef(genericParam->getDeclContext());
-
     unsigned abbrCode = DeclTypeAbbrCodes[GenericTypeParamDeclLayout::Code];
     GenericTypeParamDeclLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                 addDeclBaseNameRef(genericParam->getName()),
-                                contextID,
                                 genericParam->isImplicit(),
                                 genericParam->getDepth(),
                                 genericParam->getIndex());


### PR DESCRIPTION
Around Swift 3.1/4.0, @DougGregor and I completely banished GenericParamLists and "out of context" archetypes from SIL, so I don't think this bad case can happen anymore because a SIL function cannot reference another declaration's generic parameter.