### PR TITLE
[ConstraintSystem] Don't try to eagerly deallocate fixes

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4930,8 +4930,6 @@ bool ConstraintSystem::recordFix(ConstraintFix *fix) {
 
   if (existingFix == Fixes.end())
     Fixes.push_back(fix);
-  else // if fix couldn't be recorded, it means that it's no longer needed.
-    Allocator.Deallocate(fix);
 
   return false;
 }


### PR DESCRIPTION
`Fix` life-time is pretty limited as it is, and we'd have
to distinguish between standalone fixes and ones attached
to constraints, which is not worth the trouble.

Resolves: rdar://problem/43285774

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
