### PR TITLE
Preserve 'let'-ness of stored properties in key paths.

### DIFF
--- a/include/swift/ABI/KeyPath.h
+++ b/include/swift/ABI/KeyPath.h
@@ -82,6 +82,10 @@ class KeyPathComponentHeader {
            offset;
   }
 
+  static constexpr uint32_t isLetBit(bool isLet) {
+    return isLet ? 0 : _SwiftKeyPathComponentHeader_StoredMutableFlag;
+  }
+
 public:
   static constexpr bool offsetCanBeInline(unsigned offset) {
     return offset <= _SwiftKeyPathComponentHeader_MaximumOffsetPayload;
@@ -92,24 +96,27 @@ public:
                                      unsigned offset) {
     return KeyPathComponentHeader(
       (_SwiftKeyPathComponentHeader_StructTag
-      << _SwiftKeyPathComponentHeader_DiscriminatorShift)
-      | validateInlineOffset(offset));
+       << _SwiftKeyPathComponentHeader_DiscriminatorShift)
+      | validateInlineOffset(offset)
+      | isLetBit(isLet));
   }
   
   constexpr static KeyPathComponentHeader
   forStructComponentWithOutOfLineOffset(bool isLet) {
     return KeyPathComponentHeader(
       (_SwiftKeyPathComponentHeader_StructTag
-      << _SwiftKeyPathComponentHeader_DiscriminatorShift)
-      | _SwiftKeyPathComponentHeader_OutOfLineOffsetPayload);
+       << _SwiftKeyPathComponentHeader_DiscriminatorShift)
+      | _SwiftKeyPathComponentHeader_OutOfLineOffsetPayload
+      | isLetBit(isLet));
   }
 
   constexpr static KeyPathComponentHeader
   forStructComponentWithUnresolvedFieldOffset(bool isLet) {
     return KeyPathComponentHeader(
       (_SwiftKeyPathComponentHeader_StructTag
-      << _SwiftKeyPathComponentHeader_DiscriminatorShift)
-      | _SwiftKeyPathComponentHeader_UnresolvedFieldOffsetPayload);
+       << _SwiftKeyPathComponentHeader_DiscriminatorShift)
+      | _SwiftKeyPathComponentHeader_UnresolvedFieldOffsetPayload
+      | isLetBit(isLet));
   }
   
   constexpr static KeyPathComponentHeader
@@ -117,32 +124,36 @@ public:
                                     unsigned offset) {
     return KeyPathComponentHeader(
       (_SwiftKeyPathComponentHeader_ClassTag
-      << _SwiftKeyPathComponentHeader_DiscriminatorShift)
-      | validateInlineOffset(offset));
+       << _SwiftKeyPathComponentHeader_DiscriminatorShift)
+      | validateInlineOffset(offset)
+      | isLetBit(isLet));
   }
 
   constexpr static KeyPathComponentHeader
   forClassComponentWithOutOfLineOffset(bool isLet) {
     return KeyPathComponentHeader(
       (_SwiftKeyPathComponentHeader_ClassTag
-      << _SwiftKeyPathComponentHeader_DiscriminatorShift)
-      | _SwiftKeyPathComponentHeader_OutOfLineOffsetPayload);
+       << _SwiftKeyPathComponentHeader_DiscriminatorShift)
+      | _SwiftKeyPathComponentHeader_OutOfLineOffsetPayload
+      | isLetBit(isLet));
   }
   
   constexpr static KeyPathComponentHeader
   forClassComponentWithUnresolvedFieldOffset(bool isLet) {
     return KeyPathComponentHeader(
       (_SwiftKeyPathComponentHeader_ClassTag
-      << _SwiftKeyPathComponentHeader_DiscriminatorShift)
-      | _SwiftKeyPathComponentHeader_UnresolvedFieldOffsetPayload);
+       << _SwiftKeyPathComponentHeader_DiscriminatorShift)
+      | _SwiftKeyPathComponentHeader_UnresolvedFieldOffsetPayload
+      | isLetBit(isLet));
   }
   
   constexpr static KeyPathComponentHeader
   forClassComponentWithUnresolvedIndirectOffset(bool isLet) {
     return KeyPathComponentHeader(
       (_SwiftKeyPathComponentHeader_ClassTag
-      << _SwiftKeyPathComponentHeader_DiscriminatorShift)
-      | _SwiftKeyPathComponentHeader_UnresolvedIndirectOffsetPayload);
+       << _SwiftKeyPathComponentHeader_DiscriminatorShift)
+      | _SwiftKeyPathComponentHeader_UnresolvedIndirectOffsetPayload
+      | isLetBit(isLet));
   }
   
   constexpr static KeyPathComponentHeader

