### PR TITLE
[Diagnostics] Don't try to diagnose missing conformance for any type …

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -144,7 +144,8 @@ bool MissingConformanceFailure::diagnose() {
     // If this is a static, initializer or operator call,
     // let's not try to diagnose it here, but refer to expression
     // diagnostics.
-    if (isa<BinaryExpr>(applyExpr) || isa<TypeExpr>(anchor))
+    if (isa<PrefixUnaryExpr>(applyExpr) || isa<PostfixUnaryExpr>(applyExpr) ||
+        isa<BinaryExpr>(applyExpr) || isa<TypeExpr>(anchor))
       return false;
 
     if (auto *fnType = ownerType->getAs<AnyFunctionType>()) {

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -657,7 +657,8 @@ example21890157.property = "confusing"  // expected-error {{value of optional ty
 
 struct UnaryOp {}
 
-_ = -UnaryOp() // expected-error {{argument type 'UnaryOp' does not conform to expected type 'SignedNumeric'}}
+_ = -UnaryOp() // expected-error {{unary operator '-' cannot be applied to an operand of type 'UnaryOp'}}
+// expected-note@-1 {{overloads for '-' exist with these partially matching parameter lists: (Float), (Double), (Float80)}}
 
 
 // <rdar://problem/23433271> Swift compiler segfault in failure diagnosis

--- a/validation-test/stdlib/FixedPointDiagnostics.swift.gyb
+++ b/validation-test/stdlib/FixedPointDiagnostics.swift.gyb
@@ -3,13 +3,13 @@
 // RUN: %line-directive %t/main.swift -- %target-swift-frontend -typecheck -verify -swift-version 3 %t/main.swift
 
 func testUnaryMinusInUnsigned() {
-  var a: UInt8 = -(1) // expected-error {{argument type 'UInt8' does not conform to expected type 'SignedNumeric'}} expected-note * {{}} expected-warning * {{}}
+  var a: UInt8 = -(1) // expected-error {{cannot convert value of type 'Int' to specified type 'UInt8'}} expected-note * {{}} expected-warning * {{}}
 
-  var b: UInt16 = -(1) // expected-error {{argument type 'UInt16' does not conform to expected type 'SignedNumeric'}} expected-note * {{}} expected-warning * {{}}
+  var b: UInt16 = -(1) // expected-error {{cannot convert value of type 'Int' to specified type 'UInt16'}} expected-note * {{}} expected-warning * {{}}
 
-  var c: UInt32 = -(1) // expected-error {{argument type 'UInt32' does not conform to expected type 'SignedNumeric'}} expected-note * {{}} expected-warning * {{}}
+  var c: UInt32 = -(1) // expected-error {{cannot convert value of type 'Int' to specified type 'UInt32'}} expected-note * {{}} expected-warning * {{}}
 
-  var d: UInt64 = -(1) // expected-error {{argument type 'UInt64' does not conform to expected type 'SignedNumeric'}} expected-note * {{}} expected-warning * {{}}
+  var d: UInt64 = -(1) // expected-error {{cannot convert value of type 'Int' to specified type 'UInt64'}} expected-note * {{}} expected-warning * {{}}
 }
 
 // Int and UInt are not identical to any fixed-size integer type


### PR DESCRIPTION
…of operator call

My original diagnostic changes included only `BinaryExpr` but there
are also postfix/prefix that I missed.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
