### PR TITLE
New way of directly building FunctionType::Params from ParameterLists

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5772,8 +5772,8 @@ public:
   }
 
   /// Set the interface type of this enum element to the constructor function
-  /// type; (Self) -> Result or (Self) -> (Args...) -> Result.
-  bool computeType();
+  /// type; (Self.Type) -> Self or (Self.Type) -> (Args...) -> Self.
+  void computeType();
 
   Type getArgumentInterfaceType() const;
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4729,10 +4729,6 @@ public:
   /// was specified separately from the parameter name.
   SourceLoc getArgumentNameLoc() const { return ArgumentNameLoc; }
   
-  /// Retrieve the parameter type flags corresponding to the declaration of
-  /// this parameter's argument type.
-  ParameterTypeFlags getParameterFlags() const;
-  
   SourceLoc getSpecifierLoc() const { return SpecifierLoc; }
     
   bool isTypeLocImplicit() const { return Bits.ParamDecl.IsTypeLocImplicit; }

--- a/include/swift/AST/ParameterList.h
+++ b/include/swift/AST/ParameterList.h
@@ -132,24 +132,6 @@ public:
   void getParams(SmallVectorImpl<AnyFunctionType::Param> &params,
                  llvm::function_ref<Type(ParamDecl *)> getType) const;
 
-  /// Return a TupleType or ParenType for this parameter list,
-  /// based on types provided by a callback.
-  Type getType(const ASTContext &C,
-               llvm::function_ref<Type(ParamDecl *)> getType) const;
-
-  /// Return a TupleType or ParenType for this parameter list, written in terms
-  /// of contextual archetypes.
-  Type getType(const ASTContext &C) const;
-
-  /// Return a TupleType or ParenType for this parameter list, written in terms
-  /// of interface types.
-  Type getInterfaceType(const ASTContext &C) const;
-
-  /// Return the full function type for a set of curried parameter lists that
-  /// returns the specified result type written in terms of interface types.
-  static Type getFullInterfaceType(Type resultType, ArrayRef<ParameterList*> PL,
-                                   const ASTContext &C);
-
 
   /// Return the full source range of this parameter.
   SourceRange getSourceRange() const;

--- a/include/swift/AST/ParameterList.h
+++ b/include/swift/AST/ParameterList.h
@@ -123,6 +123,15 @@ public:
   ParameterList *clone(const ASTContext &C,
                        OptionSet<CloneFlags> options = None) const;
 
