### PR TITLE
Enforce exclusivity dynamically in more situations.

### DIFF
--- a/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
+++ b/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
@@ -36,6 +36,7 @@
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILUndef.h"
 #include "swift/SILOptimizer/Analysis/ClosureScope.h"
+#include "swift/SILOptimizer/Analysis/PostOrderAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 
 using namespace swift;
@@ -68,7 +69,6 @@ struct AddressCapture {
 
   AddressCapture(Operand &oper)
       : site(oper.getUser()), calleeArgIdx(site.getCalleeArgIndex(oper)) {
-    assert(isa<PartialApplyInst>(site));
     if (site.getOrigCalleeConv().getSILArgumentConvention(calleeArgIdx)
         != SILArgumentConvention::Indirect_InoutAliasable) {
       site = ApplySite();
@@ -272,8 +272,16 @@ void SelectEnforcement::analyzeProjection(ProjectBoxInst *projection) {
 
       continue;
     }
-    if (isa<PartialApplyInst>(user))
-      Captures.emplace_back(AddressCapture(*use));
+    // Handle both partial applies and directly applied non-escaping closures.
+    if (ApplySite::isa(user)) {
+      AddressCapture capture(*use);
+      if (capture.isValid())
+        Captures.emplace_back(capture);
+      else
+        // Only full apply sites can have non-inout_aliasable address arguments,
+        // but those aren't actually captures.
+        assert(FullApplySite::isa(user));
+    }
   }
 }
 
@@ -463,6 +471,13 @@ void SelectEnforcement::updateCapture(AddressCapture capture) {
     if (hasPotentiallyEscapedAt(user))
       dynamicCaptures.recordCapture(capture);
   };
+  SingleValueInstruction *PAIUser = dyn_cast<PartialApplyInst>(capture.site);
+  if (!PAIUser) {
+    // This is a full apply site. Immediately record the capture and return.
+    captureIfEscaped(capture.site.getInstruction());
+    return;
+  }
+  // For partial applies, check all use points of the closure.
   llvm::SmallSetVector<SingleValueInstruction *, 8> worklist;
   auto visitUse = [&](Operand *oper) {
     auto *user = oper->getUser();
@@ -513,7 +528,6 @@ void SelectEnforcement::updateCapture(AddressCapture capture) {
       captureIfEscaped(user);
     }
   };
-  SingleValueInstruction *PAIUser = dyn_cast<PartialApplyInst>(capture.site);
   while (true) {
     for (auto *oper : PAIUser->getUses())
       visitUse(oper);
@@ -553,11 +567,10 @@ class AccessEnforcementSelection : public SILModuleTransform {
   // they reference.
   DynamicCaptures dynamicCaptures;
 
-  // Per-function book-keeping. A box is processed the first time one of it's
-  // accesses is handled. Don't process it again for subsequent accesses.
-  llvm::DenseSet<AllocBoxInst *> handledBoxes;
-
 #ifndef NDEBUG
+  // Per-function book-keeping to verify that a box is processed before all of
+  // its accesses and captures are seen.
+  llvm::DenseSet<AllocBoxInst *> handledBoxes;
   llvm::DenseSet<SILFunction *> visited;
 #endif
 
@@ -568,7 +581,7 @@ protected:
   void processFunction(SILFunction *F);
   SourceAccess getAccessKindForBox(ProjectBoxInst *projection);
   SourceAccess getSourceAccess(SILValue address);
-  void handlePartialApply(PartialApplyInst *PAI);
+  void handleApply(ApplySite apply);
   void handleAccess(BeginAccessInst *access);
 };
 
@@ -580,6 +593,9 @@ void AccessEnforcementSelection::run() {
 }
 
 void AccessEnforcementSelection::processFunction(SILFunction *F) {
+  if (F->isExternalDeclaration())
+    return;
+
   LLVM_DEBUG(llvm::dbgs() << "Access Enforcement Selection in " << F->getName()
                           << "\n");
 
@@ -599,29 +615,43 @@ void AccessEnforcementSelection::processFunction(SILFunction *F) {
   }
   visited.insert(F);
 #endif
+
   // Deserialized functions, which have been mandatory inlined, no longer meet
   // the structural requirements on access markers required by this pass.
   if (F->wasDeserializedCanonical())
     return;
 
-  for (auto &bb : *F) {
-    for (auto ii = bb.begin(), ie = bb.end(); ii != ie;) {
+  // Perform an RPO walk so that boxes are always processed before their access.
+  auto *PO = getAnalysis<PostOrderAnalysis>()->get(F);
+  for (SILBasicBlock *bb : PO->getReversePostOrder()) {
+    for (auto ii = bb->begin(), ie = bb->end(); ii != ie;) {
       SILInstruction *inst = &*ii;
       ++ii;
 
-      if (auto access = dyn_cast<BeginAccessInst>(inst))
+      // Analyze all boxes. Even if they aren't accessed in this function, they
+      // may still have captures that require dynamic enforcement because the
+      // box has escaped prior to the capture.
+      if (auto box = dyn_cast<AllocBoxInst>(inst)) {
+        SelectEnforcement(dynamicCaptures, box).run();
+        assert(handledBoxes.insert(box).second);
+
+      } else if (auto access = dyn_cast<BeginAccessInst>(inst))
         handleAccess(access);
 
       else if (auto access = dyn_cast<BeginUnpairedAccessInst>(inst))
         assert(access->getEnforcement() == SILAccessEnforcement::Dynamic);
 
-      else if(auto pa = dyn_cast<PartialApplyInst>(inst))
-        handlePartialApply(pa);
+      // Check for unboxed captures in both partial_applies and direct
+      // applications of non-escaping closures.
+      else if (auto apply = ApplySite::isa(inst))
+        handleApply(apply);
     }
   }
   invalidateAnalysis(F, SILAnalysis::InvalidationKind::Instructions);
+#ifndef NDEBUG
   // There's no need to track handled boxes across functions.
   handledBoxes.clear();
+#endif
 }
 
 SourceAccess
@@ -690,19 +720,17 @@ SourceAccess AccessEnforcementSelection::getSourceAccess(SILValue address) {
   return SourceAccess::getStaticAccess();
 }
 
-void AccessEnforcementSelection::handlePartialApply(PartialApplyInst *PAI) {
-  ApplySite site(PAI);
-  auto calleeTy = PAI->getOrigCalleeType();
+void AccessEnforcementSelection::handleApply(ApplySite apply) {
+  auto calleeTy = apply.getOrigCalleeType();
   SILFunctionConventions calleeConv(calleeTy, *getModule());
 
-  for (Operand &oper : site.getArgumentOperands()) {
+  for (Operand &oper : apply.getArgumentOperands()) {
     AddressCapture capture(oper);
     if (!capture.isValid())
       continue;
 
-    // This partial apply creates a non-escaping closure. Check if the closure
-    // captures any Boxed variables from this scope. If so, check if the box
-    // escapes before the access just as we do for normal accesses.
+    // This is a non-escaping closure argument. If the argument requires dynamic
+    // access, record that in dynamicCaptures.
     auto sourceAccess = getSourceAccess(oper.get());
     switch (sourceAccess.kind) {
     case SourceAccess::StaticAccess:
@@ -714,8 +742,11 @@ void AccessEnforcementSelection::handlePartialApply(PartialApplyInst *PAI) {
       break;
     }
     case SourceAccess::BoxAccess:
-      if (handledBoxes.insert(sourceAccess.allocBox).second)
-        SelectEnforcement(dynamicCaptures, sourceAccess.allocBox).run();
+      // Captures of box projections are handled during SelectEnforcement, which
+      // determines the access enforcement for all users of a box. Within
+      // SelectEnforcement, we know whether the box has escaped before the
+      // capture. Here there's just nothing to do.
+      assert(handledBoxes.count(sourceAccess.allocBox));
       break;
     }
   }
@@ -734,10 +765,7 @@ void AccessEnforcementSelection::handleAccess(BeginAccessInst *access) {
     setDynamicEnforcement(access);
     break;
   case SourceAccess::BoxAccess:
-    // If this box was handled, the access enforcement would already be set.
-    assert(!handledBoxes.count(sourceAccess.allocBox));
-    SelectEnforcement(dynamicCaptures, sourceAccess.allocBox).run();
-    break;
+    llvm_unreachable("All boxes must have already been selected.");
   }
 }
 

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -360,7 +360,7 @@ bb0(%0 : $Base):
  return %5 : $()
 }
 
-sil public_external @partial_empty_box : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <()>, @inout ()) -> ()
+sil public_external @partial_empty_box : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <()>, @inout_aliasable ()) -> ()
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @empty_box()
 sil @empty_box : $@convention(thin) () -> () {
@@ -370,8 +370,8 @@ entry:
   // CHECK: store %swift.opaque* undef
   %b = alloc_box $<τ_0_0> { var τ_0_0 } <()>
   %ba = project_box %b : $<τ_0_0> { var τ_0_0 } <()>, 0
-  %f = function_ref @partial_empty_box : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <()>, @inout ()) -> ()
-  %g = partial_apply %f(%b, %ba) : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <()>, @inout ()) -> ()
+  %f = function_ref @partial_empty_box : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <()>, @inout_aliasable ()) -> ()
+  %g = partial_apply %f(%b, %ba) : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <()>, @inout_aliasable ()) -> ()
   return undef : $()
 }
 

