### PR TITLE
[build-script] Disable the 'swiftpr' lldb test whitelist

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2823,7 +2823,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 # Watchpoint testing is currently disabled: see rdar://38566150.
                 if [[ "$(true_false ${LLDB_TEST_SWIFT_ONLY})" == "TRUE" ]]; then
                     LLDB_TEST_SUBDIR_CLAUSE="--test-subdir lang/swift"
-                    LLDB_TEST_CATEGORIES="--skip-category=watchpoint --skip-category=dwo --skip-category=dsym --skip-category=gmodules -G swiftpr"
+                    LLDB_TEST_CATEGORIES="--skip-category=watchpoint --skip-category=dwo --skip-category=dsym --skip-category=gmodules"
                 else
                     LLDB_TEST_SUBDIR_CLAUSE=""
                     LLDB_TEST_CATEGORIES="--skip-category=watchpoint"


### PR DESCRIPTION
This change makes the bots run all swift lldb tests during PR testing
instead of only running a whitelisted set of tests. This will increase
coverage of lldb during PR testing and catch breaking changes earlier.

When this change lands, it's possible that flaky lldb tests may block
swift PRs from landing. We plan on filing bugs for these tests, skipping
them, and re-enabling them as soon as possible.

rdar://42984532