### PR TITLE
Add Frontend.NumInstructions statistic, populated on macOS by rusage_info_v4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -898,6 +898,11 @@ cmake_pop_check_state()
 
 check_symbol_exists(wait4 "sys/wait.h" HAVE_WAIT4)
 
+check_symbol_exists(proc_pid_rusage "libproc.h" HAVE_PROC_PID_RUSAGE)
+if(HAVE_PROC_PID_RUSAGE)
+    list(APPEND CMAKE_REQUIRED_LIBRARIES proc)
+endif()
+
 if (LLVM_ENABLE_DOXYGEN)
   message(STATUS "Doxygen: enabled")
 endif()

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -80,6 +80,9 @@ DRIVER_STATISTIC(ChildrenMaxRSS)
 /// EXIT_SUCCESS.
 FRONTEND_STATISTIC(Frontend, NumProcessFailures)
 
+/// Total instruction count in each frontend process.
+FRONTEND_STATISTIC(Frontend, NumInstructions)
+
 /// Number of source buffers visible in the source manager.
 FRONTEND_STATISTIC(AST, NumSourceBuffers)
 

--- a/include/swift/Config.h.in
+++ b/include/swift/Config.h.in
@@ -10,6 +10,8 @@
 
 #cmakedefine HAVE_WAIT4 1
 
+#cmakedefine HAVE_PROC_PID_RUSAGE 1
+
 #cmakedefine01 SWIFT_DARWIN_ENABLE_STABLE_ABI_BIT
 
 #endif // SWIFT_CONFIG_H

--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -27,12 +27,16 @@
 #include "llvm/Support/raw_ostream.h"
 #include <chrono>
 #include <limits>
+#include <unistd.h>
 
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
 #ifdef HAVE_SYS_RESOURCE_H
 #include <sys/resource.h>
+#endif
+#ifdef HAVE_PROC_PID_RUSAGE
+#include <libproc.h>
 #endif
 
 namespace swift {
@@ -481,6 +485,18 @@ FrontendStatsTracer::~FrontendStatsTracer()
     Reporter->saveAnyFrontendStatsEvents(*this, false);
 }
 
+// Copy any interesting process-wide resource accounting stats to
+// associated fields in the provided AlwaysOnFrontendCounters.
+void updateProcessWideFrontendCounters(
+    UnifiedStatsReporter::AlwaysOnFrontendCounters &C) {
+#if defined(HAVE_PROC_PID_RUSAGE) && defined(RUSAGE_INFO_V4)
+  struct rusage_info_v4 ru;
+  if (0 == proc_pid_rusage(getpid(), RUSAGE_INFO_V4, (rusage_info_t *)&ru)) {
+    C.NumInstructions = ru.ri_instructions;
+  }
+#endif
+}
+
 static inline void
 saveEvent(StringRef StatName,
           int64_t Curr, int64_t Last,
@@ -516,6 +532,7 @@ UnifiedStatsReporter::saveAnyFrontendStatsEvents(
   auto Now = llvm::TimeRecord::getCurrentTime();
   auto &Curr = getFrontendCounters();
   auto &Last = *LastTracedFrontendCounters;
+  updateProcessWideFrontendCounters(Curr);
   if (EventProfilers) {
     auto TimeDelta = Now;
     TimeDelta -= EventProfilers->LastUpdated;
@@ -591,6 +608,8 @@ UnifiedStatsReporter::~UnifiedStatsReporter()
       C.NumProcessFailures++;
     }
   }
+
+  updateProcessWideFrontendCounters(getFrontendCounters());
 
   // NB: Timer needs to be Optional<> because it needs to be destructed early;
   // LLVM will complain about double-stopping a timer if you tear down a

--- a/test/Misc/stats_dir_instructions.swift
+++ b/test/Misc/stats_dir_instructions.swift
@@ -1,0 +1,10 @@
+// REQUIRES: OS=macosx
+// RUN: %empty-directory(%t)
+// RUN: %target-swiftc_driver -o %t/main -module-name main -stats-output-dir %t %s
+// RUN: %{python} %utils/process-stats-dir.py --set-csv-baseline %t/frontend.csv %t
+// RUN: %FileCheck -input-file %t/frontend.csv %s
+// CHECK: {{"Frontend.NumInstructions"	[1-9][0-9]*$}}
+
+public func foo() {
+    print("hello")
+}


### PR DESCRIPTION
After all the fussing around I have done trying to get a reliable external tool to read off the PMC instruction counts for a subprocess tree on macOS (a la linux perf(1)) I was somewhat astonished to learn that XNU these days just _always tracks_ every task's PMC-read instruction count (see: https://github.com/apple/darwin-xnu/blob/master/osfmk/kern/kern_monotonic.c and https://github.com/apple/darwin-xnu/blob/master/osfmk/x86_64/monotonic_x86_64.c) and returns it as a standard field in its rusage_info_v4 structure, if you ask via proc_pid_rusage.

So: this patch adds instruction counts to UnifiedStatsCollector / -stats-output-dir. I will be plumbing it through everything else subsequently -- it's a much less-noisy number to use than the time values, while being a decent proxy for it at the granularity we're concerned with -- but this gets the ball rolling.