+  /// Return a list of function parameters for this parameter list,
+  /// based on the interface types of the parameters in this list.
+  void getParams(SmallVectorImpl<AnyFunctionType::Param> &params) const;
+
+  /// Return a list of function parameters for this parameter list,
+  /// based on types provided by a callback.
+  void getParams(SmallVectorImpl<AnyFunctionType::Param> &params,
+                 llvm::function_ref<Type(ParamDecl *)> getType) const;
+
   /// Return a TupleType or ParenType for this parameter list,
   /// based on types provided by a callback.
   Type getType(const ASTContext &C,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4799,11 +4799,6 @@ ParamDecl *ParamDecl::createSelf(SourceLoc loc, DeclContext *DC,
   return selfDecl;
 }
 
-ParameterTypeFlags ParamDecl::getParameterFlags() const {
-  return ParameterTypeFlags::fromParameterType(getType(), isVariadic(),
-                                               getValueOwnership());
-}
-
 /// Return the full source range of this parameter.
 SourceRange ParamDecl::getSourceRange() const {
   SourceLoc APINameLoc = getArgumentNameLoc();

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1632,10 +1632,7 @@ ImportedType ClangImporter::Implementation::importFunctionType(
   if (clangDecl->isNoReturn())
     swiftResultTy = SwiftContext.getNeverType();
 
-  // Form the function type.
-  auto argTy = parameterList->getType(SwiftContext);
-  auto fnTy = FunctionType::get(argTy, swiftResultTy);
-  return {fnTy, importedType.isImplicitlyUnwrapped()};
+  return {swiftResultTy, importedType.isImplicitlyUnwrapped()};
 }
 
 ParameterList *ClangImporter::Implementation::importFunctionParameterList(
@@ -2196,20 +2193,13 @@ ImportedType ClangImporter::Implementation::importMethodType(
     swiftResultTy = SwiftContext.getNeverType();
   }
 
-  FunctionType::ExtInfo extInfo;
-
   if (errorInfo) {
     foreignErrorInfo = getForeignErrorInfo(*errorInfo, errorParamType,
                                            origSwiftResultTy);
-
-    // Mark that the function type throws.
-    extInfo = extInfo.withThrows(true);
   }
 
-  // Form the function type.
-  auto fnTy = FunctionType::get((*bodyParams)->getInterfaceType(SwiftContext),
-                                swiftResultTy->mapTypeOutOfContext(), extInfo);
-  return {fnTy, importedType.isImplicitlyUnwrapped()};
+  return {swiftResultTy->mapTypeOutOfContext(),
+          importedType.isImplicitlyUnwrapped()};
 }
 
 ImportedType ClangImporter::Implementation::importAccessorMethodType(
@@ -2269,9 +2259,7 @@ ImportedType ClangImporter::Implementation::importAccessorMethodType(
     isIUO = false;
   }
 
-  auto fnTy =
-      FunctionType::get((*params)->getInterfaceType(SwiftContext), resultTy);
-  return {fnTy, isIUO};
+  return {resultTy, isIUO};
 }
 
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1889,17 +1889,14 @@ getForeignErrorInfo(ForeignErrorConvention::Info errorInfo,
   llvm_unreachable("bad error convention");
 }
 
-// Sometimes re-mapping type from one context to another is required,
-// because the other context might have some of the generic parameters
-// bound to concerete types, which means that we might loose generic
-// signature when converting from class method to constructor and that
-// is going to result in incorrect type interpretation of the method.
-static Type mapTypeIntoContext(const DeclContext *fromDC,
-                               const DeclContext *toDC, Type type) {
+// 'toDC' must be a subclass or a type conforming to the protocol
+// 'fromDC'.
+static Type mapGenericArgs(const DeclContext *fromDC,
+                           const DeclContext *toDC, Type type) {
   if (fromDC == toDC)
-    return toDC->mapTypeIntoContext(type);
+    return type;
 
-  auto subs = toDC->getDeclaredTypeInContext()->getContextSubstitutionMap(
+  auto subs = toDC->getDeclaredInterfaceType()->getContextSubstitutionMap(
                                             toDC->getParentModule(), fromDC);
   return type.subst(subs);
 }
@@ -1999,7 +1996,7 @@ ImportedType ClangImporter::Implementation::importMethodType(
   if (!swiftResultTy)
     return {Type(), false};
 
-  swiftResultTy = mapTypeIntoContext(origDC, dc, swiftResultTy);
+  swiftResultTy = mapGenericArgs(origDC, dc, swiftResultTy);
 
   CanType errorParamType;
 
@@ -2095,7 +2092,7 @@ ImportedType ClangImporter::Implementation::importMethodType(
     if (!swiftParamTy)
       return {Type(), false};
 
-    swiftParamTy = mapTypeIntoContext(origDC, dc, swiftParamTy);
+    swiftParamTy = mapGenericArgs(origDC, dc, swiftParamTy);
 
     // If this is the error parameter, remember it, but don't build it
     // into the parameter type.
@@ -2140,7 +2137,7 @@ ImportedType ClangImporter::Implementation::importMethodType(
                                            importSourceLoc(param->getLocation()),
                                            bodyName,
                                            ImportedHeaderUnit);
-    paramInfo->setInterfaceType(swiftParamTy->mapTypeOutOfContext());
+    paramInfo->setInterfaceType(swiftParamTy);
     recordImplicitUnwrapForDecl(paramInfo, paramIsIUO);
 
     // Determine whether we have a default argument.
@@ -2198,7 +2195,7 @@ ImportedType ClangImporter::Implementation::importMethodType(
                                            origSwiftResultTy);
   }
 
-  return {swiftResultTy->mapTypeOutOfContext(),
+  return {swiftResultTy,
           importedType.isImplicitlyUnwrapped()};
 }
 
@@ -2231,14 +2228,14 @@ ImportedType ClangImporter::Implementation::importAccessorMethodType(
   if (!importedType)
     return {Type(), false};
 
-  auto propertyTy = mapTypeIntoContext(origDC, dc, importedType.getType());
+  auto propertyTy = mapGenericArgs(origDC, dc, importedType.getType());
   bool isIUO = importedType.isImplicitlyUnwrapped();
 
   // Now build up the resulting FunctionType and parameters.
   Type resultTy;
   if (isGetter) {
     *params = ParameterList::createEmpty(SwiftContext);
-    resultTy = propertyTy->mapTypeOutOfContext();
+    resultTy = propertyTy;
   } else {
     const clang::ParmVarDecl *param = clangDecl->parameters().front();
     ImportedName fullBodyName = importFullName(param, CurrentVersion);
@@ -2252,7 +2249,7 @@ ImportedType ClangImporter::Implementation::importAccessorMethodType(
                                            /*label loc*/SourceLoc(),
                                            argLabel, nameLoc, bodyName,
                                            /*dummy DC*/ImportedHeaderUnit);
-    paramInfo->setInterfaceType(propertyTy->mapTypeOutOfContext());
+    paramInfo->setInterfaceType(propertyTy);
 
     *params = ParameterList::create(SwiftContext, paramInfo);
     resultTy = SwiftContext.getVoidDecl()->getDeclaredInterfaceType();

--- a/lib/Sema/TypeCheckREPL.cpp
+++ b/lib/Sema/TypeCheckREPL.cpp
@@ -242,9 +242,11 @@ void REPLChecker::generatePrintOfExpression(StringRef NameStr, Expr *E) {
       new (Context) ClosureExpr(params, SourceLoc(), SourceLoc(), SourceLoc(),
                                 TypeLoc(), discriminator, newTopLevel);
 
-  CE->setType(ParameterList::getFullInterfaceType(
-      TupleType::getEmpty(Context), params, Context));
-  
+  SmallVector<AnyFunctionType::Param, 1> args;
+  params->getParams(args);
+  CE->setType(FunctionType::get(args, TupleType::getEmpty(Context),
+                                FunctionType::ExtInfo()));
+
   // Convert the pattern to a string we can print.
   llvm::SmallString<16> PrefixString;
   PrefixString += "// ";

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -485,14 +485,21 @@
                 },
                 {
                   "kind": "TypeNominal",
-                  "name": "Metatype",
-                  "printedName": "Number.Type",
+                  "name": "Paren",
+                  "printedName": "(Number.Type)",
                   "children": [
                     {
                       "kind": "TypeNominal",
-                      "name": "Number",
-                      "printedName": "Number",
-                      "usr": "s:4cake6NumberO"
+                      "name": "Metatype",
+                      "printedName": "Number.Type",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Number",
+                          "printedName": "Number",
+                          "usr": "s:4cake6NumberO"
+                        }
+                      ]
                     }
                   ]
                 }


### PR DESCRIPTION
Recent changes centralized the code for computing the type of functions, subscripts, and enum elements. This removed a lot of duplication but there was still a hack there because to go from a ParameterList to a FunctionType, we had to turn the ParameterList into a TupleType, and then decompose the TupleType into an array of FunctionType::Params. That's silly, so let's make a way to build FunctionType::Params directly and remove all of the old code.