### PR TITLE
[TF API] Use scalar->tensor conversion for Tensor.subscript to avoid send/receive

### DIFF
--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -1158,7 +1158,7 @@ public extension Tensor {
       // Gather implementation is below:
       // return #tfop("GatherV2", self, Tensor<Int32>(index), Tensor<Int32>(0),
       //              Tindices: Int32.self)
-      let indexTensor = Tensor<Int32>([index])
+      let indexTensor = Tensor<Int32>(index).rankLifted()
       let remainingZeros: Tensor<Int32> = Raw.fill(
         dims: (rankTensor - 1).rankLifted(), value: Tensor<Int32>(0))
       let startIndices = indexTensor.concatenated(with: remainingZeros)


### PR DESCRIPTION
In `Tensor.subscript(_:)`, when `index` is not constant but comes from `_TFGetScalarOrDie()`, it'll trigger send/receive because the compiler cannot recognize that the single element of the array literal operand to `__tf_tensor_from_scalars_1d` comes from `_TFGetScalarOrDie()`. 

We should use the `_TFMakeScalarTensor` instead so that the compiler can promote the combination of `_TFGetScalarOrDie` and `_TFMakeScalarTensor` to graph.

Resolves [SR-8225](https://bugs.swift.org/browse/SR-8225). 