### PR TITLE
[sil-pass-manager] Wire up pass manager to the new deserialization notification infrastructure.

### DIFF
--- a/include/swift/SIL/Notifications.h
+++ b/include/swift/SIL/Notifications.h
@@ -13,9 +13,232 @@
 #ifndef SWIFT_SIL_NOTIFICATIONS_H
 #define SWIFT_SIL_NOTIFICATIONS_H
 
+#include "swift/Basic/LLVM.h"
+#include "swift/Basic/STLExtras.h"
+#include "llvm/ADT/PointerUnion.h"
+#include "llvm/ADT/SmallVector.h"
+#include <memory>
+
 namespace swift {
 
 class SILNode;
+class ModuleDecl;
+class SILFunction;
+class SILWitnessTable;
+class SILDefaultWitnessTable;
+class SILGlobalVariable;
+class SILVTable;
+
+/// An abstract class for handling SIL deserialization notifications.
+///
+/// This is an interface that should be implemented by clients that wish to
+/// maintain a list of notification handlers. In contrast, handler
+/// implementations should instead subclass DeserializationNotificationHandler
+/// so that default no-op implementations can be inherited and so that it can be
+/// passed into DeserializationNotificationHandlerSet.
+class DeserializationNotificationHandlerBase {
+public:
+  /// Observe that we deserialized a function declaration.
+  virtual void didDeserialize(ModuleDecl *mod, SILFunction *fn) = 0;
+
+  /// Observe that we successfully deserialized a function body.
+  virtual void didDeserializeFunctionBody(ModuleDecl *mod, SILFunction *fn) = 0;
+
+  /// Observe that we successfully deserialized a witness table's entries.
+  virtual void didDeserializeWitnessTableEntries(ModuleDecl *mod,
+                                                 SILWitnessTable *wt) = 0;
+
+  /// Observe that we successfully deserialized a default witness table's
+  /// entries.
+  virtual void
+  didDeserializeDefaultWitnessTableEntries(ModuleDecl *mod,
+                                           SILDefaultWitnessTable *wt) = 0;
+
+  /// Observe that we deserialized a global variable declaration.
+  virtual void didDeserialize(ModuleDecl *mod, SILGlobalVariable *var) = 0;
+
+  /// Observe that we deserialized a v-table declaration.
+  virtual void didDeserialize(ModuleDecl *mod, SILVTable *vtable) = 0;
+
+  /// Observe that we deserialized a witness-table declaration.
+  virtual void didDeserialize(ModuleDecl *mod, SILWitnessTable *wtable) = 0;
+
+  /// Observe that we deserialized a default witness-table declaration.
+  virtual void didDeserialize(ModuleDecl *mod,
+                              SILDefaultWitnessTable *wtable) = 0;
+
+  virtual ~DeserializationNotificationHandlerBase() = default;
+};
+
+/// A no-op implementation of DeserializationNotificationHandlerBase. Intended
+/// to allow for users to implement only one of the relevant methods and have
+/// all other methods be no-ops.
+class DeserializationNotificationHandler
+    : public DeserializationNotificationHandlerBase {
+public:
+  /// Observe that we deserialized a function declaration.
+  virtual void didDeserialize(ModuleDecl *mod, SILFunction *fn) override {}
+
+  /// Observe that we successfully deserialized a function body.
+  virtual void didDeserializeFunctionBody(ModuleDecl *mod,
+                                          SILFunction *fn) override {}
+
+  /// Observe that we successfully deserialized a witness table's entries.
+  virtual void didDeserializeWitnessTableEntries(ModuleDecl *mod,
+                                                 SILWitnessTable *wt) override {
+  }
+
+  /// Observe that we successfully deserialized a default witness table's
+  /// entries.
+  virtual void didDeserializeDefaultWitnessTableEntries(
+      ModuleDecl *mod, SILDefaultWitnessTable *wt) override {}
+
+  /// Observe that we deserialized a global variable declaration.
+  virtual void didDeserialize(ModuleDecl *mod,
+                              SILGlobalVariable *var) override {}
+
+  /// Observe that we deserialized a v-table declaration.
+  virtual void didDeserialize(ModuleDecl *mod, SILVTable *vtable) override {}
+
+  /// Observe that we deserialized a witness-table declaration.
+  virtual void didDeserialize(ModuleDecl *mod,
+                              SILWitnessTable *wtable) override {}
+
+  /// Observe that we deserialized a default witness-table declaration.
+  virtual void didDeserialize(ModuleDecl *mod,
+                              SILDefaultWitnessTable *wtable) override {}
+
+  virtual StringRef getName() const = 0;
+
+  virtual ~DeserializationNotificationHandler() = default;
+};
+
+/// A notification handler that only overrides didDeserializeFunctionBody and
+/// calls the passed in function pointer.
+class FunctionBodyDeserializationNotificationHandler final
+    : public DeserializationNotificationHandler {
+public:
+  using Handler = void (*)(ModuleDecl *, SILFunction *);
+
+private:
+  Handler handler;
+
+public:
+  FunctionBodyDeserializationNotificationHandler(Handler handler)
+      : handler(handler) {}
+  virtual ~FunctionBodyDeserializationNotificationHandler() {}
+
+  void didDeserializeFunctionBody(ModuleDecl *mod, SILFunction *fn) override {
+    (*handler)(mod, fn);
+  }
+
+  StringRef getName() const override {
+    return "FunctionBodyDeserializationNotificationHandler";
+  }
+};
+
+/// A type that contains a set of unique DeserializationNotificationHandlers and
+/// implements DeserializationNotificationHandlerBase by iterating over the
+/// stored handlers and calling each handler's implementation.
+class DeserializationNotificationHandlerSet final
+    : public DeserializationNotificationHandlerBase {
+public:
+  using NotificationUniquePtr =
+    std::unique_ptr<DeserializationNotificationHandler>;
+
+private:
+  /// A list of deserialization callbacks that update the SILModule and other
+  /// parts of SIL as deserialization occurs.
+  ///
+  /// We use 3 here since that is the most that will ever be used today in the
+  /// compiler. If that changed, that number should be changed as well. The
+  /// specific users are:
+  ///
+  /// 1. SILModule's serialization callback.
+  /// 2. SILPassManager notifications.
+  /// 3. Access Enforcement Stripping notification.
+  SmallVector<NotificationUniquePtr, 3> handlerSet;
+
+public:
+  DeserializationNotificationHandlerSet() = default;
+  ~DeserializationNotificationHandlerSet() = default;
+
+  bool erase(DeserializationNotificationHandler *handler) {
+    auto iter = find_if(handlerSet, [&](const NotificationUniquePtr &h) {
+      return handler == h.get();
+    });
+    if (iter == handlerSet.end())
+      return false;
+    handlerSet.erase(iter);
+    return true;
+  }
+
+  void add(NotificationUniquePtr &&handler) {
+    // Since we store unique_ptrs and are accepting a movable rvalue here, we
+    // should never have a case where we have a notification added twice. But
+    // just to be careful, lets use an assert.
+    assert(!count_if(handlerSet, [&](const NotificationUniquePtr &h) {
+             return handler.get() == h.get();
+           }) && "Two unique ptrs pointing at the same memory?!");
+    handlerSet.emplace_back(std::move(handler));
+  }
+
+  static DeserializationNotificationHandler *
+  getUnderlyingHandler(const NotificationUniquePtr &h) {
+    return h.get();
+  }
+
+  /// An iterator into the notification set that returns a bare
+  /// 'DeserializationNotificationHandler *' projected from one of the
+  /// underlying std::unique_ptr<DeserializationNotificationHandler>.
+  using iterator = llvm::mapped_iterator<
+      decltype(handlerSet)::const_iterator,
+      decltype(&DeserializationNotificationHandlerSet::getUnderlyingHandler)>;
+  using range = llvm::iterator_range<iterator>;
+
+  /// Returns an iterator to the first element of the handler set.
+  ///
+  /// NOTE: This iterator has a value_type of
+  /// 'DeserializationNotificationHandler'.
+  iterator begin() const {
+    auto *fptr = &DeserializationNotificationHandlerSet::getUnderlyingHandler;
+    return llvm::map_iterator(handlerSet.begin(), fptr);
+  }
+
+  /// Returns an iterator to the end of the handler set.
+  ///
+  /// NOTE: This iterator has a value_type of
+  /// 'DeserializationNotificationHandler'.
+  iterator end() const {
+    auto *fptr = &DeserializationNotificationHandlerSet::getUnderlyingHandler;
+    return llvm::map_iterator(handlerSet.end(), fptr);
+  }
+
+  /// Returns a range that iterates over bare pointers projected from the
+  /// internal owned memory pointers in the handlerSet.
+  ///
+  /// NOTE: The underlying iterator value_type here is
+  /// 'DeserializationNotificationHandler *'.
+  auto getRange() const -> range { return llvm::make_range(begin(), end()); }
+
+  //===--------------------------------------------------------------------===//
+  // DeserializationNotificationHandler implementation via chaining to the
+  // handlers we contain.
+  //===--------------------------------------------------------------------===//
+
+  void didDeserialize(ModuleDecl *mod, SILFunction *fn) override;
+  void didDeserializeFunctionBody(ModuleDecl *mod, SILFunction *fn) override;
+  void didDeserializeWitnessTableEntries(ModuleDecl *mod,
+                                         SILWitnessTable *wt) override;
+  void
+  didDeserializeDefaultWitnessTableEntries(ModuleDecl *mod,
+                                           SILDefaultWitnessTable *wt) override;
+  void didDeserialize(ModuleDecl *mod, SILGlobalVariable *var) override;
+  void didDeserialize(ModuleDecl *mod, SILVTable *vtable) override;
+  void didDeserialize(ModuleDecl *mod, SILWitnessTable *wtable) override;
+  void didDeserialize(ModuleDecl *mod,
+                      SILDefaultWitnessTable *wtable) override;
+};
 
 /// A protocol (or interface) for handling value deletion notifications.
 ///
@@ -24,7 +247,6 @@ class SILNode;
 /// analysis that need to invalidate data structures that contain pointers.
 /// This is similar to LLVM's ValueHandle.
 struct DeleteNotificationHandler {
-
   DeleteNotificationHandler() { }
   virtual ~DeleteNotificationHandler() {}
 
@@ -38,7 +260,6 @@ struct DeleteNotificationHandler {
   virtual bool needsNotifications() { return false; }
 };
 
-} // end swift namespace
+} // namespace swift
 
 #endif
