### PR TITLE
Fix test/IRGen/MachO-objc-sections.swift on bots where the simulator …

### DIFF
--- a/test/IRGen/MachO-objc-sections.swift
+++ b/test/IRGen/MachO-objc-sections.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -target x86_64-apple-ios8.0 -parse-stdlib -enable-objc-interop -disable-objc-attr-requires-foundation-module -I %S/Inputs/usr/include -emit-ir %s -o - | %FileCheck %s -check-prefix CHECK-MACHO
+// RUN: %swift -target arm64-apple-ios8.0 -parse-stdlib -enable-objc-interop -disable-objc-attr-requires-foundation-module -I %S/Inputs/usr/include -emit-ir %s -o - | %FileCheck %s -check-prefix CHECK-MACHO
 
 // REQUIRES: OS=ios
 


### PR DESCRIPTION
…is not built

The target x86_64-apple-ios8.0 requires the simulator to be built. Use arm64-apple-ios instead.

rdar://43158624