### PR TITLE
[DNM] [stdlib] Improvements to RandomNumberGenerator

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -144,8 +144,8 @@ SWIFT_READNONE SWIFT_RUNTIME_STDLIB_INTERNAL
 __swift_size_t _stdlib_malloc_size(const void *ptr);
 
 // Random number for stdlib
-SWIFT_RUNTIME_STDLIB_INTERNAL
-void _stdlib_random(void *buf, __swift_size_t nbytes);
+SWIFT_RUNTIME_STDLIB_API
+void swift_stdlib_random(void *buf, __swift_size_t nbytes);
 
 // Math library functions
 static inline SWIFT_ALWAYS_INLINE

--- a/stdlib/public/core/CollectionAlgorithms.swift
+++ b/stdlib/public/core/CollectionAlgorithms.swift
@@ -451,7 +451,6 @@ extension MutableCollection where Self : RandomAccessCollection {
   public mutating func shuffle<T: RandomNumberGenerator>(
     using generator: inout T
   ) {
-    let count = self.count
     guard count > 1 else { return }
     var amount = count
     var currentIndex = startIndex

--- a/stdlib/public/core/Random.swift
+++ b/stdlib/public/core/Random.swift
@@ -63,28 +63,41 @@ public protocol RandomNumberGenerator {
   mutating func next() -> UInt64
 
   // FIXME: De-underscore after swift-evolution amendment
-  mutating func _fill(bytes buffer: UnsafeMutableRawBufferPointer)
+  mutating func fillBytes(_ buffer: UnsafeMutableRawBufferPointer)
 }
 
 extension RandomNumberGenerator {
+  
   @inlinable
-  public mutating func _fill(bytes buffer: UnsafeMutableRawBufferPointer) {
-    // FIXME: Optimize
-    var chunk: UInt64 = 0
-    var chunkBytes = 0
-    for i in 0..<buffer.count {
-      if chunkBytes == 0 {
-        chunk = next()
-        chunkBytes = UInt64.bitWidth / 8
-      }
-      buffer[i] = UInt8(truncatingIfNeeded: chunk)
-      chunk >>= UInt8.bitWidth
-      chunkBytes -= 1
+  public mutating func fillBytes(_ buffer: UnsafeMutableRawBufferPointer) {
+    guard let dest = buffer.baseAddress else {
+      return
     }
+    
+    let blocks = buffer.count / MemoryLayout<UInt64>.size
+    
+    for i in 0 ..< blocks {
+      buffer.storeBytes(
+        of: next(),
+        toByteOffset: i * MemoryLayout<UInt64>.size,
+        as: UInt64.self
+      )
+    }
+    
+    let bytesWritten = blocks * MemoryLayout<UInt64>.size
+    
+    guard bytesWritten != buffer.count else {
+      return
+    }
+    
+    var tmp = next()
+    _memcpy(
+      dest: dest.advanced(by: bytesWritten),
+      src: &tmp,
+      size: UInt(buffer.count - blocks)
+    )
   }
-}
-
-extension RandomNumberGenerator {
+  
   /// Returns a value from a uniform, independent distribution of binary data.
   ///
   /// Use this method when you need random binary data to generate another
@@ -95,7 +108,7 @@ extension RandomNumberGenerator {
   /// - Returns: A random value of `T`. Bits are randomly distributed so that
   ///   every value of `T` is equally likely to be returned.
   @inlinable
-  public mutating func next<T: FixedWidthInteger & UnsignedInteger>() -> T {
+  public mutating func next<T: FixedWidthInteger>() -> T {
     return T._random(using: &self)
   }
 
@@ -111,10 +124,10 @@ extension RandomNumberGenerator {
   /// - Returns: A random value of `T` in the range `0..<upperBound`. Every
   ///   value in the range `0..<upperBound` is equally likely to be returned.
   @inlinable
-  public mutating func next<T: FixedWidthInteger & UnsignedInteger>(
+  public mutating func next<T: FixedWidthInteger>(
     upperBound: T
   ) -> T {
-    _precondition(upperBound != 0, "upperBound cannot be zero.")
+    _precondition(upperBound > 0, "upperBound must not be lower than zero.")
     let tmp = (T.max % upperBound) + 1
     let range = tmp == upperBound ? 0 : tmp
     var random: T = 0
@@ -164,14 +177,14 @@ public struct SystemRandomNumberGenerator : RandomNumberGenerator {
   @inlinable
   public mutating func next() -> UInt64 {
     var random: UInt64 = 0
-    _stdlib_random(&random, MemoryLayout<UInt64>.size)
+    swift_stdlib_random(&random, MemoryLayout<UInt64>.size)
     return random
   }
 
   @inlinable
-  public mutating func _fill(bytes buffer: UnsafeMutableRawBufferPointer) {
-    if !buffer.isEmpty {
-      _stdlib_random(buffer.baseAddress!, buffer.count)
+  public mutating func fillBytes(_ buffer: UnsafeMutableRawBufferPointer) {
+    if let dest = buffer.baseAddress {
+      swift_stdlib_random(dest, buffer.count)
     }
   }
 }

--- a/stdlib/public/core/Random.swift
+++ b/stdlib/public/core/Random.swift
@@ -94,7 +94,7 @@ extension RandomNumberGenerator {
     _memcpy(
       dest: dest.advanced(by: bytesWritten),
       src: &tmp,
-      size: UInt(buffer.count - blocks)
+      size: UInt(buffer.count - bytesWritten)
     )
   }
   

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -117,8 +117,8 @@ static swift::_SwiftHashingParameters initializeHashingParameters() {
     return { 0, 0, true };
   }
   __swift_uint64_t seed0 = 0, seed1 = 0;
-  swift::_stdlib_random(&seed0, sizeof(seed0));
-  swift::_stdlib_random(&seed1, sizeof(seed1));
+  swift::swift_stdlib_random(&seed0, sizeof(seed0));
+  swift::swift_stdlib_random(&seed1, sizeof(seed1));
   return { seed0, seed1, false };
 }
 

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -298,7 +298,7 @@ size_t swift::_stdlib_malloc_size(const void *ptr) {
 #error No malloc_size analog known for this platform/libc.
 #endif
 
-// _stdlib_random
+// swift_stdlib_random
 //
 // Should the implementation of this function add a new platform/change for a
 // platform, make sure to also update the documentation regarding platform
@@ -307,16 +307,16 @@ size_t swift::_stdlib_malloc_size(const void *ptr) {
 
 #if defined(__APPLE__)
 
-SWIFT_RUNTIME_STDLIB_INTERNAL
-void swift::_stdlib_random(void *buf, __swift_size_t nbytes) {
+SWIFT_RUNTIME_STDLIB_API
+void swift::swift_stdlib_random(void *buf, __swift_size_t nbytes) {
   arc4random_buf(buf, nbytes);
 }
 
 #elif defined(_WIN32) && !defined(__CYGWIN__)
 #warning TODO: Test _stdlib_random on Windows
 
-SWIFT_RUNTIME_STDLIB_INTERNAL
-void swift::_stdlib_random(void *buf, __swift_size_t nbytes) {
+SWIFT_RUNTIME_STDLIB_API
+void swift::swift_stdlib_random(void *buf, __swift_size_t nbytes) {
   NTSTATUS status = BCryptGenRandom(nullptr,
                                     static_cast<PUCHAR>(buf),
                                     static_cast<ULONG>(nbytes),
@@ -344,8 +344,8 @@ void swift::_stdlib_random(void *buf, __swift_size_t nbytes) {
 #define GETRANDOM_AVAILABLE
 #endif
 
-SWIFT_RUNTIME_STDLIB_INTERNAL
-void swift::_stdlib_random(void *buf, __swift_size_t nbytes) {
+SWIFT_RUNTIME_STDLIB_API
+void swift::swift_stdlib_random(void *buf, __swift_size_t nbytes) {
   while (nbytes > 0) {
     __swift_ssize_t actual_nbytes = -1;
 #if defined(GETRANDOM_AVAILABLE)

--- a/validation-test/stdlib/Random.swift
+++ b/validation-test/stdlib/Random.swift
@@ -6,9 +6,9 @@ import StdlibCollectionUnittest
 
 let RandomTests = TestSuite("Random")
 
-// _fill(bytes:)
+// fillBytes(_:)
 
-RandomTests.test("_fill(bytes:)") {
+RandomTests.test("fillBytes(_:)") {
   for count in [100, 1000] {
     var bytes1 = [UInt8](repeating: 0, count: count)
     var bytes2 = [UInt8](repeating: 0, count: count)
@@ -18,11 +18,11 @@ RandomTests.test("_fill(bytes:)") {
     expectEqual(bytes2, zeros)
     
     var g = SystemRandomNumberGenerator()
-    bytes1.withUnsafeMutableBytes { g._fill(bytes: $0) }
+    bytes1.withUnsafeMutableBytes { g.fillBytes($0) }
     expectNotEqual(bytes1, bytes2)
     expectNotEqual(bytes1, zeros)
     
-    bytes2.withUnsafeMutableBytes { g._fill(bytes: $0) }
+    bytes2.withUnsafeMutableBytes { g.fillBytes($0) }
     expectNotEqual(bytes1, bytes2)
     expectNotEqual(bytes2, zeros)
   }
@@ -229,8 +229,6 @@ RandomTests.test("different random number generators") {
 }
 
 // Random floating points with max values (SR-8178)
-
-var lcrng = LCRNG(seed: 1234567890)
 
 public struct RotatingRNG: RandomNumberGenerator {
   public let rotation: [() -> UInt64] = [


### PR DESCRIPTION
This is currently pending evolution proposal. Some of the problems I want to tackle in this proposal are:

1. Introduce `fillBytes(_:)` to `RandomNumberGenerator`
2. Unconstrain `next<T: FixedWidthInteger & UnsignedInteger>` to simply `next<T: FixedWidthInteger>`
3. Fix the bug where implementors of `RandomNumberGenerator` did not have requirements.
```swift
// No compiler complaints about needing to implement `next() -> UInt64`
struct MersenneTwister: RandomNumberGenerator {}
```

I've since already done 1 and 2, but 3 is something I'm still looking at. It could be that the best solution is just renaming the function signature to `next<T>(_ type: T.Type) -> T`, but like I said in the [forum post](https://forums.swift.org/t/trying-to-use-the-new-randomnumbergenerator-protocol/12919/12), the compiler produces some not so user friendly diagnostics. I know these diagnostics are correct, however I'm not sure we want to expose the user to something like this. The only other option is renaming `next() -> UInt64` to something like `nextWord() -> UInt64`.

There are a few other things that I've done in this patch, like clean up a few dead lines of code, and correctly mark `_stdlib_random` (which is now `swift_stdlib_random`).

cc: @stephentyrone  @lorentey 