### PR TITLE
Tweak Parse and SILGen to support loading swiftinterface files

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -6318,22 +6318,19 @@ parseDeclDeinit(ParseDeclOptions Flags, DeclAttributes &Attributes) {
 
   // Parse extraneous parentheses and remove them with a fixit.
   auto skipParameterListIfPresent = [this] {
-    if (Tok.is(tok::l_paren)) {
-      SourceRange ParenRange;
-      SourceLoc LParenLoc = consumeToken();
-      SourceLoc RParenLoc;
-      skipUntil(tok::r_paren);
+    SourceLoc LParenLoc;
+    if (!consumeIf(tok::l_paren, LParenLoc))
+      return;
+    SourceLoc RParenLoc;
+    skipUntil(tok::r_paren);
 
-      if (Tok.is(tok::r_paren)) {
-        SourceLoc RParenLoc = consumeToken();
-        ParenRange = SourceRange(LParenLoc, RParenLoc);
-
-        diagnose(ParenRange.Start, diag::destructor_params)
-          .fixItRemove(ParenRange);
-      } else {
-        diagnose(Tok, diag::opened_destructor_expected_rparen);
-        diagnose(LParenLoc, diag::opening_paren);
-      }
+    if (Tok.is(tok::r_paren)) {
+      SourceLoc RParenLoc = consumeToken();
+      diagnose(LParenLoc, diag::destructor_params)
+        .fixItRemove(SourceRange(LParenLoc, RParenLoc));
+    } else {
+      diagnose(Tok, diag::opened_destructor_expected_rparen);
+      diagnose(LParenLoc, diag::opening_paren);
     }
   };
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4086,11 +4086,23 @@ bool Parser::parseGetSetImpl(ParseDeclOptions Flags,
                              SourceLoc &LastValidLoc, SourceLoc StaticLoc,
                              SourceLoc VarLBLoc) {
   // Properties in protocols use a very limited syntax.
-  // SIL mode uses the same syntax.
+  // SIL mode and textual interfaces use the same syntax.
   // Otherwise, we have a normal var or subscript declaration and we need
   // parse the full complement of specifiers, along with their bodies.
-  bool parsingLimitedSyntax =
-    Flags.contains(PD_InProtocol) || isInSILMode();
+  bool parsingLimitedSyntax = Flags.contains(PD_InProtocol);
+  if (!parsingLimitedSyntax) {
+    switch (SF.Kind) {
+    case SourceFileKind::Interface:
+      // FIXME: Textual interfaces /can/ have inlinable code but don't have to.
+    case SourceFileKind::SIL:
+      parsingLimitedSyntax = true;
+      break;
+    case SourceFileKind::Library:
+    case SourceFileKind::Main:
+    case SourceFileKind::REPL:
+      break;
+    }
+  }
 
   // If the body is completely empty, preserve it.  This is at best a getter with
   // an implicit fallthrough off the end.

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -941,7 +941,7 @@ void SILGenModule::emitDestructor(ClassDecl *cd, DestructorDecl *dd) {
 
   // Emit the destroying destructor.
   // Destructors are a necessary part of class metadata, so can't be delayed.
-  {
+  if (dd->hasBody()) {
     SILDeclRef destroyer(dd, SILDeclRef::Kind::Destroyer);
     SILFunction *f = getFunction(destroyer, ForDefinition);
     preEmitFunction(destroyer, dd, f, dd);

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -776,9 +776,9 @@ void SILGenModule::emitConstructor(ConstructorDecl *decl) {
           postEmitFunction(constant, f);
         });
 
-    // If this constructor was imported, we don't need the initializing
-    // constructor to be emitted.
-    if (!decl->hasClangNode()) {
+    // Constructors may not have bodies if they've been imported, or if they've
+    // been parsed from a textual interface.
+    if (decl->hasBody()) {
       SILDeclRef initConstant(decl, SILDeclRef::Kind::Initializer);
       emitOrDelayFunction(
           *this, initConstant,
@@ -796,14 +796,16 @@ void SILGenModule::emitConstructor(ConstructorDecl *decl) {
     }
   } else {
     // Struct and enum constructors do everything in a single function.
-    emitOrDelayFunction(
-        *this, constant, [this, constant, decl, declCtx](SILFunction *f) {
-          preEmitFunction(constant, decl, f, decl);
-          PrettyStackTraceSILFunction X("silgen emitConstructor", f);
-          f->setProfiler(getOrCreateProfilerForConstructors(declCtx, decl));
-          SILGenFunction(*this, *f, decl).emitValueConstructor(decl);
-          postEmitFunction(constant, f);
-        });
+    if (decl->hasBody()) {
+      emitOrDelayFunction(
+          *this, constant, [this, constant, decl, declCtx](SILFunction *f) {
+            preEmitFunction(constant, decl, f, decl);
+            PrettyStackTraceSILFunction X("silgen emitConstructor", f);
+            f->setProfiler(getOrCreateProfilerForConstructors(declCtx, decl));
+            SILGenFunction(*this, *f, decl).emitValueConstructor(decl);
+            postEmitFunction(constant, f);
+          });
+    }
   }
 }
 

--- a/test/ModuleInterface/SmokeTest.swiftinterface
+++ b/test/ModuleInterface/SmokeTest.swiftinterface
@@ -10,6 +10,15 @@
 
 // CHECK-LABEL: public class Test
 public class Test {
+  // CHECK: public init(){{$}}
+  public init()
+
+  // CHECK: public func method(){{$}}
+  public func method()
+
+  // CHECK: public subscript(_: Int) -> Void{{$}}
+  public subscript(_: Int) -> Void { get set }
+
   // NEGATIVE-NOT: deinit
   deinit
 } // CHECK: {{^}$}}

--- a/test/ModuleInterface/SmokeTest.swiftinterface
+++ b/test/ModuleInterface/SmokeTest.swiftinterface
@@ -6,5 +6,11 @@
 // RUN: %target-swift-frontend -emit-module -o %t/SmokeTest.swiftmodule %s
 // RUN: %target-swift-ide-test -print-module -module-to-print SmokeTest -I %t -source-filename x -print-access | %FileCheck %s
 
+// CHECK: public var readOnlyVar: Int { get }{{$}}
+public var readOnlyVar: Int { get }
+
+// CHECK: public var readWriteVar: Int{{$}}
+public var readWriteVar: Int { get set }
+
 // CHECK: public func verySimpleFunction(){{$}}
 public func verySimpleFunction()

--- a/test/ModuleInterface/SmokeTest.swiftinterface
+++ b/test/ModuleInterface/SmokeTest.swiftinterface
@@ -8,8 +8,8 @@
 // RUN: %FileCheck %s < %t/SmokeTest.txt
 // RUN: %FileCheck -check-prefix NEGATIVE %s < %t/SmokeTest.txt
 
-// CHECK-LABEL: public class Test
-public class Test {
+// CHECK-LABEL: public class TestClass
+public class TestClass {
   // CHECK: public init(){{$}}
   public init()
 
@@ -19,8 +19,44 @@ public class Test {
   // CHECK: public subscript(_: Int) -> Void{{$}}
   public subscript(_: Int) -> Void { get set }
 
+  // CHECK: public var prop: Int{{$}}
+  public var prop: Int { get set }
+
   // NEGATIVE-NOT: deinit
   deinit
+} // CHECK: {{^}$}}
+
+// CHECK-LABEL: public enum TestEnum
+public enum TestEnum {
+  // CHECK: case a
+  case a
+
+  // CHECK: public init(){{$}}
+  public init()
+
+  // CHECK: public func method(){{$}}
+  public func method()
+
+  // CHECK: public subscript(_: Int) -> Void{{$}}
+  public subscript(_: Int) -> Void { get set }
+
+  // CHECK: public var prop: Int{{$}}
+  public var prop: Int { get set }
+} // CHECK: {{^}$}}
+
+// CHECK-LABEL: public struct TestStruct
+public struct TestStruct {
+  // CHECK: public init(){{$}}
+  public init()
+
+  // CHECK: public func method(){{$}}
+  public func method()
+
+  // CHECK: public subscript(_: Int) -> Void{{$}}
+  public subscript(_: Int) -> Void { get set }
+
+  // CHECK: public var prop: Int{{$}}
+  public var prop: Int { get set }
 } // CHECK: {{^}$}}
 
 // CHECK: public var readOnlyVar: Int { get }{{$}}

--- a/test/ModuleInterface/SmokeTest.swiftinterface
+++ b/test/ModuleInterface/SmokeTest.swiftinterface
@@ -4,7 +4,15 @@
 // ...and then make sure parse-and-typecheck-and-serialize works.
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t/SmokeTest.swiftmodule %s
-// RUN: %target-swift-ide-test -print-module -module-to-print SmokeTest -I %t -source-filename x -print-access | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print SmokeTest -I %t -source-filename x -print-interface > %t/SmokeTest.txt
+// RUN: %FileCheck %s < %t/SmokeTest.txt
+// RUN: %FileCheck -check-prefix NEGATIVE %s < %t/SmokeTest.txt
+
+// CHECK-LABEL: public class Test
+public class Test {
+  // NEGATIVE-NOT: deinit
+  deinit
+} // CHECK: {{^}$}}
 
 // CHECK: public var readOnlyVar: Int { get }{{$}}
 public var readOnlyVar: Int { get }

--- a/test/Parse/init_deinit.swift
+++ b/test/Parse/init_deinit.swift
@@ -17,8 +17,8 @@ struct FooStructConstructorC {
 
 struct FooStructDeinitializerA {
   deinit // expected-error {{expected '{' for deinitializer}}
-  deinit x // expected-error {{deinitializers cannot have a name}} {{10-12=}}
-  deinit x() // expected-error {{deinitializers cannot have a name}} {{10-11=}}
+  deinit x // expected-error {{deinitializers cannot have a name}} {{10-12=}}  expected-error {{expected '{' for deinitializer}}
+  deinit x() // expected-error {{deinitializers cannot have a name}} {{10-11=}} expected-error {{no parameter clause allowed on deinitializer}} {{11-13=}} expected-error {{expected '{' for deinitializer}}
 }
 
 struct FooStructDeinitializerB {
@@ -35,6 +35,10 @@ class FooClassDeinitializerA {
 
 class FooClassDeinitializerB {
   deinit { }
+}
+
+class FooClassDeinitializerC {
+  deinit x (a : Int) {} // expected-error {{deinitializers cannot have a name}} {{10-12=}} expected-error{{no parameter clause allowed on deinitializer}}{{12-22=}}
 }
 
 init {} // expected-error {{initializers may only be declared within a type}} expected-error {{expected '('}} {{5-5=()}}


### PR DESCRIPTION
Handle accessors, initializers, and deinitializers without bodies, which will all appear in textual interface files.