### PR TITLE
XFAIL test/Profiler/instrprof_tsan.swift

### DIFF
--- a/test/Profiler/instrprof_tsan.swift
+++ b/test/Profiler/instrprof_tsan.swift
@@ -1,5 +1,8 @@
 // RUN: %target-swift-frontend -emit-ir -profile-generate -sanitize=thread %s | %FileCheck %s
 
+// rdar://43422035 unsupported option for target i386-apple-ios
+// XFAIL: CPU=i386
+
 // CHECK: define {{.*}}empty
 // CHECK-NOT: load{{.*}}empty
 // CHECK: ret void


### PR DESCRIPTION
Fails on simulator with  unsupported option '-sanitize=thread' for target 'i386-apple-ios7.0'
rdar://43422035