### PR TITLE
[IRGen] Handle ProtocolInfo for protocols whose members aren't used

### DIFF
--- a/include/swift/SIL/SILWitnessVisitor.h
+++ b/include/swift/SIL/SILWitnessVisitor.h
@@ -122,9 +122,18 @@ public:
     // Add the associated types if we haven't yet.
     addAssociatedTypes();
 
+    if (asDerived().shouldVisitRequirementSignatureOnly())
+      return;
+
     // Visit the witnesses for the direct members of a protocol.
     for (Decl *member : protocol->getMembers())
       ASTVisitor<T>::visit(member);
+  }
+
+  /// If true, only the base protocols and associated types will be visited.
+  /// The base implementation returns false.
+  bool shouldVisitRequirementSignatureOnly() const {
+    return false;
   }
 
   /// Fallback for unexpected protocol requirements.

--- a/lib/IRGen/Fulfillment.cpp
+++ b/lib/IRGen/Fulfillment.cpp
@@ -209,7 +209,8 @@ bool FulfillmentMap::searchWitnessTable(
 
   bool hadFulfillment = false;
 
-  auto &pi = IGM.getProtocolInfo(protocol);
+  auto &pi = IGM.getProtocolInfo(protocol,
+                                 ProtocolInfoKind::RequirementSignature);
 
   for (auto &entry : pi.getWitnessEntries()) {
     if (!entry.isBase()) continue;

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -182,7 +182,8 @@ llvm::Value *irgen::emitArchetypeWitnessTableRef(IRGenFunction &IGF,
            "non-opened archetype lacking generic environment?");
     SmallVector<ProtocolEntry, 4> entries;
     for (auto p : archetype->getConformsTo()) {
-      const ProtocolInfo &impl = IGF.IGM.getProtocolInfo(p);
+      const ProtocolInfo &impl =
+          IGF.IGM.getProtocolInfo(p, ProtocolInfoKind::RequirementSignature);
       entries.push_back(ProtocolEntry(p, impl));
     }
 
@@ -227,7 +228,9 @@ llvm::Value *irgen::emitArchetypeWitnessTableRef(IRGenFunction &IGF,
     CanType depType = CanType(entry.first);
     ProtocolDecl *requirement = entry.second;
 
-    auto &lastPI = IGF.IGM.getProtocolInfo(lastProtocol);
+    const ProtocolInfo &lastPI =
+        IGF.IGM.getProtocolInfo(lastProtocol,
+                                ProtocolInfoKind::RequirementSignature);
 
     // If it's a type parameter, it's self, and this is a base protocol
     // requirement.

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -920,7 +920,8 @@ llvm::Constant *IRGenModule::getAddrOfAssociatedTypeGenericParamRef(
     
     // Find the offset of the associated type entry in witness tables of this
     // protocol.
-    auto &protoInfo = getProtocolInfo(assocType->getProtocol());
+    auto &protoInfo = getProtocolInfo(assocType->getProtocol(),
+                                      ProtocolInfoKind::RequirementSignature);
     auto index = protoInfo.getAssociatedTypeIndex(AssociatedType(assocType))
       .getValue();
     

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -974,7 +974,8 @@ emitKeyPathComponent(IRGenModule &IGM,
           idValue = llvm::ConstantInt::get(IGM.SizeTy, offset.getValue());
           idResolved = true;
         } else if (auto methodProto = dyn_cast<ProtocolDecl>(dc)) {
-          auto &protoInfo = IGM.getProtocolInfo(methodProto);
+          auto &protoInfo = IGM.getProtocolInfo(methodProto,
+                                                ProtocolInfoKind::Full);
           auto index = protoInfo.getFunctionIndex(
                                cast<AbstractFunctionDecl>(declRef.getDecl()));
           idValue = llvm::ConstantInt::get(IGM.SizeTy, -index.getValue());

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -654,7 +654,7 @@ namespace {
     }
 
     void addRequirements() {
-      auto &pi = IGM.getProtocolInfo(Proto);
+      auto &pi = IGM.getProtocolInfo(Proto, ProtocolInfoKind::Full);
 
       B.fillPlaceholderWithInt(*NumRequirements, IGM.Int32Ty,
                                pi.getNumWitnesses());
@@ -692,7 +692,8 @@ namespace {
     void addAssociatedTypeNames() {
       std::string AssociatedTypeNames;
 
-      auto &pi = IGM.getProtocolInfo(Proto);
+      auto &pi = IGM.getProtocolInfo(Proto,
+                                     ProtocolInfoKind::RequirementSignature);
       for (auto &entry : pi.getWitnessEntries()) {
         // Add the associated type name to the list.
         if (entry.isAssociatedType()) {

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1058,12 +1058,10 @@ TypeConverter::createImmovable(llvm::Type *type, Size size, Alignment align) {
 }
 
 static TypeInfo *invalidTypeInfo() { return (TypeInfo*) 1; }
-static ProtocolInfo *invalidProtocolInfo() { return (ProtocolInfo*) 1; }
 
 TypeConverter::TypeConverter(IRGenModule &IGM)
   : IGM(IGM),
-    FirstType(invalidTypeInfo()),
-    FirstProtocol(invalidProtocolInfo()) {
+    FirstType(invalidTypeInfo()) {
   // FIXME: In LLDB, everything is completely fragile, so that IRGen can query
   // the size of resilient types. Of course this is not the right long term
   // solution, because it won't work once the swiftmodule file is not in
@@ -1081,9 +1079,9 @@ TypeConverter::~TypeConverter() {
     delete Cur;
   }
   
-  for (const ProtocolInfo *I = FirstProtocol; I != invalidProtocolInfo(); ) {
+  for (const ProtocolInfo *I = FirstProtocol; I != nullptr; ) {
     const ProtocolInfo *Cur = I;
-    I = Cur->NextConverted;
+    I = Cur->NextConverted.getPointer();
     delete Cur;
   }
 }

--- a/lib/IRGen/GenType.h
+++ b/lib/IRGen/GenType.h
@@ -70,7 +70,7 @@ private:
   llvm::DenseMap<ProtocolDecl*, const ProtocolInfo*> Protocols;
   const TypeInfo *FirstType;
   
-  const ProtocolInfo *FirstProtocol;
+  const ProtocolInfo *FirstProtocol = nullptr;
   const LoadableTypeInfo *NativeObjectTI = nullptr;
   const LoadableTypeInfo *UnknownObjectTI = nullptr;
   const LoadableTypeInfo *BridgeObjectTI = nullptr;
@@ -146,7 +146,7 @@ public:
   const LoadableTypeInfo &getWitnessTablePtrTypeInfo();
   const LoadableTypeInfo &getEmptyTypeInfo();
   const TypeInfo &getResilientStructTypeInfo(IsABIAccessible_t abiAccessible);
-  const ProtocolInfo &getProtocolInfo(ProtocolDecl *P);
+  const ProtocolInfo &getProtocolInfo(ProtocolDecl *P, ProtocolInfoKind kind);
   const LoadableTypeInfo &getOpaqueStorageTypeInfo(Size storageSize,
                                                    Alignment storageAlign);
   const TypeInfo &getMetatypeTypeInfo(MetatypeRepresentation representation);

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -129,6 +129,7 @@ namespace irgen {
   class NominalMetadataLayout;
   class OutliningMetadataCollector;
   class ProtocolInfo;
+  enum class ProtocolInfoKind : uint8_t;
   class Signature;
   class StructMetadataLayout;
   struct SymbolicMangling;
@@ -703,7 +704,7 @@ private:
   
 //--- Types -----------------------------------------------------------------
 public:
-  const ProtocolInfo &getProtocolInfo(ProtocolDecl *D);
+  const ProtocolInfo &getProtocolInfo(ProtocolDecl *D, ProtocolInfoKind kind);
 
   // Not strictly a type operation, but similar.
   const ConformanceInfo &

--- a/test/IRGen/Inputs/protocol_accessor_multifile_other.swift
+++ b/test/IRGen/Inputs/protocol_accessor_multifile_other.swift
@@ -8,3 +8,13 @@ extension Proto {
 var globalExistential: Proto {
   fatalError()
 }
+
+protocol ClassProtoBase: AnyObject {
+  var baseProp: Int { get set }
+}
+protocol ClassProto: ClassProtoBase {
+  var prop: Int { get set }
+}
+func getClassExistential() -> ClassProto? {
+  fatalError()
+}

--- a/test/IRGen/protocol_accessor_multifile.swift
+++ b/test/IRGen/protocol_accessor_multifile.swift
@@ -2,6 +2,9 @@
 // RUN: %FileCheck %s < %t.ll
 // RUN: %FileCheck -check-prefix NEGATIVE %s < %t.ll
 
+// CHECK: @"$S27protocol_accessor_multifile5ProtoMp" = external global
+// NEGATIVE-NOT: @"$S27protocol_accessor_multifile10ClassProtoMp" =
+
 // CHECK-LABEL: define{{.*}} void @"$S27protocol_accessor_multifile14useExistentialyyF"()
 func useExistential() {
   // CHECK: [[BOX:%.+]] = alloca %T27protocol_accessor_multifile5ProtoP,
@@ -12,4 +15,21 @@ func useExistential() {
   // CHECK: ret void
 }
 
-// NEGATIVE-NOT: @"$S27protocol_accessor_multifile5ProtoMp" = 
+class GenericContext<T: Proto> {
+  // CHECK-LABEL: define{{.*}} void @"$S27protocol_accessor_multifile14GenericContextC04testdE0yyFZ
+  static func testGenericContext() {
+    // CHECK: [[SELF:%.+]] = bitcast %swift.type* %0 to %swift.type**
+    // CHECK: [[WITNESS_TABLE:%.+]] = getelementptr inbounds %swift.type*, %swift.type** [[SELF]],
+    // CHECK: = load %swift.type*, %swift.type** [[WITNESS_TABLE]]
+    // CHECK: ret void
+  }
+}
+
+// CHECK-LABEL: define{{.*}} void @"$S27protocol_accessor_multifile19useClassExistentialyyF"()
+func useClassExistential() {
+  let g = getClassExistential()
+  // CHECK: [[G_TYPE:%.+]] = call %swift.type* @swift_getObjectType({{%.+}} {{%.+}})
+  // CHECK: call swiftcc void {{%.+}}(i{{32|64}} 1, {{%.+}} {{%.+}}, %swift.type* [[G_TYPE]], i8** {{%.+}})
+  g?.baseProp = 1
+  // CHECK: ret void
+}


### PR DESCRIPTION
Certain uses of protocols only formally need the requirement signature, not any of the method requirements. This results in IRGen seeing a protocol where none of the members have been validated except the associated types. Account for this by allowing ProtocolInfo to only contain the layout for the base protocols and associated types, if requested.

Note that this relies on the layout of a witness table always putting the "requirement signature part" at the front, or at least at offsets that aren't affected by function requirements.

rdar://problem/43260117