### PR TITLE
Serialize fewer archetypes

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t VERSION_MINOR = 447; // Last change: extension type is interface type
+const uint16_t VERSION_MINOR = 448; // Last change: assoc type default is interface type
 
 using DeclIDField = BCFixed<31>;
 

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t VERSION_MINOR = 446; // Last change: sil default witness table
+const uint16_t VERSION_MINOR = 447; // Last change: extension type is interface type
 
 using DeclIDField = BCFixed<31>;
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2838,25 +2838,11 @@ void NominalTypeDecl::computeType() {
 
 enum class DeclTypeKind : unsigned {
   DeclaredType,
-  DeclaredTypeInContext,
   DeclaredInterfaceType
 };
 
 static Type computeNominalType(NominalTypeDecl *decl, DeclTypeKind kind) {
   ASTContext &ctx = decl->getASTContext();
-
-  // Handle the declared type in context.
-  if (kind == DeclTypeKind::DeclaredTypeInContext) {
-    auto interfaceType =
-      computeNominalType(decl, DeclTypeKind::DeclaredInterfaceType);
-
-    if (!decl->isGenericContext())
-      return interfaceType;
-
-    auto *genericEnv = decl->getGenericEnvironmentOfContext();
-    return GenericEnvironment::mapTypeIntoContext(
-        genericEnv, interfaceType);
-  }
 
   // Get the parent type.
   Type Ty;
@@ -2867,20 +2853,14 @@ static Type computeNominalType(NominalTypeDecl *decl, DeclTypeKind kind) {
       auto *nominal = dc->getSelfNominalTypeDecl();
       if (nominal)
         Ty = nominal->getDeclaredType();
-      else
-        Ty = ErrorType::get(ctx);
       break;
     }
-    case DeclTypeKind::DeclaredTypeInContext:
-      llvm_unreachable("Handled above");
     case DeclTypeKind::DeclaredInterfaceType:
       Ty = dc->getDeclaredInterfaceType();
+      if (Ty->is<ErrorType>())
+        Ty = Type();
       break;
     }
-    if (!Ty)
-      return Type();
-    if (Ty->is<ErrorType>())
-      Ty = Type();
   }
 
   if (decl->getGenericParams() &&
@@ -2888,8 +2868,6 @@ static Type computeNominalType(NominalTypeDecl *decl, DeclTypeKind kind) {
     switch (kind) {
     case DeclTypeKind::DeclaredType:
       return UnboundGenericType::get(decl, Ty, ctx);
-    case DeclTypeKind::DeclaredTypeInContext:
-      llvm_unreachable("Handled above");
     case DeclTypeKind::DeclaredInterfaceType: {
       // Note that here, we need to be able to produce a type
       // before the decl has been validated, so we rely on
@@ -2923,8 +2901,10 @@ Type NominalTypeDecl::getDeclaredTypeInContext() const {
     return DeclaredTyInContext;
 
   auto *decl = const_cast<NominalTypeDecl *>(this);
-  decl->DeclaredTyInContext = computeNominalType(decl,
-                                                 DeclTypeKind::DeclaredTypeInContext);
+
+  auto interfaceType = getDeclaredInterfaceType();
+  decl->DeclaredTyInContext = mapTypeIntoContext(interfaceType);
+
   return DeclaredTyInContext;
 }
 

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -101,59 +101,21 @@ GenericTypeParamType *DeclContext::getProtocolSelfType() const {
       ->castTo<GenericTypeParamType>();
 }
 
-enum class DeclTypeKind : unsigned {
-  DeclaredType,
-  DeclaredTypeInContext,
-  DeclaredInterfaceType
-};
-
-static Type computeExtensionType(const ExtensionDecl *ED, DeclTypeKind kind) {
-  auto type = ED->getExtendedType();
-  if (!type) {
-    if (ED->isInvalid())
-      return ErrorType::get(ED->getASTContext());
-    return Type();
-  }
-
-  if (type->is<UnboundGenericType>()) {
-    auto *resolver = ED->getASTContext().getLazyResolver();
-    assert(resolver && "Too late to resolve extensions");
-    resolver->resolveExtension(const_cast<ExtensionDecl *>(ED));
-    type = ED->getExtendedType();
-  }
-
-  if (type->hasError())
-    return type;
-
-  switch (kind) {
-  case DeclTypeKind::DeclaredType:
-    return type->getAnyNominal()->getDeclaredType();
-  case DeclTypeKind::DeclaredTypeInContext:
-    return type;
-  case DeclTypeKind::DeclaredInterfaceType: {
-    // FIXME: Need a sugar-preserving getExtendedInterfaceType for extensions
-    if (auto nominal = type->getAnyNominal())
-      return nominal->getDeclaredInterfaceType();
-
-    auto typealias = cast<TypeAliasDecl>(type->getAnyGeneric());
-    return typealias->getUnderlyingTypeLoc().getType();
-  }
-  }
-
-  llvm_unreachable("Unhandled DeclTypeKind in switch.");
-}
-
 Type DeclContext::getDeclaredTypeInContext() const {
   if (auto *ED = dyn_cast<ExtensionDecl>(this))
-    return computeExtensionType(ED, DeclTypeKind::DeclaredTypeInContext);
+    return ED->mapTypeIntoContext(getDeclaredInterfaceType());
   if (auto *NTD = dyn_cast<NominalTypeDecl>(this))
     return NTD->getDeclaredTypeInContext();
   return Type();
 }
 
 Type DeclContext::getDeclaredInterfaceType() const {
-  if (auto *ED = dyn_cast<ExtensionDecl>(this))
-    return computeExtensionType(ED, DeclTypeKind::DeclaredInterfaceType);
+  if (auto *ED = dyn_cast<ExtensionDecl>(this)) {
+    auto *NTD = ED->getExtendedNominal();
+    if (NTD == nullptr)
+      return ErrorType::get(ED->getASTContext());
+    return NTD->getDeclaredInterfaceType();
+  }
   if (auto *NTD = dyn_cast<NominalTypeDecl>(this))
     return NTD->getDeclaredInterfaceType();
   return Type();

--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -1014,7 +1014,7 @@ void swift::lookupVisibleDecls(VisibleDeclConsumer &Consumer,
         }
       }
     } else if (auto ED = dyn_cast<ExtensionDecl>(DC)) {
-      ExtendedType = ED->getExtendedType();
+      ExtendedType = ED->getDeclaredTypeInContext();
       if (ExtendedType)
         BaseDecl = ExtendedType->getNominalOrBoundGenericNominal();
     } else if (auto ND = dyn_cast<NominalTypeDecl>(DC)) {

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -468,7 +468,8 @@ void NormalProtocolConformance::differenceAndStoreConditionalRequirements()
     return;
   }
 
-  auto nominal = DC->getSelfNominalTypeDecl();
+  auto *ext = cast<ExtensionDecl>(DC);
+  auto nominal = ext->getExtendedNominal();
   auto typeSig = nominal->getGenericSignature();
 
   // A non-generic type won't have conditional requirements.
@@ -477,17 +478,25 @@ void NormalProtocolConformance::differenceAndStoreConditionalRequirements()
     return;
   }
 
-  auto extensionSig = DC->getGenericSignatureOfContext();
+  auto extensionSig = ext->getGenericSignature();
   if (!extensionSig) {
     if (auto lazyResolver = ctxt.getLazyResolver()) {
-      lazyResolver->resolveExtension(cast<ExtensionDecl>(DC));
-      extensionSig = DC->getGenericSignatureOfContext();
+      lazyResolver->resolveExtension(ext);
+      extensionSig = ext->getGenericSignature();
     }
   }
 
   // The type is generic, but the extension doesn't have a signature yet, so
-  // we can't do any differencing.
+  // we might be in a recursive validation situation.
   if (!extensionSig) {
+    // If the extension is invalid, it won't ever get a signature, so we
+    // "succeed" with an empty result instead.
+    if (ext->isInvalid()) {
+      success({});
+      return;
+    }
+
+    // Otherwise we'll try again later.
     failure();
     return;
   }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4281,7 +4281,7 @@ namespace {
         SmallVector<Type, 2> genericArgs;
         for (auto paramTy :
              env->getGenericSignature()->getInnermostGenericParams()) {
-          genericArgs.push_back(env->mapTypeIntoContext(paramTy));
+          genericArgs.push_back(paramTy);
         }
         Type extendedType =
           BoundGenericClassType::get(objcClass, nullptr, genericArgs);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4910,7 +4910,7 @@ void TypeChecker::validateExtension(ExtensionDecl *ext) {
   TypeResolutionOptions options(TypeResolverContext::ExtensionBinding);
   options |= TypeResolutionFlags::AllowUnboundGenerics;
   if (validateType(ext->getExtendedTypeLoc(),
-                   TypeResolution::forContextual(dc), options)) {
+                   TypeResolution::forInterface(dc), options)) {
     ext->setInvalid();
     ext->getExtendedTypeLoc().setInvalidType(Context);
     return;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3828,7 +3828,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
     if (!defaultDefinition.isNull()) {
       if (validateType(
             defaultDefinition,
-            TypeResolution::forContextual(
+            TypeResolution::forInterface(
               assocType->getDeclContext()),
             None)) {
         defaultDefinition.setInvalidType(Context);
@@ -3836,7 +3836,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
         // associatedtype X = X is invalid
         auto mentionsItself =
             defaultDefinition.getType().findIf([&](Type type) {
-              if (auto DMT = type->getAs<ArchetypeType>()) {
+              if (auto DMT = type->getAs<DependentMemberType>()) {
                 return DMT->getAssocType() == assocType;
               }
               return false;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4884,9 +4884,7 @@ checkExtensionGenericParams(TypeChecker &tc, ExtensionDecl *ext, Type type,
                                          ext, inferExtendedTypeReqs,
                                          mustInferRequirements);
 
-  Type extContextType =
-    env->mapTypeIntoContext(extInterfaceType);
-  return { env, extContextType };
+  return { env, extInterfaceType };
 }
 
 void TypeChecker::validateExtension(ExtensionDecl *ext) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5261,13 +5261,8 @@ void TypeChecker::inferDefaultWitnesses(ProtocolDecl *proto) {
     if (!defaultedAssocType)
       return nullptr;;
 
-    Type defaultType = defaultedAssocType->getDefaultDefinitionLoc().getType();
+    Type defaultType = defaultedAssocType->getDefaultDefinitionType();
     if (!defaultType)
-      return nullptr;
-
-    // Map out of its protocol context...
-    defaultType = defaultType->mapTypeOutOfContext();
-    if (defaultType->hasError())
       return nullptr;
 
     if (defaultedAssocTypeOut)

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -778,11 +778,11 @@ AssociatedTypeDecl *AssociatedTypeInference::findDefaultedAssociatedType(
     if (!overriddenDefault) continue;
 
     Type overriddenType =
-      overriddenDefault->getDefaultDefinitionLoc().getType();
+      overriddenDefault->getDefaultDefinitionType();
     assert(overriddenType);
     if (!overriddenType) continue;
 
-    CanType key = overriddenType->mapTypeOutOfContext()->getCanonicalType();
+    CanType key = overriddenType->getCanonicalType();
     if (canonicalTypes.insert(key).second)
       results.push_back(overriddenDefault);
   }
@@ -854,20 +854,14 @@ Type AssociatedTypeInference::computeDefaultTypeWitness(
     }
   }
 
-  Type defaultType = defaultedAssocType->getDefaultDefinitionLoc().getType();
+  Type defaultType = defaultedAssocType->getDefaultDefinitionType();
 
   // FIXME: Circularity
   if (!defaultType)
     return Type();
 
-  // If the associated type came from a different protocol, map it into our
-  // protocol's context.
-  if (defaultedAssocType->getDeclContext() != proto) {
-    defaultType = defaultType->mapTypeOutOfContext();
-    defaultType = proto->mapTypeIntoContext(defaultType);
-    if (!defaultType) return Type();
-  }
-
+  // Map it into our protocol's context.
+  defaultType = proto->mapTypeIntoContext(defaultType);
   defaultType = defaultType.subst(
                           QueryTypeSubstitutionMap{substitutions},
                           LookUpConformanceInModule(dc->getParentModule()));

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2704,6 +2704,7 @@ void Serializer::writeDecl(const Decl *D) {
     auto contextID = addDeclContextRef(extension->getDeclContext());
     Type baseTy = extension->getExtendedType();
     assert(!baseTy->hasUnboundGenericType());
+    assert(!baseTy->hasArchetype());
 
     // FIXME: Use the canonical type here in order to minimize circularity
     // issues at deserialization time. A known problematic case here is

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -90,7 +90,7 @@ func overlapping_sub_bad<U: P1>(_: U) {
 
 
 struct SameType<T> {}
-// CHECK-LABEL: ExtensionDecl line={{.*}} base=SameType<Int>
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=SameType<T>
 // CHECK-NEXT: (normal_conformance type=SameType<T> protocol=P2
 // CHECK-NEXT:   same_type: T Int)
 extension SameType: P2 where T == Int {}
@@ -104,7 +104,7 @@ func same_type_bad<U>(_: U) {
 
 
 struct SameTypeGeneric<T, U> {}
-// CHECK-LABEL: ExtensionDecl line={{.*}} base=SameTypeGeneric<T, T>
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=SameTypeGeneric<T, U>
 // CHECK-NEXT: (normal_conformance type=SameTypeGeneric<T, U> protocol=P2
 // CHECK-NEXT:   same_type: T U)
 extension SameTypeGeneric: P2 where T == U {}
@@ -126,7 +126,7 @@ func same_type_bad<U, V>(_: U, _: V) {
 
 
 struct Infer<T, U> {}
-// CHECK-LABEL: ExtensionDecl line={{.*}} base=Infer<Constrained<U>, U>
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=Infer<T, U>
 // CHECK-NEXT: (normal_conformance type=Infer<T, U> protocol=P2
 // CHECK-NEXT:   same_type: T Constrained<U>
 // CHECK-NEXT:   conforms_to:  U P1)
@@ -142,7 +142,7 @@ func infer_bad<U: P1, V>(_: U, _: V) {
 }
 
 struct InferRedundant<T, U: P1> {}
-// CHECK-LABEL: ExtensionDecl line={{.*}} base=InferRedundant<Constrained<U>, U>
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=InferRedundant<T, U>
 // CHECK-NEXT: (normal_conformance type=InferRedundant<T, U> protocol=P2
 // CHECK-NEXT:   same_type: T Constrained<U>)
 extension InferRedundant: P2 where T == Constrained<U> {}
@@ -341,12 +341,12 @@ extension TwoDisjointConformances: P2 where T == String {}
 // signature, meaning the stored conditional requirement is T: P1, which isn't
 // true in the original type's generic signature.
 struct RedundancyOrderDependenceGood<T: P1, U> {}
-// CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceGood<T, T>
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceGood<T, U>
 // CHECK-NEXT: (normal_conformance type=RedundancyOrderDependenceGood<T, U> protocol=P2
 // CHECK-NEXT:   same_type: T U)
 extension RedundancyOrderDependenceGood: P2 where U: P1, T == U {}
 struct RedundancyOrderDependenceBad<T, U: P1> {}
-// CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceBad<T, T>
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceBad<T, U>
 // CHECK-NEXT: (normal_conformance type=RedundancyOrderDependenceBad<T, U> protocol=P2
 // CHECK-NEXT:   conforms_to: T P1
 // CHECK-NEXT:   same_type: T U)


### PR DESCRIPTION
The extended type of an extension, and the default type of an associated type, should both be stored as interface types. We prefer not to serialize archetypes because deserializing them is more expensive, since it requires constructing a GenericSignatureBuilder.