### PR TITLE
[WIP] IRGen: Use prefab value witness tables for uninhabited and @objc enums.

### DIFF
--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -983,18 +983,28 @@ getAddrOfKnownValueWitnessTable(IRGenModule &IGM, CanType type) {
   
   if (auto nom = type->getAnyNominal()) {
     // TODO: Generic metadata patterns relative-reference their VWT, which won't
-    // work if it's in a different module without supporting indirection through
-    // the GOT.
+    // work if the VWT is in a different module without supporting indirection
+    // through the GOT.
     if (nom->isGenericContext())
       return nullptr;
-    // TODO: Enums need additional value witnesses for their tag manipulation.
-    if (isa<EnumDecl>(nom))
-      return nullptr;
+    // TODO: Non-C enums have extra inhabitants and also need additional value
+    // witnesses for their tag manipulation (except when they're empty, in
+    // which case values never exist to witness).
+    if (auto enumDecl = dyn_cast<EnumDecl>(nom))
+      if (!enumDecl->isObjC() && !type->isUninhabited())
+        return nullptr;
   }
-  
+ 
+  auto &C = IGM.Context;
+
   type = getFormalTypeInContext(type);
   
   auto &ti = IGM.getTypeInfoForUnlowered(AbstractionPattern::getOpaque(), type);
+
+  // Empty types can use empty tuple witnesses.
+  if (ti.isKnownEmpty(ResilienceExpansion::Maximal))
+    return IGM.getAddrOfValueWitnessTable(TupleType::getEmpty(C));
+
   // We only have witnesses for fixed type info.
   auto *fixedTI = dyn_cast<FixedTypeInfo>(&ti);
   if (!fixedTI)
@@ -1003,7 +1013,6 @@ getAddrOfKnownValueWitnessTable(IRGenModule &IGM, CanType type) {
   CanType witnessSurrogate;
 
   // Handle common POD type layouts.
-  auto &C = type->getASTContext();
   ReferenceCounting refCounting;
   if (fixedTI->isPOD(ResilienceExpansion::Maximal)
       && fixedTI->getFixedExtraInhabitantCount(IGM) == 0) {

--- a/test/IRGen/empty_enum.swift
+++ b/test/IRGen/empty_enum.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s
+
+// CHECK: @"$S10empty_enum6JamaisOMf" =
+//   CHECK-SAME: @"$SytWV"
+
+enum Jamais {}

--- a/test/IRGen/objc_ns_enum.swift
+++ b/test/IRGen/objc_ns_enum.swift
@@ -8,9 +8,9 @@
 import Foundation
 import gizmo
 
-// CHECK: @"$SSo16NSRuncingOptionsVWV" = linkonce_odr hidden constant
 // CHECK: @"$SSo16NSRuncingOptionsVMn" = linkonce_odr hidden constant
 // CHECK: @"$SSo16NSRuncingOptionsVN" = linkonce_odr hidden constant
+//   CHECK-SAME: @"$SBi{{[0-9]+}}_WV"
 // CHECK: @"$SSo16NSRuncingOptionsVSQSCMc" = linkonce_odr hidden constant %swift.protocol_conformance_descriptor { {{.*}}@"$SSo16NSRuncingOptionsVSQSCWa
 // CHECK: @"$SSo28NeverActuallyMentionedByNameVSQSCWp" = linkonce_odr hidden constant
 


### PR DESCRIPTION
@objc enums don't support reflection and aren't given extra inhabitants, so we never in practice use their enum value witnesses (and the ones we generated were wrong!), and we can share the prefab value witnesses for the builtin integer types for C enums. All uninhabited types like Never can also share an arbitrary value witness table; the value witnesses will never be invoked.