### PR TITLE
[SILProfiler] Don't crash when coverage info for lazy getters is inco…

### DIFF
--- a/lib/SIL/SILProfiler.cpp
+++ b/lib/SIL/SILProfiler.cpp
@@ -260,6 +260,16 @@ struct MapRegionCounters : public ASTWalker {
     } else if (auto *ACE = dyn_cast<AbstractClosureExpr>(E)) {
       return visitClosureExpr(*this, ACE, [&] { mapRegion(ACE); });
     }
+
+    // rdar://42792053
+    // TODO: There's an outstanding issue here with LazyInitializerExpr. A LIE
+    // is copied into the body of a property getter after type-checking (before
+    // coverage). ASTWalker only visits this expression once via the property's
+    // VarDecl, and does not visit it again within the getter. This results in
+    // missing coverage. SILGen treats the init expr as part of the getter, but
+    // its SILProfiler has no information about the init because the LIE isn't
+    // visited here.
+
     return {true, E};
   }
 };

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -653,8 +653,10 @@ void SILGenFunction::emitProfilerIncrement(ASTNode N) {
   auto &C = B.getASTContext();
   const auto &RegionCounterMap = SP->getRegionCounterMap();
   auto CounterIt = RegionCounterMap.find(N);
-  assert(CounterIt != RegionCounterMap.end() &&
-         "cannot increment non-existent counter");
+
+  // TODO: Assert that this cannot happen (rdar://42792053).
+  if (CounterIt == RegionCounterMap.end())
+    return;
 
   auto Int32Ty = getLoweredType(BuiltinIntegerType::get(32, C));
   auto Int64Ty = getLoweredType(BuiltinIntegerType::get(64, C));

--- a/test/Profiler/coverage_class.swift
+++ b/test/Profiler/coverage_class.swift
@@ -39,3 +39,11 @@ struct S2 {
   // CHECK-NEXT: [[@LINE+1]]:26 -> [[@LINE+1]]:27 : (1 - 0)
   var m1: Int = g1 ? 0 : 1
 }
+
+// Test that the crash from SR-8429 is avoided. Follow-up work is
+// needed to generate the correct coverage mapping here. Coverage for
+// `offset` should be associated with its getter, not the class
+// constructor.
+class C2 {
+  lazy var offset: Int = true ? 30 : 55
+}


### PR DESCRIPTION
…mplete

ASTWalker visits a lazy_initializer_expr once within its associated
var_decl (by way of the parent nominal type). However, SILGen visits the
lazy_initializer_expr while inside of the var_decl's getter. The result
is that there is no coverage mapping information for the contents of the
lazy init within the getter's SILProfiler.

Fixing this will require reworking how profile counters are assigned to
be more in line with what SILGen needs.

As a stop-gap, this patch prevents SILGen from asserting that coverage
mappings are complete with a defensive check which prevents a crash seen
in SR-8429.

rdar://42792053