### PR TITLE
[Parse] Don't use getAsNominalTypeOrNominalTypeExtensionContext in Parse

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -4311,7 +4311,7 @@ public:
   }
 
   void getOverrideCompletions(SourceLoc Loc) {
-    if (!CurrDeclContext->getSelfNominalTypeDecl())
+    if (!CurrDeclContext->isTypeContext())
       return;
     if (isa<ProtocolDecl>(CurrDeclContext))
       return;

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -921,7 +921,7 @@ ParserResult<Pattern> Parser::parsePattern() {
   }
     
   case tok::code_complete:
-    if (!CurDeclContext->getSelfNominalTypeDecl()) {
+    if (!CurDeclContext->isTypeContext()) {
       // This cannot be an overridden property, so just eat the token. We cannot
       // code complete anything here -- we expect an identifier.
       consumeToken(tok::code_complete);

--- a/validation-test/IDE/crashers_2_fixed/sr8554.swift
+++ b/validation-test/IDE/crashers_2_fixed/sr8554.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=COMPLETE -source-filename=%s
+
+extension UnknownTy {
+  var #^COMPLETE^#
+}


### PR DESCRIPTION
~`DeclContext::getAsNominalTypeOrNominalTypeExtensionContext()`~ `getSelfNominalTypeDecl()` requires fully parsed AST. Use `isTypeContext()` instead.

https://bugs.swift.org/browse/SR-8554
rdar://problem/43394866
