### PR TITLE
[ClangImporter] A method can't interfere with an existing property

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4773,11 +4773,12 @@ namespace {
           dc->lookupQualified(lookupContext, name,
                               NL_QualifiedDefault | NL_KnownNoDependency,
                               lookup);
+          bool foundMethod = false;
           for (auto result : lookup) {
             if (isa<FuncDecl>(result) &&
                 result->isInstanceMember() == decl->isInstanceProperty() &&
                 result->getFullName().getArgumentNames().empty())
-              return nullptr;
+              foundMethod = true;
 
             if (auto var = dyn_cast<VarDecl>(result)) {
               // If the selectors of the getter match in Objective-C, we have an
@@ -4788,6 +4789,8 @@ namespace {
                 overridden = var;
             }
           }
+          if (foundMethod && !overridden)
+            return nullptr;
         }
 
         if (overridden) {

--- a/test/ClangImporter/Inputs/custom-modules/RedeclaredProperties/RPFirst.h
+++ b/test/ClangImporter/Inputs/custom-modules/RedeclaredProperties/RPFirst.h
@@ -1,4 +1,8 @@
-@interface RPFoo
+@protocol RPProto
+- (nullable id)accessorInProto;
+@end
+
+@interface RPFoo <RPProto>
 @property (readonly, nonnull) int *nonnullToNullable;
 @property (readonly, nullable) int *nullableToNonnull;
 @property (readonly, nonnull) id typeChangeMoreSpecific;
@@ -9,4 +13,10 @@
 
 - (nullable id)accessorDeclaredFirstAsNullable;
 @property (readonly, nonnull) id accessorDeclaredFirstAsNullable;
+
+@property (readonly, nullable) id accessorInProto;
+@end
+
+@interface RPBase <RPProto>
+@property (readonly, nonatomic, nullable) id accessorInProto;
 @end

--- a/test/ClangImporter/Inputs/custom-modules/RedeclaredProperties/RPSecond.h
+++ b/test/ClangImporter/Inputs/custom-modules/RedeclaredProperties/RPSecond.h
@@ -3,4 +3,9 @@
 @property (readwrite, nonnull) int *nullableToNonnull;
 @property (readwrite, nonnull) RPFoo *typeChangeMoreSpecific;
 @property (readwrite, nonnull) id typeChangeMoreGeneral;
+@property (readwrite, nullable) id accessorInProto;
+@end
+
+@interface RPSub : RPBase
+@property (readwrite, nonatomic, nullable) id accessorInProto;
 @end

--- a/test/ClangImporter/objc_redeclared_properties.swift
+++ b/test/ClangImporter/objc_redeclared_properties.swift
@@ -27,4 +27,10 @@ func test(obj: RPFoo) {
 
   if let _ = obj.accessorRedeclaredAsNullable {} // expected-error {{initializer for conditional binding must have Optional type}}
   if let _ = obj.accessorDeclaredFirstAsNullable {} // expected-error {{initializer for conditional binding must have Optional type}}
+
+  obj.accessorInProto = nil // okay
+}
+
+func sr8490(obj: RPSub) {
+  obj.accessorInProto = nil
 }


### PR DESCRIPTION
That is, if we encounter a property declaration, and a no-argument method is visible, it's only a problem if there's not already a property there. (Arguably this means that it's either not a problem at all, or that we shouldn't be mirroring protocol methods onto classes if there's a conflicting property, but this change doesn't attempt to answer that.)

[SR-8490](https://bugs.swift.org/browse/SR-8490) / rdar://problem/43057062