### PR TITLE
Assume it's okay for decls in a cross-module extension to be public

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2482,10 +2482,12 @@ getAccessScopeForFormalAccess(const ValueDecl *VD,
       // Just check the base type. If it's a constrained extension, Sema should
       // have already enforced access more strictly.
       if (auto nominal = enclosingExt->getExtendedNominal()) {
-        auto nominalAccess =
-            getAdjustedFormalAccess(nominal, useDC,
-                                    treatUsableFromInlineAsPublic);
-        access = std::min(access, nominalAccess);
+        if (nominal->getParentModule() == enclosingExt->getParentModule()) {
+          auto nominalAccess =
+              getAdjustedFormalAccess(nominal, useDC,
+                                      treatUsableFromInlineAsPublic);
+          access = std::min(access, nominalAccess);
+        }
       }
 
     } else {

--- a/test/ClangImporter/MixedSource/Inputs/import-as-member-swift.h
+++ b/test/ClangImporter/MixedSource/Inputs/import-as-member-swift.h
@@ -1,0 +1,5 @@
+@class Outer;
+
+struct Nested {
+  int value;
+} __attribute((swift_name("Outer.Nested")));

--- a/test/ClangImporter/MixedSource/import-as-member-swift.swift
+++ b/test/ClangImporter/MixedSource/import-as-member-swift.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-frontend -import-objc-header %S/Inputs/import-as-member-swift.h -typecheck -enable-objc-interop -disable-objc-attr-requires-foundation-module %s
+
+@objc internal class Outer {}
+
+_ = Outer.Nested()


### PR DESCRIPTION
...even if the base decl isn't.

This isn't normally possible, but it can come up when an imported type is import-as-member'd onto an internal Swift declaration. This isn't even such an unreasonable thing to do, since internal Swift declarations are exposed in the generated header for an app.

rdar://problem/43312660