### PR TITLE
[benchmark] Added benchmark for heapSort path of stdlib sort

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -141,6 +141,7 @@ set(SWIFT_BENCH_MODULES
     single-source/SetTests
     single-source/SevenBoom
     single-source/Sim2DArray
+    single-source/SortIntPyramids
     single-source/SortLargeExistentials
     single-source/SortLettersInPlace
     single-source/SortStrings

--- a/benchmark/single-source/SortIntPyramids.swift
+++ b/benchmark/single-source/SortIntPyramids.swift
@@ -1,0 +1,74 @@
+import TestsUtils
+
+// This benchmark aims to measuare heapSort path of stdlib sorting function.
+// Datasets in this benchmark are influenced by stdlib partition function,
+// therefore if stdlib partion implementation changes we should correct these
+// datasets or disable/skip this benchmark
+public let SortIntPyramid = [
+  BenchmarkInfo(
+    name: "SortIntPyramid",
+    runFunction: run_SortIntPyramid,
+    tags: [.validation, .api, .algorithm]),
+  BenchmarkInfo(
+    name: "SortAdjacentIntPyramids",
+    runFunction: run_SortAdjacentIntPyramids,
+    tags: [.validation, .api, .algorithm]),
+]
+
+// let A - array sorted in ascending order,
+// A^R - reversed array A, + - array concatenation operator
+// A indices are in range 1...A.length
+// define the pyramid as A + A^R
+// define pyramid height as A[A.length]
+
+// On 92% of following dataset stdlib sorting function will use heapSort.
+// number of ranges sorted by heapSort: 26
+// median heapSort range length: 198
+// maximum -||-: 1774
+// average -||-: 357
+
+// pyramid hight
+let pH = 5000
+let pyramidTemplate: [Int] = (1...pH) + (1...pH).reversed()
+
+// let A - array sorted in ascending order,
+// A^R - reversed array A, + - array concatenation operator,
+// A indices are in range 1...A.length.
+// define adjacent pyramid as A + A^R + A + A^R,
+// defne adjacent pyramid hight as A[A.length].
+
+
+// On 25% of following dataset stdlib sorting function will use heapSort.
+// number of ranges sorted by heapSort: 71
+// median heapSort range length: 28
+// maximum -||-: 120
+// average -||-: 36
+
+// adjacent pyramids hight.
+let aPH = pH / 2
+let adjacentPyramidsTemplate: [Int] = (1...aPH) + (1...aPH).reversed()
+                                    + (1...aPH) + (1...aPH).reversed()
+
+@inline(never)
+public func run_SortIntPyramid(_ N: Int) {
+  for _ in 1...25*N {
+    var pyramid = pyramidTemplate
+
+    // sort pyramid in place.
+    pyramid.sort()
+
+    // Check whether pyramid is sorted.
+    CheckResults(pyramid[0] <= pyramid[pyramid.count/2])
+  }
+}
+
+@inline(never)
+public func run_SortAdjacentIntPyramids(_ N: Int) {
+  for _ in 1...25*N {
+    var adjacentPyramids = adjacentPyramidsTemplate
+    adjacentPyramids.sort()
+    // Check whether pyramid is sorted.
+    CheckResults(
+      adjacentPyramids[0] <= adjacentPyramids[adjacentPyramids.count/2])
+  }
+}

--- a/benchmark/single-source/SortIntPyramids.swift
+++ b/benchmark/single-source/SortIntPyramids.swift
@@ -27,7 +27,7 @@ public let SortIntPyramid = [
 // maximum -||-: 1774
 // average -||-: 357
 
-// pyramid hight
+// pyramid height
 let pH = 5000
 let pyramidTemplate: [Int] = (1...pH) + (1...pH).reversed()
 
@@ -44,7 +44,7 @@ let pyramidTemplate: [Int] = (1...pH) + (1...pH).reversed()
 // maximum -||-: 120
 // average -||-: 36
 
-// adjacent pyramids hight.
+// adjacent pyramids height.
 let aPH = pH / 2
 let adjacentPyramidsTemplate: [Int] = (1...aPH) + (1...aPH).reversed()
                                     + (1...aPH) + (1...aPH).reversed()

--- a/benchmark/single-source/SortIntPyramids.swift
+++ b/benchmark/single-source/SortIntPyramids.swift
@@ -4,7 +4,7 @@ import TestsUtils
 // Datasets in this benchmark are influenced by stdlib partition function,
 // therefore if stdlib partion implementation changes we should correct these
 // datasets or disable/skip this benchmark
-public let SortIntPyramid = [
+public let SortIntPyramids = [
   BenchmarkInfo(
     name: "SortIntPyramid",
     runFunction: run_SortIntPyramid,

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -132,6 +132,7 @@ import SequenceAlgos
 import SetTests
 import SevenBoom
 import Sim2DArray
+import SortIntPyramids
 import SortLargeExistentials
 import SortLettersInPlace
 import SortStrings
@@ -296,6 +297,7 @@ registerBenchmark(SequenceAlgos)
 registerBenchmark(SetTests)
 registerBenchmark(SevenBoom)
 registerBenchmark(Sim2DArray)
+registerBenchmark(SortIntPyramids)
 registerBenchmark(SortLargeExistentials)
 registerBenchmark(SortLettersInPlace)
 registerBenchmark(SortStrings)


### PR DESCRIPTION
Current sorting benchmarks doesn't measure heapSort performance, so now it's really hard to improve 
all code related to heapSort routines functions ( _siftDown, _heapify). 

This benchmark makes sorting benchmarks more complete allowing us to measure performance of "heapSort part" in introSort. 

