### PR TITLE
[TF API] Re-implement Tensor subscript setter 

### DIFF
--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -1227,12 +1227,12 @@ public extension Tensor {
       // TODO: The horrendous mess of type-casting is necessary due to GPU ops
       // (Gather, ScatterNd) not accepting Int32 for particular inputs. Refactor
       // if possible.
-      let lowerBound = Tensor<Int32>([bounds.lowerBound])
+      let lowerBound = Tensor<Int32>(bounds.lowerBound).rankLifted()
       let remainingZeros: Tensor<Int32> = Raw.fill(
         dims: (rankTensor - 1).rankLifted(), value: Tensor<Int32>(0))
       let startIndices = lowerBound.concatenated(with: remainingZeros)
 
-      let boundSize = Tensor<Int32>([bounds.upperBound])
+      let boundSize = Tensor<Int32>(bounds.upperBound).rankLifted()
         - lowerBound - Tensor<Int32>(Tensor<Float>(shapeTensor)[0])
       let scatterIndices: Tensor<Int32> = [[0]]
       let offset: Tensor<Int32> = Tensor<Int32>(

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -1185,7 +1185,7 @@ public extension Tensor {
     set {
       let left = self[0..<index]
       let right = self[index+1..<_TFGetScalarOrDie(shapeTensor[0].handle)]
-      self = Raw.concatV2([left, Tensor([newValue]), right], axis: Tensor<Int32>(0))
+      self = Raw.concatV2([left, newValue.rankLifted(), right], axis: Tensor<Int32>(0))
     }
   }
 

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -1183,11 +1183,9 @@ public extension Tensor {
     }
     @inline(__always)
     set {
-      let range1: Range = 0..<index
-      let t1 = self[range1]
-      let range2: Range = index+1..<self.shape[0]
-      let t2 = self[range2]
-      self = Raw.concatV2([t1, Tensor([newValue]), t2], axis: Tensor<Int32>(0))
+      let left = self[0..<index]
+      let right = self[index+1..<_TFGetScalarOrDie(shapeTensor[0].handle)]
+      self = Raw.concatV2([left, Tensor([newValue]), right], axis: Tensor<Int32>(0))
     }
   }
 

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -1183,18 +1183,11 @@ public extension Tensor {
     }
     @inline(__always)
     set {
-      let orig = self[index]
-      // FIXME: Currently there's no existing non-in-place slice updating
-      // operator in TensorFlow. But since most scalar types are numeric, we do
-      // a hack by using arithmetic operations. We need to find a proper
-      // solution soon.
-      let diff = Tensor(handle: #tfop("Sub", newValue, orig))
-      let scatteredDiff = Raw.scatterNd(
-        indices: Tensor<Int32>(shape: [1, 1], scalars: [index]),
-        updates: Tensor([diff]),
-        shape: shapeTensor
-      )
-      self = Tensor(handle: #tfop("Add", handle, scatteredDiff))
+      let range1: Range = 0..<index
+      let t1 = self[range1]
+      let range2: Range = index+1..<self.shape[0]
+      let t2 = self[range2]
+      self = Raw.concatV2([t1, Tensor([newValue]), t2], axis: Tensor<Int32>(0))
     }
   }
 

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -199,6 +199,8 @@ TensorTests.testAllBackends("SliceUpdate") {
   t2[0][2] = Tensor(3)
   expectEqual(ShapedArray(shape:[2, 3], scalars: [0, 0, 0, 4, 5, 6]), t1.array)
   expectEqual(ShapedArray(shape:[2, 3], scalars: [0, 0, 3, 4, 5, 6]), t2.array)
+  t2[1][2] = Tensor(10)
+  expectEqual(ShapedArray(shape:[2, 3], scalars: [0, 0, 3, 4, 5, 10]), t2.array)
 }
 
 TensorTests.test("WholeTensorSlicing") {

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -193,7 +193,7 @@ TensorTests.testAllBackends("SliceIndexing") {
 }
 
 TensorTests.testAllBackends("SliceUpdate") {
-  var t1 = Tensor<Float>([[1, 2, 3],[4, 5, 6]])
+  var t1 = Tensor<Float>([[1, 2, 3], [4, 5, 6]])
   t1[0] = Tensor(zeros: [3])
   var t2 = t1
   t2[0][2] = Tensor(3)
@@ -201,6 +201,14 @@ TensorTests.testAllBackends("SliceUpdate") {
   expectEqual(ShapedArray(shape:[2, 3], scalars: [0, 0, 3, 4, 5, 6]), t2.array)
   t2[1][2] = Tensor(10)
   expectEqual(ShapedArray(shape:[2, 3], scalars: [0, 0, 3, 4, 5, 10]), t2.array)
+
+  var t3 = Tensor<Bool>([[true, true, true], [false, false, false]])
+  t3[0][1] = Tensor(false)
+  expectEqual(ShapedArray(shape:[2, 3],
+                          scalars: [true, false, true, false, false, false]),
+              t3.array)
+  t3[0] = Tensor(shape: [3], repeating: false)
+  expectEqual(ShapedArray(shape:[2, 3], repeating: false), t3.array)
 }
 
 TensorTests.test("WholeTensorSlicing") {

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -197,18 +197,17 @@ TensorTests.testAllBackends("SliceUpdate") {
   t1[0] = Tensor(zeros: [3])
   var t2 = t1
   t2[0][2] = Tensor(3)
-  expectEqual(ShapedArray(shape:[2, 3], scalars: [0, 0, 0, 4, 5, 6]), t1.array)
-  expectEqual(ShapedArray(shape:[2, 3], scalars: [0, 0, 3, 4, 5, 6]), t2.array)
-  t2[1][2] = Tensor(10)
-  expectEqual(ShapedArray(shape:[2, 3], scalars: [0, 0, 3, 4, 5, 10]), t2.array)
-
   var t3 = Tensor<Bool>([[true, true, true], [false, false, false]])
   t3[0][1] = Tensor(false)
+  var t4 = Tensor<Bool>([[true, true, true], [false, false, false]])
+  t4[0] = Tensor(shape: [3], repeating: false)
+  expectEqual(ShapedArray(shape:[2, 3], scalars: [0, 0, 0, 4, 5, 6]), t1.array)
+  expectEqual(ShapedArray(shape:[2, 3], scalars: [0, 0, 3, 4, 5, 6]), t2.array)
   expectEqual(ShapedArray(shape:[2, 3],
                           scalars: [true, false, true, false, false, false]),
               t3.array)
-  t3[0] = Tensor(shape: [3], repeating: false)
-  expectEqual(ShapedArray(shape:[2, 3], repeating: false), t3.array)
+  expectEqual(ShapedArray(shape:[2, 3], repeating: false), t4.array)
+
 }
 
 TensorTests.test("WholeTensorSlicing") {

--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -192,24 +192,6 @@ TensorTests.testAllBackends("SliceIndexing") {
   expectEqual(Array(stride(from: 3.0, to: 5, by: 1)), array1D.scalars)
 }
 
-TensorTests.testAllBackends("SliceUpdate") {
-  var t1 = Tensor<Float>([[1, 2, 3], [4, 5, 6]])
-  t1[0] = Tensor(zeros: [3])
-  var t2 = t1
-  t2[0][2] = Tensor(3)
-  var t3 = Tensor<Bool>([[true, true, true], [false, false, false]])
-  t3[0][1] = Tensor(false)
-  var t4 = Tensor<Bool>([[true, true, true], [false, false, false]])
-  t4[0] = Tensor(shape: [3], repeating: false)
-  expectEqual(ShapedArray(shape:[2, 3], scalars: [0, 0, 0, 4, 5, 6]), t1.array)
-  expectEqual(ShapedArray(shape:[2, 3], scalars: [0, 0, 3, 4, 5, 6]), t2.array)
-  expectEqual(ShapedArray(shape:[2, 3],
-                          scalars: [true, false, true, false, false, false]),
-              t3.array)
-  expectEqual(ShapedArray(shape:[2, 3], repeating: false), t4.array)
-
-}
-
 TensorTests.test("WholeTensorSlicing") {
   let t: Tensor<Int32> = [[[1, 1, 1], [2, 2, 2]],
                           [[3, 3, 3], [4, 4, 4]],

--- a/test/TensorFlowRuntime/tensor_api.swift
+++ b/test/TensorFlowRuntime/tensor_api.swift
@@ -1,0 +1,33 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize
+//
+// This test suite is for tensor API and has been created because tensor.swift
+// has static shape restrictions for TPU send/receive. Until the restriction is
+// resolved, API tests that incur send/receive should reside here.“
+
+import TensorFlow
+import TensorFlowUnittest
+import StdlibUnittest
+
+var TensorNonTPUTests = TestSuite("TensorNonTPU")
+
+TensorNonTPUTests.testAllBackends("SliceUpdate") {
+  var t1 = Tensor<Float>([[1, 2, 3], [4, 5, 6]])
+  t1[0] = Tensor(zeros: [3])
+  expectEqual(ShapedArray(shape:[2, 3], scalars: [0, 0, 0, 4, 5, 6]), t1.array)
+  var t2 = t1
+  t2[0][2] = Tensor(3)
+  expectEqual(ShapedArray(shape:[2, 3], scalars: [0, 0, 3, 4, 5, 6]), t2.array)
+  var t3 = Tensor<Bool>([[true, true, true], [false, false, false]])
+  t3[0][1] = Tensor(false)
+  expectEqual(ShapedArray(shape:[2, 3],
+                          scalars: [true, false, true, false, false, false]),
+              t3.array)
+  var t4 = Tensor<Bool>([[true, true, true], [false, false, false]])
+  t4[0] = Tensor(shape: [3], repeating: false)
+  expectEqual(ShapedArray(shape:[2, 3], repeating: false), t4.array)
+
+}
+
+runAllTests()

--- a/test/TensorFlowRuntime/tensor_api.swift
+++ b/test/TensorFlowRuntime/tensor_api.swift
@@ -27,7 +27,6 @@ TensorNonTPUTests.testAllBackends("SliceUpdate") {
   var t4 = Tensor<Bool>([[true, true, true], [false, false, false]])
   t4[0] = Tensor(shape: [3], repeating: false)
   expectEqual(ShapedArray(shape:[2, 3], repeating: false), t4.array)
-
 }
 
 runAllTests()


### PR DESCRIPTION
This patch implements a more type-safe version of `Tensor` subscript setter using concatenation. Now slice update on tensors with non-numeric data types is supported.