### PR TITLE
[build-script] Don't clobber PKG_CONFIG_PATH

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2587,7 +2587,7 @@ for host in "${ALL_HOSTS[@]}"; do
 
                 # Set the PKG_CONFIG_PATH so that core-foundation can find the libraries and
                 # header files
-                export PKG_CONFIG_PATH="${ICU_TMPLIBDIR}/pkgconfig"
+                export PKG_CONFIG_PATH="${ICU_TMPLIBDIR}/pkgconfig:${PKG_CONFIG_PATH}"
                 swift_cmake_options=(
                     "${swift_cmake_options[@]}"
                     -DSWIFT_${SWIFT_HOST_VARIANT_SDK}_${SWIFT_HOST_VARIANT_ARCH}_ICU_UC_INCLUDE:STRING="${ICU_TMPINSTALL}/include"


### PR DESCRIPTION
Overwriting this variable can cause the build to break when pkg-config tries to find packages that aren't ICU. Prepending the ICU path so it takes precedence is a less fragile solution.

My builds failed when building Swift on CentOS until I tried this patch.