### PR TITLE
[Diagnostics] NFC: Move logic common to all requirement failures into…

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1529,8 +1529,10 @@ ERROR(type_does_not_conform_in_decl_ref,none,
 ERROR(type_does_not_conform_decl_owner,none,
       "%0 %1 requires that %2 conform to %3",
       (DescriptiveDeclKind, DeclName, Type, Type))
-NOTE(where_type_does_not_conform_type,none,
+NOTE(where_requirement_failure_one_subst,none,
      "where %0 = %1", (Type, Type))
+NOTE(where_requirement_failure_both_subst,none,
+     "where %0 = %1, %2 = %3", (Type, Type, Type, Type))
 NOTE(requirement_implied_by_conditional_conformance,none,
      "requirement from conditional conformance of %0 to %1", (Type, Type))
 NOTE(candidate_types_equal_requirement,none,


### PR DESCRIPTION
… `RequirementFailure`

This is going to make adding same-type and superclass requirement
failures might easier, because they only have to supply custom
diagnostic messages and substituted types.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
