### PR TITLE
IRGen: Call coro.alloca.free on the token not the address of a coro.alloca.alloc

### DIFF
--- a/lib/IRGen/GenOpaque.cpp
+++ b/lib/IRGen/GenOpaque.cpp
@@ -482,10 +482,9 @@ void IRGenFunction::emitDeallocateDynamicAlloca(StackAddress address) {
   if (isCoroutine()) {
     auto allocToken = address.getExtraInfo();
     assert(allocToken && "dynamic alloca in coroutine without alloc token?");
-    (void)allocToken;
     auto freeFn = llvm::Intrinsic::getDeclaration(
         &IGM.Module, llvm::Intrinsic::ID::coro_alloca_free);
-    Builder.CreateCall(freeFn, address.getAddressPointer());
+    Builder.CreateCall(freeFn, allocToken);
     return;
   }
 


### PR DESCRIPTION
Test case in #18722. The test case is separate because of dependence on #18717.

rdar://43311065
