### PR TITLE
Require macOS/x86_64 in a TSan IRGen test

### DIFF
--- a/test/Profiler/instrprof_tsan.swift
+++ b/test/Profiler/instrprof_tsan.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -emit-ir -profile-generate -sanitize=thread %s | %FileCheck %s
 
-// rdar://43422035 unsupported option for target i386-apple-ios
-// XFAIL: CPU=i386
+// REQUIRES: OS=macosx
+// REQUIRES: CPU=x86_64
 
 // CHECK: define {{.*}}empty
 // CHECK-NOT: load{{.*}}empty


### PR DESCRIPTION
rdar://43422035