### PR TITLE
[TBDGen] Remove TBD options from FrontendOptions

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -38,6 +38,7 @@
 #include "swift/Sema/SourceLoader.h"
 #include "swift/Serialization/Validation.h"
 #include "swift/Subsystems.h"
+#include "swift/TBDGen/TBDGen.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Option/ArgList.h"
@@ -70,6 +71,7 @@ class CompilerInvocation {
   MigratorOptions MigratorOpts;
   SILOptions SILOpts;
   IRGenOptions IRGenOpts;
+  TBDGenOptions TBDGenOpts;
   /// The \c SyntaxParsingCache to use when parsing the main file of this
   /// invocation
   SyntaxParsingCache *MainFileSyntaxParsingCache = nullptr;
@@ -196,6 +198,9 @@ public:
 
   FrontendOptions &getFrontendOptions() { return FrontendOpts; }
   const FrontendOptions &getFrontendOptions() const { return FrontendOpts; }
+
+  TBDGenOptions &getTBDGenOptions() { return TBDGenOpts; }
+  const TBDGenOptions &getTBDGenOptions() const { return TBDGenOpts; }
 
   ClangImporterOptions &getClangImporterOptions() { return ClangImporterOpts; }
   const ClangImporterOptions &getClangImporterOptions() const {

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -260,19 +260,6 @@ public:
   /// Compare the symbols in the IR against the TBD file we would generate.
   TBDValidationMode ValidateTBDAgainstIR = TBDValidationMode::Default;
 
-  /// The install_name to use in the TBD file.
-  std::string TBDInstallName;
-
-  // The current project version to use in the generated TBD file. Defaults
-  // to 1, which matches the default if the DYLIB_CURRENT_VERSION build setting
-  // is not set.
-  version::Version TBDCurrentVersion = {1, 0, 0};
-
-  // The dylib compatibility-version to use in the generated TBD file. Defaults
-  // to 1, which matches the default if the DYLIB_COMPATIBILITY_VERSION build
-  // setting is not set.
-  version::Version TBDCompatibilityVersion = {1, 0, 0};
-
   /// An enum with different modes for automatically crashing at defined times.
   enum class DebugCrashMode {
     None, ///< Don't automatically crash.

--- a/include/swift/TBDGen/TBDGen.h
+++ b/include/swift/TBDGen/TBDGen.h
@@ -24,30 +24,39 @@ namespace swift {
 class FileUnit;
 class ModuleDecl;
 
-/// \brief The current ABI version of Swift, as tapi labels it.
+/// The current ABI version of Swift, as tapi labels it.
 const uint8_t TAPI_SWIFT_ABI_VERSION = 5;
 
-/// \brief Options for controlling the exact set of symbols included in the TBD
+/// Options for controlling the exact set of symbols included in the TBD
 /// output.
 struct TBDGenOptions {
-  /// \brief Whether this compilation has multiple IRGen instances.
+  /// Whether this compilation has multiple IRGen instances.
   bool HasMultipleIGMs;
-  /// \brief The install-name used for the compilation.
-  llvm::StringRef InstallName;
-  /// \brief The module link name (for force loading).
-  llvm::StringRef ModuleLinkName;
-  /// \brief The current project version.
-  version::Version CurrentVersion;
-  /// \brief The dylib compatibility version.
-  version::Version CompatibilityVersion;
+
+  /// The install_name to use in the TBD file.
+  std::string InstallName;
+
+  /// The module link name (for force loading).
+  std::string ModuleLinkName;
+
+  /// The current project version to use in the generated TBD file. Defaults
+  /// to 1, which matches the default if the DYLIB_CURRENT_VERSION build setting
+  /// is not set.
+  version::Version CurrentVersion = {1, 0, 0};
+
+  /// The dylib compatibility-version to use in the generated TBD file. Defaults
+  /// to 1, which matches the default if the DYLIB_COMPATIBILITY_VERSION build
+  /// setting is not set.
+  version::Version CompatibilityVersion = {1, 0, 0};
 };
 
 void enumeratePublicSymbols(FileUnit *module, llvm::StringSet<> &symbols,
-                            TBDGenOptions &opts);
+                            const TBDGenOptions &opts);
 void enumeratePublicSymbols(ModuleDecl *module, llvm::StringSet<> &symbols,
-                            TBDGenOptions &opts);
+                            const TBDGenOptions &opts);
 
-void writeTBDFile(ModuleDecl *M, llvm::raw_ostream &os, TBDGenOptions &opts);
+void writeTBDFile(ModuleDecl *M, llvm::raw_ostream &os,
+                  const TBDGenOptions &opts);
 
 } // end namespace swift
 

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -214,21 +214,6 @@ void ArgsToFrontendOptionsConverter::computeTBDOptions() {
                      A->getOption().getPrefixedName(), value);
     }
   }
