### PR TITLE
[swiftSyntax] Make AbsolutePosition a value type

### DIFF
--- a/tools/SwiftSyntax/AbsolutePosition.swift
+++ b/tools/SwiftSyntax/AbsolutePosition.swift
@@ -12,7 +12,7 @@
 
 /// An absolute position in a source file as text - the absolute utf8Offset from
 /// the start, line, and column.
-public final class AbsolutePosition {
+public struct AbsolutePosition {
   public let utf8Offset: Int
   public let line: Int
   public let column: Int


### PR DESCRIPTION
`AbsolutePosition` had value semantics anyway, the only reason it was a reference type was so that we can use it in `AtomicCache`. But that can be worked around by boxing it into a reference type.