### PR TITLE
Minor IRGen cleanups

### DIFF
--- a/lib/IRGen/DebugTypeInfo.cpp
+++ b/lib/IRGen/DebugTypeInfo.cpp
@@ -65,8 +65,7 @@ DebugTypeInfo DebugTypeInfo::getLocalVariable(DeclContext *DC,
                                               VarDecl *Decl, swift::Type Ty,
                                               const TypeInfo &Info) {
 
-  auto DeclType =
-      Decl->hasInterfaceType() ? Decl->getInterfaceType() : Decl->getType();
+  auto DeclType = Decl->getInterfaceType();
   auto RealType = Ty;
 
   // DynamicSelfType is also sugar as far as debug info is concerned.
@@ -101,9 +100,7 @@ DebugTypeInfo DebugTypeInfo::getGlobal(SILGlobalVariable *GV,
   if (auto *Decl = GV->getDecl()) {
     DC = Decl->getDeclContext();
     GE = DC->getGenericEnvironmentOfContext();
-    auto DeclType =
-        (Decl->hasType() ? Decl->getType()
-                         : DC->mapTypeIntoContext(Decl->getInterfaceType()));
+    auto DeclType = Decl->getType();
     if (DeclType->isEqual(LowTy))
       Type = DeclType.getPointer();
   }

--- a/lib/IRGen/EnumMetadataVisitor.h
+++ b/lib/IRGen/EnumMetadataVisitor.h
@@ -55,11 +55,11 @@ public:
 
     // Generic arguments.
     // This must always be the first piece of trailing data.
-    asImpl().addGenericFields(Target, Target->getDeclaredTypeInContext());
+    asImpl().addGenericFields(Target);
 
     // Reserve a word to cache the payload size if the type has dynamic layout.
     auto &strategy = getEnumImplStrategy(IGM,
-           Target->DeclContext::getDeclaredTypeInContext()->getCanonicalType());
+           Target->getDeclaredTypeInContext()->getCanonicalType());
     if (strategy.needsPayloadSizeInMetadata())
       asImpl().addPayloadSize();
   }
@@ -82,10 +82,8 @@ public:
   void addMetadataFlags() { addPointer(); }
   void addValueWitnessTable() { addPointer(); }
   void addNominalTypeDescriptor() { addPointer(); }
