### PR TITLE
[libSyntax] Reenable caching of token nodes

### DIFF
--- a/lib/Syntax/SyntaxArena.cpp
+++ b/lib/Syntax/SyntaxArena.cpp
@@ -29,6 +29,9 @@ struct SyntaxArena::Implementation {
   /// List of pointers to the allocated RawSyntax
   std::vector<RawSyntax *> AllocatedRawSyntaxList;
 
+  /// Cached Tokens.
+  llvm::FoldingSet<RawSyntaxCacheNode> CachedTokens;
+
   Implementation() = default;
   void *Allocate(size_t size, size_t alignment) {
     return Allocator.Allocate(size, alignment);
@@ -122,6 +125,38 @@ RC<RawSyntax> RawSyntax::getToken(SyntaxArena &Arena, tok TokKind,
                                   llvm::ArrayRef<TriviaPiece> LeadingTrivia,
                                   llvm::ArrayRef<TriviaPiece> TrailingTrivia) {
 
-  return RawSyntax::make(TokKind, Text, LeadingTrivia, TrailingTrivia,
-                         SourcePresence::Present, &Arena);
+  // Determine whether this token is worth to cache.
+  if (
+      // Is string_literal with >16 length.
+      (TokKind == tok::string_literal && Text.size() > 16) ||
+      // Has leading comment trivia et al.
+      any_of(LeadingTrivia,
+             [](const syntax::TriviaPiece &T) { return T.getText().size(); }) ||
+      // Has trailing comment trivia et al.
+      any_of(TrailingTrivia,
+             [](const syntax::TriviaPiece &T) { return T.getText().size(); })) {
+
+    // Do not use cache.
+    return RawSyntax::make(TokKind, Text, LeadingTrivia, TrailingTrivia,
+                           SourcePresence::Present, &Arena);
+  }
+
+  // This node is cacheable. Get or create.
+  auto &CachedTokens = Arena.Impl.CachedTokens;
+
+  llvm::FoldingSetNodeID ID;
+  RawSyntax::Profile(ID, TokKind, Text, LeadingTrivia, TrailingTrivia);
+
+  void *insertPos = nullptr;
+  if (auto existing = CachedTokens.FindNodeOrInsertPos(ID, insertPos))
+    // Found in the cache. Just return it.
+    return existing->get();
+
+  // Could not found in the cache. Create it.
+  auto Raw = RawSyntax::make(TokKind, Text, LeadingTrivia, TrailingTrivia,
+                             SourcePresence::Present, &Arena);
+  auto IDRef = ID.Intern(Arena.getAllocator());
+  auto CacheNode = new (Arena) RawSyntaxCacheNode(Raw.get(), IDRef);
+  CachedTokens.InsertNode(CacheNode, insertPos);
+  return Raw;
 }

--- a/test/Syntax/Inputs/serialize_multiple_decls.json
+++ b/test/Syntax/Inputs/serialize_multiple_decls.json
@@ -1,9 +1,9 @@
 {
-  "id": 20,
+  "id": 18,
   "kind": "SourceFile",
   "layout": [
     {
-      "id": 19,
+      "id": 17,
       "kind": "CodeBlockItemList",
       "layout": [
         {
@@ -110,11 +110,11 @@
           "presence": "Present"
         },
         {
-          "id": 16,
+          "id": 14,
           "kind": "CodeBlockItem",
           "layout": [
             {
-              "id": 15,
+              "id": 13,
               "kind": "StructDecl",
               "layout": [
                 null,
@@ -157,11 +157,11 @@
                 null,
                 null,
                 {
-                  "id": 14,
+                  "id": 12,
                   "kind": "MemberDeclBlock",
                   "layout": [
                     {
-                      "id": 11,
+                      "id": 3,
                       "tokenKind": {
                         "kind": "l_brace"
                       },
@@ -170,13 +170,13 @@
                       "presence": "Present"
                     },
                     {
-                      "id": 12,
+                      "id": 11,
                       "kind": "MemberDeclList",
                       "layout": [],
                       "presence": "Present"
                     },
                     {
-                      "id": 13,
+                      "id": 5,
                       "tokenKind": {
                         "kind": "r_brace"
                       },
@@ -204,7 +204,7 @@
       "presence": "Present"
     },
     {
-      "id": 18,
+      "id": 16,
       "tokenKind": {
         "kind": "eof",
         "text": ""

--- a/test/Syntax/Inputs/serialize_struct_decl.json
+++ b/test/Syntax/Inputs/serialize_struct_decl.json
@@ -1,17 +1,17 @@
 {
-  "id": 41,
+  "id": 40,
   "kind": "SourceFile",
   "layout": [
     {
-      "id": 40,
+      "id": 39,
       "kind": "CodeBlockItemList",
       "layout": [
         {
-          "id": 37,
+          "id": 36,
           "kind": "CodeBlockItem",
           "layout": [
             {
-              "id": 36,
+              "id": 35,
               "kind": "StructDecl",
               "layout": [
                 null,
@@ -66,7 +66,7 @@
                 null,
                 null,
                 {
-                  "id": 35,
+                  "id": 34,
                   "kind": "MemberDeclBlock",
                   "layout": [
                     {
@@ -79,7 +79,7 @@
                       "presence": "Present"
                     },
                     {
-                      "id": 33,
+                      "id": 32,
                       "kind": "MemberDeclList",
                       "layout": [
                         {
@@ -201,11 +201,11 @@
                           "presence": "Present"
                         },
                         {
-                          "id": 32,
+                          "id": 31,
                           "kind": "MemberDeclListItem",
                           "layout": [
                             {
-                              "id": 31,
+                              "id": 30,
                               "kind": "VariableDecl",
                               "layout": [
                                 null,
@@ -234,11 +234,11 @@
                                   "presence": "Present"
                                 },
                                 {
-                                  "id": 30,
+                                  "id": 29,
                                   "kind": "PatternBindingList",
                                   "layout": [
                                     {
-                                      "id": 29,
+                                      "id": 28,
                                       "kind": "PatternBinding",
                                       "layout": [
                                         {
@@ -264,11 +264,11 @@
                                           "presence": "Present"
                                         },
                                         {
-                                          "id": 28,
+                                          "id": 27,
                                           "kind": "TypeAnnotation",
                                           "layout": [
                                             {
-                                              "id": 18,
+                                              "id": 7,
                                               "tokenKind": {
                                                 "kind": "colon"
                                               },
@@ -282,11 +282,11 @@
                                               "presence": "Present"
                                             },
                                             {
-                                              "id": 27,
+                                              "id": 26,
                                               "kind": "SimpleTypeIdentifier",
                                               "layout": [
                                                 {
-                                                  "id": 19,
+                                                  "id": 18,
                                                   "tokenKind": {
                                                     "kind": "identifier",
                                                     "text": "Array"
@@ -301,11 +301,11 @@
                                                   "presence": "Present"
                                                 },
                                                 {
-                                                  "id": 26,
+                                                  "id": 25,
                                                   "kind": "GenericArgumentClause",
                                                   "layout": [
                                                     {
-                                                      "id": 20,
+                                                      "id": 19,
                                                       "tokenKind": {
                                                         "kind": "l_angle"
                                                       },
@@ -319,19 +319,19 @@
                                                       "presence": "Present"
                                                     },
                                                     {
-                                                      "id": 24,
+                                                      "id": 23,
                                                       "kind": "GenericArgumentList",
                                                       "layout": [
                                                         {
-                                                          "id": 23,
+                                                          "id": 22,
                                                           "kind": "GenericArgument",
                                                           "layout": [
                                                             {
-                                                              "id": 22,
+                                                              "id": 21,
                                                               "kind": "SimpleTypeIdentifier",
                                                               "layout": [
                                                                 {
-                                                                  "id": 21,
+                                                                  "id": 20,
                                                                   "tokenKind": {
                                                                     "kind": "identifier",
                                                                     "text": "Int"
@@ -357,7 +357,7 @@
                                                       "presence": "Present"
                                                     },
                                                     {
-                                                      "id": 25,
+                                                      "id": 24,
                                                       "tokenKind": {
                                                         "kind": "r_angle"
                                                       },
@@ -394,7 +394,7 @@
                       "presence": "Present"
                     },
                     {
-                      "id": 34,
+                      "id": 33,
                       "tokenKind": {
                         "kind": "r_brace"
                       },
@@ -426,7 +426,7 @@
       "presence": "Present"
     },
     {
-      "id": 39,
+      "id": 38,
       "tokenKind": {
         "kind": "eof",
         "text": ""

--- a/test/incrParse/Outputs/incrementalTransfer.json
+++ b/test/incrParse/Outputs/incrementalTransfer.json
@@ -1,9 +1,9 @@
 {
-  "id": 93,
+  "id": 82,
   "kind": "SourceFile",
   "layout": [
     {
-      "id": 92,
+      "id": 81,
       "kind": "CodeBlockItemList",
       "layout": [
         {
@@ -11,17 +11,17 @@
           "omitted": true
         },
         {
-          "id": 89,
+          "id": 78,
           "kind": "CodeBlockItem",
           "layout": [
             {
-              "id": 88,
+              "id": 77,
               "kind": "FunctionDecl",
               "layout": [
                 null,
                 null,
                 {
-                  "id": 66,
+                  "id": 55,
                   "tokenKind": {
                     "kind": "kw_func"
                   },
@@ -40,7 +40,7 @@
                   "presence": "Present"
                 },
                 {
-                  "id": 67,
+                  "id": 56,
                   "tokenKind": {
                     "kind": "identifier",
                     "text": "bar"
@@ -51,15 +51,15 @@
                 },
                 null,
                 {
-                  "id": 72,
+                  "id": 61,
                   "kind": "FunctionSignature",
                   "layout": [
                     {
-                      "id": 71,
+                      "id": 60,
                       "kind": "ParameterClause",
                       "layout": [
                         {
-                          "id": 68,
+                          "id": 57,
                           "tokenKind": {
                             "kind": "l_paren"
                           },
@@ -68,13 +68,13 @@
                           "presence": "Present"
                         },
                         {
-                          "id": 69,
+                          "id": 58,
                           "kind": "FunctionParameterList",
                           "layout": [],
                           "presence": "Present"
                         },
                         {
-                          "id": 70,
+                          "id": 59,
                           "tokenKind": {
                             "kind": "r_paren"
                           },
@@ -97,11 +97,11 @@
                 },
                 null,
                 {
-                  "id": 87,
+                  "id": 76,
                   "kind": "CodeBlock",
                   "layout": [
                     {
-                      "id": 73,
+                      "id": 62,
                       "tokenKind": {
                         "kind": "l_brace"
                       },
@@ -110,21 +110,21 @@
                       "presence": "Present"
                     },
                     {
-                      "id": 85,
+                      "id": 74,
                       "kind": "CodeBlockItemList",
                       "layout": [
                         {
-                          "id": 84,
+                          "id": 73,
                           "kind": "CodeBlockItem",
                           "layout": [
                             {
-                              "id": 83,
+                              "id": 72,
                               "kind": "VariableDecl",
                               "layout": [
                                 null,
                                 null,
                                 {
-                                  "id": 74,
+                                  "id": 63,
                                   "tokenKind": {
                                     "kind": "kw_let"
                                   },
@@ -147,19 +147,19 @@
                                   "presence": "Present"
                                 },
                                 {
-                                  "id": 82,
+                                  "id": 71,
                                   "kind": "PatternBindingList",
                                   "layout": [
                                     {
-                                      "id": 81,
+                                      "id": 70,
                                       "kind": "PatternBinding",
                                       "layout": [
                                         {
-                                          "id": 76,
+                                          "id": 65,
                                           "kind": "IdentifierPattern",
                                           "layout": [
                                             {
-                                              "id": 75,
+                                              "id": 64,
                                               "tokenKind": {
                                                 "kind": "identifier",
                                                 "text": "x"
@@ -178,11 +178,11 @@
                                         },
                                         null,
                                         {
-                                          "id": 80,
+                                          "id": 69,
                                           "kind": "InitializerClause",
                                           "layout": [
                                             {
-                                              "id": 77,
+                                              "id": 66,
                                               "tokenKind": {
                                                 "kind": "equal"
                                               },
@@ -196,11 +196,11 @@
                                               "presence": "Present"
                                             },
                                             {
-                                              "id": 79,
+                                              "id": 68,
                                               "kind": "StringLiteralExpr",
                                               "layout": [
                                                 {
-                                                  "id": 78,
+                                                  "id": 67,
                                                   "tokenKind": {
                                                     "kind": "string_literal",
                                                     "text": "\"hello world\""
@@ -232,14 +232,14 @@
                           "presence": "Present"
                         },
                         {
-                          "id": 43,
+                          "id": 38,
                           "omitted": true
                         }
                       ],
                       "presence": "Present"
                     },
                     {
-                      "id": 86,
+                      "id": 75,
                       "tokenKind": {
                         "kind": "r_brace"
                       },
@@ -264,14 +264,14 @@
           "presence": "Present"
         },
         {
-          "id": 61,
+          "id": 50,
           "omitted": true
         }
       ],
       "presence": "Present"
     },
     {
-      "id": 91,
+      "id": 80,
       "tokenKind": {
         "kind": "eof",
         "text": ""


### PR DESCRIPTION
If we accept that two token nodes in the same syntax tree can have the same `NodeId` if they have the same content and trivia, we can enable caching of token nodes again.

As a side effect this will also speed up the transfer of a syntax tree to the client side since two tokens that are exactly the same will receive the same ID and thus will only be transferred once if incremental syntax tree transfer is enabled.