### PR TITLE
[ClangImporter] Swift classes found by @class need to be validated

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4342,9 +4342,13 @@ namespace {
         }
       }
 
-      if (found)
+      if (found) {
+        if (auto *typeResolver = Impl.getTypeResolver())
+          typeResolver->resolveDeclSignature(found);
+
         Impl.ImportedDecls[{decl->getCanonicalDecl(),
                             getActiveSwiftVersion()}] = found;
+      }
 
       return found;
     }

--- a/test/ClangImporter/MixedSource/Inputs/forward-declarations-other.swift
+++ b/test/ClangImporter/MixedSource/Inputs/forward-declarations-other.swift
@@ -1,0 +1,1 @@
+@objc class ClassInOtherFile {}

--- a/test/ClangImporter/MixedSource/Inputs/forward-declarations.h
+++ b/test/ClangImporter/MixedSource/Inputs/forward-declarations.h
@@ -1,0 +1,5 @@
+@class ClassInOtherFile;
+
+@interface Base
+- (ClassInOtherFile *)getClassInstanceWithoutMentioningItsName;
+@end

--- a/test/ClangImporter/MixedSource/forward-declarations.swift
+++ b/test/ClangImporter/MixedSource/forward-declarations.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -emit-ir -primary-file %s %S/Inputs/forward-declarations-other.swift -import-objc-header %S/Inputs/forward-declarations.h -enable-objc-interop -disable-objc-attr-requires-foundation-module -module-name main | %FileCheck %s
+
+class Sub: Base {
+  // CHECK-LABEL: define{{.*}} void @"$S4main3SubC4testyyF"
+  func test() {
+    // CHECK: [[BASE_SELF:%.+]] = bitcast %T4main3SubC* %0 to %TSo4BaseC*
+    // CHECK: [[SELECTOR:%.+]] = load i8*, i8** @"\01L_selector(getClassInstanceWithoutMentioningItsName)"
+    // CHECK: [[OPAQUE_SELF:%.+]] = bitcast %TSo4BaseC* %2 to {{%.+}}*
+    // CHECK: [[RESULT:%.+]] = call {{%.+}}* bitcast (void ()* @objc_msgSend to {{%.+}}* ({{%.+}}*, i8*)*)({{%.+}}* [[OPAQUE_SELF]], i8* [[SELECTOR]])
+    // CHECK: [[OPAQUE_RESULT:%.+]] = bitcast {{%.+}}* [[RESULT]] to i8*
+    // CHECK: call i8* @objc_retainAutoreleasedReturnValue(i8* [[OPAQUE_RESULT]])
+    _ = self.getClassInstanceWithoutMentioningItsName()
+    // CHECK: call void @swift_release(%swift.refcounted* {{%.+}})
+    // CHECK: ret void
+  }
+}


### PR DESCRIPTION
Otherwise, it's possible for someone to use them without mentioning them by name, leading to AST semantic requests happening after type checking has already finished.

Found while investigating rdar://problem/43312726, but there's more there. Possibly related to [SR-8530](
https://bugs.swift.org/browse/SR-8530) or [SR-8531](
https://bugs.swift.org/browse/SR-8531).