### PR TITLE
[IRGen] Simplify the ownership of ProtocolInfo

### DIFF
--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1078,12 +1078,6 @@ TypeConverter::~TypeConverter() {
     I = Cur->NextConverted;
     delete Cur;
   }
-  
-  for (const ProtocolInfo *I = FirstProtocol; I != nullptr; ) {
-    const ProtocolInfo *Cur = I;
-    I = Cur->NextConverted.getPointer();
-    delete Cur;
-  }
 }
 
 void TypeConverter::pushGenericContext(CanGenericSignature signature) {

--- a/lib/IRGen/GenType.h
+++ b/lib/IRGen/GenType.h
@@ -67,10 +67,9 @@ public:
 private:
   bool CompletelyFragile = false;
 
-  llvm::DenseMap<ProtocolDecl*, const ProtocolInfo*> Protocols;
+  llvm::DenseMap<ProtocolDecl*, std::unique_ptr<const ProtocolInfo>> Protocols;
   const TypeInfo *FirstType;
   
-  const ProtocolInfo *FirstProtocol = nullptr;
   const LoadableTypeInfo *NativeObjectTI = nullptr;
   const LoadableTypeInfo *UnknownObjectTI = nullptr;
   const LoadableTypeInfo *BridgeObjectTI = nullptr;

--- a/lib/IRGen/ProtocolInfo.h
+++ b/lib/IRGen/ProtocolInfo.h
@@ -165,26 +165,25 @@ enum class ProtocolInfoKind : uint8_t {
 class ProtocolInfo final :
     private llvm::TrailingObjects<ProtocolInfo, WitnessTableEntry> {
   friend TrailingObjects;
-
-  /// A singly-linked-list of all the protocols that have been laid out.
-  llvm::PointerIntPair<const ProtocolInfo *, 1, ProtocolInfoKind> NextConverted;
   friend class TypeConverter;
-
-  ProtocolInfoKind getKind() const {
-    return NextConverted.getInt();
-  }
 
   /// The number of table entries in this protocol layout.
   unsigned NumTableEntries;
 
+  ProtocolInfoKind Kind;
+
+  ProtocolInfoKind getKind() const {
+    return Kind;
+  }
+
   ProtocolInfo(ArrayRef<WitnessTableEntry> table, ProtocolInfoKind kind)
-      : NextConverted(nullptr, kind), NumTableEntries(table.size()) {
+      : NumTableEntries(table.size()), Kind(kind) {
     std::uninitialized_copy(table.begin(), table.end(),
                             getTrailingObjects<WitnessTableEntry>());
   }
 
-  static ProtocolInfo *create(ArrayRef<WitnessTableEntry> table,
-                              ProtocolInfoKind kind);
+  static std::unique_ptr<ProtocolInfo> create(ArrayRef<WitnessTableEntry> table,
+                                              ProtocolInfoKind kind);
 
 public:
   /// The number of witness slots in a conformance to this protocol;


### PR DESCRIPTION
Rather than keep a singly-linked list of ProtocolInfo objects to free, just rely on them being cached in the single DenseMap in TypeConverter. No functionality change.