--- a/test/SILOptimizer/access_enforcement_selection.sil
+++ b/test/SILOptimizer/access_enforcement_selection.sil
@@ -8,7 +8,6 @@ sil_stage raw
 // Test undef begin_access operands.
 // CHECK-LABEL: sil hidden @undefStack : $@convention(thin) (Builtin.Int64) -> Builtin.Int64 {
 // CHECK: bb0(%0 : @trivial $Builtin.Int64):
-// CHECK: unreachable
 // CHECK: bb1:
 // CHECK: [[WRITE:%.*]] = begin_access [modify] [static] undef : $*Builtin.Int64
 // CHECK: store %{{.*}} to [trivial] [[WRITE]] : $*Builtin.Int64
@@ -21,7 +20,7 @@ sil_stage raw
 // CHECK-LABEL: } // end sil function 'undefStack'
 sil hidden @undefStack : $@convention(thin) (Builtin.Int64) -> Builtin.Int64 {
 bb0(%0 : @trivial $Builtin.Int64):
-  unreachable
+  br bb1
 
 bb1:
   %23 = integer_literal $Builtin.Int64, 42
@@ -34,7 +33,6 @@ bb2:
   %29 = begin_access [read] [unknown] undef : $*Builtin.Int64
   %30 = load [trivial] %29 : $*Builtin.Int64
   end_access %29 : $*Builtin.Int64
-  dealloc_stack undef : $*Builtin.Int64
   return %30 : $Builtin.Int64
 }
 
