### PR TITLE
[libSyntax] Generate TokenKinds.def from gyb_syntax_support

### DIFF
--- a/include/swift/Syntax/CMakeLists.txt
+++ b/include/swift/Syntax/CMakeLists.txt
@@ -10,6 +10,7 @@ set(generated_include_sources
     SyntaxBuilders.h.gyb
     SyntaxFactory.h.gyb
     SyntaxVisitor.h.gyb
+    TokenKinds.def.gyb
     Trivia.h.gyb)
 
 add_gyb_target(swift-syntax-generated-headers

--- a/include/swift/Syntax/TokenKinds.def.gyb
+++ b/include/swift/Syntax/TokenKinds.def.gyb
@@ -1,3 +1,10 @@
+%{
+  # -*- mode: Swift -*-
+  from gyb_syntax_support import *
+  # Ignore the following admonition it applies to the resulting .def file only
+}%
+//// Automatically Generated From TokenKinds.def.gyb.
+//// Do Not Edit Directly!
 //===--- TokenKinds.def - Swift Tokenizer Metaprogramming -----------------===//
 //
 // This source file is part of the Swift.org open source project
@@ -137,29 +144,18 @@
 #endif
 
 // Keywords that start decls.
-DECL_KEYWORD(associatedtype)
-DECL_KEYWORD(class)
-DECL_KEYWORD(deinit)
-DECL_KEYWORD(enum)
-DECL_KEYWORD(extension)
-DECL_KEYWORD(func)
-DECL_KEYWORD(import)
-DECL_KEYWORD(init)
-DECL_KEYWORD(inout)
-DECL_KEYWORD(let)
-DECL_KEYWORD(operator)
-DECL_KEYWORD(precedencegroup)
-DECL_KEYWORD(protocol)
-DECL_KEYWORD(struct)
-DECL_KEYWORD(subscript)
-DECL_KEYWORD(typealias)
-DECL_KEYWORD(var)
+% for token in SYNTAX_TOKENS:
+%   if isinstance(token, Token.Punctuator):
+${token.macro_name()}(${token.unprefixed_kind}, "${token.text}")
+%   elif isinstance(token, Token.PoundObjectLiteral):
+${token.macro_name()}(${token.unprefixed_kind}, "${token.description}", ${token.protocol})
+%   else:
+${token.macro_name()}(${token.unprefixed_kind})
+%   end
+%   end
 
-DECL_KEYWORD(fileprivate)
-DECL_KEYWORD(internal)
-DECL_KEYWORD(private)
-DECL_KEYWORD(public)
-DECL_KEYWORD(static)
+// The following tokens are irrelevant for swiftSyntax and thus only declared 
+// in this .def file
 
 SIL_KEYWORD(undef)
 SIL_KEYWORD(sil)
@@ -172,137 +168,14 @@ SIL_KEYWORD(sil_default_witness_table)
 SIL_KEYWORD(sil_coverage_map)
 SIL_KEYWORD(sil_scope)
 
-// Statement keywords.
-STMT_KEYWORD(defer)
-STMT_KEYWORD(if)
-STMT_KEYWORD(guard)
-STMT_KEYWORD(do)
-STMT_KEYWORD(repeat)
-STMT_KEYWORD(else)
-STMT_KEYWORD(for)
-STMT_KEYWORD(in)
-STMT_KEYWORD(while)
-STMT_KEYWORD(return)
-STMT_KEYWORD(break)
-STMT_KEYWORD(continue)
-STMT_KEYWORD(fallthrough)
-STMT_KEYWORD(switch)
-STMT_KEYWORD(case)
-STMT_KEYWORD(default)
-STMT_KEYWORD(where)
-STMT_KEYWORD(catch)
-STMT_KEYWORD(throw)
-
-// Expression keywords.
-EXPR_KEYWORD(as)
-EXPR_KEYWORD(Any)
-EXPR_KEYWORD(false)
-EXPR_KEYWORD(is)
-EXPR_KEYWORD(nil)
-EXPR_KEYWORD(rethrows)
-EXPR_KEYWORD(super)
-EXPR_KEYWORD(self)
-EXPR_KEYWORD(Self)
-EXPR_KEYWORD(true)
-EXPR_KEYWORD(try)
-EXPR_KEYWORD(throws)
-KEYWORD(__FILE__)
-KEYWORD(__LINE__)
-KEYWORD(__COLUMN__)
-KEYWORD(__FUNCTION__)
-KEYWORD(__DSO_HANDLE__)
-
-// Pattern keywords.
-PAT_KEYWORD(_)
-
-// Punctuators.
-PUNCTUATOR(l_paren,       "(")
-PUNCTUATOR(r_paren,       ")")
-PUNCTUATOR(l_brace,       "{")
-PUNCTUATOR(r_brace,       "}")
-PUNCTUATOR(l_square,      "[")
-PUNCTUATOR(r_square,      "]")
-PUNCTUATOR(l_angle,       "<")
-PUNCTUATOR(r_angle,       ">")
-
-PUNCTUATOR(period,        ".")
-PUNCTUATOR(period_prefix, ".")
-PUNCTUATOR(comma,         ",")
-PUNCTUATOR(colon,         ":")
-PUNCTUATOR(semi,          ";")
-PUNCTUATOR(equal,         "=")
-PUNCTUATOR(at_sign,       "@")
-PUNCTUATOR(pound,         "#")
-
-PUNCTUATOR(amp_prefix,    "&")
-PUNCTUATOR(arrow,         "->")
-
-PUNCTUATOR(backtick,      "`")
-
-PUNCTUATOR(backslash, "\\")
-
-PUNCTUATOR(exclaim_postfix, "!") // if left-bound
-
-PUNCTUATOR(question_postfix, "?") // if left-bound
-PUNCTUATOR(question_infix,"?")    // if not left-bound
-
 PUNCTUATOR(sil_dollar,    "$")    // Only in SIL mode.
 PUNCTUATOR(sil_exclamation, "!")    // Only in SIL mode.
 
-// string_literal might be exploded to {quote segment quote} in the Parser.
-PUNCTUATOR(string_quote, "\"")
-PUNCTUATOR(multiline_string_quote, "\"\"\"")
-
-// Keywords prefixed with a '#'.  "keyPath" becomes "tok::pound_keyPath".
-POUND_KEYWORD(keyPath)
-POUND_KEYWORD(line)
-POUND_KEYWORD(selector)
-POUND_KEYWORD(file)
-POUND_KEYWORD(column)
-POUND_KEYWORD(function)
-POUND_KEYWORD(dsohandle)
-
-// Directive '#' keywords.
-POUND_DIRECTIVE_KEYWORD(sourceLocation)
-POUND_DIRECTIVE_KEYWORD(warning)
-POUND_DIRECTIVE_KEYWORD(error)
-
-// Conditional compilation '#' keywords.
-POUND_COND_DIRECTIVE_KEYWORD(if)
-POUND_COND_DIRECTIVE_KEYWORD(else)
-POUND_COND_DIRECTIVE_KEYWORD(elseif)
-POUND_COND_DIRECTIVE_KEYWORD(endif)
-
-// Keywords prefixed with a '#' that are build configurations.
-POUND_CONFIG(available)
-
-// Object literals and their corresponding protocols.
-POUND_OBJECT_LITERAL(fileLiteral, "file reference", ExpressibleByFileReferenceLiteral)
-POUND_OBJECT_LITERAL(imageLiteral, "image", ExpressibleByImageLiteral)
-POUND_OBJECT_LITERAL(colorLiteral, "color", ExpressibleByColorLiteral)
-
-// Single-token literals
-LITERAL(integer_literal)
-LITERAL(floating_literal)
-LITERAL(string_literal)
-
-// Miscellaneous tokens.
-MISC(unknown)
 MISC(eof)
 MISC(code_complete)
-MISC(identifier)
-MISC(oper_binary_unspaced)   // "x+y"
-MISC(oper_binary_spaced)     // "x + y"
-MISC(oper_postfix)
-MISC(oper_prefix)
-MISC(dollarident)
 MISC(sil_local_name)       // %42 in SIL mode.
 MISC(comment)
 
-MISC(contextual_keyword)
-MISC(string_segment)
-MISC(string_interpolation_anchor)
-MISC(kw_yield)               // the contextual "yield" keyword
 
 #undef TOKEN
 #undef KEYWORD

--- a/test/SwiftSyntax/AllTokenKindsInSyntaxGybSupport.c
+++ b/test/SwiftSyntax/AllTokenKindsInSyntaxGybSupport.c
@@ -1,6 +1,0 @@
-// RUN: %utils/gyb --line-directive '' %S/Inputs/TokenKindList.txt.gyb | sort > %T/python_kinds.txt
-// RUN: %swift-syntax-test --dump-all-syntax-tokens | sort > %T/def_kinds.txt
-// RUN: diff %T/def_kinds.txt %T/python_kinds.txt
-
-// Check that all token kinds listed in TokenKinds.def are also in
-// gyb_syntax_support/Token.py

--- a/test/SwiftSyntax/Inputs/TokenKindList.txt.gyb
+++ b/test/SwiftSyntax/Inputs/TokenKindList.txt.gyb
@@ -1,6 +1,0 @@
-%{
-  from gyb_syntax_support import *
-}%
-% for token in SYNTAX_TOKENS:
-${token.kind}
-% end

--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -50,7 +50,6 @@ enum class ActionType {
   DeserializeRawTree,
   ParseOnly,
   ParserGen,
-  DumpAllSyntaxTokens,
   EOFPos,
   None
 };
@@ -88,10 +87,6 @@ Action(llvm::cl::desc("Action (required):"),
                    "deserialize-raw-tree",
                    "Parse the JSON file from the serialized raw tree "
                    "to the original"),
-        clEnumValN(ActionType::DumpAllSyntaxTokens,
-                   "dump-all-syntax-tokens",
-                   "Dump the names of all token kinds that shall be included "
-                   "in swiftSyntax"),
         clEnumValN(ActionType::EOFPos,
                    "eof",
                    "Parse the source file, calculate the absolute position"
@@ -772,31 +767,6 @@ int dumpParserGen(const char *MainExecutablePath, const StringRef InputFile) {
   });
 }
 
