### PR TITLE
[ConstraintSystem] Add `kind` to generic requirement locator

### DIFF
--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -243,9 +243,26 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) {
       out << "conditional requirement #" << llvm::utostr(elt.getValue());
       break;
 
-    case TypeParameterRequirement:
-      out << "type parameter requirement #" << llvm::utostr(elt.getValue());
+    case TypeParameterRequirement: {
+      out << "type parameter requirement #" << llvm::utostr(elt.getValue())
+          << " (";
+      switch (static_cast<RequirementKind>(elt.getValue2())) {
+      case RequirementKind::Conformance:
+        out << "conformance";
+        break;
+      case RequirementKind::Superclass:
+        out << "superclass";
+        break;
+      case RequirementKind::SameType:
+        out << "same-type";
+        break;
+      case RequirementKind::Layout:
+        out << "layout";
+        break;
+      }
+      out << ")";
       break;
+    }
 
     case ImplicitlyUnwrappedDisjunctionChoice:
       out << "implicitly unwrapped disjunction choice";

--- a/lib/Sema/ConstraintLocator.h
+++ b/lib/Sema/ConstraintLocator.h
@@ -174,9 +174,9 @@ public:
     case TupleElement:
     case KeyPathComponent:
     case ConditionalRequirement:
-    case TypeParameterRequirement:
       return 1;
 
+    case TypeParameterRequirement:
     case ApplyArgToParam:
       return 2;
     }
@@ -365,8 +365,10 @@ public:
       return PathElement(ConditionalRequirement, index);
     }
 
-    static PathElement getTypeRequirementComponent(unsigned index) {
-      return PathElement(TypeParameterRequirement, index);
+    static PathElement getTypeRequirementComponent(unsigned index,
+                                                   RequirementKind kind) {
+      return PathElement(TypeParameterRequirement, index,
+                         static_cast<unsigned>(kind));
     }
 
     /// \brief Retrieve the kind of path element.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1189,7 +1189,8 @@ void ConstraintSystem::openGenericRequirements(
     addConstraint(
         *openedReq,
         locator.withPathElement(ConstraintLocator::OpenedGeneric)
-            .withPathElement(LocatorPathElt::getTypeRequirementComponent(pos)));
+            .withPathElement(
+                LocatorPathElt::getTypeRequirementComponent(pos, kind)));
   }
 }
 


### PR DESCRIPTION
Having requirement kind encoded in the locator helps to identify
what kind of fix to generate (applicable to same-type, superclass)
without retrieving requirement itself.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
