### PR TITLE
[DNM][stdlib] Ditching heapSort part from stdlib sort

### DIFF
--- a/stdlib/public/core/Sort.swift
+++ b/stdlib/public/core/Sort.swift
@@ -456,8 +456,7 @@ func _introSort<C: MutableCollection & RandomAccessCollection>(
   if count < 2 {
     return
   }
-  // Set max recursion depth to 2*floor(log(N)), as suggested in the introsort
-  // paper: http://www.cs.rpi.edu/~musser/gp/introsort.ps
+
   try _introSortImpl(
     &elements,
     subRange: range,


### PR DESCRIPTION
Checking the opportunity of removing heapSort part from stdlib sort to reduce its code size. 

The goal of this PR is only to figure out  performance impact of heapSort part.