### PR TITLE
[ModuleInterface] More changes to printing and parsing .swiftinterface files

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -112,8 +112,8 @@ public:
 };
 
 struct ShouldPrintChecker {
-  virtual bool shouldPrint(const Decl *D, PrintOptions &Options);
-  bool shouldPrint(const Pattern *P, PrintOptions &Options);
+  virtual bool shouldPrint(const Decl *D, const PrintOptions &Options);
+  bool shouldPrint(const Pattern *P, const PrintOptions &Options);
   virtual ~ShouldPrintChecker() = default;
 };
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -73,7 +73,7 @@ PrintOptions PrintOptions::printTextualInterfaceFile() {
   result.SkipImports = true;
 
   class UsableFromInlineOnly : public ShouldPrintChecker {
-    bool shouldPrint(const Decl *D, PrintOptions &options) override {
+    bool shouldPrint(const Decl *D, const PrintOptions &options) override {
       if (auto *VD = dyn_cast<ValueDecl>(D)) {
         AccessScope accessScope =
             VD->getFormalAccessScope(/*useDC*/nullptr,
@@ -1303,7 +1303,8 @@ void PrintAST::printPatternType(const Pattern *P) {
   }
 }
 
-bool ShouldPrintChecker::shouldPrint(const Pattern *P, PrintOptions &Options) {
+bool ShouldPrintChecker::shouldPrint(const Pattern *P,
+                                     const PrintOptions &Options) {
   bool ShouldPrint = false;
   P->forEachVariable([&](const VarDecl *VD) {
     ShouldPrint |= shouldPrint(VD, Options);
@@ -1311,7 +1312,8 @@ bool ShouldPrintChecker::shouldPrint(const Pattern *P, PrintOptions &Options) {
   return ShouldPrint;
 }
 
-bool ShouldPrintChecker::shouldPrint(const Decl *D, PrintOptions &Options) {
+bool ShouldPrintChecker::shouldPrint(const Decl *D,
+                                     const PrintOptions &Options) {
   if (auto *ED= dyn_cast<ExtensionDecl>(D)) {
     if (Options.printExtensionContentAsMembers(ED))
       return false;

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -26,7 +26,7 @@
 
 using namespace swift;
 
-static bool shouldPrintAsFavorable(const Decl *D, PrintOptions &Options) {
+static bool shouldPrintAsFavorable(const Decl *D, const PrintOptions &Options) {
   if (!Options.TransformContext ||
       !D->getDeclContext()->isExtensionContext() ||
       !Options.TransformContext->isPrintingSynthesizedExtension())
@@ -42,7 +42,7 @@ static bool shouldPrintAsFavorable(const Decl *D, PrintOptions &Options) {
 }
 
 class ModulePrinterPrintableChecker: public ShouldPrintChecker {
-  bool shouldPrint(const Decl *D, PrintOptions &Options) override {
+  bool shouldPrint(const Decl *D, const PrintOptions &Options) override {
     if (!shouldPrintAsFavorable(D, Options))
       return false;
     return ShouldPrintChecker::shouldPrint(D, Options);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5481,6 +5481,8 @@ ParserResult<EnumDecl> Parser::parseDeclEnum(ParseDeclOptions Flags,
                                         { }, nullptr, CurDeclContext);
   setLocalDiscriminator(ED);
   ED->getAttrs() = Attributes;
+  if (SF.Kind == SourceFileKind::Interface)
+    ED->setAddedImplicitInitializers();
 
   ContextChange CC(*this, ED);
 
@@ -5753,6 +5755,8 @@ ParserResult<StructDecl> Parser::parseDeclStruct(ParseDeclOptions Flags,
                                             CurDeclContext);
   setLocalDiscriminator(SD);
   SD->getAttrs() = Attributes;
+  if (SF.Kind == SourceFileKind::Interface)
+    SD->setAddedImplicitInitializers();
 
   ContextChange CC(*this, SD);
 
@@ -5840,9 +5844,9 @@ ParserResult<ClassDecl> Parser::parseDeclClass(ParseDeclOptions Flags,
   ClassDecl *CD = new (Context) ClassDecl(ClassLoc, ClassName, ClassNameLoc,
                                           { }, nullptr, CurDeclContext);
   setLocalDiscriminator(CD);
-
-  // Attach attributes.
   CD->getAttrs() = Attributes;
+  if (SF.Kind == SourceFileKind::Interface)
+    CD->setAddedImplicitInitializers();
 
   ContextChange CC(*this, CD);
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5138,6 +5138,19 @@ static void diagnoseClassWithoutInitializers(TypeChecker &tc,
 }
 
 void TypeChecker::maybeDiagnoseClassWithoutInitializers(ClassDecl *classDecl) {
+  if (auto *SF = classDecl->getParentSourceFile()) {
+    // Allow classes without initializers in SIL and textual interface files.
+    switch (SF->Kind) {
+    case SourceFileKind::SIL:
+    case SourceFileKind::Interface:
+      return;
+    case SourceFileKind::Library:
+    case SourceFileKind::Main:
+    case SourceFileKind::REPL:
+      break;
+    }
+  }
+
   // Some heuristics to skip emitting a diagnostic if the class is already
   // irreperably busted.
   if (classDecl->isInvalid() ||

--- a/test/ModuleInterface/SmokeTest.swiftinterface
+++ b/test/ModuleInterface/SmokeTest.swiftinterface
@@ -29,6 +29,14 @@ public class TestClass {
   deinit
 } // CHECK: {{^}$}}
 
+// CHECK-LABEL: public class TestEmptyClass {
+public class TestEmptyClass {
+} // CHECK-NEXT: {{^}$}}
+
+// CHECK-LABEL: public struct TestEmptyStruct {
+public struct TestEmptyStruct {
+} // CHECK-NEXT: {{^}$}}
+
 // CHECK-LABEL: public enum TestEnum
 public enum TestEnum {
   // CHECK: case a

--- a/test/ModuleInterface/SmokeTest.swiftinterface
+++ b/test/ModuleInterface/SmokeTest.swiftinterface
@@ -22,6 +22,9 @@ public class TestClass {
   // CHECK: public var prop: Int{{$}}
   public var prop: Int { get set }
 
+  // CHECK: public static var propWithNoAccessors: Int{{$}}
+  public static var propWithNoAccessors: Int
+
   // NEGATIVE-NOT: deinit
   deinit
 } // CHECK: {{^}$}}
@@ -42,6 +45,9 @@ public enum TestEnum {
 
   // CHECK: public var prop: Int{{$}}
   public var prop: Int { get set }
+
+  // CHECK: public static var propWithNoAccessors: Int{{$}}
+  public static var propWithNoAccessors: Int
 } // CHECK: {{^}$}}
 
 // CHECK-LABEL: public struct TestStruct
@@ -57,7 +63,13 @@ public struct TestStruct {
 
   // CHECK: public var prop: Int{{$}}
   public var prop: Int { get set }
+
+  // CHECK: public static var propWithNoAccessors: Int{{$}}
+  public static var propWithNoAccessors: Int
 } // CHECK: {{^}$}}
+
+// CHECK: public let globalWithNoAccessors: Int{{$}}
+public let globalWithNoAccessors: Int
 
 // CHECK: public var readOnlyVar: Int { get }{{$}}
 public var readOnlyVar: Int { get }

--- a/test/ModuleInterface/conformances.swift
+++ b/test/ModuleInterface/conformances.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -emit-interface-path %t.swiftinterface -emit-module -o /dev/null %s
+// RUN: %FileCheck %s < %t.swiftinterface
+// RUN: %FileCheck -check-prefix NEGATIVE %s < %t.swiftinterface
+
+// CHECK-LABEL: public protocol SimpleProto {
+public protocol SimpleProto {
+  // CHECK: associatedtype Element
+  associatedtype Element
+  // CHECK: associatedtype Inferred
+  associatedtype Inferred
+  func inference(_: Inferred)
+} // CHECK: {{^}$}}
+
+// CHECK-LABEL: public struct SimplImpl<Element> : SimpleProto {
+public struct SimplImpl<Element>: SimpleProto {
+  // NEGATIVE-NOT: typealias Element =
+  // CHECK: public func inference(_: Int){{$}}
+  public func inference(_: Int) {}
+  // CHECK: public typealias Inferred = Swift.Int
+} // CHECK: {{^}$}}


### PR DESCRIPTION
- Don't print typealiases that match generic params
- Allow global/static variables without initial values
- Don't synthesize initializers in swiftinterface files