### PR TITLE
Add some proper diagnostics to the API digester

### DIFF
--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -93,6 +93,11 @@ ERROR(attr_only_on_parameters, none,
 ERROR(function_type_no_parens,none,
       "single argument function types require parentheses", ())
 
+// FIXME: Used by swift-api-digester. Don't want to set up a separate diagnostics
+// file just for one error.
+ERROR(sdk_node_unrecognized_key,none,
+      "unrecognized key '%0' in SDK node", (StringRef))
+
 //------------------------------------------------------------------------------
 // MARK: Circular reference diagnostics
 //------------------------------------------------------------------------------

--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -94,9 +94,11 @@ ERROR(function_type_no_parens,none,
       "single argument function types require parentheses", ())
 
 // FIXME: Used by swift-api-digester. Don't want to set up a separate diagnostics
-// file just for one error.
+// file just for two errors.
 ERROR(sdk_node_unrecognized_key,none,
       "unrecognized key '%0' in SDK node", (StringRef))
+ERROR(sdk_node_unrecognized_node_kind,none,
+      "unrecognized SDK node kind '%0'", (StringRef))
 
 //------------------------------------------------------------------------------
 // MARK: Circular reference diagnostics

--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -94,11 +94,17 @@ ERROR(function_type_no_parens,none,
       "single argument function types require parentheses", ())
 
 // FIXME: Used by swift-api-digester. Don't want to set up a separate diagnostics
-// file just for two errors.
+// file just for a few errors.
 ERROR(sdk_node_unrecognized_key,none,
       "unrecognized key '%0' in SDK node", (StringRef))
 ERROR(sdk_node_unrecognized_node_kind,none,
       "unrecognized SDK node kind '%0'", (StringRef))
+ERROR(sdk_node_unrecognized_type_attr_kind,none,
+      "unrecognized type attribute '%0' in SDK node", (StringRef))
+ERROR(sdk_node_unrecognized_decl_attr_kind,none,
+      "unrecognized declaration attribute '%0' in SDK node", (StringRef))
+ERROR(sdk_node_unrecognized_decl_kind,none,
+      "unrecognized declaration kind '%0' in SDK node", (StringRef))
 
 //------------------------------------------------------------------------------
 // MARK: Circular reference diagnostics

--- a/include/swift/IDE/APIDigesterData.h
+++ b/include/swift/IDE/APIDigesterData.h
@@ -33,7 +33,7 @@ enum class SDKNodeKind: uint8_t {
 #include "DigesterEnums.def"
 };
 
-SDKNodeKind parseSDKNodeKind(StringRef Content);
+Optional<SDKNodeKind> parseSDKNodeKind(StringRef Content);
 
 enum class NodeAnnotation: uint8_t{
 #define NODE_ANNOTATION(NAME) NAME,

--- a/lib/IDE/APIDigesterData.cpp
+++ b/lib/IDE/APIDigesterData.cpp
@@ -39,10 +39,11 @@ operator<<(raw_ostream &Out, const NodeAnnotation Value) {
   llvm_unreachable("Undefined SDK node kind.");
 }
 
-SDKNodeKind swift::ide::api::parseSDKNodeKind(StringRef Content) {
-  return llvm::StringSwitch<SDKNodeKind>(Content)
+Optional<SDKNodeKind> swift::ide::api::parseSDKNodeKind(StringRef Content) {
+  return llvm::StringSwitch<Optional<SDKNodeKind>>(Content)
 #define NODE_KIND(NAME, VALUE) .Case(#VALUE, SDKNodeKind::NAME)
 #include "swift/IDE/DigesterEnums.def"
+    .Default(None)
   ;
 }
 
@@ -326,7 +327,7 @@ serializeDiffItem(llvm::BumpPtrAllocator &Alloc,
   switch (parseDiffItemKind(DiffItemKind)) {
   case APIDiffItemKind::ADK_CommonDiffItem: {
     return new (Alloc.Allocate<CommonDiffItem>())
-      CommonDiffItem(parseSDKNodeKind(NodeKind),
+      CommonDiffItem(*parseSDKNodeKind(NodeKind),
                      parseSDKNodeAnnotation(NodeAnnotation), ChildIndex,
                      LeftUsr, RightUsr, LeftComment, RightComment, ModuleName);
   }

--- a/test/api-digester/diagnostics.json
+++ b/test/api-digester/diagnostics.json
@@ -2,6 +2,8 @@
   "kind": "Root",
   "name": "TopLevel",
   "printedName": "TopLevel",
-  "children": [],
-  "badKey": ["foo", "bar", "baz"]
+  "badKey": ["foo", "bar", "baz"],
+  "children": [
+    { "kind": "Zyzyx" }
+  ]
 }

--- a/test/api-digester/diagnostics.json
+++ b/test/api-digester/diagnostics.json
@@ -4,6 +4,11 @@
   "printedName": "TopLevel",
   "badKey": ["foo", "bar", "baz"],
   "children": [
-    { "kind": "Zyzyx" }
+    {
+      "kind": "Zyzyx",
+      "typeAttributes": ["autoclosure", "fnord", "inout", "Available"],
+      "declAttributes": ["Available", "Fnord", "ObjC", "inout"],
+      "declKind": "Subroutine"
+    }
   ]
 }

--- a/test/api-digester/diagnostics.json
+++ b/test/api-digester/diagnostics.json
@@ -1,0 +1,7 @@
+{
+  "kind": "Root",
+  "name": "TopLevel",
+  "printedName": "TopLevel",
+  "children": [],
+  "badKey": ["foo", "bar", "baz"]
+}

--- a/test/api-digester/diagnostics.swift
+++ b/test/api-digester/diagnostics.swift
@@ -1,0 +1,7 @@
+// REQUIRES: OS=macosx
+// RUN: not %api-digester -deserialize-sdk -input-paths %S/diagnostics.json -o - 2>&1 | %FileCheck %s
+
+// CHECK: diagnostics.json:6:3: error: unrecognized key 'badKey' in SDK node
+
+// Make sure we don't try to output a result:
+// CHECK-NOT: "kind": "Root",

--- a/test/api-digester/diagnostics.swift
+++ b/test/api-digester/diagnostics.swift
@@ -1,7 +1,8 @@
 // REQUIRES: OS=macosx
 // RUN: not %api-digester -deserialize-sdk -input-paths %S/diagnostics.json -o - 2>&1 | %FileCheck %s
 
-// CHECK: diagnostics.json:6:3: error: unrecognized key 'badKey' in SDK node
+// CHECK: diagnostics.json:5:3: error: unrecognized key 'badKey' in SDK node
+// CHECK: diagnostics.json:7:15: error: unrecognized SDK node kind 'Zyzyx'
 
 // Make sure we don't try to output a result:
 // CHECK-NOT: "kind": "Root",

--- a/test/api-digester/diagnostics.swift
+++ b/test/api-digester/diagnostics.swift
@@ -2,7 +2,12 @@
 // RUN: not %api-digester -deserialize-sdk -input-paths %S/diagnostics.json -o - 2>&1 | %FileCheck %s
 
 // CHECK: diagnostics.json:5:3: error: unrecognized key 'badKey' in SDK node
-// CHECK: diagnostics.json:7:15: error: unrecognized SDK node kind 'Zyzyx'
+// CHECK: diagnostics.json:8:15: error: unrecognized SDK node kind 'Zyzyx'
+// CHECK: diagnostics.json:9:41: error: unrecognized type attribute 'fnord' in SDK node
+// CHECK: diagnostics.json:9:59: error: unrecognized type attribute 'Available' in SDK node
+// CHECK: diagnostics.json:10:39: error: unrecognized declaration attribute 'Fnord' in SDK node
+// CHECK: diagnostics.json:10:56: error: unrecognized declaration attribute 'inout' in SDK node
+// CHECK: diagnostics.json:11:19: error: unrecognized declaration kind 'Subroutine' in SDK node
 
 // Make sure we don't try to output a result:
 // CHECK-NOT: "kind": "Root",

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -1057,7 +1057,14 @@ SDKNode* SDKNode::constructSDKNode(SDKContext &Ctx,
     if (auto keyKind = parseKeyKind(keyString)) {
       switch(*keyKind) {
       case KeyKind::KK_kind:
-        Kind = parseSDKNodeKind(GetScalarString(Pair.getValue()));
+        if (auto parsedKind = parseSDKNodeKind(GetScalarString(Pair.getValue()))) {
+          Kind = *parsedKind;
+        } else {
+          auto range = convertRange(Pair.getValue()->getSourceRange());
+          Ctx.getDiags().diagnose(range.Start, diag::sdk_node_unrecognized_node_kind,
+                                  GetScalarString(Pair.getValue()))
+            .highlight(range);
+        }
         break;
       case KeyKind::KK_name:
         Info.Name = GetScalarString(Pair.getValue());

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -263,6 +263,8 @@ struct ABIAttributeInfo {
 class SDKContext {
   llvm::StringSet<> TextData;
   llvm::BumpPtrAllocator Allocator;
+  llvm::SourceMgr SM;
+  
   UpdatedNodesMap UpdateMap;
   NodeMap TypeAliasUpdateMap;
   NodeMap RevertTypeAliasUpdateMap;
@@ -306,6 +308,9 @@ public:
   }
   TypeMemberDiffVector &getTypeMemberDiffs() {
     return TypeMemberDiffs;
+  }
+  llvm::SourceMgr &getSourceMgr() {
+    return SM;
   }
   bool checkingABI() const { return ABI; }
   ArrayRef<ABIAttributeInfo> getABIAttributeInfo() const { return ABIAttrs; }
@@ -2010,8 +2015,8 @@ parseJsonEmit(SDKContext &Ctx, StringRef FileName) {
     llvm_unreachable("Failed to read JSON file");
   }
   StringRef Buffer = FileBufOrErr->get()->getBuffer();
-  llvm::SourceMgr SM;
-  yaml::Stream Stream(Buffer, SM);
+  yaml::Stream Stream(llvm::MemoryBufferRef(Buffer, FileName),
+                      Ctx.getSourceMgr());
   SDKNode *Result = nullptr;
   for (auto DI = Stream.begin(); DI != Stream.end(); ++ DI) {
     assert(DI != Stream.end() && "Failed to read a document");


### PR DESCRIPTION
Currently, errors in the JSON input data for swift-api-digester cause assertions to fail. Naturally, these errors don't indicate the source location of the problem or any other useful data about it. This PR makes us able to properly diagnose errors using `DiagnosticEngine` and adds errors for five stringly-typed fields, such as object keys and `DeclKind`s.

This definitely needs to be reviewed before it gets merged, because I'm not sure I'm going about this the right way—some parts of `APIContext` here end up duplicating the functionality of `ASTContext`, so it might make more sense to use an `ASTContext` instead, even for subcommands which don't need to manipulate an actual AST. Suggestions are welcome.

(I know that swift-api-digester is intended to be a test tool, but even test tools can benefit from a little polish sometimes—one of these errors made updating stdlib-stable.json after a rebase much easier.)