### PR TITLE
[Parse] Remove Status |= Status

### DIFF
--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1445,7 +1445,6 @@ Parser::parseStmtConditionElement(SmallVectorImpl<StmtConditionElement> &result,
       T(InVarOrLetPattern, wasLet ? IVOLP_InLet : IVOLP_InVar);
     
     ThePattern = parseMatchingPattern(/*isExprBasic*/ true);
-    Status |= Status;
     
     if (ThePattern.isNonNull()) {
       auto *P = new (Context) VarPattern(IntroducerLoc, wasLet,


### PR DESCRIPTION
This was meant to be `Status |= ThePattern`. But it should actually be removed because we don't want to propagate`isParseError()` as it's recovered, and we propagate `hasCodeCompletion()` below.