### PR TITLE
Added SROA support in deabastraction, which allows us to const-evaluate individual struct fields, even when other fields in the same struct are not const.

### DIFF
--- a/include/swift/SILOptimizer/Utils/Local.h
+++ b/include/swift/SILOptimizer/Utils/Local.h
@@ -656,7 +656,7 @@ void promoteAllocsToSSA(ArrayRef<AllocStackInst*> allocs,
 
 // SWIFT_ENABLE_TENSORFLOW
 /// Run scalar-replacement-of-aggregate on the input set of instructions.
-bool runSROAOnInsts(llvm::ArrayRef<AllocStackInst *> Worklist);
+bool runSROAOnInsts(ArrayRef<AllocStackInst *> Insts);
 
 } // end namespace swift
 

--- a/include/swift/SILOptimizer/Utils/Local.h
+++ b/include/swift/SILOptimizer/Utils/Local.h
@@ -654,6 +654,10 @@ protected:
 void promoteAllocsToSSA(ArrayRef<AllocStackInst*> allocs,
                         DominanceInfo *domInfo);
 
+// SWIFT_ENABLE_TENSORFLOW
+/// Run scalar-replacement-of-aggregate on the input set of instructions.
+bool runSROAOnInsts(llvm::ArrayRef<AllocStackInst *> Worklist);
+
 } // end namespace swift
 
 #endif

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -4460,6 +4460,11 @@ void TFPartition::run() {
 bool TFPartition::processFunction(
     SILFunction *hostFn,
     SmallVectorImpl<HostPartitionContext> &hostPartitionContexts) {
+  // If something crashes, make sure the pretty stack trace says what we
+  // were doing.
+  llvm::PrettyStackTraceFormat X("TFPartition on function %s",
+                                 hostFn->getName().str().c_str());
+
   std::unique_ptr<TFFunctionPartition> partitioner;
   if (partitionFunction(hostFn, partitioner)) {
     return true; // error already emitted.

--- a/lib/SILOptimizer/Transforms/SILSROA.cpp
+++ b/lib/SILOptimizer/Transforms/SILSROA.cpp
@@ -287,10 +287,9 @@ void SROAMemoryUseAnalyzer::chopUpAlloca(
   eraseFromParentWithDebugInsts(AI);
 }
 
-bool swift::runSROAOnInsts(llvm::ArrayRef<AllocStackInst *> Worklist) {
+bool swift::runSROAOnInsts(ArrayRef<AllocStackInst *> Insts) {
   bool Changed = false;
-  llvm::SmallVector<AllocStackInst *, 16> WorklistVec(Worklist.begin(),
-                                                      Worklist.end());
+  SmallVector<AllocStackInst *, 16> WorklistVec(Insts.begin(), Insts.end());
   while (!WorklistVec.empty()) {
     AllocStackInst *AI = WorklistVec.back();
     WorklistVec.pop_back();
@@ -307,7 +306,7 @@ bool swift::runSROAOnInsts(llvm::ArrayRef<AllocStackInst *> Worklist) {
 }
 
 static bool runSROAOnFunction(SILFunction &Fn) {
-  llvm::SmallVector<AllocStackInst *, 16> Worklist;
+  SmallVector<AllocStackInst *, 16> Worklist;
 
   // For each basic block BB in Fn...
   for (auto &BB : Fn)

--- a/test/TensorFlow/deabstraction_finished.swift
+++ b/test/TensorFlow/deabstraction_finished.swift
@@ -173,6 +173,10 @@ struct SimpleIterator {
 public func testShapeList2() {
   let t = Tensor<Int32>([0])
   let handle: VariantHandle = #tfop(
+    "TensorSliceDataset", [t],
+    Toutput_types: [Int32.self],
+    output_shapes: [TensorShape()]
+  )
   let dataset = SimpleDataset(handle: handle, elementShape: TensorShape())
   let resource = #tfop("AnonymousIterator",
                        output_types: [Int32.self],

--- a/test/TensorFlow/deabstraction_finished.swift
+++ b/test/TensorFlow/deabstraction_finished.swift
@@ -158,6 +158,30 @@ public func testShapeList() {
             output_shapes: [dataset.elementShape]) as ResourceHandle
 }
 
+// Another test case for SR-8463.
+struct SimpleIterator {
+  let handle: ResourceHandle
+  let elementShape: TensorShape
+
+  mutating func next() -> Tensor<Float> {
+    return #tfop("IteratorGetNext", handle,
+                 output_types: [Int32.self],
+                 output_shapes: [elementShape])
+  }
+}
+
+public func testShapeList2() {
+  let t = Tensor<Int32>([0])
+  let handle: VariantHandle = #tfop(
+  let dataset = SimpleDataset(handle: handle, elementShape: TensorShape())
+  let resource = #tfop("AnonymousIterator",
+                       output_types: [Int32.self],
+                       output_shapes: [dataset.elementShape]) as ResourceHandle
+
+  var it = SimpleIterator(handle: resource, elementShape: dataset.elementShape)
+  _ = it.next()
+}
+
 // CHECK-LABEL: ---- INPUT FUNCTION {{.*}}testShapeList
 // CHECK: graph_op "AnonymousIterator"() {output_types: [$Int32.Type: $Int32], output_shapes: [$TensorShape: ([$Int32: ])]
 


### PR DESCRIPTION
This is a more thorough fix to https://bugs.swift.org/browse/SR-8463, based on
discussion with @lattner and other team members.

Improved deabstraction and reduced sends/recvs in some compiler tests under `-Onone`!

The changes to SILSROA.cpp can be upstreamed if needed.
