### PR TITLE
[WIP] Hash table unification

### DIFF
--- a/stdlib/public/SwiftShims/GlobalObjects.h
+++ b/stdlib/public/SwiftShims/GlobalObjects.h
@@ -48,7 +48,7 @@ struct _SwiftUnsafeBitMap {
 struct _SwiftHashTable {
   __swift_intptr_t count;
   __swift_intptr_t capacity;
-  __swift_intptr_t scale;
+  __swift_intptr_t bucketCount;
   void *map;
 };
 

--- a/stdlib/public/SwiftShims/GlobalObjects.h
+++ b/stdlib/public/SwiftShims/GlobalObjects.h
@@ -45,13 +45,6 @@ struct _SwiftUnsafeBitMap {
   __swift_intptr_t bitCount;
 };
 
-struct _SwiftHashTable {
-  __swift_intptr_t count;
-  __swift_intptr_t capacity;
-  __swift_intptr_t bucketCount;
-  void *map;
-};
-
 struct _SwiftDictionaryBodyStorage {
   __swift_intptr_t capacity;
   __swift_intptr_t count;
@@ -61,7 +54,9 @@ struct _SwiftDictionaryBodyStorage {
 };
 
 struct _SwiftSetBodyStorage {
-  struct _SwiftHashTable hashTable;
+  __swift_uint64_t count;
+  __swift_uint64_t capacity;
+  __swift_uint64_t scale;
   __swift_uint64_t seed0;
   __swift_uint64_t seed1;
   void *rawElements;

--- a/stdlib/public/SwiftShims/GlobalObjects.h
+++ b/stdlib/public/SwiftShims/GlobalObjects.h
@@ -46,10 +46,10 @@ struct _SwiftUnsafeBitMap {
 };
 
 struct _SwiftHashTable {
-  __swift_intptr_t scale;
   __swift_intptr_t capacity;
   __swift_intptr_t count;
-  void *rawMap;
+  __swift_intptr_t scale;
+  void *map;
 };
 
 struct _SwiftDictionaryBodyStorage {

--- a/stdlib/public/SwiftShims/GlobalObjects.h
+++ b/stdlib/public/SwiftShims/GlobalObjects.h
@@ -46,8 +46,8 @@ struct _SwiftUnsafeBitMap {
 };
 
 struct _SwiftHashTable {
-  __swift_intptr_t capacity;
   __swift_intptr_t count;
+  __swift_intptr_t capacity;
   __swift_intptr_t scale;
   void *map;
 };

--- a/stdlib/public/SwiftShims/GlobalObjects.h
+++ b/stdlib/public/SwiftShims/GlobalObjects.h
@@ -45,6 +45,13 @@ struct _SwiftUnsafeBitMap {
   __swift_intptr_t bitCount;
 };
 
+struct _SwiftHashTable {
+  __swift_intptr_t scale;
+  __swift_intptr_t capacity;
+  __swift_intptr_t count;
+  void *rawMap;
+};
+
 struct _SwiftDictionaryBodyStorage {
   __swift_intptr_t capacity;
   __swift_intptr_t count;
@@ -54,10 +61,10 @@ struct _SwiftDictionaryBodyStorage {
 };
 
 struct _SwiftSetBodyStorage {
-  __swift_intptr_t capacity;
-  __swift_intptr_t count;
-  struct _SwiftUnsafeBitMap initializedEntries;
-  void *keys;
+  struct _SwiftHashTable hashTable;
+  __swift_uint64_t seed0;
+  __swift_uint64_t seed1;
+  void *rawElements;
 };
 
 struct _SwiftEmptyDictionaryStorage {

--- a/stdlib/public/core/ArrayShared.swift
+++ b/stdlib/public/core/ArrayShared.swift
@@ -61,7 +61,6 @@ func _deallocateUninitializedArray<Element>(
 // Utility method for collections that wish to implement CustomStringConvertible
 // and CustomDebugStringConvertible using a bracketed list of elements,
 // like an array.
-@inlinable // FIXME(sil-serialize-all)
 internal func _makeCollectionDescription<C: Collection>
   (for items: C, withTypeName type: String?) -> String {
   var result = ""

--- a/stdlib/public/core/Bitmap.swift
+++ b/stdlib/public/core/Bitmap.swift
@@ -1,0 +1,361 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A simple bitmap of a fixed number of bits.
+@_fixed_layout
+@usableFromInline
+internal struct _Bitmap {
+  /// The first word's worth of bits.
+  @usableFromInline
+  internal var _word0: Word
+
+  /// The storage holding the rest of the bits.
+  /// Only allocated when we have more bits than can fit in an UInt.
+  @usableFromInline
+  internal var _storage: Storage?
+
+  @inlinable
+  internal init(bitCount: Int) {
+    _word0 = Word(0)
+    if bitCount > UInt.bitWidth {
+      _storage = Storage.allocate(bitCount: bitCount - Word.bitWidth)
+    }
+  }
+}
+
+extension _Bitmap {
+  @inlinable
+  internal var _wordCount: Int {
+    @inline(__always) get {
+      return 1 + (_storage?._wordCount ?? 0)
+    }
+  }
+
+  @inlinable
+  internal var _bitCount: Int {
+    @inline(__always) get {
+      return _wordCount * Word.bitWidth
+    }
+  }
+
+  @inlinable
+  @inline(__always)
+  internal func _isValid(_ element: Int) -> Bool {
+    return element >= 0 && element <= _bitCount
+  }
+
+  @inlinable
+  @inline(__always)
+  internal mutating func isUniquelyReferenced() -> Bool {
+    return _isUnique_native(&_storage)
+  }
+
+  @inlinable
+  @inline(__always)
+  internal mutating func ensureUnique() {
+    let isUnique = isUniquelyReferenced()
+    guard !isUnique, let storage = _storage else { return }
+    _storage = storage.copy()
+  }
+}
+
+extension _Bitmap {
+  @inlinable
+  internal func contains(_ element: Int) -> Bool {
+    precondition(_isValid(element), "Value out of bounds")
+    return _uncheckedContains(element)
+  }
+
+  @inlinable
+  @inline(__always)
+  internal func _uncheckedContains(_ element: Int) -> Bool {
+    _sanityCheck(_isValid(element), "Value out of bounds")
+    let (word, bit) = Word._split(element)
+    if word == 0 {
+      return _word0._uncheckedContains(bit)
+    }
+    return _storage![_unchecked: word - 1]._uncheckedContains(bit)
+  }
+
+  @inlinable
+  @discardableResult
+  internal mutating func insert(
+    _ element: Int
+  ) -> (inserted: Bool, memberAfterInsert: Int) {
+    precondition(_isValid(element), "Value out of bounds")
+    return (_uncheckedInsert(element), element)
+  }
+
+  @inlinable
+  @inline(__always)
+  @discardableResult
+  internal mutating func _uncheckedInsert(_ element: Int) -> Bool {
+    _sanityCheck(_isValid(element), "Value out of bounds")
+    let (word, bit) = Word._split(element)
+    if word == 0 {
+      return _word0._uncheckedInsert(bit)
+    }
+    ensureUnique()
+    return _storage![_unchecked: word - 1]._uncheckedInsert(bit)
+  }
+
+  @inlinable
+  @discardableResult
+  internal mutating func remove(_ element: Int) -> Int? {
+    precondition(_isValid(element), "Value out of bounds")
+    return _uncheckedRemove(element) ? element : nil
+  }
+
+  @inlinable
+  @inline(__always)
+  @discardableResult
+  internal mutating func _uncheckedRemove(_ element: Int) -> Bool {
+    _sanityCheck(_isValid(element), "Value out of bounds")
+    let (word, bit) = Word._split(element)
+    if word == 0 {
+      return _word0._uncheckedRemove(bit)
+    }
+    ensureUnique()
+    return _storage![_unchecked: word - 1]._uncheckedRemove(bit)
+  }
+}
+
+extension _Bitmap {
+  @_fixed_layout
+  @usableFromInline
+  internal struct Word {
+    @usableFromInline
+    internal var _value: UInt
+
+    @inlinable
+    internal init(_ value: UInt) {
+      self._value = value
+    }
+  }
+}
+
+extension _Bitmap.Word {
+  @inlinable
+  internal static var bitWidth: Int {
+    @inline(__always)
+    get {
+      return UInt.bitWidth
+    }
+  }
+
+  @inlinable
+  @inline(__always)
+  internal static func _split(_ value: Int) -> (word: Int, bit: Int) {
+    return (
+      word: value / UInt.bitWidth,
+      bit: value % UInt.bitWidth)
+  }
+
+  @inlinable
+  @inline(__always)
+  internal func _uncheckedContains(_ bit: Int) -> Bool {
+    _sanityCheck(bit >= 0 && bit < UInt.bitWidth)
+    return _value & (1 << bit) != 0
+  }
+
+  @inlinable
+  @inline(__always)
+  internal mutating func _uncheckedInsert(_ bit: Int) -> Bool {
+    _sanityCheck(bit >= 0 && bit < UInt.bitWidth)
+    let mask: UInt = 1 << bit
+    let inserted = _value & mask == 0
+    _value |= mask
+    return inserted
+  }
+
+  @inlinable
+  @inline(__always)
+  internal mutating func _uncheckedRemove(_ bit: Int) -> Bool {
+    _sanityCheck(bit >= 0 && bit < UInt.bitWidth)
+    let mask: UInt = 1 << bit
+    let removed = _value & mask != 0
+    _value &= ~mask
+    return removed
+  }
+}
+
+extension _Bitmap.Word: Sequence, IteratorProtocol {
+  @inlinable
+  internal var count: Int {
+    return _value.nonzeroBitCount
+  }
+
+  @inlinable
+  internal var underestimatedCount: Int {
+    return count
+  }
+
+  @inlinable
+  internal mutating func next() -> Int? {
+    guard _value != 0 else { return nil }
+    let bit = _value.trailingZeroBitCount
+    _value &= ~((1 as UInt) << bit)
+    return bit
+  }
+}
+
+extension _Bitmap {
+  /// A simple bitmap storage class with room for a specific number of
+  /// tail-allocated bits.
+  @_fixed_layout
+  @usableFromInline
+  internal final class Storage {
+    @usableFromInline
+    internal fileprivate(set) var _wordCount: Int
+    internal init(_doNotCall: ()) {
+      _sanityCheckFailure("This class cannot be directly initialized")
+    }
+  }
+}
+
+extension _Bitmap.Storage {
+  @usableFromInline
+  internal typealias Word = _Bitmap.Word
+
+  @inlinable
+  @inline(__always)
+  internal static func wordCount(forBitCount bitCount: Int) -> Int {
+    return (bitCount + Word.bitWidth - 1) / Word.bitWidth
+  }
+
+  internal static func _allocateUninitialized(
+    wordCount: Int
+  ) -> _Bitmap.Storage {
+    let storage = Builtin.allocWithTailElems_1(
+      _Bitmap.Storage.self,
+      wordCount._builtinWordValue, Word.self)
+    storage._wordCount = wordCount
+    return storage
+  }
+
+  @usableFromInline
+  @_effects(releasenone)
+  internal static func allocate(bitCount: Int) -> _Bitmap.Storage {
+    let wordCount = _Bitmap.Storage.wordCount(forBitCount: bitCount)
+    let storage = _allocateUninitialized(wordCount: wordCount)
+    storage._words.initialize(repeating: Word(0), count: storage._wordCount)
+    return storage
+  }
+
+  @usableFromInline
+  @_effects(releasenone)
+  internal func copy() -> _Bitmap.Storage {
+    let storage = _Bitmap.Storage._allocateUninitialized(wordCount: _wordCount)
+    storage._words.initialize(from: self._words, count: storage._wordCount)
+    return storage
+  }
+
+  @inlinable
+  internal var _words: UnsafeMutablePointer<Word> {
+    @inline(__always)
+    get {
+      let addr = Builtin.projectTailElems(self, Word.self)
+      return UnsafeMutablePointer(addr)
+    }
+  }
+
+  @inlinable
+  @inline(__always)
+  internal func _isValid(_ word: Int) -> Bool {
+    return word >= 0 && word < _wordCount
+  }
+
+  @inlinable
+  internal subscript(_unchecked word: Int) -> Word {
+    @inline(__always)
+    get {
+      _sanityCheck(_isValid(word))
+      return _words[word]
+    }
+    @inline(__always)
+    set {
+      _sanityCheck(_isValid(word))
+      _words[word] = newValue
+    }
+  }
+
+  @inlinable
+  internal var count: Int {
+    var count = 0
+    for word in 0 ..< _wordCount {
+      count += _words[word].count
+    }
+    return count
+  }
+}
+
+extension _Bitmap: Sequence {
+  @usableFromInline
+  internal typealias Element = Int
+
+  @inlinable
+  internal var count: Int {
+    var count = _word0.count
+    guard let storage = _storage else { return count }
+    for w in 0 ..< storage._wordCount {
+      count += storage._words[w].count
+    }
+    return count
+  }
+
+  @inlinable
+  internal var underestimatedCount: Int {
+    return count
+  }
+
+  @inlinable
+  func makeIterator() -> Iterator {
+    return Iterator(self)
+  }
+
+  @usableFromInline
+  @_fixed_layout
+  internal struct Iterator: IteratorProtocol {
+    @usableFromInline
+    internal var _word: Word
+    @usableFromInline
+    internal var _wordIndex: Int
+    @usableFromInline
+    internal let _storage: Storage?
+
+    @inlinable
+    internal init(_ bitmap: _Bitmap) {
+      self._word = bitmap._word0
+      self._wordIndex = 0
+      self._storage = bitmap._storage
+    }
+
+    @inlinable
+    internal mutating func next() -> Int? {
+      if let v = _word.next() {
+        return _wordIndex * Word.bitWidth + v
+      }
+      guard let storage = _storage else { return nil }
+      while _wordIndex < storage._wordCount {
+        _word = storage._words[_wordIndex]
+        // Note that _wordIndex is offset by 1 due to word0;
+        // this is why the index needs to be incremented at exactly this point.
+        _wordIndex += 1
+        if let v = _word.next() {
+          return _wordIndex * Word.bitWidth + v
+        }
+      }
+      return nil
+    }
+  }
+}
+

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -31,6 +31,7 @@ set(SWIFTLIB_ESSENTIAL
   Assert.swift
   AssertCommon.swift
   BidirectionalCollection.swift
+  Bitmap.swift
   Bool.swift
   BridgeObjectiveC.swift
   BridgeStorage.swift

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -71,6 +71,7 @@ set(SWIFTLIB_ESSENTIAL
   HashedCollectionsAnyHashableExtensions.swift
   Hasher.swift
   Hashing.swift
+  HashTable.swift
   HeapBuffer.swift
   ICU.swift
   Indices.swift

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1446,7 +1446,7 @@ extension Dictionary: Equatable where Value: Equatable {
 
   #if _runtime(_ObjC)
     case (.cocoa(let lhsCocoa), .cocoa(let rhsCocoa)):
-      return _stdlib_NSObject_isEqual(lhsCocoa.object, rhsCocoa.object)
+      return lhsCocoa == rhsCocoa
 
     case (.native(let lhsNative), .cocoa(let rhsCocoa)):
 
@@ -2957,7 +2957,7 @@ internal struct _CocoaDictionary: _DictionaryBuffer {
     i = i.successor()
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @usableFromInline
   internal func index(forKey key: Key) -> Index? {
     // Fast path that does not involve creating an array of all keys.  In case
     // the key is present, this lookup is a penalty for the slow path, but the
@@ -3033,6 +3033,16 @@ internal struct _CocoaDictionary: _DictionaryBuffer {
       result.count += 1
     }
     return result
+  }
+}
+
+extension _CocoaDictionary: Equatable {
+  @usableFromInline
+  internal static func ==(
+    lhs: _CocoaDictionary,
+    rhs: _CocoaDictionary
+  ) -> Bool {
+    return _stdlib_NSObject_isEqual(lhs.object, rhs.object)
   }
 }
 #endif

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1338,7 +1338,6 @@ extension Dictionary {
       return true
     }
 
-    @inlinable
     public var description: String {
       return _makeCollectionDescription(for: self, withTypeName: nil)
     }
@@ -1409,7 +1408,6 @@ extension Dictionary {
       return count == 0
     }
 
-    @inlinable
     public var description: String {
       return _makeCollectionDescription(for: self, withTypeName: nil)
     }

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -112,8 +112,9 @@
         "SwiftNativeNSArray.swift"],
       "HashedCollections": [
         "Dictionary.swift",
-        "HashedCollectionsAnyHashableExtensions.swift",
         "Set.swift",
+        "HashedCollectionsAnyHashableExtensions.swift",
+        "HashTable.swift"
       ]
     }
   ],

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -166,12 +166,15 @@
   "Playground": [
     "PlaygroundDisplay.swift"
   ],
-  "Misc": [
-    "AnyHashable.swift",
-    "Interval.swift",
-    "Hashing.swift",
-    "SipHash.swift",
+  "Hashing": [
+    "Hashable.swift",
     "Hasher.swift",
+    "SipHash.swift",
+    "AnyHashable.swift",
+    "Hashing.swift"
+  ],
+  "Misc": [
+    "Interval.swift",
     "ErrorType.swift",
     "InputStream.swift",
     "LifetimeManager.swift",
@@ -196,7 +199,6 @@
     "DebuggerSupport.swift",
     "Equatable.swift",
     "Comparable.swift",
-    "Hashable.swift",
     "Codable.swift",
     "MigrationSupport.swift"
   ]

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -171,7 +171,8 @@
     "Hasher.swift",
     "SipHash.swift",
     "AnyHashable.swift",
-    "Hashing.swift"
+    "Hashing.swift",
+    "Bitmap.swift"  
   ],
   "Misc": [
     "Interval.swift",

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -19,9 +19,9 @@ internal protocol _HashTableDelegate {
 @_fixed_layout
 internal struct _HashTable {
   @usableFromInline
-  internal let capacity: Int
-  @usableFromInline
   internal var count: Int
+  @usableFromInline
+  internal let capacity: Int
 
   // Bits 0..<6 hold the size scale.
   // Bits 6... are reserved for future use. (E.g., remembering reserveCapacity
@@ -31,14 +31,11 @@ internal struct _HashTable {
 
   internal let map: UnsafeMutablePointer<MapEntry>
 
-  internal init(scale: Int, count: Int, map: UnsafeMutablePointer<MapEntry>) {
+  internal init(scale: Int, map: UnsafeMutablePointer<MapEntry>) {
     _sanityCheck(scale >= 0 && scale < Int.bitWidth - 1)
-    _sanityCheck(count >= 0 && count < (1 << scale) - 1)
-    let capacity = _HashTable.capacity(forScale: scale)
-    _sanityCheck(count <= capacity)
-    self.capacity = capacity
-    self.count = count
     self.limits = scale
+    self.count = 0
+    self.capacity = _HashTable.capacity(forScale: scale)
     self.map = map
 
     map.assign(repeating: .unoccupied, count: bucketCount)

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -74,7 +74,7 @@ extension _HashTable {
 }
 
 extension _HashTable {
-  internal struct MapEntry: Equatable {
+  internal struct MapEntry {
     internal static var payloadMask: UInt8 { return 0x7F }
     internal static var unoccupied: MapEntry { return MapEntry(_value: 0) }
 
@@ -110,6 +110,15 @@ extension _HashTable {
   }
 }
 
+extension _HashTable.MapEntry: Equatable {
+  @inline(__always)
+  internal static func ==(
+    lhs: _HashTable.MapEntry,
+    rhs: _HashTable.MapEntry
+  ) -> Bool {
+    return lhs.value == rhs.value
+  }
+}
 extension _HashTable {
   @inlinable
   internal var scale: Int {

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -1,0 +1,441 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+internal protocol _HashTableDelegate {
+  func hashValue(at index: _HashTable.Index) -> Int
+  func moveEntry(from source: _HashTable.Index, to target: _HashTable.Index)
+}
+
+@usableFromInline
+@_fixed_layout
+internal struct _HashTable {
+  @usableFromInline
+  internal let scale: Int
+  @usableFromInline
+  internal let capacity: Int
+  @usableFromInline
+  internal var count: Int
+  @usableFromInline
+  internal let rawMap: UnsafeMutableRawPointer
+
+  internal init(scale: Int, count: Int, map: UnsafeMutablePointer<MapEntry>) {
+    _sanityCheck(scale >= 0 && scale < Int.bitWidth - 1)
+    _sanityCheck(count >= 0 && count < (1 << scale) - 1)
+    let capacity = Int(Double(1 &<< scale) / _HashTable.maxLoadFactorInverse)
+    _sanityCheck(count <= capacity)
+    self.scale = scale
+    self.capacity = capacity
+    self.count = count
+    self.rawMap = UnsafeMutableRawPointer(map)
+
+    map.assign(repeating: .unoccupied, count: bucketCount)
+  }
+}
+
+extension _HashTable {
+  /// The inverse of the hash table load factor.
+  @_transparent
+  private static var maxLoadFactorInverse: Double {
+    return 4 / 3
+  }
+
+  @usableFromInline
+  internal static func scale(
+    forCapacity capacity: Int
+  ) -> Int {
+    let capacity = Swift.max(capacity, 1)
+    // `capacity + 1` below ensures that we don't fill in the last hole.
+    let bucketCount = Swift.max(
+      Int((Double(capacity) * maxLoadFactorInverse).rounded(.up)),
+      capacity + 1)
+    // Actual bucket count is the next power of two greater than or equal to the
+    // minimum count satisying the load factor constraint.
+    let scale = (Swift.max(bucketCount, 2) - 1)._binaryLogarithm() + 1
+    _sanityCheck(scale < Int.bitWidth)
+    return scale
+  }
+}
+
+extension _HashTable {
+  internal struct MapEntry: Equatable {
+    internal static var payloadMask: UInt8 { return 0x7F }
+    internal static var unoccupied: MapEntry { return MapEntry(_value: 0) }
+
+    internal var value: UInt8
+
+    @inline(__always)
+    private init(_value: UInt8) {
+      self.value = _value
+    }
+
+    @inline(__always)
+    internal init(payload: UInt8) {
+      _sanityCheck(payload < 0x80)
+      self.init(_value: 0x80 | payload)
+    }
+
+    internal var isOccupied: Bool {
+      @inline(__always) get { return value & 0x80 != 0 }
+    }
+
+    internal var payload: UInt8 {
+      @inline(__always) get {
+        return value & _HashTable.MapEntry.payloadMask
+      }
+    }
+
+    @inline(__always)
+    internal static func forHashValue(_ hashValue: Int) -> MapEntry {
+      let payload = hashValue &>> (Int.bitWidth &- 7)
+      return MapEntry(
+        payload: UInt8(truncatingIfNeeded: payload) & MapEntry.payloadMask)
+    }
+  }
+
+  internal var map: UnsafeMutablePointer<MapEntry> {
+    @inline(__always)
+    get {
+      return rawMap.assumingMemoryBound(to: MapEntry.self)
+    }
+  }
+}
+
+extension _HashTable {
+  @usableFromInline
+  internal var bucketCount: Int {
+    @inline(__always) get {
+      return 1 &<< scale
+    }
+  }
+
+  @usableFromInline
+  internal var bucketMask: Int {
+    @inline(__always) get {
+      // The bucket count is a positive power of two, so subtracting 1 will
+      // never overflow and get us a nice mask.
+      return bucketCount &- 1
+    }
+  }
+
+  @inlinable
+  @inline(__always)
+  internal func _isValid(_ bucket: Int) -> Bool {
+    return bucket >= 0 && bucket < bucketCount
+  }
+
+  @usableFromInline
+  @_effects(readonly)
+  internal func _isOccupied(_ bucket: Int) -> Bool {
+    _sanityCheck(_isValid(bucket))
+    return map[bucket].isOccupied
+  }
+
+  /// The next bucket after `bucket`, with wraparound at the end of the table.
+  internal func _succ(_ bucket: Int) -> Int {
+    // Bucket is less than bucketCount, which is power of two less than
+    // Int.max. Therefore adding 1 does not overflow.
+    return (bucket &+ 1) & bucketMask
+  }
+
+  /// The previous bucket after `bucket`, with wraparound at the beginning of
+  /// the table.
+  internal func _pred(_ bucket: Int) -> Int {
+    // Bucket is not negative. Therefore subtracting 1 does not overflow.
+    return (bucket &- 1) & bucketMask
+  }
+
+  /// The next unoccupied bucket after `bucket`, with wraparound.
+  internal func _nextHole(atOrAfter bucket: Int) -> Int {
+    var bucket = bucket
+    while map[bucket].isOccupied {
+      bucket = _succ(bucket)
+    }
+    return bucket
+  }
+
+  /// The next unoccupied bucket after `bucket`, with wraparound.
+  internal func _nextHole(after bucket: Int) -> Int {
+    return _nextHole(atOrAfter: _succ(bucket))
+  }
+
+  /// The previous unoccupied bucket before `bucket`, with wraparound.
+  internal func _prevHole(before bucket: Int) -> Int {
+    var bucket = _pred(bucket)
+    while map[bucket].isOccupied {
+      bucket = _pred(bucket)
+    }
+    return bucket
+  }
+
+  /// The next occupied bucket after `bucket`, without wraparound.
+  internal func _occupiedBucket(after bucket: Int) -> Int {
+    _sanityCheck(bucket < bucketCount)
+    var bucket = bucket + 1
+    while bucket < bucketCount && !map[bucket].isOccupied {
+      bucket += 1
+    }
+    return bucket
+  }
+}
+
+extension _HashTable {
+  @_fixed_layout
+  @usableFromInline
+  internal struct OccupiedIndices: Sequence, IteratorProtocol {
+    internal var bucket: Int
+    internal let count: Int
+    internal let base: UnsafeMutablePointer<MapEntry>
+
+    @usableFromInline
+    @_effects(releasenone)
+    internal init(
+      base: UnsafeMutableRawPointer,
+      count: Int) {
+      self.bucket = -1
+      self.count = count
+      self.base = base.assumingMemoryBound(to: MapEntry.self)
+    }
+
+    @usableFromInline
+    @_effects(releasenone)
+    internal mutating func next() -> Index? {
+      guard bucket != count else { return nil }
+      bucket += 1
+      while bucket != count && !base[bucket].isOccupied {
+        bucket += 1
+      }
+      guard bucket != count else { return nil }
+      return Index(bucket: bucket)
+    }
+  }
+
+  @inlinable
+  var occupiedIndices: OccupiedIndices {
+    return OccupiedIndices(base: rawMap, count: bucketCount)
+  }
+}
+
+extension _HashTable {
+  @_fixed_layout
+  @usableFromInline
+  internal struct Index {
+    @usableFromInline
+    internal var bucket: Int
+
+    @inlinable
+    internal init(bucket: Int) {
+      self.bucket = bucket
+    }
+  }
+}
+
+extension _HashTable.Index: Equatable {
+  @inlinable
+  internal
+  static func ==(lhs: _HashTable.Index, rhs: _HashTable.Index) -> Bool {
+    return lhs.bucket == rhs.bucket
+  }
+}
+
+extension _HashTable.Index: Comparable {
+  @inlinable
+  internal
+  static func < (lhs: _HashTable.Index, rhs: _HashTable.Index) -> Bool {
+    return lhs.bucket < rhs.bucket
+  }
+}
+
+
+extension _HashTable {
+  @inlinable
+  internal func isValid(_ i: Index) -> Bool {
+    return _isValid(i.bucket)
+  }
+
+  @usableFromInline
+  @_effects(readonly)
+  internal func isOccupied(_ i: Index) -> Bool {
+    return _isValid(i.bucket) && _isOccupied(i.bucket)
+  }
+
+  @usableFromInline
+  @_effects(readonly)
+  internal func checkOccupied(_ i: Index) {
+    _precondition(isOccupied(i),
+      "Attempting to access Collection elements using an invalid Index")
+  }
+
+  @usableFromInline
+  internal var startIndex: Index {
+    @_effects(readonly)
+    get {
+      // We start at "bucket after -1" instead of "0" because we need to find
+      // the first occupied slot.
+      return Index(bucket: _occupiedBucket(after: -1))
+    }
+  }
+
+  @inlinable
+  internal var endIndex: Index {
+    return Index(bucket: bucketCount)
+  }
+
+  @usableFromInline
+  @_effects(readonly)
+  internal func index(after i: Index) -> Index {
+    checkOccupied(i)
+    return Index(bucket: _occupiedBucket(after: i.bucket))
+  }
+
+  /// Return the bucket for the first member that may have a matching hash
+  /// value, or if there's no such member, return an unoccupied bucket that is
+  /// suitable for inserting a new member with the specified hash value.
+  @usableFromInline
+  @_effects(readonly)
+  internal func lookupFirst(hashValue: Int) -> (index: Index, found: Bool) {
+    let index = Index(bucket: hashValue & bucketMask)
+    let entry = MapEntry.forHashValue(hashValue)
+    return _lookupChain(startingAt: index, lookingFor: entry)
+  }
+
+  /// Return the next bucket after `bucket` in the collision chain for the
+  /// specified hash value. `bucket` must have been returned by `lookupFirst` or
+  /// `lookupNext`, with `found == true`.
+  @usableFromInline
+  @_effects(readonly)
+  internal func lookupNext(
+    hashValue: Int,
+    after index: Index
+  ) -> (index: Index, found: Bool) {
+    let bucket = _succ(index.bucket)
+    let entry = MapEntry.forHashValue(hashValue)
+    return _lookupChain(startingAt: Index(bucket: bucket), lookingFor: entry)
+  }
+
+  internal func _lookupChain(
+    startingAt index: Index,
+    lookingFor entry: MapEntry
+  ) -> (index: Index, found: Bool) {
+    var bucket = index.bucket
+    // We guarantee there's always a hole in the table, so we just loop until we
+    // find one.
+    while true {
+      switch map[bucket] {
+      case entry:
+        return (Index(bucket: bucket), true)
+      case MapEntry.unoccupied:
+        return (Index(bucket: bucket), false)
+      default:
+        bucket = _succ(bucket)
+      }
+    }
+  }
+
+
+  @usableFromInline
+  @_effects(releasenone)
+  internal mutating func copyContents(of other: _HashTable) {
+    _sanityCheck(scale == other.scale)
+    self.count = other.count
+    self.map.assign(from: other.map, count: self.bucketCount)
+  }
+
+  /// Insert a new entry with the specified hash value into the table.
+  /// The entry must not already exist in the table -- duplicates are ignored.
+  @usableFromInline
+  @_effects(releasenone)
+  internal mutating func insertNew(hashValue: Int) -> Index {
+    _sanityCheck(count < capacity)
+    let bucket = _nextHole(atOrAfter: hashValue & bucketMask)
+    map[bucket] = MapEntry.forHashValue(hashValue)
+    count += 1
+    return Index(bucket: bucket)
+  }
+
+  /// Insert a new entry for an element with the specified hash value at
+  /// `bucket`. The bucket must have been returned by `lookupFirst` or
+  /// `lookupNext` for the same hash value, with `found == false`.
+  @usableFromInline
+  @_effects(releasenone)
+  internal mutating func insert(hashValue: Int, at index: Index) {
+    _sanityCheck(count < capacity)
+    _sanityCheck(!map[index.bucket].isOccupied)
+    map[index.bucket] = MapEntry.forHashValue(hashValue)
+    count += 1
+  }
+
+  internal mutating func removeAll() {
+    map.assign(repeating: .unoccupied, count: bucketCount)
+    count = 0
+  }
+
+  @inline(__always)
+  internal mutating func delete<D: _HashTableDelegate>(
+    at index: Index,
+    hashValue: Int,
+    with delegate: D
+  ) {
+    _sanityCheck(map[index.bucket] == MapEntry.forHashValue(hashValue))
+
+    // Remove the element.
+    self.count -= 1
+
+    let idealBucket = hashValue & bucketMask
+
+    // If we've put a hole in a chain of contiguous elements, some element after
+    // the hole may belong where the new hole is.
+    var hole = index.bucket
+
+    // Find the first and last buckets in the contiguous chain containing hole.
+    let start = _prevHole(before: idealBucket)
+    let end = _pred(_nextHole(after: hole))
+
+    // Relocate out-of-place elements in the chain, repeating until none are
+    // found.
+    while hole != end {
+      // Walk backwards from the end of the chain looking for something out of
+      // place.
+      // FIXME: Walking forwards may be more efficient if we expect long chains.
+      var candidate = end
+      while candidate != hole {
+        let candidateHash = delegate.hashValue(at: Index(bucket: candidate))
+        _sanityCheck(map[candidate] == MapEntry.forHashValue(candidateHash))
+        let ideal = candidateHash & bucketMask
+
+        // Does this element belong between start and hole?  We need two
+        // separate tests depending on whether [start, hole] wraps around the
+        // end of the storage.
+        let c0 = ideal >= start
+        let c1 = ideal <= hole
+        if start <= hole ? (c0 && c1) : (c0 || c1) {
+          break // Found it
+        }
+        candidate = _pred(candidate)
+      }
+
+      if candidate == hole {
+        // No out-of-place elements found. It is safe to leave the hole in
+        // place; we're done adjusting.
+        break
+      }
+
+      // Move the found element into the hole.
+      map[hole] = map[candidate]
+      delegate.moveEntry(
+        from: Index(bucket: candidate),
+        to: Index(bucket: hole))
+      hole = candidate
+    }
+    // Mark new hole as empty.
+    map[hole] = .unoccupied
+  }
+}

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -72,8 +72,12 @@ extension _HashTable {
 
 extension _HashTable {
   internal struct MapEntry {
-    internal static var payloadMask: UInt8 { return 0x7F }
-    internal static var unoccupied: MapEntry { return MapEntry(_value: 0) }
+    internal static var payloadMask: UInt8 {
+      @inline(__always) get { return 0x7F }
+    }
+    internal static var unoccupied: MapEntry {
+      @inline(__always) get { return MapEntry(_value: 0) }
+    }
 
     internal var value: UInt8
 

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -442,6 +442,15 @@ extension _HashTable {
 }
 
 extension _HashTable {
+  // Create a bitmap of the same size as this hash table's bucket count.
+  @usableFromInline
+  @_effects(releasenone)
+  internal func createBitmap() -> _Bitmap {
+    return _Bitmap(bitCount: self.bucketCount)
+  }
+}
+
+extension _HashTable {
   internal func _invariantCheck(with delegate: _HashTableDelegate) {
 #if INTERNAL_CHECKS_ENABLED
     _sanityCheck(scale >= 0 && scale < Int.bitWidth - 1,

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -161,6 +161,7 @@ extension _HashTable {
   }
 
   /// The next bucket after `bucket`, with wraparound at the end of the table.
+  @inline(__always)
   internal func _succ(_ bucket: Int) -> Int {
     // Bucket is less than bucketCount, which is power of two less than
     // Int.max. Therefore adding 1 does not overflow.
@@ -169,6 +170,7 @@ extension _HashTable {
 
   /// The previous bucket after `bucket`, with wraparound at the beginning of
   /// the table.
+  @inline(__always)
   internal func _pred(_ bucket: Int) -> Int {
     // Bucket is not negative. Therefore subtracting 1 does not overflow.
     return (bucket &- 1) & bucketMask
@@ -254,6 +256,7 @@ extension _HashTable {
     internal var bucket: Int
 
     @inlinable
+    @inline(__always)
     internal init(bucket: Int) {
       self.bucket = bucket
     }
@@ -262,6 +265,7 @@ extension _HashTable {
 
 extension _HashTable.Index: Equatable {
   @inlinable
+  @inline(__always)
   internal
   static func ==(lhs: _HashTable.Index, rhs: _HashTable.Index) -> Bool {
     return lhs.bucket == rhs.bucket
@@ -270,6 +274,7 @@ extension _HashTable.Index: Equatable {
 
 extension _HashTable.Index: Comparable {
   @inlinable
+  @inline(__always)
   internal
   static func < (lhs: _HashTable.Index, rhs: _HashTable.Index) -> Bool {
     return lhs.bucket < rhs.bucket
@@ -307,9 +312,9 @@ extension _HashTable {
     }
   }
 
-  @usableFromInline
+  @inlinable
   internal var endIndex: Index {
-    @_effects(readonly)
+    @inline(__always)
     get {
       return Index(bucket: bucketCount)
     }
@@ -347,6 +352,7 @@ extension _HashTable {
     return _lookupChain(startingAt: Index(bucket: bucket), lookingFor: entry)
   }
 
+  @inline(__always)
   internal func _lookupChain(
     startingAt index: Index,
     lookingFor entry: MapEntry

--- a/stdlib/public/core/Hasher.swift
+++ b/stdlib/public/core/Hasher.swift
@@ -332,6 +332,13 @@ public struct Hasher {
     }
   }
 
+  /// Generate a new random seed using `SystemRandomNumberGenerator`.
+  @inlinable
+  internal static func _randomSeed() -> _Seed {
+    var random = SystemRandomNumberGenerator()
+    return (random.next(), random.next())
+  }
+
   /// Adds the given value to this hasher, mixing its essential parts into the
   /// hasher state.
   ///

--- a/stdlib/public/core/Hashing.swift
+++ b/stdlib/public/core/Hashing.swift
@@ -29,8 +29,6 @@ internal var _hashContainerDefaultMaxLoadFactorInverse: Double {
 ///
 /// This function is part of the runtime because `Bool` type is bridged to
 /// `ObjCBool`, which is in Foundation overlay.
-/// FIXME(sil-serialize-all): this should be internal
-@usableFromInline // FIXME(sil-serialize-all)
 @_silgen_name("swift_stdlib_NSObject_isEqual")
 internal func _stdlib_NSObject_isEqual(_ lhs: AnyObject, _ rhs: AnyObject) -> Bool
 #endif

--- a/stdlib/public/core/Hashing.swift
+++ b/stdlib/public/core/Hashing.swift
@@ -111,7 +111,7 @@ final internal class _SwiftEmptyNSEnumerator
 /// Using a dedicated class for this rather than a _HeapBuffer makes it easy to
 /// recognize these in heap dumps etc.
 internal final class _BridgingHashBuffer {
-  internal var _bucketCount: Int
+  internal var _entryCount: Int
 
   // This type is made with allocWithTailElems, so no init is ever called.
   // But we still need to have an init to satisfy the compiler.
@@ -119,16 +119,16 @@ internal final class _BridgingHashBuffer {
     _sanityCheckFailure("This class cannot be directly initialized")
   }
 
-  internal static func create(bucketCount: Int) -> _BridgingHashBuffer {
+  internal static func create(entryCount: Int) -> _BridgingHashBuffer {
     let object = Builtin.allocWithTailElems_1(
       _BridgingHashBuffer.self,
-      bucketCount._builtinWordValue, AnyObject.self)
-    object._bucketCount = bucketCount
+      entryCount._builtinWordValue, AnyObject.self)
+    object._entryCount = entryCount
     return object
   }
 
   deinit {
-    _sanityCheck(_bucketCount == -1)
+    _sanityCheck(_entryCount == -1)
   }
 
   private var _baseAddress: UnsafeMutablePointer<AnyObject> {
@@ -137,20 +137,20 @@ internal final class _BridgingHashBuffer {
   }
 
   internal subscript(index: _HashTable.Index) -> AnyObject {
-    _sanityCheck(index.bucket >= 0 && index.bucket < _bucketCount)
-    return _baseAddress[index.bucket]
+    _sanityCheck(index.offset >= 0 && index.offset < _entryCount)
+    return _baseAddress[index.offset]
   }
 
   internal func initialize(at index: _HashTable.Index, to object: AnyObject) {
-    _sanityCheck(index.bucket >= 0 && index.bucket < _bucketCount)
-    (_baseAddress + index.bucket).initialize(to: object)
+    _sanityCheck(index.offset >= 0 && index.offset < _entryCount)
+    (_baseAddress + index.offset).initialize(to: object)
   }
 
-  internal func invalidate(with indices: _HashTable.OccupiedIndices) {
+  internal func invalidate(with indices: _HashTable.Indices) {
     for index in indices {
-      (_baseAddress + index.bucket).deinitialize(count: 1)
+      (_baseAddress + index.offset).deinitialize(count: 1)
     }
-    _bucketCount = -1
+    _entryCount = -1
   }
 }
 #endif

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1969,14 +1969,16 @@ extension _NativeSet {
     hashValue: Int
   ) -> (index: Index, found: Bool) {
     var (index, found) = _storage.hashTable.lookupFirst(hashValue: hashValue)
-    while found {
-      if uncheckedElement(at: index) == element {
-        return (index, true)
-      }
+    if _fastPath(!found || uncheckedElement(at: index) == element) {
+      return (index, found)
+    }
+    while true {
       (index, found) =
         _storage.hashTable.lookupNext(hashValue: hashValue, after: index)
+      if !found || uncheckedElement(at: index) == element {
+        return (index, found)
+      }
     }
-    return (index, false)
   }
 }
 

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -2036,10 +2036,19 @@ extension _NativeSet {
   }
 
   @inlinable
-  internal mutating func update(with element: Element, isUnique: Bool) -> Element? {
-    _ = ensureUnique(isUnique: isUnique, capacity: count + 1)
-    let hashValue = self.hashValue(for: element)
-    let (index, found) = find(element, hashValue: hashValue)
+  internal mutating func update(
+    with element: Element,
+    isUnique: Bool
+  ) -> Element? {
+    var hashValue = self.hashValue(for: element)
+    var (index, found) = find(element, hashValue: hashValue)
+    let (_, rehashed) = ensureUnique(
+      isUnique: isUnique,
+      capacity: count + (found ? 0 : 1))
+    if rehashed {
+      hashValue = self.hashValue(for: element)
+      (index, found) = find(element, hashValue: hashValue)
+    }
     if found {
       let old = (elements + index.bucket).move()
       uncheckedInitializeElement(at: index, to: element)

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1720,7 +1720,6 @@ internal struct _NativeSet<Element: Hashable> {
 }
 
 extension _NativeSet {
-  @inlinable
   internal var bucketCount: Int {
     return _assumeNonNegative(_storage.hashTable.bucketCount)
   }

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -852,9 +852,7 @@ extension Set: SetAlgebra {
   @inlinable
   public func isStrictSuperset<S: Sequence>(of possibleStrictSubset: S) -> Bool
     where S.Element == Element {
-    if possibleStrictSubset.underestimatedCount >= self.count {
-      return false
-    }
+    if isEmpty { return false }
     if let s = possibleStrictSubset as? Set<Element> {
       return isStrictSuperset(of: s)
     }

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -3501,3 +3501,28 @@ extension Set {
     }
   }
 }
+
+extension Set {
+  @usableFromInline // @testable
+  internal func _invariantCheck() {
+#if INTERNAL_CHECKS_ENABLED
+    guard case .native(let native) = self._variant else {
+      return
+    }
+    native._invariantCheck()
+#endif
+  }
+}
+
+extension _NativeSet {
+  @usableFromInline // @testable
+  internal func _invariantCheck() {
+#if INTERNAL_CHECKS_ENABLED
+    _sanityCheck(
+      _storage === _SwiftRawSetStorage.empty ||
+      _isValidAddress(UInt(bitPattern: _storage.rawElements)),
+    "Invalid rawElements pointer")
+    _storage.hashTable._invariantCheck(with: self)
+#endif
+  }
+}

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1059,7 +1059,6 @@ extension Set: SetAlgebra {
 
 extension Set: CustomStringConvertible, CustomDebugStringConvertible {
   /// A string that represents the contents of the set.
-  @inlinable
   public var description: String {
     return _makeCollectionDescription(for: self, withTypeName: nil)
   }

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1423,7 +1423,7 @@ internal class _SwiftRawSetStorage: _SwiftNativeNSSet {
   internal final var hashTable: _HashTable
 
   @usableFromInline
-  internal var seed: (UInt64, UInt64)
+  internal var seed: Hasher._Seed
 
   @usableFromInline
   @nonobjc

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -440,7 +440,7 @@ extension Set: Equatable {
 
   #if _runtime(_ObjC)
     case (.cocoa(let lhsCocoa), .cocoa(let rhsCocoa)):
-      return _stdlib_NSObject_isEqual(lhsCocoa.object, rhsCocoa.object)
+      return lhsCocoa == rhsCocoa
 
     case (.native(let lhsNative), .cocoa(let rhsCocoa)):
       if lhsNative.count != rhsCocoa.count {
@@ -2432,6 +2432,13 @@ internal struct _CocoaSet {
   }
 }
 
+extension _CocoaSet: Equatable {
+  @usableFromInline
+  internal static func ==(lhs: _CocoaSet, rhs: _CocoaSet) -> Bool {
+    return _stdlib_NSObject_isEqual(lhs.object, rhs.object)
+  }
+}
+
 extension _CocoaSet: _SetBuffer {
   @usableFromInline
   internal typealias Element = AnyObject
@@ -2495,7 +2502,7 @@ extension _CocoaSet: _SetBuffer {
     return object.member(element) != nil
   }
 
-  @inlinable
+  @usableFromInline
   internal func element(at i: Index) -> AnyObject {
     let value: AnyObject? = i.allKeys[i.currentKeyIndex]
     _sanityCheck(value != nil, "Item not found in underlying NSSet")

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -881,9 +881,16 @@ extension Set: SetAlgebra {
   @inlinable
   public func isDisjoint<S: Sequence>(with other: S) -> Bool
     where S.Element == Element {
-    // FIXME(performance): Don't need to build a set.
-    let otherSet = Set(other)
-    return isDisjoint(with: otherSet)
+    return _isDisjoint(with: other)
+  }
+
+  @inlinable
+  internal func _isDisjoint<S: Sequence>(with other: S) -> Bool
+    where S.Element == Element {
+    for element in other {
+      if self.contains(element) { return false }
+    }
+    return true
   }
 
   /// Returns a new set with the elements of both this set and the given
@@ -1290,12 +1297,7 @@ extension Set {
   ///   otherwise, `false`.
   @inlinable
   public func isDisjoint(with other: Set<Element>) -> Bool {
-    for member in self {
-      if other.contains(member) {
-        return false
-      }
-    }
-    return true
+    return _isDisjoint(with: other)
   }
 
   /// Returns a new set containing the elements of this set that do not occur

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -185,11 +185,6 @@ extension Set {
   }
 #endif
 
-  //
-  // All APIs below should dispatch to `_variant`, without doing any
-  // additional processing.
-  //
-
 #if _runtime(_ObjC)
   /// Private initializer used for bridging.
   ///
@@ -276,11 +271,13 @@ extension Set: Sequence {
   /// - Complexity: O(1)
   @inlinable
   public func contains(_ member: Element) -> Bool {
+    defer { _fixLifetime(self) }
     return _variant.contains(member)
   }
 
   @inlinable
   public func _customContainsEquatableElement(_ member: Element) -> Bool? {
+    defer { _fixLifetime(self) }
     return contains(member)
   }
 }
@@ -327,6 +324,7 @@ extension Set: Collection {
   /// If the set is empty, `startIndex` is equal to `endIndex`.
   @inlinable
   public var startIndex: Index {
+    defer { _fixLifetime(self) }
     return _variant.startIndex
   }
 
@@ -336,17 +334,20 @@ extension Set: Collection {
   /// If the set is empty, `endIndex` is equal to `startIndex`.
   @inlinable
   public var endIndex: Index {
+    defer { _fixLifetime(self) }
     return _variant.endIndex
   }
 
   /// Accesses the member at the given position.
   @inlinable
   public subscript(position: Index) -> Element {
+    defer { _fixLifetime(self) }
     return _variant.element(at: position)
   }
 
   @inlinable
   public func index(after i: Index) -> Index {
+    defer { _fixLifetime(self) }
     return _variant.index(after: i)
   }
 
@@ -362,6 +363,7 @@ extension Set: Collection {
   /// - Complexity: O(1)
   @inlinable
   public func firstIndex(of member: Element) -> Index? {
+    defer { _fixLifetime(self) }
     return _variant.index(for: member)
   }
 
@@ -369,6 +371,7 @@ extension Set: Collection {
   public func _customIndexOfEquatableElement(
      _ member: Element
     ) -> Index?? {
+    defer { _fixLifetime(self) }
     return Optional(firstIndex(of: member))
   }
 
@@ -376,6 +379,7 @@ extension Set: Collection {
   public func _customLastIndexOfEquatableElement(
      _ member: Element
     ) -> Index?? {
+    defer { _fixLifetime(self) }
     // The first and last elements are the same because each element is unique.
     return _customIndexOfEquatableElement(member)
   }
@@ -402,6 +406,7 @@ extension Set: Collection {
   /// If the set is empty, the value of this property is `nil`.
   @inlinable
   public var first: Element? {
+    defer { _fixLifetime(self) }
     // FIXME: It'd better to use an iterator than to subscript with startIndex,
     // because startIndex is currently O(n) in bridged sets. However,
     // enumerators aren't guaranteed to have the same element order as allKeys.
@@ -579,6 +584,7 @@ extension Set: SetAlgebra {
   public mutating func insert(
     _ newMember: Element
   ) -> (inserted: Bool, memberAfterInsert: Element) {
+    defer { _fixLifetime(self) }
     return _variant.insert(newMember)
   }
 
@@ -605,6 +611,7 @@ extension Set: SetAlgebra {
   @inlinable
   @discardableResult
   public mutating func update(with newMember: Element) -> Element? {
+    defer { _fixLifetime(self) }
     return _variant.update(with: newMember)
   }
 
@@ -625,6 +632,7 @@ extension Set: SetAlgebra {
   @inlinable
   @discardableResult
   public mutating func remove(_ member: Element) -> Element? {
+    defer { _fixLifetime(self) }
     return _variant.remove(member)
   }
 
@@ -637,6 +645,7 @@ extension Set: SetAlgebra {
   @inlinable
   @discardableResult
   public mutating func remove(at position: Index) -> Element {
+    defer { _fixLifetime(self) }
     return _variant.remove(at: position)
   }
 
@@ -647,6 +656,7 @@ extension Set: SetAlgebra {
   ///   default is `false`.
   @inlinable
   public mutating func removeAll(keepingCapacity keepCapacity: Bool = false) {
+    defer { _fixLifetime(self) }
     _variant.removeAll(keepingCapacity: keepCapacity)
   }
 
@@ -663,6 +673,7 @@ extension Set: SetAlgebra {
   @inlinable
   @discardableResult
   public mutating func removeFirst() -> Element {
+    defer { _fixLifetime(self) }
     _precondition(!isEmpty, "Can't removeFirst from an empty Set")
     return remove(at: startIndex)
   }
@@ -749,6 +760,7 @@ extension Set: SetAlgebra {
   @inlinable
   public func isSubset<S: Sequence>(of possibleSuperset: S) -> Bool
     where S.Element == Element {
+    defer { _fixLifetime(self) }
     if self.isEmpty { return true }
     if self.count == 1 { return possibleSuperset.contains(self.first!) }
     if let s = possibleSuperset as? Set<Element> {
@@ -787,6 +799,7 @@ extension Set: SetAlgebra {
   @inlinable
   public func isStrictSubset<S: Sequence>(of possibleStrictSuperset: S) -> Bool
     where S.Element == Element {
+    defer { _fixLifetime(self) }
     if let s = possibleStrictSuperset as? Set<Element> {
       return isStrictSubset(of: s)
     }
@@ -819,6 +832,7 @@ extension Set: SetAlgebra {
   @inlinable
   public func isSuperset<S: Sequence>(of possibleSubset: S) -> Bool
     where S.Element == Element {
+    defer { _fixLifetime(self) }
     if possibleSubset.underestimatedCount > self.count {
       return false
     }
@@ -852,6 +866,7 @@ extension Set: SetAlgebra {
   @inlinable
   public func isStrictSuperset<S: Sequence>(of possibleStrictSubset: S) -> Bool
     where S.Element == Element {
+    defer { _fixLifetime(self) }
     if isEmpty { return false }
     if let s = possibleStrictSubset as? Set<Element> {
       return isStrictSuperset(of: s)
@@ -885,6 +900,7 @@ extension Set: SetAlgebra {
   @inlinable
   internal func _isDisjoint<S: Sequence>(with other: S) -> Bool
     where S.Element == Element {
+    defer { _fixLifetime(self) }
     for element in other {
       if self.contains(element) { return false }
     }
@@ -938,6 +954,7 @@ extension Set: SetAlgebra {
   @inlinable
   public mutating func formUnion<S: Sequence>(_ other: S)
     where S.Element == Element {
+    defer { _fixLifetime(self) }
     _variant.formUnion(other)
   }
 
@@ -958,6 +975,7 @@ extension Set: SetAlgebra {
   @inlinable
   public func subtracting<S: Sequence>(_ other: S) -> Set<Element>
     where S.Element == Element {
+    defer { _fixLifetime(self) }
     return Set(_native: _variant.subtracting(other))
   }
 
@@ -977,12 +995,14 @@ extension Set: SetAlgebra {
   @inlinable
   public mutating func subtract<S: Sequence>(_ other: S)
     where S.Element == Element {
+    defer { _fixLifetime(self) }
     _subtract(other)
   }
 
   @inlinable
   internal mutating func _subtract<S: Sequence>(_ other: S)
   where S.Element == Element {
+    defer { _fixLifetime(self) }
     guard _variant.isUniquelyReferenced() else {
       self = Set(_native: _variant.subtracting(other))
       return
@@ -1011,6 +1031,7 @@ extension Set: SetAlgebra {
   @inlinable
   public func intersection<S: Sequence>(_ other: S) -> Set<Element>
     where S.Element == Element {
+    defer { _fixLifetime(self) }
     return Set(_native: _variant.intersection(other))
   }
 
@@ -1052,6 +1073,7 @@ extension Set: SetAlgebra {
   @inlinable
   public func symmetricDifference<S: Sequence>(_ other: S) -> Set<Element>
     where S.Element == Element {
+    defer { _fixLifetime(self) }
     if let other = other as? Set<Element> {
       return Set(_native: _variant.symmetricDifference(other))
     }
@@ -1212,6 +1234,7 @@ extension Set {
   /// - Parameter other: Another set.
   @inlinable
   public mutating func subtract(_ other: Set<Element>) {
+    defer { _fixLifetime(self); _fixLifetime(other) }
     _subtract(other)
   }
 
@@ -1230,6 +1253,7 @@ extension Set {
   /// - Returns: `true` if the set is a subset of `other`; otherwise, `false`.
   @inlinable
   public func isSubset(of other: Set<Element>) -> Bool {
+    defer { _fixLifetime(self); _fixLifetime(other) }
     guard self.count > 0 else { return true }
     guard self.count <= other.count else { return false }
     for member in self {
@@ -1256,6 +1280,7 @@ extension Set {
   ///   `false`.
   @inlinable
   public func isSuperset(of other: Set<Element>) -> Bool {
+    defer { _fixLifetime(self); _fixLifetime(other) }
     return other.isSubset(of: self)
   }
 
@@ -1275,6 +1300,7 @@ extension Set {
   ///   otherwise, `false`.
   @inlinable
   public func isDisjoint(with other: Set<Element>) -> Bool {
+    defer { _fixLifetime(self); _fixLifetime(other) }
     return _isDisjoint(with: other)
   }
 
@@ -1294,6 +1320,7 @@ extension Set {
   /// - Returns: A new set.
   @inlinable
   public func subtracting(_ other: Set<Element>) -> Set<Element> {
+    defer { _fixLifetime(self); _fixLifetime(other) }
     return Set(_native: _variant.subtracting(other))
   }
 
@@ -1316,6 +1343,7 @@ extension Set {
   ///   `other`; otherwise, `false`.
   @inlinable
   public func isStrictSuperset(of other: Set<Element>) -> Bool {
+    defer { _fixLifetime(self); _fixLifetime(other) }
     return self.count > other.count && self.isSuperset(of: other)
   }
 
@@ -1340,6 +1368,7 @@ extension Set {
   ///   `other`; otherwise, `false`.
   @inlinable
   public func isStrictSubset(of other: Set<Element>) -> Bool {
+    defer { _fixLifetime(self); _fixLifetime(other) }
     return other.isStrictSuperset(of: self)
   }
 
@@ -1361,6 +1390,7 @@ extension Set {
   /// - Returns: A new set.
   @inlinable
   public func intersection(_ other: Set<Element>) -> Set<Element> {
+    defer { _fixLifetime(self); _fixLifetime(other) }
     return Set(_native: _variant.intersection(other))
   }
 
@@ -1383,6 +1413,7 @@ extension Set {
   /// - Parameter other: Another set.
   @inlinable
   public mutating func formSymmetricDifference(_ other: Set<Element>) {
+    defer { _fixLifetime(self); _fixLifetime(other) }
     self = self.symmetricDifference(other)
   }
 }
@@ -1404,10 +1435,8 @@ internal protocol _SetBuffer {
   func element(at i: Index) -> Element
 }
 
-/// An instance of this class has all `Set` data tail-allocated.  Enough bytes
-/// are allocated to hold the _HashTable's metadata entries as well of all
-/// buckets.  The data layout starts with the metadata entries, followed by the
-/// element-sized buckets.
+/// An instance of this class has all `Set` data tail-allocated, starting with
+/// hash table metadata, followed by element storage.
 ///
 /// **Note:** The precise layout of this type is relied on in the runtime
 /// to provide a statically allocated empty singleton.
@@ -1416,18 +1445,29 @@ internal protocol _SetBuffer {
 @usableFromInline
 @_objc_non_lazy_realization
 internal class _SwiftRawSetStorage: _SwiftNativeNSSet {
-  // The _HashTable struct contains pointers into tail-allocated storage, so
-  // this is unsafe and needs `_fixLifetime` calls in the caller.
+  /// The current number of occupied entries in this hash table.
   @usableFromInline
   @nonobjc
-  internal final var hashTable: _HashTable
+  internal final var _count: Int
+
+  /// The maximum number of entries that can be inserted into this hash table
+  /// without exceeding its maximum load factor.
+  @usableFromInline
+  @nonobjc
+  internal final var _capacity: Int
+
+  /// The scale of this hash table. The number of buckets is 2 raised to the
+  /// power of `scale`.
+  @usableFromInline
+  @nonobjc
+  internal final var _scale: Int
 
   @usableFromInline
-  internal final var seed: Hasher._Seed
+  internal final var _seed: Hasher._Seed
 
   @usableFromInline
   @nonobjc
-  internal final var rawElements: UnsafeMutableRawPointer
+  internal final var _rawElements: UnsafeMutableRawPointer
 
   // This type is made with allocWithTailElems, so no init is ever called.
   // But we still need to have an init to satisfy the compiler.
@@ -1438,6 +1478,37 @@ internal class _SwiftRawSetStorage: _SwiftNativeNSSet {
 
   @usableFromInline
   internal func invalidate() {}
+
+  @inlinable
+  @nonobjc
+  internal final var _bucketCount: Int {
+    @inline(__always) get { return 1 &<< _scale }
+  }
+
+  @inlinable
+  @nonobjc
+  internal final var _entryCount: Int {
+    @inline(__always) get { return 1 &<< (_scale &+ 3) }
+  }
+
+  @inlinable
+  @nonobjc
+  internal final var _buckets: UnsafeMutablePointer<_HashTable.Bucket> {
+    @inline(__always) get {
+      let bucketsAddr = Builtin.projectTailElems(self, _HashTable.Bucket.self)
+      return UnsafeMutablePointer(bucketsAddr)
+    }
+  }
+
+  // The _HashTable struct contains pointers into tail-allocated storage, so
+  // this is unsafe and needs `_fixLifetime` calls in the caller.
+  @inlinable
+  @nonobjc
+  internal final var _hashTable: _HashTable {
+    @inline(__always) get {
+      return _HashTable(buckets: _buckets, bucketCount: _bucketCount)
+    }
+  }
 }
 
 /// The storage class for the singleton empty set.
@@ -1526,30 +1597,18 @@ internal final class _SwiftNativeSetStorage<
   }
 
   deinit {
-    let elements = self.elements
-
-    if !_isPOD(Element.self) && hashTable.count > 0 {
-      for index in hashTable.occupiedIndices {
-        (elements + index.bucket).deinitialize(count: 1)
+    if !_isPOD(Element.self) && _count > 0 {
+      for index in _hashTable.indices {
+        (_elements + index.offset).deinitialize(count: 1)
       }
-      hashTable.count = -1
+      _count = -1
     }
-
     _fixLifetime(self)
   }
 
   @usableFromInline
   internal override func invalidate() {
-    hashTable.count = -1
-  }
-
-  @inlinable
-  static internal func allocate(
-    capacity: Int,
-    seed: Hasher._Seed
-  ) -> _SwiftNativeSetStorage {
-    let scale = _HashTable.scale(forCapacity: Swift.max(1 ,capacity))
-    return allocate(scale: scale, seed: seed)
+    _count = -1
   }
 
   @usableFromInline
@@ -1558,32 +1617,35 @@ internal final class _SwiftNativeSetStorage<
     scale: Int,
     seed: Hasher._Seed
   ) -> _SwiftNativeSetStorage {
-    _sanityCheck(scale >= 0 && scale < Int.bitWidth - 1)
+    // The entry count must be representable by an Int value; hence the scale's
+    // weird upper bound.
+    _sanityCheck(scale >= 0 && scale < Int.bitWidth - 4)
+
     let bucketCount = 1 &<< scale
+    let entryCount = 1 &<< (scale + 3)
     let storage = Builtin.allocWithTailElems_2(
       _SwiftNativeSetStorage<Element>.self,
-      bucketCount._builtinWordValue, _HashTable.MapEntry.self,
-      bucketCount._builtinWordValue, Element.self)
+      bucketCount._builtinWordValue, _HashTable.Bucket.self,
+      entryCount._builtinWordValue, Element.self)
 
-    let mapAddr = Builtin.projectTailElems(storage, _HashTable.MapEntry.self)
+    let bucketsAddr = Builtin.projectTailElems(storage, _HashTable.Bucket.self)
     let elementsAddr = Builtin.getTailAddr_Word(
-      mapAddr,
-      bucketCount._builtinWordValue,
-      _HashTable.MapEntry.self,
+      bucketsAddr, bucketCount._builtinWordValue, _HashTable.Bucket.self,
       Element.self)
-    storage.hashTable = _HashTable(
-      scale: scale,
-      map: UnsafeMutablePointer(mapAddr))
-    storage.rawElements = UnsafeMutableRawPointer(elementsAddr)
-    storage.seed = seed
+    storage._count = 0
+    storage._capacity = _HashTable.capacity(forScale: scale)
+    storage._scale = scale
+    storage._rawElements = UnsafeMutableRawPointer(elementsAddr)
+    storage._seed = seed
+    storage._buckets.assign(repeating: _HashTable.Bucket(0), count: bucketCount)
     return storage
   }
 
   @inlinable
-  final var elements: UnsafeMutablePointer<Element> {
+  final var _elements: UnsafeMutablePointer<Element> {
     @inline(__always)
     get {
-      return self.rawElements.assumingMemoryBound(to: Element.self)
+      return self._rawElements.assumingMemoryBound(to: Element.self)
     }
   }
 
@@ -1609,7 +1671,7 @@ internal final class _SwiftNativeSetStorage<
 
   @objc
   internal var count: Int {
-    return hashTable.count
+    return _count
   }
 
   @objc
@@ -1627,7 +1689,7 @@ internal final class _SwiftNativeSetStorage<
       theState.state = 1 // Arbitrary non-zero value.
       theState.itemsPtr = AutoreleasingUnsafeMutablePointer(objects)
       theState.mutationsPtr = _fastEnumerationStorageMutationsPtr
-      theState.extra.0 = CUnsignedLong(asNative.startIndex.bucket)
+      theState.extra.0 = CUnsignedLong(asNative.startIndex.offset)
     }
 
     // Test 'objects' rather than 'count' because (a) this is very rare anyway,
@@ -1637,21 +1699,24 @@ internal final class _SwiftNativeSetStorage<
       return 0
     }
 
+    let hashTable = _hashTable
     let unmanagedObjects = _UnmanagedAnyObjectArray(objects!)
-    var index = _HashTable.Index(bucket: Int(theState.extra.0))
-    hashTable.checkOccupied(index)
-    let endIndex = asNative.endIndex
+    var index = _HashTable.Index(offset: Int(theState.extra.0))
+    let endIndex = hashTable.endIndex
+    if index != endIndex {
+      hashTable.checkOccupied(index)
+    }
     var stored = 0
     for i in 0..<count {
       guard index < endIndex else { break }
 
-      let element = asNative.uncheckedElement(at: index)
+      let element = _elements[index.offset]
       unmanagedObjects[i] = _bridgeAnythingToObjectiveC(element)
 
       stored += 1
-      asNative.formIndex(after: &index)
+      hashTable.formIndex(after: &index)
     }
-    theState.extra.0 = CUnsignedLong(index.bucket)
+    theState.extra.0 = CUnsignedLong(index.offset)
     state.pointee = theState
     return stored
   }
@@ -1663,7 +1728,7 @@ internal final class _SwiftNativeSetStorage<
 
     let (index, found) = asNative.find(native)
     guard found else { return nil }
-    return _bridgeAnythingToObjectiveC(asNative.uncheckedElement(at: index))
+    return _bridgeAnythingToObjectiveC(_elements[index.offset])
   }
 #endif
 }
@@ -1695,11 +1760,13 @@ internal struct _NativeSet<Element: Hashable> {
     self._storage = storage
   }
 
-  @inlinable
+  @usableFromInline
+  @_effects(releasenone)
   internal init(capacity: Int) {
-    self._storage = _SwiftNativeSetStorage<Element>.allocate(
-      capacity: capacity,
-      seed: Hasher._randomSeed())
+    let scale = _HashTable.scale(forCapacity: capacity)
+    let seed = _HashTable.newSeed(forScale: scale)
+    self._storage =
+      _SwiftNativeSetStorage<Element>.allocate(scale: scale, seed: seed)
   }
 
 #if _runtime(_ObjC)
@@ -1721,10 +1788,10 @@ internal struct _NativeSet<Element: Hashable> {
 
 extension _NativeSet {
   @inlinable
-  internal var bucketCount: Int {
+  internal var entryCount: Int {
     @inline(__always)
     get {
-      return _assumeNonNegative(_storage.hashTable.bucketCount)
+      return _assumeNonNegative(_storage._entryCount)
     }
   }
 
@@ -1732,15 +1799,7 @@ extension _NativeSet {
   internal var capacity: Int {
     @inline(__always)
     get {
-      return _assumeNonNegative(_storage.hashTable.capacity)
-    }
-  }
-
-  @inlinable
-  internal var indices: _HashTable.OccupiedIndices {
-    @inline(__always)
-    get {
-      return _storage.hashTable.occupiedIndices
+      return _assumeNonNegative(_storage._capacity)
     }
   }
 
@@ -1748,85 +1807,71 @@ extension _NativeSet {
   internal var elements: UnsafeMutablePointer<Element> {
     @inline(__always)
     get {
-      return _storage.rawElements.assumingMemoryBound(to: Element.self)
+      return _storage._rawElements.assumingMemoryBound(to: Element.self)
+    }
+  }
+
+  @inlinable
+  internal var hashTable: _HashTable {
+    @inline(__always) get {
+      return _storage._hashTable
     }
   }
 
   @inlinable
   @inline(__always)
-  internal func uncheckedElement(at i: Index) -> Element {
-    _sanityCheck(_storage.hashTable.isOccupied(i))
-    defer { _fixLifetime(self) }
-    return elements[i.bucket]
+  internal func uncheckedElement(at index: Index) -> Element {
+    _sanityCheck(hashTable.isOccupied(index))
+    return elements[index.offset]
   }
 
   @usableFromInline @_transparent
-  internal func uncheckedDestroyElement(at i: Index) {
-    _sanityCheck(_storage.hashTable.isValid(i))
-    defer { _fixLifetime(self) }
-    (elements + i.bucket).deinitialize(count: 1)
+  internal func uncheckedDestroy(at index: Index) {
+    _sanityCheck(hashTable.isValid(index))
+    (elements + index.offset).deinitialize(count: 1)
   }
 
   @usableFromInline @_transparent
-  internal func uncheckedInitializeElement(at i: Index, to element: Element) {
-    _sanityCheck(_storage.hashTable.isValid(i))
-    defer { _fixLifetime(self) }
-    (elements + i.bucket).initialize(to: element)
-  }
-
-  @usableFromInline @_transparent
-  internal func uncheckedMoveInitializeElement(
-    from source: _NativeSet,
-    at sourceIndex: Index,
-    to targetIndex: Index
-  ) {
-    _sanityCheck(source._storage.hashTable.isOccupied(sourceIndex))
-    _sanityCheck(_storage.hashTable.isValid(targetIndex))
-    defer { _fixLifetime(self) }
-    (elements + targetIndex.bucket).moveInitialize(
-      from: source.elements + sourceIndex.bucket,
-      count: 1)
+  internal func uncheckedInitialize(at index: Index, to element: Element) {
+    _sanityCheck(hashTable.isValid(index))
+    (elements + index.offset).initialize(to: element)
   }
 }
 
 extension _NativeSet {
   @inlinable
   internal mutating func reallocate(
-    isUnique: Bool,
+    movingElements move: Bool,
     capacity: Int
   ) -> Bool {
     let scale = _HashTable.scale(forCapacity: capacity)
-    let rehash = (scale != _storage.hashTable.scale)
+    let rehash = (scale != _storage._scale)
 
     // We generate a unique hash seed whenever we change the size of the hash
     // table, so that we avoid certain copy operations becoming quadratic,
     // without breaking value semantics. (For background details, see
     // https://bugs.swift.org/browse/SR-3268)
-    let seed = rehash ? Hasher._randomSeed() : _storage.seed
+    let seed = rehash ? _HashTable.newSeed(forScale: scale) : _storage._seed
 
     var result = _NativeSet(
       _SwiftNativeSetStorage<Element>.allocate(scale: scale, seed: seed))
-    switch (isUnique, rehash) {
-    case (true, true): // Move & rehash elements
-      for index in self.indices {
-        result._unsafeMoveNew(from: self, at: index)
-      }
-      _storage.invalidate()
-    case (true, false): // Move elements to same buckets in new storage
-      result._storage.hashTable.copyContents(of: _storage.hashTable)
-      for index in self.indices {
-        result.uncheckedMoveInitializeElement(from: self, at: index, to: index)
+    let hashTable = self.hashTable
+    switch (move, rehash) {
+    case (true, _): // Move & rehash elements
+      for index in hashTable.indices {
+        result._unsafeMoveNew(from: self.elements + index.offset)
       }
       _storage.invalidate()
     case (false, true): // Copy & rehash elements
-      for index in self.indices {
-        result.insertNew(self.uncheckedElement(at: index))
+      for index in hashTable.indices {
+        result._unsafeInsertNew(self.uncheckedElement(at: index))
       }
-    case (false, false): // Copy elements to same buckets in new storage
-      result._storage.hashTable.copyContents(of: _storage.hashTable)
-      for index in self.indices {
+    case (false, false): // Copy elements to same entries in new storage
+      result.hashTable.copyContents(of: hashTable)
+      result._storage._count = self.count
+      for index in hashTable.indices {
         let element = uncheckedElement(at: index)
-        result.uncheckedInitializeElement(at: index, to: element)
+        result.uncheckedInitialize(at: index, to: element)
       }
     }
     _storage = result._storage
@@ -1842,32 +1887,46 @@ extension _NativeSet {
     if isUnique && capacity <= self.capacity {
       return (false, false)
     }
-    return (true, reallocate(isUnique: isUnique, capacity: capacity))
+    return (true, reallocate(movingElements: isUnique, capacity: capacity))
   }
 }
 
 extension _NativeSet: _SetBuffer {
   @usableFromInline
   internal typealias Index = _HashTable.Index
+  @usableFromInline
+  internal typealias Indices = _HashTable.Indices
 
   @inlinable
   internal var startIndex: Index {
-    return _storage.hashTable.startIndex
+    return hashTable.startIndex
   }
 
   @inlinable
   internal var endIndex: Index {
-    return _storage.hashTable.endIndex
+    return hashTable.endIndex
   }
 
   @inlinable
-  internal func index(after i: Index) -> Index {
-    return _storage.hashTable.index(after: i)
+  internal func index(after index: Index) -> Index {
+    return hashTable.index(after: index)
   }
 
   @inlinable
-  internal func formIndex(after i: inout Index) {
-    i = index(after: i)
+  internal func formIndex(after index: inout Index) {
+    hashTable.formIndex(after: &index)
+  }
+
+  @inlinable
+  internal var indices: _HashTable.Indices {
+    @inline(__always)
+    get {
+      // Note: _HashTable.Indices does not include a storage reference, so all
+      // callers must manually ensure self survives all usages of the returned
+      // struct.  (Top-level Set operations already include a _fixLifetime for
+      // this.)
+      return hashTable.indices
+    }
   }
 
   @inlinable
@@ -1884,38 +1943,36 @@ extension _NativeSet: _SetBuffer {
   @inlinable
   internal var count: Int {
     get {
-      return _assumeNonNegative(_storage.hashTable.count)
+      return _assumeNonNegative(_storage._count)
     }
   }
 
   @inlinable
   @inline(__always)
   internal func contains(_ member: Element) -> Bool {
-    if count == 0 { // Fast path that avoids computing the hash of the key.
-      return false
-    }
+    // if count == 0 {
+    //   // Fast path that avoids computing the hash of the key.
+    //   return false
+    // }
     return find(member).found
   }
 
   @inlinable
   @inline(__always)
   internal func element(at index: Index) -> Element {
-    _storage.hashTable.checkOccupied(index)
-    defer { _fixLifetime(self) }
-    return elements[index.bucket]
+    hashTable.checkOccupied(index)
+    return elements[index.offset]
   }
 }
 
 extension _NativeSet: _HashTableDelegate {
   internal func hashValue(at index: Index) -> Int {
-    return uncheckedElement(at: index)._rawHashValue(seed: _storage.seed)
+    return uncheckedElement(at: index)._rawHashValue(seed: _storage._seed)
   }
 
   internal func moveEntry(from source: Index, to target: Index) {
-    _sanityCheck(source != target)
-    (elements + target.bucket).moveInitialize(
-      from: elements + source.bucket,
-      count: 1)
+    (elements + target.offset)
+      .moveInitialize(from: elements + source.offset, count: 1)
   }
 }
 
@@ -1949,7 +2006,7 @@ extension _NativeSet {
   @inlinable
   @inline(__always)
   internal func hashValue(for element: Element) -> Int {
-    return element._rawHashValue(seed: _storage.seed)
+    return element._rawHashValue(seed: _storage._seed)
   }
 
   @inlinable
@@ -1958,23 +2015,18 @@ extension _NativeSet {
     return find(element, hashValue: self.hashValue(for: element))
   }
 
-  /// Search for a given key starting from the specified bucket.
+  /// Search for a given element, assuming it has the specified hash value.
   ///
-  /// If the key is not present, returns the position where it could be
-  /// inserted.
+  /// If the element is not present in this set, return the position where it
+  /// could be inserted.
   @inlinable
-  @inline(__always)
   internal func find(
     _ element: Element,
     hashValue: Int
   ) -> (index: Index, found: Bool) {
-    var (index, found) = _storage.hashTable.lookupFirst(hashValue: hashValue)
-    if _fastPath(!found || uncheckedElement(at: index) == element) {
-      return (index, found)
-    }
+    var candidates = hashTable.lookup(hashValue: hashValue)
     while true {
-      (index, found) =
-        _storage.hashTable.lookupNext(hashValue: hashValue, after: index)
+      let (index, found) = candidates.next()
       if !found || uncheckedElement(at: index) == element {
         return (index, found)
       }
@@ -1988,13 +2040,13 @@ extension _NativeSet {
     where S.Element == Element {
     // Allocate a temporary bitmap to mark elements in self that we've seen in
     // possibleSuperset.
-    var bitmap = _Bitmap(bitCount: self.bucketCount)
+    var bitmap = _Bitmap(bitCount: self.entryCount)
     var seen = 0
     for element in possibleSuperset {
       // Found a new element of self in possibleSuperset.
       let (index, found) = find(element)
       guard found else { continue }
-      if bitmap._uncheckedInsert(index.bucket) {
+      if bitmap._uncheckedInsert(index.offset) {
         seen += 1
         if seen == self.count {
           return true
@@ -2009,7 +2061,7 @@ extension _NativeSet {
     where S.Element == Element {
     // Allocate a temporary bitmap to mark elements in self that we've seen in
     // possibleSuperset.
-    var bitmap = _Bitmap(bitCount: self.bucketCount)
+    var bitmap = _Bitmap(bitCount: self.entryCount)
     var seen = 0
     var isStrict = false
     for element in possibleSuperset {
@@ -2021,7 +2073,7 @@ extension _NativeSet {
         }
         continue
       }
-      if bitmap._uncheckedInsert(index.bucket) {
+      if bitmap._uncheckedInsert(index.offset) {
         // Found a new element of self in possibleSuperset.
         seen += 1
         if seen == self.count && isStrict {
@@ -2037,12 +2089,12 @@ extension _NativeSet {
     where S.Element == Element {
     // Allocate a temporary bitmap to mark elements in self that we've seen in
     // possibleStrictSubset.
-    var bitmap = _Bitmap(bitCount: self.bucketCount)
+    var bitmap = _Bitmap(bitCount: self.entryCount)
     var seen = 0
     for element in possibleSubset {
       let (index, found) = find(element)
       guard found else { return false }
-      if bitmap._uncheckedInsert(index.bucket) {
+      if bitmap._uncheckedInsert(index.offset) {
         // Found a new element of possibleSubset in self.
         seen += 1
         if seen == self.count {
@@ -2058,11 +2110,11 @@ extension _NativeSet {
     markingElementsIn other: S
   ) -> (bitmap: _Bitmap, count: Int)
   where S.Element == Element {
-    var bitmap = _Bitmap(bitCount: self.bucketCount)
+    var bitmap = _Bitmap(bitCount: self.entryCount)
     var count = 0
     for element in other {
       let (index, found) = find(element)
-      if found, bitmap._uncheckedInsert(index.bucket) {
+      if found, bitmap._uncheckedInsert(index.offset) {
         count += 1
       }
     }
@@ -2098,7 +2150,7 @@ extension _NativeSet {
     if dupeCount == 0 { return self }
     if dupeCount == self.count { return _NativeSet() }
     var result = _NativeSet(capacity: self.count - dupeCount)
-    for index in self.indices where !dupes._uncheckedContains(index.bucket) {
+    for index in self.indices where !dupes._uncheckedContains(index.offset) {
       result.insertNew(self.uncheckedElement(at: index))
     }
     return result
@@ -2117,8 +2169,8 @@ extension _NativeSet {
       return other
     }
     var result = _NativeSet(capacity: dupeCount)
-    for bucket in dupes {
-      result.insertNew(self.uncheckedElement(at: Index(bucket: bucket)))
+    for offset in dupes {
+      result.insertNew(self.uncheckedElement(at: Index(offset: offset)))
     }
     _sanityCheck(result.count == dupeCount)
     return result
@@ -2131,13 +2183,13 @@ extension _NativeSet {
     // in a bitmap, and collect distinct elements from `other` in an array.
     // This minimizes hashing, and ensures that we'll have an exact count for
     // the result set, preventing rehashings during insertions.
-    var dupes = _Bitmap(bitCount: self.bucketCount)
+    var dupes = _Bitmap(bitCount: self.entryCount)
     var dupeCount = 0
     var distinctsInOther: [Element] = []
     for element in other {
       let (index, found) = find(element)
       if found {
-        if dupes._uncheckedInsert(index.bucket) {
+        if dupes._uncheckedInsert(index.offset) {
           dupeCount += 1
         }
       } else {
@@ -2146,7 +2198,7 @@ extension _NativeSet {
     }
     var result = _NativeSet<Element>(
       capacity: count - dupeCount + distinctsInOther.count)
-    for index in self.indices where !dupes._uncheckedContains(index.bucket) {
+    for index in self.indices where !dupes._uncheckedContains(index.offset) {
       result.insertNew(self.uncheckedElement(at: index))
     }
     for element in distinctsInOther {
@@ -2165,14 +2217,14 @@ extension _NativeSet {
     // and `other` in two bitmaps.  This minimizes hashing, and ensures that
     // we'll have an exact count for the result set, preventing rehashings
     // during insertions.
-    var selfDupes = _Bitmap(bitCount: self.bucketCount)
-    var otherDupes = _Bitmap(bitCount: other.bucketCount)
+    var selfDupes = _Bitmap(bitCount: self.entryCount)
+    var otherDupes = _Bitmap(bitCount: other.entryCount)
     var dupeCount = 0
     for otherIndex in other.indices {
       let (selfIndex, found) = self.find(other.uncheckedElement(at: otherIndex))
       if found {
-        if !selfDupes._uncheckedInsert(selfIndex.bucket) ||
-          !otherDupes._uncheckedInsert(otherIndex.bucket) {
+        if !selfDupes._uncheckedInsert(selfIndex.offset) ||
+          !otherDupes._uncheckedInsert(otherIndex.offset) {
           ELEMENT_TYPE_OF_SET_VIOLATES_HASHABLE_REQUIREMENTS(Element.self)
         }
         dupeCount += 1
@@ -2180,10 +2232,10 @@ extension _NativeSet {
     }
     var result = _NativeSet<Element>(
       capacity: self.count + other.count - 2 * dupeCount)
-    for i in self.indices where !selfDupes._uncheckedContains(i.bucket) {
+    for i in self.indices where !selfDupes._uncheckedContains(i.offset) {
       result.insertNew(self.uncheckedElement(at: i))
     }
-    for i in other.indices where !otherDupes._uncheckedContains(i.bucket) {
+    for i in other.indices where !otherDupes._uncheckedContains(i.offset) {
       result.insertNew(other.uncheckedElement(at: i))
     }
     return result
@@ -2200,7 +2252,7 @@ internal func ELEMENT_TYPE_OF_SET_VIOLATES_HASHABLE_REQUIREMENTS(
     "Fatal error",
     """
     Duplicate elements of type '\(elementType)' were found in a Set.
-    This usually means that either the type violates Hashable's requirements, or
+    This usually means either that the type violates Hashable's requirements, or
     that members of such a set were mutated after insertion.
     """,
     flags: _fatalErrorFlags())
@@ -2208,34 +2260,33 @@ internal func ELEMENT_TYPE_OF_SET_VIOLATES_HASHABLE_REQUIREMENTS(
 
 extension _NativeSet {
   @inlinable
-  internal func _unsafeMoveNew(from source: _NativeSet, at sourceIndex: Index) {
-    _sanityCheck(source._storage.hashTable.isOccupied(sourceIndex))
+  internal func _unsafeMoveNew(from source: UnsafeMutablePointer<Element>) {
     _sanityCheck(count + 1 <= capacity)
-    let sourcePtr = source.elements + sourceIndex.bucket
-    let hashValue = self.hashValue(for: sourcePtr.pointee)
+    let hashValue = self.hashValue(for: source.pointee)
     if _isDebugAssertConfiguration() {
       // In debug builds, perform a full lookup and trap if we detect duplicate
       // elements -- these imply that the Element type violates Hashable
       // requirements. This is generally more costly than a direct insertion,
       // because we'll need to compare elements in case of hash collisions.
-      let (index, found) = find(sourcePtr.pointee, hashValue: hashValue)
+      let (index, found) = find(source.pointee, hashValue: hashValue)
       guard !found else {
         ELEMENT_TYPE_OF_SET_VIOLATES_HASHABLE_REQUIREMENTS(Element.self)
       }
-      _storage.hashTable.insert(hashValue: hashValue, at: index)
-      uncheckedMoveInitializeElement(from: source, at: sourceIndex, to: index)
+      hashTable.insert(hashValue: hashValue, at: index)
+      uncheckedInitialize(at: index, to: source.move())
     } else {
-      let index = _storage.hashTable.insertNew(hashValue: hashValue)
-      uncheckedMoveInitializeElement(from: source, at: sourceIndex, to: index)
+      let index = hashTable.insertNew(hashValue: hashValue)
+      uncheckedInitialize(at: index, to: source.move())
     }
+    _storage._count += 1
   }
 
   /// Insert a new element into uniquely held storage.
-  /// Storage must be uniquely referenced.
+  /// Storage must be uniquely referenced with adequate capacity.
   /// The `element` must not be already present in the Set.
   @inlinable
-  internal mutating func insertNew(_ element: Element) {
-    _ = ensureUnique(isUnique: true, capacity: count + 1)
+  internal mutating func _unsafeInsertNew(_ element: Element) {
+    _sanityCheck(count + 1 <= capacity)
     let hashValue = self.hashValue(for: element)
     if _isDebugAssertConfiguration() {
       // In debug builds, perform a full lookup and trap if we detect duplicate
@@ -2246,12 +2297,22 @@ extension _NativeSet {
       guard !found else {
         ELEMENT_TYPE_OF_SET_VIOLATES_HASHABLE_REQUIREMENTS(Element.self)
       }
-      _storage.hashTable.insert(hashValue: hashValue, at: index)
-      uncheckedInitializeElement(at: index, to: element)
+      hashTable.insert(hashValue: hashValue, at: index)
+      uncheckedInitialize(at: index, to: element)
     } else {
-      let index = _storage.hashTable.insertNew(hashValue: hashValue)
-      uncheckedInitializeElement(at: index, to: element)
+      let index = hashTable.insertNew(hashValue: hashValue)
+      uncheckedInitialize(at: index, to: element)
     }
+    _storage._count += 1
+  }
+
+  /// Insert a new element into uniquely held storage.
+  /// Storage must be uniquely referenced.
+  /// The `element` must not be already present in the Set.
+  @inlinable
+  internal mutating func insertNew(_ element: Element) {
+    _ = ensureUnique(isUnique: true, capacity: count + 1)
+    _unsafeInsertNew(element)
   }
 }
 
@@ -2276,17 +2337,18 @@ extension _NativeSet {
       (index, found) = find(element, hashValue: hashValue)
     }
     if found {
-      let old = (elements + index.bucket).move()
-      uncheckedInitializeElement(at: index, to: element)
+      let old = (elements + index.offset).move()
+      uncheckedInitialize(at: index, to: element)
       return old
     }
-    _storage.hashTable.insert(hashValue: hashValue, at: index)
-    uncheckedInitializeElement(at: index, to: element)
+    hashTable.insert(hashValue: hashValue, at: index)
+    uncheckedInitialize(at: index, to: element)
+    _storage._count += 1
     return nil
   }
 
   /// A variant of insert that returns the inserted index rather than the
-  /// element stored in the corresponding bucket.
+  /// corresponding member.
   @inlinable
   @discardableResult
   internal mutating func _insert(
@@ -2303,8 +2365,9 @@ extension _NativeSet {
         ELEMENT_TYPE_OF_SET_VIOLATES_HASHABLE_REQUIREMENTS(Element.self)
       }
     }
-    _storage.hashTable.insert(hashValue: hashValue, at: index)
-    uncheckedInitializeElement(at: index, to: element)
+    hashTable.insert(hashValue: hashValue, at: index)
+    _storage._count += 1
+    uncheckedInitialize(at: index, to: element)
     return (true, index)
   }
 
@@ -2323,7 +2386,8 @@ extension _NativeSet {
   @usableFromInline
   @_effects(releasenone)
   internal mutating func _delete(at index: Index, hashValue: Int) {
-    _storage.hashTable.delete(at: index, hashValue: hashValue, with: self)
+    hashTable.delete(hashValue: hashValue, at: index, with: self)
+    _storage._count -= 1
   }
 
   @inlinable
@@ -2345,18 +2409,18 @@ extension _NativeSet {
       }
     }
 
-    let old = (elements + index.bucket).move()
+    let old = (elements + index.offset).move()
     _delete(at: index, hashValue: hashValue)
     return old
   }
 
   @inlinable
   internal mutating func remove(at index: Index, isUnique: Bool) -> Element {
-    _precondition(_storage.hashTable.isOccupied(index), "Invalid index")
+    _precondition(hashTable.isOccupied(index), "Invalid index")
     let (_, rehashed) = ensureUnique(isUnique: isUnique, capacity: capacity)
     _sanityCheck(!rehashed)
 
-    let old = (elements + index.bucket).move()
+    let old = (elements + index.offset).move()
     _delete(at: index, hashValue: self.hashValue(for: old))
     return old
   }
@@ -2364,15 +2428,17 @@ extension _NativeSet {
   @usableFromInline
   internal mutating func removeAll(isUnique: Bool) {
     guard isUnique else {
-      _storage = _SwiftNativeSetStorage<Element>.allocate(
-        scale: self._storage.hashTable.scale,
-        seed: Hasher._randomSeed())
+      let scale = self._storage._scale
+      let seed = _HashTable.newSeed(forScale: scale)
+      _storage =
+        _SwiftNativeSetStorage<Element>.allocate(scale: scale, seed: seed)
       return
     }
     for index in indices {
-      uncheckedDestroyElement(at: index)
+      uncheckedDestroy(at: index)
     }
-    _storage.hashTable.removeAll()
+    hashTable.removeAll()
+    _storage._count = 0
   }
 }
 
@@ -2530,7 +2596,7 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
     }
 
     // Allocate and initialize heap storage for bridged objects.
-    let bridged = _BridgingHashBuffer.create(bucketCount: native.bucketCount)
+    let bridged = _BridgingHashBuffer.create(entryCount: native.entryCount)
     for index in native.indices {
       let object = _bridgeAnythingToObjectiveC(native.element(at: index))
       bridged.initialize(at: index, to: object)
@@ -2596,7 +2662,7 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
       theState.state = 1 // Arbitrary non-zero value.
       theState.itemsPtr = AutoreleasingUnsafeMutablePointer(objects)
       theState.mutationsPtr = _fastEnumerationStorageMutationsPtr
-      theState.extra.0 = CUnsignedLong(native.startIndex.bucket)
+      theState.extra.0 = CUnsignedLong(native.startIndex.offset)
     }
 
     // Test 'objects' rather than 'count' because (a) this is very rare anyway,
@@ -2607,7 +2673,7 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
     }
 
     let unmanagedObjects = _UnmanagedAnyObjectArray(objects!)
-    var currIndex = _NativeSet<Element>.Index(bucket: Int(theState.extra.0))
+    var currIndex = _NativeSet<Element>.Index(offset: Int(theState.extra.0))
     let endIndex = native.endIndex
     var stored = 0
 
@@ -2626,7 +2692,7 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
       stored += 1
       native.formIndex(after: &currIndex)
     }
-    theState.extra.0 = CUnsignedLong(currIndex.bucket)
+    theState.extra.0 = CUnsignedLong(currIndex.offset)
     state.pointee = theState
     return stored
   }
@@ -3341,13 +3407,13 @@ extension Set.Index: Hashable {
     switch _variant {
     case .native(let nativeIndex):
       hasher.combine(0 as UInt8)
-      hasher.combine(nativeIndex.bucket)
+      hasher.combine(nativeIndex.offset)
     case .cocoa(let cocoaIndex):
       hasher.combine(1 as UInt8)
       hasher.combine(cocoaIndex.currentKeyIndex)
     }
   #else
-    hasher.combine(_asNative.bucket)
+    hasher.combine(_asNative.offset)
   #endif
   }
 }
@@ -3383,7 +3449,7 @@ extension _NativeSet.Iterator: IteratorProtocol {
   @inlinable
   internal mutating func next() -> Element? {
     guard index != endIndex else { return nil }
-    let result = base.element(at: index)
+    let result = base.uncheckedElement(at: index)
     base.formIndex(after: &index)
     return result
   }
@@ -3698,6 +3764,7 @@ public typealias SetIndex<Element: Hashable> = Set<Element>.Index
 public typealias SetIterator<Element: Hashable> = Set<Element>.Iterator
 
 extension Set {
+  // FIXME: Remove
   public // @testable performance metrics
   var _stats: (maxLookups: Int, averageLookups: Double, maxCollisions: Int)? {
     guard case .native(let native) = _variant else { return nil }
@@ -3722,17 +3789,17 @@ extension _NativeSet {
   ) -> (displacement: Int, collisions: Int) {
     let element = uncheckedElement(at: index)
     let hashValue = self.hashValue(for: element)
-    let ideal = hashValue & _storage.hashTable.bucketMask
+    let ideal = hashTable._idealBucket(forHashValue: hashValue)
     let delta = ideal <= index.bucket
       ? index.bucket - ideal
-      : index.bucket - ideal + bucketCount
-    var b = ideal
+      : index.bucket + _storage._bucketCount - ideal
+    var i = Index(bucket: ideal, slot: .start)
     var collisions = 0
-    while b != index.bucket {
-      if _storage.hashTable.map[b] == _HashTable.MapEntry.forHashValue(hashValue) {
+    while i != index {
+      if hashTable[i] == _HashTable.Entry(forHashValue: hashValue) {
         collisions += 1
       }
-      b = _storage.hashTable._succ(b)
+      i.offset = (i.offset + 1) & (entryCount - 1)
     }
     return (delta, collisions)
   }
@@ -3740,23 +3807,27 @@ extension _NativeSet {
 
 extension _NativeSet {
   // FIXME: Remove
+  @usableFromInline
   internal func _dump() -> String {
     var result = ""
     defer { _fixLifetime(self) }
-    let hashTable = _storage.hashTable
-    let bits = String(unsafeBitCast(self, to: UInt.self), radix: 16)
-    result += "Native set of \(Element.self) at 0x\(bits)\n"
-    result += "  count: \(hashTable.count)\n"
-    result += "  capacity: \(hashTable.capacity)\n"
-    result += "  scale: \(hashTable.scale)\n"
+    let bitPattern = String(unsafeBitCast(self, to: UInt.self), radix: 16)
+    result += "Native set of \(Element.self) at 0x\(bitPattern)\n"
+    result += "  count: \(self.count)\n"
+    result += "  capacity: \(self.capacity)\n"
+    result += "  entryCount: \(self.entryCount)\n"
+    result += "  scale: \(self._storage._scale)\n"
     result += "  bucketCount: \(hashTable.bucketCount)\n"
+    for b in 0 ..< hashTable.bucketCount {
+      result += "  (\(b)): \(String(hashTable.buckets[b]._value, radix: 16))\n"
+    }
     for i in indices {
       let element = uncheckedElement(at: i)
       let hashValue = self.hashValue(for: element)
       let stats = self.stats(ofElementAt: i)
       let h = String(UInt(bitPattern: hashValue), radix: 16)
-      let hl = String(hashTable.map[i.bucket].payload << 1, radix: 16)
-      result += "  <\(i.bucket)> "
+      let hl = String(hashTable[i].payload << 1, radix: 16)
+      result += "  <\(i.offset)> "
       result += "delta: \(stats.displacement) (\(stats.collisions) coll) "
       result += "hash: \(hl)/\(h): "
       result += "\(element)\n"
@@ -3790,8 +3861,9 @@ extension Set {
 }
 
 extension Set {
-  @usableFromInline // @testable
-  internal func _invariantCheck() {
+  // FIXME: Remove
+  public // @testable
+  func _invariantCheck() {
 #if INTERNAL_CHECKS_ENABLED
     guard case .native(let native) = self._variant else {
       return
@@ -3802,14 +3874,25 @@ extension Set {
 }
 
 extension _NativeSet {
+  // FIXME: Remove
   @usableFromInline // @testable
   internal func _invariantCheck() {
 #if INTERNAL_CHECKS_ENABLED
     _sanityCheck(
       _storage === _SwiftRawSetStorage.empty ||
-      _isValidAddress(UInt(bitPattern: _storage.rawElements)),
-    "Invalid rawElements pointer")
-    _storage.hashTable._invariantCheck(with: self)
+      _isValidAddress(UInt(bitPattern: _storage._rawElements)),
+      "Invalid rawElements pointer")
+    _sanityCheck(count >= 0 && count < entryCount,
+      "Invalid Set count")
+    _sanityCheck(capacity == _HashTable.capacity(forScale: _storage._scale),
+      "Invalid Set capacity")
+    _sanityCheck(capacity >= 0 && capacity < entryCount,
+      "Set's capacity is inconsistent with its entryCount")
+    _sanityCheck(count <= capacity,
+      "Set count exceeds its capacity")
+    let observedCount = hashTable._invariantCheck(with: self)
+    _sanityCheck(observedCount == count,
+      "Hash table count doesn't match the number of occupied entries")
 #endif
   }
 }

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1573,7 +1573,6 @@ internal final class _SwiftNativeSetStorage<
       Element.self)
     storage.hashTable = _HashTable(
       scale: scale,
-      count: 0,
       map: UnsafeMutablePointer(mapAddr))
     storage.rawElements = UnsafeMutableRawPointer(elementsAddr)
     storage.seed = seed

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1387,10 +1387,8 @@ extension Set {
   }
 }
 
-//===--- APIs templated for Dictionary and Set ----------------------------===//
-
 /// This protocol is only used for compile-time checks that
-/// every buffer type implements all required operations.
+/// every Set type implements all required operations.
 internal protocol _SetBuffer {
   associatedtype Element
   associatedtype Index
@@ -1406,16 +1404,14 @@ internal protocol _SetBuffer {
   func element(at i: Index) -> Element
 }
 
-/// An instance of this class has all `Set` data tail-allocated.
-/// Enough bytes are allocated to hold the bitmap for marking valid entries,
-/// keys, and values. The data layout starts with the bitmap, followed by the
-/// keys, followed by the values.
-//
-// See the docs at the top of the file for more details on this type
-//
-// NOTE: The precise layout of this type is relied on in the runtime
-// to provide a statically allocated empty singleton.
-// See stdlib/public/stubs/GlobalObjects.cpp for details.
+/// An instance of this class has all `Set` data tail-allocated.  Enough bytes
+/// are allocated to hold the _HashTable's metadata entries as well of all
+/// buckets.  The data layout starts with the metadata entries, followed by the
+/// element-sized buckets.
+///
+/// **Note:** The precise layout of this type is relied on in the runtime
+/// to provide a statically allocated empty singleton.
+/// See stdlib/public/stubs/GlobalObjects.cpp for details.
 @_fixed_layout // FIXME(sil-serialize-all)
 @usableFromInline
 @_objc_non_lazy_realization
@@ -3432,8 +3428,8 @@ extension Set {
     }
   }
 
-  /// Returns the native Dictionary hidden inside this NSDictionary;
-  /// returns nil otherwise.
+  /// Returns the native `Set` hidden inside the given `NSSet` instance; returns
+  /// `nil` otherwise.
   public static func _bridgeFromObjectiveCAdoptingNativeStorageOf(
     _ s: AnyObject
   ) -> Set<Element>? {
@@ -3447,7 +3443,7 @@ extension Set {
     if s === _SwiftRawSetStorage.empty {
       return Set()
     }
-    // FIXME: what if `s` is native storage, but for different key/value type?
+    // FIXME: what if `s` is native storage, but for different element type?
     return nil
   }
 }

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -169,7 +169,7 @@ extension Set {
   ///   storage buffer.
   @inlinable
   public init(minimumCapacity: Int) {
-    _variant = .native(_NativeSet(minimumCapacity: minimumCapacity))
+    _variant = .native(_NativeSet(capacity: minimumCapacity))
   }
 
   /// Private initializer.
@@ -192,7 +192,8 @@ extension Set {
   /// * `Element` is bridged verbatim to Objective-C (i.e.,
   ///   is a reference type).
   @inlinable
-  public init(_immutableCocoaSet: _NSSet) {
+  public // SPI(Foundation)
+  init(_immutableCocoaSet: _NSSet) {
     _sanityCheck(_isBridgedVerbatimToObjectiveC(Element.self),
       "Set can be backed by NSSet _variant only when the member type can be bridged verbatim to Objective-C")
     _variant = _Variant.cocoa(_CocoaSet(_immutableCocoaSet))
@@ -201,7 +202,6 @@ extension Set {
 }
 
 extension Set: ExpressibleByArrayLiteral {
-
   //
   // `ExpressibleByArrayLiteral` conformance
   //
@@ -225,7 +225,18 @@ extension Set: ExpressibleByArrayLiteral {
   /// - Parameter elements: A variadic list of elements of the new set.
   @inlinable
   public init(arrayLiteral elements: Element...) {
-    self.init(_native: _NativeSet.fromArray(elements))
+    if elements.isEmpty {
+      self.init()
+      return
+    }
+    var native = _NativeSet<Element>(capacity: elements.count)
+    for element in elements {
+      let inserted = native._insert(element, isUnique: true).inserted
+      if !inserted {
+        // FIXME: Shouldn't this trap?
+      }
+    }
+    self.init(_native: native)
   }
 }
 
@@ -324,7 +335,7 @@ extension Set: Collection {
   /// Accesses the member at the given position.
   @inlinable
   public subscript(position: Index) -> Element {
-    return _variant.assertingGet(at: position)
+    return _variant.element(at: position)
   }
 
   @inlinable
@@ -344,7 +355,7 @@ extension Set: Collection {
   /// - Complexity: O(1)
   @inlinable
   public func firstIndex(of member: Element) -> Index? {
-    return _variant.index(forKey: member)
+    return _variant.index(for: member)
   }
 
   @inlinable
@@ -418,9 +429,9 @@ extension Set: Equatable {
         return false
       }
 
-      for member in lhs {
+      for member in lhsNative {
         let (_, found) =
-          rhsNative._find(member)
+          rhsNative.find(member)
         if !found {
           return false
         }
@@ -436,19 +447,12 @@ extension Set: Equatable {
         return false
       }
 
-      let endIndex = lhsNative.endIndex
-      var i = lhsNative.startIndex
-      while i != endIndex {
-        let key = lhsNative.assertingGet(at: i)
-        let bridgedKey: AnyObject = _bridgeAnythingToObjectiveC(key)
-        let optRhsValue: AnyObject? = rhsCocoa.maybeGet(bridgedKey)
-        if let rhsValue = optRhsValue {
-          if key == _forceBridgeFromObjectiveC(rhsValue, Element.self) {
-            i = lhsNative.index(after: i)
-            continue
-          }
+      for i in lhsNative.indices {
+        let key = lhsNative.element(at: i)
+        let bridgedKey = _bridgeAnythingToObjectiveC(key)
+        if rhsCocoa.contains(bridgedKey) {
+          continue
         }
-        i = lhsNative.index(after: i)
         return false
       }
       return true
@@ -468,7 +472,7 @@ extension Set: Hashable {
   ///   of this instance.
   @inlinable
   public func hash(into hasher: inout Hasher) {
-    // FIXME(ABI)#177: <rdar://problem/18915294> Cache Set<T> hashValue
+    // FIXME: <rdar://problem/18915294> Cache Set<T> hashValue
     var hash = 0
     let seed = hasher._generateSeed()
     for member in self {
@@ -1381,7 +1385,7 @@ extension Set {
 
 /// This protocol is only used for compile-time checks that
 /// every buffer type implements all required operations.
-internal protocol _SetBuffer { // FIXME: Remove or refactor for Set.
+internal protocol _SetBuffer {
   associatedtype Element
   associatedtype Index
 
@@ -1389,12 +1393,11 @@ internal protocol _SetBuffer { // FIXME: Remove or refactor for Set.
   var endIndex: Index { get }
   func index(after i: Index) -> Index
   func formIndex(after i: inout Index)
-  func index(forKey key: Element) -> Index?
+  func index(for element: Element) -> Index?
   var count: Int { get }
 
   func contains(_ member: Element) -> Bool
-  func assertingGet(at i: Index) -> Element
-  func maybeGet(_ key: Element) -> Element?
+  func element(at i: Index) -> Element
 }
 
 /// An instance of this class has all `Set` data tail-allocated.
@@ -1410,89 +1413,71 @@ internal protocol _SetBuffer { // FIXME: Remove or refactor for Set.
 @_fixed_layout // FIXME(sil-serialize-all)
 @usableFromInline
 @_objc_non_lazy_realization
-internal class _RawNativeSetStorage: _SwiftNativeNSSet, _NSSetCore {
-  @usableFromInline // FIXME(sil-serialize-all)
+internal class _SwiftRawSetStorage: _SwiftNativeNSSet {
+  // The _HashTable struct contains pointers into tail-allocated storage, so
+  // this is unsafe and needs `_fixLifetime` calls in the caller.
+  @usableFromInline
   @nonobjc
-  internal final var bucketCount: Int
+  internal final var hashTable: _HashTable
 
-  @usableFromInline // FIXME(sil-serialize-all)
-  internal final var count: Int
+  @usableFromInline
+  internal var seed: (UInt64, UInt64)
 
-  @usableFromInline // FIXME(sil-serialize-all)
-  internal final var initializedEntries: _UnsafeBitMap
-
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline
   @nonobjc
-  internal final var keys: UnsafeMutableRawPointer
-
-  @usableFromInline // FIXME(sil-serialize-all)
-  internal final var seed: (UInt64, UInt64)
-
-  // This API is unsafe and needs a `_fixLifetime` in the caller.
-  @inlinable // FIXME(sil-serialize-all)
-  @nonobjc
-  internal final
-  var _initializedHashtableEntriesBitMapBuffer: UnsafeMutablePointer<UInt> {
-    return UnsafeMutablePointer(Builtin.projectTailElems(self, UInt.self))
-  }
-
-  /// The empty singleton that is used for every single Dictionary that is
-  /// created without any elements. The contents of the storage should never
-  /// be mutated.
-  @inlinable
-  @nonobjc
-  internal static var empty: _RawNativeSetStorage {
-    return Builtin.bridgeFromRawPointer(
-      Builtin.addressof(&_swiftEmptySetStorage))
-  }
+  internal final var rawElements: UnsafeMutableRawPointer
 
   // This type is made with allocWithTailElems, so no init is ever called.
   // But we still need to have an init to satisfy the compiler.
   @nonobjc
   internal init(_doNotCallMe: ()) {
+    _sanityCheckFailure("This class cannot be directly initialized")
+  }
+
+  internal func invalidate() {}
+}
+
+/// The storage class for the singleton empty set.
+/// The single instance of this class is created by the runtime.
+@usableFromInline
+internal class _SwiftEmptySetStorage: _SwiftRawSetStorage {
+  override internal init(_doNotCallMe: ()) {
     _sanityCheckFailure("Only create this by using the `empty` singleton")
   }
 
 #if _runtime(_ObjC)
+  @objc
+  internal required init(objects: UnsafePointer<AnyObject?>, count: Int) {
+    _sanityCheckFailure("Don't call this designated initializer")
+  }
+#endif
+}
+
+extension _SwiftRawSetStorage {
+  /// The empty singleton that is used for every single Set that is created
+  /// without any elements. The contents of the storage must never be mutated.
+  @inlinable
+  @nonobjc
+  internal static var empty: _SwiftEmptySetStorage {
+    return Builtin.bridgeFromRawPointer(
+      Builtin.addressof(&_swiftEmptySetStorage))
+  }
+}
+
+
+extension _SwiftEmptySetStorage: _NSSetCore {
+#if _runtime(_ObjC)
   //
   // NSSet implementation, assuming Self is the empty singleton
   //
-
-  /// Get the NSEnumerator implementation for self.
-  /// _HashableTypedNativeSetStorage overloads this to give
-  /// _NativeSelfNSEnumerator proper type parameters.
   @objc
-  internal func enumerator() -> _NSEnumerator {
-    return _SwiftSetNSEnumerator<AnyObject>(_NativeSet(_storage: self))
+  internal var count: Int {
+    return 0
   }
 
   @objc(copyWithZone:)
   internal func copy(with zone: _SwiftNSZone?) -> AnyObject {
     return self
-  }
-
-  @objc(countByEnumeratingWithState:objects:count:)
-  internal func countByEnumerating(
-    with state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
-    objects: UnsafeMutablePointer<AnyObject>?, count: Int
-  ) -> Int {
-    // Even though we never do anything in here, we need to update the
-    // state so that callers know we actually ran.
-
-    var theState = state.pointee
-    if theState.state == 0 {
-      theState.state = 1 // Arbitrary non-zero value.
-      theState.itemsPtr = AutoreleasingUnsafeMutablePointer(objects)
-      theState.mutationsPtr = _fastEnumerationStorageMutationsPtr
-    }
-    state.pointee = theState
-
-    return 0
-  }
-
-  @objc
-  internal required init(objects: UnsafePointer<AnyObject?>, count: Int) {
-    _sanityCheckFailure("don't call this designated initializer")
   }
 
   @objc
@@ -1502,71 +1487,141 @@ internal class _RawNativeSetStorage: _SwiftNativeNSSet, _NSSetCore {
 
   @objc
   internal func objectEnumerator() -> _NSEnumerator {
-    return enumerator()
+    return _SwiftEmptyNSEnumerator()
+  }
+
+  @objc(countByEnumeratingWithState:objects:count:)
+  internal func countByEnumerating(
+    with state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
+    objects: UnsafeMutablePointer<AnyObject>?, count: Int
+  ) -> Int {
+    // Even though we never do anything in here, we need to update the
+    // state so that callers know we actually ran.
+    var theState = state.pointee
+    if theState.state == 0 {
+      theState.state = 1 // Arbitrary non-zero value.
+      theState.itemsPtr = AutoreleasingUnsafeMutablePointer(objects)
+      theState.mutationsPtr = _fastEnumerationStorageMutationsPtr
+    }
+    state.pointee = theState
+    return 0
   }
 #endif
 }
 
-// See the docs at the top of this file for a description of this type
-@_fixed_layout // FIXME(sil-serialize-all)
+@_fixed_layout
 @usableFromInline
-internal class _TypedNativeSetStorage<Element>: _RawNativeSetStorage {
+internal final class _SwiftNativeSetStorage<
+  Element: Hashable
+>: _SwiftRawSetStorage, _NSSetCore {
+
+  // This type is made with allocWithTailElems, so no init is ever called.
+  // But we still need to have an init to satisfy the compiler.
+  @nonobjc
+  override internal init(_doNotCallMe: ()) {
+    _sanityCheckFailure("This class cannot be directly initialized")
+  }
 
   deinit {
-    let keys = self.keys.assumingMemoryBound(to: Element.self)
+    let elements = self.elements
 
-    if !_isPOD(Element.self) {
-      for i in 0 ..< bucketCount {
-        if initializedEntries[i] {
-          (keys+i).deinitialize(count: 1)
-        }
+    if !_isPOD(Element.self) && hashTable.count > 0 {
+      for index in hashTable.occupiedIndices {
+        (elements + index.bucket).deinitialize(count: 1)
       }
+      hashTable.count = -1
     }
 
     _fixLifetime(self)
   }
 
-  // This type is made with allocWithTailElems, so no init is ever called.
-  // But we still need to have an init to satisfy the compiler.
-  @nonobjc
-  override internal init(_doNotCallMe: ()) {
-    _sanityCheckFailure("Only create this by calling Buffer's inits")
+  internal override func invalidate() {
+    hashTable.count = -1
   }
 
-#if _runtime(_ObjC)
-  @objc
-  internal required init(objects: UnsafePointer<AnyObject?>, count: Int) {
-    _sanityCheckFailure("don't call this designated initializer")
-  }
-#endif
-}
-
-// See the docs at the top of this file for a description of this type
-@_fixed_layout // FIXME(sil-serialize-all)
-@usableFromInline
-final internal class _HashableTypedNativeSetStorage<Element: Hashable>
-  : _TypedNativeSetStorage<Element> {
-  // This type is made with allocWithTailElems, so no init is ever called.
-  // But we still need to have an init to satisfy the compiler.
-  @nonobjc
-  override internal init(_doNotCallMe: ()) {
-    _sanityCheckFailure("Only create this by calling Buffer's inits'")
+  @usableFromInline
+  static internal func allocate(capacity: Int) -> _SwiftNativeSetStorage {
+    let scale = _HashTable.scale(forCapacity: Swift.max(1 ,capacity))
+    return allocate(scale: scale)
   }
 
-#if _runtime(_ObjC)
-  // NSSet bridging:
+  static internal func allocate(scale: Int) -> _SwiftNativeSetStorage {
+    _sanityCheck(scale >= 0 && scale < Int.bitWidth - 1)
+    let bucketCount = 1 &<< scale
+    let storage = Builtin.allocWithTailElems_2(
+      _SwiftNativeSetStorage<Element>.self,
+      bucketCount._builtinWordValue, _HashTable.MapEntry.self,
+      bucketCount._builtinWordValue, Element.self)
+
+    let mapAddr = Builtin.projectTailElems(storage, _HashTable.MapEntry.self)
+    let elementsAddr = Builtin.getTailAddr_Word(
+      mapAddr,
+      bucketCount._builtinWordValue,
+      _HashTable.MapEntry.self,
+      Element.self)
+    storage.hashTable = _HashTable(
+      scale: scale,
+      count: 0,
+      map: UnsafeMutablePointer(mapAddr))
+    storage.rawElements = UnsafeMutableRawPointer(elementsAddr)
+
+    // We assign a unique hash seed to each distinct hash table size, so that we
+    // avoid certain copy operations becoming quadratic, without breaking value
+    // semantics. (See https://bugs.swift.org/browse/SR-3268)
+    //
+    // We don't need to generate a brand new seed for each table size: it's
+    // enough to change a single bit in the global seed by XORing the bucket
+    // count to it. (The bucket count is always a power of two.)
+    //
+    // FIXME: Use an approximation of true per-instance seeding. We can't just
+    // use the base address, because COW copies need to share the same seed.
+    let seed = Hasher._seed
+    let perturbation = bucketCount
+    storage.seed = (seed.0 ^ UInt64(truncatingIfNeeded: perturbation), seed.1)
+
+    return storage
+  }
+
+  @inlinable
+  final var elements: UnsafeMutablePointer<Element> {
+    @inline(__always)
+    get {
+      return self.rawElements.assumingMemoryBound(to: Element.self)
+    }
+  }
 
   internal var asNative: _NativeSet<Element> {
-    return _NativeSet(_storage: self)
+    return _NativeSet(self)
+  }
+
+#if _runtime(_ObjC)
+  // _NSSetCore implementation
+  //
+  // FIXME: These should be moved to an extension, but @objc members aren't
+  // supported in extensions of generic classes.
+
+  @objc
+  internal init(objects: UnsafePointer<AnyObject?>, count: Int) {
+    _sanityCheckFailure("Don't call this designated initializer")
+  }
+
+  @objc(copyWithZone:)
+  internal func copy(with zone: _SwiftNSZone?) -> AnyObject {
+    return self
   }
 
   @objc
-  internal override func enumerator() -> _NSEnumerator {
-    return _SwiftSetNSEnumerator<Element>(_NativeSet(_storage: self))
+  internal var count: Int {
+    return hashTable.count
+  }
+
+  @objc
+  internal func objectEnumerator() -> _NSEnumerator {
+    return _SwiftSetNSEnumerator(asNative)
   }
 
   @objc(countByEnumeratingWithState:objects:count:)
-  internal override func countByEnumerating(
+  internal func countByEnumerating(
     with state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
     objects: UnsafeMutablePointer<AnyObject>?, count: Int
   ) -> Int {
@@ -1586,49 +1641,37 @@ final internal class _HashableTypedNativeSetStorage<Element: Hashable>
     }
 
     let unmanagedObjects = _UnmanagedAnyObjectArray(objects!)
-    var currIndex = _NativeSet<Element>.Index(bucket: Int(theState.extra.0))
+    var index = _HashTable.Index(bucket: Int(theState.extra.0))
+    hashTable.checkOccupied(index)
     let endIndex = asNative.endIndex
     var stored = 0
     for i in 0..<count {
-      if (currIndex == endIndex) {
-        break
-      }
+      guard index < endIndex else { break }
 
-      unmanagedObjects[i] = asNative.bridgedKey(at: currIndex)
+      let element = asNative.uncheckedElement(at: index)
+      unmanagedObjects[i] = _bridgeAnythingToObjectiveC(element)
 
       stored += 1
-      asNative.formIndex(after: &currIndex)
+      asNative.formIndex(after: &index)
     }
-    theState.extra.0 = CUnsignedLong(currIndex.bucket)
+    theState.extra.0 = CUnsignedLong(index.bucket)
     state.pointee = theState
     return stored
   }
 
-  @nonobjc
-  internal func getObjectFor(_ aKey: AnyObject) -> AnyObject? {
-    guard let nativeKey = _conditionallyBridgeFromObjectiveC(aKey, Element.self)
+  @objc
+  internal func member(_ object: AnyObject) -> AnyObject? {
+    guard let native = _conditionallyBridgeFromObjectiveC(object, Element.self)
     else { return nil }
 
-    let (i, found) = asNative._find(nativeKey)
-    if found {
-      return asNative.bridgedValue(at: i)
-    }
-    return nil
-  }
-
-  @objc
-  internal required init(objects: UnsafePointer<AnyObject?>, count: Int) {
-    _sanityCheckFailure("don't call this designated initializer")
-  }
-
-  @objc
-  override internal func member(_ object: AnyObject) -> AnyObject? {
-    return getObjectFor(object)
+    let (index, found) = asNative.find(native)
+    guard found else { return nil }
+    return _bridgeAnythingToObjectiveC(asNative.uncheckedElement(at: index))
   }
 #endif
 }
 
-/// A wrapper around _RawNativeSetStorage that provides most of the
+/// A wrapper around _SwiftRawSetStorage that provides most of the
 /// implementation of Set.
 ///
 /// This type and most of its functionality doesn't require Hashable at all.
@@ -1637,217 +1680,178 @@ final internal class _HashableTypedNativeSetStorage<Element: Hashable>
 /// Hashable can be found in an extension.
 @usableFromInline
 @_fixed_layout
-internal struct _NativeSet<Element> {
-  /// See this comments on _RawNativeSetStorage and its subclasses to
+internal struct _NativeSet<Element: Hashable> {
+  /// See this comments on _SwiftRawSetStorage and its subclasses to
   /// understand why we store an untyped storage here.
   @usableFromInline
-  internal var _storage: _RawNativeSetStorage
+  internal var _storage: _SwiftRawSetStorage
 
   /// Constructs an instance from the empty singleton.
   @inlinable
   internal init() {
-    self._storage = _RawNativeSetStorage.empty
+    self._storage = _SwiftRawSetStorage.empty
   }
 
   /// Constructs a native set adopting the given storage.
   @inlinable
-  internal init(_storage: _RawNativeSetStorage) {
-    self._storage = _storage
-  }
-
-  /// Creates a Buffer with a storage that is typed, but doesn't understand
-  /// Hashing. Mostly for bridging; prefer `init(minimumCapacity:)`.
-  @inlinable // FIXME(sil-serialize-all)
-  internal init(_exactBucketCount bucketCount: Int, unhashable: ()) {
-    let bitmapWordCount = _UnsafeBitMap.sizeInWords(forSizeInBits: bucketCount)
-    let storage = Builtin.allocWithTailElems_2(
-      _TypedNativeSetStorage<Element>.self,
-      bitmapWordCount._builtinWordValue, UInt.self,
-      bucketCount._builtinWordValue, Element.self)
-    self.init(_exactBucketCount: bucketCount, storage: storage)
-  }
-
-  /// Given a bucket count and uninitialized _RawNativeSetStorage, completes the
-  /// initialization and returns a Buffer.
-  @inlinable // FIXME(sil-serialize-all)
-  internal init(
-    _exactBucketCount bucketCount: Int,
-    storage: _RawNativeSetStorage
-  ) {
-    storage.bucketCount = bucketCount
-    storage.count = 0
-
-    self.init(_storage: storage)
-
-    let initializedEntries = _UnsafeBitMap(
-        storage: _initializedHashtableEntriesBitMapBuffer,
-        bitCount: bucketCount)
-    initializedEntries.initializeToZero()
-
-    // Compute all the array offsets now, so we don't have to later
-    let bitmapAddr = Builtin.projectTailElems(_storage, UInt.self)
-    let bitmapWordCount = _UnsafeBitMap.sizeInWords(forSizeInBits: bucketCount)
-    let keysAddr = Builtin.getTailAddr_Word(bitmapAddr,
-           bitmapWordCount._builtinWordValue, UInt.self, Element.self)
-
-    // Initialize header
-    _storage.initializedEntries = initializedEntries
-    _storage.keys = UnsafeMutableRawPointer(keysAddr)
-    // We assign a unique hash seed to each distinct hash table size, so that we
-    // avoid certain copy operations becoming quadratic, without breaking value
-    // semantics. (See https://bugs.swift.org/browse/SR-3268)
-    //
-    // We don't need to generate a brand new seed for each table size: it's
-    // enough to change a single bit in the global seed by XORing the bucket
-    // count to it. (The bucket count is always a power of two.)
-    //
-    // FIXME: Use an approximation of true per-instance seeding. We can't just
-    // use the base address, because COW copies need to share the same seed.
-    let seed = Hasher._seed
-    let perturbation = bucketCount
-    _storage.seed = (seed.0 ^ UInt64(truncatingIfNeeded: perturbation), seed.1)
-  }
-
-  // Forwarding the individual fields of the storage in various forms
-
-  @inlinable
-  internal var bucketCount: Int {
-    return _assumeNonNegative(_storage.bucketCount)
+  internal init(_ storage: _SwiftRawSetStorage) {
+    self._storage = storage
   }
 
   @inlinable
-  internal var count: Int {
-    set {
-      _storage.count = newValue
-    }
-    get {
-      return _assumeNonNegative(_storage.count)
-    }
-  }
-
-  @inlinable
-  internal
-  var _initializedHashtableEntriesBitMapBuffer: UnsafeMutablePointer<UInt> {
-    return _storage._initializedHashtableEntriesBitMapBuffer
-  }
-
-  // This API is unsafe and needs a `_fixLifetime` in the caller.
-  @inlinable
-  internal var keys: UnsafeMutablePointer<Element> {
-    return _storage.keys.assumingMemoryBound(to: Element.self)
-  }
-
-  // Most of the implementation of the _SetBuffer protocol,
-  // but only the parts that don't actually rely on hashing.
-
-  @inlinable
-  @inline(__always)
-  internal func key(at i: Int) -> Element {
-    _sanityCheck(i >= 0 && i < bucketCount)
-    _sanityCheck(isInitializedEntry(at: i))
-    defer { _fixLifetime(self) }
-
-    let res = (keys + i).pointee
-    return res
+  internal init(capacity: Int) {
+    self._storage = _SwiftNativeSetStorage<Element>.allocate(capacity: capacity)
   }
 
 #if _runtime(_ObjC)
-  /// Returns the key at the given Index, bridged.
-  ///
-  /// Intended for use with verbatim bridgeable keys.
   @inlinable
-  internal func bridgedKey(at index: Index) -> AnyObject {
-    let k = key(at: index.bucket)
-    return _bridgeAnythingToObjectiveC(k)
+  internal init(_ cocoa: _CocoaSet) {
+    self.init(cocoa, capacity: cocoa.count)
   }
 
-  /// Returns the value at the given Index, bridged.
-  ///
-  /// Intended for use with verbatim bridgeable keys.
   @inlinable
-  internal func bridgedValue(at index: Index) -> AnyObject {
-    let v = value(at: index.bucket)
-    return _bridgeAnythingToObjectiveC(v)
+  internal init(_ cocoa: _CocoaSet, capacity: Int) {
+    _sanityCheck(cocoa.count <= capacity)
+    self.init(capacity: capacity)
+    for element in cocoa {
+      insertNew(_forceBridgeFromObjectiveC(element, Element.self))
+    }
   }
 #endif
+}
+
+extension _NativeSet {
+  @inlinable
+  internal var bucketCount: Int {
+    return _assumeNonNegative(_storage.hashTable.bucketCount)
+  }
 
   @inlinable
-  internal func isInitializedEntry(at i: Int) -> Bool {
-    _sanityCheck(i >= 0 && i < bucketCount)
-    defer { _fixLifetime(self) }
+  internal var capacity: Int {
+    return _assumeNonNegative(_storage.hashTable.capacity)
+  }
 
-    return _storage.initializedEntries[i]
+  @inlinable
+  internal var indices: _HashTable.OccupiedIndices {
+    @inline(__always)
+    get {
+      return _storage.hashTable.occupiedIndices
+    }
+  }
+
+  @inlinable
+  internal var elements: UnsafeMutablePointer<Element> {
+    @inline(__always)
+    get {
+      return _storage.rawElements.assumingMemoryBound(to: Element.self)
+    }
+  }
+
+  @inlinable
+  @inline(__always)
+  internal func uncheckedElement(at i: Index) -> Element {
+    _sanityCheck(_storage.hashTable.isOccupied(i))
+    defer { _fixLifetime(self) }
+    return elements[i.bucket]
   }
 
   @usableFromInline @_transparent
-  internal func destroyEntry(at i: Int) {
-    _sanityCheck(isInitializedEntry(at: i))
+  internal func uncheckedDestroyElement(at i: Index) {
+    _sanityCheck(_storage.hashTable.isValid(i))
     defer { _fixLifetime(self) }
-
-    (keys + i).deinitialize(count: 1)
-    _storage.initializedEntries[i] = false
+    (elements + i.bucket).deinitialize(count: 1)
   }
 
   @usableFromInline @_transparent
-  internal func initializeKey(_ k: Element, at i: Int) {
-    _sanityCheck(!isInitializedEntry(at: i))
+  internal func uncheckedInitializeElement(at i: Index, to element: Element) {
+    _sanityCheck(_storage.hashTable.isValid(i))
     defer { _fixLifetime(self) }
-
-    (keys + i).initialize(to: k)
-    _storage.initializedEntries[i] = true
+    (elements + i.bucket).initialize(to: element)
   }
 
   @usableFromInline @_transparent
-  internal func moveInitializeEntry(
-    from: _NativeSet,
-    at: Int,
-    toEntryAt: Int
+  internal func uncheckedMoveInitializeElement(
+    from source: _NativeSet,
+    at sourceIndex: Index,
+    to targetIndex: Index
   ) {
-    _sanityCheck(!isInitializedEntry(at: toEntryAt))
-
+    _sanityCheck(source._storage.hashTable.isOccupied(sourceIndex))
+    _sanityCheck(_storage.hashTable.isValid(targetIndex))
     defer { _fixLifetime(self) }
-
-    (keys + toEntryAt).initialize(to: (from.keys + at).move())
-    from._storage.initializedEntries[at] = false
-    _storage.initializedEntries[toEntryAt] = true
+    (elements + targetIndex.bucket).moveInitialize(
+      from: source.elements + sourceIndex.bucket,
+      count: 1)
   }
+}
 
-  /// Alias for key(at:) in Sets for better code reuse
-  @usableFromInline @_transparent
-  internal func value(at i: Int) -> Element {
-    return key(at: i)
+extension _NativeSet {
+  @usableFromInline
+  @_effects(releasenone)
+  internal mutating func reallocate(
+    isUnique: Bool,
+    capacity: Int
+  ) -> (reallocated: Bool, rehashed: Bool) {
+    let scale = _HashTable.scale(forCapacity: capacity)
+    let result = _NativeSet(
+      _SwiftNativeSetStorage<Element>.allocate(scale: scale))
+    let rehash = (scale != _storage.hashTable.scale)
+    switch (isUnique, rehash) {
+    case (true, true): // Move & rehash elements
+      for index in self.indices {
+        result.moveNew(from: self, at: index)
+      }
+      _storage.invalidate()
+    case (true, false): // Move elements to same buckets in new storage
+      result._storage.hashTable.copyContents(of: _storage.hashTable)
+      for index in self.indices {
+        result.uncheckedMoveInitializeElement(from: self, at: index, to: index)
+      }
+      _storage.invalidate()
+    case (false, true): // Copy & rehash elements
+      for index in self.indices {
+        result.insertNew(self.uncheckedElement(at: index))
+      }
+    case (false, false): // Copy elements to same buckets in new storage
+      result._storage.hashTable.copyContents(of: _storage.hashTable)
+      for index in self.indices {
+        let element = uncheckedElement(at: index)
+        result.uncheckedInitializeElement(at: index, to: element)
+      }
+    }
+    _storage = result._storage
+    return (true, rehash)
   }
 
   @inlinable
-  internal func setKey(_ key: Element, at i: Int) {
-    _sanityCheck(i >= 0 && i < bucketCount)
-    _sanityCheck(isInitializedEntry(at: i))
-    defer { _fixLifetime(self) }
-
-    (keys + i).pointee = key
+  @inline(__always)
+  internal mutating func ensureUnique(
+    isUnique: Bool,
+    capacity: Int
+  ) -> (reallocated: Bool, rehashed: Bool) {
+    if isUnique && capacity <= self.capacity {
+      return (false, false)
+    }
+    return reallocate(isUnique: isUnique, capacity: capacity)
   }
+}
+
+extension _NativeSet: _SetBuffer {
+  @usableFromInline
+  internal typealias Index = _HashTable.Index
 
   @inlinable
   internal var startIndex: Index {
-    // We start at "index after -1" instead of "0" because we need to find the
-    // first occupied slot.
-    return index(after: Index(bucket: -1))
+    return _storage.hashTable.startIndex
   }
 
   @inlinable
   internal var endIndex: Index {
-    return Index(bucket: bucketCount)
+    return _storage.hashTable.endIndex
   }
 
   @inlinable
   internal func index(after i: Index) -> Index {
-    _precondition(i != endIndex)
-    var idx = i.bucket + 1
-    while idx < bucketCount && !isInitializedEntry(at: idx) {
-      idx += 1
-    }
-
-    return Index(bucket: idx)
+    return _storage.hashTable.index(after: i)
   }
 
   @inlinable
@@ -1856,48 +1860,55 @@ internal struct _NativeSet<Element> {
   }
 
   @inlinable
-  internal func assertingGet(at i: Index) -> Element {
-    _precondition(i.bucket >= 0 && i.bucket < bucketCount)
-    _precondition(
-      isInitializedEntry(at: i.bucket),
-      "Attempting to access Set elements using an invalid Index")
-    let key = self.key(at: i.bucket)
-    return key
+  @inline(__always)
+  internal func index(for element: Element) -> Index? {
+    if count == 0 {
+      // Fast path that avoids computing the hash of the key.
+      return nil
+    }
+    let (i, found) = find(element)
+    return found ? i : nil
+  }
+
+  @inlinable
+  internal var count: Int {
+    get {
+      return _assumeNonNegative(_storage.hashTable.count)
+    }
+  }
+
+  @inlinable
+  @inline(__always)
+  internal func contains(_ member: Element) -> Bool {
+    if count == 0 { // Fast path that avoids computing the hash of the key.
+      return false
+    }
+    return find(member).found
+  }
+
+  @inlinable
+  @inline(__always)
+  internal func element(at index: Index) -> Element {
+    _storage.hashTable.checkOccupied(index)
+    defer { _fixLifetime(self) }
+    return elements[index.bucket]
   }
 }
 
-extension _NativeSet/*: _SetBuffer*/ where Element: Hashable {
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
-  internal init(minimumCapacity: Int) {
-    let bucketCount = _NativeSet.bucketCount(
-      forCapacity: minimumCapacity,
-      maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
-    self.init(bucketCount: bucketCount)
+extension _NativeSet: _HashTableDelegate {
+  internal func hashValue(at index: Index) -> Int {
+    return uncheckedElement(at: index)._rawHashValue(seed: _storage.seed)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
-  internal init(bucketCount: Int) {
-    // Actual bucket count is the next power of 2 greater than or equal to
-    // bucketCount. Make sure that is representable.
-    _sanityCheck(bucketCount <= (Int.max >> 1) + 1)
-    let buckets = 1 &<< ((Swift.max(bucketCount, 2) - 1)._binaryLogarithm() + 1)
-    self.init(_exactBucketCount: buckets)
+  internal func moveEntry(from source: Index, to target: Index) {
+    _sanityCheck(source != target)
+    (elements + target.bucket).moveInitialize(
+      from: elements + source.bucket,
+      count: 1)
   }
+}
 
-  /// Create a buffer instance with room for at least 'bucketCount' entries,
-  /// marking all entries invalid.
-  @inlinable // FIXME(sil-serialize-all)
-  internal init(_exactBucketCount bucketCount: Int) {
-    let bitmapWordCount = _UnsafeBitMap.sizeInWords(forSizeInBits: bucketCount)
-    let storage = Builtin.allocWithTailElems_2(
-      _HashableTypedNativeSetStorage<Element>.self,
-      bitmapWordCount._builtinWordValue, UInt.self,
-      bucketCount._builtinWordValue, Element.self)
-    self.init(_exactBucketCount: bucketCount, storage: storage)
-  }
-
+extension _NativeSet {
 #if _runtime(_ObjC)
   @usableFromInline
   internal func bridged() -> _NSSet {
@@ -1907,9 +1918,10 @@ extension _NativeSet/*: _SetBuffer*/ where Element: Hashable {
     // Temporary var for SOME type safety before a cast.
     let nsSet: _NSSetCore
 
-    if _isBridgedVerbatimToObjectiveC(Element.self) ||
-      self._storage === _RawNativeSetStorage.empty {
-      nsSet = self._storage
+    if _storage === _SwiftRawSetStorage.empty {
+      nsSet = _SwiftRawSetStorage.empty
+    } else if _isBridgedVerbatimToObjectiveC(Element.self) {
+      nsSet = unsafeDowncast(_storage, to: _SwiftNativeSetStorage<Element>.self)
     } else {
       nsSet = _SwiftDeferredNSSet(self)
     }
@@ -1920,259 +1932,272 @@ extension _NativeSet/*: _SetBuffer*/ where Element: Hashable {
     return unsafeBitCast(nsSet, to: _NSSet.self)
   }
 #endif
+}
 
+extension _NativeSet: CustomStringConvertible {
   /// A textual representation of `self`.
-  @inlinable // FIXME(sil-serialize-all)
+  @usableFromInline
   internal var description: String {
     var result = ""
 #if INTERNAL_CHECKS_ENABLED
-    for i in 0..<bucketCount {
-      if isInitializedEntry(at: i) {
-        let key = self.key(at: i)
-        result += "bucket \(i), ideal bucket = \(_bucket(key)), key = \(key)\n"
-      } else {
-        result += "bucket \(i), empty\n"
-      }
+    for i in indices {
+      let element = uncheckedElement(at: i)
+      let hashValue = self.hashValue(for: element)
+      let ideal = hashValue & _storage.hashTable.bucketMask
+      let delta = ideal < i.bucket // Distance from ideal bucket
+        ? i.bucket - ideal
+        : i.bucket - ideal + bucketCount
+      result += "bucket: \(i.bucket), delta: \(delta), element: \(element)\n"
     }
 #endif
     return result
   }
+}
 
-  @inlinable // FIXME(sil-serialize-all)
-  internal var _bucketMask: Int {
-    // The bucket count is not negative, therefore subtracting 1 will not
-    // overflow.
-    return bucketCount &- 1
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always) // For performance reasons.
-  internal func _bucket(_ k: Element) -> Int {
-    return k._rawHashValue(seed: _storage.seed) & _bucketMask
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
-  internal func _index(after bucket: Int) -> Int {
-    // Bucket is within 0 and bucketCount. Therefore adding 1 does not overflow.
-    return (bucket &+ 1) & _bucketMask
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
-  internal func _prev(_ bucket: Int) -> Int {
-    // Bucket is not negative. Therefore subtracting 1 does not overflow.
-    return (bucket &- 1) & _bucketMask
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
+extension _NativeSet {
+  @inlinable
   @inline(__always)
-  internal func _find(_ key: Element) -> (pos: Index, found: Bool) {
-    return _find(key, startBucket: _bucket(key))
+  internal func hashValue(for element: Element) -> Int {
+    return element._rawHashValue(seed: _storage.seed)
+  }
+
+  @inlinable
+  @inline(__always)
+  internal func find(_ element: Element) -> (index: Index, found: Bool) {
+    return find(element, hashValue: self.hashValue(for: element))
   }
 
   /// Search for a given key starting from the specified bucket.
   ///
   /// If the key is not present, returns the position where it could be
   /// inserted.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   @inline(__always)
-  internal func _find(_ key: Element, startBucket: Int)
-    -> (pos: Index, found: Bool) {
-
-    var bucket = startBucket
-
-    // The invariant guarantees there's always a hole, so we just loop
-    // until we find one
-    while true {
-      let isHole = !isInitializedEntry(at: bucket)
-      if isHole {
-        return (Index(bucket: bucket), false)
+  internal func find(
+    _ element: Element,
+    hashValue: Int
+  ) -> (index: Index, found: Bool) {
+    var (index, found) = _storage.hashTable.lookupFirst(hashValue: hashValue)
+    while found {
+      if uncheckedElement(at: index) == element {
+        return (index, true)
       }
-      if self.key(at: bucket) == key {
-        return (Index(bucket: bucket), true)
+      (index, found) =
+        _storage.hashTable.lookupNext(hashValue: hashValue, after: index)
+    }
+    return (index, false)
+  }
+}
+
+// This function has a highly visible name to make it stand out in stack traces.
+@usableFromInline
+@inline(never)
+internal func ELEMENT_TYPE_OF_SET_VIOLATES_HASHABLE_REQUIREMENTS(
+  _ elementType: Any.Type
+) -> Never {
+  fatalError("""
+    Duplicate elements of type '\(elementType)' were found in a Set.
+    This usually means that either the type violates Hashable's requirements, or
+    that members of such a set were mutated after insertion.
+    """)
+}
+
+extension _NativeSet {
+  @inlinable
+  internal func moveNew(from source: _NativeSet, at sourceIndex: Index) {
+    _sanityCheck(source._storage.hashTable.isOccupied(sourceIndex))
+    _sanityCheck(count + 1 <= capacity)
+    let sourcePtr = source.elements + sourceIndex.bucket
+    let hashValue = self.hashValue(for: sourcePtr.pointee)
+    if _isDebugAssertConfiguration() {
+      // In debug builds, perform a full lookup and trap if we detect duplicate
+      // elements -- these imply that the Element type violates Hashable
+      // requirements. This is generally more costly than a direct insertion,
+      // because we'll need to compare elements in case of hash collisions.
+      let (index, found) = find(sourcePtr.pointee, hashValue: hashValue)
+      guard !found else {
+        ELEMENT_TYPE_OF_SET_VIOLATES_HASHABLE_REQUIREMENTS(Element.self)
       }
-      bucket = _index(after: bucket)
+      _storage.hashTable.insert(hashValue: hashValue, at: index)
+      uncheckedMoveInitializeElement(from: source, at: sourceIndex, to: index)
+    } else {
+      let index = _storage.hashTable.insertNew(hashValue: hashValue)
+      uncheckedMoveInitializeElement(from: source, at: sourceIndex, to: index)
     }
   }
 
-  @usableFromInline @_transparent
-  internal static func bucketCount(
-    forCapacity capacity: Int,
-    maxLoadFactorInverse: Double
-  ) -> Int {
-    // `capacity + 1` below ensures that we don't fill in the last hole
-    return Swift.max(
-      Int((Double(capacity) * maxLoadFactorInverse).rounded(.up)),
-      capacity + 1)
-  }
-
-  /// Buffer should be uniquely referenced.
-  /// The `key` should not be present in the Set.
+  /// Storage should be uniquely referenced with enough capacity.
+  /// The `element` should not be present in the Set.
   /// This function does *not* update `count`.
-
-  @inlinable // FIXME(sil-serialize-all)
-  internal func unsafeAddNew(key newKey: Element) {
-    let (i, found) = _find(newKey)
-    _precondition(
-      !found, "Duplicate element found in Set. Elements may have been mutated after insertion")
-    initializeKey(newKey, at: i.bucket)
-  }
-
-
-  @inlinable // FIXME(sil-serialize-all)
-  internal static func fromArray(_ elements: [Element]) -> _NativeSet<Element> {
-    if elements.isEmpty {
-      return _NativeSet()
-    }
-
-    var native = _NativeSet<Element>(minimumCapacity: elements.count)
-
-    var count = 0
-    for key in elements {
-      let (i, found) = native._find(key)
-      if found {
-        continue
+  @inlinable
+  internal func insertNew(_ element: Element) {
+    _sanityCheck(count + 1 <= capacity)
+    let hashValue = self.hashValue(for: element)
+    if _isDebugAssertConfiguration() {
+      // In debug builds, perform a full lookup and trap if we detect duplicate
+      // elements -- these imply that the Element type violates Hashable
+      // requirements. This is generally more costly than a direct insertion,
+      // because we'll need to compare elements in case of hash collisions.
+      let (index, found) = find(element, hashValue: hashValue)
+      guard !found else {
+        ELEMENT_TYPE_OF_SET_VIOLATES_HASHABLE_REQUIREMENTS(Element.self)
       }
-      native.initializeKey(key, at: i.bucket)
-      count += 1
+      _storage.hashTable.insert(hashValue: hashValue, at: index)
+      uncheckedInitializeElement(at: index, to: element)
+    } else {
+      let index = _storage.hashTable.insertNew(hashValue: hashValue)
+      uncheckedInitializeElement(at: index, to: element)
     }
-    native.count = count
-
-    return native
   }
 }
 
-extension _NativeSet where Element: Hashable {
-  /// - parameter idealBucket: The ideal bucket for the element being deleted.
-  /// - parameter bucket: The bucket containing the element to be deleted.
-  /// Precondition: there should be an initialized entry in the specified
-  /// bucket.
-  @inlinable // FIXME(sil-serialize-all)
-  internal mutating func _delete(idealBucket: Int, bucket: Int) {
-    _sanityCheck(isInitializedEntry(at: bucket), "expected initialized entry")
-
-    // remove the element
-    destroyEntry(at: bucket)
-    self.count -= 1
-
-    // If we've put a hole in a chain of contiguous elements, some
-    // element after the hole may belong where the new hole is.
-    var hole = bucket
-
-    // Find the first bucket in the contiguous chain
-    var start = idealBucket
-    while isInitializedEntry(at: _prev(start)) {
-      start = _prev(start)
-    }
-
-    // Find the last bucket in the contiguous chain
-    var lastInChain = hole
-    var b = _index(after: lastInChain)
-    while isInitializedEntry(at: b) {
-      lastInChain = b
-      b = _index(after: b)
-    }
-
-    // Relocate out-of-place elements in the chain, repeating until
-    // none are found.
-    while hole != lastInChain {
-      // Walk backwards from the end of the chain looking for
-      // something out-of-place.
-      var b = lastInChain
-      while b != hole {
-        let idealBucket = _bucket(self.key(at: b))
-
-        // Does this element belong between start and hole?  We need
-        // two separate tests depending on whether [start, hole] wraps
-        // around the end of the storage
-        let c0 = idealBucket >= start
-        let c1 = idealBucket <= hole
-        if start <= hole ? (c0 && c1) : (c0 || c1) {
-          break // Found it
-        }
-        b = _prev(b)
-      }
-
-      if b == hole { // No out-of-place elements found; we're done adjusting
-        break
-      }
-
-      // Move the found element into the hole
-      moveInitializeEntry(from: self, at: b, toEntryAt: hole)
-      hole = b
-    }
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
-  mutating func _removeAll() {
-    for b in 0 ..< bucketCount {
-      if isInitializedEntry(at: b) {
-        destroyEntry(at: b)
-      }
-    }
-    count = 0
-  }
-}
-
-extension _NativeSet/*: _SetBuffer*/ where Element: Hashable {
-  //
-  // _SetBuffer conformance
-  //
-
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
-  internal func index(forKey key: Element) -> Index? {
-    if count == 0 {
-      // Fast path that avoids computing the hash of the key.
-      return nil
-    }
-    let (i, found) = _find(key)
-    return found ? i : nil
+extension _NativeSet {
+  @inlinable
+  internal mutating func reserveCapacity(_ capacity: Int, isUnique: Bool) {
+    _ = ensureUnique(isUnique: isUnique, capacity: capacity)
   }
 
   @inlinable
-  @inline(__always)
-  internal func contains(_ member: Element) -> Bool {
-    if count == 0 {
-      // Fast path that avoids computing the hash of the key.
-      return false
+  internal mutating func update(with element: Element, isUnique: Bool) -> Element? {
+    _ = ensureUnique(isUnique: isUnique, capacity: count + 1)
+    let hashValue = self.hashValue(for: element)
+    let (index, found) = find(element, hashValue: hashValue)
+    if found {
+      let old = (elements + index.bucket).move()
+      uncheckedInitializeElement(at: index, to: element)
+      return old
     }
-    return _find(member).found
+    _storage.hashTable.insert(hashValue: hashValue, at: index)
+    uncheckedInitializeElement(at: index, to: element)
+    return nil
   }
 
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
-  internal func maybeGet(_ key: Element) -> Element? {
-    if count == 0 {
-      // Fast path that avoids computing the hash of the key.
+  /// A variant of insert that returns the inserted index rather than the
+  /// element stored in the corresponding bucket.
+  @inlinable
+  @discardableResult
+  internal mutating func _insert(
+    _ element: Element,
+    isUnique: Bool
+  ) -> (inserted: Bool, index: Index) {
+    var hashValue = self.hashValue(for: element)
+    var (index, found) = find(element, hashValue: hashValue)
+    if found { return (false, index) }
+    if ensureUnique(isUnique: isUnique, capacity: count + 1).rehashed {
+      hashValue = self.hashValue(for: element)
+      (index, found) = find(element, hashValue: hashValue)
+      guard !found else {
+        ELEMENT_TYPE_OF_SET_VIOLATES_HASHABLE_REQUIREMENTS(Element.self)
+      }
+    }
+    _storage.hashTable.insert(hashValue: hashValue, at: index)
+    uncheckedInitializeElement(at: index, to: element)
+    return (true, index)
+  }
+
+  @inlinable
+  internal mutating func insert(
+    _ element: Element,
+    isUnique: Bool
+  ) -> (inserted: Bool, memberAfterInsert: Element) {
+    let (inserted, index) = _insert(element, isUnique: isUnique)
+    if inserted {
+      return (true, element)
+    }
+    return (false, uncheckedElement(at: index))
+  }
+
+  @usableFromInline
+  @_effects(releasenone)
+  internal mutating func _delete(at index: Index, hashValue: Int) {
+    _storage.hashTable.delete(at: index, hashValue: hashValue, with: self)
+  }
+
+  @inlinable
+  internal mutating func remove(_ member: Element, isUnique: Bool) -> Element? {
+    var hashValue = self.hashValue(for: member)
+    var (index, found) = find(member, hashValue: hashValue)
+
+    // Fast path: if the key is not present, we will not mutate the set, so
+    // don't force unique buffer.
+    if !found {
       return nil
     }
 
-    let (i, found) = _find(key)
-    if found {
-      return self.key(at: i.bucket)
+    if ensureUnique(isUnique: isUnique, capacity: capacity).rehashed {
+      hashValue = self.hashValue(for: member)
+      (index, found) = find(member, hashValue: hashValue)
+      guard found else {
+        ELEMENT_TYPE_OF_SET_VIOLATES_HASHABLE_REQUIREMENTS(Element.self)
+      }
     }
-    return nil
+
+    let old = (elements + index.bucket).move()
+    _delete(at: index, hashValue: hashValue)
+    return old
+  }
+
+  @inlinable
+  internal mutating func remove(at index: Index, isUnique: Bool) -> Element {
+    _precondition(_storage.hashTable.isOccupied(index), "Invalid index")
+    let (_, rehashed) = ensureUnique(isUnique: isUnique, capacity: capacity)
+    _sanityCheck(!rehashed)
+
+    let old = (elements + index.bucket).move()
+    _delete(at: index, hashValue: self.hashValue(for: old))
+    return old
+  }
+
+  @usableFromInline
+  internal mutating func removeAll(isUnique: Bool) {
+    guard isUnique else {
+      _storage = _SwiftNativeSetStorage<Element>.allocate(
+        scale: self._storage.hashTable.scale)
+      return
+    }
+    for index in indices {
+      uncheckedDestroyElement(at: index)
+    }
+    _storage.hashTable.removeAll()
   }
 }
 
 #if _runtime(_ObjC)
-/// An NSEnumerator that works with any _NativeSet of verbatim bridgeable
-/// elements. Used by the various NSSet impls.
-final internal class _SwiftSetNSEnumerator<Element>
+/// An NSEnumerator that works with any native Set. Non-verbatim bridged sets
+/// need to supply a _SwiftDeferredNSSet instance to provide access to bridged
+/// values. Used by the various NSSet implementations.
+final internal class _SwiftSetNSEnumerator<Element: Hashable>
   : _SwiftNativeNSEnumerator, _NSEnumerator {
-
   internal var base: _NativeSet<Element>
-  internal var nextIndex: _NativeSet<Element>.Index
-  internal var endIndex: _NativeSet<Element>.Index
+  internal var deferred: _SwiftDeferredNSSet<Element>?
+  internal var nextIndex: _HashTable.Index
+  internal var endIndex: _HashTable.Index
 
   internal override required init() {
     _sanityCheckFailure("don't call this designated initializer")
   }
 
   internal init(_ base: _NativeSet<Element>) {
+    _sanityCheck(_isBridgedVerbatimToObjectiveC(Element.self))
     self.base = base
-    nextIndex = base.startIndex
-    endIndex = base.endIndex
+    self.deferred = nil
+    self.nextIndex = base.startIndex
+    self.endIndex = base.endIndex
+  }
+
+  internal init(_ deferred: _SwiftDeferredNSSet<Element>) {
+    _sanityCheck(!_isBridgedVerbatimToObjectiveC(Element.self))
+    self.base = deferred.native
+    self.deferred = deferred
+    self.nextIndex = base.startIndex
+    self.endIndex = base.endIndex
+  }
+
+  private func bridgedElement(at index: _HashTable.Index) -> AnyObject {
+    if let deferred = self.deferred {
+      return deferred.bridgedElements[index]
+    }
+    return _bridgeAnythingToObjectiveC(base.uncheckedElement(at: index))
   }
 
   //
@@ -2186,9 +2211,9 @@ final internal class _SwiftSetNSEnumerator<Element>
     if nextIndex == endIndex {
       return nil
     }
-    let key = base.bridgedKey(at: nextIndex)
+    let index = nextIndex
     base.formIndex(after: &nextIndex)
-    return key
+    return self.bridgedElement(at: index)
   }
 
   @objc(countByEnumeratingWithState:objects:count:)
@@ -2211,11 +2236,9 @@ final internal class _SwiftSetNSEnumerator<Element>
 
     // Return only a single element so that code can start iterating via fast
     // enumeration, terminate it, and continue via NSEnumerator.
-    let key = base.bridgedKey(at: nextIndex)
-    base.formIndex(after: &nextIndex)
-
     let unmanagedObjects = _UnmanagedAnyObjectArray(objects)
-    unmanagedObjects[0] = key
+    unmanagedObjects[0] = self.bridgedElement(at: nextIndex)
+    base.formIndex(after: &nextIndex)
     state.pointee = theState
     return 1
   }
@@ -2236,7 +2259,7 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
   //
   // Do not access this property directly.
   @nonobjc
-  private var _heapStorageBridged_DoNotUse: AnyObject?
+  private var _bridgedElements_DoNotUse: AnyObject? = nil
 
   /// The unbridged elements.
   internal var native: _NativeSet<Element>
@@ -2246,62 +2269,64 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
     super.init()
   }
 
+  deinit {
+    if native.count > 0, let bridged = _bridgedElements {
+      bridged.invalidate(with: native.indices)
+    }
+  }
+
   /// Returns the pointer to the stored property, which contains bridged
   /// Set elements.
   @nonobjc
-  private var _bridgedStoragePtr: UnsafeMutablePointer<AnyObject?> {
-    return _getUnsafePointerToStoredProperties(self).assumingMemoryBound(
-      to: Optional<AnyObject>.self)
+  private var _bridgedElementsPtr: UnsafeMutablePointer<AnyObject?>
+  {
+    return _getUnsafePointerToStoredProperties(self)
+      .assumingMemoryBound(to: Optional<AnyObject>.self)
   }
 
   /// The buffer for bridged Set elements, if present.
   @nonobjc
-  private var _bridgedStorage: _RawNativeSetStorage? {
-    get {
-      if let ref = _stdlib_atomicLoadARCRef(object: _bridgedStoragePtr) {
-        return unsafeDowncast(ref, to: _RawNativeSetStorage.self)
-      }
-      return nil
+  private var _bridgedElements: _BridgingHashBuffer? {
+    if let ref = _stdlib_atomicLoadARCRef(object: _bridgedElementsPtr) {
+      return unsafeDowncast(ref, to: _BridgingHashBuffer.self)
     }
+    return nil
   }
 
   /// Attach a buffer for bridged Set elements.
   @nonobjc
-  private func _initializeBridgedStorage(_ storage: AnyObject) {
-    _stdlib_atomicInitializeARCRef(object: _bridgedStoragePtr, desired: storage)
+  private func _initializeBridgedElements(
+    _ storage: _BridgingHashBuffer
+  ) -> Bool {
+    return _stdlib_atomicInitializeARCRef(
+      object: _bridgedElementsPtr,
+      desired: storage)
   }
 
   /// Returns the bridged Set values.
-  internal var bridged: _NativeSet<AnyObject> {
-    return _NativeSet(_storage: _bridgedStorage!)
+  @nonobjc
+  internal var bridgedElements: _BridgingHashBuffer {
+    return _bridgedElements!
   }
 
   @nonobjc
   internal func bridgeEverything() {
-    if _fastPath(_bridgedStorage != nil) {
+    if _fastPath(_bridgedElements != nil) {
       return
     }
 
-    // FIXME: rdar://problem/19486139 (split bridged buffers for keys and values)
-    // We bridge keys and values unconditionally here, even if one of them
-    // actually is verbatim bridgeable (e.g. Dictionary<Int, AnyObject>).
-    // Investigate only allocating the buffer for a Set in this case.
-
-    // Create native set for bridged data.
-    let bridged = _NativeSet<AnyObject>(
-      _exactBucketCount: native.bucketCount,
-      unhashable: ())
-
-    // Bridge everything.
-    for i in 0..<native.bucketCount {
-      if native.isInitializedEntry(at: i) {
-        let key = _bridgeAnythingToObjectiveC(native.key(at: i))
-        bridged.initializeKey(key, at: i)
-      }
+    // Allocate and initialize heap storage for bridged objects.
+    let bridged = _BridgingHashBuffer.create(bucketCount: native.bucketCount)
+    for index in native.indices {
+      let object = _bridgeAnythingToObjectiveC(native.element(at: index))
+      bridged.initialize(at: index, to: object)
     }
 
     // Atomically put the bridged elements in place.
-    _initializeBridgedStorage(bridged._storage)
+    if !_initializeBridgedElements(bridged) {
+      // Lost the race.
+      bridged.invalidate(with: native.indices)
+    }
   }
 
   //
@@ -2324,33 +2349,26 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
   }
 
   @objc
-  internal func member(_ object: AnyObject) -> AnyObject? {
-    guard let element =
-      _conditionallyBridgeFromObjectiveC(object, Element.self)
-    else { return nil }
-
-    let (i, found) = native._find(element)
-    if found {
-      bridgeEverything()
-      return bridged.value(at: i.bucket)
-    }
-    return nil
-  }
-
-  @objc
-  internal func objectEnumerator() -> _NSEnumerator {
-    return enumerator()
-  }
-
-  @objc
   internal var count: Int {
     return native.count
   }
 
   @objc
-  internal func enumerator() -> _NSEnumerator {
+  internal func member(_ object: AnyObject) -> AnyObject? {
+    guard let element =
+      _conditionallyBridgeFromObjectiveC(object, Element.self)
+    else { return nil }
+
+    let (index, found) = native.find(element)
+    guard found else { return nil }
     bridgeEverything()
-    return _SwiftSetNSEnumerator<AnyObject>(bridged)
+    return bridgedElements[index]
+  }
+
+  @objc
+  internal func objectEnumerator() -> _NSEnumerator {
+    bridgeEverything()
+    return _SwiftSetNSEnumerator(self)
   }
 
   @objc(countByEnumeratingWithState:objects:count:)
@@ -2389,7 +2407,7 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
         break
       }
 
-      let bridgedKey = bridged.key(at: currIndex.bucket)
+      let bridgedKey = bridgedElements[currIndex]
       unmanagedObjects[i] = bridgedKey
       stored += 1
       native.formIndex(after: &currIndex)
@@ -2399,14 +2417,12 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
     return stored
   }
 }
-#else
-final internal class _SwiftDeferredNSSet<Element: Hashable> { }
 #endif
 
 #if _runtime(_ObjC)
 @usableFromInline
 @_fixed_layout
-internal struct _CocoaSet: _SetBuffer {
+internal struct _CocoaSet {
   @usableFromInline
   internal let object: _NSSet
 
@@ -2414,6 +2430,11 @@ internal struct _CocoaSet: _SetBuffer {
   internal init(_ object: _NSSet) {
     self.object = object
   }
+}
+
+extension _CocoaSet: _SetBuffer {
+  @usableFromInline
+  internal typealias Element = AnyObject
 
   @inlinable
   internal var startIndex: Index {
@@ -2427,39 +2448,44 @@ internal struct _CocoaSet: _SetBuffer {
 
   @inlinable
   internal func index(after i: Index) -> Index {
-    return i.successor()
+    var i = i
+    formIndex(after: &i)
+    return i
   }
 
-  @inlinable
+  @usableFromInline
+  @_effects(releasenone)
   internal func formIndex(after i: inout Index) {
-    // FIXME: swift-3-indexing-model: optimize if possible.
-    i = i.successor()
+    _precondition(i.base.object === self.object, "Invalid index")
+    _precondition(i.currentKeyIndex < i.allKeys.value,
+      "Cannot increment endIndex")
+    i.currentKeyIndex += 1
   }
 
-  @inlinable
-  internal func index(forKey key: AnyObject) -> Index? {
+  @usableFromInline
+  internal func index(for element: AnyObject) -> Index? {
     // Fast path that does not involve creating an array of all keys.  In case
     // the key is present, this lookup is a penalty for the slow path, but the
     // potential savings are significant: we could skip a memory allocation and
     // a linear search.
-    if maybeGet(key) == nil {
+    if !contains(element) {
       return nil
     }
 
     let allKeys = _stdlib_NSSet_allObjects(object)
-    var keyIndex = -1
+    var index = -1
     for i in 0..<allKeys.value {
-      if _stdlib_NSObject_isEqual(key, allKeys[i]) {
-        keyIndex = i
+      if _stdlib_NSObject_isEqual(element, allKeys[i]) {
+        index = i
         break
       }
     }
-    _sanityCheck(keyIndex >= 0,
-        "Key was found in fast path, but not found later?")
-    return Index(self, allKeys, keyIndex)
+    _sanityCheck(index >= 0,
+      "Element was found in fast path, but not found later?")
+    return Index(self, allKeys, index)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   internal var count: Int {
     return object.count
   }
@@ -2469,31 +2495,11 @@ internal struct _CocoaSet: _SetBuffer {
     return object.member(element) != nil
   }
 
-  @inlinable // FIXME(sil-serialize-all)
-  internal func assertingGet(at i: Index) -> AnyObject {
+  @inlinable
+  internal func element(at i: Index) -> AnyObject {
     let value: AnyObject? = i.allKeys[i.currentKeyIndex]
     _sanityCheck(value != nil, "Item not found in underlying NSSet")
     return value!
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
-  @inline(__always)
-  internal func maybeGet(_ key: AnyObject) -> AnyObject? {
-    return object.member(key)
-  }
-
-  @usableFromInline
-  internal func _toNative<Element: Hashable>(
-    bucketCount: Int
-  ) -> _NativeSet<Element> {
-    var newNativeSet = _NativeSet<Element>(bucketCount: bucketCount)
-    let oldCocoaIterator = _CocoaSet.Iterator(self)
-    while let element = oldCocoaIterator.next() {
-      newNativeSet.unsafeAddNew(
-        key: _forceBridgeFromObjectiveC(element, Element.self))
-      newNativeSet.count += 1
-    }
-    return newNativeSet
   }
 }
 #endif
@@ -2509,13 +2515,14 @@ extension Set {
   }
 }
 
-extension Set._Variant: _SetBuffer {
+extension Set._Variant {
   @usableFromInline @_transparent
   internal var guaranteedNative: Bool {
     return _canBeClass(Element.self) == 0
   }
 
   @inlinable
+  @inline(__always)
   internal mutating func isUniquelyReferenced() -> Bool {
     // Note that &self drills down through .native(_NativeSet) to the first
     // property in _NativeSet, which is the reference to the storage.
@@ -2537,6 +2544,7 @@ extension Set._Variant: _SetBuffer {
 
   @inlinable
   internal var asNative: _NativeSet<Element> {
+    @inline(__always)
     get {
       switch self {
       case .native(let nativeSet):
@@ -2547,19 +2555,10 @@ extension Set._Variant: _SetBuffer {
 #endif
       }
     }
+    @inline(__always)
     set {
       self = .native(newValue)
     }
-  }
-
-  @inlinable
-  internal mutating func ensureNative() {
-#if _runtime(_ObjC)
-    if _fastPath(guaranteedNative) { return }
-    if case .cocoa(let cocoaSet) = self {
-      migrateToNative(cocoaSet)
-    }
-#endif
   }
 
 #if _runtime(_ObjC)
@@ -2574,103 +2573,19 @@ extension Set._Variant: _SetBuffer {
   }
 #endif
 
-  /// Return true if self is native.
-  @inlinable
-  internal var _isNative: Bool {
-#if _runtime(_ObjC)
-    switch self {
-    case .native:
-      return true
-    case .cocoa:
-      return false
-    }
-#else
-    return true
-#endif
-  }
-
-  @inline(__always)
-  @inlinable // FIXME(sil-serialize-all)
-  internal mutating func _ensureUniqueNative(
-    withBucketCount desiredBucketCount: Int
-  ) -> (reallocated: Bool, capacityChanged: Bool) {
-    let oldBucketCount = asNative.bucketCount
-    if oldBucketCount >= desiredBucketCount && isUniquelyReferenced() {
-      return (reallocated: false, capacityChanged: false)
-    }
-
-    let oldNativeSet = asNative
-    var newNativeSet = _NativeSet<Element>(bucketCount: desiredBucketCount)
-    let newBucketCount = newNativeSet.bucketCount
-    for i in 0..<oldBucketCount {
-      if oldNativeSet.isInitializedEntry(at: i) {
-        if oldBucketCount == newBucketCount {
-          let key = oldNativeSet.key(at: i)
-          newNativeSet.initializeKey(key, at: i)
-        } else {
-          let key = oldNativeSet.key(at: i)
-          newNativeSet.unsafeAddNew(key: key)
-        }
-      }
-    }
-    newNativeSet.count = oldNativeSet.count
-
-    self = .native(newNativeSet)
-    return (reallocated: true,
-      capacityChanged: oldBucketCount != newBucketCount)
-  }
-
-  @inline(__always)
-  @inlinable // FIXME(sil-serialize-all)
-  internal mutating func ensureUniqueNative(
-    withCapacity minimumCapacity: Int
-  ) -> (reallocated: Bool, capacityChanged: Bool) {
-    let bucketCount = _NativeSet<Element>.bucketCount(
-      forCapacity: minimumCapacity,
-      maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
-    return ensureUniqueNative(withBucketCount: bucketCount)
-  }
-
-  /// Ensure this we hold a unique reference to a native buffer
-  /// having at least `minimumCapacity` elements.
-  @inlinable // FIXME(sil-serialize-all)
-  internal mutating func ensureUniqueNative(
-    withBucketCount desiredBucketCount: Int
-  ) -> (reallocated: Bool, capacityChanged: Bool) {
-#if _runtime(_ObjC)
-    // This is in a separate variable to make the uniqueness check work in
-    // unoptimized builds; see https://bugs.swift.org/browse/SR-6437
-    let n = _isNative
-    if n {
-      return _ensureUniqueNative(withBucketCount: desiredBucketCount)
-    }
-
-    switch self {
-    case .native:
-      fatalError("This should have been handled earlier")
-    case .cocoa(let cocoaSet):
-      self = .native(cocoaSet._toNative(bucketCount: desiredBucketCount))
-      return (reallocated: true, capacityChanged: true)
-    }
-#else
-    return _ensureUniqueNative(withBucketCount: desiredBucketCount)
-#endif
-  }
-
-#if _runtime(_ObjC)
-  @usableFromInline
-  internal mutating func migrateToNative(_ cocoaSet: _CocoaSet) {
-    let allocated = ensureUniqueNative(
-      withCapacity: cocoaSet.count).reallocated
-    _sanityCheck(allocated, "failed to allocate native Set buffer")
-  }
-#endif
-
   /// Reserves enough space for the specified number of elements to be stored
   /// without reallocating additional storage.
   @inlinable
   internal mutating func reserveCapacity(_ capacity: Int) {
-    _ = ensureUniqueNative(withCapacity: capacity)
+    switch self {
+    case .native:
+      let isUnique = isUniquelyReferenced()
+      asNative.reserveCapacity(capacity, isUnique: isUnique)
+#if _runtime(_ObjC)
+    case .cocoa(let cocoa):
+      self = .native(_NativeSet(cocoa, capacity: capacity))
+#endif
+    }
   }
 
   /// The number of elements that can be stored without expanding the current
@@ -2680,23 +2595,20 @@ extension Set._Variant: _SetBuffer {
   /// collection, since any addition will trigger a copy of the elements into
   /// newly allocated storage. For native storage, this is the element count
   /// at which adding any more elements will exceed the load factor.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   internal var capacity: Int {
     switch self {
     case .native:
-      return Int(Double(asNative.bucketCount) /
-        _hashContainerDefaultMaxLoadFactorInverse)
+      return asNative.capacity
 #if _runtime(_ObjC)
     case .cocoa(let cocoaSet):
       return cocoaSet.count
 #endif
     }
   }
+}
 
-  //
-  // _SetBuffer conformance
-  //
-
+extension Set._Variant: _SetBuffer {
   @usableFromInline
   internal typealias Index = Set<Element>.Index
 
@@ -2750,310 +2662,37 @@ extension Set._Variant: _SetBuffer {
 
   @inlinable
   internal func formIndex(after i: inout Index) {
-    // FIXME: swift-3-indexing-model: optimize if possible.
     i = index(after: i)
   }
 
   @inlinable
   @inline(__always)
-  internal func index(forKey key: Element) -> Index? {
+  internal func index(for element: Element) -> Index? {
     if _fastPath(guaranteedNative) {
-      if let nativeIndex = asNative.index(forKey: key) {
-        return ._native(nativeIndex)
+      if let index = asNative.index(for: element) {
+        return ._native(index)
       }
       return nil
     }
 
     switch self {
     case .native:
-      if let nativeIndex = asNative.index(forKey: key) {
-        return ._native(nativeIndex)
+      if let index = asNative.index(for: element) {
+        return ._native(index)
       }
       return nil
-#if _runtime(_ObjC)
-    case .cocoa(let cocoaSet):
-      let anyObjectKey: AnyObject = _bridgeAnythingToObjectiveC(key)
-      if let cocoaIndex = cocoaSet.index(forKey: anyObjectKey) {
-        return ._cocoa(cocoaIndex)
-      }
-      return nil
-#endif
-    }
-  }
-
-  @inlinable
-  internal func assertingGet(at i: Index) -> Element {
-    if _fastPath(guaranteedNative) {
-      return asNative.assertingGet(at: i._asNative)
-    }
-
-    switch self {
-    case .native:
-      return asNative.assertingGet(at: i._asNative)
-#if _runtime(_ObjC)
-    case .cocoa(let cocoaSet):
-      let anyObjectValue = cocoaSet.assertingGet(at: i._asCocoa)
-      let nativeValue = _forceBridgeFromObjectiveC(anyObjectValue, Element.self)
-      return nativeValue
-#endif
-    }
-  }
-
-  @inlinable
-  @inline(__always)
-  internal func contains(_ member: Element) -> Bool {
-    if _fastPath(guaranteedNative) {
-      return asNative.contains(member)
-    }
-    switch self {
-    case .native(let native):
-      return native.contains(member)
 #if _runtime(_ObjC)
     case .cocoa(let cocoa):
-      let cocoaKey = _bridgeAnythingToObjectiveC(member)
-      return cocoa.contains(cocoaKey)
+      let cocoaElement = _bridgeAnythingToObjectiveC(element)
+      if let index = cocoa.index(for: cocoaElement) {
+        return ._cocoa(index)
+      }
+      return nil
 #endif
     }
   }
-
-#if _runtime(_ObjC)
-  @inline(never)
-  @usableFromInline
-  internal static func maybeGetFromCocoa(
-    _ cocoaSet: _CocoaSet, forKey key: Element
-  ) -> Element? {
-    let anyObjectKey: AnyObject = _bridgeAnythingToObjectiveC(key)
-    if let anyObjectValue = cocoaSet.maybeGet(anyObjectKey) {
-      return _forceBridgeFromObjectiveC(anyObjectValue, Element.self)
-    }
-    return nil
-  }
-#endif
 
   @inlinable
-  @inline(__always)
-  internal func maybeGet(_ key: Element) -> Element? {
-    if _fastPath(guaranteedNative) {
-      return asNative.maybeGet(key)
-    }
-
-    switch self {
-    case .native:
-      return asNative.maybeGet(key)
-#if _runtime(_ObjC)
-    case .cocoa(let cocoaSet):
-      return Set._Variant.maybeGetFromCocoa(cocoaSet, forKey: key)
-#endif
-    }
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
-  internal mutating func nativeUpdate(
-    with key: Element
-  ) -> Element? {
-    var (i, found) = asNative._find(key)
-
-    let minBuckets = found
-      ? asNative.bucketCount
-      : _NativeSet<Element>.bucketCount(
-          forCapacity: asNative.count + 1,
-          maxLoadFactorInverse: _hashContainerDefaultMaxLoadFactorInverse)
-
-    let (_, capacityChanged) = ensureUniqueNative(withBucketCount: minBuckets)
-    if capacityChanged {
-      i = asNative._find(key).pos
-    }
-
-    let old: Element? = found ? asNative.key(at: i.bucket) : nil
-    if found {
-      asNative.setKey(key, at: i.bucket)
-    } else {
-      asNative.initializeKey(key, at: i.bucket)
-      asNative.count += 1
-    }
-
-    return old
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
-  @discardableResult
-  internal mutating func update(with value: Element) -> Element? {
-    if _fastPath(guaranteedNative) {
-      return nativeUpdate(with: value)
-    }
-
-    switch self {
-    case .native:
-      return nativeUpdate(with: value)
-#if _runtime(_ObjC)
-    case .cocoa(let cocoaSet):
-      migrateToNative(cocoaSet)
-      return nativeUpdate(with: value)
-#endif
-    }
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
-  @discardableResult
-  internal mutating func insert(
-    _ key: Element
-  ) -> (inserted: Bool, memberAfterInsert: Element) {
-    ensureNative()
-
-    var (i, found) = asNative._find(key)
-    if found {
-      return (inserted: false, memberAfterInsert: asNative.key(at: i.bucket))
-    }
-
-    let minCapacity = asNative.count + 1
-    let (_, capacityChanged) = ensureUniqueNative(withCapacity: minCapacity)
-
-    if capacityChanged {
-      i = asNative._find(key).pos
-    }
-
-    asNative.initializeKey(key, at: i.bucket)
-    asNative.count += 1
-
-    return (inserted: true, memberAfterInsert: key)
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
-  internal mutating func nativeRemove(_ member: Element) -> Element? {
-    var idealBucket = asNative._bucket(member)
-    var (index, found) = asNative._find(member, startBucket: idealBucket)
-
-    // Fast path: if the key is not present, we will not mutate the set,
-    // so don't force unique buffer.
-    if !found {
-      return nil
-    }
-
-    // This is in a separate variable to make the uniqueness check work in
-    // unoptimized builds; see https://bugs.swift.org/browse/SR-6437
-    let bucketCount = asNative.bucketCount
-    let (_, capacityChanged) = ensureUniqueNative(withBucketCount: bucketCount)
-    var native = asNative
-    if capacityChanged {
-      idealBucket = native._bucket(member)
-      (index, found) = native._find(member, startBucket: idealBucket)
-      _sanityCheck(found, "key was lost during buffer migration")
-    }
-    let old = native.key(at: index.bucket)
-    native._delete(idealBucket: idealBucket, bucket: index.bucket)
-    return old
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
-  internal mutating func nativeRemove(
-    at nativeIndex: _NativeSet<Element>.Index
-  ) -> Element {
-    // This is in a separate variable to make the uniqueness check work in
-    // unoptimized builds; see https://bugs.swift.org/browse/SR-6437
-    let bucketCount = asNative.bucketCount
-    // The provided index should be valid, so we will always mutating the
-    // set buffer.  Request unique buffer.
-    _ = ensureUniqueNative(withBucketCount: bucketCount)
-    var native = asNative
-
-    let result = native.assertingGet(at: nativeIndex)
-    let key = result
-
-    let idealBucket = native._bucket(key)
-    native._delete(idealBucket: idealBucket, bucket: nativeIndex.bucket)
-    return result
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
-  @discardableResult
-  internal mutating func remove(at index: Index) -> Element {
-    if _fastPath(guaranteedNative) {
-      return nativeRemove(at: index._asNative)
-    }
-
-    switch self {
-    case .native:
-      return nativeRemove(at: index._asNative)
-#if _runtime(_ObjC)
-    case .cocoa(let cocoaSet):
-      // We have to migrate the data first.  But after we do so, the Cocoa
-      // index becomes useless, so get the key first.
-      //
-      // FIXME(performance): fuse data migration and element deletion into one
-      // operation.
-      let index = index._asCocoa
-      let cocoaMember: AnyObject = index.allKeys[index.currentKeyIndex]
-      migrateToNative(cocoaSet)
-      let member = _forceBridgeFromObjectiveC(cocoaMember, Element.self)
-      let old = nativeRemove(member)
-      _sanityCheck(member == old, "bridging did not preserve equality")
-      return member
-#endif
-    }
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
-  @discardableResult
-  internal mutating func remove(_ member: Element) -> Element? {
-    if _fastPath(guaranteedNative) {
-      return nativeRemove(member)
-    }
-
-    switch self {
-    case .native:
-      return nativeRemove(member)
-#if _runtime(_ObjC)
-    case .cocoa(let cocoaSet):
-      let cocoaMember = _bridgeAnythingToObjectiveC(member)
-      if cocoaSet.maybeGet(cocoaMember) == nil {
-        return nil
-      }
-      migrateToNative(cocoaSet)
-      return nativeRemove(member)
-#endif
-    }
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
-  internal mutating func nativeRemoveAll() {
-    if !isUniquelyReferenced() {
-        asNative = _NativeSet<Element>(_exactBucketCount: asNative.bucketCount)
-        return
-    }
-
-    // We have already checked for the empty dictionary case and unique
-    // reference, so we will always mutate the dictionary buffer.
-    var native = asNative
-    native._removeAll()
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
-  internal mutating func removeAll(keepingCapacity keepCapacity: Bool) {
-    if count == 0 {
-      return
-    }
-
-    if !keepCapacity {
-      self = .native(_NativeSet<Element>())
-      return
-    }
-
-    if _fastPath(guaranteedNative) {
-      nativeRemoveAll()
-      return
-    }
-
-    switch self {
-    case .native:
-      nativeRemoveAll()
-#if _runtime(_ObjC)
-    case .cocoa(let cocoaSet):
-      self = .native(_NativeSet(minimumCapacity: cocoaSet.count))
-#endif
-    }
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
   internal var count: Int {
     if _fastPath(guaranteedNative) {
       return asNative.count
@@ -3069,10 +2708,172 @@ extension Set._Variant: _SetBuffer {
     }
   }
 
+  @inlinable
+  @inline(__always)
+  internal func contains(_ member: Element) -> Bool {
+    if _fastPath(guaranteedNative) {
+      return asNative.contains(member)
+    }
+    switch self {
+    case .native:
+      return asNative.contains(member)
+#if _runtime(_ObjC)
+    case .cocoa(let cocoa):
+      return cocoa.contains(_bridgeAnythingToObjectiveC(member))
+#endif
+    }
+  }
+
+  @inlinable
+  internal func element(at i: Index) -> Element {
+    if _fastPath(guaranteedNative) {
+      return asNative.element(at: i._asNative)
+    }
+
+    switch self {
+    case .native:
+      return asNative.element(at: i._asNative)
+#if _runtime(_ObjC)
+    case .cocoa(let cocoa):
+      let cocoaMember = cocoa.element(at: i._asCocoa)
+      return _forceBridgeFromObjectiveC(cocoaMember, Element.self)
+#endif
+    }
+  }
+}
+
+extension Set._Variant {
+  @inlinable
+  internal mutating func update(with value: Element) -> Element? {
+    if _fastPath(guaranteedNative) {
+      let isUnique = self.isUniquelyReferenced()
+      return asNative.update(with: value, isUnique: isUnique)
+    }
+
+    switch self {
+    case .native:
+      let isUnique = self.isUniquelyReferenced()
+      return asNative.update(with: value, isUnique: isUnique)
+#if _runtime(_ObjC)
+    case .cocoa(let cocoa):
+      // Make sure we have space for an extra element.
+      var native = _NativeSet<Element>(cocoa, capacity: cocoa.count + 1)
+      let old = native.update(with: value, isUnique: true)
+      self = .native(native)
+      return old
+#endif
+    }
+  }
+
+  @inlinable
+  internal mutating func insert(
+    _ element: Element
+  ) -> (inserted: Bool, memberAfterInsert: Element) {
+    if _fastPath(guaranteedNative) {
+      let isUnique = self.isUniquelyReferenced()
+      return asNative.insert(element, isUnique: isUnique)
+    }
+
+    switch self {
+    case .native:
+      let isUnique = self.isUniquelyReferenced()
+      return asNative.insert(element, isUnique: isUnique)
+#if _runtime(_ObjC)
+    case .cocoa(let cocoa):
+      // Make sure we have space for an extra element.
+      var native = _NativeSet<Element>(cocoa, capacity: cocoa.count + 1)
+      let result = native.insert(element, isUnique: true)
+      self = .native(native)
+      return result
+#endif
+    }
+  }
+
+  @inlinable
+  @discardableResult
+  internal mutating func remove(at index: Index) -> Element {
+    if _fastPath(guaranteedNative) {
+      let isUnique = isUniquelyReferenced()
+      return asNative.remove(at: index._asNative, isUnique: isUnique)
+    }
+
+    switch self {
+    case .native:
+      let isUnique = isUniquelyReferenced()
+      return asNative.remove(at: index._asNative, isUnique: isUnique)
+#if _runtime(_ObjC)
+    case .cocoa(let cocoaSet):
+      // We have to migrate the data first.  But after we do so, the Cocoa
+      // index becomes useless, so get the key first.
+      //
+      // FIXME(performance): fuse data migration and element deletion into one
+      // operation.
+      let index = index._asCocoa
+      let cocoaMember = index.allKeys[index.currentKeyIndex]
+      var native = _NativeSet<Element>(cocoaSet)
+      let nativeMember = _forceBridgeFromObjectiveC(cocoaMember, Element.self)
+      let old = native.remove(nativeMember, isUnique: true)
+      _sanityCheck(nativeMember == old, "bridging did not preserve equality")
+      self = .native(native)
+      return nativeMember
+#endif
+    }
+  }
+
+  @inlinable
+  @discardableResult
+  internal mutating func remove(_ member: Element) -> Element? {
+    if _fastPath(guaranteedNative) {
+      let isUnique = isUniquelyReferenced()
+      return asNative.remove(member, isUnique: isUnique)
+    }
+
+    switch self {
+    case .native:
+      let isUnique = isUniquelyReferenced()
+      return asNative.remove(member, isUnique: isUnique)
+#if _runtime(_ObjC)
+    case .cocoa(let cocoa):
+      let cocoaMember = _bridgeAnythingToObjectiveC(member)
+      if !cocoa.contains(cocoaMember) {
+        return nil
+      }
+      var native = _NativeSet<Element>(cocoa)
+      let old = native.remove(member, isUnique: true)
+      self = .native(native)
+      _sanityCheck(old != nil, "bridging did not preserve equality")
+      return old
+#endif
+    }
+  }
+
+  @inlinable
+  internal mutating func removeAll(keepingCapacity keepCapacity: Bool) {
+    if !keepCapacity {
+      self = .native(_NativeSet<Element>())
+      return
+    }
+    if count == 0 {
+      return
+    }
+
+    switch self {
+    case .native:
+      let isUnique = isUniquelyReferenced()
+      asNative.removeAll(isUnique: isUnique)
+#if _runtime(_ObjC)
+    case .cocoa(let cocoaSet):
+      self = .native(_NativeSet(capacity: cocoaSet.count))
+#endif
+    }
+  }
+}
+
+extension Set._Variant {
   /// Returns an iterator over the elements.
   ///
   /// - Complexity: O(1).
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   @inline(__always)
   internal func makeIterator() -> Set<Element>.Iterator {
     switch self {
@@ -3083,40 +2884,6 @@ extension Set._Variant: _SetBuffer {
       return ._cocoa(cocoaSet.makeIterator())
 #endif
     }
-  }
-}
-
-extension _NativeSet {
-  @_fixed_layout // FIXME(sil-serialize-all)
-  @usableFromInline
-  internal struct Index {
-    @usableFromInline
-    internal var bucket: Int
-
-    @inlinable // FIXME(sil-serialize-all)
-    internal init(bucket: Int) {
-      self.bucket = bucket
-    }
-  }
-}
-
-extension _NativeSet.Index: Equatable {
-  @inlinable // FIXME(sil-serialize-all)
-  internal static func == (
-    lhs: _NativeSet.Index,
-    rhs: _NativeSet.Index
-  ) -> Bool {
-    return lhs.bucket == rhs.bucket
-  }
-}
-
-extension _NativeSet.Index: Comparable {
-  @inlinable // FIXME(sil-serialize-all)
-  internal static func < (
-    lhs: _NativeSet.Index,
-    rhs: _NativeSet.Index
-  ) -> Bool {
-    return lhs.bucket < rhs.bucket
   }
 }
 
@@ -3168,17 +2935,6 @@ extension _CocoaSet {
       self.base = base
       self.allKeys = allKeys
       self.currentKeyIndex = currentKeyIndex
-    }
-
-    /// Returns the next consecutive value after `self`.
-    ///
-    /// - Precondition: The next value is representable.
-    @inlinable // FIXME(sil-serialize-all)
-    internal func successor() -> Index {
-      // FIXME: swift-3-indexing-model: remove this method.
-      _precondition(
-        currentKeyIndex < allKeys.value, "Cannot increment endIndex")
-      return Index(base, allKeys, currentKeyIndex + 1)
     }
   }
 }
@@ -3351,10 +3107,6 @@ extension _NativeSet: Sequence {
   @usableFromInline
   @_fixed_layout
   internal struct Iterator {
-    // For native buffer, we keep two indices to keep track of the iteration
-    // progress and the buffer owner to make the buffer non-uniquely
-    // referenced.
-    //
     // Iterator is iterating over a frozen view of the collection
     // state, so it should keep its own reference to the buffer.
     @usableFromInline
@@ -3382,7 +3134,7 @@ extension _NativeSet.Iterator: IteratorProtocol {
   @inlinable
   internal mutating func next() -> Element? {
     guard index != endIndex else { return nil }
-    let result = base.assertingGet(at: index)
+    let result = base.element(at: index)
     base.formIndex(after: &index)
     return result
   }
@@ -3432,6 +3184,7 @@ extension _CocoaSet: Sequence {
   }
 
   @usableFromInline
+  @_effects(releasenone)
   internal func makeIterator() -> Iterator {
     return Iterator(self)
   }
@@ -3598,34 +3351,28 @@ public struct _SetBuilder<Element: Hashable> {
   internal var _target: _NativeSet<Element>
   @usableFromInline
   internal let _requestedCount: Int
-  @usableFromInline
-  internal var _actualCount: Int
 
   @inlinable
   public init(count: Int) {
-    _target = _NativeSet(minimumCapacity: count)
+    _target = _NativeSet(capacity: count)
     _requestedCount = count
-    _actualCount = 0
   }
 
   @inlinable
   public mutating func add(member: Element) {
-    _target.unsafeAddNew(key: member)
-    _actualCount += 1
+    _precondition(_target.count < _requestedCount,
+      "Can't add more members than promised")
+    _target.insertNew(member)
   }
 
   @inlinable
   public mutating func take() -> Set<Element> {
-    _precondition(_actualCount >= 0,
+    _precondition(_target.capacity > 0 || _requestedCount == 0,
       "Cannot take the result twice")
-    _precondition(_actualCount == _requestedCount,
+    _precondition(_target.count == _requestedCount,
       "The number of members added does not match the promised count")
 
-    // Finish building the `Set`.
-    _target.count = _actualCount
-
     // Prevent taking the result twice.
-    _actualCount = -1
     var result = _NativeSet<Element>()
     swap(&result, &_target)
     return Set(_native: result)
@@ -3647,7 +3394,7 @@ extension Set {
 
   /// The total number of elements that the set can contain without
   /// allocating new storage.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   public var capacity: Int {
     return _variant.capacity
   }
@@ -3691,21 +3438,16 @@ extension Set {
   public static func _bridgeFromObjectiveCAdoptingNativeStorageOf(
     _ s: AnyObject
   ) -> Set<Element>? {
-
     // Try all three NSSet impls that we currently provide.
-
     if let deferred = s as? _SwiftDeferredNSSet<Element> {
       return Set(_native: deferred.native)
     }
-
-    if let nativeStorage = s as? _HashableTypedNativeSetStorage<Element> {
-      return Set(_native: _NativeSet(_storage: nativeStorage))
+    if let nativeStorage = s as? _SwiftNativeSetStorage<Element> {
+      return Set(_native: _NativeSet(nativeStorage))
     }
-
-    if s === _RawNativeSetStorage.empty {
+    if s === _SwiftRawSetStorage.empty {
       return Set()
     }
-
     // FIXME: what if `s` is native storage, but for different key/value type?
     return nil
   }

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -2616,15 +2616,15 @@ extension Set._Variant: _SetBuffer {
   @inlinable
   internal var startIndex: Index {
     if _fastPath(guaranteedNative) {
-      return ._native(asNative.startIndex)
+      return Index(_native: asNative.startIndex)
     }
 
     switch self {
     case .native:
-      return ._native(asNative.startIndex)
+      return Index(_native: asNative.startIndex)
 #if _runtime(_ObjC)
     case .cocoa(let cocoaSet):
-      return ._cocoa(cocoaSet.startIndex)
+      return Index(_cocoa: cocoaSet.startIndex)
 #endif
     }
   }
@@ -2632,15 +2632,15 @@ extension Set._Variant: _SetBuffer {
   @inlinable
   internal var endIndex: Index {
     if _fastPath(guaranteedNative) {
-      return ._native(asNative.endIndex)
+      return Index(_native: asNative.endIndex)
     }
 
     switch self {
     case .native:
-      return ._native(asNative.endIndex)
+      return Index(_native: asNative.endIndex)
 #if _runtime(_ObjC)
     case .cocoa(let cocoaSet):
-      return ._cocoa(cocoaSet.endIndex)
+      return Index(_cocoa: cocoaSet.endIndex)
 #endif
     }
   }
@@ -2648,15 +2648,15 @@ extension Set._Variant: _SetBuffer {
   @inlinable
   internal func index(after i: Index) -> Index {
     if _fastPath(guaranteedNative) {
-      return ._native(asNative.index(after: i._asNative))
+      return Index(_native: asNative.index(after: i._asNative))
     }
 
     switch self {
     case .native:
-      return ._native(asNative.index(after: i._asNative))
+      return Index(_native: asNative.index(after: i._asNative))
 #if _runtime(_ObjC)
     case .cocoa(let cocoaSet):
-      return ._cocoa(cocoaSet.index(after: i._asCocoa))
+      return Index(_cocoa: cocoaSet.index(after: i._asCocoa))
 #endif
     }
   }
@@ -2671,7 +2671,7 @@ extension Set._Variant: _SetBuffer {
   internal func index(for element: Element) -> Index? {
     if _fastPath(guaranteedNative) {
       if let index = asNative.index(for: element) {
-        return ._native(index)
+        return Index(_native: index)
       }
       return nil
     }
@@ -2679,14 +2679,14 @@ extension Set._Variant: _SetBuffer {
     switch self {
     case .native:
       if let index = asNative.index(for: element) {
-        return ._native(index)
+        return Index(_native: index)
       }
       return nil
 #if _runtime(_ObjC)
     case .cocoa(let cocoa):
       let cocoaElement = _bridgeAnythingToObjectiveC(element)
       if let index = cocoa.index(for: cocoaElement) {
-        return ._cocoa(index)
+        return Index(_cocoa: index)
       }
       return nil
 #endif
@@ -2975,10 +2975,10 @@ extension Set {
 #endif
     }
 
-    @usableFromInline // FIXME(sil-serialize-all)
+    @usableFromInline
     internal var _variant: _Variant
 
-    @inlinable // FIXME(sil-serialize-all)
+    @inlinable
     internal init(_variant: _Variant) {
       self._variant = _variant
     }
@@ -2987,16 +2987,14 @@ extension Set {
 
 extension Set.Index {
   @inlinable
-  internal static func _native(
-    _ index: _NativeSet<Element>.Index
-  ) -> Set.Index {
-    return Set.Index(_variant: .native(index))
+  internal init(_native index: _NativeSet<Element>.Index) {
+    self.init(_variant: .native(index))
   }
 
 #if _runtime(_ObjC)
   @inlinable
-  internal static func _cocoa(_ index: _CocoaSet.Index) -> Set.Index {
-    return Set.Index(_variant: .cocoa(index))
+  internal init(_cocoa index: _CocoaSet.Index) {
+    self.init(_variant: .cocoa(index))
   }
 #endif
 

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -2196,11 +2196,14 @@ extension _NativeSet {
 internal func ELEMENT_TYPE_OF_SET_VIOLATES_HASHABLE_REQUIREMENTS(
   _ elementType: Any.Type
 ) -> Never {
-  fatalError("""
+  _assertionFailure(
+    "Fatal error",
+    """
     Duplicate elements of type '\(elementType)' were found in a Set.
     This usually means that either the type violates Hashable's requirements, or
     that members of such a set were mutated after insertion.
-    """)
+    """,
+    flags: _fatalErrorFlags())
 }
 
 extension _NativeSet {

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -178,6 +178,13 @@ extension Set {
     _variant = .native(_native)
   }
 
+#if _runtime(_ObjC)
+  @inlinable
+  internal init(_cocoa: _CocoaSet) {
+    _variant = .cocoa(_cocoa)
+  }
+#endif
+
   //
   // All APIs below should dispatch to `_variant`, without doing any
   // additional processing.
@@ -195,8 +202,8 @@ extension Set {
   public // SPI(Foundation)
   init(_immutableCocoaSet: _NSSet) {
     _sanityCheck(_isBridgedVerbatimToObjectiveC(Element.self),
-      "Set can be backed by NSSet _variant only when the member type can be bridged verbatim to Objective-C")
-    _variant = _Variant.cocoa(_CocoaSet(_immutableCocoaSet))
+      "Set can be backed by NSSet only when the member type can be bridged verbatim to Objective-C")
+    self.init(_cocoa: _CocoaSet(_immutableCocoaSet))
   }
 #endif
 }
@@ -1129,9 +1136,9 @@ public func _setDownCast<BaseValue, DerivedValue>(_ source: Set<BaseValue>)
   && _isClassOrObjCExistential(DerivedValue.self) {
     switch source._variant {
     case .native(let nativeSet):
-      return Set(_immutableCocoaSet: nativeSet.bridged())
+      return Set(_cocoa: _CocoaSet(nativeSet.bridged()))
     case .cocoa(let cocoaSet):
-      return Set(_immutableCocoaSet: cocoaSet.object)
+      return Set(_cocoa: cocoaSet)
     }
   }
 #endif

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1423,7 +1423,7 @@ internal class _SwiftRawSetStorage: _SwiftNativeNSSet {
   internal final var hashTable: _HashTable
 
   @usableFromInline
-  internal var seed: Hasher._Seed
+  internal final var seed: Hasher._Seed
 
   @usableFromInline
   @nonobjc

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -2733,22 +2733,13 @@ extension Set {
 }
 
 extension Set._Variant {
-  @usableFromInline @_transparent
-  internal var guaranteedNative: Bool {
-    return _canBeClass(Element.self) == 0
-  }
-
   @inlinable
   @inline(__always)
   internal mutating func isUniquelyReferenced() -> Bool {
-    // Note that &self drills down through .native(_NativeSet) to the first
-    // property in _NativeSet, which is the reference to the storage.
-    if _fastPath(guaranteedNative) {
-      return _isUnique_native(&self)
-    }
-
     switch self {
     case .native:
+      // Note that `&self` drills down through `.native(_NativeSet)` to the
+      // first property in `_NativeSet`, which is the reference to the storage.
       return _isUnique_native(&self)
 #if _runtime(_ObjC)
     case .cocoa:
@@ -2831,10 +2822,6 @@ extension Set._Variant: _SetBuffer {
 
   @inlinable
   internal var startIndex: Index {
-    if _fastPath(guaranteedNative) {
-      return Index(_native: asNative.startIndex)
-    }
-
     switch self {
     case .native:
       return Index(_native: asNative.startIndex)
@@ -2847,10 +2834,6 @@ extension Set._Variant: _SetBuffer {
 
   @inlinable
   internal var endIndex: Index {
-    if _fastPath(guaranteedNative) {
-      return Index(_native: asNative.endIndex)
-    }
-
     switch self {
     case .native:
       return Index(_native: asNative.endIndex)
@@ -2863,10 +2846,6 @@ extension Set._Variant: _SetBuffer {
 
   @inlinable
   internal func index(after i: Index) -> Index {
-    if _fastPath(guaranteedNative) {
-      return Index(_native: asNative.index(after: i._asNative))
-    }
-
     switch self {
     case .native:
       return Index(_native: asNative.index(after: i._asNative))
@@ -2885,13 +2864,6 @@ extension Set._Variant: _SetBuffer {
   @inlinable
   @inline(__always)
   internal func index(for element: Element) -> Index? {
-    if _fastPath(guaranteedNative) {
-      if let index = asNative.index(for: element) {
-        return Index(_native: index)
-      }
-      return nil
-    }
-
     switch self {
     case .native:
       if let index = asNative.index(for: element) {
@@ -2911,10 +2883,6 @@ extension Set._Variant: _SetBuffer {
 
   @inlinable
   internal var count: Int {
-    if _fastPath(guaranteedNative) {
-      return asNative.count
-    }
-
     switch self {
     case .native:
       return asNative.count
@@ -2928,9 +2896,6 @@ extension Set._Variant: _SetBuffer {
   @inlinable
   @inline(__always)
   internal func contains(_ member: Element) -> Bool {
-    if _fastPath(guaranteedNative) {
-      return asNative.contains(member)
-    }
     switch self {
     case .native:
       return asNative.contains(member)
@@ -2943,10 +2908,6 @@ extension Set._Variant: _SetBuffer {
 
   @inlinable
   internal func element(at i: Index) -> Element {
-    if _fastPath(guaranteedNative) {
-      return asNative.element(at: i._asNative)
-    }
-
     switch self {
     case .native:
       return asNative.element(at: i._asNative)
@@ -2962,11 +2923,6 @@ extension Set._Variant: _SetBuffer {
 extension Set._Variant {
   @inlinable
   internal mutating func update(with value: Element) -> Element? {
-    if _fastPath(guaranteedNative) {
-      let isUnique = self.isUniquelyReferenced()
-      return asNative.update(with: value, isUnique: isUnique)
-    }
-
     switch self {
     case .native:
       let isUnique = self.isUniquelyReferenced()
@@ -2986,11 +2942,6 @@ extension Set._Variant {
   internal mutating func insert(
     _ element: Element
   ) -> (inserted: Bool, memberAfterInsert: Element) {
-    if _fastPath(guaranteedNative) {
-      let isUnique = self.isUniquelyReferenced()
-      return asNative.insert(element, isUnique: isUnique)
-    }
-
     switch self {
     case .native:
       let isUnique = self.isUniquelyReferenced()
@@ -3009,11 +2960,6 @@ extension Set._Variant {
   @inlinable
   @discardableResult
   internal mutating func remove(at index: Index) -> Element {
-    if _fastPath(guaranteedNative) {
-      let isUnique = isUniquelyReferenced()
-      return asNative.remove(at: index._asNative, isUnique: isUnique)
-    }
-
     switch self {
     case .native:
       let isUnique = isUniquelyReferenced()
@@ -3040,11 +2986,6 @@ extension Set._Variant {
   @inlinable
   @discardableResult
   internal mutating func remove(_ member: Element) -> Element? {
-    if _fastPath(guaranteedNative) {
-      let isUnique = isUniquelyReferenced()
-      return asNative.remove(member, isUnique: isUnique)
-    }
-
     switch self {
     case .native:
       let isUnique = isUniquelyReferenced()
@@ -3322,11 +3263,6 @@ extension Set.Index {
 #endif
 
   @usableFromInline @_transparent
-  internal var _guaranteedNative: Bool {
-    return _canBeClass(Element.self) == 0
-  }
-
-  @usableFromInline @_transparent
   internal var _asNative: _NativeSet<Element>.Index {
     switch _variant {
     case .native(let nativeIndex):
@@ -3357,10 +3293,6 @@ extension Set.Index: Equatable {
     lhs: Set<Element>.Index,
     rhs: Set<Element>.Index
   ) -> Bool {
-    if _fastPath(lhs._guaranteedNative) {
-      return lhs._asNative == rhs._asNative
-    }
-
     switch (lhs._variant, rhs._variant) {
     case (.native(let lhsNative), .native(let rhsNative)):
       return lhsNative == rhsNative
@@ -3380,10 +3312,6 @@ extension Set.Index: Comparable {
     lhs: Set<Element>.Index,
     rhs: Set<Element>.Index
   ) -> Bool {
-    if _fastPath(lhs._guaranteedNative) {
-      return lhs._asNative < rhs._asNative
-    }
-
     switch (lhs._variant, rhs._variant) {
     case (.native(let lhsNative), .native(let rhsNative)):
       return lhsNative < rhsNative
@@ -3406,11 +3334,6 @@ extension Set.Index: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {
   #if _runtime(_ObjC)
-    if _fastPath(_guaranteedNative) {
-      hasher.combine(0 as UInt8)
-      hasher.combine(_asNative.bucket)
-      return
-    }
     switch _variant {
     case .native(let nativeIndex):
       hasher.combine(0 as UInt8)
@@ -3598,11 +3521,6 @@ extension Set.Iterator {
 #endif
 
   @usableFromInline @_transparent
-  internal var _guaranteedNative: Bool {
-    return _canBeClass(Element.self) == 0
-  }
-
-  @usableFromInline @_transparent
   internal var _asNative: _NativeSet<Element>.Iterator {
     get {
       switch _variant {
@@ -3628,10 +3546,6 @@ extension Set.Iterator: IteratorProtocol {
   @inlinable
   @inline(__always)
   public mutating func next() -> Element? {
-    if _fastPath(_guaranteedNative) {
-      return _asNative.next()
-    }
-
     switch _variant {
     case .native:
       return _asNative.next()

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -88,22 +88,18 @@ swift::_SwiftEmptySetStorage swift::_swiftEmptySetStorage = {
   
   // _SwiftSetBodyStorage body;
   {
-    // _SwiftHashTable hashTable;
-    {
-      // Setting the scale to 0 makes for a bucketCount of 1 -- so that the
-      // storage consists of a single unoccupied bucket. The capacity is set to
-      // 0 so that any insertion will lead to real storage being allocated.
-      0, // int count;
-      0, // int capacity;
-      1, // int bucketCount;
-      &swift::_swiftEmptySetStorage.entries, // void *map
-    },
+    // Setting the scale to 0 makes for a bucketCount of 1 -- so that the
+    // storage consists of a single unoccupied bucket. The capacity is set to
+    // 0 so that any insertion will lead to real storage being allocated.
+    0, // int count;
+    0, // int capacity;
+    0, // int scale;
     0, // uint64 seed0;
     0, // uint64 seed1;
     (void *)1, // void *rawElements; (non-null garbage)
   },
 
-  0 // int entries; (zeroed bytes)
+  0 // int buckets; (zeroed bytes)
 };
 
 static swift::_SwiftHashingParameters initializeHashingParameters() {

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -34,7 +34,7 @@ ClassMetadata CLASS_METADATA_SYM(s27_RawNativeDictionaryStorage);
 
 // _direct type metadata for Swift._RawNativeSetStorage
 SWIFT_RUNTIME_STDLIB_API
-ClassMetadata CLASS_METADATA_SYM(s20_RawNativeSetStorage);
+ClassMetadata CLASS_METADATA_SYM(s21_SwiftEmptySetStorage);
 } // namespace swift
 
 SWIFT_RUNTIME_STDLIB_API
@@ -83,27 +83,27 @@ SWIFT_RUNTIME_STDLIB_API
 swift::_SwiftEmptySetStorage swift::_swiftEmptySetStorage = {
   // HeapObject header;
   {
-    &swift::CLASS_METADATA_SYM(s20_RawNativeSetStorage), // isa pointer
+    &swift::CLASS_METADATA_SYM(s21_SwiftEmptySetStorage), // isa pointer
   },
   
-  // _SwiftDictionaryBodyStorage body;
+  // _SwiftSetBodyStorage body;
   {
-    // We set the capacity to 1 so that there's an empty hole to search.
-    // Any insertion will lead to a real storage being allocated, because 
-    // Dictionary guarantees there's always another empty hole after insertion.
-    1, // int capacity;                                    
-    0, // int count;
-    
-    // _SwiftUnsafeBitMap initializedEntries
+    // _SwiftHashTable hashTable;
     {
-      &swift::_swiftEmptySetStorage.entries, // unsigned int* values;
-      1 // int bitCount; (1 so there's something for iterators to read)
+      // We set the capacity to 1 so that there's an empty hole to search.
+      // Any insertion will lead to a real storage being allocated, because 
+      // Dictionary guarantees there's always another empty hole after insertion.
+      0, // int scale;
+      1, // int capacity;                                    
+      0, // int count;
+      &swift::_swiftEmptySetStorage.entries, // void *rawMap
     },
-    
-    (void*)1 // void* keys; (non-null garbage)
+    0, // uint64 seed0;
+    0, // uint64 seed1;
+    (void *)1, // void *rawElements; (non-null garbage)
   },
 
-  0 // int entries; (zero'd bits)
+  0 // int entries; (zeroed bytes)
 };
 
 static swift::_SwiftHashingParameters initializeHashingParameters() {

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -95,7 +95,7 @@ swift::_SwiftEmptySetStorage swift::_swiftEmptySetStorage = {
       // 0 so that any insertion will lead to real storage being allocated.
       0, // int count;
       0, // int capacity;
-      0, // int scale;
+      1, // int bucketCount;
       &swift::_swiftEmptySetStorage.entries, // void *map
     },
     0, // uint64 seed0;

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -93,8 +93,8 @@ swift::_SwiftEmptySetStorage swift::_swiftEmptySetStorage = {
       // Setting the scale to 0 makes for a bucketCount of 1 -- so that the
       // storage consists of a single unoccupied bucket. The capacity is set to
       // 0 so that any insertion will lead to real storage being allocated.
-      0, // int capacity;
       0, // int count;
+      0, // int capacity;
       0, // int scale;
       &swift::_swiftEmptySetStorage.entries, // void *map
     },

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -32,7 +32,7 @@ ClassMetadata CLASS_METADATA_SYM(s18_EmptyArrayStorage);
 SWIFT_RUNTIME_STDLIB_API
 ClassMetadata CLASS_METADATA_SYM(s27_RawNativeDictionaryStorage);
 
-// _direct type metadata for Swift._RawNativeSetStorage
+// _direct type metadata for Swift._SwiftEmptySetStorage
 SWIFT_RUNTIME_STDLIB_API
 ClassMetadata CLASS_METADATA_SYM(s21_SwiftEmptySetStorage);
 } // namespace swift
@@ -90,13 +90,13 @@ swift::_SwiftEmptySetStorage swift::_swiftEmptySetStorage = {
   {
     // _SwiftHashTable hashTable;
     {
-      // We set the capacity to 1 so that there's an empty hole to search.
-      // Any insertion will lead to a real storage being allocated, because 
-      // Dictionary guarantees there's always another empty hole after insertion.
-      0, // int scale;
-      1, // int capacity;                                    
+      // Setting the scale to 0 makes for a bucketCount of 1 -- so that the
+      // storage consists of a single unoccupied bucket. The capacity is set to
+      // 0 so that any insertion will lead to real storage being allocated.
+      0, // int capacity;
       0, // int count;
-      &swift::_swiftEmptySetStorage.entries, // void *rawMap
+      0, // int scale;
+      &swift::_swiftEmptySetStorage.entries, // void *map
     },
     0, // uint64 seed0;
     0, // uint64 seed1;

--- a/validation-test/stdlib/Bitmap.swift
+++ b/validation-test/stdlib/Bitmap.swift
@@ -1,0 +1,281 @@
+// RUN: %target-run-stdlib-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var BitmapTests = TestSuite("Bitmap")
+
+BitmapTests.test("Word.bitWidth") {
+  expectEqual(_Bitmap.Word.bitWidth, UInt.bitWidth)
+}
+
+BitmapTests.test("Word._split(_:)") {
+#if arch(i386) || arch(arm)
+  for i in 0...31 {
+    let comps = _Bitmap.Word._split(i)
+    expectEqual(0, comps.word, "i=\(i)")
+    expectEqual(i, comps.bit, "i=\(i)")
+  }
+  for i in 32...63 {
+    let comps = _Bitmap.Word._split(i)
+    expectEqual(1, comps.word, "i=\(i)")
+    expectEqual(i - 32, comps.bit, "i=\(i)")
+  }
+  for i in 64...95 {
+    let comps = _Bitmap.Word._split(i)
+    expectEqual(2, comps.word, "i=\(i)")
+    expectEqual(i - 64, comps.bit, "i=\(i)")
+  }
+  for i in 96...127 {
+    let comps = _Bitmap.Word._split(i)
+    expectEqual(3, comps.word, "i=\(i)")
+    expectEqual(i - 96, comps.bit, "i=\(i)")
+  }
+#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
+  for i in 0...63 {
+    let comps = _Bitmap.Word._split(i)
+    expectEqual(0, comps.word, "i=\(i)")
+    expectEqual(i, comps.bit, "i=\(i)")
+  }
+  for i in 64...127 {
+    let comps = _Bitmap.Word._split(i)
+    expectEqual(1, comps.word, "i=\(i)")
+    expectEqual(i - 64, comps.bit, "i=\(i)")
+  }
+  for i in 128...191 {
+    let comps = _Bitmap.Word._split(i)
+    expectEqual(2, comps.word, "i=\(i)")
+    expectEqual(i - 128, comps.bit, "i=\(i)")
+  }
+  for i in 192...255 {
+    let comps = _Bitmap.Word._split(i)
+    expectEqual(3, comps.word, "i=\(i)")
+    expectEqual(i - 192, comps.bit, "i=\(i)")
+  }
+#else
+  _UnimplementedError()
+#endif
+}
+
+BitmapTests.test("Word._uncheckedContains(_:)") {
+  typealias Word = _Bitmap.Word
+  for i in 0 ..< Word.bitWidth {
+    expectEqual(Word(0)._uncheckedContains(i), false, "i=\(i)")
+    expectEqual(Word(1)._uncheckedContains(i), i == 0, "i=\(i)")
+    expectEqual(Word(2)._uncheckedContains(i), i == 1, "i=\(i)")
+    expectEqual(Word(4)._uncheckedContains(i), i == 2, "i=\(i)")
+    expectEqual(Word(8)._uncheckedContains(i), i == 3, "i=\(i)")
+    expectEqual(Word(15)._uncheckedContains(i), i <= 3, "i=\(i)")
+    expectEqual(Word(~1)._uncheckedContains(i), i != 0, "i=\(i)")
+    expectEqual(Word(~2)._uncheckedContains(i), i != 1, "i=\(i)")
+    expectEqual(Word(~4)._uncheckedContains(i), i != 2, "i=\(i)")
+    expectEqual(Word(~8)._uncheckedContains(i), i != 3, "i=\(i)")
+    expectEqual(Word(~15)._uncheckedContains(i), i > 3, "i=\(i)")
+    expectEqual(Word(UInt.max)._uncheckedContains(i), true, "i=\(i)")
+  }
+}
+
+BitmapTests.test("Word._uncheckedInsert(_:)") {
+  typealias Word = _Bitmap.Word
+  var word = Word(0)
+  for i in 0 ..< Word.bitWidth {
+    expectFalse(word._uncheckedContains(i))
+    expectTrue(word._uncheckedInsert(i))
+    expectTrue(word._uncheckedContains(i))
+    expectFalse(word._uncheckedInsert(i))
+  }
+  expectEqual(word._value, UInt.max)
+}
+
+BitmapTests.test("Word._uncheckedRemove(_:)") {
+  typealias Word = _Bitmap.Word
+  var word = Word(UInt.max)
+  for i in 0 ..< Word.bitWidth {
+    expectTrue(word._uncheckedContains(i))
+    expectTrue(word._uncheckedRemove(i))
+    expectFalse(word._uncheckedContains(i))
+    expectFalse(word._uncheckedRemove(i))
+  }
+  expectEqual(word._value, 0)
+}
+
+BitmapTests.test("Word.count") {
+  typealias Word = _Bitmap.Word
+  var word = Word(0)
+  for i in 0 ..< Word.bitWidth {
+    expectEqual(word.count, i)
+    _ = word._uncheckedInsert(i)
+    expectEqual(word.count, i + 1)
+  }
+  for i in 0 ..< Word.bitWidth {
+    expectEqual(word.count, Word.bitWidth - i)
+    _ = word._uncheckedRemove(i)
+    expectEqual(word.count, Word.bitWidth - i - 1)
+  }
+}
+
+BitmapTests.test("Word.makeIterator()") {
+  typealias Word = _Bitmap.Word
+  expectEqual(Array(Word(0)), [])
+  expectEqual(Array(Word(1)), [0])
+  expectEqual(Array(Word(2)), [1])
+  expectEqual(Array(Word(3)), [0, 1])
+  expectEqual(Array(Word(42)), [1, 3, 5])
+  expectEqual(Array(Word(UInt.max)), Array(0..<UInt.bitWidth))
+}
+
+BitmapTests.test("Storage.wordCount(forBitCount:)") {
+  typealias Storage = _Bitmap.Storage
+  expectEqual(0, Storage.wordCount(forBitCount: 0))
+#if arch(i386) || arch(arm)
+  for i in 1...32 {
+    expectEqual(1, Storage.wordCount(forBitCount: i), "i=\(i)")
+  }
+  for i in 33...64 {
+    expectEqual(2, Storage.wordCount(forBitCount: i), "i=\(i)")
+  }
+  for i in 65...96 {
+    expectEqual(3, Storage.wordCount(forBitCount: i), "i=\(i)")
+  }
+  for i in 97...128 {
+    expectEqual(4, Storage.wordCount(forBitCount: i), "i=\(i)")
+  }
+#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
+  for i in 1...64 {
+    expectEqual(1, Storage.wordCount(forBitCount: i), "i=\(i)")
+  }
+  for i in 65...128 {
+    expectEqual(2, Storage.wordCount(forBitCount: i), "i=\(i)")
+  }
+  for i in 193...256 {
+    expectEqual(4, Storage.wordCount(forBitCount: i), "i=\(i)")
+  }
+#else
+  _UnimplementedError()
+#endif
+}
+
+let bitCounts = [
+  0, 1, 2, 3, 7, 8, 9, 31, 32, 33, 48, 63, 64, 65, 127, 128, 129, 1024, 10000
+]
+
+let primes: Set<Int> = [
+  2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71,
+  73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137, 139, 149, 151,
+  157, 163, 167, 173, 179, 181, 191, 193, 197, 199, 211, 223, 227, 229, 233,
+  239, 241, 251, 257, 263, 269, 271, 277, 281, 283, 293, 307, 311, 313, 317,
+  331, 337, 347, 349, 353, 359, 367, 373, 379, 383, 389, 397, 401, 409, 419,
+  421, 431, 433, 439, 443, 449, 457, 461, 463, 467, 479, 487, 491, 499
+]
+
+BitmapTests.test("_Bitmap:InitializedToZero")
+.forEach(in: bitCounts) { bitCount in
+  let bitmap = _Bitmap(bitCount: bitCount)
+  expectEqual(bitmap.count, 0)
+  for bit in 0 ..< bitCount {
+    expectFalse(bitmap.contains(bit))
+  }
+}
+
+BitmapTests.test("_Bitmap:Allocation")
+.forEach(in: bitCounts) { bitCount in
+  let bitmap = _Bitmap(bitCount: bitCount)
+  expectEqual(bitmap._storage != nil, bitCount > _Bitmap.Word.bitWidth)
+}
+
+BitmapTests.test("_Bitmap.contains(_:)")
+.forEach(in: bitCounts) { bitCount in
+  var bitmap = _Bitmap(bitCount: bitCount)
+  for p in primes where p < bitCount {
+    expectFalse(bitmap.contains(p), "\(p)")
+    _ = bitmap.insert(p)
+    expectTrue(bitmap.contains(p), "\(p)")
+  }
+  for i in 0 ..< bitCount {
+    expectEqual(bitmap.contains(i), primes.contains(i), "\(i)")
+  }
+}
+
+BitmapTests.test("_Bitmap.insert(_:)")
+.forEach(in: bitCounts) { bitCount in
+  var bitmap = _Bitmap(bitCount: bitCount)
+  for p in primes where p < bitCount {
+    let (inserted, member) = bitmap.insert(p)
+    expectTrue(inserted, "\(p)")
+    expectEqual(member, p, "\(p)")
+  }
+  for p in primes where p < bitCount {
+    let (inserted, member) = bitmap.insert(p)
+    expectFalse(inserted, "\(p)")
+    expectEqual(member, p, "\(p)")
+  }
+  for i in 0 ..< bitCount {
+    expectEqual(bitmap.contains(i), primes.contains(i), "\(i)")
+  }
+}
+
+BitmapTests.test("_Bitmap.insert(_:):COW")
+.forEach(in: bitCounts) { bitCount in
+  for bit in primes where bit < bitCount {
+    var bitmap = _Bitmap(bitCount: bitCount)
+    let copy = bitmap
+
+    bitmap.insert(bit)
+    expectTrue(bitmap.contains(bit), "\(bit)")
+    expectFalse(copy.contains(bit), "\(bit)")
+  }
+}
+
+BitmapTests.test("_Bitmap.remove(_:)")
+.forEach(in: bitCounts) { bitCount in
+  var bitmap = _Bitmap(bitCount: bitCount)
+  for i in 0 ..< bitCount {
+    bitmap.insert(i)
+  }
+  for bit in primes where bit < bitCount {
+    expectEqual(bitmap.remove(bit), bit, "\(bit)")
+  }
+  for bit in primes where bit < bitCount {
+    expectNil(bitmap.remove(bit), "\(bit)")
+  }
+  for i in 0 ..< bitCount {
+    expectEqual(bitmap.contains(i), !primes.contains(i), "\(i)")
+  }
+}
+
+BitmapTests.test("_Bitmap.remove(_:):COW")
+.forEach(in: bitCounts) { bitCount in
+  var bitmap = _Bitmap(bitCount: bitCount)
+  for bit in primes where bit < bitCount {
+    bitmap.insert(bit)
+  }
+  for bit in primes where bit < bitCount {
+    var copy = bitmap
+    expectEqual(copy.remove(bit), bit, "\(bit)")
+    expectFalse(copy.contains(bit), "\(bit)")
+    expectTrue(bitmap.contains(bit), "\(bit)")
+  }
+}
+
+BitmapTests.test("_Bitmap.count")
+.forEach(in: bitCounts) { bitCount in
+  var bitmap = _Bitmap(bitCount: bitCount)
+  var c = 0
+  for bit in primes where bit < bitCount {
+    bitmap.insert(bit)
+    c += 1
+  }
+  expectEqual(c, bitmap.count)
+}
+
+BitmapTests.test("_Bitmap.makeIterator()")
+.forEach(in: bitCounts) { bitCount in
+  var bitmap = _Bitmap(bitCount: bitCount)
+  let bits = primes.filter { $0 < bitCount }
+  for b in bits {
+    bitmap.insert(b)
+  }
+  expectEqual(Array(bitmap), bits.sorted())
+}
+
+runAllTests()

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -123,7 +123,11 @@ func isNativeSet<T : Hashable>(_ s: Set<T>) -> Bool {
 #if _runtime(_ObjC)
 func isNativeNSSet(_ s: NSSet) -> Bool {
   let className: NSString = NSStringFromClass(type(of: s)) as NSString
-  return ["_SwiftDeferredNSSet", "NativeSetStorage"].contains {
+  return [
+    "_SwiftDeferredNSSet",
+    "_SwiftEmptySetStorage",
+    "_SwiftNativeSetStorage"
+  ].contains {
     className.range(of: $0).length > 0
   }
 }

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -3078,6 +3078,7 @@ SetTestSuite.test("formSymmetricDifference")
   .code {
   // Overlap with 4040, 5050, 6060
   var s1 = Set([1010, 2020, 3030, 4040, 5050, 6060])
+  let s1_copy = s1
   let s2 = Set([1010])
   let result = Set([2020, 3030, 4040, 5050, 6060])
 
@@ -3085,10 +3086,11 @@ SetTestSuite.test("formSymmetricDifference")
   let identity1 = s1._rawIdentifier()
   s1.formSymmetricDifference(s2)
 
-  // Removing just one element shouldn't cause an identity change
-  expectEqual(identity1, s1._rawIdentifier())
+  // COW should trigger a copy
+  expectNotEqual(identity1, s1._rawIdentifier())
 
   expectEqual(s1, result)
+  expectEqual(s1_copy, Set([1010, 2020, 3030, 4040, 5050, 6060]))
 
   // A ⨁ A == {}
   s1.formSymmetricDifference(s1)

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -1795,12 +1795,14 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.Remove")
 SetTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
   do {
     var s = getBridgedVerbatimSet([])
-    let identity1 = s._rawIdentifier()
     expectTrue(isCocoaSet(s))
     expectEqual(0, s.count)
 
+    let emptySet = Set<Int>()
+    expectNotEqual(emptySet._rawIdentifier(), s._rawIdentifier())
+
     s.removeAll()
-    expectEqual(identity1, s._rawIdentifier())
+    expectEqual(emptySet._rawIdentifier(), s._rawIdentifier())
     expectEqual(0, s.count)
   }
 
@@ -1857,12 +1859,14 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.RemoveAll") {
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAll") {
   do {
     var s = getBridgedNonverbatimSet([])
-    let identity1 = s._rawIdentifier()
     expectTrue(isNativeSet(s))
     expectEqual(0, s.count)
 
+    let emptySet = Set<Int>()
+    expectNotEqual(emptySet._rawIdentifier(), s._rawIdentifier())
+
     s.removeAll()
-    expectEqual(identity1, s._rawIdentifier())
+    expectEqual(emptySet._rawIdentifier(), s._rawIdentifier())
     expectEqual(0, s.count)
   }
 


### PR DESCRIPTION
- Extract low-level hash table operations into a type-agnostic `_HashTable` struct, parts of which can potentially be made resilient.
- Store 7 additional bits of the hash value directly in each entry's metadata field. (The hope is that this will allow us to use a much higher max load factor, by making collision chains dramatically cheaper.)
- Updated storage class hierarchy and internal storage layout for `Set` and (soon) `Dictionary`.
- New representation for the type-punned empty singleton storage.
- Slightly less memory overhead for deferred bridging. (This is especially relevant for `Dictionary` where only one of the element types may need non-verbatim bridging.)

This hasn't been fully debugged yet, and also needs to be extensively benchmarked/fine-tuned.

An lldb data formatter update will need to land before merging this PR.