### PR TITLE
[Name lookup] Don't look at a type's members when checking inherited types

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3779,10 +3779,6 @@ private:
 class ProtocolDecl final : public NominalTypeDecl {
   SourceLoc ProtocolLoc;
 
-  /// The syntactic representation of the where clause in a protocol like
-  /// `protocol ... where ... { ... }`.
-  TrailingWhereClause *TrailingWhere;
-
   llvm::DenseMap<ValueDecl *, Witness> DefaultWitnesses;
 
   /// The generic signature representing exactly the new requirements introduced
@@ -3994,11 +3990,6 @@ public:
   /// Create the generic parameters of this protocol if the haven't been
   /// created yet.
   void createGenericParamsIfMissing();
-
-  /// Retrieve the trailing where clause on this protocol, if it exists.
-  TrailingWhereClause *getTrailingWhereClause() const {
-    return TrailingWhere;
-  }
 
   /// Retrieve the requirements that describe this protocol.
   ///

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3569,7 +3569,7 @@ ProtocolDecl::ProtocolDecl(DeclContext *DC, SourceLoc ProtocolLoc,
                            TrailingWhereClause *TrailingWhere)
     : NominalTypeDecl(DeclKind::Protocol, DC, Name, NameLoc, Inherited,
                       nullptr),
-      ProtocolLoc(ProtocolLoc), TrailingWhere(TrailingWhere) {
+      ProtocolLoc(ProtocolLoc) {
   Bits.ProtocolDecl.RequiresClassValid = false;
   Bits.ProtocolDecl.RequiresClass = false;
   Bits.ProtocolDecl.ExistentialConformsToSelfValid = false;
@@ -3579,6 +3579,7 @@ ProtocolDecl::ProtocolDecl(DeclContext *DC, SourceLoc ProtocolLoc,
   Bits.ProtocolDecl.NumRequirementsInSignature = 0;
   Bits.ProtocolDecl.HasMissingRequirements = false;
   Bits.ProtocolDecl.KnownProtocol = 0;
+  setTrailingWhereClause(TrailingWhere);
 }
 
 llvm::TinyPtrVector<ProtocolDecl *>

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -7491,6 +7491,17 @@ GenericSignature *GenericSignatureBuilder::computeGenericSignature(
   return sig;
 }
 
+/// Add all of the generic parameters from the given parameter list (and it's
+/// outer generic parameter lists) to the given generic signature builder.
+static void addAllGenericParams(GenericSignatureBuilder &builder,
+                                GenericParamList *genericParams) {
+  if (!genericParams) return;
+
+  addAllGenericParams(builder, genericParams->getOuterParameters());
+  for (auto gp : *genericParams)
+    builder.addGenericParameter(gp);
+}
+
 GenericSignature *GenericSignatureBuilder::computeRequirementSignature(
                                                      ProtocolDecl *proto) {
   GenericSignatureBuilder builder(proto->getASTContext());
@@ -7501,12 +7512,12 @@ GenericSignature *GenericSignatureBuilder::computeRequirementSignature(
       lazyResolver->resolveDeclSignature(proto);
   }
 
-  // Add the 'self' parameter.
-  auto selfType =
-    proto->getSelfInterfaceType()->castTo<GenericTypeParamType>();
-  builder.addGenericParameter(selfType);
+  // Add all of the generic parameters.
+  addAllGenericParams(builder, proto->getGenericParams());
 
   // Add the conformance of 'self' to the protocol.
+  auto selfType =
+    proto->getSelfInterfaceType()->castTo<GenericTypeParamType>();
   auto requirement =
     Requirement(RequirementKind::Conformance, selfType,
                 proto->getDeclaredInterfaceType());

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -929,7 +929,30 @@ UnqualifiedLookup::UnqualifiedLookup(DeclName Name, DeclContext *DC,
           if (!isCascadingUse.hasValue())
             isCascadingUse = ED->isCascadingContextForLookup(false);
         } else if (auto *ND = dyn_cast<NominalTypeDecl>(DC)) {
-          populateLookupDeclsFromContext(ND);
+          // Only look at members of this type (or its inherited types) when
+          // inside the body or a protocol's top-level 'where' clause. (Why the
+          // 'where' clause? Because that's where you put constraints on
+          // inherited associated types.)
+          bool wantsMemberLookup = false;
+          if (Loc.isValid() && ND->getBraces().isValid()) {
+            if (Ctx.SourceMgr.rangeContainsTokenLoc(ND->getBraces(), Loc)) {
+              wantsMemberLookup = true;
+            } else if (isa<ProtocolDecl>(ND)) {
+              if (auto *whereClause = ND->getTrailingWhereClause()) {
+                SourceRange whereClauseRange = whereClause->getSourceRange();
+                if (whereClauseRange.isValid() &&
+                    Ctx.SourceMgr.rangeContainsTokenLoc(whereClauseRange, Loc)){
+                  wantsMemberLookup = true;
+                }
+              }
+            }
+          } else {
+            // FIXME: Is this possible? Can we do unqualified lookup in a
+            // nominal type without a source location?
+            wantsMemberLookup = true;
+          }
+          if (wantsMemberLookup)
+            populateLookupDeclsFromContext(ND);
           BaseDC = DC;
           MetaBaseDC = DC;
           if (!isCascadingUse.hasValue())

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -591,7 +591,7 @@ bool shouldLookupMembers(D *decl, SourceLoc loc) {
   // inherited associated types.)
 
   // When we have no source-location information, we have to perform member
-  // lookuo.
+  // lookup.
   if (loc.isInvalid() || decl->getBraces().isInvalid())
     return true;
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -600,15 +600,12 @@ bool shouldLookupMembers(D *decl, SourceLoc loc) {
   if (ctx.SourceMgr.rangeContainsTokenLoc(decl->getBraces(), loc))
     return true;
 
-  // Within a protocol 'where' clause, we can also look for members of the
-  // protocol.
-  if (decl->getAsProtocolOrProtocolExtensionContext()) {
-    if (auto *whereClause = decl->getTrailingWhereClause()) {
-      SourceRange whereClauseRange = whereClause->getSourceRange();
-      if (whereClauseRange.isValid() &&
-          ctx.SourceMgr.rangeContainsTokenLoc(whereClauseRange, loc)) {
-        return true;
-      }
+  // Within 'where' clause, we can also look for members.
+  if (auto *whereClause = decl->getTrailingWhereClause()) {
+    SourceRange whereClauseRange = whereClause->getSourceRange();
+    if (whereClauseRange.isValid() &&
+        ctx.SourceMgr.rangeContainsTokenLoc(whereClauseRange, loc)) {
+      return true;
     }
   }
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3192,7 +3192,8 @@ Type TypeBase::getSuperclassForDecl(const ClassDecl *baseClass,
 
     t = t->getSuperclass(useArchetypes);
   }
-  llvm_unreachable("no inheritance relationship between given classes");
+
+  return ErrorType::get(this);
 }
 
 TypeSubstitutionMap

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3193,6 +3193,15 @@ Type TypeBase::getSuperclassForDecl(const ClassDecl *baseClass,
     t = t->getSuperclass(useArchetypes);
   }
 
+#ifndef NDEBUG
+  auto *currentClass = getConcreteTypeForSuperclassTraversing(this)
+      ->getClassOrBoundGenericClass();
+  while (currentClass && currentClass != baseClass)
+    currentClass = currentClass->getSuperclassDecl();
+  assert(currentClass == baseClass &&
+         "no inheritance relationship between given classes");
+#endif
+
   return ErrorType::get(this);
 }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -248,20 +248,6 @@ void TypeChecker::checkInheritanceClause(Decl *decl,
   } else if (auto ext = dyn_cast<ExtensionDecl>(decl)) {
     DC = ext;
     options |= TypeResolutionFlags::AllowUnavailableProtocol;
-  } else if (isa<GenericTypeParamDecl>(decl)) {
-    // For generic parameters, we want name lookup to look at just the
-    // signature of the enclosing entity.
-    DC = decl->getDeclContext();
-    if (auto nominal = dyn_cast<NominalTypeDecl>(DC)) {
-      DC = nominal;
-    } else if (auto ext = dyn_cast<ExtensionDecl>(DC)) {
-      DC = ext;
-    } else if (auto func = dyn_cast<AbstractFunctionDecl>(DC)) {
-      DC = func;
-    } else if (!DC->isModuleScopeContext()) {
-      // Skip the generic parameter's context entirely.
-      DC = DC->getParent();
-    }
   } else {
     DC = decl->getDeclContext();
   }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -244,11 +244,9 @@ void TypeChecker::checkInheritanceClause(Decl *decl,
   DeclContext *DC;
   if (auto nominal = dyn_cast<NominalTypeDecl>(decl)) {
     DC = nominal;
-    options = TypeResolutionOptions(TypeResolverContext::GenericSignature);
     options |= TypeResolutionFlags::AllowUnavailableProtocol;
   } else if (auto ext = dyn_cast<ExtensionDecl>(decl)) {
     DC = ext;
-    options = TypeResolutionOptions(TypeResolverContext::GenericSignature);
     options |= TypeResolutionFlags::AllowUnavailableProtocol;
   } else if (isa<GenericTypeParamDecl>(decl)) {
     // For generic parameters, we want name lookup to look at just the
@@ -256,13 +254,10 @@ void TypeChecker::checkInheritanceClause(Decl *decl,
     DC = decl->getDeclContext();
     if (auto nominal = dyn_cast<NominalTypeDecl>(DC)) {
       DC = nominal;
-      options = TypeResolutionOptions(TypeResolverContext::GenericSignature);
     } else if (auto ext = dyn_cast<ExtensionDecl>(DC)) {
       DC = ext;
-      options = TypeResolutionOptions(TypeResolverContext::GenericSignature);
     } else if (auto func = dyn_cast<AbstractFunctionDecl>(DC)) {
       DC = func;
-      options = TypeResolutionOptions(TypeResolverContext::GenericSignature);
     } else if (!DC->isModuleScopeContext()) {
       // Skip the generic parameter's context entirely.
       DC = DC->getParent();

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -242,18 +242,9 @@ void TypeChecker::checkGenericParamList(GenericSignatureBuilder *builder,
   assert(genericParams->size() > 0 &&
          "Parsed an empty generic parameter list?");
 
-  // Determine where and how to perform name lookup for the generic
-  // parameter lists and where clause.
+  // Determine where and how to perform name lookup.
   TypeResolutionOptions options = None;
   DeclContext *lookupDC = genericParams->begin()[0]->getDeclContext();
-  if (!lookupDC->isModuleScopeContext()) {
-    assert((isa<GenericTypeDecl>(lookupDC) ||
-            isa<ExtensionDecl>(lookupDC) ||
-            isa<AbstractFunctionDecl>(lookupDC) ||
-            isa<SubscriptDecl>(lookupDC)) &&
-           "not a proper generic parameter context?");
-    options = TypeResolutionOptions(TypeResolverContext::GenericSignature);
-  }    
 
   // First, add the generic parameters to the generic signature builder.
   // Do this before checking the inheritance clause, since it may

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -33,21 +33,6 @@ Type InheritedTypeRequest::evaluate(
       options |= TypeResolutionFlags::AllowUnavailableProtocol;
     } else {
       dc = typeDecl->getDeclContext();
-
-      if (isa<GenericTypeParamDecl>(typeDecl)) {
-        // For generic parameters, we want name lookup to look at just the
-        // signature of the enclosing entity.
-        if (auto nominal = dyn_cast<NominalTypeDecl>(dc)) {
-          dc = nominal;
-        } else if (auto ext = dyn_cast<ExtensionDecl>(dc)) {
-          dc = ext;
-        } else if (auto func = dyn_cast<AbstractFunctionDecl>(dc)) {
-          dc = func;
-        } else if (!dc->isModuleScopeContext()) {
-          // Skip the generic parameter's context entirely.
-          dc = dc->getParent();
-        }
-      }
     }
   } else {
     auto ext = decl.get<ExtensionDecl *>();

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -30,7 +30,6 @@ Type InheritedTypeRequest::evaluate(
   if (auto typeDecl = decl.dyn_cast<TypeDecl *>()) {
     if (auto nominal = dyn_cast<NominalTypeDecl>(typeDecl)) {
       dc = nominal;
-      options = TypeResolutionOptions(TypeResolverContext::GenericSignature);
       options |= TypeResolutionFlags::AllowUnavailableProtocol;
     } else {
       dc = typeDecl->getDeclContext();
@@ -40,13 +39,10 @@ Type InheritedTypeRequest::evaluate(
         // signature of the enclosing entity.
         if (auto nominal = dyn_cast<NominalTypeDecl>(dc)) {
           dc = nominal;
-          options = TypeResolutionOptions(TypeResolverContext::GenericSignature);
         } else if (auto ext = dyn_cast<ExtensionDecl>(dc)) {
           dc = ext;
-          options = TypeResolutionOptions(TypeResolverContext::GenericSignature);
         } else if (auto func = dyn_cast<AbstractFunctionDecl>(dc)) {
           dc = func;
-          options = TypeResolutionOptions(TypeResolverContext::GenericSignature);
         } else if (!dc->isModuleScopeContext()) {
           // Skip the generic parameter's context entirely.
           dc = dc->getParent();
@@ -56,7 +52,6 @@ Type InheritedTypeRequest::evaluate(
   } else {
     auto ext = decl.get<ExtensionDecl *>();
     dc = ext;
-    options = TypeResolutionOptions(TypeResolverContext::GenericSignature);
     options |= TypeResolutionFlags::AllowUnavailableProtocol;
   }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -300,7 +300,9 @@ Type TypeChecker::resolveTypeInContext(
       if (!sig)
         return ErrorType::get(Context);
       auto superclassType = sig->getSuperclassBound(selfType);
-      assert(superclassType);
+      if (!superclassType)
+        return ErrorType::get(Context);
+
       selfType = superclassType;
     }
   }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -297,6 +297,8 @@ Type TypeChecker::resolveTypeInContext(
       //
       // Get the superclass of the 'Self' type parameter.
       auto *sig = foundDC->getGenericSignatureOfContext();
+      if (!sig)
+        return ErrorType::get(Context);
       auto superclassType = sig->getSuperclassBound(selfType);
       assert(superclassType);
       selfType = superclassType;
@@ -763,15 +765,12 @@ static Type diagnoseUnknownType(TypeChecker &tc, DeclContext *dc,
 
     // Try ignoring access control.
     DeclContext *lookupDC = dc;
-    if (options.getBaseContext() == TypeResolverContext::GenericSignature)
-      lookupDC = dc->getParentForLookup();
-
     NameLookupOptions relookupOptions = lookupOptions;
     relookupOptions |= NameLookupFlags::KnownPrivate;
     relookupOptions |= NameLookupFlags::IgnoreAccessControl;
     auto inaccessibleResults =
-        tc.lookupUnqualifiedType(lookupDC, comp->getIdentifier(), comp->getIdLoc(),
-                                 relookupOptions);
+        tc.lookupUnqualifiedType(lookupDC, comp->getIdentifier(),
+                                 comp->getIdLoc(), relookupOptions);
     if (!inaccessibleResults.empty()) {
       // FIXME: What if the unviable candidates have different levels of access?
       auto first = cast<TypeDecl>(inaccessibleResults.front().getValueDecl());
@@ -890,84 +889,6 @@ static Type diagnoseUnknownType(TypeChecker &tc, DeclContext *dc,
   return ErrorType::get(tc.Context);
 }
 
-static Type
-resolveTopLevelIdentTypeComponent(TypeChecker &TC, DeclContext *DC,
-                                  ComponentIdentTypeRepr *comp,
-                                  TypeResolutionOptions options,
-                                  GenericTypeResolver *resolver);
-
-static Type
-resolveGenericSignatureComponent(TypeChecker &TC, DeclContext *DC,
-                                 ComponentIdentTypeRepr *comp,
-                                 TypeResolutionOptions options,
-                                 GenericTypeResolver *resolver) {
-  if (!DC->isInnermostContextGeneric())
-    return Type();
-
-  auto *genericParams = DC->getGenericParamsOfContext();
-
-  if (!isa<ExtensionDecl>(DC)) {
-    auto matchingParam =
-      std::find_if(genericParams->begin(), genericParams->end(),
-                   [comp](const GenericTypeParamDecl *param) {
-                     return param->getFullName().matchesRef(comp->getIdentifier());
-                   });
-
-    if (matchingParam == genericParams->end())
-      return Type();
-
-    comp->setValue(*matchingParam, nullptr);
-    return resolveTopLevelIdentTypeComponent(TC, DC, comp, options, resolver);
-  }
-
-  // If we are inside an extension of a nested type, we have to visit
-  // all outer parameter lists. Otherwise, we will visit them when
-  // name lookup goes ahead and checks the outer DeclContext.
-  for (auto *outerParams = genericParams;
-       outerParams != nullptr;
-       outerParams = outerParams->getOuterParameters()) {
-    auto matchingParam =
-      std::find_if(outerParams->begin(), outerParams->end(),
-                   [comp](const GenericTypeParamDecl *param) {
-                     return param->getFullName().matchesRef(comp->getIdentifier());
-                   });
-
-    if (matchingParam != outerParams->end()) {
-      comp->setValue(*matchingParam, nullptr);
-      return resolveTopLevelIdentTypeComponent(TC, DC, comp, options, resolver);
-    }
-  }
-
-  // If the lookup occurs from within a trailing 'where' clause of
-  // a constrained extension, also look for associated types and typealiases
-  // in the protocol.
-  if (genericParams->hasTrailingWhereClause() &&
-      comp->getIdLoc().isValid() &&
-      TC.Context.SourceMgr.rangeContainsTokenLoc(
-        genericParams->getTrailingWhereClauseSourceRange(),
-          comp->getIdLoc())) {
-    auto nominal = DC->getAsNominalTypeOrNominalTypeExtensionContext();
-    SmallVector<ValueDecl *, 4> decls;
-    if (DC->lookupQualified(nominal,
-                            comp->getIdentifier(),
-                            NL_OnlyTypes|NL_QualifiedDefault|NL_ProtocolMembers,
-                            decls)) {
-      for (const auto decl : decls) {
-        // FIXME: Better ambiguity handling.
-        auto typeDecl = cast<TypeDecl>(decl);
-
-        if (!isa<ProtocolDecl>(typeDecl->getDeclContext())) continue;
-
-        comp->setValue(typeDecl, DC);
-        return resolveTopLevelIdentTypeComponent(TC, DC, comp, options,
-                                                 resolver);
-      }
-    }
-  }
-
-  return Type();
-}
-
 /// Resolve the given identifier type representation as an unqualified type,
 /// returning the type it references.
 ///
@@ -1008,20 +929,6 @@ resolveTopLevelIdentTypeComponent(TypeChecker &TC, DeclContext *DC,
     auto selfType = resolver->mapTypeIntoContext(
       func->getDeclContext()->getSelfInterfaceType());
     return DynamicSelfType::get(selfType, TC.Context);
-  }
-
-  // For lookups within the generic signature, look at the generic
-  // parameters (only), then move up to the enclosing context.
-  if (options.getBaseContext() == TypeResolverContext::GenericSignature) {
-    Type type = resolveGenericSignatureComponent(
-      TC, DC, comp, options, resolver);
-    if (type)
-      return type;
-
-    if (!DC->isCascadingContextForLookup(/*excludeFunctions*/false))
-      options |= TypeResolutionFlags::KnownNonCascadingDependency;
-
-    lookupDC = DC->getParentForLookup();
   }
 
   auto id = comp->getIdentifier();
@@ -2692,7 +2599,6 @@ Type TypeResolver::resolveImplicitlyUnwrappedOptionalType(
   case TypeResolverContext::EnumPatternPayload:
   case TypeResolverContext::TypeAliasDecl:
   case TypeResolverContext::GenericRequirement:
-  case TypeResolverContext::GenericSignature:
   case TypeResolverContext::ImmediateOptionalTypeArgument:
   case TypeResolverContext::InExpression:
   case TypeResolverContext::EditorPlaceholderExpr:
@@ -2945,7 +2851,10 @@ Type TypeChecker::substMemberTypeWithBase(ModuleDecl *module,
           nominalDecl, baseTy,
           nominalDecl->getASTContext());
     }
-    
+
+    if (baseTy && baseTy->is<ErrorType>())
+      return baseTy;
+
     return NominalType::get(
         nominalDecl, baseTy,
         nominalDecl->getASTContext());

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -561,10 +561,6 @@ enum class TypeResolverContext : uint8_t {
   /// Whether we are checking the underlying type of a typealias.
   TypeAliasDecl,
 
-  /// Whether we are looking only in the generic signature of the context
-  /// we're searching, rather than the entire context.
-  GenericSignature,
-
   /// Whether we are in a requirement of a generic declaration
   GenericRequirement,
 
@@ -650,7 +646,6 @@ public:
     case Context::EnumElementDecl:
     case Context::EnumPatternPayload:
     case Context::TypeAliasDecl:
-    case Context::GenericSignature:
     case Context::GenericRequirement:
     case Context::ImmediateOptionalTypeArgument:
     case Context::AbstractFunctionDecl:

--- a/test/decl/typealias/protocol.swift
+++ b/test/decl/typealias/protocol.swift
@@ -272,7 +272,7 @@ extension P10 where T == Int { } // expected-warning{{neither type in same-type 
 
 extension P10 where A == X<T> { }
 
-extension P10 where A == X<U> { } // expected-error{{use of undeclared type 'U'}}
+extension P10 where A == X<U> { }
 
 extension P10 where A == X<Self.U> { }
 

--- a/validation-test/compiler_crashers_2_fixed/0153-rdar39130543.swift
+++ b/validation-test/compiler_crashers_2_fixed/0153-rdar39130543.swift
@@ -1,5 +1,5 @@
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
+// RUN: %target-swift-frontend %s -emit-ir
+
 
 protocol P20 { }
 


### PR DESCRIPTION
Teach unqualified name lookup not to look at the members of a nominal type or extension therefore when performing lookup in the inheritance clause of nominal type or extension. This was previously implemented in the type checker, but sink this logic down into `UnqualifiedLookup`, removing it from the type checker.

Built on top of @jrose-apple's excellent start.