### PR TITLE
[Stats] Change NumInstructions to NumInstructionsExecuted, accept 0 when on VMs.

### DIFF
--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -80,8 +80,8 @@ DRIVER_STATISTIC(ChildrenMaxRSS)
 /// EXIT_SUCCESS.
 FRONTEND_STATISTIC(Frontend, NumProcessFailures)
 
-/// Total instruction count in each frontend process.
-FRONTEND_STATISTIC(Frontend, NumInstructions)
+/// Total instructions-executed count in each frontend process.
+FRONTEND_STATISTIC(Frontend, NumInstructionsExecuted)
 
 /// Number of source buffers visible in the source manager.
 FRONTEND_STATISTIC(AST, NumSourceBuffers)

--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -492,7 +492,7 @@ void updateProcessWideFrontendCounters(
 #if defined(HAVE_PROC_PID_RUSAGE) && defined(RUSAGE_INFO_V4)
   struct rusage_info_v4 ru;
   if (0 == proc_pid_rusage(getpid(), RUSAGE_INFO_V4, (rusage_info_t *)&ru)) {
-    C.NumInstructions = ru.ri_instructions;
+    C.NumInstructionsExecuted = ru.ri_instructions;
   }
 #endif
 }

--- a/test/Misc/stats_dir_instructions.swift
+++ b/test/Misc/stats_dir_instructions.swift
@@ -3,7 +3,9 @@
 // RUN: %target-swiftc_driver -o %t/main -module-name main -stats-output-dir %t %s
 // RUN: %{python} %utils/process-stats-dir.py --set-csv-baseline %t/frontend.csv %t
 // RUN: %FileCheck -input-file %t/frontend.csv %s
-// CHECK: {{"Frontend.NumInstructions"	[1-9][0-9]*$}}
+//
+// Note: this may be zero if we're on a machine with no hardware counters (eg. a VM)
+// CHECK: {{"Frontend.NumInstructionsExecuted"	[0-9]*$}}
 
 public func foo() {
     print("hello")


### PR DESCRIPTION
Renames the counter to something a little more explicit before we get too used to the other one (requested by @gottesmm)