### PR TITLE
Fixed GPU execution for dataset_api runtime test.

### DIFF
--- a/stdlib/public/TensorFlow/Dataset.swift
+++ b/stdlib/public/TensorFlow/Dataset.swift
@@ -46,8 +46,8 @@ public extension SingleValueDataset {
   // users must specify the element shape for today.
   @inlinable @inline(__always)
   public init(elements: Tensor<Scalar>, elementShape: TensorShape) {
-    // A dataset graph function must run on TF CPU.
-    TensorFlow.enableCPU()
+    // A dataset creation op only runs on TF CPU.
+    enableCPU()
     self.init(
       _handle: #tfop(
         "TensorSliceDataset", [elements],
@@ -81,8 +81,8 @@ public extension SingleValueDataset {
   func map<T>(
     _ transform: @convention(tensorflow) (Tensor<Scalar>) -> Tensor<T>
   ) -> SingleValueDataset {
-    // A dataset graph function must run on TF CPU.
-    TensorFlow.enableCPU()
+    // A dataset creation op only runs on TF CPU.
+    enableCPU()
     return SingleValueDataset(
       _handle: #tfop(
         "MapDataset", _handle, [], f: transform, Targuments: [],
@@ -96,8 +96,8 @@ public extension SingleValueDataset {
   func filter(
     _ isIncluded: @convention(tensorflow) (Tensor<Scalar>) -> Tensor<Bool>
   ) -> SingleValueDataset {
-    // A dataset graph function must run on TF CPU.
-    TensorFlow.enableCPU()
+    // A dataset creation op only runs on TF CPU.
+    enableCPU()
     return SingleValueDataset(
       _handle: #tfop(
         "FilterDataset", _handle, [], predicate: isIncluded, Targuments: [],

--- a/stdlib/public/TensorFlow/Dataset.swift
+++ b/stdlib/public/TensorFlow/Dataset.swift
@@ -46,6 +46,8 @@ public extension SingleValueDataset {
   // users must specify the element shape for today.
   @inlinable @inline(__always)
   public init(elements: Tensor<Scalar>, elementShape: TensorShape) {
+    // A dataset graph function must run on TF CPU.
+    TensorFlow.enableCPU()
     self.init(
       _handle: #tfop(
         "TensorSliceDataset", [elements],
@@ -79,6 +81,8 @@ public extension SingleValueDataset {
   func map<T>(
     _ transform: @convention(tensorflow) (Tensor<Scalar>) -> Tensor<T>
   ) -> SingleValueDataset {
+    // A dataset graph function must run on TF CPU.
+    TensorFlow.enableCPU()
     return SingleValueDataset(
       _handle: #tfop(
         "MapDataset", _handle, [], f: transform, Targuments: [],
@@ -92,6 +96,8 @@ public extension SingleValueDataset {
   func filter(
     _ isIncluded: @convention(tensorflow) (Tensor<Scalar>) -> Tensor<Bool>
   ) -> SingleValueDataset {
+    // A dataset graph function must run on TF CPU.
+    TensorFlow.enableCPU()
     return SingleValueDataset(
       _handle: #tfop(
         "FilterDataset", _handle, [], predicate: isIncluded, Targuments: [],


### PR DESCRIPTION
All runtime tests are expected to pass in GPU mode now (though some control flow tests are still disabled for GPU and need to be debugged.) 

```
../llvm/utils/lit/lit.py -sv --param swift_tensorflow_gpu=true --param swift_test_mode=optimize --param swift_tensorflow_path=../build/bazel-bin/tensorflow ../build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/test-linux-x86_64/TensorFlowRuntime/
```