### PR TITLE
[stdlib] Remove the `UnboundedRange_` enum

### DIFF
--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -827,22 +827,7 @@ extension Comparable {
 ///     let word2 = "grisly"
 ///     let changes = countLetterChanges(word1[...], word2[...])
 ///     // changes == 2
-@_frozen // namespace
-public enum UnboundedRange_ {
-  // FIXME: replace this with a computed var named `...` when the language makes
-  // that possible.
-
-  /// Creates an unbounded range expression.
-  ///
-  /// The unbounded range operator (`...`) is valid only within a collection's
-  /// subscript.
-  public static postfix func ... (_: UnboundedRange_) -> () {
-    // This function is uncallable
-  }
-}
-
-/// The type of an unbounded range operator.
-public typealias UnboundedRange = (UnboundedRange_)->()
+public typealias UnboundedRange = (Never) -> PartialRangeFrom<Never>
 
 extension Collection {
   /// Accesses the contiguous subrange of the collection's elements specified

--- a/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-abi.swift.expected
@@ -73,3 +73,5 @@ Var _RawDictionaryStorage.empty has declared type change from _EmptyDictionarySi
 Var _RawSetStorage.empty has declared type change from _EmptySetSingleton to __EmptySetSingleton
 
 Func tryReallocateUniquelyReferenced(buffer:newMinimumCapacity:) has been removed
+
+Enum UnboundedRange_ has been removed

--- a/test/api-digester/Outputs/stability-stdlib-source.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source.swift.expected
@@ -1,1 +1,4 @@
 Func tryReallocateUniquelyReferenced(buffer:newMinimumCapacity:) has been removed
+
+/* FIXME(SR-9283): TypeAlias UnboundedRange has underlying type change from (UnboundedRange_) -> () to (Never) -> PartialRangeFrom<Never> */
+Enum UnboundedRange_ has been removed

--- a/test/type/types.swift
+++ b/test/type/types.swift
@@ -20,7 +20,7 @@ var d4 : () -> Int = { d2 }  // expected-error{{function produces expected type 
 
 var e0 : [Int]
 e0[] // expected-error {{cannot subscript a value of type '[Int]' with an index of type '()'}}
-  // expected-note @-1 {{overloads for 'subscript' exist with these partially matching parameter lists: ((UnboundedRange_) -> ()), (Int), (R), (Range<Int>), (Range<Self.Index>)}}
+  // expected-note @-1 {{overloads for 'subscript' exist with these partially matching parameter lists: ((Never) -> PartialRangeFrom<Never>), (Int), (R), (Range<Int>), (Range<Self.Index>)}}
 
 var f0 : [Float]
 var f1 : [(Int,Int)]


### PR DESCRIPTION
This pull request changes the `UnboundedRange` typealias to `(Never) -> PartialRangeFrom<Never>`, using the `Never: Comparable` conformance from [SE-0215][].

[SE-0215]: <https://github.com/apple/swift-evolution/blob/master/proposals/0215-conform-never-to-hashable-and-equatable.md>