### PR TITLE
[libSyntax] Resolve a memory leak leaking the syntax tree

### DIFF
--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1016,6 +1016,13 @@ struct ParserUnit::Implementation {
             Opts.CollectParsedToken,
             Opts.BuildSyntaxTree)) {
   }
+
+  ~Implementation() {
+    // We need to delete the parser before the context so that it can finalize
+    // its SourceFileSyntax while it is still alive
+    TheParser.reset();
+    delete &Ctx;
+  }
 };
 
 ParserUnit::ParserUnit(SourceManager &SM, unsigned BufferID)

--- a/lib/Syntax/SyntaxArena.cpp
+++ b/lib/Syntax/SyntaxArena.cpp
@@ -75,16 +75,16 @@ class RawSyntaxCacheNode : public llvm::FoldingSetNode {
   friend llvm::FoldingSetTrait<RawSyntaxCacheNode>;
 
   /// Associated RawSyntax.
-  RawSyntax *Obj;
+  RC<RawSyntax> Obj;
   /// FoldingSet node identifier of the associated RawSyntax.
   llvm::FoldingSetNodeIDRef IDRef;
 
 public:
-  RawSyntaxCacheNode(RawSyntax *Obj, const llvm::FoldingSetNodeIDRef IDRef)
+  RawSyntaxCacheNode(RC<RawSyntax> Obj, const llvm::FoldingSetNodeIDRef IDRef)
       : Obj(Obj), IDRef(IDRef) {}
 
   /// Retrieve assciated RawSyntax.
-  RawSyntax *get() { return Obj; }
+  RC<RawSyntax> get() { return Obj; }
 
   // Only allow allocation of Node using the allocator in SyntaxArena.
   void *operator new(size_t Bytes, SyntaxArena &Arena,
@@ -156,7 +156,7 @@ RC<RawSyntax> RawSyntax::getToken(SyntaxArena &Arena, tok TokKind,
   auto Raw = RawSyntax::make(TokKind, Text, LeadingTrivia, TrailingTrivia,
                              SourcePresence::Present, &Arena);
   auto IDRef = ID.Intern(Arena.getAllocator());
-  auto CacheNode = new (Arena) RawSyntaxCacheNode(Raw.get(), IDRef);
+  auto CacheNode = new (Arena) RawSyntaxCacheNode(Raw, IDRef);
   CachedTokens.InsertNode(CacheNode, insertPos);
   return Raw;
 }


### PR DESCRIPTION
This resolves a memory leak that occurred if `RawSyntax` nodes are allocated without an arena using `operator new`. A `ParserUnit` would never release its `ASTContext` which in turn retains the `SourceFile` and thus the syntax tree. Deleting the `ASTContext` resolves this leak.

We need to then retain `RawSyntax` nodes from `RawSyntaxCacheNode` so they are not freed while still being referenced.