### PR TITLE
Add some unit tests for writing scalar summary, to verify the backend works. 

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
+++ b/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
@@ -694,8 +694,10 @@ bool SingleExitLoopTransformer::transform() {
     for (const SILInstruction &inst : *loop->getHeader()) {
       if (auto graphOp = dyn_cast<GraphOperationInst>(&inst)) {
         StringRef name = graphOp->getName().str();
+        // FIXME: generalize the logic for deciding side-effecting ops.
         if (name.startswith("tfc.SendToHost") ||
-            name.startswith("tfc.RecvFromHost")) {
+            name.startswith("tfc.RecvFromHost") ||
+            name.startswith("WriteScalarSummary")) {
           hasEffectfulOps = true;
           break;
         }

--- a/lib/SILOptimizer/Mandatory/TFDeviceSupport.h
+++ b/lib/SILOptimizer/Mandatory/TFDeviceSupport.h
@@ -198,57 +198,6 @@ struct GraphFunctionDeviceInfo {
     ++numUsedDeviceTypes;
   }
 
-  // Chooses a device for this tfop, extends `operands` and `newInstName`
-  // accordingly with the device attribute, and tracks the chosen device in
-  // `usedDeviceTypes`.
-  //
-  // If `opDevice` is already set, respects that device choice. Otherwise,
-  // chooses a device based on this deviceInfo and op kernel device
-  // availability.
-  //
-  // For some tfops (e.g. "tfc.scalarToTensor"), device placement is handled
-  // specially, so this function call will be a no-op.
-  //
-  // TODO: remove this function once we complete the migration to GraphOpInst.
-  void handleDevicePlacementLegacy(llvm::StringRef opType,
-                                   llvm::StringRef opDevice, SILBuilder &B,
-                                   SILLocation loc,
-                                   SmallVectorImpl<SILValue> &operands,
-                                   std::string &newInstName) {
-    // No device placement for this special-case "pseudo-op" for
-    // scalar-to-tensor promotion. It will later be translated by compiler (in
-    // PartitionCloner) into real TF ops, where device placement is handled at
-    // that time.
-    if (opType == "tfc.scalarToTensor") {
-      assert(opDevice.empty());
-      return;
-    }
-
-    DeviceType chosenDevice;
-    if (!opDevice.empty())
-      chosenDevice = getOpDeviceType(opDevice);
-    else
-      chosenDevice = chooseDevice(opType);
-
-    markDeviceUsed(chosenDevice);
-
-    // Example output SIL:
-    // %2 = string_literal utf8 "/device:GPU:0"        // user: %3
-    // %3 = builtin "__tfop_Const,dtype,value$tensor,__device"(%0 : $@thin
-    // %Float.Type, %1 : $Builtin.FPIEEE64, %2 : $Builtin.RawPointer) :
-    // %$TensorHandle<Float> // user: %4
-    //
-    // Note we generate the StringLiteral inst for op device even when the input
-    // `opDevice` is not empty. This is redundant but keeps the code simple, and
-    // we expect the original StringLiteral inst for the op device to get DCE'd
-    // in a later compiler pass.
-    auto deviceString = getDeviceString(chosenDevice);
-    auto deviceStrInst = B.createStringLiteral(
-        loc, llvm::StringRef(deviceString), StringLiteralInst::Encoding::UTF8);
-    operands.push_back(deviceStrInst);
-    newInstName += std::string(",") + DEVICE_ATTR;
-  }
-
   // Choose a device for the graphOpInst under construction, extend `attributes`
   // accordingly with the device attribute, and track the chosen device in
   // `usedDeviceTypes`.
@@ -275,21 +224,7 @@ private:
     numUsedDeviceTypes = 1;
   }
 
-  DeviceType chooseDevice(llvm::StringRef opType) const {
-    if (opType == "tfc.RecvFromHost" || opType == "tfc.SendToHost")
-      return DeviceType::CPU;
-
-    // Dataset / iterator related ops.
-    if (opType == "OneShotIterator" || opType == "IteratorGetNext" ||
-        opType == "TensorSliceDataset")
-      return DeviceType::CPU;
-
-    // Place this inst on the device given by this deviceInfo.
-    // FIXME: Use the op kernel device availability info to select a device for
-    // `opType` -- if that op has no available kernel on `primaryDeviceType`, a
-    // different device should be returned.
-    return primaryDeviceType;
-  }
+  DeviceType chooseDevice(llvm::StringRef opType) const;
 
   // Actual TF devices involved in the tensor computation.
   // It cannot contain DeviceType::ALL.


### PR DESCRIPTION
This unblocks the work for API design.

The added unit tests can be compiled and executed, with tensorboard visualization as in:

```
$ ../build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/bin/swift -O test/TensorFlow/test_tmp.swift

$ ll logdir_s4tf
total 12
drwxr-xr-x  2 <user_id> primarygroup 4096 Aug 15 13:24 ./
drwxr-xr-x 20 <user_id> primarygroup 4096 Aug 15 13:21 ../
-rw-r--r--  1 <user_id> primarygroup  126 Aug 15 13:24 events.out.tfevents.1534364656.<machine_id>.v2

$ tensorboard --logdir=./logdir_s4tf
TensorBoard 1.9.0 at http://<machine_id>:6006 (Press CTRL+C to quit)
```

We didn't add runtime tests for this, because tests that write to files need some care to manage (e.g. need to delete the output files), and also there is no easy way to verify the written files are correct.

But the main complexity / risk here is in compiling and generating the right code/graph, so compiler-only tests should suffice.

Also deleted dead code in `handleDevicePlacementLegacy()`.