@@ -65,7 +63,7 @@ sil hidden @markFuncEscape : $@convention(thin) () -> () {
 }
 
 
-sil @takesInoutAndClosure : $@convention(thin) (@inout Builtin.Int64, @owned @callee_owned () -> ()) -> ()
+sil @takesInoutAndClosure : $@convention(thin) (@inout Builtin.Int64, @guaranteed @callee_guaranteed () -> ()) -> ()
 sil @closureCapturingByStorageAddress : $@convention(thin) (@inout_aliasable Builtin.Int64) -> ()
 
 // Test static enforcement of box addresses that escape via closure
@@ -75,12 +73,13 @@ sil @closureCapturingByStorageAddress : $@convention(thin) (@inout_aliasable Bui
 // CHECK: bb0:
 // CHECK:  [[BOX:%.*]] = alloc_box ${ var Builtin.Int64 }, var, name "x"
 // CHECK:  [[ADR:%.*]] = project_box [[BOX]] : ${ var Builtin.Int64 }, 0
-// CHECK:  [[FUNC:%.*]] = function_ref @takesInoutAndClosure : $@convention(thin) (@inout Builtin.Int64, @owned @callee_owned () -> ()) -> ()
+// CHECK:  [[FUNC:%.*]] = function_ref @takesInoutAndClosure : $@convention(thin) (@inout Builtin.Int64, @guaranteed @callee_guaranteed () -> ()) -> ()
 // CHECK:  [[CLOSURE:%.*]] = function_ref @closureCapturingByStorageAddress : $@convention(thin) (@inout_aliasable Builtin.Int64) -> ()
-// CHECK:  [[PA:%.*]] = partial_apply [[CLOSURE]]([[ADR]]) : $@convention(thin) (@inout_aliasable Builtin.Int64) -> ()
+// CHECK:  [[PA:%.*]] = partial_apply [callee_guaranteed] [[CLOSURE]]([[ADR]]) : $@convention(thin) (@inout_aliasable Builtin.Int64) -> ()
 // CHECK:  [[MODIFY:%.*]] = begin_access [modify] [static] [[ADR]] : $*Builtin.Int64
-// CHECK:  %{{.*}} = apply [[FUNC]]([[MODIFY]], [[PA]]) : $@convention(thin) (@inout Builtin.Int64, @owned @callee_owned () -> ()) -> ()
+// CHECK:  %{{.*}} = apply [[FUNC]]([[MODIFY]], [[PA]]) : $@convention(thin) (@inout Builtin.Int64, @guaranteed @callee_guaranteed () -> ()) -> ()
 // CHECK:  end_access [[MODIFY]] : $*Builtin.Int64
+// CHECK:  destroy_value [[PA]]
 // CHECK:  destroy_value [[BOX]] : ${ var Builtin.Int64 }
 // CHECK:  return %{{.*}} : $()
 // CHECK-LABEL:} // end sil function 'escapeAsArgumentToPartialApply'
@@ -88,12 +87,13 @@ sil hidden @escapeAsArgumentToPartialApply : $@convention(thin) () -> () {
 bb0:
   %2 = alloc_box ${ var Builtin.Int64 }, var, name "x"
   %3 = project_box %2 : ${ var Builtin.Int64 }, 0
-  %4 = function_ref @takesInoutAndClosure : $@convention(thin) (@inout Builtin.Int64, @owned @callee_owned () -> ()) -> ()
+  %4 = function_ref @takesInoutAndClosure : $@convention(thin) (@inout Builtin.Int64, @guaranteed @callee_guaranteed () -> ()) -> ()
   %5 = function_ref @closureCapturingByStorageAddress : $@convention(thin) (@inout_aliasable Builtin.Int64) -> ()
-  %6 = partial_apply %5(%3) : $@convention(thin) (@inout_aliasable Builtin.Int64) -> ()
+  %6 = partial_apply [callee_guaranteed] %5(%3) : $@convention(thin) (@inout_aliasable Builtin.Int64) -> ()
   %7 = begin_access [modify] [unknown] %3 : $*Builtin.Int64
-  %8 = apply %4(%7, %6) : $@convention(thin) (@inout Builtin.Int64, @owned @callee_owned () -> ()) -> ()
+  %8 = apply %4(%7, %6) : $@convention(thin) (@inout Builtin.Int64, @guaranteed @callee_guaranteed () -> ()) -> ()
   end_access %7 : $*Builtin.Int64
+  destroy_value %6 : $@callee_guaranteed () -> ()
   destroy_value %2 : ${ var Builtin.Int64 }
   %9 = tuple ()
   return %9 : $()
@@ -206,15 +206,15 @@ sil @borrowClosure : $@convention(thin) () -> () {
   %copy = copy_value %box : ${ var Builtin.Int64 }
 
   %f = function_ref @borrowedClosure : $@convention(thin) (@inout_aliasable Builtin.Int64) -> ()
-  %closure = partial_apply %f(%addr) : $@convention(thin) (@inout_aliasable Builtin.Int64) -> ()
+  %closure = partial_apply [callee_guaranteed] %f(%addr) : $@convention(thin) (@inout_aliasable Builtin.Int64) -> ()
 
   // closure is borrowed.
-  %borrow = begin_borrow %closure : $@callee_owned () -> ()
-  %closure_copy = copy_value %borrow : $@callee_owned () -> ()
-  end_borrow %borrow from %closure : $@callee_owned () -> (), $@callee_owned () -> ()
+  %borrow = begin_borrow %closure : $@callee_guaranteed () -> ()
+  %closure_copy = copy_value %borrow : $@callee_guaranteed () -> ()
+  end_borrow %borrow from %closure : $@callee_guaranteed () -> (), $@callee_guaranteed () -> ()
 
-  destroy_value %closure_copy : $@callee_owned () -> ()
-  destroy_value %closure : $@callee_owned () -> ()
+  destroy_value %closure_copy : $@callee_guaranteed () -> ()
+  destroy_value %closure : $@callee_guaranteed () -> ()
   destroy_value %copy : ${ var Builtin.Int64 }
   destroy_value %box : ${ var Builtin.Int64 }
   %empty = tuple ()
@@ -250,14 +250,79 @@ bb0:
   // outer access (presumably its uses were mandatory inlined)
   %4 = begin_access [modify] [static] %3 : $*Builtin.Int64
   %5 = function_ref @serializedClosureCapturingByStorageAddress : $@convention(thin) (@inout_aliasable Builtin.Int64) -> ()
-  %6 = partial_apply %5(%4) : $@convention(thin) (@inout_aliasable Builtin.Int64) -> ()
+  %6 = partial_apply [callee_guaranteed] %5(%4) : $@convention(thin) (@inout_aliasable Builtin.Int64) -> ()
   %7 = begin_access [modify] [static] %4 : $*Builtin.Int64
-  %8 = function_ref @takesInoutAndClosure : $@convention(thin) (@inout Builtin.Int64, @owned @callee_owned () -> ()) -> ()
-  %9 = apply %8(%7, %6) : $@convention(thin) (@inout Builtin.Int64, @owned @callee_owned () -> ()) -> ()
+  %8 = function_ref @takesInoutAndClosure : $@convention(thin) (@inout Builtin.Int64, @guaranteed @callee_guaranteed () -> ()) -> ()
+  %9 = apply %8(%7, %6) : $@convention(thin) (@inout Builtin.Int64, @guaranteed @callee_guaranteed () -> ()) -> ()
   end_access %7 : $*Builtin.Int64
   end_access %4 : $*Builtin.Int64
+  destroy_value %6 : $@callee_guaranteed () -> ()
   destroy_value %2 : ${ var Builtin.Int64 }
   destroy_value %1 : ${ var Builtin.Int64 }
   %10 = tuple ()
   return %10 : $()
+}
+
+// -----------------------------------------------------------------------------
+// <rdar://problem/43122715> [Exclusivity] failure to diagnose escaping closures
+// called within directly applied noescape closures.
+//
+// The top level function, testDirectApplyNoescapeDynamic, has no
+// access markers, but it does define a box that escapes into two
+// closures. Since one of thoses captures is a box, they both need
+// dynamic enforcement. The unique thing about this case is that the
+// non-escaping closure is directly applied, so has no partial_apply
+// to indicate the presence of a captured argument.
+
+sil [noinline] @takeInoutAndPerform : $@convention(thin) (@inout Builtin.Int64, @guaranteed @callee_guaranteed () -> ()) -> ()
+
+// CHECK-LABEL: sil @testDirectApplyNoescapeDynamic : $@convention(thin) (Builtin.Int64) -> () {
+// CHECK-LABEL:  // end sil function 'testDirectApplyNoescapeDynamic'
+sil @testDirectApplyNoescapeDynamic : $@convention(thin) (Builtin.Int64) -> () {
+bb0(%0 : @trivial $Builtin.Int64):
+  %box = alloc_box ${ var Builtin.Int64 }, var, name "localVal"
+  %boxproj = project_box %box : ${ var Builtin.Int64 }, 0
+
+  store %0 to [trivial] %boxproj : $*Builtin.Int64
+
+  %closureF = function_ref @directApplyNoescapeDynamicClosure : $@convention(thin) (@guaranteed { var Builtin.Int64 }) -> ()
+  %boxCopy = copy_value %box : ${ var Builtin.Int64 }
+  %closure = partial_apply [callee_guaranteed] %closureF(%boxCopy) : $@convention(thin) (@guaranteed { var Builtin.Int64 }) -> ()
+
+  %directF = function_ref @directApplyNoescapeDynamicAppliedClosure : $@convention(thin) (@guaranteed @callee_guaranteed () -> (), @inout_aliasable Builtin.Int64) -> ()
+  %call = apply %directF(%closure, %boxproj) : $@convention(thin) (@guaranteed @callee_guaranteed () -> (), @inout_aliasable Builtin.Int64) -> ()
+  destroy_value %closure : $@callee_guaranteed () -> ()
+  destroy_value %box : ${ var Builtin.Int64 }
+  %v = tuple ()
+  return %v : $()
+}
+
+// CHECK-LABEL: sil private @directApplyNoescapeDynamicClosure : $@convention(thin) (@guaranteed { var Builtin.Int64 }) -> () {
+// CHECK: [[BOX:%.*]] = project_box %0 : ${ var Builtin.Int64 }, 0
+// CHECK: begin_access [modify] [dynamic] [[BOX]] : $*Builtin.Int64
+// CHECK-LABEL:  // end sil function 'directApplyNoescapeDynamicClosure'
+sil private @directApplyNoescapeDynamicClosure : $@convention(thin) (@guaranteed { var Builtin.Int64 }) -> () {
+bb0(%0 : @guaranteed ${ var Builtin.Int64 }):
+  %1 = project_box %0 : ${ var Builtin.Int64 }, 0
+  %4 = integer_literal $Builtin.Int64, 3
+
+  %7 = begin_access [modify] [unknown] %1 : $*Builtin.Int64
+  assign %4 to %7 : $*Builtin.Int64
+  end_access %7 : $*Builtin.Int64
+  %10 = tuple ()
+  return %10 : $()
+}
+
+// CHECK-LABEL: sil private @directApplyNoescapeDynamicAppliedClosure : $@convention(thin) (@guaranteed @callee_guaranteed () -> (), @inout_aliasable Builtin.Int64) -> () {
+// CHECK: begin_access [modify] [dynamic] %1 : $*Builtin.Int64
+// CHECK-LABEL: end sil function 'directApplyNoescapeDynamicAppliedClosure'
+sil private @directApplyNoescapeDynamicAppliedClosure : $@convention(thin) (@guaranteed @callee_guaranteed () -> (), @inout_aliasable Builtin.Int64) -> () {
+bb0(%0 : @guaranteed $@callee_guaranteed () -> (), %1 : @trivial $*Builtin.Int64):
+  %4 = begin_access [modify] [unknown] %1 : $*Builtin.Int64
+
+  %5 = function_ref @takesInoutAndClosure : $@convention(thin) (@inout Builtin.Int64, @guaranteed @callee_guaranteed () -> ()) -> ()
+  %6 = apply %5(%4, %0) : $@convention(thin) (@inout Builtin.Int64, @guaranteed @callee_guaranteed () -> ()) -> ()
+  end_access %4 : $*Builtin.Int64
+  %8 = tuple ()
+  return %8 : $()
 }


### PR DESCRIPTION
[WIP] I'll commit the test cases tomorrow. This is for SCK testing and review.

A directly applied noescape closure that captures a local requires
dynamic enforcement if that local escaped prior to the direct
application. Previously this was only statically enforced, which could
miss conflicts.

It's unlikely that an actual conflict could occur, but can happen in
cases like this:

func noescapeConflict() {
  var localVal = 0
  let nestedModify = { localVal = 3 }
  _ = {
    takeInoutAndPerform(&localVal, closure: nestedModify)
  }()
}

Code isn't normally written like this, but the general pattern of
passing an escaping closure as an argument to a noescape closure may
arise when using withoutActuallyEscaping. Even in that case, it's
highly unlikely that a real conflict would exist.

For this case to be handled correcly, we must also never allow a
closure passed to withoutActuallyEscaping to be SILGen's as a
non-escaping closure. Doing so would result in a non-escaping closure
to be passed as an argument to the withoutActuallyEscaping trailing
closure, which is also non-escaping. That directly violates the
Non-Escaping Recursion Restriction, but there would be no way to
diagnose the violation, creating a hole in the exclusivity model.
