### PR TITLE
Extended deabstraction to support functions whose params/results are function-typed.

### DIFF
--- a/include/swift/AST/TensorFlow.h
+++ b/include/swift/AST/TensorFlow.h
@@ -73,7 +73,9 @@ namespace tf {
 
     /// Return true if the specified type contains a TensorFlow value type that
     /// will be exposed after deabstraction.
-    bool containsTensorFlowValue(Type ty);
+    /// If `checkHigherOrderFunctions`, also check for a function-typed `ty`, if
+    /// its parameter of result contains any TensorFlow value type.
+    bool containsTensorFlowValue(Type ty, bool checkHigherOrderFunctions);
 
   private:
     bool structContainsTensorFlowValue(StructDecl *decl);

--- a/include/swift/AST/TensorFlow.h
+++ b/include/swift/AST/TensorFlow.h
@@ -74,7 +74,7 @@ namespace tf {
     /// Return true if the specified type contains a TensorFlow value type that
     /// will be exposed after deabstraction.
     /// If `checkHigherOrderFunctions`, also check for a function-typed `ty`, if
-    /// its parameter of result contains any TensorFlow value type.
+    /// its parameter or result contains any TensorFlow value type.
     bool containsTensorFlowValue(Type ty, bool checkHigherOrderFunctions);
 
   private:

--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -1754,11 +1754,13 @@ bool TensorFunctionClassifier::shouldBePartitioned(SILFunction *fn) {
 bool TensorFunctionClassifier::containsTensorFlowValue(
     CanSILFunctionType fnType) {
   for (auto &result : fnType->getResults())
-    if (containsTensorFlowValue(result.getType()))
+    if (containsTensorFlowValue(result.getType(),
+                                /*checkHigherOrderFunctions*/ true))
       return true;
 
   for (auto &param : fnType->getParameters())
-    if (containsTensorFlowValue(param.getType()))
+    if (containsTensorFlowValue(param.getType(),
+                                /*checkHigherOrderFunctions*/ true))
       return true;
 
   return false;

--- a/lib/SILOptimizer/Mandatory/TFUtilities.h
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.h
@@ -350,7 +350,7 @@ public:
   /// Return true if the specified type contains a TensorFlow value type that
   /// will be exposed after deabstraction.
   /// If `checkHigherOrderFunctions`, also check for a function-typed `ty`, if
-  /// its parameter of result contains any TensorFlow value type.
+  /// its parameter or result contains any TensorFlow value type.
   bool containsTensorFlowValue(Type ty, bool checkHigherOrderFunctions) {
     return tctfc.containsTensorFlowValue(ty, checkHigherOrderFunctions);
   }
@@ -358,7 +358,7 @@ public:
   /// Return true if the specified type contains a TensorFlow value type that
   /// will be exposed after deabstraction.
   /// If `checkHigherOrderFunctions`, also check for a function-typed `ty`, if
-  /// its parameter of result contains any TensorFlow value type.
+  /// its parameter or result contains any TensorFlow value type.
   bool containsTensorFlowValue(SILType ty, bool checkHigherOrderFunctions) {
     return containsTensorFlowValue(ty.getASTType(), checkHigherOrderFunctions);
   }

--- a/lib/SILOptimizer/Mandatory/TFUtilities.h
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.h
@@ -342,20 +342,25 @@ public:
   bool shouldBePartitioned(SILFunction *fn);
 
   /// Return true if the specified function type has TensorFlow values in its
-  /// argument or result list, even if they are abstracted by structs or
-  /// tuples.
+  /// argument or result list (and do so recursively, if `fnType` has an
+  /// argument or result that is itself function-typed), even if they are
+  /// abstracted by structs or tuples.
   bool containsTensorFlowValue(CanSILFunctionType fnType);
 
   /// Return true if the specified type contains a TensorFlow value type that
   /// will be exposed after deabstraction.
-  bool containsTensorFlowValue(Type ty) {
-    return tctfc.containsTensorFlowValue(ty);
+  /// If `checkHigherOrderFunctions`, also check for a function-typed `ty`, if
+  /// its parameter of result contains any TensorFlow value type.
+  bool containsTensorFlowValue(Type ty, bool checkHigherOrderFunctions) {
+    return tctfc.containsTensorFlowValue(ty, checkHigherOrderFunctions);
   }
 
   /// Return true if the specified type contains a TensorFlow value type that
   /// will be exposed after deabstraction.
-  bool containsTensorFlowValue(SILType ty) {
-    return containsTensorFlowValue(ty.getASTType());
+  /// If `checkHigherOrderFunctions`, also check for a function-typed `ty`, if
+  /// its parameter of result contains any TensorFlow value type.
+  bool containsTensorFlowValue(SILType ty, bool checkHigherOrderFunctions) {
+    return containsTensorFlowValue(ty.getASTType(), checkHigherOrderFunctions);
   }
 };
 

--- a/test/TensorFlow/deabstraction_finished.swift
+++ b/test/TensorFlow/deabstraction_finished.swift
@@ -181,3 +181,17 @@ public func noescapeFuncAsAttr(_ f: @convention(tensorflow) (Tensor<Float>) -> T
 
 // CHECK-LABEL: ---- INPUT FUNCTION {{.*}}noescapeFuncAsAttr
 // CHECK: graph_op "FilterDataset,i,L,e"(%{{.*}} : $VariantHandle, %{{.*}} : $TensorHandle<Int32>) {predicate: @{{.*}}isZero{{.*}} : $@convention(tensorflow) (@guaranteed Tensor<Float>) -> @owned Tensor<Bool>
+
+// Support higher-order functions that process tensors.
+// foo() is not a partitionable function.
+public func foo(tfOp: () -> Tensor<Float>) {
+  let _ = tfOp()
+}
+
+// Deabstraction should inline foo into bar().
+public func bar() {
+  foo(tfOp: { return Tensor<Float>(1.0) })
+}
+
+// CHECK-LABEL: --- INPUT FUNCTION {{.*}}bar
+// CHECK: graph_op "Const"


### PR DESCRIPTION
This is a prerequisite to deleting code in TFPartition.cpp that handles builtin
tfops. It helps maintain the invariant deabstraction output should only contain
graph_op insts, and no builtin tfops.