--- a/include/swift/ABI/KeyPath.h
+++ b/include/swift/ABI/KeyPath.h
@@ -88,7 +88,8 @@ public:
   }
 
   constexpr static KeyPathComponentHeader
-  forStructComponentWithInlineOffset(unsigned offset) {
+  forStructComponentWithInlineOffset(bool isLet,
+                                     unsigned offset) {
     return KeyPathComponentHeader(
       (_SwiftKeyPathComponentHeader_StructTag
       << _SwiftKeyPathComponentHeader_DiscriminatorShift)
@@ -96,7 +97,7 @@ public:
   }
   
   constexpr static KeyPathComponentHeader
-  forStructComponentWithOutOfLineOffset() {
+  forStructComponentWithOutOfLineOffset(bool isLet) {
     return KeyPathComponentHeader(
       (_SwiftKeyPathComponentHeader_StructTag
       << _SwiftKeyPathComponentHeader_DiscriminatorShift)
@@ -104,7 +105,7 @@ public:
   }
 
   constexpr static KeyPathComponentHeader
-  forStructComponentWithUnresolvedFieldOffset() {
+  forStructComponentWithUnresolvedFieldOffset(bool isLet) {
     return KeyPathComponentHeader(
       (_SwiftKeyPathComponentHeader_StructTag
       << _SwiftKeyPathComponentHeader_DiscriminatorShift)
@@ -112,7 +113,8 @@ public:
   }
   
   constexpr static KeyPathComponentHeader
-  forClassComponentWithInlineOffset(unsigned offset) {
+  forClassComponentWithInlineOffset(bool isLet,
+                                    unsigned offset) {
     return KeyPathComponentHeader(
       (_SwiftKeyPathComponentHeader_ClassTag
       << _SwiftKeyPathComponentHeader_DiscriminatorShift)
@@ -120,7 +122,7 @@ public:
   }
 
   constexpr static KeyPathComponentHeader
-  forClassComponentWithOutOfLineOffset() {
+  forClassComponentWithOutOfLineOffset(bool isLet) {
     return KeyPathComponentHeader(
       (_SwiftKeyPathComponentHeader_ClassTag
       << _SwiftKeyPathComponentHeader_DiscriminatorShift)
@@ -128,7 +130,7 @@ public:
   }
   
   constexpr static KeyPathComponentHeader
-  forClassComponentWithUnresolvedFieldOffset() {
+  forClassComponentWithUnresolvedFieldOffset(bool isLet) {
     return KeyPathComponentHeader(
       (_SwiftKeyPathComponentHeader_ClassTag
       << _SwiftKeyPathComponentHeader_DiscriminatorShift)
@@ -136,7 +138,7 @@ public:
   }
   
   constexpr static KeyPathComponentHeader
-  forClassComponentWithUnresolvedIndirectOffset() {
+  forClassComponentWithUnresolvedIndirectOffset(bool isLet) {
     return KeyPathComponentHeader(
       (_SwiftKeyPathComponentHeader_ClassTag
       << _SwiftKeyPathComponentHeader_DiscriminatorShift)

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -766,6 +766,10 @@ void verifyMangledNameRoundtrip(const Metadata *metadata);
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
 const TypeContextDescriptor *swift_getTypeContextDescriptor(const Metadata *type);
 
+// Defined in KeyPath.swift in the standard library.
+SWIFT_RUNTIME_EXPORT
+const HeapObject *swift_getKeyPath(const void *pattern, const void *arguments);
+
 } // end namespace swift
 
 #endif // SWIFT_RUNTIME_METADATA_H

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -773,22 +773,23 @@ emitKeyPathComponent(IRGenModule &IGM,
   case KeyPathPatternComponent::Kind::StoredProperty: {
     auto property = cast<VarDecl>(component.getStoredPropertyDecl());
     
-    auto addFixedOffset = [&](bool isStruct, llvm::Constant *offset) {
+    auto addFixedOffset = [&](bool isStruct, bool isLet,
+                              llvm::Constant *offset) {
       if (auto offsetInt = dyn_cast_or_null<llvm::ConstantInt>(offset)) {
         auto offsetValue = offsetInt->getValue().getZExtValue();
         if (KeyPathComponentHeader::offsetCanBeInline(offsetValue)) {
           auto header = isStruct
             ? KeyPathComponentHeader
-                ::forStructComponentWithInlineOffset(offsetValue)
+                ::forStructComponentWithInlineOffset(isLet, offsetValue)
             : KeyPathComponentHeader
-                ::forClassComponentWithInlineOffset(offsetValue);
+                ::forClassComponentWithInlineOffset(isLet, offsetValue);
           fields.addInt32(header.getData());
           return;
         }
       }
       auto header = isStruct
-        ? KeyPathComponentHeader::forStructComponentWithOutOfLineOffset()
-        : KeyPathComponentHeader::forClassComponentWithOutOfLineOffset();
+        ? KeyPathComponentHeader::forStructComponentWithOutOfLineOffset(isLet)
+        : KeyPathComponentHeader::forClassComponentWithOutOfLineOffset(isLet);
       fields.addInt32(header.getData());
       fields.add(llvm::ConstantExpr::getTruncOrBitCast(offset, IGM.Int32Ty));
     };
@@ -801,7 +802,7 @@ emitKeyPathComponent(IRGenModule &IGM,
                                                             loweredBaseTy,
                                                             property)) {
         // We have a known constant fixed offset.
-        addFixedOffset(/*struct*/ true, offset);
+        addFixedOffset(/*struct*/ true, property->isLet(), offset);
         break;
       }
 
@@ -811,7 +812,7 @@ emitKeyPathComponent(IRGenModule &IGM,
       auto fieldOffset = metadataLayout.getStaticFieldOffset(property);
 
       auto header = KeyPathComponentHeader
-        ::forStructComponentWithUnresolvedFieldOffset();
+        ::forStructComponentWithUnresolvedFieldOffset(property->isLet());
       fields.addInt32(header.getData());
       fields.addInt32(fieldOffset.getValue());
       break;
@@ -829,14 +830,14 @@ emitKeyPathComponent(IRGenModule &IGM,
                                                                 loweredBaseTy,
                                                                 property);
         assert(offset && "no constant offset for ConstantDirect field?!");
-        addFixedOffset(/*struct*/ false, offset);
+        addFixedOffset(/*struct*/ false, property->isLet(), offset);
         break;
       }
       case FieldAccess::NonConstantDirect: {
         // A constant offset that's determined at class realization time.
         // We have to load the offset from a global ivar.
         auto header = KeyPathComponentHeader
-          ::forClassComponentWithUnresolvedIndirectOffset();
+          ::forClassComponentWithUnresolvedIndirectOffset(property->isLet());
         fields.addInt32(header.getData());
         fields.addAlignmentPadding(IGM.getPointerAlignment());
         auto offsetVar = IGM.getAddrOfFieldOffset(property, NotForDefinition);
@@ -846,8 +847,8 @@ emitKeyPathComponent(IRGenModule &IGM,
       case FieldAccess::ConstantIndirect: {
         // An offset that depends on the instance's generic parameterization,
         // but whose field offset is at a known vtable offset.
-        auto header =
-          KeyPathComponentHeader::forClassComponentWithUnresolvedFieldOffset();
+        auto header = KeyPathComponentHeader
+          ::forClassComponentWithUnresolvedFieldOffset(property->isLet());
         fields.addInt32(header.getData());
         auto fieldOffset =
           getClassFieldOffsetOffset(IGM,

--- a/stdlib/public/SwiftShims/KeyPath.h
+++ b/stdlib/public/SwiftShims/KeyPath.h
@@ -59,17 +59,23 @@ static const __swift_uint32_t _SwiftKeyPathComponentHeader_ExternalTag
 static const __swift_uint32_t
 _SwiftKeyPathComponentHeader_TrivialPropertyDescriptorMarker = 0U;
 
+static const __swift_uint32_t _SwiftKeyPathComponentHeader_StoredOffsetPayloadMask
+  = 0x007FFFFFU;
+
 static const __swift_uint32_t _SwiftKeyPathComponentHeader_MaximumOffsetPayload
-  = 0x00FFFFFCU;
+  = 0x007FFFFCU;
   
 static const __swift_uint32_t _SwiftKeyPathComponentHeader_UnresolvedIndirectOffsetPayload
-  = 0x00FFFFFDU;
+  = 0x007FFFFDU;
   
 static const __swift_uint32_t _SwiftKeyPathComponentHeader_UnresolvedFieldOffsetPayload
-  = 0x00FFFFFEU;
+  = 0x007FFFFEU;
 
 static const __swift_uint32_t _SwiftKeyPathComponentHeader_OutOfLineOffsetPayload
-  = 0x00FFFFFFU;
+  = 0x007FFFFFU;
+  
+static const __swift_uint32_t _SwiftKeyPathComponentHeader_StoredMutableFlag
+  = 0x00800000U;
 
 static const __swift_uint32_t _SwiftKeyPathComponentHeader_OptionalChainPayload
   = 0;

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -2069,7 +2069,10 @@ internal var keyPathObjectHeaderSize: Int {
 }
 
 // Runtime entry point to instantiate a key path object.
-@_cdecl("swift_getKeyPath")
+// Note that this has a compatibility override shim in the runtime so that
+// future compilers can backward-deploy support for instantiating new key path
+// pattern features.
+@_cdecl("swift_getKeyPathImpl")
 public func _swift_getKeyPath(pattern: UnsafeMutableRawPointer,
                               arguments: UnsafeRawPointer)
     -> UnsafeRawPointer {

--- a/stdlib/public/runtime/CompatibilityOverride.def
+++ b/stdlib/public/runtime/CompatibilityOverride.def
@@ -17,16 +17,21 @@
 
 /// #define OVERRIDE(name, ret, attrs, namespace, typedArgs, namedArgs)
 ///   Provides information about an overridable function.
-///   - name is the name of the function, without any leading swift_ or namespace.
+///   - name is the name of the function, without any leading swift_ or
+///     namespace.
 ///   - ret is the return type of the function.
 ///   - attrs is the attributes, if any, applied to the function definition.
-///   - namespace is the namespace, if any, the function is in, including a trailing ::
-///   - typedArgs is the argument list, including types, surrounded by parentheses
-///   - namedArgs is the list of argument names, with no types, surrounded by parentheses
+///   - namespace is the namespace, if any, the function is in, including a
+///     trailing ::
+///   - typedArgs is the argument list, including types, surrounded by
+///     parentheses
+///   - namedArgs is the list of argument names, with no types, surrounded by
+///     parentheses
 ///
-/// The entries are organized by group. A user may define OVERRIDE to get all entries,
-/// or define one or more of OVERRIDE_METADATALOOKUP, OVERRIDE_CASTING, OVERRIDE_OBJC,
-/// OVERRIDE_FOREIGN, or OVERRIDE_PROTOCOLCONFORMANCE to get only those entries.
+/// The entries are organized by group. A user may define OVERRIDE to get all
+/// entries, or define one or more of OVERRIDE_METADATALOOKUP, OVERRIDE_CASTING,
+/// OVERRIDE_OBJC, OVERRIDE_FOREIGN, OVERRIDE_PROTOCOLCONFORMANCE,
+/// and OVERRIDE_KEYPATH to get only those entries.
 
 // NOTE: this file is used to build the definition of OverrideSection in
 // CompatibilityOverride.cpp, which is part of the ABI. Do not move or remove entries
@@ -38,6 +43,7 @@
 #  define OVERRIDE_OBJC OVERRIDE
 #  define OVERRIDE_FOREIGN OVERRIDE
 #  define OVERRIDE_PROTOCOLCONFORMANCE OVERRIDE
+#  define OVERRIDE_KEYPATH OVERRIDE
 #else
 #  ifndef OVERRIDE_METADATALOOKUP
 #    define OVERRIDE_METADATALOOKUP(...)
@@ -53,6 +59,9 @@
 #  endif
 #  ifndef OVERRIDE_PROTOCOLCONFORMANCE
 #    define OVERRIDE_PROTOCOLCONFORMANCE(...)
+#  endif
+#  ifndef OVERRIDE_KEYPATH
+#    define OVERRIDE_KEYPATH(...)
 #  endif
 #endif
 
@@ -127,6 +136,10 @@ OVERRIDE_PROTOCOLCONFORMANCE(conformsToProtocol, const WitnessTable *, , swift::
                               const ProtocolDescriptor *protocol),
                              (type, protocol))
 
+OVERRIDE_KEYPATH(getKeyPath, const HeapObject *, , swift::,
+                 (const void *pattern, const void *arguments),
+                 (pattern, arguments))
+
 #if SWIFT_OBJC_INTEROP
 
 OVERRIDE_OBJC(dynamicCastObjCClass, const void *, , swift::,
@@ -169,3 +182,4 @@ OVERRIDE_FOREIGN(dynamicCastForeignClassUnconditional, const void *, , swift::,
 #undef OVERRIDE_OBJC
 #undef OVERRIDE_FOREIGN
 #undef OVERRIDE_PROTOCOLCONFORMANCE
+#undef OVERRIDE_KEYPATH

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -46,6 +46,7 @@
 #endif
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Hashing.h"
+#include "CompatibilityOverride.h"
 #include "ErrorObject.h"
 #include "ExistentialMetadataImpl.h"
 #include "swift/Runtime/Debug.h"
@@ -4239,3 +4240,14 @@ void swift::verifyMangledNameRoundtrip(const Metadata *metadata) {
 const TypeContextDescriptor *swift::swift_getTypeContextDescriptor(const Metadata *type) {
     return type->getTypeContextDescriptor();
 }
+
+// Emit compatibility override shims for keypath runtime functionality. The
+// implementation of these functions is in the standard library in
+// KeyPath.swift.
+
+SWIFT_RUNTIME_STDLIB_SPI
+const HeapObject *swift_getKeyPathImpl(const void *pattern,
+                                       const void *arguments);
+
+#define OVERRIDE_KEYPATH COMPATIBILITY_OVERRIDE
+#include "CompatibilityOverride.def"

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -205,7 +205,7 @@ sil_vtable C {}
 // CHECK-SAME: i32 8,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
 //             -- struct with runtime-resolved offset
-// CHECK-SAME: <i32 0x01fffffe>,
+// CHECK-SAME: <i32 0x017ffffe>,
 // CHECK-32-SAME: i32 16 }>
 // CHECK-64-SAME: i32 32 }>
 
@@ -218,7 +218,7 @@ sil_vtable C {}
 // CHECK-SAME: i32 8,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
 //             -- struct with runtime-resolved offset
-// CHECK-SAME: <i32 0x01fffffe>,
+// CHECK-SAME: <i32 0x017ffffe>,
 // CHECK-32-SAME: i32 20 }>
 // CHECK-64-SAME: i32 36 }>
 

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -45,8 +45,8 @@ sil_vtable C {}
 //               -- instantiable in-line, size 4
 // CHECK-SAME: <i32 0x8000_0004>,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
-// -- offset of S.x
-// CHECK-SAME: <i32 0x0100_0000> }>
+// -- offset of S.x, mutable
+// CHECK-SAME: <i32 0x0180_0000> }>
 
 // -- %b: S.y
 // CHECK: [[KP_B:@keypath.*]] = private global <{ {{.*}} }> <{
@@ -56,7 +56,7 @@ sil_vtable C {}
 //               -- instantiable in-line, size 4
 // CHECK-SAME: <i32 0x8000_0004>,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
-// -- offset of S.y
+// -- offset of S.y, immutable
 // CHECK-32-SAME: <i32 0x0100_0004> }>
 // CHECK-64-SAME: <i32 0x0100_0008> }>
 
@@ -68,9 +68,9 @@ sil_vtable C {}
 //               -- instantiable in-line, size 4
 // CHECK-SAME: <i32 0x8000_0004>,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
-// -- offset of S.z
-// CHECK-32-SAME: <i32 0x0100_0010> }>
-// CHECK-64-SAME: <i32 0x0100_0018> }>
+// -- offset of S.z, mutable
+// CHECK-32-SAME: <i32 0x0180_0010> }>
+// CHECK-64-SAME: <i32 0x0180_0018> }>
 
 // -- %d: C.x
 // CHECK: [[KP_D:@keypath.*]] = private global <{ {{.*}} }> <{
@@ -80,9 +80,9 @@ sil_vtable C {}
 //               -- instantiable in-line, size 4
 // CHECK-SAME: <i32 0x8000_0004>,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
-// -- 0x0300_0000 (class) + offset of C.x
-// CHECK-32-SAME: <i32 0x0300_0008> }>
-// CHECK-64-SAME: <i32 0x0300_0010> }>
+// -- 0x0300_0000 (class) + mutable + offset of C.x
+// CHECK-32-SAME: <i32 0x0380_0008> }>
+// CHECK-64-SAME: <i32 0x0380_0010> }>
 
 // -- %e: C.y
 // CHECK: [[KP_E:@keypath.*]] = private global <{ {{.*}} }> <{
@@ -92,7 +92,7 @@ sil_vtable C {}
 //               -- instantiable in-line, size 4
 // CHECK-SAME: <i32 0x8000_0004>,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
-// -- 0x0300_0000 (class) + offset of C.y
+// -- 0x0300_0000 (class) + immutable + offset of C.y
 // CHECK-32-SAME: <i32 0x0300_000c> }>
 // CHECK-64-SAME: <i32 0x0300_0018> }>
 
@@ -104,9 +104,9 @@ sil_vtable C {}
 //               -- instantiable in-line, size 4
 // CHECK-SAME: <i32 0x8000_0004>,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
-// -- 0x0300_0000 (class) + offset of C.z
-// CHECK-32-SAME: <i32 0x0300_0018> }>
-// CHECK-64-SAME: <i32 0x0300_0028> }>
+// -- 0x0300_0000 (class) + mutable offset of C.z
+// CHECK-32-SAME: <i32 0x0380_0018> }>
+// CHECK-64-SAME: <i32 0x0380_0028> }>
 
 // -- %g: S.z.x
 // CHECK: [[KP_G:@keypath.*]] = private global <{ {{.*}} }> <{
@@ -119,13 +119,13 @@ sil_vtable C {}
 // CHECK-64-SAME: <i32 0x8000_0014>,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
 // -- offset of S.z
-// CHECK-32-SAME: <i32 0x0100_0010>,
-// CHECK-64-SAME: <i32 0x0100_0018>,
+// CHECK-32-SAME: <i32 0x0180_0010>,
+// CHECK-64-SAME: <i32 0x0180_0018>,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
 // CHECK: %swift.type* (i8*)*
 // -- 0x0300_0000 (class) + offset of C.x
-// CHECK-32-SAME: <i32 0x0300_0008> }>
-// CHECK-64-SAME: <i32 0x0300_0010> }>
+// CHECK-32-SAME: <i32 0x0380_0008> }>
+// CHECK-64-SAME: <i32 0x0380_0010> }>
 
 // -- %h: C.z.x
 // CHECK: [[KP_H:@keypath.*]] = private global <{ {{.*}} }> <{
@@ -138,12 +138,12 @@ sil_vtable C {}
 // CHECK-64-SAME: <i32 0x8000_0014>,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
 // -- 0x0300_0000 (class) + offset of C.z
-// CHECK-32-SAME: <i32 0x0300_0018>,
-// CHECK-64-SAME: <i32 0x0300_0028>,
+// CHECK-32-SAME: <i32 0x0380_0018>,
+// CHECK-64-SAME: <i32 0x0380_0028>,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
 // CHECK: %swift.type* (i8*)*
 // -- offset of S.x
-// CHECK-SAME: <i32 0x0100_0000> }>
+// CHECK-SAME: <i32 0x0180_0000> }>
 
 // -- %k: computed
 // CHECK: [[KP_K:@keypath.*]] = private global <{ {{.*}} }> <{
@@ -204,8 +204,8 @@ sil_vtable C {}
 //             -- size 8
 // CHECK-SAME: i32 8,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
-//             -- struct with runtime-resolved offset
-// CHECK-SAME: <i32 0x017ffffe>,
+//             -- struct with runtime-resolved offset, mutable
+// CHECK-SAME: <i32 0x01fffffe>,
 // CHECK-32-SAME: i32 16 }>
 // CHECK-64-SAME: i32 32 }>
 
@@ -218,7 +218,7 @@ sil_vtable C {}
 // CHECK-SAME: i32 8,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
 //             -- struct with runtime-resolved offset
-// CHECK-SAME: <i32 0x017ffffe>,
+// CHECK-SAME: <i32 0x01fffffe>,
 // CHECK-32-SAME: i32 20 }>
 // CHECK-64-SAME: i32 36 }>
 

--- a/test/IRGen/keypaths_objc.sil
+++ b/test/IRGen/keypaths_objc.sil
@@ -18,13 +18,13 @@ sil_vtable C {}
 sil @x_get : $@convention(thin) (@in_guaranteed C) -> @out NSString
 
 // CHECK: [[KEYPATH_A:@keypath.*]] = private global
-// --             0x0200_0002: computed, get-only, indirect identifier
+// --             computed, get-only, indirect identifier
 // CHECK-SAME: <i32 0x0200_0002>,
 // CHECK-SAME: i8** @"\01L_selector(x)"
 
 // CHECK: [[KEYPATH_B:@keypath.*]] = private global
-// --             0x037ffffd: class stored property with indirect offset
-// CHECK-SAME: <i32 0x037ffffd>,
+// --             class mutable stored property with indirect offset
+// CHECK-SAME: <i32 0x03fffffd>,
 // CHECK-SAME: @"$S13keypaths_objc1CC6storedSivpWvd"
 
 // CHECK-LABEL: define swiftcc void @objc_only_property()

--- a/test/IRGen/keypaths_objc.sil
+++ b/test/IRGen/keypaths_objc.sil
@@ -23,8 +23,8 @@ sil @x_get : $@convention(thin) (@in_guaranteed C) -> @out NSString
 // CHECK-SAME: i8** @"\01L_selector(x)"
 
 // CHECK: [[KEYPATH_B:@keypath.*]] = private global
-// --             0x03fffffd: class stored property with indirect offset
-// CHECK-SAME: <i32 0x03fffffd>,
+// --             0x037ffffd: class stored property with indirect offset
+// CHECK-SAME: <i32 0x037ffffd>,
 // CHECK-SAME: @"$S13keypaths_objc1CC6storedSivpWvd"
 
 // CHECK-LABEL: define swiftcc void @objc_only_property()

--- a/test/IRGen/property_descriptor.sil
+++ b/test/IRGen/property_descriptor.sil
@@ -39,17 +39,15 @@ public struct ExternalReabstractions<T> {
   @sil_stored public var reabstracted: () -> () { get set }
 }
 
-// -- 0xff_fffe - struct property, offset resolved from field offset vector in metadata
+// -- struct property, offset resolved from field offset vector in metadata
 // CHECK-64: @"$S19property_descriptor15ExternalGenericV2roxvpMV" =
-// CHECK-64-SAME: <{ <i32 0x01ff_fffe>, i32 32 }>, align 8
 // CHECK-32: @"$S19property_descriptor15ExternalGenericV2roxvpMV" =
-// CHECK-32-SAME: <{ <i32 0x01ff_fffe>, i32 16 }>, align 4
+// CHECK-SAME: <{ <i32 0x017f_fffe>,
 sil_property #ExternalGeneric.ro <T: Comparable> (
   stored_property #ExternalGeneric.ro : $T)
 // CHECK-64: @"$S19property_descriptor15ExternalGenericV2rwxvpMV" =
-// CHECK-64-SAME: <{ <i32 0x01ff_fffe>, i32 36 }>, align 8
 // CHECK-32: @"$S19property_descriptor15ExternalGenericV2rwxvpMV" =
-// CHECK-32-SAME: <{ <i32 0x01ff_fffe>, i32 20 }>, align 4
+// CHECK-SAME: <{ <i32 0x017f_fffe>,
 sil_property #ExternalGeneric.rw <T: Comparable> (
   stored_property #ExternalGeneric.rw : $T)
 

--- a/test/IRGen/property_descriptor.sil
+++ b/test/IRGen/property_descriptor.sil
@@ -42,12 +42,12 @@ public struct ExternalReabstractions<T> {
 // -- struct property, offset resolved from field offset vector in metadata
 // CHECK-64: @"$S19property_descriptor15ExternalGenericV2roxvpMV" =
 // CHECK-32: @"$S19property_descriptor15ExternalGenericV2roxvpMV" =
-// CHECK-SAME: <{ <i32 0x017f_fffe>,
+// CHECK-SAME: <{ <i32 0x01ff_fffe>,
 sil_property #ExternalGeneric.ro <T: Comparable> (
   stored_property #ExternalGeneric.ro : $T)
 // CHECK-64: @"$S19property_descriptor15ExternalGenericV2rwxvpMV" =
 // CHECK-32: @"$S19property_descriptor15ExternalGenericV2rwxvpMV" =
-// CHECK-SAME: <{ <i32 0x017f_fffe>,
+// CHECK-SAME: <{ <i32 0x01ff_fffe>,
 sil_property #ExternalGeneric.rw <T: Comparable> (
   stored_property #ExternalGeneric.rw : $T)
 

--- a/test/stdlib/Inputs/KeyPathMultiModule_b.swift
+++ b/test/stdlib/Inputs/KeyPathMultiModule_b.swift
@@ -35,6 +35,8 @@ public struct A {
     get { return 0 }
     set { }
   }
+
+  public let immutable: Int = 1738
 }
 
 public struct B<U> {
@@ -86,6 +88,10 @@ public func A_y_keypath() -> KeyPath<A, Int> {
 
 public func A_z_keypath() -> KeyPath<A, Int> {
   return \A.z
+}
+
+public func A_immutable_keypath() -> KeyPath<A, Int> {
+  return \A.immutable
 }
 
 public func A_subscript_withGeneric_keypath<T: Hashable>(index: T)
@@ -197,6 +203,8 @@ open class ResilientRoot {
   open var storedA = "a"
   open var storedB = "b"
 
+  public let storedLet = "c"
+
   open var virtual: String {
     get { return "foo" }
     set { }
@@ -236,6 +244,9 @@ public func ResilientRoot_storedA_keypath() -> KeyPath<ResilientRoot, String> {
 }
 public func ResilientRoot_storedB_keypath() -> KeyPath<ResilientRoot, String> {
   return \ResilientRoot.storedB
+}
+public func ResilientRoot_storedLet_keypath() -> KeyPath<ResilientRoot, String> {
+  return \ResilientRoot.storedLet
 }
 public func ResilientRoot_virtual_keypath() -> KeyPath<ResilientRoot, String> {
   return \ResilientRoot.virtual

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -g %s -o %t/a.out
+// RUN: %target-build-swift -swift-version 5 -g %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
@@ -12,6 +12,8 @@ final class C<T> {
   var x: Int
   var y: LifetimeTracked?
   var z: T
+  let immutable: String
+  private(set) var secretlyMutable: String
 
   var computed: T {
     get {
@@ -26,6 +28,8 @@ final class C<T> {
     self.x = x
     self.y = y
     self.z = z
+    self.immutable = "\(x) \(y) \(z)"
+    self.secretlyMutable = immutable
   }
 }
 
@@ -33,10 +37,14 @@ struct Point: Equatable {
   var x: Double
   var y: Double
   var trackLifetime = LifetimeTracked(123)
+  let hypotenuse: Double
+  private(set) var secretlyMutableHypotenuse: Double
   
   init(x: Double, y: Double) {
     self.x = x
     self.y = y
+    hypotenuse = x*x + y*y
+    secretlyMutableHypotenuse = x*x + y*y
   }
   
   static func ==(a: Point, b: Point) -> Bool {
@@ -693,6 +701,13 @@ keyPath.test("offsets") {
   expectNil(NOPLayout.offset(of: \NonOffsetableProperties.z))
 }
 
+keyPath.test("let-ness") {
+  expectNil(\C<Int>.immutable as? ReferenceWritableKeyPath)
+  expectNotNil(\C<Int>.secretlyMutable as? ReferenceWritableKeyPath)
+  expectNil(\Point.hypotenuse as? WritableKeyPath)
+  expectNotNil(\Point.secretlyMutableHypotenuse as? WritableKeyPath)
+}
+
 // SR-6096
 
 protocol Protocol6096 {}
@@ -712,6 +727,7 @@ extension Int: Protocol6096 {}
 keyPath.test("optional chaining component that needs generic instantiation") {
   Value6096<Int>().doSomething()
 }
+
 
 runAllTests()
 

--- a/test/stdlib/KeyPathMultiModule.swift
+++ b/test/stdlib/KeyPathMultiModule.swift
@@ -52,6 +52,7 @@ keyPathMultiModule.test("identity across multiple modules") {
     expectEqualWithHashes(A_x_keypath(), \A.x)
     expectEqualWithHashes(A_y_keypath(), \A.y)
     expectEqualWithHashes(A_z_keypath(), \A.z)
+    expectEqualWithHashes(A_immutable_keypath(), \A.immutable)
     expectEqualWithHashes(A_subscript_withGeneric_keypath(index: 0), \A.[withGeneric: 0])
     expectEqualWithHashes(A_subscript_withGeneric_keypath(index: "butt"),
                 \A.[withGeneric: "butt"])
@@ -156,6 +157,8 @@ keyPathMultiModule.test("identity across multiple modules") {
                           \ResilientRoot.storedA)
     expectEqualWithHashes(ResilientRoot_storedB_keypath(),
                           \ResilientRoot.storedB)
+    expectEqualWithHashes(ResilientRoot_storedLet_keypath(),
+                          \ResilientRoot.storedLet)
     expectEqualWithHashes(ResilientRoot_virtual_keypath(),
                           \ResilientRoot.virtual)
     expectEqualWithHashes(ResilientRoot_virtualRO_keypath(),

--- a/unittests/runtime/Stdlib.cpp
+++ b/unittests/runtime/Stdlib.cpp
@@ -252,3 +252,10 @@ const long long $Ss12_ClassMirrorVs01_B0sWP[1] = {0};
 // type metadata accessor for Swift._ClassMirror
 SWIFT_RUNTIME_STDLIB_INTERNAL
 const long long $Ss12_ClassMirrorVMa[1] = {0};
+
+// KeyPath
+
+SWIFT_RUNTIME_STDLIB_SPI
+const HeapObject *swift_getKeyPathImpl(const void *p, const void *a) {
+  abort();
+}


### PR DESCRIPTION
Fixes SR-6502 | rdar://problem/35773760.