-

--- a/include/swift/SILOptimizer/PassManager/PassManager.h
+++ b/include/swift/SILOptimizer/PassManager/PassManager.h
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/SIL/Notifications.h"
 #include "swift/SILOptimizer/Analysis/Analysis.h"
 #include "swift/SILOptimizer/PassManager/PassPipeline.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
@@ -100,6 +101,14 @@ class SILPassManager {
 
   /// The IRGen SIL passes. These have to be dynamically added by IRGen.
   llvm::DenseMap<unsigned, SILTransform *> IRGenPasses;
+
+  /// The notification handler for this specific SILPassManager.
+  ///
+  /// This is not owned by the pass manager, it is owned by the SILModule which
+  /// is guaranteed to outlive any pass manager associated with it. We keep this
+  /// bare pointer to ensure that we can deregister the notification after this
+  /// pass manager is destroyed.
+  DeserializationNotificationHandler *deserializationNotificationHandler;
 
 public:
   /// C'tor. It creates and registers all analysis passes, which are defined

--- a/include/swift/Serialization/SerializedSILLoader.h
+++ b/include/swift/Serialization/SerializedSILLoader.h
@@ -15,6 +15,7 @@
 
 #include "swift/AST/Decl.h"
 #include "swift/AST/Identifier.h"
+#include "swift/SIL/Notifications.h"
 #include "swift/SIL/SILDeclRef.h"
 #include "swift/SIL/SILLinkage.h"
 #include <memory>
@@ -36,56 +37,22 @@ class SILDefaultWitnessTable;
 /// in ASTContext. It provides lookupSILFunction that will perform lookup
 /// on each SILDeserializer.
 class SerializedSILLoader {
-public:
-  class Callback {
-  public:
-    /// Observe that we deserialized a function declaration.
-    virtual void didDeserialize(ModuleDecl *M, SILFunction *fn) {}
-
-    /// Observe that we successfully deserialized a function body.
-    virtual void didDeserializeFunctionBody(ModuleDecl *M, SILFunction *fn) {}
-
-    /// Observe that we successfully deserialized a witness table's entries.
-    virtual void didDeserializeWitnessTableEntries(ModuleDecl *M,
-                                                   SILWitnessTable *wt) {}
-
-    /// Observe that we successfully deserialized a default witness table's
-    /// entries.
-    virtual void didDeserializeDefaultWitnessTableEntries(ModuleDecl *M,
-                                                  SILDefaultWitnessTable *wt) {}
-
-    /// Observe that we deserialized a global variable declaration.
-    virtual void didDeserialize(ModuleDecl *M, SILGlobalVariable *var) {}
-
-    /// Observe that we deserialized a v-table declaration.
-    virtual void didDeserialize(ModuleDecl *M, SILVTable *vtable) {}
-
-    /// Observe that we deserialized a witness-table declaration.
-    virtual void didDeserialize(ModuleDecl *M, SILWitnessTable *wtable) {}
-
-    /// Observe that we deserialized a default witness-table declaration.
-    virtual void didDeserialize(ModuleDecl *M, SILDefaultWitnessTable *wtable) {}
-
-    virtual ~Callback() = default;
-  private:
-    virtual void _anchor();
-  };
-
 private:
-  std::vector<std::unique_ptr<SILDeserializer> > LoadedSILSections;
+  std::vector<std::unique_ptr<SILDeserializer>> LoadedSILSections;
 
-  explicit SerializedSILLoader(ASTContext &ctx, SILModule *SILMod,
-                               Callback *callback);
+  explicit SerializedSILLoader(
+      ASTContext &ctx, SILModule *SILMod,
+      DeserializationNotificationHandlerSet *callbacks);
 
 public:
   /// Create a new loader.
   ///
-  /// \param callback - not owned by the loader
-  static std::unique_ptr<SerializedSILLoader> create(ASTContext &ctx,
-                                                     SILModule *SILMod,
-                                                     Callback *callback) {
+  /// \param callbacks - not owned by the loader
+  static std::unique_ptr<SerializedSILLoader>
+  create(ASTContext &ctx, SILModule *SILMod,
+         DeserializationNotificationHandlerSet *callbacks) {
     return std::unique_ptr<SerializedSILLoader>(
-      new SerializedSILLoader(ctx, SILMod, callback));
+        new SerializedSILLoader(ctx, SILMod, callbacks));
   }
   ~SerializedSILLoader();
 

--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -10,6 +10,7 @@ add_swift_library(swiftSIL STATIC
   Linker.cpp
   LinearLifetimeChecker.cpp
   LoopInfo.cpp
+  Notifications.cpp
   OptimizationRemark.cpp
   PrettyStackTrace.cpp
   Projection.cpp

--- a/lib/SIL/Notifications.cpp
+++ b/lib/SIL/Notifications.cpp
@@ -1,0 +1,54 @@
+//===--- Notifications.cpp ------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-notifications"
+#include "swift/SIL/Notifications.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace swift;
+
+//===----------------------------------------------------------------------===//
+// DeserializationNotificationHandler Impl of
+// DeserializationNotificationHandlerSet
+//===----------------------------------------------------------------------===//
+
+#ifdef DNS_CHAIN_METHOD
+#error "DNS_CHAIN_METHOD is defined?!"
+#endif
+#define DNS_CHAIN_METHOD(Name, FirstTy, SecondTy)                              \
+  void DeserializationNotificationHandlerSet::did##Name(FirstTy first,         \
+                                                        SecondTy second) {     \
+    LLVM_DEBUG(llvm::dbgs()                                                    \
+               << "*** Deserialization Notification: " << #Name << " ***\n");  \
+    for (auto *p : getRange()) {                                               \
+      LLVM_DEBUG(llvm::dbgs()                                                  \
+                 << "    Begin Notifying: " << p->getName() << "\n");          \
+      p->did##Name(first, second);                                             \
+      LLVM_DEBUG(llvm::dbgs()                                                  \
+                 << "    End Notifying: " << p->getName() << "\n");            \
+    }                                                                          \
+    LLVM_DEBUG(llvm::dbgs()                                                    \
+               << "*** Completed Deserialization Notifications for " #Name     \
+                  "\n");                                                       \
+  }
+DNS_CHAIN_METHOD(Deserialize, ModuleDecl *, SILFunction *)
+DNS_CHAIN_METHOD(DeserializeFunctionBody, ModuleDecl *, SILFunction *)
+DNS_CHAIN_METHOD(DeserializeWitnessTableEntries, ModuleDecl *,
+                 SILWitnessTable *)
+DNS_CHAIN_METHOD(DeserializeDefaultWitnessTableEntries, ModuleDecl *,
+                 SILDefaultWitnessTable *)
+DNS_CHAIN_METHOD(Deserialize, ModuleDecl *, SILGlobalVariable *)
+DNS_CHAIN_METHOD(Deserialize, ModuleDecl *, SILVTable *)
+DNS_CHAIN_METHOD(Deserialize, ModuleDecl *, SILWitnessTable *)
+DNS_CHAIN_METHOD(Deserialize, ModuleDecl *, SILDefaultWitnessTable *)
+#undef DNS_CHAIN_METHOD

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -11,28 +11,30 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "sil-module"
-#include "swift/Serialization/SerializedSILLoader.h"
+#include "swift/SIL/SILModule.h"
+#include "Linker.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/ProtocolConformance.h"
-#include "swift/SIL/FormalLinkage.h"
-#include "swift/SIL/SILDebugScope.h"
-#include "swift/SIL/SILModule.h"
-#include "swift/Strings.h"
-#include "Linker.h"
-#include "swift/SIL/SILVisitor.h"
-#include "swift/SIL/SILValue.h"
 #include "swift/ClangImporter/ClangModule.h"
+#include "swift/SIL/FormalLinkage.h"
+#include "swift/SIL/Notifications.h"
+#include "swift/SIL/SILDebugScope.h"
+#include "swift/SIL/SILValue.h"
+#include "swift/SIL/SILVisitor.h"
+#include "swift/Serialization/SerializedSILLoader.h"
+#include "swift/Strings.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/ADT/SmallString.h"
-#include "llvm/ADT/StringSwitch.h"
 #include "llvm/ADT/Statistic.h"
+#include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/YAMLTraits.h"
 #include <functional>
 using namespace swift;
 using namespace Lowering;
 
-class SILModule::SerializationCallback : public SerializedSILLoader::Callback {
+class SILModule::SerializationCallback final
+    : public DeserializationNotificationHandler {
   void didDeserialize(ModuleDecl *M, SILFunction *fn) override {
     updateLinkage(fn);
   }
@@ -83,19 +85,21 @@ class SILModule::SerializationCallback : public SerializedSILLoader::Callback {
     }
   }
 
-  void didDeserializeFunctionBody(ModuleDecl *M, SILFunction *fn) override {
-    // Callbacks are currently applied in the order they are registered.
-    for (auto callBack : fn->getModule().getDeserializationCallbacks())
-      callBack(M, fn);
+  StringRef getName() const override {
+    return "SILModule::SerializationCallback";
   }
 };
 
 SILModule::SILModule(ModuleDecl *SwiftModule, SILOptions &Options,
                      const DeclContext *associatedDC, bool wholeModule)
     : TheSwiftModule(SwiftModule), AssociatedDeclContext(associatedDC),
-      Stage(SILStage::Raw), Callback(new SILModule::SerializationCallback()),
-      wholeModule(wholeModule), Options(Options), serialized(false),
-      SerializeSILAction(), Types(*this) {}
+      Stage(SILStage::Raw), wholeModule(wholeModule), Options(Options),
+      serialized(false), SerializeSILAction(), Types(*this) {
+  // We always add the base SILModule serialization callback.
+  std::unique_ptr<DeserializationNotificationHandler> callback(
+      new SILModule::SerializationCallback());
+  deserializationNotificationHandlers.add(std::move(callback));
+}
 
 SILModule::~SILModule() {
   // Decrement ref count for each SILGlobalVariable with static initializers.
@@ -469,8 +473,8 @@ SILVTable *SILModule::lookUpVTable(const ClassDecl *C) {
 SerializedSILLoader *SILModule::getSILLoader() {
   // If the SILLoader is null, create it.
   if (!SILLoader)
-    SILLoader = SerializedSILLoader::create(getASTContext(), this,
-                                            Callback.get());
+    SILLoader = SerializedSILLoader::create(
+        getASTContext(), this, &deserializationNotificationHandlers);
   // Return the SerializedSILLoader.
   return SILLoader.get();
 }
@@ -569,25 +573,17 @@ lookUpFunctionInVTable(ClassDecl *Class, SILDeclRef Member) {
   return nullptr;
 }
 
-void SILModule::registerDeserializationCallback(
-    SILFunctionBodyCallback callBack) {
-  if (std::find(DeserializationCallbacks.begin(),
-                DeserializationCallbacks.end(), callBack)
-      == DeserializationCallbacks.end())
-    DeserializationCallbacks.push_back(callBack);
+void SILModule::registerDeserializationNotificationHandler(
+    std::unique_ptr<DeserializationNotificationHandler> &&handler) {
+  deserializationNotificationHandlers.add(std::move(handler));
 }
 
-ArrayRef<SILModule::SILFunctionBodyCallback>
-SILModule::getDeserializationCallbacks() {
-  return DeserializationCallbacks;
-}
-
-void SILModule::
-registerDeleteNotificationHandler(DeleteNotificationHandler* Handler) {
+void SILModule::registerDeleteNotificationHandler(
+    DeleteNotificationHandler *handler) {
   // Ask the handler (that can be an analysis, a pass, or some other data
   // structure) if it wants to receive delete notifications.
-  if (Handler->needsNotifications()) {
-    NotificationHandlers.insert(Handler);
+  if (handler->needsNotifications()) {
+    NotificationHandlers.insert(handler);
   }
 }
 

--- a/lib/SILOptimizer/Mandatory/AccessMarkerElimination.cpp
+++ b/lib/SILOptimizer/Mandatory/AccessMarkerElimination.cpp
@@ -181,8 +181,13 @@ struct AccessMarkerEliminationPass : SILModuleTransform {
 
       // Markers from all current SIL functions are stripped. Register a
       // callback to strip an subsequently loaded functions on-the-fly.
-      if (!EnableOptimizedAccessMarkers)
-        M.registerDeserializationCallback(prepareSILFunctionForOptimization);
+      if (!EnableOptimizedAccessMarkers) {
+        using NotificationHandlerTy =
+            FunctionBodyDeserializationNotificationHandler;
+        auto *n = new NotificationHandlerTy(prepareSILFunctionForOptimization);
+        std::unique_ptr<DeserializationNotificationHandler> ptr(n);
+        M.registerDeserializationNotificationHandler(std::move(ptr));
+      }
     }
   }
 };

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -230,11 +230,36 @@ public:
   }
 };
 
+//===----------------------------------------------------------------------===//
+//                 Serialization Notification Implementation
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+class PassManagerDeserializationNotificationHandler final
+    : public DeserializationNotificationHandler {
+  NullablePtr<SILPassManager> pm;
+
+public:
+  PassManagerDeserializationNotificationHandler(SILPassManager *pm) : pm(pm) {}
+  ~PassManagerDeserializationNotificationHandler() override = default;
+
+  StringRef getName() const override {
+    return "PassManagerDeserializationNotificationHandler";
+  }
+
+  /// Observe that we deserialized a function declaration.
+  void didDeserialize(ModuleDecl *mod, SILFunction *fn) override {
+    pm.get()->notifyAnalysisOfFunction(fn);
+  }
+};
+
+} // end anonymous namespace
 
 SILPassManager::SILPassManager(SILModule *M, llvm::StringRef Stage,
-                               bool isMandatoryPipeline) :
-  Mod(M), StageName(Stage), isMandatoryPipeline(isMandatoryPipeline) {
-  
+                               bool isMandatoryPipeline)
+    : Mod(M), StageName(Stage), isMandatoryPipeline(isMandatoryPipeline),
+      deserializationNotificationHandler(nullptr) {
 #define ANALYSIS(NAME) \
   Analyses.push_back(create##NAME##Analysis(Mod));
 #include "swift/SILOptimizer/Analysis/Analysis.def"
@@ -243,6 +268,11 @@ SILPassManager::SILPassManager(SILModule *M, llvm::StringRef Stage,
     A->initialize(this);
     M->registerDeleteNotificationHandler(A);
   }
+
+  std::unique_ptr<DeserializationNotificationHandler> handler(
+      new PassManagerDeserializationNotificationHandler(this));
+  deserializationNotificationHandler = handler.get();
+  M->registerDeserializationNotificationHandler(std::move(handler));
 }
 
 SILPassManager::SILPassManager(SILModule *M, irgen::IRGenModule *IRMod,
@@ -538,6 +568,10 @@ void SILPassManager::execute() {
 SILPassManager::~SILPassManager() {
   assert(IRGenPasses.empty() && "Must add IRGen SIL passes that were "
                                 "registered to the list of transformations");
+
+  // Remove our deserialization notification handler.
+  Mod->removeDeserializationNotificationHandler(
+      deserializationNotificationHandler);
 
   // Free all transformations.
   for (auto *T : Transformations)

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -136,8 +136,9 @@ public:
   }
 };
 
-SILDeserializer::SILDeserializer(ModuleFile *MF, SILModule &M,
-                                 SerializedSILLoader::Callback *callback)
+SILDeserializer::SILDeserializer(
+    ModuleFile *MF, SILModule &M,
+    DeserializationNotificationHandlerSet *callback)
     : MF(MF), SILMod(M), Callback(callback) {
 
   SILCursor = MF->getSILCursor();

--- a/lib/Serialization/DeserializeSIL.h
+++ b/lib/Serialization/DeserializeSIL.h
@@ -28,7 +28,7 @@ namespace swift {
     
     ModuleFile *MF;
     SILModule &SILMod;
-    SerializedSILLoader::Callback *Callback;
+    DeserializationNotificationHandlerSet *Callback;
 
     /// The cursor used to lazily load SILFunctions.
     llvm::BitstreamCursor SILCursor;
@@ -150,7 +150,8 @@ public:
     ///
     /// TODO: Globals.
     void getAll(bool UseCallback = true) {
-      llvm::SaveAndRestore<SerializedSILLoader::Callback *> SaveCB(Callback);
+      llvm::SaveAndRestore<DeserializationNotificationHandlerSet *> SaveCB(
+          Callback);
 
       if (!UseCallback)
         Callback = nullptr;
@@ -183,9 +184,9 @@ public:
     /// Deserialize all Property descriptors inside the module and add them
     /// to SILMod.
     void getAllProperties();
-    
+
     SILDeserializer(ModuleFile *MF, SILModule &M,
-                    SerializedSILLoader::Callback *callback);
+                    DeserializationNotificationHandlerSet *callback);
 
     // Out of line to avoid instantiation OnDiskChainedHashTable here.
     ~SILDeserializer();

--- a/lib/Serialization/SerializedSILLoader.cpp
+++ b/lib/Serialization/SerializedSILLoader.cpp
@@ -20,16 +20,16 @@
 
 using namespace swift;
 
-SerializedSILLoader::SerializedSILLoader(ASTContext &Ctx,
-                                         SILModule *SILMod,
-                                         Callback *callback) {
+SerializedSILLoader::SerializedSILLoader(
+    ASTContext &Ctx, SILModule *SILMod,
+    DeserializationNotificationHandlerSet *callbacks) {
 
   // Get a list of SerializedModules from ASTContext.
   // FIXME: Iterating over LoadedModules is not a good way to do this.
   for (auto &Entry : Ctx.LoadedModules) {
     for (auto File : Entry.second->getFiles()) {
       if (auto LoadedAST = dyn_cast<SerializedASTFile>(File)) {
-        auto Des = new SILDeserializer(&LoadedAST->File, *SILMod, callback);
+        auto Des = new SILDeserializer(&LoadedAST->File, *SILMod, callbacks);
 #ifndef NDEBUG
         SILMod->verify();
 #endif
@@ -181,5 +181,3 @@ void SerializedSILLoader::getAllProperties() {
     Des->getAllProperties();
 }
 
-// Anchor the SerializedSILLoader v-table.
-void SerializedSILLoader::Callback::_anchor() {}


### PR DESCRIPTION
This uses the new deserialization notification infrastructure to ensure that pass manager notifications are sent out when we deserialize function declarations.

The first commit is in a separate PR: #18724. Please just review the second PR.

rdar://42301529