### PR TITLE
[4.2] [SILGen] Forming transitive capture lists, need to unique on value not value+flags

### DIFF
--- a/include/swift/AST/CaptureInfo.h
+++ b/include/swift/AST/CaptureInfo.h
@@ -64,6 +64,12 @@ public:
 
   bool isDynamicSelfMetadata() const { return !Value.getPointer(); }
 
+  CapturedValue mergeFlags(CapturedValue cv) {
+    assert(Value.getPointer() == cv.Value.getPointer() &&
+           "merging flags on two different value decls");
+    return CapturedValue(Value.getPointer(), getFlags() & cv.getFlags());
+  }
+
   ValueDecl *getDecl() const {
     assert(Value.getPointer() && "dynamic Self metadata capture does not "
            "have a value");

--- a/test/SILGen/capture-transitive.swift
+++ b/test/SILGen/capture-transitive.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %s | %FileCheck %s
 // SR-8398
 func fibonacci(_ n: Int) -> Int {
   var cache: [Int: Int] = [:]

--- a/test/SILGen/capture-transitive.swift
+++ b/test/SILGen/capture-transitive.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// SR-8398
+func fibonacci(_ n: Int) -> Int {
+  var cache: [Int: Int] = [:]
+
+  func recursive(_ m: Int) -> Int {
+    return cache[m] ?? {
+      // Make sure cache is only captured once in the closure
+      // CHECK: implicit closure #1 in recursive #1
+      // CHECK-LABEL: sil private [transparent] @{{.*}}9fibonacci{{.*}}9recursive{{.*}} : $@convention(thin) (Int, @guaranteed { var Dictionary<Int, Int> }) -> (Int, @error Error)
+      // CHECK: closure #1 in implicit closure #1 in recursive #1
+      // CHECK-LABEL: sil private @{{.*}}9fibonacci{{.*}}9recursive{{.*}} : $@convention(thin) (Int, @guaranteed { var Dictionary<Int, Int> }) -> Int
+      let output = m < 2 ? m : recursive(m - 1) + recursive(m - 2)
+      cache[m] = output
+      return output
+      }()
+  }
+  return recursive(n)
+}
+

--- a/test/SILGen/capture-transitive.swift
+++ b/test/SILGen/capture-transitive.swift
@@ -18,3 +18,24 @@ func fibonacci(_ n: Int) -> Int {
   return recursive(n)
 }
 
+class C {
+    required init() {}
+    func f() {}
+    // Make sure that we capture dynamic self type if an explicit self isn't guaranteed
+    func returnsSelf() -> Self {
+        return { self.f(); return .init() }()
+        // CHECK-LABEL: sil private @{{.*}}returnsSelf{{.*}} : $@convention(thin) (@guaranteed C) -> @owned C
+    }
+
+    func returnsSelf1() -> Self {
+        return { [weak self] in self?.f(); return .init() }()
+        // CHECK-LABEL: sil private @{{.*}}returnsSelf{{.*}}  : $@convention(thin) (@guaranteed { var @sil_weak Optional<C> }, @thick @dynamic_self C.Type) -> @owned C
+    }
+
+    func returnsSelf2() -> Self {
+        return { [unowned self] in self.f(); return .init() }()
+        // CHECK-LABEL: sil private @{{.*}}returnsSelf{{.*}}  : $@convention(thin) (@guaranteed @sil_unowned C, @thick @dynamic_self C.Type) -> @owned C
+    }
+}
+
+


### PR DESCRIPTION
Explanation: When capturing from a nested context, we would treat the captured value as a distinct variable in the nested context, causing the variable to be copied instead of shared with the outer context.

Scope: Silent miscompile. Regression from 4.1

Issue: SR-8398 | rdar://problem/42742744

Risk: Low, the change is limited in scope and should only impact capture emission.

Testing: Swift CI, test case from SR, compatibility suite

Author: @gregomni 

Reviewed by: @slavapestov 