### PR TITLE
remove unused allocation

### DIFF
--- a/lib/SIL/SILConstants.cpp
+++ b/lib/SIL/SILConstants.cpp
@@ -540,9 +540,6 @@ private:
 SymbolicValue SymbolicValue::getUnknown(SILNode *node, UnknownReason reason,
                                         llvm::ArrayRef<SourceLoc> callStack,
                                         llvm::BumpPtrAllocator &allocator) {
-  auto *rawCallStack = allocator.Allocate<SourceLoc>(callStack.size());
-  std::uninitialized_copy(callStack.begin(), callStack.end(), rawCallStack);
-
   assert(node && "node must be present");
   SymbolicValue result;
   result.representationKind = RK_Unknown;


### PR DESCRIPTION
This unused allocation causes a crash when the compiler is built in google's repo!

I think I found the reason for the crash. LLVM's BumpPtrAllocator does not work correctly when your first allocation request is for 0 bytes. The [Allocate function is marked LLVM_ATTRIBUTE_RETURNS_NONNULL](https://github.com/llvm-mirror/llvm/blob/41bee7d4780bf808aba3ad86dd0ce2b2d5e40da3/include/llvm/Support/Allocator.h#L213), but it returns null when your first allocation request is for 0 bytes. This is undefined behavior that crashes the program. It seems like this was [noticed and discussed](https://groups.google.com/forum/#!msg/llvm-dev/IjX59Kl0I6U/jV8vVeukDAAJ) in the past, but no one concluded anything. I'll go ask llvm-dev about the problem again.

Anyways, this PR fixes our crash so we're not blocked on getting the LLVM BumpPtrAllocator situation resolved.