### PR TITLE
[libSyntax] Partly revert #18698 to fix ASAN bot

### DIFF
--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1016,13 +1016,6 @@ struct ParserUnit::Implementation {
             Opts.CollectParsedToken,
             Opts.BuildSyntaxTree)) {
   }
-
-  ~Implementation() {
-    // We need to delete the parser before the context so that it can finalize
-    // its SourceFileSyntax while it is still alive
-    TheParser.reset();
-    delete &Ctx;
-  }
 };
 
 ParserUnit::ParserUnit(SourceManager &SM, unsigned BufferID)


### PR DESCRIPTION
This partly reverts #18698 to resolve the ASAN failure we saw in https://ci.swift.org/view/Dashboard/job/oss-swift-incremental-ASAN-RA-osx/2244/testReport/junit/Swift(macosx-x86_64)/SwiftSyntax/VisitorTest_swift/