### PR TITLE
[IDE] Fix a crasher in SynthesizedExtensionAnalyzer

### DIFF
--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -263,13 +263,10 @@ struct SynthesizedExtensionAnalyzer::Implementation {
   InfoMap(collectSynthesizedExtensionInfo(AllGroups)) {}
 
   unsigned countInherits(ExtensionDecl *ED) {
-    unsigned Count = 0;
-    for (auto TL : ED->getInherited()) {
-      auto *nominal = TL.getType()->getAnyNominal();
-      if (nominal && Options.shouldPrint(nominal))
-        Count ++;
-    }
-    return Count;
+    SmallVector<TypeLoc, 4> Results;
+    getInheritedForPrinting(
+        ED, [&](const Decl *D) { return Options.shouldPrint(D); }, Results);
+    return Results.size();
   }
 
   std::pair<SynthesizedExtensionInfo, ExtensionMergeInfo>

--- a/test/SourceKit/CursorInfo/rdar_41593893.swift
+++ b/test/SourceKit/CursorInfo/rdar_41593893.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+// RUN: %sourcekitd-test -req=cursor -pos=8:37 %t/first.swift -- %t/first.swift %t/second.swift | %FileCheck %s
+
+// CHECK: source.lang.swift.ref.var.instance (6:9-6:12)
+
+
+// BEGIN first.swift
+protocol ChatDataSourceDelegateProtocol {
+    func chatDataSourceDidUpdate()
+}
+
+class BaseChatViewController {
+    var foo = 1
+    func bar() {
+      print(self . /*cursor-info->*/foo)
+    }
+}
+
+// BEGIN second.swift
+extension BaseChatViewController: ChatDataSourceDelegateProtocol {
+    func chatDataSourceDidUpdate() { fatalError() }
+}


### PR DESCRIPTION
Count inheritance by `getInheritedForPrinting()` (align with ASTPrinter).

rdar://problem/41593893