-void printToken(const StringRef name) {
-  // We don't expect any SIL related tokens on the SwiftSyntax side
-  if (name == "sil_dollar" ||
-      name == "sil_exclamation" ||
-      name == "sil_local_name") {
-    return;
-  }
-
-  // These token kinds are internal only and should not be exposed on the
-  // SwiftSyntax side
-  if (name == "code_complete" ||
-      name == "comment" ||
-      name == "eof") {
-    return;
-  }
-  llvm::outs() << name << '\n';
-}
-
-int dumpAllSyntaxTokens() {
-  #define TOKEN(KW) printToken(#KW);
-  #define SIL_KEYWORD(KW)
-  #include "swift/Syntax/TokenKinds.def"
-  return EXIT_SUCCESS;
-}
-
 int dumpEOFSourceLoc(const char *MainExecutablePath,
                      const StringRef InputFile) {
   return parseFile(MainExecutablePath, InputFile,
@@ -848,9 +818,6 @@ int invokeCommand(const char *MainExecutablePath,
     case ActionType::ParserGen:
       ExitCode = dumpParserGen(MainExecutablePath, InputSourceFilename);
       break;
-    case ActionType::DumpAllSyntaxTokens:
-      ExitCode = dumpAllSyntaxTokens();
-      break;
     case ActionType::EOFPos:
       ExitCode = dumpEOFSourceLoc(MainExecutablePath, InputSourceFilename);
       break;
@@ -869,13 +836,7 @@ int main(int argc, char *argv[]) {
   llvm::cl::ParseCommandLineOptions(argc, argv, "Swift Syntax Test\n");
 
   int ExitCode = EXIT_SUCCESS;
-
-  if (options::Action == ActionType::DumpAllSyntaxTokens) {
-    // DumpAllSyntaxTokens doesn't require an input file. Hande it before we 
-    // reach input file handling
-    return dumpAllSyntaxTokens();
-  }
-
+  
   if (options::InputSourceFilename.empty() &&
       options::InputSourceDirectory.empty()) {
     llvm::errs() << "input source file is required\n";

--- a/utils/gyb_syntax_support/Token.py
+++ b/utils/gyb_syntax_support/Token.py
@@ -8,10 +8,14 @@ class Token(object):
     Represents the specification for a Token in the TokenSyntax file.
     """
 
-    def __init__(self, name, kind, serialization_code, text=None, 
-                 classification='None', is_keyword=False):
+    def __init__(self, name, kind, serialization_code, unprefixed_kind=None, 
+                 text=None, classification='None', is_keyword=False):
         self.name = name
         self.kind = kind
+        if unprefixed_kind is None:
+            self.unprefixed_kind = kind
+        else:
+            self.unprefixed_kind = unprefixed_kind
         self.serialization_code = serialization_code
         self.text = text or ""
         self.classification = classification_by_name(classification)
@@ -29,172 +33,301 @@ class Keyword(Token):
     Represents a keyword token.
     """
 
-    def __init__(self, name, text, serialization_code):
-        Token.__init__(self, name, 'kw_' + text, serialization_code, text=text, 
-                       classification='Keyword', is_keyword=True)
+    def __init__(self, name, text, serialization_code, 
+                 classification='Keyword'):
+        Token.__init__(self, name, 'kw_' + text, serialization_code, 
+                       unprefixed_kind=text, text=text,  
+                       classification=classification, is_keyword=True)
+
+    def macro_name(self):
+        return "KEYWORD"
+
+
+class SwiftKeyword(Keyword):
+    def macro_name(self):
+        return "SWIFT_KEYWORD"
+
+
+class DeclKeyword(SwiftKeyword):
+    def macro_name(self):
+        return "DECL_KEYWORD"
+
+
+class StmtKeyword(SwiftKeyword):
+    def macro_name(self):
+        return "STMT_KEYWORD"
+
+
+class ExprKeyword(SwiftKeyword):
+    def macro_name(self):
+        return "EXPR_KEYWORD"
+
+
+class PatternKeyword(SwiftKeyword):
+    def macro_name(self):
+        return "PAT_KEYWORD"
+
+
+class SilKeyword(Keyword):
+    def macro_name(self):
+        return "SIL_KEYWORD"
+
+
+class PoundKeyword(Token):
+    def __init__(self, name, kind, text, serialization_code, 
+                 classification='Keyword'):
+        Token.__init__(self, name, 'pound_' + kind, serialization_code,
+                       unprefixed_kind=kind, text=text,  
+                       classification=classification, is_keyword=True)
+
+    def macro_name(self):
+        return "POUND_KEYWORD"
+
+
+class PoundObjectLiteral(PoundKeyword):
+    def __init__(self, name, kind, text, serialization_code, description, 
+                 protocol, classification='ObjectLiteral'):
+        PoundKeyword.__init__(self, name, kind, text, serialization_code, 
+                              classification)
+        self.description = description
+        self.protocol = protocol
+
+    def macro_name(self):
+        return "POUND_OBJECT_LITERAL"
+
+
+class PoundConfig(PoundKeyword):
+    def macro_name(self):
+        return "POUND_CONFIG"
+
+
+class PoundDirectiveKeyword(PoundKeyword):
+    def __init__(self, name, kind, text, serialization_code, 
+                 classification='PoundDirectiveKeyword'):
+        PoundKeyword.__init__(self, name, kind, text, serialization_code, 
+                              classification)
+
+    def macro_name(self):
+        return "POUND_DIRECTIVE_KEYWORD"
+
+
+class PoundConditionalDirectiveKeyword(PoundDirectiveKeyword):
+    def __init__(self, name, kind, text, serialization_code, 
+                 classification='PoundDirectiveKeyword'):
+        PoundKeyword.__init__(self, name, kind, text, serialization_code, 
+                              classification)
+
+    def macro_name(self):
+        return "POUND_COND_DIRECTIVE_KEYWORD"
+
+
+class Punctuator(Token):
+    def macro_name(self):
+        return "PUNCTUATOR"
+
+
+class Literal(Token):
+    def macro_name(self):
+        return "LITERAL"
+
+
+class Misc(Token):
+    def macro_name(self):
+        return "MISC"    
 
 
 SYNTAX_TOKENS = [
-    Keyword('Associatedtype', 'associatedtype', serialization_code=1),
-    Keyword('Class', 'class', serialization_code=2),
-    Keyword('Deinit', 'deinit', serialization_code=3),
-    Keyword('Enum', 'enum', serialization_code=4),
-    Keyword('Extension', 'extension', serialization_code=5),
-    Keyword('Func', 'func', serialization_code=6),
-    Keyword('Import', 'import', serialization_code=7),
-    Keyword('Init', 'init', serialization_code=8),
-    Keyword('Inout', 'inout', serialization_code=9),
-    Keyword('Let', 'let', serialization_code=10),
-    Keyword('Operator', 'operator', serialization_code=11),
-    Keyword('Precedencegroup', 'precedencegroup', serialization_code=12),
-    Keyword('Protocol', 'protocol', serialization_code=13),
-    Keyword('Struct', 'struct', serialization_code=14),
-    Keyword('Subscript', 'subscript', serialization_code=15),
-    Keyword('Typealias', 'typealias', serialization_code=16),
-    Keyword('Var', 'var', serialization_code=17),
-    Keyword('Fileprivate', 'fileprivate', serialization_code=18),
-    Keyword('Internal', 'internal', serialization_code=19),
-    Keyword('Private', 'private', serialization_code=20),
-    Keyword('Public', 'public', serialization_code=21),
-    Keyword('Static', 'static', serialization_code=22),
-    Keyword('Defer', 'defer', serialization_code=23),
-    Keyword('If', 'if', serialization_code=24),
-    Keyword('Guard', 'guard', serialization_code=25),
-    Keyword('Do', 'do', serialization_code=26),
-    Keyword('Repeat', 'repeat', serialization_code=27),
-    Keyword('Else', 'else', serialization_code=28),
-    Keyword('For', 'for', serialization_code=29),
-    Keyword('In', 'in', serialization_code=30),
-    Keyword('While', 'while', serialization_code=31),
-    Keyword('Return', 'return', serialization_code=32),
-    Keyword('Break', 'break', serialization_code=33),
-    Keyword('Continue', 'continue', serialization_code=34),
-    Keyword('Fallthrough', 'fallthrough', serialization_code=35),
-    Keyword('Switch', 'switch', serialization_code=36),
-    Keyword('Case', 'case', serialization_code=37),
-    Keyword('Default', 'default', serialization_code=38),
-    Keyword('Where', 'where', serialization_code=39),
-    Keyword('Catch', 'catch', serialization_code=40),
-    Keyword('As', 'as', serialization_code=41),
-    Keyword('Any', 'Any', serialization_code=42),
-    Keyword('False', 'false', serialization_code=43),
-    Keyword('Is', 'is', serialization_code=44),
-    Keyword('Nil', 'nil', serialization_code=45),
-    Keyword('Rethrows', 'rethrows', serialization_code=46),
-    Keyword('Super', 'super', serialization_code=47),
-    Keyword('Self', 'self', serialization_code=48),
-    Keyword('CapitalSelf', 'Self', serialization_code=49),
-    Keyword('Throw', 'throw', serialization_code=50),
-    Keyword('True', 'true', serialization_code=51),
-    Keyword('Try', 'try', serialization_code=52),
-    Keyword('Throws', 'throws', serialization_code=53),
+    # Keywords that start decls
+    DeclKeyword('Associatedtype', 'associatedtype', serialization_code=1),
+    DeclKeyword('Class', 'class', serialization_code=2),
+    DeclKeyword('Deinit', 'deinit', serialization_code=3),
+    DeclKeyword('Enum', 'enum', serialization_code=4),
+    DeclKeyword('Extension', 'extension', serialization_code=5),
+    DeclKeyword('Func', 'func', serialization_code=6),
+    DeclKeyword('Import', 'import', serialization_code=7),
+    DeclKeyword('Init', 'init', serialization_code=8),
+    DeclKeyword('Inout', 'inout', serialization_code=9),
+    DeclKeyword('Let', 'let', serialization_code=10),
+    DeclKeyword('Operator', 'operator', serialization_code=11),
+    DeclKeyword('Precedencegroup', 'precedencegroup', serialization_code=12),
+    DeclKeyword('Protocol', 'protocol', serialization_code=13),
+    DeclKeyword('Struct', 'struct', serialization_code=14),
+    DeclKeyword('Subscript', 'subscript', serialization_code=15),
+    DeclKeyword('Typealias', 'typealias', serialization_code=16),
+    DeclKeyword('Var', 'var', serialization_code=17),
+
+    DeclKeyword('Fileprivate', 'fileprivate', serialization_code=18),
+    DeclKeyword('Internal', 'internal', serialization_code=19),
+    DeclKeyword('Private', 'private', serialization_code=20),
+    DeclKeyword('Public', 'public', serialization_code=21),
+    DeclKeyword('Static', 'static', serialization_code=22),
+
+    # Statement keywords
+    StmtKeyword('Defer', 'defer', serialization_code=23),
+    StmtKeyword('If', 'if', serialization_code=24),
+    StmtKeyword('Guard', 'guard', serialization_code=25),
+    StmtKeyword('Do', 'do', serialization_code=26),
+    StmtKeyword('Repeat', 'repeat', serialization_code=27),
+    StmtKeyword('Else', 'else', serialization_code=28),
+    StmtKeyword('For', 'for', serialization_code=29),
+    StmtKeyword('In', 'in', serialization_code=30),
+    StmtKeyword('While', 'while', serialization_code=31),
+    StmtKeyword('Return', 'return', serialization_code=32),
+    StmtKeyword('Break', 'break', serialization_code=33),
+    StmtKeyword('Continue', 'continue', serialization_code=34),
+    StmtKeyword('Fallthrough', 'fallthrough', serialization_code=35),
+    StmtKeyword('Switch', 'switch', serialization_code=36),
+    StmtKeyword('Case', 'case', serialization_code=37),
+    StmtKeyword('Default', 'default', serialization_code=38),
+    StmtKeyword('Where', 'where', serialization_code=39),
+    StmtKeyword('Catch', 'catch', serialization_code=40),
+    StmtKeyword('Throw', 'throw', serialization_code=50),
+
+    # Expression keywords
+    ExprKeyword('As', 'as', serialization_code=41),
+    ExprKeyword('Any', 'Any', serialization_code=42),
+    ExprKeyword('False', 'false', serialization_code=43),
+    ExprKeyword('Is', 'is', serialization_code=44),
+    ExprKeyword('Nil', 'nil', serialization_code=45),
+    ExprKeyword('Rethrows', 'rethrows', serialization_code=46),
+    ExprKeyword('Super', 'super', serialization_code=47),
+    ExprKeyword('Self', 'self', serialization_code=48),
+    ExprKeyword('CapitalSelf', 'Self', serialization_code=49),
+    ExprKeyword('True', 'true', serialization_code=51),
+    ExprKeyword('Try', 'try', serialization_code=52),
+    ExprKeyword('Throws', 'throws', serialization_code=53),
+
     Keyword('__FILE__', '__FILE__', serialization_code=54),
     Keyword('__LINE__', '__LINE__', serialization_code=55),
     Keyword('__COLUMN__', '__COLUMN__', serialization_code=56),
     Keyword('__FUNCTION__', '__FUNCTION__', serialization_code=57),
     Keyword('__DSO_HANDLE__', '__DSO_HANDLE__', serialization_code=58),
-    Keyword('Wildcard', '_', serialization_code=59),
-    Keyword('Yield', 'yield', serialization_code=116),
-    Token('PoundAvailable', 'pound_available', text='#available',
-          is_keyword=True, classification='Keyword', serialization_code=60),
-    Token('PoundEndif', 'pound_endif', text='#endif',
-          is_keyword=True, classification='PoundDirectiveKeyword', 
-          serialization_code=61),
-    Token('PoundElse', 'pound_else', text='#else',
-          is_keyword=True, classification='PoundDirectiveKeyword', 
-          serialization_code=62),
-    Token('PoundElseif', 'pound_elseif', text='#elseif',
-          is_keyword=True, classification='PoundDirectiveKeyword', 
-          serialization_code=63),
-    Token('PoundIf', 'pound_if', text='#if',
-          is_keyword=True, classification='PoundDirectiveKeyword', 
-          serialization_code=64),
-    Token('PoundSourceLocation', 'pound_sourceLocation',
-          text='#sourceLocation', is_keyword=True,
-          classification='PoundDirectiveKeyword', serialization_code=65),
-    Token('PoundWarning', 'pound_warning', text='#warning', is_keyword=True, 
-          classification='PoundDirectiveKeyword', serialization_code=66),
-    Token('PoundError', 'pound_error', text='#error', is_keyword=True,
-          classification='PoundDirectiveKeyword', serialization_code=67),
-    Token('PoundFile', 'pound_file', text='#file',
-          is_keyword=True, classification='Keyword', serialization_code=68),
-    Token('PoundLine', 'pound_line', text='#line',
-          is_keyword=True, classification='Keyword', serialization_code=69),
-    Token('PoundColumn', 'pound_column', text='#column',
-          is_keyword=True, classification='Keyword', serialization_code=70),
-    Token('PoundDsohandle', 'pound_dsohandle', text='#dsohandle',
-          is_keyword=True, classification='Keyword', serialization_code=71),
-    Token('PoundFunction', 'pound_function', text='#function',
-          is_keyword=True, classification='Keyword', serialization_code=72),
-    Token('PoundSelector', 'pound_selector', text='#selector',
-          is_keyword=True, classification='Keyword', serialization_code=73),
-    Token('PoundKeyPath', 'pound_keyPath', text='#keyPath',
-          is_keyword=True, classification='Keyword', serialization_code=74),
-    Token('PoundColorLiteral', 'pound_colorLiteral', text='#colorLiteral',
-          is_keyword=True, classification='ObjectLiteral', 
-          serialization_code=75),
-    Token('PoundFileLiteral', 'pound_fileLiteral', text='#fileLiteral',
-          is_keyword=True, classification='ObjectLiteral', 
-          serialization_code=76),
-    Token('PoundImageLiteral', 'pound_imageLiteral', text='#imageLiteral',
-          is_keyword=True, classification='ObjectLiteral', 
-          serialization_code=77),
-    Token('Arrow', 'arrow', text='->', serialization_code=78),
-    Token('Backtick', 'backtick', text='`', serialization_code=79),
-    Token('AtSign', 'at_sign', text='@', classification='Attribute', 
-          serialization_code=80),
-    Token('Pound', 'pound', text='#', serialization_code=81),
-    Token('Colon', 'colon', text=':', serialization_code=82),
-    Token('Semicolon', 'semi', text=';', serialization_code=83),
-    Token('Comma', 'comma', text=',', serialization_code=84),
-    Token('Period', 'period', text='.', serialization_code=85),
-    Token('Equal', 'equal', text='=', serialization_code=86),
-    Token('PrefixPeriod', 'period_prefix', text='.', serialization_code=87),
-    Token('LeftParen', 'l_paren', text='(', serialization_code=88),
-    Token('RightParen', 'r_paren', text=')', serialization_code=89),
-    Token('LeftBrace', 'l_brace', text='{', serialization_code=90),
-    Token('RightBrace', 'r_brace', text='}', serialization_code=91),
-    Token('LeftSquareBracket', 'l_square', text='[', serialization_code=92),
-    Token('RightSquareBracket', 'r_square', text=']', serialization_code=93),
-    Token('LeftAngle', 'l_angle', text='<', serialization_code=94),
-    Token('RightAngle', 'r_angle', text='>', serialization_code=95),
-    Token('PrefixAmpersand', 'amp_prefix', text='&', serialization_code=96),
-    Token('PostfixQuestionMark', 'question_postfix', text='?', 
-          serialization_code=97),
-    Token('InfixQuestionMark', 'question_infix', text='?', 
-          serialization_code=98),
-    Token('ExclamationMark', 'exclaim_postfix', text='!', 
-          serialization_code=99),
-    Token('Backslash', 'backslash', text='\\\\', serialization_code=100),
-    Token('StringInterpolationAnchor', 'string_interpolation_anchor',
-          text=')', classification='StringInterpolationAnchor', 
-          serialization_code=101),
-    Token('StringQuote', 'string_quote', text='\\\"', 
-          classification='StringLiteral', serialization_code=102),
-    Token('MultilineStringQuote', 'multiline_string_quote',
-          text='\\\"\\\"\\\"', classification='StringLiteral', 
-          serialization_code=103),
-    Token('StringSegment', 'string_segment', classification='StringLiteral', 
-          serialization_code=104),
-    Token('Identifier', 'identifier', classification=None, 
-          serialization_code=105),
-    Token('DollarIdentifier', 'dollarident', 
-          classification='DollarIdentifier', serialization_code=106),
-    Token('UnspacedBinaryOperator', 'oper_binary_unspaced', 
-          serialization_code=107),
-    Token('SpacedBinaryOperator', 'oper_binary_spaced', 
-          serialization_code=108),
-    Token('PrefixOperator', 'oper_prefix', serialization_code=109),
-    Token('PostfixOperator', 'oper_postfix', serialization_code=110),
-    Token('IntegerLiteral', 'integer_literal', 
-          classification='IntegerLiteral', serialization_code=111),
-    Token('FloatingLiteral', 'floating_literal', 
-          classification='FloatingLiteral', serialization_code=112),
-    Token('StringLiteral', 'string_literal',
-          classification='StringLiteral', serialization_code=113),
-    Token('ContextualKeyword', 'contextual_keyword', classification='Keyword', 
-          serialization_code=114),
-    Token('Unknown', 'unknown', serialization_code=115),
+
+    # Pattern keywords
+    PatternKeyword('Wildcard', '_', serialization_code=59),
+
+    # Punctuators
+    Punctuator('LeftParen', 'l_paren', text='(', serialization_code=88),
+    Punctuator('RightParen', 'r_paren', text=')', serialization_code=89),
+    Punctuator('LeftBrace', 'l_brace', text='{', serialization_code=90),
+    Punctuator('RightBrace', 'r_brace', text='}', serialization_code=91),
+    Punctuator('LeftSquareBracket', 'l_square', text='[', 
+               serialization_code=92),
+    Punctuator('RightSquareBracket', 'r_square', text=']', 
+               serialization_code=93),
+    Punctuator('LeftAngle', 'l_angle', text='<', serialization_code=94),
+    Punctuator('RightAngle', 'r_angle', text='>', serialization_code=95),
+
+    Punctuator('Period', 'period', text='.', serialization_code=85),
+    Punctuator('PrefixPeriod', 'period_prefix', text='.', 
+               serialization_code=87),
+    Punctuator('Comma', 'comma', text=',', serialization_code=84),
+    Punctuator('Colon', 'colon', text=':', serialization_code=82),
+    Punctuator('Semicolon', 'semi', text=';', serialization_code=83),
+    Punctuator('Equal', 'equal', text='=', serialization_code=86),
+    Punctuator('AtSign', 'at_sign', text='@', classification='Attribute', 
+               serialization_code=80),
+    Punctuator('Pound', 'pound', text='#', serialization_code=81),
+
+    Punctuator('PrefixAmpersand', 'amp_prefix', text='&', 
+               serialization_code=96),
+    Punctuator('Arrow', 'arrow', text='->', serialization_code=78),
+
+
+    Punctuator('Backtick', 'backtick', text='`', serialization_code=79),
+
+    Punctuator('Backslash', 'backslash', text='\\\\', serialization_code=100),    
+
+    Punctuator('ExclamationMark', 'exclaim_postfix', text='!', 
+               serialization_code=99),
+
+    Punctuator('PostfixQuestionMark', 'question_postfix', text='?', 
+               serialization_code=97),
+    Punctuator('InfixQuestionMark', 'question_infix', text='?', 
+               serialization_code=98),
+
+    Punctuator('StringQuote', 'string_quote', text='\\\"', 
+               classification='StringLiteral', serialization_code=102),
+    Punctuator('MultilineStringQuote', 'multiline_string_quote',
+               text='\\\"\\\"\\\"', classification='StringLiteral', 
+               serialization_code=103),
+
+    # Keywords prefixed with a '#'.
+
+    PoundKeyword('PoundKeyPath', 'keyPath', text='#keyPath', 
+                 serialization_code=74),
+    PoundKeyword('PoundLine', 'line', text='#line', 
+                 serialization_code=69),
+    PoundKeyword('PoundSelector', 'selector', text='#selector',
+                 serialization_code=73),
+    PoundKeyword('PoundFile', 'file', text='#file', 
+                 serialization_code=68),
+    PoundKeyword('PoundColumn', 'column', text='#column',
+                 serialization_code=70),
+    PoundKeyword('PoundFunction', 'function', text='#function',
+                 serialization_code=72),
+    PoundKeyword('PoundDsohandle', 'dsohandle', text='#dsohandle',
+                 serialization_code=71),
+
+    PoundDirectiveKeyword('PoundSourceLocation', 'sourceLocation',
+                          text='#sourceLocation', serialization_code=65),
+    PoundDirectiveKeyword('PoundWarning', 'warning', text='#warning', 
+                          serialization_code=66),
+    PoundDirectiveKeyword('PoundError', 'error', text='#error', 
+                          serialization_code=67),
+
+    PoundConditionalDirectiveKeyword('PoundIf', 'if', text='#if',
+                                     serialization_code=64),
+    PoundConditionalDirectiveKeyword('PoundElse', 'else', text='#else',
+                                     serialization_code=62),
+    PoundConditionalDirectiveKeyword('PoundElseif', 'elseif', 
+                                     text='#elseif', serialization_code=63),
+    PoundConditionalDirectiveKeyword('PoundEndif', 'endif', 
+                                     text='#endif', serialization_code=61),
+
+    PoundConfig('PoundAvailable', 'available', text='#available',
+                serialization_code=60),
+
+    PoundObjectLiteral('PoundFileLiteral', 'fileLiteral', 
+                       text='#fileLiteral', serialization_code=76, 
+                       description='file reference', 
+                       protocol='ExpressibleByFileReferenceLiteral'),
+    PoundObjectLiteral('PoundImageLiteral', 'imageLiteral', 
+                       text='#imageLiteral', serialization_code=77, 
+                       description='image', 
+                       protocol='ExpressibleByImageLiteral'),
+    PoundObjectLiteral('PoundColorLiteral', 'colorLiteral', 
+                       text='#colorLiteral', serialization_code=75,
+                       description='color', 
+                       protocol='ExpressibleByColorLiteral'),
+
+    Literal('IntegerLiteral', 'integer_literal', 
+            classification='IntegerLiteral', serialization_code=111),
+    Literal('FloatingLiteral', 'floating_literal', 
+            classification='FloatingLiteral', serialization_code=112),
+    Literal('StringLiteral', 'string_literal',
+            classification='StringLiteral', serialization_code=113),
+
+    Misc('Unknown', 'unknown', serialization_code=115),
+    Misc('Identifier', 'identifier', classification=None, 
+         serialization_code=105),
+    Misc('UnspacedBinaryOperator', 'oper_binary_unspaced', 
+         serialization_code=107),
+    Misc('SpacedBinaryOperator', 'oper_binary_spaced', serialization_code=108),
+    Misc('PostfixOperator', 'oper_postfix', serialization_code=110),
+    Misc('PrefixOperator', 'oper_prefix', serialization_code=109),
+    Misc('DollarIdentifier', 'dollarident', classification='DollarIdentifier', 
+         serialization_code=106),
+
+    Misc('ContextualKeyword', 'contextual_keyword', classification='Keyword', 
+         serialization_code=114),
+    Misc('StringSegment', 'string_segment', classification='StringLiteral', 
+         serialization_code=104),
+    Misc('StringInterpolationAnchor', 'string_interpolation_anchor',
+         text=')', classification='StringInterpolationAnchor', 
+         serialization_code=101),
+    Misc('Yield', 'kw_yield', serialization_code=116, text='yield'),
+
 ]
 
 SYNTAX_TOKEN_MAP = {token.name + 'Token': token for token in SYNTAX_TOKENS}


### PR DESCRIPTION
It's not particularly nice to generate a `.def` file using `gyb` but this eliminates the need to declare the same tokens twice, once for the Swift side and once for the C++ side.