### PR TITLE
Use atomic profile counter updates when TSan is enabled

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -262,8 +262,13 @@ void swift::performLLVMOptimizations(IRGenOptions &Opts, llvm::Module *Module,
       TargetMachine->getTargetIRAnalysis()));
 
   // If we're generating a profile, add the lowering pass now.
-  if (Opts.GenerateProfile)
-    ModulePasses.add(createInstrProfilingLegacyPass());
+  if (Opts.GenerateProfile) {
+    // TODO: Surface the option to emit atomic profile counter increments at
+    // the driver level.
+    InstrProfOptions Options;
+    Options.Atomic = bool(Opts.Sanitizers & SanitizerKind::Thread);
+    ModulePasses.add(createInstrProfilingLegacyPass(Options));
+  }
 
   PMBuilder.populateModulePassManager(ModulePasses);
 

--- a/test/Profiler/instrprof_tsan.swift
+++ b/test/Profiler/instrprof_tsan.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -emit-ir -profile-generate -sanitize=thread %s | %FileCheck %s
+
+// CHECK: define {{.*}}empty
+// CHECK-NOT: load{{.*}}empty
+// CHECK: ret void
+func empty() {
+}
+
+empty()


### PR DESCRIPTION
This suppresses TSan diagnostics about racy profile counter updates.

rdar://40477803