### PR TITLE
[Diagnostics] Extract requirement declaration context retrieval into …

### DIFF
--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -134,7 +134,12 @@ public:
   Type getOwnerType() const;
 
   /// Generic requirement associated with the failure.
-  const Requirement &getRequirement();
+  const Requirement &getRequirement() const;
+
+protected:
+  /// Retrieve declaration contextual where current
+  /// requirement has been introduced.
+  const DeclContext *getRequirementDC() const;
 
 private:
   /// Retrieve declaration associated with failing generic requirement.


### PR DESCRIPTION
…its own method

Change logic to traverse the chain of declaration contexts
starting for "affected" declaration's parent and check if the
requirement is satisfied by one of them, if so return it as
requirement's declaration context.

Extract this logic into a method on `RequirementFailure` to make
it accessible for other types of requirement failure diagnostics.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
