### PR TITLE
[ConstExpr] Support const-evaluating `thin_to_thick_function` and `convert_function`.

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
@@ -196,6 +196,12 @@ SymbolicValue ConstExprFunctionState::computeConstantValue(SILValue value) {
 
   if (auto *fri = dyn_cast<FunctionRefInst>(value))
     return SymbolicValue::getFunction(fri->getReferencedFunction());
+  
+  if (auto *tttfi = dyn_cast<ThinToThickFunctionInst>(value))
+    return getConstantValue(tttfi->getOperand());
+
+  if (auto *cfi = dyn_cast<ConvertFunctionInst>(value))
+    return getConstantValue(cfi->getOperand());
 
   // If we have a reference to a metatype, constant fold any substitutable
   // types.


### PR DESCRIPTION
When a function is passed as a `@noescape` closure argument, `convert_function` is being used to convert a normal (escaping) function type to a `@noescape` type. Constexpr is now extended to handle function conversion instructions: `convert_function` and `thin_to_thick_function`.

On the TensorFlow side, `@TensorFlowGraph` functions, just like any other top-level functions, are not `@noescape`. When higher-order functions' closure arguments are used as `#tfop` attributes, they should be constant-evaluated.

Resolves [SR-8520](https://bugs.swift.org/browse/SR-8520).