### PR TITLE
[CodeCompletion] Remove unresolved type in prepareForRetypechecking()

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -412,7 +412,8 @@ static void prepareForRetypechecking(Expr *E) {
   assert(E);
   struct Eraser : public ASTWalker {
     std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
-      if (expr && expr->getType() && expr->getType()->hasError())
+      if (expr && expr->getType() && (expr->getType()->hasError() ||
+                                      expr->getType()->hasUnresolvedType()))
         expr->setType(Type());
       if (auto *ACE = dyn_cast_or_null<AutoClosureExpr>(expr)) {
         return { true, ACE->getSingleExpressionBody() };
@@ -420,13 +421,15 @@ static void prepareForRetypechecking(Expr *E) {
       return { true, expr };
     }
     bool walkToTypeLocPre(TypeLoc &TL) override {
-      if (TL.getType() && TL.getType()->hasError())
+      if (TL.getType() && (TL.getType()->hasError() ||
+                           TL.getType()->hasUnresolvedType()))
         TL.setType(Type());
       return true;
     }
 
     std::pair<bool, Pattern*> walkToPatternPre(Pattern *P) override {
-      if (P && P->hasType() && P->getType()->hasError()) {
+      if (P && P->hasType() && (P->getType()->hasError() ||
+                                P->getType()->hasUnresolvedType())) {
         P->setType(Type());
       }
       return { true, P };
@@ -3304,6 +3307,7 @@ public:
       // FIXME: This is workaround for getTypeOfExpressionWithoutApplying()
       // modifies type of 'expr'.
       expr->setType(Ty);
+      prepareForRetypechecking(expr);
     };
 
     // We allocate these expressions on the stack because we know they can't
@@ -3425,8 +3429,8 @@ public:
     Expr *expr = SE;
     if (!typeCheckCompletionSequence(const_cast<DeclContext *>(CurrDeclContext),
                                      expr)) {
-
-      if (!LHS->getType()->getRValueType()->getOptionalObjectType()) {
+      if (!LHS->getType() ||
+          !LHS->getType()->getRValueType()->getOptionalObjectType()) {
         // Don't complete optional operators on non-optional types.
         // FIXME: can we get the type-checker to disallow these for us?
         if (op->getName().str() == "??")

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -182,6 +182,7 @@ void ConstraintSystem::PotentialBindings::addPotentialBinding(
   // check whether we can combine it with another
   // supertype binding by computing the 'join' of the types.
   if (binding.Kind == AllowedBindingKind::Supertypes &&
+      !binding.BindingType->hasUnresolvedType() &&
       !binding.BindingType->hasTypeVariable() &&
       !binding.BindingType->hasUnboundGenericType() &&
       !binding.DefaultedProtocol && !binding.isDefaultableBinding() &&

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2242,7 +2242,7 @@ bool TypeChecker::typeCheckCompletionSequence(Expr *&expr, DeclContext *DC) {
 
   // Attempt to solve the constraint system.
   SmallVector<Solution, 4> viable;
-  if (CS.solve(expr, viable, FreeTypeVariableBinding::UnresolvedType))
+  if (CS.solve(expr, viable, FreeTypeVariableBinding::Disallow))
     return true;
 
   auto &solution = viable[0];
@@ -2255,12 +2255,7 @@ bool TypeChecker::typeCheckCompletionSequence(Expr *&expr, DeclContext *DC) {
   auto &solutionCS = solution.getConstraintSystem();
   expr->setType(solution.simplifyType(solutionCS.getType(expr)));
   auto completionType = solution.simplifyType(solutionCS.getType(CCE));
-
-  // If completion expression is unresolved it doesn't provide
-  // any meaningful information so shouldn't be in the results.
-  if (completionType->is<UnresolvedType>())
-    return true;
-
+  assert(!completionType->hasUnresolvedType());
   CCE->setType(completionType);
   return false;
 }

--- a/test/SourceKit/CodeComplete/complete_inner.swift
+++ b/test/SourceKit/CodeComplete/complete_inner.swift
@@ -38,7 +38,7 @@ func test010(x: E1, y: FooBar) {
 // RUN: %sourcekitd-test -req=complete.open -pos=26:11 -req-opts=filtertext=one %s -- %s | %FileCheck %s -check-prefix=INNER_POSTFIX_0b
 // INNER_POSTFIX_0b-NOT: key.description: "one{{.+}}"
 // INNER_POSTFIX_0b: key.description: "one",{{$}}
-// INNER_POSTFIX_0b: key.description: "one...",{{$}}
+// INNER_POSTFIX_0b: key.description: "one.",{{$}}
 // INNER_POSTFIX_0b-NOT: key.description: "one{{.+}}"
 
 // RUN: %sourcekitd-test -req=complete.open -pos=29:9 -req-opts=filtertext=pro %s -- %s | %FileCheck %s -check-prefix=INNER_POSTFIX_1

--- a/validation-test/IDE/crashers_2_fixed/rdar41224316.swift
+++ b/validation-test/IDE/crashers_2_fixed/rdar41224316.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+
+func test(str: String?) {
+  _ = str == nil #^A^#
+}


### PR DESCRIPTION
Unresolved type attached to expressions may fail re-typechecking. Reset them to null type so it properly re-typechecked.

Also, disallow unresolved type in `typeCheckCompletionSequence()`. It doesn't provide useful completions to developers.

rdar://problem/41224316