### PR TITLE
[Type checker] Eliminate redundant "duplicate inheritance" diagnostics.

### DIFF
--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -91,14 +91,8 @@ ProtocolDecl *DeclContext::getAsProtocolExtensionContext() const {
 GenericTypeParamType *DeclContext::getProtocolSelfType() const {
   assert(getAsProtocolOrProtocolExtensionContext() && "not a protocol");
 
-  auto genericParams = getGenericParamsOfContext();
-
-  if (!genericParams) {
-    if (auto proto = dyn_cast<ProtocolDecl>(this)) {
-      getASTContext().getLazyResolver()
-          ->resolveDeclSignature(const_cast<ProtocolDecl *>(proto));
-      genericParams = getGenericParamsOfContext();
-    }
+  if (auto proto = dyn_cast<ProtocolDecl>(this)) {
+    const_cast<ProtocolDecl *>(proto)->createGenericParamsIfMissing();
   }
 
   return getGenericParamsOfContext()->getParams().front()

--- a/test/decl/inherit/inherit.swift
+++ b/test/decl/inherit/inherit.swift
@@ -8,10 +8,9 @@ public protocol P1 { }
 class B : A, A { } // expected-error{{duplicate inheritance from 'A'}}{{12-15=}}
 
 // Duplicate inheritance from protocol
-class B2 : P, P { } // expected-error{{duplicate inheritance from 'P'}}{{13-16=}}
-// FIXME: These are unnecessary
-// expected-note@-2 {{'B2' declares conformance to protocol 'P' here}}
-// expected-error@-3 {{redundant conformance of 'B2' to protocol 'P'}}
+class B2 : P, P { }
+// expected-note@-1 {{'B2' declares conformance to protocol 'P' here}}
+// expected-error@-2 {{redundant conformance of 'B2' to protocol 'P'}}
 
 // Multiple inheritance
 class C : B, A { } // expected-error{{multiple inheritance from classes 'B' and 'A'}}
@@ -46,7 +45,7 @@ struct S2 : struct { } // expected-error{{expected type}}
 struct S3 : P, P & Q { } // expected-error {{redundant conformance of 'S3' to protocol 'P'}}
                          // expected-error @-1 {{non-class type 'S3' cannot conform to class protocol 'Q'}}
                          // expected-note @-2 {{'S3' declares conformance to protocol 'P' here}}
-struct S4 : P, P { }     // FIXME: expected-error {{duplicate inheritance from 'P'}}
+struct S4 : P, P { }
 // expected-error@-1{{redundant conformance of 'S4' to protocol 'P'}}
 // expected-note@-2{{'S4' declares conformance to protocol 'P' here}}
 struct S6 : P & { }      // expected-error {{expected identifier for type name}}


### PR DESCRIPTION
The `GenericSignatureBuilder` and `ConformanceLookupTable` handle duplication
diagnostics for protocols that occur in the inheritance clause. Avoid
redundantly diagnosing these within `checkInheritanceClause()`.
