### PR TITLE
[Name lookup] Clean up qualified and type lookup

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -500,7 +500,7 @@ public:
   /// lookup.
   ///
   /// \returns true if anything was found.
-  bool lookupQualified(ArrayRef<NominalTypeDecl *> types, DeclName member,
+  bool lookupQualified(ArrayRef<TypeDecl *> types, DeclName member,
                        NLOptions options,
                        SmallVectorImpl<ValueDecl *> &decls) const;
 

--- a/include/swift/AST/LookupKinds.h
+++ b/include/swift/AST/LookupKinds.h
@@ -37,29 +37,25 @@ enum NLOptions : unsigned {
   /// Remove overridden declarations from the set of results.
   NL_RemoveOverridden = 0x08,
 
-  /// For existentials involving the special \c AnyObject protocol,
-  /// allow lookups to find members of all classes.
-  NL_DynamicLookup = 0x10,
-
   /// Don't check access when doing lookup into a type.
   ///
   /// This option is not valid when performing lookup into a module.
-  NL_IgnoreAccessControl = 0x20,
+  NL_IgnoreAccessControl = 0x10,
 
   /// This lookup is known to be a non-cascading dependency, i.e. one that does
   /// not affect downstream files.
   ///
   /// \see NL_KnownDependencyMask
-  NL_KnownNonCascadingDependency = 0x40,
+  NL_KnownNonCascadingDependency = 0x20,
 
   /// This lookup is known to be a cascading dependency, i.e. one that can
   /// affect downstream files.
   ///
   /// \see NL_KnownDependencyMask
-  NL_KnownCascadingDependency = 0x80,
+  NL_KnownCascadingDependency = 0x40,
 
   /// This lookup should only return type declarations.
-  NL_OnlyTypes = 0x100,
+  NL_OnlyTypes = 0x80,
 
   /// This lookup is known to not add any additional dependencies to the
   /// primary source file.

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2176,8 +2176,8 @@ TypeDecl *EquivalenceClass::lookupNestedType(
     if (decl) {
       SmallVector<ValueDecl *, 2> foundMembers;
       decl->getParentModule()->lookupQualified(
-          typeToSearch, name,
-          NL_QualifiedDefault | NL_OnlyTypes | NL_ProtocolMembers, nullptr,
+          decl, name,
+          NL_QualifiedDefault | NL_OnlyTypes | NL_ProtocolMembers,
           foundMembers);
       for (auto member : foundMembers) {
         if (auto type = dyn_cast<TypeDecl>(member)) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4765,7 +4765,7 @@ namespace {
           // If we're importing into the primary @interface for something, as
           // opposed to an extension, make sure we don't try to load any
           // categories...by just looking into the super type.
-          lookupContext = classDecl->getSuperclassDecl  ();
+          lookupContext = classDecl->getSuperclassDecl();
         }
 
         if (lookupContext) {
@@ -7651,8 +7651,8 @@ void ClangImporter::Implementation::startedImportingEntity() {
 static void finishTypeWitnesses(
     NormalProtocolConformance *conformance) {
   auto *dc = conformance->getDeclContext();
+  auto nominal = dc->getAsNominalTypeOrNominalTypeExtensionContext();
   auto *module = dc->getParentModule();
-  auto &ctx = module->getASTContext();
 
   auto *proto = conformance->getProtocol();
   auto selfType = conformance->getType();
@@ -7669,8 +7669,8 @@ static void finishTypeWitnesses(
                            NL_OnlyTypes |
                            NL_ProtocolMembers);
 
-      dc->lookupQualified(selfType, assocType->getFullName(), options,
-                          ctx.getLazyResolver(), lookupResults);
+      dc->lookupQualified(nominal, assocType->getFullName(), options,
+                          lookupResults);
       for (auto member : lookupResults) {
         auto typeDecl = cast<TypeDecl>(member);
         if (isa<AssociatedTypeDecl>(typeDecl)) continue;

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -628,10 +628,6 @@ SmallVector<OverrideMatch, 2> OverrideMatcher::match(
     auto lookupOptions = defaultMemberLookupOptions;
 
     // Class methods cannot override declarations only
-    // visible via dynamic dispatch.
-    lookupOptions -= NameLookupFlags::DynamicLookup;
-
-    // Class methods cannot override declarations only
     // visible as protocol requirements or protocol
     // extension members.
     lookupOptions -= NameLookupFlags::ProtocolMembers;

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -370,8 +370,6 @@ LookupResult TypeChecker::lookupMember(DeclContext *dc,
   NLOptions subOptions = NL_QualifiedDefault;
   if (options.contains(NameLookupFlags::KnownPrivate))
     subOptions |= NL_KnownNonCascadingDependency;
-  if (options.contains(NameLookupFlags::DynamicLookup))
-    subOptions |= NL_DynamicLookup;
   if (options.contains(NameLookupFlags::IgnoreAccessControl))
     subOptions |= NL_IgnoreAccessControl;
 

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -132,8 +132,7 @@ lookupEnumMemberElement(TypeChecker &TC, DeclContext *DC, Type ty,
 
   // Look up the case inside the enum.
   // FIXME: We should be able to tell if this is a private lookup.
-  NameLookupOptions lookupOptions
-    = defaultMemberLookupOptions - NameLookupFlags::DynamicLookup;
+  NameLookupOptions lookupOptions = defaultMemberLookupOptions;
   LookupResult foundElements = TC.lookupMember(DC, ty, name, lookupOptions);
   return filterForEnumElement(TC, DC, UseLoc,
                               /*unqualifiedLookup=*/false, foundElements);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -489,15 +489,11 @@ enum class TypeResolutionFlags : uint16_t {
   /// Whether this type resolution is guaranteed not to affect downstream files.
   KnownNonCascadingDependency = 1 << 8,
 
-  /// Whether we should resolve only the structure of the resulting
-  /// type rather than its complete semantic properties.
-  ResolveStructure = 1 << 9,
-
   /// Whether we are at the direct base of a type expression.
-  Direct = 1 << 10,
+  Direct = 1 << 9,
 
   /// Whether we should not produce diagnostics if the type is invalid.
-  SilenceErrors = 1 << 11,
+  SilenceErrors = 1 << 10,
 };
 
 /// Type resolution contexts that require special handling.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -309,8 +309,7 @@ inline NameLookupOptions operator|(NameLookupFlags flag1,
 
 /// Default options for member name lookup.
 const NameLookupOptions defaultMemberLookupOptions
-  = NameLookupFlags::DynamicLookup |
-    NameLookupFlags::ProtocolMembers |
+  = NameLookupFlags::ProtocolMembers |
     NameLookupFlags::PerformConformanceCheck;
 
 /// Default options for constructor lookup.


### PR DESCRIPTION
Introduce several cleanups around `lookupQualified()`:

* Use the decl-based `lookupQualified()` wherever we can
* Eliminate some extra lookup flags that are no longer used
* Loosen `lookupQualified()` to accept `TypeDecls` and do the resolution itself