-  void addGenericArgument(CanType argument) { addPointer(); }
-  void addGenericWitnessTable(CanType argument, ProtocolConformanceRef conf) {
-    addPointer();
-  }
+  void addGenericArgument() { addPointer(); }
+  void addGenericWitnessTable() { addPointer(); }
   void addPayloadSize() { addPointer(); }
   void noteStartOfTypeSpecificMembers() {}
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -3188,7 +3188,6 @@ namespace {
 
 /// Emit the type metadata or metadata template for a struct.
 void irgen::emitStructMetadata(IRGenModule &IGM, StructDecl *structDecl) {
-  // TODO: structs nested within generic types
   ConstantInitBuilder initBuilder(IGM);
   auto init = initBuilder.beginStruct();
   init.setPacked(true);
@@ -3405,7 +3404,6 @@ namespace {
 } // end anonymous namespace
 
 void irgen::emitEnumMetadata(IRGenModule &IGM, EnumDecl *theEnum) {
-  // TODO: enums nested inside generic types
   ConstantInitBuilder initBuilder(IGM);
   auto init = initBuilder.beginStruct();
   init.setPacked(true);

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1929,13 +1929,12 @@ namespace {
     void emitInitializeMethodOverrides(IRGenFunction &IGF,
                                        llvm::Value *metadata) {}
 
-    void addGenericArgument(CanType argTy, ClassDecl *forClass) {
-      B.addNullPointer(IGM.TypeMetadataPtrTy);
+    void addGenericArgument(ClassDecl *forClass) {
+      llvm_unreachable("Fixed class metadata cannot have generic parameters");
     }
 
-    void addGenericWitnessTable(CanType argTy, ProtocolConformanceRef conf,
-                                ClassDecl *forClass) {
-      B.addNullPointer(IGM.WitnessTablePtrTy);
+    void addGenericWitnessTable(ClassDecl *forClass) {
+      llvm_unreachable("Fixed class metadata cannot have generic requirements");
     }
   };
 
@@ -1986,10 +1985,9 @@ namespace {
       }
     }
 
-    void addGenericArgument(CanType argTy, ClassDecl *forClass) {}
+    void addGenericArgument(ClassDecl *forClass) {}
 
-    void addGenericWitnessTable(CanType argTy, ProtocolConformanceRef conf,
-                                ClassDecl *forClass) {}
+    void addGenericWitnessTable(ClassDecl *forClass) {}
   };
 
   /// Base class for laying out class metadata.
@@ -2275,13 +2273,12 @@ namespace {
 
     void addMethodOverride(SILDeclRef baseRef, SILDeclRef declRef) {}
 
-    void addGenericArgument(CanType argTy, ClassDecl *forClass) {
-      Members.addGenericArgument(argTy, forClass);
+    void addGenericArgument(ClassDecl *forClass) {
+      Members.addGenericArgument(forClass);
     }
 
-    void addGenericWitnessTable(CanType argTy, ProtocolConformanceRef conf,
-                                ClassDecl *forClass) {
-      Members.addGenericWitnessTable(argTy, conf, forClass);
+    void addGenericWitnessTable(ClassDecl *forClass) {
+      Members.addGenericWitnessTable(forClass);
     }
 
   protected:
@@ -3036,11 +3033,11 @@ namespace {
       B.addAlignmentPadding(super::IGM.getPointerAlignment());
     }
 
-    void addGenericArgument(CanType type) {
+    void addGenericArgument() {
       B.addNullPointer(IGM.TypeMetadataPtrTy);
     }
 
-    void addGenericWitnessTable(CanType type, ProtocolConformanceRef conf) {
+    void addGenericWitnessTable() {
       B.addNullPointer(IGM.WitnessTablePtrTy);
     }
 
@@ -3287,11 +3284,11 @@ namespace {
       B.add(emitNominalTypeDescriptor());
     }
 
-    void addGenericArgument(CanType type) {
+    void addGenericArgument() {
       B.addNullPointer(IGM.TypeMetadataPtrTy);
     }
 
-    void addGenericWitnessTable(CanType type, ProtocolConformanceRef conf) {
+    void addGenericWitnessTable() {
       B.addNullPointer(IGM.WitnessTablePtrTy);
     }
 

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -3004,8 +3004,7 @@ NecessaryBindings::forFunctionInvocations(IRGenModule &IGM,
 }
 
 /// The information we need to record in generic type metadata
-/// is the information in the type's generic signature, minus the
-/// information recoverable from the type's parent type.  This is
+/// is the information in the type's generic signature.  This is
 /// simply the information that would be passed to a generic function
 /// that takes the (thick) parent metatype as an argument.
 GenericTypeRequirements::GenericTypeRequirements(IRGenModule &IGM,

--- a/lib/IRGen/MetadataLayout.cpp
+++ b/lib/IRGen/MetadataLayout.cpp
@@ -313,19 +313,18 @@ ClassMetadataLayout::ClassMetadataLayout(IRGenModule &IGM, ClassDecl *decl)
       super::noteStartOfGenericRequirements(forClass);
     }
 
-    void addGenericWitnessTable(CanType argType, ProtocolConformanceRef conf,
-                                ClassDecl *forClass) {
+    void addGenericWitnessTable(ClassDecl *forClass) {
       if (forClass == Target) {
         Layout.NumImmediateMembers++;
       }
-      super::addGenericWitnessTable(argType, conf, forClass);
+      super::addGenericWitnessTable(forClass);
     }
 
-    void addGenericArgument(CanType argType, ClassDecl *forClass) {
+    void addGenericArgument(ClassDecl *forClass) {
       if (forClass == Target) {
         Layout.NumImmediateMembers++;
       }
-      super::addGenericArgument(argType, forClass);
+      super::addGenericArgument(forClass);
     }
 
     void addMethod(SILDeclRef fn) {

--- a/lib/IRGen/NominalMetadataVisitor.h
+++ b/lib/IRGen/NominalMetadataVisitor.h
@@ -56,8 +56,7 @@ public:
   /// fields.  e.g., if B<T> extends A<T>, the witness for T in A's
   /// section should be enough.
   template <class... T>
-  void addGenericFields(NominalTypeDecl *typeDecl, Type type,
-                        T &&...args) {
+  void addGenericFields(NominalTypeDecl *typeDecl, T &&...args) {
     // The archetype order here needs to be consistent with
     // NominalTypeDescriptorBase::addGenericParams.
     
@@ -65,19 +64,13 @@ public:
     asImpl().noteStartOfGenericRequirements(args...);
 
     GenericTypeRequirements requirements(IGM, typeDecl);
-    if (requirements.empty()) return;
-
-    auto subs = type->getContextSubstitutionMap(IGM.getSwiftModule(),
-                                                typeDecl);
-    requirements.enumerateFulfillments(IGM, subs,
-                    [&](unsigned reqtIndex, CanType argType,
-                        Optional<ProtocolConformanceRef> conf) {
-      if (conf) {
-        asImpl().addGenericWitnessTable(argType, *conf, args...);
+    for (auto reqt : requirements.getRequirements()) {
+      if (reqt.Protocol) {
+        asImpl().addGenericWitnessTable(args...);
       } else {
-        asImpl().addGenericArgument(argType, args...);
+        asImpl().addGenericArgument(args...);
       }
-    });
+    }
 
     asImpl().noteEndOfGenericRequirements(args...);
   }

--- a/lib/IRGen/StructMetadataVisitor.h
+++ b/lib/IRGen/StructMetadataVisitor.h
@@ -53,7 +53,7 @@ public:
 
     // Generic arguments.
     // This must always be the first piece of trailing data.
-    asImpl().addGenericFields(Target, Target->getDeclaredTypeInContext());
+    asImpl().addGenericFields(Target);
 
     // Struct field offsets.
     asImpl().noteStartOfFieldOffsets();
@@ -87,10 +87,8 @@ public:
   void addValueWitnessTable() { addPointer(); }
   void addNominalTypeDescriptor() { addPointer(); }
   void addFieldOffset(VarDecl *) { addInt32(); }
-  void addGenericArgument(CanType argument) { addPointer(); }
-  void addGenericWitnessTable(CanType argument, ProtocolConformanceRef conf) {
-    addPointer();
-  }
+  void addGenericArgument() { addPointer(); }
+  void addGenericWitnessTable() { addPointer(); }
   void noteStartOfTypeSpecificMembers() {}
 
   void noteEndOfFieldOffsets() {

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -484,6 +484,7 @@ public:
                               Context.getIdentifier(NameBuf),
                               TypeCheckDC);
     VD->setType(MaybeLoadInitExpr->getType());
+    VD->setInterfaceType(MaybeLoadInitExpr->getType()->mapTypeOutOfContext());
     VD->setImplicit();
 
     NamedPattern *NP = new (Context) NamedPattern(VD, /*implicit*/ true);


### PR DESCRIPTION
Mostly NFC, but the NominalMetadataVisitor change means we request the superclass type of a class in fewer places, which should help with request evaluator work.