### PR TITLE
[AST] Drop resilience expansion from TypeBase::getReferenceCounting().

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -841,13 +841,9 @@ public:
   /// unknown-released.
   bool hasRetainablePointerRepresentation();
 
-  /// \brief Given that this type is a reference type, is it known to use
-  /// Swift-native reference counting?
-  bool usesNativeReferenceCounting(ResilienceExpansion resilience);
-
   /// Given that this type is a reference type, which kind of reference
   /// counting does it use?
-  ReferenceCounting getReferenceCounting(ResilienceExpansion resilience);
+  ReferenceCounting getReferenceCounting();
 
   /// Determines whether this type has a bridgeable object
   /// representation, i.e., whether it is always represented as a single

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -287,7 +287,7 @@ const TypeInfo *TypeConverter::convertArchetypeType(ArchetypeType *archetype) {
   // representation.
   if (archetype->requiresClass() ||
       (layout && layout->isRefCounted())) {
-    auto refcount = getReferenceCountingForType(IGM, CanType(archetype));
+    auto refcount = archetype->getReferenceCounting();
 
     llvm::PointerType *reprTy;
 

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -61,12 +61,6 @@
 using namespace swift;
 using namespace irgen;
 
-/// What reference counting mechanism does a class-like type have?
-ReferenceCounting irgen::getReferenceCountingForType(IRGenModule &IGM,
-                                                     CanType type) {
-  return type->getReferenceCounting(ResilienceExpansion::Maximal);
-}
-
 namespace {
   /// Layout information for class types.
   class ClassTypeInfo : public HeapTypeInfo<ClassTypeInfo> {
@@ -2180,7 +2174,7 @@ const TypeInfo *
 TypeConverter::convertClassType(CanType type, ClassDecl *D) {
   llvm::StructType *ST = IGM.createNominalType(type);
   llvm::PointerType *irType = ST->getPointerTo();
-  ReferenceCounting refcount = ::getReferenceCountingForType(IGM, type);
+  ReferenceCounting refcount = type->getReferenceCounting();
   
   SpareBitVector spareBits;
   

--- a/lib/IRGen/GenClass.h
+++ b/lib/IRGen/GenClass.h
@@ -148,10 +148,6 @@ namespace irgen {
   StructLayout *getClassLayoutWithTailElems(IRGenModule &IGM, SILType classType,
                                             llvm::ArrayRef<SILType> tailTypes);
 
-  /// What reference counting mechanism does a class-like type use?
-  ReferenceCounting getReferenceCountingForType(IRGenModule &IGM,
-                                                CanType type);
-
   ClassDecl *getRootClassForMetaclass(IRGenModule &IGM, ClassDecl *theClass);
 
   /// Does the class metadata for the given class require dynamic

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -1353,7 +1353,7 @@ static const TypeInfo *createExistentialTypeInfo(IRGenModule &IGM, CanType T) {
   if (layout.requiresClass()) {
     // If we're not using the Objective-C runtime, we can use the
     // native reference counting entry points.
-    ReferenceCounting refcounting = getReferenceCountingForType(IGM, T);
+    ReferenceCounting refcounting = T->getReferenceCounting();
 
     llvm::PointerType *reprTy = nullptr;
     if (auto superclass = layout.getSuperclass()) {

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2169,8 +2169,7 @@ namespace {
 
       // Set a flag if the class uses Swift refcounting.
       auto type = Target->getDeclaredType()->getCanonicalType();
-      if (getReferenceCountingForType(IGM, type)
-            == ReferenceCounting::Native) {
+      if (type->getReferenceCounting() == ReferenceCounting::Native) {
         flags |= ClassFlags::UsesSwiftRefcounting;
       }
 

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -341,7 +341,7 @@ class FieldTypeMetadataBuilder : public ReflectionMetadataBuilder {
 
     if (auto CD = dyn_cast<ClassDecl>(NTD)) {
       auto type = CD->getDeclaredType()->getCanonicalType();
-      auto RC = getReferenceCountingForType(IGM, type);
+      auto RC = type->getReferenceCounting();
       if (RC == ReferenceCounting::ObjC)
         kind = FieldDescriptorKind::ObjCClass;
       else

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -2268,7 +2268,7 @@ namespace {
                                    DynamicMetadataRequest request) {
       // All class types have the same layout.
       auto type = classDecl->getDeclaredType()->getCanonicalType();
-      switch (getReferenceCountingForType(IGF.IGM, type)) {
+      switch (type->getReferenceCounting()) {
       case ReferenceCounting::Native:
         return emitFromValueWitnessTable(IGF.IGM.Context.TheNativeObjectType);
 

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -22,6 +22,7 @@
 #include "swift/AST/Builtins.h"
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/ReferenceCounting.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILUndef.h"
 
@@ -366,7 +367,7 @@ static ManagedValue emitBuiltinCastToNativeObject(SILGenFunction &SGF,
                                          SGFContext C) {
   auto ty = args[0].getType().getASTType();
   (void)ty;
-  assert(ty->usesNativeReferenceCounting(ResilienceExpansion::Maximal) &&
+  assert(ty->getReferenceCounting() == ReferenceCounting::Native &&
          "Can only cast types that use native reference counting to native "
          "object");
   return emitBuiltinUnsafeCastToNativeObject(SGF, loc, substitutions,


### PR DESCRIPTION
We’re not using this parameter, and don’t expect to do so in the future,
so remove it. Also fold away `TypeBase::usesNativeReferenceCounting()`
and `irgen::getReferenceCountingForType()`, both of which are trivial.
