### PR TITLE
[AST] Small improvements to AccessScope

### DIFF
--- a/include/swift/AST/AccessScope.h
+++ b/include/swift/AST/AccessScope.h
@@ -86,6 +86,7 @@ public:
     return None;
   }
 
+  void dump() const;
 };
 
 } // end namespace swift

--- a/include/swift/AST/AttrKind.h
+++ b/include/swift/AST/AttrKind.h
@@ -18,6 +18,7 @@
 #define SWIFT_ATTRKIND_H
 
 #include "swift/Basic/InlineBitfield.h"
+#include "swift/Basic/LLVM.h"
 #include "swift/Config.h"
 #include "llvm/Support/DataTypes.h"
 
@@ -62,6 +63,9 @@ enum class AccessLevel : uint8_t {
   /// Open access is not limited, and all capabilities are unrestricted.
   Open,
 };
+
+/// Returns the in-source spelling of the given access level.
+StringRef getAccessLevelSpelling(AccessLevel value);
 
 enum class InlineKind : uint8_t {
   Never = 0,

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -282,17 +282,7 @@ static StringRef getImportKindString(ImportKind value) {
   
   llvm_unreachable("Unhandled ImportKind in switch.");
 }
-static StringRef getAccessLevelString(AccessLevel value) {
-  switch (value) {
-  case AccessLevel::Private: return "private";
-  case AccessLevel::FilePrivate: return "fileprivate";
-  case AccessLevel::Internal: return "internal";
-  case AccessLevel::Public: return "public";
-  case AccessLevel::Open: return "open";
-  }
 
-  llvm_unreachable("Unhandled AccessLevel in switch.");
-}
 static StringRef
 getForeignErrorConventionKindString(ForeignErrorConvention::Kind value) {
   switch (value) {
@@ -763,7 +753,7 @@ namespace {
 
       if (VD->hasAccess()) {
         PrintWithColorRAII(OS, AccessLevelColor) << " access="
-          << getAccessLevelString(VD->getFormalAccess());
+          << getAccessLevelSpelling(VD->getFormalAccess());
       }
 
       if (auto Overridden = VD->getOverriddenDecl()) {

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -35,6 +35,18 @@ void *AttributeBase::operator new(size_t Bytes, ASTContext &C,
   return C.Allocate(Bytes, Alignment);
 }
 
+StringRef swift::getAccessLevelSpelling(AccessLevel value) {
+  switch (value) {
+  case AccessLevel::Private: return "private";
+  case AccessLevel::FilePrivate: return "fileprivate";
+  case AccessLevel::Internal: return "internal";
+  case AccessLevel::Public: return "public";
+  case AccessLevel::Open: return "open";
+  }
+
+  llvm_unreachable("Unhandled AccessLevel in switch.");
+}
+
 /// Given a name like "autoclosure", return the type attribute ID that
 /// corresponds to it.  This returns TAK_Count on failure.
 ///
@@ -609,20 +621,10 @@ StringRef DeclAttribute::getAttrName() const {
         return "effects(unspecified)";
     }
   case DAK_AccessControl:
-  case DAK_SetterAccess:
-    switch (cast<AbstractAccessControlAttr>(this)->getAccess()) {
-    case AccessLevel::Private:
-      return "private";
-    case AccessLevel::FilePrivate:
-      return "fileprivate";
-    case AccessLevel::Internal:
-      return "internal";
-    case AccessLevel::Public:
-      return "public";
-    case AccessLevel::Open:
-      return "open";
-    }
-    llvm_unreachable("bad access level");
+  case DAK_SetterAccess: {
+    AccessLevel access = cast<AbstractAccessControlAttr>(this)->getAccess();
+    return getAccessLevelSpelling(access);
+  }
 
   case DAK_ReferenceOwnership:
     return keywordOf(cast<ReferenceOwnershipAttr>(this)->get());


### PR DESCRIPTION
- ~Make AccessScope::isPublic slightly cheaper~
- Add an AccessScope::dump helper
- Factor out a generally-available swift::getAccessLevelSpelling