### PR TITLE
Add a test case for a type checker deficiency.

### DIFF
--- a/test/SILOptimizer/exclusivity_static_diagnostics.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.swift
@@ -606,3 +606,11 @@ struct S {
     // expected-error@-1 2 {{overlapping accesses to 'self', but modification requires exclusive access; consider copying to a local variable}}
   }
 }
+
+// TODO: A conflict should also be detected here. However, the
+// typechecker does not allow it. Enable the following test if we ever
+// remove this case from the typechecker test:
+// diag_invalid_inout_captures.swift.
+// public func nestedConflict(x: inout Int) {
+//   doit(x: &x, x == 0 ? { x = 1 } : { x = 2})
+// }

--- a/test/Sema/diag_invalid_inout_captures.swift
+++ b/test/Sema/diag_invalid_inout_captures.swift
@@ -33,3 +33,10 @@ func remember(line: inout String) -> () -> Void {
     return despite_our_estrangement // expected-error {{nested function cannot capture inout parameter and escape}}
 }
 
+// This arrangement should be legal, but the type checker does not currently allow it.
+//
+// TODO: If the type checker is ever fixed, we should enable the corresponding test in
+// SILOptimizer/exclusivity_static_diagnostics.swift.
+func its_complicated(condition: inout Int) {
+  no_escape(condition == 0 ? { condition = 1 } : { condition = 2}) // expected-error 2 {{escaping closures can only capture inout parameters explicitly by value}}
+}


### PR DESCRIPTION
If the deficiency is ever fixed we want to make sure the corresponding
exclusivity checked are covered in this case.
