### PR TITLE
[stdlib] Migrate remaining stdlib tests from Swift 3

### DIFF
--- a/test/stdlib/ArrayBridge.swift.gyb
+++ b/test/stdlib/ArrayBridge.swift.gyb
@@ -14,7 +14,7 @@
 //
 // RUN: %gyb %s -o %t/ArrayBridge.swift
 // RUN: %target-clang %S/Inputs/ArrayBridge/ArrayBridge.m -c -o %t/ArrayBridgeObjC.o -g
-// RUN:  %line-directive %t/ArrayBridge.swift -- %target-build-swift %t/ArrayBridge.swift -I %S/Inputs/ArrayBridge/ -Xlinker %t/ArrayBridgeObjC.o -o %t/ArrayBridge -swift-version 3 --
+// RUN:  %line-directive %t/ArrayBridge.swift -- %target-build-swift %t/ArrayBridge.swift -I %S/Inputs/ArrayBridge/ -Xlinker %t/ArrayBridgeObjC.o -o %t/ArrayBridge -swift-version 4.2 --
 
 // RUN: %target-codesign %t/ArrayBridge
 // RUN: %target-run %t/ArrayBridge
@@ -127,7 +127,7 @@ func == (lhs: BridgeableValue, rhs: BridgeableValue) -> Bool {
 
 // A class used to test various Objective-C thunks.
 class Thunks : NSObject {
-  func createSubclass(_ value: Int) -> AnyObject {
+  @objc func createSubclass(_ value: Int) -> AnyObject {
     return Subclass(value)
   }
 
@@ -296,8 +296,8 @@ tests.test("testExplicitlyBridged/${Any}") {
 
   let bridgeableValuesAsNSArray = bridgeableValues as NSArray
   expectEqual(2, bridgeableValuesAsNSArray.count)
-  expectEqual(42, (bridgeableValuesAsNSArray[0] as AnyObject).value)
-  expectEqual(17, (bridgeableValuesAsNSArray[1] as AnyObject).value)
+  expectEqual(42, (bridgeableValuesAsNSArray[0] as! Subclass).value)
+  expectEqual(17, (bridgeableValuesAsNSArray[1] as! Subclass).value)
 
   // Make sure we can bridge back.
   let roundTrippedValues = Swift._forceBridgeFromObjectiveC(

--- a/test/stdlib/Intents.swift
+++ b/test/stdlib/Intents.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -o %t/a.out3 -swift-version 3 && %target-codesign %t/a.out3 && %target-run %t/a.out3
 // RUN: %target-build-swift %s -o %t/a.out4 -swift-version 4 && %target-codesign %t/a.out4 && %target-run %t/a.out4
+// RUN: %target-build-swift %s -o %t/a.out42 -swift-version 4.2 && %target-codesign %t/a.out42 && %target-run %t/a.out42
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
@@ -11,11 +11,7 @@ import StdlibUnittest
 
 let IntentsTestSuite = TestSuite("Intents")
 
-#if swift(>=4)
 let swiftVersion = "4"
-#else
-let swiftVersion = "3"
-#endif
 
 if #available(OSX 10.12, iOS 10.0, watchOS 3.2, *) {
 
@@ -46,10 +42,6 @@ if #available(iOS 11.0, *) {
     func f(profile: INSetProfileInCarIntent) {
       var isDefaultProfile = profile.isDefaultProfile
       expectType(Bool?.self, &isDefaultProfile)
-#if !swift(>=4)
-      var defaultProfile = profile.defaultProfile
-      expectType(Int?.self, &defaultProfile)
-#endif
     }
   }
 }

--- a/test/stdlib/UIKit.swift
+++ b/test/stdlib/UIKit.swift
@@ -1,5 +1,4 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -swift-version 3 %s -o %t/a.out3 && %target-codesign %t/a.out3 && %target-run %t/a.out3
 // RUN: %target-build-swift -swift-version 4 %s -o %t/a.out4 && %target-codesign %t/a.out4 && %target-run %t/a.out4
 // RUN: %target-build-swift -swift-version 4.2 %s -o %t/a.out4_2 && %target-codesign %t/a.out4_2 && %target-run %t/a.out4_2
 // REQUIRES: executable_test
@@ -12,10 +11,8 @@ import StdlibUnittestFoundationExtras
 
 #if swift(>=4.2)
   let UIKitTests = TestSuite("UIKit_Swift4_2")
-#elseif swift(>=4)
-  let UIKitTests = TestSuite("UIKit_Swift4")
 #else
-  let UIKitTests = TestSuite("UIKit_Swift3")
+  let UIKitTests = TestSuite("UIKit_Swift4")
 #endif
 
 #if !os(watchOS) && !os(tvOS)
@@ -144,41 +141,26 @@ UIKitTests.test("UIFont.Weight") {
 
 #if !os(watchOS)
 UIKitTests.test("UILayoutPriority") {
-  #if swift(>=4) // Swift 4
-    let lowLayoutPriority: UILayoutPriority = .defaultLow
-    let highLayoutPriority: UILayoutPriority = .defaultHigh
+  let lowLayoutPriority: UILayoutPriority = .defaultLow
+  let highLayoutPriority: UILayoutPriority = .defaultHigh
 
-    expectTrue(lowLayoutPriority < highLayoutPriority)
+  expectTrue(lowLayoutPriority < highLayoutPriority)
 
-    expectTrue(lowLayoutPriority + 2.0 == UILayoutPriority(lowLayoutPriority.rawValue + 2.0))
-    expectTrue(2.0 + lowLayoutPriority == UILayoutPriority(lowLayoutPriority.rawValue + 2.0))
-    expectTrue(lowLayoutPriority - 2.0 == UILayoutPriority(lowLayoutPriority.rawValue - 2.0))
-    expectTrue(highLayoutPriority - lowLayoutPriority == highLayoutPriority.rawValue - lowLayoutPriority.rawValue)
+  expectTrue(lowLayoutPriority + 2.0 == UILayoutPriority(lowLayoutPriority.rawValue + 2.0))
+  expectTrue(2.0 + lowLayoutPriority == UILayoutPriority(lowLayoutPriority.rawValue + 2.0))
+  expectTrue(lowLayoutPriority - 2.0 == UILayoutPriority(lowLayoutPriority.rawValue - 2.0))
+  expectTrue(highLayoutPriority - lowLayoutPriority == highLayoutPriority.rawValue - lowLayoutPriority.rawValue)
 
-    expectTrue(lowLayoutPriority + (highLayoutPriority - lowLayoutPriority) == highLayoutPriority)
+  expectTrue(lowLayoutPriority + (highLayoutPriority - lowLayoutPriority) == highLayoutPriority)
 
-    var mutablePriority = lowLayoutPriority
-    mutablePriority -= 1.0
-    mutablePriority += 2.0
-    expectTrue(mutablePriority == lowLayoutPriority + 1.0)
+  var mutablePriority = lowLayoutPriority
+  mutablePriority -= 1.0
+  mutablePriority += 2.0
+  expectTrue(mutablePriority == lowLayoutPriority + 1.0)
 
-    let priorotyRange = lowLayoutPriority...highLayoutPriority
-    expectTrue(priorotyRange.contains(.defaultLow))
-    expectFalse(priorotyRange.contains(.required))
-  #else // Swift 3
-    let lowLayoutPriority: UILayoutPriority = UILayoutPriorityDefaultLow
-    let highLayoutPriority: UILayoutPriority = UILayoutPriorityDefaultHigh
-
-    expectTrue(lowLayoutPriority < highLayoutPriority)
-
-    expectTrue(2.0 + lowLayoutPriority == lowLayoutPriority + 2.0)
-    expectTrue(lowLayoutPriority + (highLayoutPriority - lowLayoutPriority) == highLayoutPriority)
-
-    var mutablePriority = lowLayoutPriority
-    mutablePriority -= 1.0
-    mutablePriority += 2.0
-    expectTrue(mutablePriority == lowLayoutPriority + 1.0)
-  #endif
+  let priorotyRange = lowLayoutPriority...highLayoutPriority
+  expectTrue(priorotyRange.contains(.defaultLow))
+  expectFalse(priorotyRange.contains(.required))
 }
 #endif
 

--- a/validation-test/stdlib/ArrayBridging.swift
+++ b/validation-test/stdlib/ArrayBridging.swift
@@ -2,7 +2,7 @@
 //
 // RUN: %target-clang -fobjc-arc %S/Inputs/SlurpFastEnumeration/SlurpFastEnumeration.m -c -o %t/SlurpFastEnumeration.o
 // RUN: echo '#sourceLocation(file: "%s", line: 1)' > "%t/main.swift" && cat "%s" >> "%t/main.swift" && chmod -w "%t/main.swift"
-// RUN: %target-build-swift -Xfrontend -disable-access-control -I %S/Inputs/SlurpFastEnumeration/ %t/main.swift %S/Inputs/DictionaryKeyValueTypes.swift %S/Inputs/DictionaryKeyValueTypesObjC.swift -Xlinker %t/SlurpFastEnumeration.o -o %t.out -O -swift-version 3
+// RUN: %target-build-swift -Xfrontend -disable-access-control -I %S/Inputs/SlurpFastEnumeration/ %t/main.swift %S/Inputs/DictionaryKeyValueTypes.swift %S/Inputs/DictionaryKeyValueTypesObjC.swift -Xlinker %t/SlurpFastEnumeration.o -o %t.out -O -swift-version 4
 // RUN: %target-run %t.out
 // REQUIRES: executable_test
 

--- a/validation-test/stdlib/ArrayNew.swift.gyb
+++ b/validation-test/stdlib/ArrayNew.swift.gyb
@@ -3,9 +3,9 @@
 // RUN: %gyb %s -o %t/main.swift
 // RUN: if [ %target-runtime == "objc" ]; then \
 // RUN:   %target-clang -fobjc-arc %S/Inputs/SlurpFastEnumeration/SlurpFastEnumeration.m -c -o %t/SlurpFastEnumeration.o; \
-// RUN:   %line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %S/Inputs/DictionaryKeyValueTypesObjC.swift %t/main.swift -I %S/Inputs/SlurpFastEnumeration/ -Xlinker %t/SlurpFastEnumeration.o -o %t/Array -Xfrontend -disable-access-control -swift-version 3; \
+// RUN:   %line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %S/Inputs/DictionaryKeyValueTypesObjC.swift %t/main.swift -I %S/Inputs/SlurpFastEnumeration/ -Xlinker %t/SlurpFastEnumeration.o -o %t/Array -Xfrontend -disable-access-control -swift-version 4.2; \
 // RUN: else \
-// RUN:   %line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %t/main.swift -o %t/Array -Xfrontend -disable-access-control -swift-version 3; \
+// RUN:   %line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %t/main.swift -o %t/Array -Xfrontend -disable-access-control -swift-version 4.2; \
 // RUN: fi
 // RUN: %target-codesign %t/Array && %line-directive %t/main.swift -- %target-run %t/Array
 // REQUIRES: executable_test
@@ -372,7 +372,7 @@ ArrayTestSuite.test("BridgedFromObjC.Verbatim.ArrayIsCopied") {
   expectEqual(30, (nsa[1] as! TestObjCValueTy).value)
 
   // Check that the Array is not affected.
-  expectEqual(20, result[1].value)
+  expectEqual(20, (result[1] as! TestObjCValueTy).value)
 }
 
 ArrayTestSuite.test("BridgedFromObjC.Nonverbatim.ArrayIsCopied") {
@@ -393,8 +393,8 @@ ArrayTestSuite.test("BridgedFromObjC.Nonverbatim.ArrayIsCopied") {
 
 ArrayTestSuite.test("BridgedFromObjC.Verbatim.NSArrayIsRetained") {
   let nsa = NSArray(array: getAsNSArray([ 10, 20, 30 ]))
-  var a: Array<AnyObject> = convertNSArrayToArray(nsa)
-  var bridgedBack: NSArray = convertArrayToNSArray(a)
+  let a: Array<AnyObject> = convertNSArrayToArray(nsa)
+  let bridgedBack: NSArray = convertArrayToNSArray(a)
 
   expectEqual(
     unsafeBitCast(nsa, to: Int.self),
@@ -407,8 +407,8 @@ ArrayTestSuite.test("BridgedFromObjC.Verbatim.NSArrayIsRetained") {
 
 ArrayTestSuite.test("BridgedFromObjC.Nonverbatim.NSArrayIsCopied") {
   let nsa = NSArray(array: getAsNSArray([ 10, 20, 30 ]))
-  var a: Array<TestBridgedValueTy> = convertNSArrayToArray(nsa)
-  var bridgedBack: NSArray = convertArrayToNSArray(a)
+  let a: Array<TestBridgedValueTy> = convertNSArrayToArray(nsa)
+  let bridgedBack: NSArray = convertArrayToNSArray(a)
 
   expectNotEqual(
     unsafeBitCast(nsa, to: Int.self),
@@ -542,7 +542,7 @@ ArrayTestSuite.test("BridgedToObjC/Verbatim/objectAtIndex") {
   expectEqual(30, (v as! TestObjCValueTy).value)
   let idValue2 = unsafeBitCast(v, to: UInt.self)
 
-  for i in 0..<3 {
+  for _ in 0..<3 {
     expectEqual(idValue0, unsafeBitCast(a.object(at: 0) as AnyObject, to: UInt.self))
     expectEqual(idValue1, unsafeBitCast(a.object(at: 1) as AnyObject, to: UInt.self))
     expectEqual(idValue2, unsafeBitCast(a.object(at: 2) as AnyObject, to: UInt.self))
@@ -602,7 +602,7 @@ ArrayTestSuite.test("BridgedToObjC/Verbatim/getObjects") {
   expectEqual(30, (v as! TestObjCValueTy).value)
   let idValue2 = unsafeBitCast(v, to: UInt.self)
 
-  for i in 0..<3 {
+  for _ in 0..<3 {
     expectEqual(idValue0, unsafeBitCast(a.object(at: 0) as AnyObject, to: UInt.self))
     expectEqual(idValue1, unsafeBitCast(a.object(at: 1) as AnyObject, to: UInt.self))
     expectEqual(idValue2, unsafeBitCast(a.object(at: 2) as AnyObject, to: UInt.self))
@@ -815,7 +815,7 @@ ArrayTestSuite.test("BridgedToObjC/Custom/objectAtIndex") {
   expectEqual(30, (v as! TestObjCValueTy).value)
   let idValue2 = unsafeBitCast(v, to: UInt.self)
 
-  for i in 0..<3 {
+  for _ in 0..<3 {
     expectEqual(idValue0, unsafeBitCast(a.object(at: 0) as AnyObject, to: UInt.self))
     expectEqual(idValue1, unsafeBitCast(a.object(at: 1) as AnyObject, to: UInt.self))
     expectEqual(idValue2, unsafeBitCast(a.object(at: 2) as AnyObject, to: UInt.self))
@@ -876,7 +876,7 @@ ArrayTestSuite.test("BridgedToObjC/Custom/getObjects") {
   expectEqual(30, (v as! TestObjCValueTy).value)
   let idValue2 = unsafeBitCast(v, to: UInt.self)
 
-  for i in 0..<3 {
+  for _ in 0..<3 {
     expectEqual(idValue0, unsafeBitCast(a.object(at: 0) as AnyObject, to: UInt.self))
     expectEqual(idValue1, unsafeBitCast(a.object(at: 1) as AnyObject, to: UInt.self))
     expectEqual(idValue2, unsafeBitCast(a.object(at: 2) as AnyObject, to: UInt.self))
@@ -1119,14 +1119,14 @@ ArrayTestSuite.test("BridgedToObjC.Nonverbatim.RoundtripThroughSwiftArray") {
     TestBridgedValueTy.bridgeOperations = 0
     let nsa: NSArray = getAsImmutableNSArray([ 10, 20, 30 ])
     let a: Array<TestBridgedValueTy> = convertNSArrayToArray(nsa)
-    let bridgedBack = convertArrayToNSArray(a)
+    let _ = convertArrayToNSArray(a)
     expectEqual(3, TestBridgedValueTy.bridgeOperations)
   }
   do {
     TestBridgedValueTy.bridgeOperations = 0
     let nsa: NSArray = getAsImmutableNSArray([ 10, 20, 30 ])
     let a = nsa as! Array<TestBridgedValueTy>
-    let bridgedBack: NSArray = a as NSArray
+    let _: NSArray = a as NSArray
     expectEqual(3, TestBridgedValueTy.bridgeOperations)
   }
 }

--- a/validation-test/stdlib/ArrayNew.swift.gyb
+++ b/validation-test/stdlib/ArrayNew.swift.gyb
@@ -542,11 +542,9 @@ ArrayTestSuite.test("BridgedToObjC/Verbatim/objectAtIndex") {
   expectEqual(30, (v as! TestObjCValueTy).value)
   let idValue2 = unsafeBitCast(v, to: UInt.self)
 
-  for _ in 0..<3 {
-    expectEqual(idValue0, unsafeBitCast(a.object(at: 0) as AnyObject, to: UInt.self))
-    expectEqual(idValue1, unsafeBitCast(a.object(at: 1) as AnyObject, to: UInt.self))
-    expectEqual(idValue2, unsafeBitCast(a.object(at: 2) as AnyObject, to: UInt.self))
-  }
+  expectEqual(idValue0, unsafeBitCast(a.object(at: 0) as AnyObject, to: UInt.self))
+  expectEqual(idValue1, unsafeBitCast(a.object(at: 1) as AnyObject, to: UInt.self))
+  expectEqual(idValue2, unsafeBitCast(a.object(at: 2) as AnyObject, to: UInt.self))
 
   expectAutoreleasedKeysAndValues(unopt: (0, 3))
 }
@@ -602,11 +600,9 @@ ArrayTestSuite.test("BridgedToObjC/Verbatim/getObjects") {
   expectEqual(30, (v as! TestObjCValueTy).value)
   let idValue2 = unsafeBitCast(v, to: UInt.self)
 
-  for _ in 0..<3 {
-    expectEqual(idValue0, unsafeBitCast(a.object(at: 0) as AnyObject, to: UInt.self))
-    expectEqual(idValue1, unsafeBitCast(a.object(at: 1) as AnyObject, to: UInt.self))
-    expectEqual(idValue2, unsafeBitCast(a.object(at: 2) as AnyObject, to: UInt.self))
-  }
+  expectEqual(idValue0, unsafeBitCast(a.object(at: 0) as AnyObject, to: UInt.self))
+  expectEqual(idValue1, unsafeBitCast(a.object(at: 1) as AnyObject, to: UInt.self))
+  expectEqual(idValue2, unsafeBitCast(a.object(at: 2) as AnyObject, to: UInt.self))
 
   buffer.deallocate()
   _fixLifetime(a)
@@ -815,11 +811,9 @@ ArrayTestSuite.test("BridgedToObjC/Custom/objectAtIndex") {
   expectEqual(30, (v as! TestObjCValueTy).value)
   let idValue2 = unsafeBitCast(v, to: UInt.self)
 
-  for _ in 0..<3 {
-    expectEqual(idValue0, unsafeBitCast(a.object(at: 0) as AnyObject, to: UInt.self))
-    expectEqual(idValue1, unsafeBitCast(a.object(at: 1) as AnyObject, to: UInt.self))
-    expectEqual(idValue2, unsafeBitCast(a.object(at: 2) as AnyObject, to: UInt.self))
-  }
+  expectEqual(idValue0, unsafeBitCast(a.object(at: 0) as AnyObject, to: UInt.self))
+  expectEqual(idValue1, unsafeBitCast(a.object(at: 1) as AnyObject, to: UInt.self))
+  expectEqual(idValue2, unsafeBitCast(a.object(at: 2) as AnyObject, to: UInt.self))
 
   expectEqual(3, TestBridgedValueTy.bridgeOperations)
   expectAutoreleasedKeysAndValues(unopt: (0, 3))
@@ -876,11 +870,9 @@ ArrayTestSuite.test("BridgedToObjC/Custom/getObjects") {
   expectEqual(30, (v as! TestObjCValueTy).value)
   let idValue2 = unsafeBitCast(v, to: UInt.self)
 
-  for _ in 0..<3 {
-    expectEqual(idValue0, unsafeBitCast(a.object(at: 0) as AnyObject, to: UInt.self))
-    expectEqual(idValue1, unsafeBitCast(a.object(at: 1) as AnyObject, to: UInt.self))
-    expectEqual(idValue2, unsafeBitCast(a.object(at: 2) as AnyObject, to: UInt.self))
-  }
+  expectEqual(idValue0, unsafeBitCast(a.object(at: 0) as AnyObject, to: UInt.self))
+  expectEqual(idValue1, unsafeBitCast(a.object(at: 1) as AnyObject, to: UInt.self))
+  expectEqual(idValue2, unsafeBitCast(a.object(at: 2) as AnyObject, to: UInt.self))
 
   buffer.deallocate()
   _fixLifetime(a)

--- a/validation-test/stdlib/ArrayTrapsObjC.swift
+++ b/validation-test/stdlib/ArrayTrapsObjC.swift
@@ -18,7 +18,7 @@ class Derived2 : Derived { }
 ArrayTraps.test("downcast1")
   .skip(.custom(
     { _isFastAssertConfiguration() },
-    reason: "this trap is not guaranteed to happen in -Unchecked"))
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
   .code {
   let ba: [Base] = [ Derived(), Base() ]
   let da = ba as! [Derived]

--- a/validation-test/stdlib/CollectionCompatibility.swift
+++ b/validation-test/stdlib/CollectionCompatibility.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t ; mkdir -p %t
-// RUN: %target-build-swift %s -o %t/a.out3 -swift-version 3 && %target-codesign %t/a.out3 &&  %target-run %t/a.out3
 // RUN: %target-build-swift %s -o %t/a.out4 -swift-version 4 && %target-codesign %t/a.out4 && %target-run %t/a.out4
+// RUN: %target-build-swift %s -o %t/a.out42 -swift-version 4.2 && %target-codesign %t/a.out42 && %target-run %t/a.out42
 
 // REQUIRES: executable_test
 

--- a/validation-test/stdlib/DictionaryBridging.swift
+++ b/validation-test/stdlib/DictionaryBridging.swift
@@ -2,7 +2,7 @@
 //
 // RUN: %target-clang -fobjc-arc %S/Inputs/SlurpFastEnumeration/SlurpFastEnumeration.m -c -o %t/SlurpFastEnumeration.o
 // RUN: echo '#sourceLocation(file: "%s", line: 1)' > "%t/main.swift" && cat "%s" >> "%t/main.swift" && chmod -w "%t/main.swift"
-// RUN: %target-build-swift -Xfrontend -disable-access-control -I %S/Inputs/SlurpFastEnumeration/ %t/main.swift %S/Inputs/DictionaryKeyValueTypes.swift %S/Inputs/DictionaryKeyValueTypesObjC.swift -Xlinker %t/SlurpFastEnumeration.o -o %t.out -O -swift-version 3
+// RUN: %target-build-swift -Xfrontend -disable-access-control -I %S/Inputs/SlurpFastEnumeration/ %t/main.swift %S/Inputs/DictionaryKeyValueTypes.swift %S/Inputs/DictionaryKeyValueTypesObjC.swift -Xlinker %t/SlurpFastEnumeration.o -o %t.out -O -swift-version 4.2
 // RUN: %target-run %t.out
 // REQUIRES: executable_test
 // REQUIRES: stress_test

--- a/validation-test/stdlib/FixedPointDiagnostics.swift.gyb
+++ b/validation-test/stdlib/FixedPointDiagnostics.swift.gyb
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %gyb %s -o %t/main.swift
-// RUN: %line-directive %t/main.swift -- %target-swift-frontend -typecheck -verify -swift-version 3 %t/main.swift
+// RUN: %line-directive %t/main.swift -- %target-swift-frontend -typecheck -verify -swift-version 4.2 %t/main.swift
 
 func testUnaryMinusInUnsigned() {
   var a: UInt8 = -(1) // expected-error {{cannot convert value of type 'Int' to specified type 'UInt8'}} expected-note * {{}} expected-warning * {{}}
@@ -29,53 +29,53 @@ func expectSameType<T>(_: T.Type, _: T.Type) {}
 
 func test_truncatingBitPatternAPIIsStableAcrossPlatforms() {
   // Audit and update this test when adding new integer types.
-  expectSameType(Int64.self, IntMax.self)
-  expectSameType(UInt64.self, UIntMax.self)
+  expectSameType(Int64.self, IntMax.self) // expected-error {{'IntMax' has been renamed to 'Int64'}}  
+  expectSameType(UInt64.self, UIntMax.self) // expected-error {{'UIntMax' has been renamed to 'UInt64'}}
 
-  _ = UInt8(truncatingBitPattern: UInt(0))
-  _ = UInt16(truncatingBitPattern: UInt(0))
-  _ = UInt32(truncatingBitPattern: UInt(0))
+  _ = UInt8(truncatingBitPattern: UInt(0)) // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
+  _ = UInt16(truncatingBitPattern: UInt(0)) // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
+  _ = UInt32(truncatingBitPattern: UInt(0)) // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
   UInt64(truncatingBitPattern: UInt(0)) // expected-error {{incorrect argument label in call (have 'truncatingBitPattern:', expected '_truncatingBits:')}}
-  UInt(truncatingBitPattern: UInt(0))   // expected-error {{}} expected-note * {{}}
+  UInt(truncatingBitPattern: UInt(0)) // expected-error {{cannot invoke initializer for type 'UInt' with an argument list of type '(truncatingBitPattern: UInt)'}} expected-note {{overloads for 'UInt' exist with these partially matching parameter lists: (truncatingBitPattern: UInt64), (truncatingBitPattern: Int64)}}
 
-  _ = Int8(truncatingBitPattern: UInt(0))
-  _ = Int16(truncatingBitPattern: UInt(0))
-  _ = Int32(truncatingBitPattern: UInt(0))
+  _ = Int8(truncatingBitPattern: UInt(0)) // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
+  _ = Int16(truncatingBitPattern: UInt(0)) // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
+  _ = Int32(truncatingBitPattern: UInt(0)) // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
   Int64(truncatingBitPattern: UInt(0)) // expected-error {{incorrect argument label in call (have 'truncatingBitPattern:', expected '_truncatingBits:')}}
-  Int(truncatingBitPattern: UInt(0))   // expected-error {{}} expected-note * {{}}
+  Int(truncatingBitPattern: UInt(0)) // expected-error {{}} expected-note * {{}}
 
-  _ = UInt8(truncatingBitPattern: Int(0))
-  _ = UInt16(truncatingBitPattern: Int(0))
-  _ = UInt32(truncatingBitPattern: Int(0))
+  _ = UInt8(truncatingBitPattern: Int(0)) // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
+  _ = UInt16(truncatingBitPattern: Int(0)) // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
+  _ = UInt32(truncatingBitPattern: Int(0)) // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
   UInt64(truncatingBitPattern: Int(0)) // expected-error {{argument labels '(truncatingBitPattern:)' do not match any available overloads}}
   // expected-note@-1 {{overloads for 'UInt64' exist with these partially matching parameter lists}}
   UInt(truncatingBitPattern: Int(0))   // expected-error {{}} expected-note * {{}}
 
-  _ = Int8(truncatingBitPattern: Int(0))
-  _ = Int16(truncatingBitPattern: Int(0))
-  _ = Int32(truncatingBitPattern: Int(0))
+  _ = Int8(truncatingBitPattern: Int(0)) // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
+  _ = Int16(truncatingBitPattern: Int(0)) // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
+  _ = Int32(truncatingBitPattern: Int(0)) // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
   Int64(truncatingBitPattern: Int(0)) // expected-error {{}} expected-note * {{}}
   Int(truncatingBitPattern: Int(0))   // expected-error {{}} expected-note * {{}}
 
   UInt(truncatingBitPattern: UInt8(0))  // expected-error {{}} expected-note * {{}}
   UInt(truncatingBitPattern: UInt16(0))  // expected-error {{}} expected-note * {{}}
   UInt(truncatingBitPattern: UInt32(0))  // expected-error {{}} expected-note * {{}}
-  _ = UInt(truncatingBitPattern: UInt64(0))
+  _ = UInt(truncatingBitPattern: UInt64(0)) // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
 
   Int(truncatingBitPattern: UInt8(0))  // expected-error {{}} expected-note * {{}}
   Int(truncatingBitPattern: UInt16(0)) // expected-error {{}} expected-note * {{}}
   Int(truncatingBitPattern: UInt32(0)) // expected-error {{}} expected-note * {{}}
-  _ = Int(truncatingBitPattern: UInt64(0))
+  _ = Int(truncatingBitPattern: UInt64(0)) // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
 
   UInt(truncatingBitPattern: Int8(0))  // expected-error {{}} expected-note * {{}}
   UInt(truncatingBitPattern: Int16(0)) // expected-error {{}} expected-note * {{}}
   UInt(truncatingBitPattern: Int32(0)) // expected-error {{}} expected-note * {{}}
-  _ = UInt(truncatingBitPattern: Int64(0))
+  _ = UInt(truncatingBitPattern: Int64(0)) // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
 
   Int(truncatingBitPattern: Int8(0))  // expected-error {{}} expected-note * {{}}
   Int(truncatingBitPattern: Int16(0)) // expected-error {{}} expected-note * {{}}
   Int(truncatingBitPattern: Int32(0)) // expected-error {{}} expected-note * {{}}
-  _ = Int(truncatingBitPattern: Int64(0))
+  _ = Int(truncatingBitPattern: Int64(0)) // expected-error {{'init(truncatingBitPattern:)' has been renamed to 'init(truncatingIfNeeded:)'}}
 }
 
 func testMixedSignArithmetic() {
@@ -87,15 +87,15 @@ func testMixedSignArithmetic() {
     typealias Stride = ${T}.Stride
     _ = ${T}(1) + 0     // OK
     _ = 0 + ${T}(1)     // OK
-    _ = ${T}(1) + Stride(0) // expected-warning {{}} // mixed-type arithmetics
-    _ = Stride(1) + ${T}(0) // expected-warning {{}} // mixed-type arithmetics
-    _ = ${T}(1) - Stride(0) // expected-warning {{}} // mixed-type arithmetics
+    _ = ${T}(1) + Stride(0) // expected-error {{'+' is unavailable: Please use explicit type conversions or Strideable methods for mixed-type arithmetics.}}
+    _ = Stride(1) + ${T}(0) // expected-error {{'+' is unavailable: Please use explicit type conversions or Strideable methods for mixed-type arithmetics.}}
+    _ = ${T}(1) - Stride(0) // expected-error {{'-' is unavailable: Please use explicit type conversions or Strideable methods for mixed-type arithmetics.}}
     var x: ${T} = 0
     x += 1              // OK
-    x += Stride(1)      // expected-warning {{}} // mixed-type arithmetics
-    x -= Stride(1)      // expected-warning {{}} // mixed-type arithmetics
+    x += Stride(1) // expected-error {{'+=' is unavailable: Please use explicit type conversions or Strideable methods for mixed-type arithmetics.}}
+    x -= Stride(1) // expected-error {{'-=' is unavailable: Please use explicit type conversions or Strideable methods for mixed-type arithmetics.}}
 
-    _ = (x - x) as Stride   // expected-warning {{}} // ambiguous use of operator '-'
+    _ = (x - x) as Stride // expected-error {{ambiguous reference to member '-'}}
 
     //===------------------------------------------------------------------===//
     // The following errors are different because they're not being

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -3,9 +3,9 @@
 // RUN: %gyb %s -o %t/main.swift
 // RUN: if [ %target-runtime == "objc" ]; then \
 // RUN:   %target-clang -fobjc-arc %S/Inputs/SlurpFastEnumeration/SlurpFastEnumeration.m -c -o %t/SlurpFastEnumeration.o; \
-// RUN:   %line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %S/Inputs/DictionaryKeyValueTypesObjC.swift %t/main.swift -I %S/Inputs/SlurpFastEnumeration/ -Xlinker %t/SlurpFastEnumeration.o -o %t/Set -Xfrontend -disable-access-control -swift-version 3; \
+// RUN:   %line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %S/Inputs/DictionaryKeyValueTypesObjC.swift %t/main.swift -I %S/Inputs/SlurpFastEnumeration/ -Xlinker %t/SlurpFastEnumeration.o -o %t/Set -Xfrontend -disable-access-control -swift-version 4.2; \
 // RUN: else \
-// RUN:   %line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %t/main.swift -o %t/Set -Xfrontend -disable-access-control -swift-version 3; \
+// RUN:   %line-directive %t/main.swift -- %target-build-swift %S/Inputs/DictionaryKeyValueTypes.swift %t/main.swift -o %t/Set -Xfrontend -disable-access-control -swift-version 4.2; \
 // RUN: fi
 //
 // RUN: %target-codesign %t/Set && %line-directive %t/main.swift -- %target-run %t/Set
@@ -137,7 +137,7 @@ func isCocoaNSSet(_ s: NSSet) -> Bool {
 func getBridgedEmptyNSSet() -> NSSet {
   let s = Set<TestObjCKeyTy>()
 
-  let bridged = unsafeBitCast(convertSetToNSSet(s), to: NSSet.self)
+  let bridged = convertSetToNSSet(s)
   expectTrue(isNativeNSSet(bridged))
 
   return bridged
@@ -241,8 +241,7 @@ func getBridgedNSSetOfRefTypesBridgedVerbatim() -> NSSet {
   s.insert(TestObjCKeyTy(2020))
   s.insert(TestObjCKeyTy(3030))
 
-  let bridged =
-    unsafeBitCast(convertSetToNSSet(s), to: NSSet.self)
+  let bridged = convertSetToNSSet(s)
 
   expectTrue(isNativeNSSet(bridged))
 
@@ -327,7 +326,7 @@ SetTestSuite.test("Index.Hashable") {
 SetTestSuite.test("COW.Smoke") {
   var s1 = Set<TestKeyTy>(minimumCapacity: 10)
   for i in [1010, 2020, 3030]{ s1.insert(TestKeyTy(i)) }
-  var identity1 = s1._rawIdentifier()
+  let identity1 = s1._rawIdentifier()
 
   var s2 = s1
   _fixLifetime(s2)
@@ -346,10 +345,10 @@ SetTestSuite.test("COW.Smoke") {
 
 SetTestSuite.test("COW.Fast.IndexesDontAffectUniquenessCheck") {
   var s = getCOWFastSet()
-  var identity1 = s._rawIdentifier()
+  let identity1 = s._rawIdentifier()
 
-  var startIndex = s.startIndex
-  var endIndex = s.endIndex
+  let startIndex = s.startIndex
+  let endIndex = s.endIndex
   expectNotEqual(startIndex, endIndex)
   expectTrue(startIndex < endIndex)
   expectTrue(startIndex <= endIndex)
@@ -368,10 +367,10 @@ SetTestSuite.test("COW.Fast.IndexesDontAffectUniquenessCheck") {
 
 SetTestSuite.test("COW.Slow.IndexesDontAffectUniquenessCheck") {
   var s = getCOWSlowSet()
-  var identity1 = s._rawIdentifier()
+  let identity1 = s._rawIdentifier()
 
-  var startIndex = s.startIndex
-  var endIndex = s.endIndex
+  let startIndex = s.startIndex
+  let endIndex = s.endIndex
   expectNotEqual(startIndex, endIndex)
   expectTrue(startIndex < endIndex)
   expectTrue(startIndex <= endIndex)
@@ -388,10 +387,10 @@ SetTestSuite.test("COW.Slow.IndexesDontAffectUniquenessCheck") {
 }
 
 SetTestSuite.test("COW.Fast.SubscriptWithIndexDoesNotReallocate") {
-  var s = getCOWFastSet()
-  var identity1 = s._rawIdentifier()
+  let s = getCOWFastSet()
+  let identity1 = s._rawIdentifier()
 
-  var startIndex = s.startIndex
+  let startIndex = s.startIndex
   let empty = startIndex == s.endIndex
   expectNotEqual(empty, (s.startIndex < s.endIndex))
   expectTrue(s.startIndex <= s.endIndex)
@@ -404,10 +403,10 @@ SetTestSuite.test("COW.Fast.SubscriptWithIndexDoesNotReallocate") {
 }
 
 SetTestSuite.test("COW.Slow.SubscriptWithIndexDoesNotReallocate") {
-  var s = getCOWSlowSet()
-  var identity1 = s._rawIdentifier()
+  let s = getCOWSlowSet()
+  let identity1 = s._rawIdentifier()
 
-  var startIndex = s.startIndex
+  let startIndex = s.startIndex
   let empty = startIndex == s.endIndex
   expectNotEqual(empty, (s.startIndex < s.endIndex))
   expectTrue(s.startIndex <= s.endIndex)
@@ -420,14 +419,14 @@ SetTestSuite.test("COW.Slow.SubscriptWithIndexDoesNotReallocate") {
 }
 
 SetTestSuite.test("COW.Fast.ContainsDoesNotReallocate") {
-  var s = getCOWFastSet()
-  var identity1 = s._rawIdentifier()
+  let s = getCOWFastSet()
+  let identity1 = s._rawIdentifier()
 
   expectTrue(s.contains(1010))
   expectEqual(identity1, s._rawIdentifier())
 
   do {
-    var s2: Set<MinimalHashableValue> = []
+    let s2: Set<MinimalHashableValue> = []
     MinimalHashableValue.timesEqualEqualWasCalled = 0
     MinimalHashableValue.timesHashIntoWasCalled = 0
     expectFalse(s2.contains(MinimalHashableValue(42)))
@@ -442,7 +441,7 @@ SetTestSuite.test("COW.Fast.ContainsDoesNotReallocate") {
 SetTestSuite.test("COW.Slow.ContainsDoesNotReallocate")
   .code {
   var s = getCOWSlowSet()
-  var identity1 = s._rawIdentifier()
+  let identity1 = s._rawIdentifier()
 
   expectTrue(s.contains(TestKeyTy(1010)))
   expectEqual(identity1, s._rawIdentifier())
@@ -473,7 +472,7 @@ SetTestSuite.test("COW.Slow.ContainsDoesNotReallocate")
   expectTrue(s.contains(TestKeyTy(4040)))
 
   do {
-    var s2: Set<MinimalHashableClass> = []
+    let s2: Set<MinimalHashableClass> = []
     MinimalHashableClass.timesEqualEqualWasCalled = 0
     MinimalHashableClass.timesHashIntoWasCalled = 0
     expectFalse(s2.contains(MinimalHashableClass(42)))
@@ -523,8 +522,8 @@ SetTestSuite.test("COW.Slow.InsertDoesNotReallocate") {
   }
 
   do {
-    var s1 = getCOWSlowSet()
-    var identity1 = s1._rawIdentifier()
+    let s1 = getCOWSlowSet()
+    let identity1 = s1._rawIdentifier()
 
     var s2 = s1
     expectEqual(identity1, s1._rawIdentifier())
@@ -552,8 +551,8 @@ SetTestSuite.test("COW.Slow.InsertDoesNotReallocate") {
   }
 
   do {
-    var s1 = getCOWSlowSet()
-    var identity1 = s1._rawIdentifier()
+    let s1 = getCOWSlowSet()
+    let identity1 = s1._rawIdentifier()
 
     var s2 = s1
     expectEqual(identity1, s1._rawIdentifier())
@@ -581,15 +580,15 @@ SetTestSuite.test("COW.Slow.InsertDoesNotReallocate") {
 }
 
 SetTestSuite.test("COW.Fast.IndexForMemberDoesNotReallocate") {
-  var s = getCOWFastSet()
-  var identity1 = s._rawIdentifier()
+  let s = getCOWFastSet()
+  let identity1 = s._rawIdentifier()
 
   // Find an existing key.
   do {
-    var foundIndex1 = s.firstIndex(of: 1010)!
+    let foundIndex1 = s.firstIndex(of: 1010)!
     expectEqual(identity1, s._rawIdentifier())
 
-    var foundIndex2 = s.firstIndex(of: 1010)!
+    let foundIndex2 = s.firstIndex(of: 1010)!
     expectEqual(foundIndex1, foundIndex2)
 
     expectEqual(1010, s[foundIndex1])
@@ -598,13 +597,13 @@ SetTestSuite.test("COW.Fast.IndexForMemberDoesNotReallocate") {
 
   // Try to find a key that is not present.
   do {
-    var foundIndex1 = s.firstIndex(of: 1111)
+    let foundIndex1 = s.firstIndex(of: 1111)
     expectNil(foundIndex1)
     expectEqual(identity1, s._rawIdentifier())
   }
 
   do {
-    var s2: Set<MinimalHashableValue> = []
+    let s2: Set<MinimalHashableValue> = []
     MinimalHashableValue.timesEqualEqualWasCalled = 0
     MinimalHashableValue.timesHashIntoWasCalled = 0
     expectNil(s2.firstIndex(of: MinimalHashableValue(42)))
@@ -617,15 +616,15 @@ SetTestSuite.test("COW.Fast.IndexForMemberDoesNotReallocate") {
 }
 
 SetTestSuite.test("COW.Slow.IndexForMemberDoesNotReallocate") {
-  var s = getCOWSlowSet()
-  var identity1 = s._rawIdentifier()
+  let s = getCOWSlowSet()
+  let identity1 = s._rawIdentifier()
 
   // Find an existing key.
   do {
-    var foundIndex1 = s.firstIndex(of: TestKeyTy(1010))!
+    let foundIndex1 = s.firstIndex(of: TestKeyTy(1010))!
     expectEqual(identity1, s._rawIdentifier())
 
-    var foundIndex2 = s.firstIndex(of: TestKeyTy(1010))!
+    let foundIndex2 = s.firstIndex(of: TestKeyTy(1010))!
     expectEqual(foundIndex1, foundIndex2)
 
     expectEqual(TestKeyTy(1010), s[foundIndex1])
@@ -634,13 +633,13 @@ SetTestSuite.test("COW.Slow.IndexForMemberDoesNotReallocate") {
 
   // Try to find a key that is not present.
   do {
-    var foundIndex1 = s.firstIndex(of: TestKeyTy(1111))
+    let foundIndex1 = s.firstIndex(of: TestKeyTy(1111))
     expectNil(foundIndex1)
     expectEqual(identity1, s._rawIdentifier())
   }
 
   do {
-    var s2: Set<MinimalHashableClass> = []
+    let s2: Set<MinimalHashableClass> = []
     MinimalHashableClass.timesEqualEqualWasCalled = 0
     MinimalHashableClass.timesHashIntoWasCalled = 0
     expectNil(s2.firstIndex(of: MinimalHashableClass(42)))
@@ -656,7 +655,7 @@ SetTestSuite.test("COW.Fast.RemoveAtDoesNotReallocate")
   .code {
   do {
     var s = getCOWFastSet()
-    var identity1 = s._rawIdentifier()
+    let identity1 = s._rawIdentifier()
 
     let foundIndex1 = s.firstIndex(of: 1010)!
     expectEqual(identity1, s._rawIdentifier())
@@ -671,14 +670,14 @@ SetTestSuite.test("COW.Fast.RemoveAtDoesNotReallocate")
   }
 
   do {
-    var s1 = getCOWFastSet()
-    var identity1 = s1._rawIdentifier()
+    let s1 = getCOWFastSet()
+    let identity1 = s1._rawIdentifier()
 
     var s2 = s1
     expectEqual(identity1, s1._rawIdentifier())
     expectEqual(identity1, s2._rawIdentifier())
 
-    var foundIndex1 = s2.firstIndex(of: 1010)!
+    let foundIndex1 = s2.firstIndex(of: 1010)!
     expectEqual(1010, s2[foundIndex1])
     expectEqual(identity1, s1._rawIdentifier())
     expectEqual(identity1, s2._rawIdentifier())
@@ -696,7 +695,7 @@ SetTestSuite.test("COW.Slow.RemoveAtDoesNotReallocate")
   .code {
   do {
     var s = getCOWSlowSet()
-    var identity1 = s._rawIdentifier()
+    let identity1 = s._rawIdentifier()
 
     let foundIndex1 = s.firstIndex(of: TestKeyTy(1010))!
     expectEqual(identity1, s._rawIdentifier())
@@ -711,14 +710,14 @@ SetTestSuite.test("COW.Slow.RemoveAtDoesNotReallocate")
   }
 
   do {
-    var s1 = getCOWSlowSet()
-    var identity1 = s1._rawIdentifier()
+    let s1 = getCOWSlowSet()
+    let identity1 = s1._rawIdentifier()
 
     var s2 = s1
     expectEqual(identity1, s1._rawIdentifier())
     expectEqual(identity1, s2._rawIdentifier())
 
-    var foundIndex1 = s2.firstIndex(of: TestKeyTy(1010))!
+    let foundIndex1 = s2.firstIndex(of: TestKeyTy(1010))!
     expectEqual(TestKeyTy(1010), s2[foundIndex1])
     expectEqual(identity1, s1._rawIdentifier())
     expectEqual(identity1, s2._rawIdentifier())
@@ -736,7 +735,7 @@ SetTestSuite.test("COW.Fast.RemoveDoesNotReallocate")
   .code {
   do {
     var s1 = getCOWFastSet()
-    var identity1 = s1._rawIdentifier()
+    let identity1 = s1._rawIdentifier()
 
     var deleted = s1.remove(0)
     expectNil(deleted)
@@ -751,8 +750,8 @@ SetTestSuite.test("COW.Fast.RemoveDoesNotReallocate")
   }
 
   do {
-    var s1 = getCOWFastSet()
-    var identity1 = s1._rawIdentifier()
+    let s1 = getCOWFastSet()
+    let identity1 = s1._rawIdentifier()
 
     var s2 = s1
     var deleted = s2.remove(0)
@@ -775,7 +774,7 @@ SetTestSuite.test("COW.Slow.RemoveDoesNotReallocate")
   .code {
   do {
     var s1 = getCOWSlowSet()
-    var identity1 = s1._rawIdentifier()
+    let identity1 = s1._rawIdentifier()
 
     var deleted = s1.remove(TestKeyTy(0))
     expectNil(deleted)
@@ -790,8 +789,8 @@ SetTestSuite.test("COW.Slow.RemoveDoesNotReallocate")
   }
 
   do {
-    var s1 = getCOWSlowSet()
-    var identity1 = s1._rawIdentifier()
+    let s1 = getCOWSlowSet()
+    let identity1 = s1._rawIdentifier()
 
     var s2 = s1
     var deleted = s2.remove(TestKeyTy(0))
@@ -837,7 +836,7 @@ SetTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
     s.removeAll()
     // We cannot expectTrue that identity changed, since the new buffer of
     // smaller size can be allocated at the same address as the old one.
-    var identity1 = s._rawIdentifier()
+    let identity1 = s._rawIdentifier()
     expectTrue(s.capacity < originalCapacity)
     expectEqual(0, s.count)
     expectFalse(s.contains(1010))
@@ -850,7 +849,7 @@ SetTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
 
   do {
     var s = getCOWFastSet()
-    var identity1 = s._rawIdentifier()
+    let identity1 = s._rawIdentifier()
     let originalCapacity = s.capacity
     expectEqual(3, s.count)
     expectTrue(s.contains(1010))
@@ -869,14 +868,14 @@ SetTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
   }
 
   do {
-    var s1 = getCOWFastSet()
-    var identity1 = s1._rawIdentifier()
+    let s1 = getCOWFastSet()
+    let identity1 = s1._rawIdentifier()
     expectEqual(3, s1.count)
     expectTrue(s1.contains(1010))
 
     var s2 = s1
     s2.removeAll()
-    var identity2 = s2._rawIdentifier()
+    let identity2 = s2._rawIdentifier()
     expectEqual(identity1, s1._rawIdentifier())
     expectNotEqual(identity1, identity2)
     expectEqual(3, s1.count)
@@ -890,15 +889,15 @@ SetTestSuite.test("COW.Fast.RemoveAllDoesNotReallocate") {
   }
 
   do {
-    var s1 = getCOWFastSet()
-    var identity1 = s1._rawIdentifier()
+    let s1 = getCOWFastSet()
+    let identity1 = s1._rawIdentifier()
     let originalCapacity = s1.capacity
     expectEqual(3, s1.count)
     expectTrue(s1.contains(1010))
 
     var s2 = s1
     s2.removeAll(keepingCapacity: true)
-    var identity2 = s2._rawIdentifier()
+    let identity2 = s2._rawIdentifier()
     expectEqual(identity1, s1._rawIdentifier())
     expectNotEqual(identity1, identity2)
     expectEqual(3, s1.count)
@@ -923,7 +922,7 @@ SetTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
     s.removeAll()
     // We cannot expectTrue that identity changed, since the new buffer of
     // smaller size can be allocated at the same address as the old one.
-    var identity1 = s._rawIdentifier()
+    let identity1 = s._rawIdentifier()
     expectTrue(s.capacity < originalCapacity)
     expectEqual(0, s.count)
     expectFalse(s.contains(TestKeyTy(1010)))
@@ -936,7 +935,7 @@ SetTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
 
   do {
     var s = getCOWSlowSet()
-    var identity1 = s._rawIdentifier()
+    let identity1 = s._rawIdentifier()
     let originalCapacity = s.capacity
     expectEqual(3, s.count)
     expectTrue(s.contains(TestKeyTy(1010)))
@@ -955,14 +954,14 @@ SetTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
   }
 
   do {
-    var s1 = getCOWSlowSet()
-    var identity1 = s1._rawIdentifier()
+    let s1 = getCOWSlowSet()
+    let identity1 = s1._rawIdentifier()
     expectEqual(3, s1.count)
     expectTrue(s1.contains(TestKeyTy(1010)))
 
     var s2 = s1
     s2.removeAll()
-    var identity2 = s2._rawIdentifier()
+    let identity2 = s2._rawIdentifier()
     expectEqual(identity1, s1._rawIdentifier())
     expectNotEqual(identity1, identity2)
     expectEqual(3, s1.count)
@@ -976,15 +975,15 @@ SetTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
   }
 
   do {
-    var s1 = getCOWSlowSet()
-    var identity1 = s1._rawIdentifier()
+    let s1 = getCOWSlowSet()
+    let identity1 = s1._rawIdentifier()
     let originalCapacity = s1.capacity
     expectEqual(3, s1.count)
     expectTrue(s1.contains(TestKeyTy(1010)))
 
     var s2 = s1
     s2.removeAll(keepingCapacity: true)
-    var identity2 = s2._rawIdentifier()
+    let identity2 = s2._rawIdentifier()
     expectEqual(identity1, s1._rawIdentifier())
     expectNotEqual(identity1, identity2)
     expectEqual(3, s1.count)
@@ -1000,40 +999,40 @@ SetTestSuite.test("COW.Slow.RemoveAllDoesNotReallocate") {
 }
 
 SetTestSuite.test("COW.Fast.FirstDoesNotReallocate") {
-  var s = getCOWFastSet()
-  var identity1 = s._rawIdentifier()
+  let s = getCOWFastSet()
+  let identity1 = s._rawIdentifier()
 
   expectNotNil(s.first)
   expectEqual(identity1, s._rawIdentifier())
 }
 
 SetTestSuite.test("COW.Fast.CountDoesNotReallocate") {
-  var s = getCOWFastSet()
-  var identity1 = s._rawIdentifier()
+  let s = getCOWFastSet()
+  let identity1 = s._rawIdentifier()
 
   expectEqual(3, s.count)
   expectEqual(identity1, s._rawIdentifier())
 }
 
 SetTestSuite.test("COW.Slow.FirstDoesNotReallocate") {
-  var s = getCOWSlowSet()
-  var identity1 = s._rawIdentifier()
+  let s = getCOWSlowSet()
+  let identity1 = s._rawIdentifier()
 
   expectNotNil(s.first)
   expectEqual(identity1, s._rawIdentifier())
 }
 
 SetTestSuite.test("COW.Slow.CountDoesNotReallocate") {
-  var s = getCOWSlowSet()
-  var identity1 = s._rawIdentifier()
+  let s = getCOWSlowSet()
+  let identity1 = s._rawIdentifier()
 
   expectEqual(3, s.count)
   expectEqual(identity1, s._rawIdentifier())
 }
 
 SetTestSuite.test("COW.Fast.GenerateDoesNotReallocate") {
-  var s = getCOWFastSet()
-  var identity1 = s._rawIdentifier()
+  let s = getCOWFastSet()
+  let identity1 = s._rawIdentifier()
 
   var iter = s.makeIterator()
   var items: [Int] = []
@@ -1045,8 +1044,8 @@ SetTestSuite.test("COW.Fast.GenerateDoesNotReallocate") {
 }
 
 SetTestSuite.test("COW.Slow.GenerateDoesNotReallocate") {
-  var s = getCOWSlowSet()
-  var identity1 = s._rawIdentifier()
+  let s = getCOWSlowSet()
+  let identity1 = s._rawIdentifier()
 
   var iter = s.makeIterator()
   var items: [Int] = []
@@ -1058,11 +1057,11 @@ SetTestSuite.test("COW.Slow.GenerateDoesNotReallocate") {
 }
 
 SetTestSuite.test("COW.Fast.EqualityTestDoesNotReallocate") {
-  var s1 = getCOWFastSet()
-  var identity1 = s1._rawIdentifier()
+  let s1 = getCOWFastSet()
+  let identity1 = s1._rawIdentifier()
 
-  var s2 = getCOWFastSet()
-  var identity2 = s2._rawIdentifier()
+  let s2 = getCOWFastSet()
+  let identity2 = s2._rawIdentifier()
 
   expectEqual(s1, s2)
   expectEqual(identity1, s1._rawIdentifier())
@@ -1070,11 +1069,11 @@ SetTestSuite.test("COW.Fast.EqualityTestDoesNotReallocate") {
 }
 
 SetTestSuite.test("COW.Slow.EqualityTestDoesNotReallocate") {
-  var s1 = getCOWFastSet()
-  var identity1 = s1._rawIdentifier()
+  let s1 = getCOWFastSet()
+  let identity1 = s1._rawIdentifier()
 
-  var s2 = getCOWFastSet()
-  var identity2 = s2._rawIdentifier()
+  let s2 = getCOWFastSet()
+  let identity2 = s2._rawIdentifier()
 
   expectEqual(s1, s2)
   expectEqual(identity1, s1._rawIdentifier())
@@ -1086,28 +1085,28 @@ SetTestSuite.test("COW.Slow.EqualityTestDoesNotReallocate") {
 //===---
 
 SetTestSuite.test("deleteChainCollision") {
-  var k1 = TestKeyTy(value: 1010, hashValue: 0)
-  var k2 = TestKeyTy(value: 2020, hashValue: 0)
-  var k3 = TestKeyTy(value: 3030, hashValue: 0)
+  let k1 = TestKeyTy(value: 1010, hashValue: 0)
+  let k2 = TestKeyTy(value: 2020, hashValue: 0)
+  let k3 = TestKeyTy(value: 3030, hashValue: 0)
 
   helperDeleteThree(k1, k2, k3)
 }
 
 SetTestSuite.test("deleteChainNoCollision") {
-  var k1 = TestKeyTy(value: 1010, hashValue: 0)
-  var k2 = TestKeyTy(value: 2020, hashValue: 1)
-  var k3 = TestKeyTy(value: 3030, hashValue: 2)
+  let k1 = TestKeyTy(value: 1010, hashValue: 0)
+  let k2 = TestKeyTy(value: 2020, hashValue: 1)
+  let k3 = TestKeyTy(value: 3030, hashValue: 2)
 
   helperDeleteThree(k1, k2, k3)
 }
 
 SetTestSuite.test("deleteChainCollision2") {
-  var k1_0 = TestKeyTy(value: 1010, hashValue: 0)
-  var k2_0 = TestKeyTy(value: 2020, hashValue: 0)
-  var k3_2 = TestKeyTy(value: 3030, hashValue: 2)
-  var k4_0 = TestKeyTy(value: 4040, hashValue: 0)
-  var k5_2 = TestKeyTy(value: 5050, hashValue: 2)
-  var k6_0 = TestKeyTy(value: 6060, hashValue: 0)
+  let k1_0 = TestKeyTy(value: 1010, hashValue: 0)
+  let k2_0 = TestKeyTy(value: 2020, hashValue: 0)
+  let k3_2 = TestKeyTy(value: 3030, hashValue: 2)
+  let k4_0 = TestKeyTy(value: 4040, hashValue: 0)
+  let k5_2 = TestKeyTy(value: 5050, hashValue: 2)
+  let k6_0 = TestKeyTy(value: 6060, hashValue: 0)
 
   var s = Set<TestKeyTy>(minimumCapacity: 10)
 
@@ -1224,7 +1223,7 @@ class CustomImmutableNSSet : NSSet {
 }
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.SetIsCopied") {
-  var (s, nss) = getBridgedVerbatimSetAndNSMutableSet()
+  let (s, nss) = getBridgedVerbatimSetAndNSMutableSet()
   expectTrue(isCocoaSet(s))
 
   expectTrue(s.contains(TestObjCKeyTy(1010)))
@@ -1237,7 +1236,7 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.SetIsCopied") {
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.SetIsCopied") {
-  var (s, nss) = getBridgedNonverbatimSetAndNSMutableSet()
+  let (s, nss) = getBridgedNonverbatimSetAndNSMutableSet()
   expectTrue(isNativeSet(s))
 
   expectTrue(s.contains(TestBridgedKeyTy(1010)))
@@ -1251,11 +1250,11 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.SetIsCopied") {
 
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.NSSetIsRetained") {
-  var nss: NSSet = NSSet(set: getAsNSSet([ 1010, 1020, 1030 ]))
+  let nss: NSSet = NSSet(set: getAsNSSet([ 1010, 1020, 1030 ]))
 
-  var s: Set<NSObject> = convertNSSetToSet(nss)
+  let s: Set<NSObject> = convertNSSetToSet(nss)
 
-  var bridgedBack: NSSet = convertSetToNSSet(s)
+  let bridgedBack: NSSet = convertSetToNSSet(s)
 
   expectEqual(
     unsafeBitCast(nss, to: Int.self),
@@ -1267,11 +1266,11 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.NSSetIsRetained") {
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.NSSetIsCopied") {
-  var nss: NSSet = NSSet(set: getAsNSSet([ 1010, 1020, 1030 ]))
+  let nss: NSSet = NSSet(set: getAsNSSet([ 1010, 1020, 1030 ]))
 
-  var s: Set<TestBridgedKeyTy> = convertNSSetToSet(nss)
+  let s: Set<TestBridgedKeyTy> = convertNSSetToSet(nss)
 
-  var bridgedBack: NSSet = convertSetToNSSet(s)
+  let bridgedBack: NSSet = convertSetToNSSet(s)
 
   expectNotEqual(
     unsafeBitCast(nss, to: Int.self),
@@ -1284,19 +1283,19 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.NSSetIsCopied") {
 
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.ImmutableSetIsRetained") {
-  var nss: NSSet = CustomImmutableNSSet(_privateInit: ())
+  let nss: NSSet = CustomImmutableNSSet(_privateInit: ())
 
   CustomImmutableNSSet.timesCopyWithZoneWasCalled = 0
   CustomImmutableNSSet.timesMemberWasCalled = 0
   CustomImmutableNSSet.timesObjectEnumeratorWasCalled = 0
   CustomImmutableNSSet.timesCountWasCalled = 0
-  var s: Set<NSObject> = convertNSSetToSet(nss)
+  let s: Set<NSObject> = convertNSSetToSet(nss)
   expectEqual(1, CustomImmutableNSSet.timesCopyWithZoneWasCalled)
   expectEqual(0, CustomImmutableNSSet.timesMemberWasCalled)
   expectEqual(0, CustomImmutableNSSet.timesObjectEnumeratorWasCalled)
   expectEqual(0, CustomImmutableNSSet.timesCountWasCalled)
 
-  var bridgedBack: NSSet = convertSetToNSSet(s)
+  let bridgedBack: NSSet = convertSetToNSSet(s)
   expectEqual(
     unsafeBitCast(nss, to: Int.self),
     unsafeBitCast(bridgedBack, to: Int.self))
@@ -1307,19 +1306,19 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.ImmutableSetIsRetained") {
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.ImmutableSetIsCopied") {
-  var nss: NSSet = CustomImmutableNSSet(_privateInit: ())
+  let nss: NSSet = CustomImmutableNSSet(_privateInit: ())
 
   CustomImmutableNSSet.timesCopyWithZoneWasCalled = 0
   CustomImmutableNSSet.timesMemberWasCalled = 0
   CustomImmutableNSSet.timesObjectEnumeratorWasCalled = 0
   CustomImmutableNSSet.timesCountWasCalled = 0
-  var s: Set<TestBridgedKeyTy> = convertNSSetToSet(nss)
+  let s: Set<TestBridgedKeyTy> = convertNSSetToSet(nss)
   expectEqual(0, CustomImmutableNSSet.timesCopyWithZoneWasCalled)
   expectEqual(0, CustomImmutableNSSet.timesMemberWasCalled)
   expectEqual(1, CustomImmutableNSSet.timesObjectEnumeratorWasCalled)
   expectNotEqual(0, CustomImmutableNSSet.timesCountWasCalled)
 
-  var bridgedBack: NSSet = convertSetToNSSet(s)
+  let bridgedBack: NSSet = convertSetToNSSet(s)
   expectNotEqual(
     unsafeBitCast(nss, to: Int.self),
     unsafeBitCast(bridgedBack, to: Int.self))
@@ -1331,8 +1330,8 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.ImmutableSetIsCopied") {
 
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.IndexForMember") {
-  var s = getBridgedVerbatimSet()
-  var identity1 = s._rawIdentifier()
+  let s = getBridgedVerbatimSet()
+  let identity1 = s._rawIdentifier()
   expectTrue(isCocoaSet(s))
 
   // Find an existing key.
@@ -1351,8 +1350,8 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.IndexForMember") {
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.IndexForMember") {
-  var s = getBridgedNonverbatimSet()
-  var identity1 = s._rawIdentifier()
+  let s = getBridgedNonverbatimSet()
+  let identity1 = s._rawIdentifier()
 
   do {
     var member = s[s.firstIndex(of: TestBridgedKeyTy(1010))!]
@@ -1372,13 +1371,13 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.IndexForMember") {
 SetTestSuite.test("BridgedFromObjC.Verbatim.Insert") {
   do {
     var s = getBridgedVerbatimSet()
-    var identity1 = s._rawIdentifier()
+    let identity1 = s._rawIdentifier()
     expectTrue(isCocoaSet(s))
 
     expectFalse(s.contains(TestObjCKeyTy(2040)))
     s.insert(TestObjCKeyTy(2040))
 
-    var identity2 = s._rawIdentifier()
+    let identity2 = s._rawIdentifier()
     expectNotEqual(identity1, identity2)
     expectTrue(isNativeSet(s))
     expectEqual(4, s.count)
@@ -1393,13 +1392,13 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.Insert") {
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.Insert") {
   do {
     var s = getBridgedNonverbatimSet()
-    var identity1 = s._rawIdentifier()
+    //let identity1 = s._rawIdentifier()
     expectTrue(isNativeSet(s))
 
     expectFalse(s.contains(TestBridgedKeyTy(2040)))
     s.insert(TestObjCKeyTy(2040) as TestBridgedKeyTy)
 
-    var identity2 = s._rawIdentifier()
+    //let identity2 = s._rawIdentifier()
     // Storage identity may or may not change depending on allocation behavior.
     // (s is eagerly bridged to a regular uniquely referenced native Set.)
     //expectNotEqual(identity1, identity2)
@@ -1415,12 +1414,12 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Insert") {
 }
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.SubscriptWithIndex") {
-  var s = getBridgedVerbatimSet()
-  var identity1 = s._rawIdentifier()
+  let s = getBridgedVerbatimSet()
+  let identity1 = s._rawIdentifier()
   expectTrue(isCocoaSet(s))
 
-  var startIndex = s.startIndex
-  var endIndex = s.endIndex
+  let startIndex = s.startIndex
+  let endIndex = s.endIndex
   expectNotEqual(startIndex, endIndex)
   expectTrue(startIndex < endIndex)
   expectTrue(startIndex <= endIndex)
@@ -1430,7 +1429,7 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.SubscriptWithIndex") {
 
   var members = [Int]()
   for i in s.indices {
-    var foundMember: AnyObject = s[i]
+    let foundMember: AnyObject = s[i]
     let member = foundMember as! TestObjCKeyTy
     members.append(member.value)
   }
@@ -1443,12 +1442,12 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.SubscriptWithIndex") {
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithIndex") {
-  var s = getBridgedNonverbatimSet()
-  var identity1 = s._rawIdentifier()
+  let s = getBridgedNonverbatimSet()
+  let identity1 = s._rawIdentifier()
   expectTrue(isNativeSet(s))
 
-  var startIndex = s.startIndex
-  var endIndex = s.endIndex
+  let startIndex = s.startIndex
+  let endIndex = s.endIndex
   expectNotEqual(startIndex, endIndex)
   expectTrue(startIndex < endIndex)
   expectTrue(startIndex <= endIndex)
@@ -1458,7 +1457,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithIndex") {
 
   var members = [Int]()
   for i in s.indices {
-    var foundMember: AnyObject = s[i] as NSObject
+    let foundMember: AnyObject = s[i] as NSObject
     let member = foundMember as! TestObjCKeyTy
     members.append(member.value)
   }
@@ -1471,12 +1470,12 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithIndex") {
 }
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.SubscriptWithIndex_Empty") {
-  var s = getBridgedVerbatimSet([])
-  var identity1 = s._rawIdentifier()
+  let s = getBridgedVerbatimSet([])
+  let identity1 = s._rawIdentifier()
   expectTrue(isCocoaSet(s))
 
-  var startIndex = s.startIndex
-  var endIndex = s.endIndex
+  let startIndex = s.startIndex
+  let endIndex = s.endIndex
   expectEqual(startIndex, endIndex)
   expectFalse(startIndex < endIndex)
   expectTrue(startIndex <= endIndex)
@@ -1490,12 +1489,12 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.SubscriptWithIndex_Empty") {
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithIndex_Empty") {
-  var s = getBridgedNonverbatimSet([])
-  var identity1 = s._rawIdentifier()
+  let s = getBridgedNonverbatimSet([])
+  let identity1 = s._rawIdentifier()
   expectTrue(isNativeSet(s))
 
-  var startIndex = s.startIndex
-  var endIndex = s.endIndex
+  let startIndex = s.startIndex
+  let endIndex = s.endIndex
   expectEqual(startIndex, endIndex)
   expectFalse(startIndex < endIndex)
   expectTrue(startIndex <= endIndex)
@@ -1510,7 +1509,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithIndex_Empty") {
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.Contains") {
   var s = getBridgedVerbatimSet()
-  var identity1 = s._rawIdentifier()
+  let identity1 = s._rawIdentifier()
   expectTrue(isCocoaSet(s))
 
   expectTrue(s.contains(TestObjCKeyTy(1010)))
@@ -1521,7 +1520,7 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.Contains") {
 
   // Inserting an item should now create storage unique from the bridged set.
   s.insert(TestObjCKeyTy(4040))
-  var identity2 = s._rawIdentifier()
+  let identity2 = s._rawIdentifier()
   expectNotEqual(identity1, identity2)
   expectTrue(isNativeSet(s))
   expectEqual(4, s.count)
@@ -1548,7 +1547,7 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.Contains") {
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.Contains") {
   var s = getBridgedNonverbatimSet()
-  var identity1 = s._rawIdentifier()
+  let identity1 = s._rawIdentifier()
   expectTrue(isNativeSet(s))
 
   expectTrue(s.contains(TestBridgedKeyTy(1010)))
@@ -1558,7 +1557,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Contains") {
   expectEqual(identity1, s._rawIdentifier())
 
   s.insert(TestBridgedKeyTy(4040))
-  var identity2 = s._rawIdentifier()
+  let identity2 = s._rawIdentifier()
 
   // Storage identity may or may not change depending on allocation behavior.
   // (s is eagerly bridged to a regular uniquely referenced native Set.)
@@ -1589,7 +1588,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Contains") {
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithMember") {
   var s = getBridgedNonverbatimSet()
-  var identity1 = s._rawIdentifier()
+  let identity1 = s._rawIdentifier()
   expectTrue(isNativeSet(s))
 
   expectTrue(s.contains(TestBridgedKeyTy(1010)))
@@ -1601,7 +1600,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.SubscriptWithMember") {
   // Insert a new member.
   // This should trigger a copy.
   s.insert(TestBridgedKeyTy(4040))
-  var identity2 = s._rawIdentifier()
+  let identity2 = s._rawIdentifier()
 
   expectTrue(isNativeSet(s))
   expectEqual(4, s.count)
@@ -1664,17 +1663,16 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAt")
 SetTestSuite.test("BridgedFromObjC.Verbatim.Remove") {
   do {
     var s = getBridgedVerbatimSet()
-    var identity1 = s._rawIdentifier()
+    let identity1 = s._rawIdentifier()
     expectTrue(isCocoaSet(s))
 
-    var deleted: AnyObject? = s.remove(TestObjCKeyTy(0))
-    expectNil(deleted)
+    expectNil(s.remove(TestObjCKeyTy(0)))
     expectEqual(identity1, s._rawIdentifier())
     expectTrue(isCocoaSet(s))
 
-    deleted = s.remove(TestObjCKeyTy(1010))
-    expectEqual(1010, deleted!.value)
-    var identity2 = s._rawIdentifier()
+    let deleted = s.remove(TestObjCKeyTy(1010)) as? TestObjCKeyTy
+    expectEqual(1010, deleted?.value)
+    let identity2 = s._rawIdentifier()
     expectNotEqual(identity1, identity2)
     expectTrue(isNativeSet(s))
     expectEqual(2, s.count)
@@ -1686,23 +1684,22 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.Remove") {
   }
 
   do {
-    var s1 = getBridgedVerbatimSet()
-    var identity1 = s1._rawIdentifier()
+    let s1 = getBridgedVerbatimSet()
+    let identity1 = s1._rawIdentifier()
 
     var s2 = s1
     expectTrue(isCocoaSet(s1))
     expectTrue(isCocoaSet(s2))
 
-    var deleted: AnyObject? = s2.remove(TestObjCKeyTy(0))
-    expectNil(deleted)
+    expectNil(s2.remove(TestObjCKeyTy(0)))
     expectEqual(identity1, s1._rawIdentifier())
     expectEqual(identity1, s2._rawIdentifier())
     expectTrue(isCocoaSet(s1))
     expectTrue(isCocoaSet(s2))
 
-    deleted = s2.remove(TestObjCKeyTy(1010))
-    expectEqual(1010, deleted!.value)
-    var identity2 = s2._rawIdentifier()
+    let deleted = s2.remove(TestObjCKeyTy(1010)) as? TestObjCKeyTy
+    expectEqual(1010, deleted?.value)
+    let identity2 = s2._rawIdentifier()
     expectNotEqual(identity1, identity2)
     expectTrue(isCocoaSet(s1))
     expectTrue(isNativeSet(s2))
@@ -1726,7 +1723,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Remove")
 
   do {
     var s = getBridgedNonverbatimSet()
-    var identity1 = s._rawIdentifier()
+    let identity1 = s._rawIdentifier()
     expectTrue(isNativeSet(s))
 
     // Trying to remove something not in the set should
@@ -1740,7 +1737,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Remove")
     // not create a new set altogether, however.
     deleted = s.remove(TestBridgedKeyTy(1010))
     expectEqual(1010, deleted!.value)
-    var identity2 = s._rawIdentifier()
+    let identity2 = s._rawIdentifier()
     expectEqual(identity1, identity2)
     expectTrue(isNativeSet(s))
     expectEqual(2, s.count)
@@ -1757,7 +1754,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Remove")
   }
 
   do {
-    var s1 = getBridgedNonverbatimSet()
+    let s1 = getBridgedNonverbatimSet()
     let identity1 = s1._rawIdentifier()
 
     var s2 = s1
@@ -1794,7 +1791,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Remove")
 SetTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
   do {
     var s = getBridgedVerbatimSet([])
-    var identity1 = s._rawIdentifier()
+    let identity1 = s._rawIdentifier()
     expectTrue(isCocoaSet(s))
     expectEqual(0, s.count)
 
@@ -1805,7 +1802,7 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
 
   do {
     var s = getBridgedVerbatimSet()
-    var identity1 = s._rawIdentifier()
+    let identity1 = s._rawIdentifier()
     expectTrue(isCocoaSet(s))
     expectEqual(3, s.count)
     expectTrue(s.contains(TestBridgedKeyTy(1010) as NSObject))
@@ -1813,18 +1810,19 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
     s.removeAll()
     expectEqual(0, s.count)
     expectFalse(s.contains(TestBridgedKeyTy(1010) as NSObject))
+    expectNotEqual(identity1, s._rawIdentifier())
   }
 
   do {
-    var s1 = getBridgedVerbatimSet()
-    var identity1 = s1._rawIdentifier()
+    let s1 = getBridgedVerbatimSet()
+    let identity1 = s1._rawIdentifier()
     expectTrue(isCocoaSet(s1))
     expectEqual(3, s1.count)
     expectTrue(s1.contains(TestBridgedKeyTy(1010) as NSObject))
 
     var s2 = s1
     s2.removeAll()
-    var identity2 = s2._rawIdentifier()
+    let identity2 = s2._rawIdentifier()
     expectEqual(identity1, s1._rawIdentifier())
     expectNotEqual(identity2, identity1)
     expectEqual(3, s1.count)
@@ -1834,15 +1832,15 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
   }
 
   do {
-    var s1 = getBridgedVerbatimSet()
-    var identity1 = s1._rawIdentifier()
+    let s1 = getBridgedVerbatimSet()
+    let identity1 = s1._rawIdentifier()
     expectTrue(isCocoaSet(s1))
     expectEqual(3, s1.count)
     expectTrue(s1.contains(TestBridgedKeyTy(1010) as NSObject))
 
     var s2 = s1
     s2.removeAll(keepingCapacity: true)
-    var identity2 = s2._rawIdentifier()
+    let identity2 = s2._rawIdentifier()
     expectEqual(identity1, s1._rawIdentifier())
     expectNotEqual(identity2, identity1)
     expectEqual(3, s1.count)
@@ -1855,7 +1853,7 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
   do {
     var s = getBridgedNonverbatimSet([])
-    var identity1 = s._rawIdentifier()
+    let identity1 = s._rawIdentifier()
     expectTrue(isNativeSet(s))
     expectEqual(0, s.count)
 
@@ -1866,7 +1864,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
 
   do {
     var s = getBridgedNonverbatimSet()
-    var identity1 = s._rawIdentifier()
+    let identity1 = s._rawIdentifier()
     expectTrue(isNativeSet(s))
     expectEqual(3, s.count)
     expectTrue(s.contains(TestBridgedKeyTy(1010)))
@@ -1874,18 +1872,19 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
     s.removeAll()
     expectEqual(0, s.count)
     expectFalse(s.contains(TestBridgedKeyTy(1010)))
+    expectNotEqual(identity1, s._rawIdentifier())
   }
 
   do {
-    var s1 = getBridgedNonverbatimSet()
-    var identity1 = s1._rawIdentifier()
+    let s1 = getBridgedNonverbatimSet()
+    let identity1 = s1._rawIdentifier()
     expectTrue(isNativeSet(s1))
     expectEqual(3, s1.count)
     expectTrue(s1.contains(TestBridgedKeyTy(1010)))
 
     var s2 = s1
     s2.removeAll()
-    var identity2 = s2._rawIdentifier()
+    let identity2 = s2._rawIdentifier()
     expectEqual(identity1, s1._rawIdentifier())
     expectNotEqual(identity2, identity1)
     expectEqual(3, s1.count)
@@ -1895,15 +1894,15 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
   }
 
   do {
-    var s1 = getBridgedNonverbatimSet()
-    var identity1 = s1._rawIdentifier()
+    let s1 = getBridgedNonverbatimSet()
+    let identity1 = s1._rawIdentifier()
     expectTrue(isNativeSet(s1))
     expectEqual(3, s1.count)
     expectTrue(s1.contains(TestBridgedKeyTy(1010)))
 
     var s2 = s1
     s2.removeAll(keepingCapacity: true)
-    var identity2 = s2._rawIdentifier()
+    let identity2 = s2._rawIdentifier()
     expectEqual(identity1, s1._rawIdentifier())
     expectNotEqual(identity2, identity1)
     expectEqual(3, s1.count)
@@ -1914,8 +1913,8 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
 }
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.Count") {
-  var s = getBridgedVerbatimSet()
-  var identity1 = s._rawIdentifier()
+  let s = getBridgedVerbatimSet()
+  let identity1 = s._rawIdentifier()
   expectTrue(isCocoaSet(s))
 
   expectEqual(3, s.count)
@@ -1923,8 +1922,8 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.Count") {
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.Count") {
-  var s = getBridgedNonverbatimSet()
-  var identity1 = s._rawIdentifier()
+  let s = getBridgedNonverbatimSet()
+  let identity1 = s._rawIdentifier()
   expectTrue(isNativeSet(s))
 
   expectEqual(3, s.count)
@@ -1932,8 +1931,8 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Count") {
 }
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.Generate") {
-  var s = getBridgedVerbatimSet()
-  var identity1 = s._rawIdentifier()
+  let s = getBridgedVerbatimSet()
+  let identity1 = s._rawIdentifier()
   expectTrue(isCocoaSet(s))
 
   var iter = s.makeIterator()
@@ -1949,8 +1948,8 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.Generate") {
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.Generate") {
-  var s = getBridgedNonverbatimSet()
-  var identity1 = s._rawIdentifier()
+  let s = getBridgedNonverbatimSet()
+  let identity1 = s._rawIdentifier()
   expectTrue(isNativeSet(s))
 
   var iter = s.makeIterator()
@@ -1966,8 +1965,8 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Generate") {
 }
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.Generate_Empty") {
-  var s = getBridgedVerbatimSet([])
-  var identity1 = s._rawIdentifier()
+  let s = getBridgedVerbatimSet([])
+  let identity1 = s._rawIdentifier()
   expectTrue(isCocoaSet(s))
 
   var iter = s.makeIterator()
@@ -1979,8 +1978,8 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.Generate_Empty") {
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.Generate_Empty") {
-  var s = getBridgedNonverbatimSet([])
-  var identity1 = s._rawIdentifier()
+  let s = getBridgedNonverbatimSet([])
+  let identity1 = s._rawIdentifier()
   expectTrue(isNativeSet(s))
 
   var iter = s.makeIterator()
@@ -1992,8 +1991,8 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Generate_Empty") {
 }
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.Generate_Huge") {
-  var s = getHugeBridgedVerbatimSet()
-  var identity1 = s._rawIdentifier()
+  let s = getHugeBridgedVerbatimSet()
+  let identity1 = s._rawIdentifier()
   expectTrue(isCocoaSet(s))
 
   var iter = s.makeIterator()
@@ -2009,8 +2008,8 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.Generate_Huge") {
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.Generate_Huge") {
-  var s = getHugeBridgedNonverbatimSet()
-  var identity1 = s._rawIdentifier()
+  let s = getHugeBridgedNonverbatimSet()
+  let identity1 = s._rawIdentifier()
   expectTrue(isNativeSet(s))
 
   var iter = s.makeIterator()
@@ -2026,7 +2025,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Generate_Huge") {
 }
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.EqualityTest_Empty") {
-  var s1 = getBridgedVerbatimSet([])
+  let s1 = getBridgedVerbatimSet([])
   expectTrue(isCocoaSet(s1))
 
   var s2 = getBridgedVerbatimSet([])
@@ -2041,12 +2040,12 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.EqualityTest_Empty") {
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.EqualityTest_Empty") {
-  var s1 = getBridgedNonverbatimSet([])
-  var identity1 = s1._rawIdentifier()
+  let s1 = getBridgedNonverbatimSet([])
+  let identity1 = s1._rawIdentifier()
   expectTrue(isNativeSet(s1))
 
   var s2 = getBridgedNonverbatimSet([])
-  var identity2 = s2._rawIdentifier()
+  let identity2 = s2._rawIdentifier()
   expectTrue(isNativeSet(s2))
   expectNotEqual(identity1, identity2)
 
@@ -2064,11 +2063,11 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.EqualityTest_Empty") {
 }
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.EqualityTest_Small") {
-  var s1 = getBridgedVerbatimSet()
+  let s1 = getBridgedVerbatimSet()
   let identity1 = s1._rawIdentifier()
   expectTrue(isCocoaSet(s1))
 
-  var s2 = getBridgedVerbatimSet()
+  let s2 = getBridgedVerbatimSet()
   let identity2 = s2._rawIdentifier()
   expectTrue(isCocoaSet(s2))
   expectNotEqual(identity1, identity2)
@@ -2079,11 +2078,11 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.EqualityTest_Small") {
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.EqualityTest_Small") {
-  var s1 = getBridgedNonverbatimSet()
+  let s1 = getBridgedNonverbatimSet()
   let identity1 = s1._rawIdentifier()
   expectTrue(isNativeSet(s1))
 
-  var s2 = getBridgedNonverbatimSet()
+  let s2 = getBridgedNonverbatimSet()
   let identity2 = s2._rawIdentifier()
   expectTrue(isNativeSet(s2))
   expectNotEqual(identity1, identity2)
@@ -2094,7 +2093,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.EqualityTest_Small") {
 }
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.ArrayOfSets") {
-  var nsa = NSMutableArray()
+  let nsa = NSMutableArray()
   for i in 0..<3 {
     nsa.add(
         getAsNSSet([1 + i,  2 + i, 3 + i]))
@@ -2102,20 +2101,20 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.ArrayOfSets") {
 
   var a = nsa as [AnyObject] as! [Set<NSObject>]
   for i in 0..<3 {
-    var s = a[i]
+    let s = a[i]
     var iter = s.makeIterator()
     var items: [Int] = []
     while let value = iter.next() {
       let v = (value as! TestObjCKeyTy).value
       items.append(v)
     }
-    var expectedItems = [1 + i, 2 + i, 3 + i]
+    let expectedItems = [1 + i, 2 + i, 3 + i]
     expectTrue(equalsUnordered(items, expectedItems))
   }
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.ArrayOfSets") {
-  var nsa = NSMutableArray()
+  let nsa = NSMutableArray()
   for i in 0..<3 {
     nsa.add(
         getAsNSSet([1 + i, 2 + i, 3 + i]))
@@ -2123,13 +2122,13 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.ArrayOfSets") {
 
   var a = nsa as [AnyObject] as! [Set<TestBridgedKeyTy>]
   for i in 0..<3 {
-    var d = a[i]
+    let d = a[i]
     var iter = d.makeIterator()
     var items: [Int] = []
     while let value = iter.next() {
       items.append(value.value)
     }
-    var expectedItems = [1 + i, 2 + i, 3 + i]
+    let expectedItems = [1 + i, 2 + i, 3 + i]
     expectTrue(equalsUnordered(items, expectedItems))
   }
 }
@@ -2191,7 +2190,7 @@ SetTestSuite.test("BridgedToObjC.Verbatim.Contains") {
   // types.
   expectNil(s.member(TestObjCInvalidKeyTy()))
 
-  for i in 0..<3 {
+  for _ in 0..<3 {
     expectEqual(idValue10,
       unsafeBitCast(s.member(TestObjCKeyTy(1010)).map { $0 as AnyObject }, to: UInt.self))
 
@@ -2425,7 +2424,7 @@ SetTestSuite.test("SetToNSSetConversion") {
   }
   let nss: NSSet = s as NSSet
 
-  expectTrue(equalsUnordered(Array(s).map { $0.value }, [1010, 2020, 3030]))
+  expectTrue(equalsUnordered(Array(nss).map {  ($0 as! TestObjCKeyTy).value }, [1010, 2020, 3030]))
 }
 
 //
@@ -2438,7 +2437,7 @@ SetTestSuite.test("SetUpcastEntryPoint") {
       s.insert(TestObjCKeyTy(i))
   }
 
-  var sAsAnyObject: Set<NSObject> = _setUpCast(s)
+  let sAsAnyObject: Set<NSObject> = _setUpCast(s)
 
   expectEqual(3, sAsAnyObject.count)
   expectTrue(sAsAnyObject.contains(TestObjCKeyTy(1010)))
@@ -2452,7 +2451,7 @@ SetTestSuite.test("SetUpcast") {
       s.insert(TestObjCKeyTy(i))
   }
 
-  var sAsAnyObject: Set<NSObject> = s
+  let sAsAnyObject: Set<NSObject> = s
 
   expectEqual(3, sAsAnyObject.count)
   expectTrue(sAsAnyObject.contains(TestObjCKeyTy(1010)))
@@ -2467,7 +2466,7 @@ SetTestSuite.test("SetUpcastBridgedEntryPoint") {
   }
 
   do {
-    var s: Set<NSObject> = _setBridgeToObjectiveC(s)
+    let s: Set<NSObject> = _setBridgeToObjectiveC(s)
 
     expectTrue(s.contains(TestBridgedKeyTy(1010) as NSObject))
     expectTrue(s.contains(TestBridgedKeyTy(2020) as NSObject))
@@ -2475,7 +2474,7 @@ SetTestSuite.test("SetUpcastBridgedEntryPoint") {
   }
 
   do {
-    var s: Set<TestObjCKeyTy> = _setBridgeToObjectiveC(s)
+    let s: Set<TestObjCKeyTy> = _setBridgeToObjectiveC(s)
 
     expectEqual(3, s.count)
     expectTrue(s.contains(TestBridgedKeyTy(1010) as TestObjCKeyTy))
@@ -2491,7 +2490,7 @@ SetTestSuite.test("SetUpcastBridged") {
   }
 
   do {
-    var s = s as! Set<NSObject>
+    let s = s as Set<NSObject>
 
     expectEqual(3, s.count)
     expectTrue(s.contains(TestBridgedKeyTy(1010) as NSObject))
@@ -2500,7 +2499,7 @@ SetTestSuite.test("SetUpcastBridged") {
   }
 
   do {
-    var s = s as Set<TestObjCKeyTy>
+    let s = s as Set<TestObjCKeyTy>
 
     expectEqual(3, s.count)
     expectTrue(s.contains(TestBridgedKeyTy(1010) as TestObjCKeyTy))
@@ -2563,9 +2562,7 @@ SetTestSuite.test("SetDowncastConditionalEntryPoint") {
 
   // Unsuccessful downcast
   s.insert("Hello, world" as NSString)
-  if let sCC = _setDownCastConditional(s) as Set<TestObjCKeyTy>? {
-    expectTrue(false)
-  }
+  expectNil(_setDownCastConditional(s) as Set<TestObjCKeyTy>?)
 }
 
 SetTestSuite.test("SetDowncastConditional") {
@@ -2586,7 +2583,7 @@ SetTestSuite.test("SetDowncastConditional") {
 
   // Unsuccessful downcast
   s.insert("Hello, world, I'm your wild girl. I'm your ch-ch-ch-ch-ch-ch cherry bomb" as NSString)
-  if let sCC = s as? Set<TestObjCKeyTy> {
+  if s is Set<TestObjCKeyTy> {
     expectTrue(false)
   }
 }
@@ -2652,9 +2649,7 @@ SetTestSuite.test("SetBridgeFromObjectiveCConditionalEntryPoint") {
 
   // Unsuccessful downcasts
   s.insert("Hello, world, I'm your wild girl. I'm your ch-ch-ch-ch-ch-ch cherry bomb" as NSString)
-  if let sVC = _setBridgeFromObjectiveCConditional(s) as Set<TestBridgedKeyTy>? {
-    expectTrue(false)
-  }
+  expectNil(_setBridgeFromObjectiveCConditional(s) as Set<TestBridgedKeyTy>?)
 }
 
 SetTestSuite.test("SetBridgeFromObjectiveCConditional") {
@@ -2685,13 +2680,13 @@ SetTestSuite.test("SetBridgeFromObjectiveCConditional") {
 
   // Unsuccessful downcasts
   s.insert("Hello, world, I'm your wild girl. I'm your ch-ch-ch-ch-ch-ch cherry bomb" as NSString)
-  if let sCm = s as? Set<TestObjCKeyTy> {
+  if s is Set<TestObjCKeyTy> {
     expectTrue(false)
   }
-  if let sVC = s as? Set<TestBridgedKeyTy> {
+  if s is Set<TestBridgedKeyTy> {
     expectTrue(false)
   }
-  if let sVm = s as? Set<TestBridgedKeyTy> {
+  if s is Set<TestBridgedKeyTy> {
     expectTrue(false)
   }
 }
@@ -2738,7 +2733,6 @@ SetTestSuite.test("isSubsetOf.Set.Set") {
 
 SetTestSuite.test("isSubsetOf.Set.Sequence") {
   let s1 = Set([1010, 2020, 3030, 4040, 5050, 6060])
-  let s2 = AnySequence([1010, 2020, 3030])
   expectTrue(Set<Int>().isSubset(of: s1))
   expectFalse(s1.isSubset(of: Set<Int>()))
   expectTrue(s1.isSubset(of: s1))
@@ -2746,7 +2740,6 @@ SetTestSuite.test("isSubsetOf.Set.Sequence") {
 
 SetTestSuite.test("isStrictSubsetOf.Set.Set") {
   let s1 = Set([1010, 2020, 3030, 4040, 5050, 6060])
-  let s2 = Set([1010, 2020, 3030])
   expectTrue(Set<Int>().isStrictSubset(of: s1))
   expectFalse(s1.isStrictSubset(of: Set<Int>()))
   expectFalse(s1.isStrictSubset(of: s1))
@@ -2754,7 +2747,6 @@ SetTestSuite.test("isStrictSubsetOf.Set.Set") {
 
 SetTestSuite.test("isStrictSubsetOf.Set.Sequence") {
   let s1 = Set([1010, 2020, 3030, 4040, 5050, 6060])
-  let s2 = AnySequence([1010, 2020, 3030])
   expectTrue(Set<Int>().isStrictSubset(of: s1))
   expectFalse(s1.isStrictSubset(of: Set<Int>()))
   expectFalse(s1.isStrictSubset(of: s1))
@@ -2940,13 +2932,13 @@ SetTestSuite.test("union") {
 
 SetTestSuite.test("formUnion") {
   // These are anagrams - they should amount to the same sets.
-  var s1 = Set("the morse code".characters)
-  let s2 = Set("here come dots".characters)
-  let s3 = Set("and then dashes".characters)
+  var s1 = Set("the morse code")
+  let s2 = Set("here come dots")
+  let s3 = Set("and then dashes")
 
   let identity1 = s1._rawIdentifier()
 
-  s1.formUnion("".characters)
+  s1.formUnion("")
   expectEqual(identity1, s1._rawIdentifier())
 
   expectEqual(s1, s2)
@@ -3006,16 +2998,14 @@ SetTestSuite.test("subtract")
 
 SetTestSuite.test("intersect") {
   let s1 = Set([1010, 2020, 3030])
-  let s2 = Set([4040, 5050, 6060])
-  var s3 = Set([1010, 2020, 3030, 4040, 5050, 6060])
-  var s4 = Set([1010, 2020, 3030])
+  let s2 = Set([1010, 2020, 3030, 4040, 5050, 6060])
 
   let identity1 = s1._rawIdentifier()
   expectEqual(Set([1010, 2020, 3030]),
     Set([1010, 2020, 3030]).intersection(Set([1010, 2020, 3030])) as Set<Int>)
   expectEqual(identity1, s1._rawIdentifier())
 
-  expectEqual(s1, s1.intersection(s3))
+  expectEqual(s1, s1.intersection(s2))
   expectEqual(identity1, s1._rawIdentifier())
 
   expectEqual(Set<Int>(), Set<Int>().intersection(Set<Int>()))
@@ -3041,7 +3031,7 @@ SetTestSuite.test("formIntersection") {
   s3.formIntersection(s2)
   expectEqual(s3, s2)
   expectTrue(s1.isDisjoint(with: s3))
-  expectNotEqual(identity1, s3._rawIdentifier())
+  expectNotEqual(identity2, s3._rawIdentifier())
 
   var s5 = Set<Int>()
   s5.formIntersection(s5)
@@ -3279,26 +3269,26 @@ func callGenericIsEmpty<C : Collection>(_ collection: C) -> Bool {
 
 SetTestSuite.test("isEmpty/ImplementationIsCustomized") {
   do {
-    var d = getMockSetWithCustomCount(count: 0)
+    let d = getMockSetWithCustomCount(count: 0)
     MockSetWithCustomCount.timesCountWasCalled = 0
     expectTrue(d.isEmpty)
     expectEqual(1, MockSetWithCustomCount.timesCountWasCalled)
   }
   do {
-    var d = getMockSetWithCustomCount(count: 0)
+    let d = getMockSetWithCustomCount(count: 0)
     MockSetWithCustomCount.timesCountWasCalled = 0
     expectTrue(callGenericIsEmpty(d))
     expectEqual(1, MockSetWithCustomCount.timesCountWasCalled)
   }
 
   do {
-    var d = getMockSetWithCustomCount(count: 4)
+    let d = getMockSetWithCustomCount(count: 4)
     MockSetWithCustomCount.timesCountWasCalled = 0
     expectFalse(d.isEmpty)
     expectEqual(1, MockSetWithCustomCount.timesCountWasCalled)
   }
   do {
-    var d = getMockSetWithCustomCount(count: 4)
+    let d = getMockSetWithCustomCount(count: 4)
     MockSetWithCustomCount.timesCountWasCalled = 0
     expectFalse(callGenericIsEmpty(d))
     expectEqual(1, MockSetWithCustomCount.timesCountWasCalled)
@@ -3308,7 +3298,6 @@ SetTestSuite.test("isEmpty/ImplementationIsCustomized") {
 
 SetTestSuite.test("count") {
   let s1 = Set([1010, 2020, 3030])
-  var s2 = Set([4040, 5050, 6060])
   expectEqual(0, Set<Int>().count)
   expectEqual(3, s1.count)
 }
@@ -3436,7 +3425,7 @@ SetTestSuite.test("misc") {
   }
 
   do {
-    var s = Set(["Hello", "world"])
+    let s = Set(["Hello", "world"])
     expectTrue(s.contains("Hello"))
     expectTrue(s.contains("world"))
   }
@@ -3481,7 +3470,7 @@ SetTestSuite.test("Hashable") {
 
 SetTestSuite.test("mutationDoesNotAffectIterator/remove,1") {
   var set = Set([1010, 1020, 1030])
-  var iter = set.makeIterator()
+  let iter = set.makeIterator()
   expectOptionalEqual(1010, set.remove(1010))
 
   expectEqualsUnordered([1010, 1020, 1030], Array(IteratorSequence(iter)))
@@ -3489,7 +3478,7 @@ SetTestSuite.test("mutationDoesNotAffectIterator/remove,1") {
 
 SetTestSuite.test("mutationDoesNotAffectIterator/remove,all") {
   var set = Set([1010, 1020, 1030])
-  var iter = set.makeIterator()
+  let iter = set.makeIterator()
   expectOptionalEqual(1010, set.remove(1010))
   expectOptionalEqual(1020, set.remove(1020))
   expectOptionalEqual(1030, set.remove(1030))
@@ -3499,7 +3488,7 @@ SetTestSuite.test("mutationDoesNotAffectIterator/remove,all") {
 
 SetTestSuite.test("mutationDoesNotAffectIterator/removeAll,keepingCapacity=false") {
   var set = Set([1010, 1020, 1030])
-  var iter = set.makeIterator()
+  let iter = set.makeIterator()
   set.removeAll(keepingCapacity: false)
 
   expectEqualsUnordered([1010, 1020, 1030], Array(IteratorSequence(iter)))
@@ -3507,7 +3496,7 @@ SetTestSuite.test("mutationDoesNotAffectIterator/removeAll,keepingCapacity=false
 
 SetTestSuite.test("mutationDoesNotAffectIterator/removeAll,keepingCapacity=true") {
   var set = Set([1010, 1020, 1030])
-  var iter = set.makeIterator()
+  let iter = set.makeIterator()
   set.removeAll(keepingCapacity: true)
 
   expectEqualsUnordered([1010, 1020, 1030], Array(IteratorSequence(iter)))

--- a/validation-test/stdlib/SwiftNativeNSBase.swift
+++ b/validation-test/stdlib/SwiftNativeNSBase.swift
@@ -15,7 +15,7 @@
 // RUN: %target-clang %S/Inputs/SwiftNativeNSBase/SwiftNativeNSBase.m -c -o %t/SwiftNativeNSBase.o -g
 // RUN: %target-clang -fobjc-arc %S/Inputs/SlurpFastEnumeration/SlurpFastEnumeration.m -c -o %t/SlurpFastEnumeration.o
 // RUN: echo '#sourceLocation(file: "%s", line: 1)' > "%t/main.swift" && cat "%s" >> "%t/main.swift" && chmod -w "%t/main.swift"
-// RUN: %target-build-swift -Xfrontend -disable-access-control  %t/main.swift %S/Inputs/DictionaryKeyValueTypes.swift %S/Inputs/DictionaryKeyValueTypesObjC.swift -I %S/Inputs/SwiftNativeNSBase/ -I %S/Inputs/SlurpFastEnumeration/ -Xlinker %t/SlurpFastEnumeration.o -Xlinker %t/SwiftNativeNSBase.o -o %t/SwiftNativeNSBase -swift-version 3
+// RUN: %target-build-swift -Xfrontend -disable-access-control  %t/main.swift %S/Inputs/DictionaryKeyValueTypes.swift %S/Inputs/DictionaryKeyValueTypesObjC.swift -I %S/Inputs/SwiftNativeNSBase/ -I %S/Inputs/SlurpFastEnumeration/ -Xlinker %t/SlurpFastEnumeration.o -Xlinker %t/SwiftNativeNSBase.o -o %t/SwiftNativeNSBase -swift-version 4.2
 // RUN: %target-codesign %t/SwiftNativeNSBase
 // RUN: %target-run %t/SwiftNativeNSBase
 // REQUIRES: executable_test


### PR DESCRIPTION
Includes some drive-by warning fixes and de-gybbing a file that wasn't using gyb.

Where there was a test for multiple versions, I've dropped 3 and added 4.2 (if it wasn't there). Where it was just testing Swift 3, I've bumped it to 4.2 (maybe we should add 4, 4.2 and 5 to everything... but that'd be a lot more tests).

Main things that needed fixing:
* Changes due to things no longer coming through as `AnyObject`
* Dropping some tests of Swift 3-only SDK APIs
* Changes in expected errors.
* Missing `@objc`
