### PR TITLE
SIL: Simplify SILLinkerVisitor::visitApplySubstitutions()

### DIFF
--- a/lib/SIL/Linker.cpp
+++ b/lib/SIL/Linker.cpp
@@ -288,30 +288,16 @@ void SILLinkerVisitor::visitProtocolConformance(
 }
 
 void SILLinkerVisitor::visitApplySubstitutions(SubstitutionMap subs) {
-  for (auto &reqt : subs.getGenericSignature()->getRequirements()) {
-    switch (reqt.getKind()) {
-    case RequirementKind::Conformance: {
-      auto conformance = subs.lookupConformance(
-          reqt.getFirstType()->getCanonicalType(),
-          cast<ProtocolDecl>(reqt.getSecondType()->getAnyNominal()))
-        .getValue();
-      
-      // Formally all conformances referenced in a function application are
-      // used. However, eagerly visiting them all at this point leads to a
-      // large blowup in the amount of SIL we read in, and we aren't very
-      // systematic about laziness. For optimization purposes we can defer
-      // reading in most conformances until we need them for devirtualization.
-      // However, we *must* pull in shared clang-importer-derived conformances
-      // we potentially use, since we may not otherwise have a local definition.
-      if (mustDeserializeProtocolConformance(Mod, conformance)) {
-        visitProtocolConformance(conformance, None);
-      }
-      break;
-    }
-    case RequirementKind::Layout:
-    case RequirementKind::SameType:
-    case RequirementKind::Superclass:
-      break;
+  for (auto conformance : subs.getConformances()) {
+    // Formally all conformances referenced in a function application are
+    // used. However, eagerly visiting them all at this point leads to a
+    // large blowup in the amount of SIL we read in, and we aren't very
+    // systematic about laziness. For optimization purposes we can defer
+    // reading in most conformances until we need them for devirtualization.
+    // However, we *must* pull in shared clang-importer-derived conformances
+    // we potentially use, since we may not otherwise have a local definition.
+    if (mustDeserializeProtocolConformance(Mod, conformance)) {
+      visitProtocolConformance(conformance, None);
     }
   }
 }


### PR DESCRIPTION
We don't have to ask the substitution map to do lookups, just iterate
over the conformances directly.