### PR TITLE
[IDE] Don't walk to ExplicitCast expr twice in ModelASTWalker

### DIFF
--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -285,8 +285,8 @@ class Observers {
 
 // CHECK: <kw>func</kw> test3(o: <type>AnyObject</type>) {
 func test3(o: AnyObject) {
-  // CHECK: <kw>let</kw> x = o <kw>as</kw>! <type>MyCls</type>
-  let x = o as! MyCls
+  // CHECK: <kw>_</kw> = o <kw>is</kw> <type>MyCls</type> ? o <kw>as</kw> <type>MyCls</type> : o <kw>as</kw>! <type>MyCls</type> <kw>as</kw> <type>MyCls</type> + <int>1</int>
+  _ = o is MyCls ? o as MyCls : o as! MyCls as MyCls + 1
 }
 
 // CHECK: <kw>class</kw> MySubClass : <type>MyCls</type> {

--- a/test/IDE/structure.swift
+++ b/test/IDE/structure.swift
@@ -276,9 +276,9 @@ struct Tuples {
   }
 }
 
-completion(a: 1) { (x: Int, y: Int) -> Int in
-  return x + y
+completion(a: 1) { (x: Any, y: Int) -> Int in
+  return x as! Int + y
 }
-// CHECK: <call><name>completion</name>(<arg><name>a</name>: 1</arg>) <arg><closure>{ (<param>x: <type>Int</type></param>, <param>y: <type>Int</type></param>) -> <type>Int</type> in
-// CHECK:    return x + y
+// CHECK: <call><name>completion</name>(<arg><name>a</name>: 1</arg>) <arg><closure>{ (<param>x: <type>Any</type></param>, <param>y: <type>Int</type></param>) -> <type>Int</type> in
+// CHECK:    return x as! Int + y
 // CHECK: }</closure></arg></call>


### PR DESCRIPTION
Explicit cast expressions (i.e. `as`, `as!`, `as?`, and `is`) appear twice in `SequenceExpr`. For instance, `a as B` is parsed as:
```
  (sequence_expr
    (unresolved_declref_expr name='a')
    (coerce_expr writtenType='B')
    (coerce_expr writtenType='B'))
```
This patch prevents `ModelASTWalker` from walking into them twice.

rdar://problem/43135727