### PR TITLE
[Runtime] Mark _swift_stdlib_operatingSystemVersion as __attribute__((const)).

### DIFF
--- a/stdlib/public/SwiftShims/FoundationShims.h
+++ b/stdlib/public/SwiftShims/FoundationShims.h
@@ -55,7 +55,7 @@ typedef struct {
 } _SwiftNSOperatingSystemVersion;
 
 SWIFT_RUNTIME_STDLIB_API
-_SwiftNSOperatingSystemVersion _swift_stdlib_operatingSystemVersion();
+_SwiftNSOperatingSystemVersion _swift_stdlib_operatingSystemVersion() __attribute__((const));
 
 #ifdef __cplusplus
 }} // extern "C", namespace swift

--- a/test/IRGen/availability.swift
+++ b/test/IRGen/availability.swift
@@ -26,3 +26,29 @@ public func dontHoist() {
       print("Not measurement")
   }
 }
+
+
+// With optimizations on, multiple #availability checks should generate only
+// a single call into _swift_stdlib_operatingSystemVersion.
+
+// CHECK-LABEL: define{{.*}} @{{.*}}multipleAvailabilityChecks
+// CHECK: call swiftcc i1 @"$Ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"(
+// CHECK: call swiftcc i1 @"$Ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"(
+// CHECK: call swiftcc i1 @"$Ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"(
+// CHECK: ret void
+
+// OPT-LABEL: define{{.*}} @{{.*}}multipleAvailabilityChecks
+// OPT: call void @_swift_stdlib_operatingSystemVersion
+// OPT-NOT: call void @_swift_stdlib_operatingSystemVersion
+// OPT: ret void
+public func multipleAvailabilityChecks() {
+  if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+    print("test one")
+  }
+  if #available(OSX 10.11, iOS 9.0, watchOS 2.0, tvOS 9.0, *) {
+    print("test two")
+  }
+  if #available(OSX 10.10, iOS 8.0, watchOS 1.0, tvOS 8.0, *) {
+    print("test three")
+  }
+}


### PR DESCRIPTION
This tells the compiler that repeated calls to this function will always generate the same result, which allows the optimizer to coalesce multiple calls, hoist calls out of loops, and other such nice things.

rdar://problem/20690429