### PR TITLE
Redistribute metadata kind constants to delineate ABI vs private values.

### DIFF
--- a/include/swift/ABI/MetadataKind.def
+++ b/include/swift/ABI/MetadataKind.def
@@ -41,47 +41,49 @@
 NOMINALTYPEMETADATAKIND(Class, 0)
 
 /// A struct type.
-NOMINALTYPEMETADATAKIND(Struct, 1)
+NOMINALTYPEMETADATAKIND(Struct, 0 | MetadataKindIsNonHeap)
 
 /// An enum type.
 /// If we add reference enums, that needs to go here.
-NOMINALTYPEMETADATAKIND(Enum, 2)
+NOMINALTYPEMETADATAKIND(Enum, 1 | MetadataKindIsNonHeap)
 
 /// An optional type.
-NOMINALTYPEMETADATAKIND(Optional, 3)
-
-/// A type whose value is not exposed in the metadata system.
-METADATAKIND(Opaque, 8)
-
-/// A tuple.
-METADATAKIND(Tuple, 9)
-
-/// A monomorphic function.
-METADATAKIND(Function, 10)
-
-/// An existential type.
-METADATAKIND(Existential, 12)
-
-/// A metatype.
-METADATAKIND(Metatype, 13)
-
-/// An ObjC class wrapper.
-METADATAKIND(ObjCClassWrapper, 14)
-
-/// An existential metatype.
-METADATAKIND(ExistentialMetatype, 15)
+NOMINALTYPEMETADATAKIND(Optional, 2 | MetadataKindIsNonHeap)
 
 /// A foreign class, such as a Core Foundation class.
-METADATAKIND(ForeignClass, 16)
+METADATAKIND(ForeignClass, 3 | MetadataKindIsNonHeap)
+
+/// A type whose value is not exposed in the metadata system.
+METADATAKIND(Opaque, 0 | MetadataKindIsRuntimePrivate | MetadataKindIsNonHeap)
+
+/// A tuple.
+METADATAKIND(Tuple, 1 | MetadataKindIsRuntimePrivate | MetadataKindIsNonHeap)
+
+/// A monomorphic function.
+METADATAKIND(Function, 2 | MetadataKindIsRuntimePrivate | MetadataKindIsNonHeap)
+
+/// An existential type.
+METADATAKIND(Existential, 3 | MetadataKindIsRuntimePrivate | MetadataKindIsNonHeap)
+
+/// A metatype.
+METADATAKIND(Metatype, 4 | MetadataKindIsRuntimePrivate | MetadataKindIsNonHeap)
+
+/// An ObjC class wrapper.
+METADATAKIND(ObjCClassWrapper, 5 | MetadataKindIsRuntimePrivate | MetadataKindIsNonHeap)
+
+/// An existential metatype.
+METADATAKIND(ExistentialMetatype, 6 | MetadataKindIsRuntimePrivate | MetadataKindIsNonHeap)
 
 /// A heap-allocated local variable using statically-generated metadata.
-METADATAKIND(HeapLocalVariable, 64)
+METADATAKIND(HeapLocalVariable, 0 | MetadataKindIsNonType)
 
 /// A heap-allocated local variable using runtime-instantiated metadata.
-METADATAKIND(HeapGenericLocalVariable, 65)
+METADATAKIND(HeapGenericLocalVariable,
+             0 | MetadataKindIsNonType | MetadataKindIsRuntimePrivate)
 
 /// A native error object.
-METADATAKIND(ErrorObject, 128)
+METADATAKIND(ErrorObject,
+             1 | MetadataKindIsNonType | MetadataKindIsRuntimePrivate)
 
 // getEnumeratedMetadataKind assumes that all the enumerated values here
 // will be <= LastEnumeratedMetadataKind.

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -47,6 +47,21 @@ struct InProcess;
 template <typename Runtime> struct TargetMetadata;
 using Metadata = TargetMetadata<InProcess>;
 
