### PR TITLE
[SR-7984] Constraint to concrete type using : should offer a fixit

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4728,7 +4728,8 @@ ConstraintResult GenericSignatureBuilder::addTypeRequirement(
       Impl->HadAnyError = true;
       Diags.diagnose(source.getLoc(), diag::requires_conformance_nonprotocol,
                      TypeLoc::withoutLoc(subjectType),
-                     TypeLoc::withoutLoc(constraintType));
+                     TypeLoc::withoutLoc(constraintType))
+        .fixItReplace(source.getLoc(), " == ");
     }
 
     return ConstraintResult::Conflicting;

--- a/test/Generics/function_defs.swift
+++ b/test/Generics/function_defs.swift
@@ -284,7 +284,7 @@ func beginsWith3<S0: P2, S1: P2>(_ seq1: S0, _ seq2: S1) -> Bool
 // Bogus requirements
 //===----------------------------------------------------------------------===//
 func nonTypeReq<T>(_: T) where T : Wibble {} // expected-error{{use of undeclared type 'Wibble'}}
-func badProtocolReq<T>(_: T) where T : Int {} // expected-error{{type 'T' constrained to non-protocol, non-class type 'Int'}}
+func badProtocolReq<T>(_: T) where T : Int {} // expected-error{{type 'T' constrained to non-protocol, non-class type 'Int'}} {{38-39===}}
 
 func nonTypeSameType<T>(_: T) where T == Wibble {} // expected-error{{use of undeclared type 'Wibble'}}
 func nonTypeSameType2<T>(_: T) where Wibble == T {} // expected-error{{use of undeclared type 'Wibble'}}


### PR DESCRIPTION
This PR adds fixit for constraint to concrete type using `:`. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-7984](https://bugs.swift.org/browse/SR-7984).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
