### PR TITLE
[CodeCompletion] Don't suggest keywords after decl introducer

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -4774,10 +4774,33 @@ void CodeCompletionCallbacksImpl::addKeywords(CodeCompletionResultSink &Sink,
     addAnyTypeKeyword(Sink);
     break;
       
-  case CompletionKind::NominalMemberBeginning:
-    addDeclKeywords(Sink);
-    addLetVarKeywords(Sink);
+  case CompletionKind::NominalMemberBeginning: {
+    bool HasDeclIntroducer = llvm::find_if(ParsedKeywords, [](const StringRef kw) {
+      return llvm::StringSwitch<bool>(kw)
+        .Case("associatedtype", true)
+        .Case("class", true)
+        .Case("deinit", true)
+        .Case("enum", true)
+        .Case("extension", true)
+        .Case("func", true)
+        .Case("import", true)
+        .Case("init", true)
+        .Case("let", true)
+        .Case("operator", true)
+        .Case("precedencegroup", true)
+        .Case("protocol", true)
+        .Case("struct", true)
+        .Case("subscript", true)
+        .Case("typealias", true)
+        .Case("var", true)
+        .Default(false);
+    }) != ParsedKeywords.end();
+    if (!HasDeclIntroducer) {
+      addDeclKeywords(Sink);
+      addLetVarKeywords(Sink);
+    }
     break;
+  }
 
   case CompletionKind::AfterIfStmtElse:
     addKeyword(Sink, "if", CodeCompletionKeywordKind::kw_if);

--- a/test/IDE/complete_declname.swift
+++ b/test/IDE/complete_declname.swift
@@ -4,11 +4,20 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOLNAME | %FileCheck %s --check-prefix=NO_COMPLETIONS
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PRECEDENCEGROUPNAME | %FileCheck %s --check-prefix=NO_COMPLETIONS
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OPERATORNAME | %FileCheck %s --check-prefix=NO_COMPLETIONS
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=LETNAME | %FileCheck %s --check-prefix=NO_COMPLETIONS
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=VARNAME | %FileCheck %s --check-prefix=NO_COMPLETIONS
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPEALIASNAME | %FileCheck %s --check-prefix=NO_COMPLETIONS
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=FUNCNAME | %FileCheck %s --check-prefix=NO_COMPLETIONS
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-keywords=false -code-completion-token=METHODNAME | %FileCheck %s --check-prefix=NO_COMPLETIONS
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-keywords=false -code-completion-token=PROPERTY_LETNAME | %FileCheck %s --check-prefix=NO_COMPLETIONS
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-keywords=false -code-completion-token=PROPERTY_VARNAME | %FileCheck %s --check-prefix=NO_COMPLETIONS
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-keywords=false -code-completion-token=PROPERTY_TYPEALIASNAME | %FileCheck %s --check-prefix=NO_COMPLETIONS
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-keywords=false -code-completion-token=METHODNAME_OVERRIDE | %FileCheck %s --check-prefix=METHODNAME_OVERRIDE
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-keywords=false -code-completion-token=ASSOCIATEDTYPENAME | %FileCheck %s --check-prefix=NO_COMPLETIONS
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-keywords=false -code-completion-token=METHODNAME_PROTOCOL | %FileCheck %s --check-prefix=NO_COMPLETIONS
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-keywords=false -code-completion-token=METHODNAME_CONFORMANCE | %FileCheck %s --check-prefix=METHODNAME_CONFORMANCE
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-keywords=false -code-completion-token=TYPEALIASNAME_CONFORMANCE | %FileCheck %s --check-prefix=TYPEALIASNAME_CONFORMANCE
 
 // NO_COMPLETIONS-NOT: Begin completions
 
@@ -18,10 +27,17 @@ enum #^ENUMNAME^#
 protocol #^PROTOCOLNAME^# {}
 precedencegroup #^PRECEDENCEGROUPNAME^#
 infix operator #^OPERATORNAME^#
+let #^LETNAME^#
+var #^VARNAME^#
+typealias #^TYPEALIASNAME^#
+func #^FUNCNAME^#
 
 class MyCls {
   func foo() {}
   func #^METHODNAME^#
+  let #^PROPERTY_LETNAME^#
+  var #^PROPERTY_VARNAME^#
+  typealias #^PROPERTY_TYPEALIASNAME^#
 }
 
 class MySub : MyCls {
@@ -32,6 +48,8 @@ class MySub : MyCls {
 }
 
 protocol P {
+  associatedtype #^ASSOCIATEDTYPENAME^#
+  associatedtype Assoc
   func foo() {}
   func #^METHODNAME_PROTOCOL^#
 }
@@ -41,4 +59,8 @@ struct MyStruct : P {
 // METHODNAME_CONFORMANCE: Begin completions, 1 items
 // METHODNAME_CONFORMANCE-NEXT: Decl[InstanceMethod]/Super: foo() {|}; name=foo()
 // METHODNAME_CONFORMANCE-NEXT: End completions
+  typealias #^TYPEALIASNAME_CONFORMANCE^#
+// TYPEALIASNAME_CONFORMANCE: Begin completions, 1 items
+// TYPEALIASNAME_CONFORMANCE-NEXT: Decl[AssociatedType]/Super: Assoc = {#(Type)#}; name=Assoc = Type
+// TYPEALIASNAME_CONFORMANCE-NEXT: End completions
 }


### PR DESCRIPTION
If any decl introducers (e.g. `func`, `let`, `typealias`, etc.) are included in parsed keywords, don't emit any keywords in completion.
