### PR TITLE
[swiftSyntax] Fix issue where swiftc was not found when swiftSyntax is build via Xcode

### DIFF
--- a/tools/SwiftSyntax/SwiftcInvocation.swift
+++ b/tools/SwiftSyntax/SwiftcInvocation.swift
@@ -146,7 +146,7 @@ struct SwiftcRunner {
   ///           - lib/
   ///             - swift/
   ///               - ${target}/
-  ///                 - ${arch}/ (only on !Darwin)
+  ///                 - ${arch}/ (only on !Darwin and if launched from Xcode)
   ///                   - libswiftSwiftSyntax.[dylib|so]
   ///         ```
   static func locateSwiftc() -> URL? {
@@ -156,9 +156,13 @@ struct SwiftcRunner {
                                .deletingLastPathComponent()
                                .deletingLastPathComponent()
                                .deletingLastPathComponent()
-#if !os(macOS)
-    swiftcURL = swiftcURL.deletingLastPathComponent()
-#endif
+
+    if swiftcURL.lastPathComponent == "lib" {
+      // We are still one level to deep because we started in ${arch},
+      // not ${target}, see comment above). Traverse one more level upwards
+      swiftcURL = swiftcURL.deletingLastPathComponent()
+    }
+
     swiftcURL = swiftcURL.appendingPathComponent("bin")
                          .appendingPathComponent("swiftc")
     guard FileManager.default.fileExists(atPath: swiftcURL.path) else {

--- a/tools/swift-swiftsyntax-test/main.swift
+++ b/tools/swift-swiftsyntax-test/main.swift
@@ -86,7 +86,7 @@ do {
   }
   exit(0)
 } catch {
-  printerr(error.localizedDescription)
+  printerr("\(error)")
   printerr("Run swift-swiftsyntax-test -help for more help.")
   exit(1)
 }


### PR DESCRIPTION
`swiftSyntax` finds `swiftc` based on the directory layout of the build folder. However, that layout is different if `swiftSyntax` is built via Xcode than if it's built with Ninja. 

For Ninja: 
```
- bin/
  - swiftc
- lib/
  - swift/
    - ${target}/
      - libswiftSwiftSyntax.[dylib|so]
```

For Xcode:
```
- bin/
  - swiftc
- lib/
  - swift/
    - macosx/
      - x86_64/
        - libswiftSwiftSyntax.[dylib|so]
```

Allow `swiftSyntax` to find `swiftc` by traversing up to the `lib` folder and then moving to `bin/` instead of hardcoding the nesting level of `libswiftSwiftSyntax.dylib` inside `lib`.