+/// Non-type metadata kinds have this bit set.
+const unsigned MetadataKindIsNonType = 0x400;
+
+/// Non-heap metadata kinds have this bit set.
+const unsigned MetadataKindIsNonHeap = 0x200;
+
+// The above two flags are negative because the "class" kind has to be zero,
+// and class metadata is both type and heap metadata.
+
+/// Runtime-private metadata has this bit set. The compiler must not statically
+/// generate metadata objects with these kinds, and external tools should not
+/// rely on the stability of these values or the precise binary layout of
+/// their associated data structures.
+const unsigned MetadataKindIsRuntimePrivate = 0x100;
+
 /// Kinds of Swift metadata records.  Some of these are types, some
 /// aren't.
 enum class MetadataKind : uint32_t {
@@ -63,11 +78,21 @@ enum class MetadataKind : uint32_t {
   /// runtime must tolerate metadata with unknown kinds.
   /// This specific value is not mapped to a valid metadata kind at this time,
   /// however.
-  LastEnumerated = 2047,
+  LastEnumerated = 0x7FF,
 };
 
 const unsigned LastEnumeratedMetadataKind =
   (unsigned)MetadataKind::LastEnumerated;
+
+inline bool isHeapMetadataKind(MetadataKind k) {
+  return !((uint32_t)k & MetadataKindIsNonHeap);
+}
+inline bool isTypeMetadataKind(MetadataKind k) {
+  return !((uint32_t)k & MetadataKindIsNonType);
+}
+inline bool isRuntimePrivateMetadataKind(MetadataKind k) {
+  return (uint32_t)k & MetadataKindIsRuntimePrivate;
+}
 
 /// Try to translate the 'isa' value of a type/heap metadata into a value
 /// of the MetadataKind enum.

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -233,7 +233,7 @@ namespace {
 /// corresponding to the given metadata kind.
 static llvm::ConstantInt *getMetadataKind(IRGenModule &IGM,
                                           MetadataKind kind) {
-  return llvm::ConstantInt::get(IGM.MetadataKindTy, uint8_t(kind));
+  return llvm::ConstantInt::get(IGM.MetadataKindTy, uint32_t(kind));
 }
 
 /// Perform the layout required for a heap object.

--- a/stdlib/private/StdlibUnittest/InspectValue.cpp
+++ b/stdlib/private/StdlibUnittest/InspectValue.cpp
@@ -16,10 +16,16 @@
 using namespace swift;
 
 SWIFT_CC(swift) LLVM_LIBRARY_VISIBILITY extern "C"
-uint32_t getMetadataKindOf(
+const char *getMetadataKindOf(
     OpaqueValue *value,
     const Metadata *type
 ) {
-  return uint32_t(type->getKind());
+  switch (type->getKind()) {
+#define METADATAKIND(NAME, VALUE) \
+  case MetadataKind::NAME: return #NAME;
+#include "swift/ABI/MetadataKind.def"
+
+  default: return "none of your business";
+  }
 }
 

--- a/stdlib/private/StdlibUnittest/InspectValue.swift
+++ b/stdlib/private/StdlibUnittest/InspectValue.swift
@@ -12,29 +12,11 @@
 
 // namespace
 public enum SwiftRuntime {
-  public enum MetadataKind : Int {
-    case `class` = 0
-    case `struct` = 1
-    case `enum` = 2
-    case optional = 3
-    case opaque = 8
-    case tuple = 9
-    case function = 10
-    case existential = 12
-    case metatype = 13
-    case objCClassWrapper = 14
-    case existentialMetatype = 15
-    case foreignClass = 16
-    case heapLocalVariable = 64
-    case heapGenericLocalVariable = 65
-    case errorObject = 128
-  }
-
   @_silgen_name("getMetadataKindOf")
-  private static func _metadataKind<T>(of value: T) -> UInt32
+  private static func _metadataKind<T>(of value: T) -> UnsafePointer<CChar>
 
-  public static func metadataKind<T>(of value: T) -> MetadataKind {
-    return MetadataKind(rawValue: Int(_metadataKind(of: value)))!
+  public static func metadataKind<T>(of value: T) -> String {
+    return String(validatingUTF8: _metadataKind(of: value))!
   }
 }
 

--- a/test/IRGen/cf.sil
+++ b/test/IRGen/cf.sil
@@ -9,7 +9,7 @@
 // CHECK: [[MUTABLE_REFRIGERATOR:%TSo24CCMutableRefrigeratorRefa]] = type
 // CHECK: [[OBJC:%objc_object]] = type
 
-// CHECK: @"$SSo17CCRefrigeratorRefaN" = linkonce_odr hidden constant <{ {{.*}} }> <{ i8** @"$SBOWV", [[INT]] 16, {{.*}}"$SSo17CCRefrigeratorRefaMn", [[TYPE]]* null, i8* null }>
+// CHECK: @"$SSo17CCRefrigeratorRefaN" = linkonce_odr hidden constant <{ {{.*}} }> <{ i8** @"$SBOWV", [[INT]] 515, {{.*}}"$SSo17CCRefrigeratorRefaMn", [[TYPE]]* null, i8* null }>
 
 // CHECK: [[MUTABLE_REFRIGERATOR_NAME:@.*]] = private constant [52 x i8] c"CCMutableRefrigerator\00NCCMutableRefrigeratorRef\00St\00\00"
 
@@ -21,7 +21,7 @@
 // CHECK-64-SAME: @"$SSo24CCMutableRefrigeratorRefaMr"
 
 // CHECK-64: @"$SSo24CCMutableRefrigeratorRefaN" = linkonce_odr hidden global <{ {{.*}} }> <{
-// CHECK-64-SAME: i8** @"$SBOWV", i64 16, {{.*}}"$SSo24CCMutableRefrigeratorRefaMn", %swift.type* null, i8* null }>
+// CHECK-64-SAME: i8** @"$SBOWV", i64 515, {{.*}}"$SSo24CCMutableRefrigeratorRefaMn", %swift.type* null, i8* null }>
 
 sil_stage canonical
 

--- a/test/IRGen/closure.swift
+++ b/test/IRGen/closure.swift
@@ -4,7 +4,7 @@
 
 // -- partial_apply context metadata
 
-// CHECK: [[METADATA:@.*]] = private constant %swift.full_boxmetadata { void (%swift.refcounted*)* @objectdestroy, i8** null, %swift.type { i64 64 }, i32 16, i8* bitcast ({ i32, i32, i32, i32 }* @"\01l__swift5_reflection_descriptor" to i8*) }
+// CHECK: [[METADATA:@.*]] = private constant %swift.full_boxmetadata { void (%swift.refcounted*)* @objectdestroy, i8** null, %swift.type { i64 1024 }, i32 16, i8* bitcast ({ i32, i32, i32, i32 }* @"\01l__swift5_reflection_descriptor" to i8*) }
 
 func a(i i: Int) -> (Int) -> Int {
   return { x in i }

--- a/test/IRGen/enum_value_semantics.sil
+++ b/test/IRGen/enum_value_semantics.sil
@@ -119,7 +119,7 @@ enum GenericFixedLayout<T> {
 // CHECK-LABEL: @"$S20enum_value_semantics20SinglePayloadTrivialOMf" =
 // CHECK-SAME:   internal constant <{ {{.*}} }> <{
 // CHECK-SAME:   i8** getelementptr inbounds ([17 x i8*], [17 x i8*]* @"$S20enum_value_semantics20SinglePayloadTrivialOWV", i32 0, i32 0),
-// CHECK-SAME:   i64 2,
+// CHECK-SAME:   i64 513,
 // CHECK-SAME:   {{.*}}* @"$S20enum_value_semantics20SinglePayloadTrivialOMn"
 // CHECK-SAME: }>
 
@@ -156,7 +156,7 @@ enum GenericFixedLayout<T> {
 // CHECK-LABEL: @"$S20enum_value_semantics23SinglePayloadNontrivialOMf" =
 // CHECK-SAME: internal constant <{ {{.*}} }> <{
 // CHECK-SAME:   i8** getelementptr inbounds ([17 x i8*], [17 x i8*]* @"$S20enum_value_semantics23SinglePayloadNontrivialOWV", i32 0, i32 0),
-// CHECK-SAME:   i64 2,
+// CHECK-SAME:   i64 513,
 // CHECK-SAME:   {{.*}}* @"$S20enum_value_semantics23SinglePayloadNontrivialOMn"
 // CHECK-SAME: }>
 
@@ -170,8 +170,8 @@ enum GenericFixedLayout<T> {
 // CHECK-SAME:    i32 trunc (i64 sub (i64 ptrtoint (%swift.type* (%swift.type_descriptor*, i8**, i8**)* @"$S20enum_value_semantics18GenericFixedLayoutOMi" to i64), i64 ptrtoint (<{ i32, i32, i32, i32 }>* @"$S20enum_value_semantics18GenericFixedLayoutOMP" to i64)) to i32),
 //   Completion function.
 // CHECK-SAME:    i32 0,
-//   Pattern flags.  0x400000 == (MetadataKind::Enum << 21).
-// CHECK-SAME:    i32 4194304,
+//   Pattern flags.  0x4020_0000 == (MetadataKind::Enum << 21).
+// CHECK-SAME:    i32 1075838976,
 //   Value witness table.
 // CHECK-SAME:    i32 trunc (i64 sub (i64 ptrtoint ([17 x i8*]* @"$S20enum_value_semantics18GenericFixedLayoutOWV" to i64), i64 ptrtoint (i32* getelementptr inbounds (<{ i32, i32, i32, i32 }>, <{ i32, i32, i32, i32 }>* @"$S20enum_value_semantics18GenericFixedLayoutOMP", i32 0, i32 3) to i64)) to i32)
 // CHECK-SAME:  }>

--- a/test/IRGen/foreign_types.sil
+++ b/test/IRGen/foreign_types.sil
@@ -17,7 +17,7 @@ import c_layout
 
 // CHECK-LABEL: @"$SSo14HasNestedUnionV18__Unnamed_struct_sVN" = linkonce_odr hidden constant
 // CHECK-SAME:  @"$SSo14HasNestedUnionV18__Unnamed_struct_sVWV"
-// CHECK-SAME:  [[INT]] 1,
+// CHECK-SAME:  [[INT]] 512,
 // CHECK-SAME:  @"$SSo14HasNestedUnionV18__Unnamed_struct_sVMn"
 // CHECK-SAME:  i32 0,
 // CHECK-SAME:  i32 4 }

--- a/test/IRGen/generic_structs.sil
+++ b/test/IRGen/generic_structs.sil
@@ -15,7 +15,7 @@ import Builtin
 // -- completion function
 // CHECK-SAME:   i32 0,
 // -- pattern flags
-// CHECK-SAME:   i32 2097153,
+// CHECK-SAME:   <i32 0x4000_0001>,
 // -- vwtable pointer
 // CHECK-SAME:   @"$S15generic_structs18FixedLayoutGenericVWV"
 // -- extra data pattern

--- a/validation-test/stdlib/AnyHashable.swift.gyb
+++ b/validation-test/stdlib/AnyHashable.swift.gyb
@@ -599,7 +599,7 @@ AnyHashableTests.test("AnyHashable(CFBitVector)/Hashable, .base") {
     hashEqualityOracle: hashEqualityOracle)
 
   do {
-    expectEqual(.foreignClass, SwiftRuntime.metadataKind(of: bitVectors.first!))
+    expectEqual("ForeignClass", SwiftRuntime.metadataKind(of: bitVectors.first!))
 
     let anyHashables = bitVectors.map(AnyHashable.init)
     checkHashable(anyHashables,
@@ -614,7 +614,7 @@ AnyHashableTests.test("AnyHashable(CFBitVector)/Hashable, .base") {
       ($0 as AnyObject) as! NSObject
     }
     expectEqual(
-      .objCClassWrapper,
+      "ObjCClassWrapper",
       SwiftRuntime.metadataKind(of: bitVectorsAsAnyObjects.first!))
 
     let anyHashables = bitVectorsAsAnyObjects.map(AnyHashable.init)
@@ -648,7 +648,7 @@ AnyHashableTests.test("AnyHashable(CFMutableBitVector)/Hashable, .base") {
 
   do {
     expectEqual(
-      .foreignClass,
+      "ForeignClass",
       SwiftRuntime.metadataKind(of: bitVectors.first!))
 
     let anyHashables = bitVectors.map(AnyHashable.init)
@@ -670,7 +670,7 @@ AnyHashableTests.test("AnyHashable(CFMutableBitVector)/Hashable, .base") {
       hashEqualityOracle: hashEqualityOracle)
 
     expectEqual(
-      .objCClassWrapper,
+      "ObjCClassWrapper",
       SwiftRuntime.metadataKind(of: bitVectorsAsAnyObjects.first!))
 
     let anyHashables = bitVectorsAsAnyObjects.map(AnyHashable.init)
@@ -731,7 +731,7 @@ AnyHashableTests.test("AnyHashable(MinimalHashablePODSwiftError)/Hashable") {
     .caseB, .caseB,
     .caseC, .caseC,
   ]
-  expectEqual(.enum, SwiftRuntime.metadataKind(of: xs.first!))
+  expectEqual("Enum", SwiftRuntime.metadataKind(of: xs.first!))
   checkHashable(xs, equalityOracle: { $0 / 2 == $1 / 2 })
   checkHashable(
     xs.map(AnyHashable.init),
@@ -752,7 +752,7 @@ AnyHashableTests.test("AnyHashable(MinimalHashableRCSwiftError)/Hashable") {
     .caseC(LifetimeTracked(1)), .caseC(LifetimeTracked(1)),
     .caseC(LifetimeTracked(2)), .caseC(LifetimeTracked(2)),
   ]
-  expectEqual(.enum, SwiftRuntime.metadataKind(of: xs.first!))
+  expectEqual("Enum", SwiftRuntime.metadataKind(of: xs.first!))
   checkHashable(
     xs,
     equalityOracle: { $0 / 2 == $1 / 2 },
@@ -1017,7 +1017,7 @@ AnyHashableTests.test("AnyHashable(_SwiftNativeNSError(MinimalHashablePODSwiftEr
     ]
   }
   expectEqual(
-    .objCClassWrapper,
+    "ObjCClassWrapper",
     SwiftRuntime.metadataKind(of: nsErrors[0]))
   expectEqual("_SwiftNativeNSError", String(describing: type(of: nsErrors[0])))
 
@@ -1069,12 +1069,12 @@ AnyHashableTests.test("AnyHashable(_SwiftNativeNSError(MinimalHashableRCSwiftErr
   }
 
   expectEqual(
-    .objCClassWrapper,
+    "ObjCClassWrapper",
     SwiftRuntime.metadataKind(of: nsErrors[0]))
   expectEqual("_SwiftNativeNSError", String(describing: type(of: nsErrors[0])))
 
   expectEqual(
-    .objCClassWrapper,
+    "ObjCClassWrapper",
     SwiftRuntime.metadataKind(of: nsErrors[1]))
   expectEqual("NSError", String(describing: type(of: nsErrors[1])))
 
@@ -1137,7 +1137,7 @@ AnyHashableTests.test("AnyHashable(NSError)/Hashable") {
     NSError(domain: "Foo", code: 2),
   ]
   expectEqual(
-    .objCClassWrapper,
+    "ObjCClassWrapper",
     SwiftRuntime.metadataKind(of: nsErrors.first!))
   checkHashable(nsErrors, equalityOracle: { $0 / 2 == $1 / 2 })
   checkHashable(


### PR DESCRIPTION
And more cleanly separate type and heap while we're at it, making it a bit easier to allocate new compiler-generated metadata kinds without worrying about stepping on the toes of runtime-generated kinds, and ask basic questions like "is this type and/or heap metadata" in a forward- and backward-compatible way.