-  if (const Arg *A = Args.getLastArg(OPT_tbd_install_name)) {
-    Opts.TBDInstallName = A->getValue();
-  }
-  if (const Arg *A = Args.getLastArg(OPT_tbd_compatibility_version)) {
-    if (auto vers = version::Version::parseVersionString(
-          A->getValue(), SourceLoc(), &Diags)) {
-      Opts.TBDCompatibilityVersion = *vers;
-    }
-  }
-  if (const Arg *A = Args.getLastArg(OPT_tbd_current_version)) {
-    if (auto vers = version::Version::parseVersionString(
-          A->getValue(), SourceLoc(), &Diags)) {
-      Opts.TBDCurrentVersion = *vers;
-    }
-  }
 }
 
 void ArgsToFrontendOptionsConverter::setUnsignedIntegerArgument(

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -979,6 +979,9 @@ static bool performCompile(CompilerInstance &Instance,
     return true;
   }
 
+  if (writeTBDIfNeeded(Invocation, Instance))
+    return true;
+
   // FIXME: This is still a lousy approximation of whether the module file will
   // be externally consumed.
   bool moduleIsPublic =
@@ -1000,9 +1003,6 @@ static bool performCompile(CompilerInstance &Instance,
 
     return hadPrintAsObjCError || hadEmitIndexDataError || Context.hadError();
   }
-
-  if (writeTBDIfNeeded(Invocation, Instance))
-    return true;
 
   assert(FrontendOptions::doesActionGenerateSIL(Action) &&
          "All actions not requiring SILGen must have been handled!");

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -782,6 +782,7 @@ static void emitReferenceDependenciesForAllPrimaryInputsIfNeeded(
 static bool writeTBDIfNeeded(CompilerInvocation &Invocation,
                              CompilerInstance &Instance) {
   const auto &frontendOpts = Invocation.getFrontendOptions();
+  const auto &tbdOpts = Invocation.getTBDGenOptions();
   if (!frontendOpts.InputsAndOutputs.hasTBDPath())
     return false;
 
@@ -793,18 +794,7 @@ static bool writeTBDIfNeeded(CompilerInvocation &Invocation,
 
   const std::string &TBDPath = Invocation.getTBDPathForWholeModule();
 
-  auto installName = frontendOpts.TBDInstallName.empty()
-                         ? "lib" + Invocation.getModuleName().str() + ".dylib"
-                         : frontendOpts.TBDInstallName;
-
-  TBDGenOptions opts;
-  opts.InstallName = installName;
-  opts.HasMultipleIGMs = Invocation.getSILOptions().hasMultipleIGMs();
-  opts.ModuleLinkName = frontendOpts.ModuleLinkName;
-  opts.CurrentVersion = frontendOpts.TBDCurrentVersion;
-  opts.CompatibilityVersion = frontendOpts.TBDCompatibilityVersion;
-
-  return writeTBD(Instance.getMainModule(), TBDPath, opts);
+  return writeTBD(Instance.getMainModule(), TBDPath, tbdOpts);
 }
 
 static std::deque<PostSILGenInputs>
@@ -1213,14 +1203,13 @@ static bool validateTBDIfNeeded(CompilerInvocation &Invocation,
   case FrontendOptions::TBDValidationMode::MissingFromTBD:
     break;
   }
-  TBDGenOptions opts;
-  opts.HasMultipleIGMs = Invocation.getSILOptions().hasMultipleIGMs();
-  opts.ModuleLinkName = frontendOpts.ModuleLinkName;
 
   const bool allSymbols = mode == FrontendOptions::TBDValidationMode::All;
   return MSF.is<SourceFile *>()
-             ? validateTBD(MSF.get<SourceFile *>(), IRModule, opts, allSymbols)
-             : validateTBD(MSF.get<ModuleDecl *>(), IRModule, opts, allSymbols);
+             ? validateTBD(MSF.get<SourceFile *>(), IRModule,
+                           Invocation.getTBDGenOptions(), allSymbols)
+             : validateTBD(MSF.get<ModuleDecl *>(), IRModule,
+                           Invocation.getTBDGenOptions(), allSymbols);
 }
 
 static bool generateCode(CompilerInvocation &Invocation,

--- a/lib/FrontendTool/TBD.cpp
+++ b/lib/FrontendTool/TBD.cpp
@@ -39,7 +39,7 @@ static std::vector<StringRef> sortSymbols(llvm::StringSet<> &symbols) {
 }
 
 bool swift::writeTBD(ModuleDecl *M, StringRef OutputFilename,
-                     TBDGenOptions &Opts) {
+                     const TBDGenOptions &Opts) {
   std::error_code EC;
   llvm::raw_fd_ostream OS(OutputFilename, EC, llvm::sys::fs::F_None);
   if (EC) {
@@ -124,7 +124,8 @@ static bool validateSymbolSet(DiagnosticEngine &diags,
 }
 
 bool swift::validateTBD(ModuleDecl *M, llvm::Module &IRModule,
-                        TBDGenOptions &opts, bool diagnoseExtraSymbolsInTBD) {
+                        const TBDGenOptions &opts,
+                        bool diagnoseExtraSymbolsInTBD) {
   llvm::StringSet<> symbols;
   enumeratePublicSymbols(M, symbols, opts);
 
@@ -133,10 +134,12 @@ bool swift::validateTBD(ModuleDecl *M, llvm::Module &IRModule,
 }
 
 bool swift::validateTBD(FileUnit *file, llvm::Module &IRModule,
-                        TBDGenOptions &opts, bool diagnoseExtraSymbolsInTBD) {
+                        const TBDGenOptions &opts,
+                        bool diagnoseExtraSymbolsInTBD) {
   llvm::StringSet<> symbols;
   enumeratePublicSymbols(file, symbols, opts);
 
   return validateSymbolSet(file->getParentModule()->getASTContext().Diags,
-                           symbols, IRModule, diagnoseExtraSymbolsInTBD);
+                           symbols, IRModule,
+                           diagnoseExtraSymbolsInTBD);
 }

--- a/lib/FrontendTool/TBD.h
+++ b/lib/FrontendTool/TBD.h
@@ -25,11 +25,14 @@ class FileUnit;
 class FrontendOptions;
 struct TBDGenOptions;
 
-bool writeTBD(ModuleDecl *M, StringRef OutputFilename, TBDGenOptions &Opts);
+bool writeTBD(ModuleDecl *M, StringRef OutputFilename,
+              const TBDGenOptions &Opts);
 bool inputFileKindCanHaveTBDValidated(InputFileKind kind);
-bool validateTBD(ModuleDecl *M, llvm::Module &IRModule, TBDGenOptions &opts,
+bool validateTBD(ModuleDecl *M, llvm::Module &IRModule,
+                 const TBDGenOptions &opts,
                  bool diagnoseExtraSymbolsInTBD);
-bool validateTBD(FileUnit *M, llvm::Module &IRModule, TBDGenOptions &opts,
+bool validateTBD(FileUnit *M, llvm::Module &IRModule,
+                 const TBDGenOptions &opts,
                  bool diagnoseExtraSymbolsInTBD);
 }
 

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -414,7 +414,7 @@ void TBDGenVisitor::addFirstFileSymbols() {
 /// Converts a version tuple into a packed version, ignoring components beyond
 /// major, minor, and subminor.
 static tapi::internal::PackedVersion
-convertToPacked(version::Version &version) {
+convertToPacked(const version::Version &version) {
   // FIXME: Warn if version is greater than 3 components?
   unsigned major = 0, minor = 0, subminor = 0;
   if (version.size() > 0) major = version[0];
@@ -426,7 +426,7 @@ convertToPacked(version::Version &version) {
 static void enumeratePublicSymbolsAndWrite(ModuleDecl *M, FileUnit *singleFile,
                                            StringSet *symbols,
                                            llvm::raw_ostream *os,
-                                           TBDGenOptions &opts) {
+                                           const TBDGenOptions &opts) {
   auto isWholeModule = singleFile == nullptr;
   const auto &target = M->getASTContext().LangOpts.Target;
   UniversalLinkageInfo linkInfo(target, opts.HasMultipleIGMs, isWholeModule);
@@ -481,15 +481,15 @@ static void enumeratePublicSymbolsAndWrite(ModuleDecl *M, FileUnit *singleFile,
 }
 
 void swift::enumeratePublicSymbols(FileUnit *file, StringSet &symbols,
-                                   TBDGenOptions &opts) {
+                                   const TBDGenOptions &opts) {
   enumeratePublicSymbolsAndWrite(file->getParentModule(), file, &symbols,
                                  nullptr, opts);
 }
 void swift::enumeratePublicSymbols(ModuleDecl *M, StringSet &symbols,
-                                   TBDGenOptions &opts) {
+                                   const TBDGenOptions &opts) {
   enumeratePublicSymbolsAndWrite(M, nullptr, &symbols, nullptr, opts);
 }
 void swift::writeTBDFile(ModuleDecl *M, llvm::raw_ostream &os,
-                         TBDGenOptions &opts) {
+                         const TBDGenOptions &opts) {
   enumeratePublicSymbolsAndWrite(M, nullptr, nullptr, &os, opts);
 }

--- a/lib/TBDGen/TBDGenVisitor.h
+++ b/lib/TBDGen/TBDGenVisitor.h
@@ -48,7 +48,7 @@ public:
 
   const UniversalLinkageInfo &UniversalLinkInfo;
   ModuleDecl *SwiftModule;
-  TBDGenOptions &Opts;
+  const TBDGenOptions &Opts;
 
 private:
   bool FileHasEntryPoint = false;
@@ -68,7 +68,7 @@ public:
   TBDGenVisitor(tapi::internal::InterfaceFile &symbols,
                 tapi::internal::ArchitectureSet archs, StringSet *stringSymbols,
                 const UniversalLinkageInfo &universalLinkInfo,
-                ModuleDecl *swiftModule, TBDGenOptions &opts)
+                ModuleDecl *swiftModule, const TBDGenOptions &opts)
       : Symbols(symbols), Archs(archs), StringSymbols(stringSymbols),
         UniversalLinkInfo(universalLinkInfo), SwiftModule(swiftModule),
         Opts(opts) {}

--- a/test/TBD/class.swift
+++ b/test/TBD/class.swift
@@ -8,6 +8,11 @@
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -enable-testing -O
 // RUN: %target-swift-frontend -enable-resilience -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -enable-testing -O
 
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/typecheck.tbd
+// RUN: %target-swift-frontend -emit-ir -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/emit-ir.tbd
+// RUN: diff -u %t/typecheck.tbd %t/emit-ir.tbd
+
 open class OpenNothing {}
 
 open class OpenInit {

--- a/test/TBD/enum.swift
+++ b/test/TBD/enum.swift
@@ -21,6 +21,12 @@
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -swift-version 4 -enable-testing -O
 // RUN: %target-swift-frontend -enable-resilience -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -swift-version 4 -enable-testing -O
 
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/typecheck.tbd
+// RUN: %target-swift-frontend -emit-ir -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/emit-ir.tbd
+// RUN: diff -u %t/typecheck.tbd %t/emit-ir.tbd
+
+
 public protocol P {}
 
 public class C {

--- a/test/TBD/function.swift
+++ b/test/TBD/function.swift
@@ -3,6 +3,11 @@
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all -swift-version 4 %s -O
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all -swift-version 4 %s -enable-testing -O
 
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/typecheck.tbd
+// RUN: %target-swift-frontend -emit-ir -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/emit-ir.tbd
+// RUN: diff -u %t/typecheck.tbd %t/emit-ir.tbd
+
 public func publicNoArgs() {}
 public func publicSomeArgs(_: Int, x: Int) {}
 public func publicWithDefault(_: Int = 0) {}

--- a/test/TBD/global.swift
+++ b/test/TBD/global.swift
@@ -7,6 +7,11 @@
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s -enable-testing -O
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all -enable-resilience -enable-testing %s -O
 
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/typecheck.tbd
+// RUN: %target-swift-frontend -emit-ir -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/emit-ir.tbd
+// RUN: diff -u %t/typecheck.tbd %t/emit-ir.tbd
+
 public let publicLet: Int = 0
 internal let internalLet: Int = 0
 private let privateLet: Int = 0

--- a/test/TBD/main.swift
+++ b/test/TBD/main.swift
@@ -1,4 +1,9 @@
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -module-name test -validate-tbd-against-ir=all %s
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -module-name test -validate-tbd-against-ir=all %s -O
 
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/typecheck.tbd
+// RUN: %target-swift-frontend -emit-ir -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/emit-ir.tbd
+// RUN: diff -u %t/typecheck.tbd %t/emit-ir.tbd
+
 // Top-level code (i.e. implicit `main`) should be handled

--- a/test/TBD/protocol.swift
+++ b/test/TBD/protocol.swift
@@ -8,6 +8,11 @@
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -enable-testing -O
 // RUN: %target-swift-frontend -enable-resilience -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -enable-testing -O
 
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/typecheck.tbd
+// RUN: %target-swift-frontend -emit-ir -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/emit-ir.tbd
+// RUN: diff -u %t/typecheck.tbd %t/emit-ir.tbd
+
 public protocol Public {
     func publicMethod()
     associatedtype PublicAT

--- a/test/TBD/specialization.swift
+++ b/test/TBD/specialization.swift
@@ -9,6 +9,11 @@
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -O -validate-tbd-against-ir=all -enable-testing %s
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -O -validate-tbd-against-ir=all -enable-resilience -enable-testing %s
 
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/typecheck.tbd
+// RUN: %target-swift-frontend -emit-ir -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/emit-ir.tbd
+// RUN: diff -u %t/typecheck.tbd %t/emit-ir.tbd
+
 // rdar://problem/40738913
 
 open class Foo {

--- a/test/TBD/struct.swift
+++ b/test/TBD/struct.swift
@@ -7,6 +7,11 @@
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s -enable-testing -O
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -validate-tbd-against-ir=all %s -enable-resilience -enable-testing -O
 
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/typecheck.tbd
+// RUN: %target-swift-frontend -emit-ir -parse-as-library -module-name test %s -emit-tbd -emit-tbd-path %t/emit-ir.tbd
+// RUN: diff -u %t/typecheck.tbd %t/emit-ir.tbd
+
 public struct StructPublicNothing {}
 
 public struct StructPublicInit {


### PR DESCRIPTION
This patch removes the duplication between FrontendOptions and
TBDGenOptions by parsing the TBDGenOptions up front similarly to IRGen
and SIL options.