### PR TITLE
[AST] Rename several DeclContext methods to be clearer and shorter

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1786,7 +1786,7 @@ public:
     return D->getKind() == DeclKind::Extension;
   }
   static bool classof(const DeclContext *C) {
-    if (auto D = C->getAsDeclOrDeclExtensionContext())
+    if (auto D = C->getAsDecl())
       return classof(D);
     return false;
   }
@@ -2117,7 +2117,7 @@ public:
     return D->getKind() == DeclKind::TopLevelCode;
   }
   static bool classof(const DeclContext *C) {
-    if (auto D = C->getAsDeclOrDeclExtensionContext())
+    if (auto D = C->getAsDecl())
       return classof(D);
     return false;
   }
@@ -2645,7 +2645,7 @@ public:
   using TypeDecl::getDeclaredInterfaceType;
 
   static bool classof(const DeclContext *C) {
-    if (auto D = C->getAsDeclOrDeclExtensionContext())
+    if (auto D = C->getAsDecl())
       return classof(D);
     return false;
   }
@@ -2719,7 +2719,7 @@ public:
     return D->getKind() == DeclKind::TypeAlias;
   }
   static bool classof(const DeclContext *C) {
-    if (auto D = C->getAsDeclOrDeclExtensionContext())
+    if (auto D = C->getAsDecl())
       return classof(D);
     return false;
   }
@@ -3205,7 +3205,7 @@ public:
   }
 
   static bool classof(const DeclContext *C) {
-    if (auto D = C->getAsDeclOrDeclExtensionContext())
+    if (auto D = C->getAsDecl())
       return classof(D);
     return false;
   }
@@ -3313,7 +3313,7 @@ public:
     return D->getKind() == DeclKind::Enum;
   }
   static bool classof(const DeclContext *C) {
-    if (auto D = C->getAsDeclOrDeclExtensionContext())
+    if (auto D = C->getAsDecl())
       return classof(D);
     return false;
   }
@@ -3408,7 +3408,7 @@ public:
     return D->getKind() == DeclKind::Struct;
   }
   static bool classof(const DeclContext *C) {
-    if (auto D = C->getAsDeclOrDeclExtensionContext())
+    if (auto D = C->getAsDecl())
       return classof(D);
     return false;
   }
@@ -3693,7 +3693,7 @@ public:
     return D->getKind() == DeclKind::Class;
   }
   static bool classof(const DeclContext *C) {
-    if (auto D = C->getAsDeclOrDeclExtensionContext())
+    if (auto D = C->getAsDecl())
       return classof(D);
     return false;
   }
@@ -4025,7 +4025,7 @@ public:
     return D->getKind() == DeclKind::Protocol;
   }
   static bool classof(const DeclContext *C) {
-    if (auto D = C->getAsDeclOrDeclExtensionContext())
+    if (auto D = C->getAsDecl())
       return classof(D);
     return false;
   }
@@ -4900,7 +4900,7 @@ public:
   }
   
   static bool classof(const DeclContext *DC) {
-    if (auto D = DC->getAsDeclOrDeclExtensionContext())
+    if (auto D = DC->getAsDecl())
       return classof(D);
     return false;
   }
@@ -5281,7 +5281,7 @@ public:
   }
 
   static bool classof(const DeclContext *DC) {
-    if (auto D = DC->getAsDeclOrDeclExtensionContext())
+    if (auto D = DC->getAsDecl())
       return classof(D);
     return false;
   }
@@ -5508,7 +5508,7 @@ public:
     return classof(static_cast<const Decl*>(D));
   }
   static bool classof(const DeclContext *DC) {
-    if (auto D = DC->getAsDeclOrDeclExtensionContext())
+    if (auto D = DC->getAsDecl())
       return classof(D);
     return false;
   }
@@ -5648,7 +5648,7 @@ public:
     return classof(static_cast<const Decl*>(D));
   }
   static bool classof(const DeclContext *DC) {
-    if (auto D = DC->getAsDeclOrDeclExtensionContext())
+    if (auto D = DC->getAsDecl())
       return classof(D);
     return false;
   }
@@ -6042,7 +6042,7 @@ public:
     return classof(static_cast<const Decl*>(D));
   }
   static bool classof(const DeclContext *DC) {
-    if (auto D = DC->getAsDeclOrDeclExtensionContext())
+    if (auto D = DC->getAsDecl())
       return classof(D);
     return false;
   }
@@ -6078,7 +6078,7 @@ public:
     return classof(static_cast<const Decl*>(D));
   }
   static bool classof(const DeclContext *DC) {
-    if (auto D = DC->getAsDeclOrDeclExtensionContext())
+    if (auto D = DC->getAsDecl())
       return classof(D);
     return false;
   }
@@ -6581,7 +6581,7 @@ inline bool Decl::isPotentiallyOverridable() const {
       isa<SubscriptDecl>(this) ||
       isa<FuncDecl>(this) ||
       isa<DestructorDecl>(this)) {
-    return getDeclContext()->getAsClassOrClassExtensionContext();
+    return getDeclContext()->getSelfClassDecl();
   } else {
     return false;
   }
@@ -6602,7 +6602,7 @@ inline const GenericContext *Decl::getAsGenericContext() const {
 }
 
 inline bool DeclContext::isExtensionContext() const {
-  if (auto D = getAsDeclOrDeclExtensionContext())
+  if (auto D = getAsDecl())
     return ExtensionDecl::classof(D);
   return false;
 }

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -213,7 +213,7 @@ class alignas(1 << DeclContextAlignInBits) DeclContext {
 
   /// If this DeclContext is a GenericType declaration or an
   /// extension thereof, return the GenericTypeDecl.
-  GenericTypeDecl *getAsTypeOrTypeExtensionContext() const;
+  GenericTypeDecl *getSelfTypeDecl() const;
 
   static ASTHierarchy getASTHierarchyFromKind(DeclContextKind Kind) {
     switch (Kind) {
@@ -238,12 +238,12 @@ class alignas(1 << DeclContextAlignInBits) DeclContext {
 
 public:
   LLVM_READONLY
-  Decl *getAsDeclOrDeclExtensionContext() {
+  Decl *getAsDecl() {
     return ParentAndKind.getInt() == ASTHierarchy::Decl ?
       reinterpret_cast<Decl*>(this + 1) : nullptr;
   }
-  const Decl *getAsDeclOrDeclExtensionContext() const {
-    return const_cast<DeclContext*>(this)->getAsDeclOrDeclExtensionContext();
+  const Decl *getAsDecl() const {
+    return const_cast<DeclContext*>(this)->getAsDecl();
   }
 
   DeclContext(DeclContextKind Kind, DeclContext *Parent)
@@ -283,36 +283,36 @@ public:
   /// If this DeclContext is a NominalType declaration or an
   /// extension thereof, return the NominalTypeDecl.
   LLVM_READONLY
-  NominalTypeDecl *getAsNominalTypeOrNominalTypeExtensionContext() const;
+  NominalTypeDecl *getSelfNominalTypeDecl() const;
 
   /// If this DeclContext is a class, or an extension on a class, return the
   /// ClassDecl, otherwise return null.
   LLVM_READONLY
-  ClassDecl *getAsClassOrClassExtensionContext() const;
+  ClassDecl *getSelfClassDecl() const;
 
   /// If this DeclContext is an enum, or an extension on an enum, return the
   /// EnumDecl, otherwise return null.
   LLVM_READONLY
-  EnumDecl *getAsEnumOrEnumExtensionContext() const;
+  EnumDecl *getSelfEnumDecl() const;
 
   /// If this DeclContext is a struct, or an extension on a struct, return the
   /// StructDecl, otherwise return null.
   LLVM_READONLY
-  StructDecl *getAsStructOrStructExtensionContext() const;
+  StructDecl *getSelfStructDecl() const;
 
   /// If this DeclContext is a protocol, or an extension on a
   /// protocol, return the ProtocolDecl, otherwise return null.
   LLVM_READONLY
-  ProtocolDecl *getAsProtocolOrProtocolExtensionContext() const;
+  ProtocolDecl *getSelfProtocolDecl() const;
 
   /// If this DeclContext is a protocol extension, return the extended protocol.
   LLVM_READONLY
-  ProtocolDecl *getAsProtocolExtensionContext() const;
+  ProtocolDecl *getExtendedProtocolDecl() const;
 
   /// \brief Retrieve the generic parameter 'Self' from a protocol or
   /// protocol extension.
   ///
-  /// Only valid if \c getAsProtocolOrProtocolExtensionContext().
+  /// Only valid if \c getSelfProtocolDecl().
   GenericTypeParamType *getProtocolSelfType() const;
 
   /// Gets the type being declared by this context.

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -484,7 +484,7 @@ public:
   SourceRange getSourceRange() const { return SourceRange(); }
 
   static bool classof(const DeclContext *DC) {
-    if (auto D = DC->getAsDeclOrDeclExtensionContext())
+    if (auto D = DC->getAsDecl())
       return classof(D);
     return false;
   }
@@ -1231,7 +1231,7 @@ public:
 };
 
 inline bool DeclContext::isModuleContext() const {
-  if (auto D = getAsDeclOrDeclExtensionContext())
+  if (auto D = getAsDecl())
     return ModuleDecl::classof(D);
   return false;
 }

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -5682,8 +5682,7 @@ class WitnessMethodInst final
 public:
   CanType getLookupType() const { return LookupType; }
   ProtocolDecl *getLookupProtocol() const {
-    return getMember().getDecl()->getDeclContext()
-             ->getAsProtocolOrProtocolExtensionContext();
+    return getMember().getDecl()->getDeclContext()->getSelfProtocolDecl();
   }
 
   ProtocolConformanceRef getConformance() const { return Conformance; }

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2418,8 +2418,7 @@ bool ASTContext::diagnoseUnintendedObjCMethodOverrides(SourceFile &sf) {
         continue;
     }
 
-    auto classDecl =
-      method->getDeclContext()->getAsClassOrClassExtensionContext();
+    auto classDecl = method->getDeclContext()->getSelfClassDecl();
     if (!classDecl)
       continue; // error-recovery path, only
 
@@ -2698,8 +2697,7 @@ bool ASTContext::diagnoseObjCUnsatisfiedOptReqConflicts(SourceFile &sf) {
   bool anyDiagnosed = false;
   for (const auto &unsatisfied : localReqs) {
     // Check whether there is a conflict here.
-    ClassDecl *classDecl =
-      unsatisfied.first->getAsClassOrClassExtensionContext();
+    ClassDecl *classDecl = unsatisfied.first->getSelfClassDecl();
     auto req = unsatisfied.second;
     auto selector = req->getObjCSelector();
     bool isInstanceMethod = req->isInstanceMember();

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1046,7 +1046,7 @@ unsigned ASTMangler::appendBoundGenericArgs(DeclContext *dc,
   // This is important when extending a nested type, because the generic
   // parameters will line up with the (semantic) nesting of the nominal type.
   if (auto ext = dyn_cast<ExtensionDecl>(decl))
-    decl = ext->getAsNominalTypeOrNominalTypeExtensionContext();
+    decl = ext->getSelfNominalTypeDecl();
 
   // Handle the generic arguments of the parent.
   unsigned currentGenericParamIdx =
@@ -1424,7 +1424,7 @@ void ASTMangler::appendContext(const DeclContext *ctx) {
       appendModule(ExtD->getParentModule());
       if (sig && ExtD->isConstrainedExtension()) {
         Mod = ExtD->getModuleContext();
-        auto nominalSig = ExtD->getAsNominalTypeOrNominalTypeExtensionContext()
+        auto nominalSig = ExtD->getSelfNominalTypeDecl()
                             ->getGenericSignatureOfContext();
         appendGenericSignature(sig, nominalSig);
       }

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2802,7 +2802,7 @@ public:
     void verifyChecked(ConstructorDecl *CD) {
       PrettyStackTraceDecl debugStack("verifying ConstructorDecl", CD);
 
-      auto *ND = CD->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
+      auto *ND = CD->getDeclContext()->getSelfNominalTypeDecl();
       if (!isa<ClassDecl>(ND) && !isa<StructDecl>(ND) && !isa<EnumDecl>(ND) &&
           !isa<ProtocolDecl>(ND) && !CD->isInvalid()) {
         Out << "ConstructorDecls outside structs, classes or enums "
@@ -2993,7 +2993,7 @@ public:
     void verifyChecked(DestructorDecl *DD) {
       PrettyStackTraceDecl debugStack("verifying DestructorDecl", DD);
 
-      auto *ND = DD->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
+      auto *ND = DD->getDeclContext()->getSelfNominalTypeDecl();
       if (!isa<ClassDecl>(ND) && !DD->isInvalid()) {
         Out << "DestructorDecls outside classes should be marked invalid";
         abort();
@@ -3009,7 +3009,7 @@ public:
           Out << "mutating function is not an instance member\n";
           abort();
         }
-        if (FD->getDeclContext()->getAsClassOrClassExtensionContext()) {
+        if (FD->getDeclContext()->getSelfClassDecl()) {
           Out << "mutating function in a class\n";
           abort();
         }

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -634,8 +634,7 @@ ConformanceLookupTable::Ordering ConformanceLookupTable::compareConformances(
   // If one of the conformances comes from the same file as the type
   // declaration, pick that one; this is so that conformance synthesis works if
   // there's any implied conformance in the same file as the type.
-  auto NTD =
-      lhs->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
+  auto NTD = lhs->getDeclContext()->getSelfNominalTypeDecl();
   auto typeSF = NTD->getParentSourceFile();
   if (typeSF) {
     if (typeSF == lhsSF)
@@ -805,8 +804,7 @@ ConformanceLookupTable::getConformance(NominalTypeDecl *nominal,
     }
   }
 
-  auto *conformingNominal =
-    conformingDC->getAsNominalTypeOrNominalTypeExtensionContext();
+  auto *conformingNominal = conformingDC->getSelfNominalTypeDecl();
 
   // Form the conformance.
   Type type = entry->getDeclContext()->getDeclaredInterfaceType();
@@ -895,7 +893,7 @@ void ConformanceLookupTable::registerProtocolConformance(
        bool synthesized) {
   auto protocol = conformance->getProtocol();
   auto dc = conformance->getDeclContext();
-  auto nominal = dc->getAsNominalTypeOrNominalTypeExtensionContext();
+  auto nominal = dc->getSelfNominalTypeDecl();
 
   // If there is an entry to update, do so.
   auto &dcConformances = AllConformances[dc];

--- a/lib/AST/DocComment.cpp
+++ b/lib/AST/DocComment.cpp
@@ -370,8 +370,7 @@ getAnyBaseClassDocComment(swift::markup::MarkupContext &MC,
 
         auto *Text = swift::markup::Text::create(MC, MC.allocateCopy(OS.str()));
 
-        auto BaseClass =
-          BaseDecl->getDeclContext()->getAsClassOrClassExtensionContext();
+        auto BaseClass = BaseDecl->getDeclContext()->getSelfClassDecl();
 
         auto *BaseClassMonospace =
           swift::markup::Code::create(MC,
@@ -448,11 +447,11 @@ swift::getCascadingDocComment(swift::markup::MarkupContext &MC, const Decl *D) {
 
   // If this refers to a class member, check to see if any
   // base classes have a doc comment and cascade it to here.
-  if (const auto *CD = D->getDeclContext()->getAsClassOrClassExtensionContext())
+  if (const auto *CD = D->getDeclContext()->getSelfClassDecl())
     if (auto BaseClassDoc = getAnyBaseClassDocComment(MC, CD, D))
       return BaseClassDoc;
 
-  if (const auto *PE = D->getDeclContext()->getAsProtocolExtensionContext())
+  if (const auto *PE = D->getDeclContext()->getExtendedProtocolDecl())
     if (auto ReqDoc = getProtocolRequirementDocComment(MC, PE, D))
       return ReqDoc;
 

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3907,8 +3907,7 @@ static Type substituteConcreteType(GenericSignatureBuilder &builder,
                                    TypeDecl *concreteDecl) {
   assert(concreteDecl);
 
-  auto *proto =
-      concreteDecl->getDeclContext()->getAsProtocolOrProtocolExtensionContext();
+  auto *proto = concreteDecl->getDeclContext()->getSelfProtocolDecl();
 
   if (!concreteDecl->hasInterfaceType())
     builder.getLazyResolver()->resolveDeclSignature(concreteDecl);
@@ -4421,8 +4420,7 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
         // to that typealias.
         if (source->kind == RequirementSource::RequirementSignatureSelf) {
           auto inheritedOwningDecl =
-            inheritedType->getDeclContext()
-              ->getAsNominalTypeOrNominalTypeExtensionContext();
+              inheritedType->getDeclContext()->getSelfNominalTypeDecl();
           Diags.diagnose(assocTypeDecl,
                          diag::associated_type_override_typealias,
                          assocTypeDecl->getFullName(),

--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -969,7 +969,7 @@ void swift::lookupVisibleDecls(VisibleDeclConsumer &Consumer,
     // We don't look for generic parameters if we are in the context of a
     // nominal type: they will be looked up anyways via `lookupVisibleMemberDecls`.
     if (DC && !isa<NominalTypeDecl>(DC)) {
-      if (auto *decl = DC->getAsDeclOrDeclExtensionContext()) {
+      if (auto *decl = DC->getAsDecl()) {
         if (auto GC = decl->getAsGenericContext()) {
           auto params = GC->getGenericParams();
           namelookup::FindLocalVal(SM, Loc, Consumer).checkGenericParams(params);
@@ -980,7 +980,7 @@ void swift::lookupVisibleDecls(VisibleDeclConsumer &Consumer,
     if (auto *SE = dyn_cast<SubscriptDecl>(DC)) {
       ExtendedType = SE->getDeclContext()->getSelfTypeInContext();
       DC = DC->getParent();
-      BaseDecl = DC->getAsNominalTypeOrNominalTypeExtensionContext();
+      BaseDecl = DC->getSelfNominalTypeDecl();
     } else if (auto *AFD = dyn_cast<AbstractFunctionDecl>(DC)) {
 
       // Look for local variables; normally, the parser resolves these

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -291,8 +291,7 @@ void SourceLookupCache::lookupClassMembers(AccessPathTy accessPath,
         continue;
 
       for (ValueDecl *vd : member.second) {
-        auto *nominal = vd->getDeclContext()
-           ->getAsNominalTypeOrNominalTypeExtensionContext();
+        auto *nominal = vd->getDeclContext()->getSelfNominalTypeDecl();
         if (nominal && nominal->getName() == accessPath.front().first)
           consumer.foundDecl(vd, DeclVisibilityKind::DynamicLookup);
       }
@@ -326,8 +325,7 @@ void SourceLookupCache::lookupClassMember(AccessPathTy accessPath,
   
   if (!accessPath.empty()) {
     for (ValueDecl *vd : iter->second) {
-      auto *nominal = vd->getDeclContext()
-         ->getAsNominalTypeOrNominalTypeExtensionContext();
+      auto *nominal = vd->getDeclContext()->getSelfNominalTypeDecl();
       if (nominal && nominal->getName() == accessPath.front().first)
         results.push_back(vd);
     }
@@ -411,7 +409,7 @@ void ModuleDecl::lookupMember(SmallVectorImpl<ValueDecl*> &results,
   size_t oldSize = results.size();
   bool alreadyInPrivateContext = false;
 
-  auto containerDecl = container->getAsDeclOrDeclExtensionContext();
+  auto containerDecl = container->getAsDecl();
   // If FileUnit, then use FileUnit::lookupValue instead.
   assert(containerDecl != nullptr && "This context does not support lookup.");
 

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -444,7 +444,7 @@ void NormalProtocolConformance::differenceAndStoreConditionalRequirements()
     return;
   }
 
-  auto nominal = DC->getAsNominalTypeOrNominalTypeExtensionContext();
+  auto nominal = DC->getSelfNominalTypeDecl();
   auto typeSig = nominal->getGenericSignature();
 
   // A non-generic type won't have conditional requirements.
@@ -1227,8 +1227,7 @@ ArrayRef<ValueDecl *>
 NominalTypeDecl::getSatisfiedProtocolRequirementsForMember(
                                              const ValueDecl *member,
                                              bool sorted) const {
-  assert(member->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext()
-           == this);
+  assert(member->getDeclContext()->getSelfNominalTypeDecl() == this);
   assert(!isa<ProtocolDecl>(this));
   prepareConformanceTable();
   return ConformanceTable->getSatisfiedProtocolRequirementsForMember(member,
@@ -1245,7 +1244,7 @@ DeclContext::getLocalProtocols(
   SmallVector<ProtocolDecl *, 2> result;
 
   // Dig out the nominal type.
-  NominalTypeDecl *nominal = getAsNominalTypeOrNominalTypeExtensionContext();
+  NominalTypeDecl *nominal = getSelfNominalTypeDecl();
   if (!nominal)
     return result;
 
@@ -1276,7 +1275,7 @@ DeclContext::getLocalConformances(
   SmallVector<ProtocolConformance *, 2> result;
 
   // Dig out the nominal type.
-  NominalTypeDecl *nominal = getAsNominalTypeOrNominalTypeExtensionContext();
+  NominalTypeDecl *nominal = getSelfNominalTypeDecl();
   if (!nominal)
     return result;
 
@@ -1405,7 +1404,7 @@ struct ProtocolConformanceTraceFormatter
     if (auto const *NPC = dyn_cast<NormalProtocolConformance>(C)) {
       NPC->getLoc().print(OS, *SM);
     } else if (auto const *DC = C->getDeclContext()) {
-      if (auto const *D = DC->getAsDeclOrDeclExtensionContext())
+      if (auto const *D = DC->getAsDecl())
         D->getLoc().print(OS, *SM);
     }
   }

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -484,10 +484,8 @@ SubstitutionMap
 SubstitutionMap::getOverrideSubstitutions(const ValueDecl *baseDecl,
                                           const ValueDecl *derivedDecl,
                                           Optional<SubstitutionMap> derivedSubs) {
-  auto *baseClass = baseDecl->getDeclContext()
-      ->getAsClassOrClassExtensionContext();
-  auto *derivedClass = derivedDecl->getDeclContext()
-      ->getAsClassOrClassExtensionContext();
+  auto *baseClass = baseDecl->getDeclContext()->getSelfClassDecl();
+  auto *derivedClass = derivedDecl->getDeclContext()->getSelfClassDecl();
 
   auto *baseSig = baseDecl->getInnermostDeclContext()
       ->getGenericSignatureOfContext();

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -59,7 +59,7 @@ printSwiftEnumElemNameInObjC(const EnumElementDecl *EL, llvm::raw_ostream &OS,
     OS << ElemName;
     return true;
   }
-  OS << getNameForObjC(EL->getDeclContext()->getAsEnumOrEnumExtensionContext());
+  OS << getNameForObjC(EL->getDeclContext()->getSelfEnumDecl());
   if (PreferredName.empty())
     ElemName = EL->getName().str();
   else

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1894,7 +1894,7 @@ getObjCObjectRepresentable(Type type, const DeclContext *dc) {
 
   // Class-constrained generic parameters, from ObjC generic classes.
   if (auto tyContext = dc->getInnermostTypeContext())
-    if (auto clas = tyContext->getAsClassOrClassExtensionContext())
+    if (auto clas = tyContext->getSelfClassDecl())
       if (clas->hasClangNode())
         if (auto archetype = type->getAs<ArchetypeType>())
           if (archetype->requiresClass())
@@ -3221,7 +3221,7 @@ TypeBase::getContextSubstitutions(const DeclContext *dc,
 
   // If the member is part of a protocol or extension thereof, we need
   // to substitute in the type of Self.
-  if (dc->getAsProtocolOrProtocolExtensionContext()) {
+  if (dc->getSelfProtocolDecl()) {
     // FIXME: This feels painfully inefficient. We're creating a dense map
     // for a single substitution.
     substitutions[dc->getSelfInterfaceType()
@@ -3231,7 +3231,7 @@ TypeBase::getContextSubstitutions(const DeclContext *dc,
   }
 
   // Find the superclass type with the context matching that of the member.
-  auto *ownerNominal = dc->getAsNominalTypeOrNominalTypeExtensionContext();
+  auto *ownerNominal = dc->getSelfNominalTypeDecl();
   if (auto *ownerClass = dyn_cast<ClassDecl>(ownerNominal))
     baseTy = baseTy->getSuperclassForDecl(ownerClass);
 

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -40,7 +40,7 @@ void swift::simple_display(
   if (auto typeRepr = ext->getExtendedTypeLoc().getTypeRepr())
     typeRepr->print(out);
   else
-    ext->getAsNominalTypeOrNominalTypeExtensionContext()->dumpRef(out);
+    ext->getSelfNominalTypeDecl()->dumpRef(out);
 }
 
 //----------------------------------------------------------------------------//

--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -88,7 +88,7 @@ static bool printObjCUSRFragment(const ValueDecl *D, StringRef ObjCName,
 static bool printObjCUSRContext(const Decl *D, raw_ostream &OS) {
   OS << clang::index::getUSRSpacePrefix();
   auto *DC = D->getDeclContext();
-  if (auto *Parent = DC->getAsNominalTypeOrNominalTypeExtensionContext()) {
+  if (auto *Parent = DC->getSelfNominalTypeDecl()) {
     auto *extContextD = dyn_cast<ExtensionDecl>(DC);
     auto ObjCName = objc_translation::getObjCNameForSwiftDecl(Parent);
     if (printObjCUSRFragment(Parent, ObjCName.first.str(), extContextD, OS))
@@ -156,7 +156,7 @@ static bool shouldUseObjCUSR(const Decl *D) {
   }
 
   if (const auto *ED = dyn_cast<ExtensionDecl>(D)) {
-    if (auto baseClass = ED->getAsClassOrClassExtensionContext()) {
+    if (auto baseClass = ED->getSelfClassDecl()) {
       return shouldUseObjCUSR(baseClass) && !baseClass->isForeign();
     }
   }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2693,8 +2693,7 @@ ClangModuleUnit::lookupNestedType(Identifier name,
       else if (originalDecl == decl)
         return true;
 
-      auto *importedContext = decl->getDeclContext()->
-          getAsNominalTypeOrNominalTypeExtensionContext();
+      auto *importedContext = decl->getDeclContext()->getSelfNominalTypeDecl();
       if (importedContext != baseType)
         return true;
 
@@ -3473,7 +3472,7 @@ ClangImporter::Implementation::loadNamedMembers(
   auto *CDC = cast<clang::DeclContext>(CD);
   assert(CD && "loadNamedMembers on a Decl without a clangDecl");
 
-  auto *nominal = DC->getAsNominalTypeOrNominalTypeExtensionContext();
+  auto *nominal = DC->getSelfNominalTypeDecl();
   auto effectiveClangContext = getEffectiveClangContext(nominal);
 
   // FIXME: The legacy of mirroring protocol members rears its ugly head,

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2481,9 +2481,7 @@ Type ClangImporter::Implementation::getSugaredTypeReference(TypeDecl *type) {
   if (auto typealias = dyn_cast<TypeAliasDecl>(type)) {
     // If this typealias is nested, retrieve the parent type.
     Type parentType;
-    if (auto nominal =
-          typealias->getDeclContext()
-            ->getAsNominalTypeOrNominalTypeExtensionContext()) {
+    if (auto nominal = typealias->getDeclContext()->getSelfNominalTypeDecl()) {
       if (!nominal->getGenericSignature())
         parentType = nominal->getDeclaredInterfaceType();
     }

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -557,7 +557,7 @@ collectDefaultImplementationForProtocolMembers(ProtocolDecl *PD,
                                                        VD->getFullName());
       assert(Result);
       for (auto *Default : Result.getMemberDecls(InterestedMemberKind::All)) {
-        if (PD == Default->getDeclContext()->getAsProtocolExtensionContext()) {
+        if (PD == Default->getDeclContext()->getExtendedProtocolDecl()) {
           DefaultMap.insert({Default, VD});
         }
       }

--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -803,7 +803,7 @@ static void VisitNodeGenericTypealias(ASTContext *ast,
                                   ArrayRef<ProtocolConformanceRef>({}));
   Type parentType;
   if (auto nominal = genericTypeAlias->getDeclContext()
-                         ->getAsNominalTypeOrNominalTypeExtensionContext()) {
+                         ->getSelfNominalTypeDecl()) {
     parentType = nominal->getDeclaredInterfaceType().subst(subMap);
   }
   NameAliasType *NAT = NameAliasType::get(

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -2156,7 +2156,7 @@ irgen::emitClassPrivateDataFields(IRGenModule &IGM,
 llvm::Constant *irgen::emitCategoryData(IRGenModule &IGM,
                                         ExtensionDecl *ext) {
   assert(IGM.ObjCInterop && "emitting RO-data outside of interop mode");
-  ClassDecl *cls = ext->getAsClassOrClassExtensionContext();
+  ClassDecl *cls = ext->getSelfClassDecl();
   assert(cls && "generating category metadata for a non-class extension");
   
   PrettyStackTraceDecl stackTraceRAII("emitting ObjC metadata for", ext);

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -144,7 +144,7 @@ public:
     class_replaceMethod = IGM.getClassReplaceMethodFn();
     class_addProtocol = IGM.getClassAddProtocolFn();
 
-    CanType origTy = ext->getAsNominalTypeOrNominalTypeExtensionContext()
+    CanType origTy = ext->getSelfNominalTypeDecl()
         ->getDeclaredType()->getCanonicalType();
     classMetadata =
       tryEmitConstantHeapMetadataRef(IGM, origTy, /*allowUninit*/ true);
@@ -3843,7 +3843,7 @@ void IRGenModule::emitExtension(ExtensionDecl *ext) {
   // Generate a category if the extension either introduces a
   // conformance to an ObjC protocol or introduces a method
   // that requires an Objective-C entry point.
-  ClassDecl *origClass = ext->getAsClassOrClassExtensionContext();
+  ClassDecl *origClass = ext->getSelfClassDecl();
   if (!origClass)
     return;
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -3224,8 +3224,7 @@ void irgen::emitStructMetadata(IRGenModule &IGM, StructDecl *structDecl) {
 void IRGenerator::noteUseOfAnyParentTypeMetadata(NominalTypeDecl *type) {
   // If this is a nested type we also potentially might need the outer types.
   auto *declCtxt = type->getDeclContext();
-  auto *parentNominalDecl =
-    declCtxt->getAsNominalTypeOrNominalTypeExtensionContext();
+  auto *parentNominalDecl = declCtxt->getSelfNominalTypeDecl();
   if (!parentNominalDecl)
     return;
 

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1420,7 +1420,7 @@ private:
     llvm::DIScope *Scope = nullptr;
     DeclContext *Context = DbgTy.getType()->getNominalOrBoundGenericNominal();
     if (Context) {
-      if (auto *D = Context->getAsNominalTypeOrNominalTypeExtensionContext())
+      if (auto *D = Context->getSelfNominalTypeDecl())
         if (auto *ClangDecl = D->getClangDecl()) {
           clang::ASTReader &Reader = *CI.getClangInstance().getModuleManager();
           auto Idx = ClangDecl->getOwningModuleID();

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -306,8 +306,8 @@ private:
       return;
 
     // match labels to properties
-    auto *TypeContext = MemberwiseInit->getDeclContext()
-                          ->getAsNominalTypeOrNominalTypeExtensionContext();
+    auto *TypeContext =
+        MemberwiseInit->getDeclContext()->getSelfNominalTypeDecl();
     if (!TypeContext || !shouldIndex(TypeContext, false))
       return;
 
@@ -743,7 +743,7 @@ bool IndexSwiftASTWalker::reportRelatedTypeRef(const TypeLoc &Ty, SymbolRoleSet 
 }
 
 static bool isDynamicVarAccessorOrFunc(ValueDecl *D, SymbolInfo symInfo) {
-  if (auto NTD = D->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext()) {
+  if (auto NTD = D->getDeclContext()->getSelfNominalTypeDecl()) {
     bool isClassOrProtocol = isa<ClassDecl>(NTD) || isa<ProtocolDecl>(NTD);
     bool isInternalAccessor =
       symInfo.SubKind == SymbolSubKind::SwiftAccessorWillSet ||
@@ -1014,7 +1014,7 @@ bool IndexSwiftASTWalker::initIndexSymbol(ExtensionDecl *ExtD, ValueDecl *Extend
 }
 
 static NominalTypeDecl *getNominalParent(ValueDecl *D) {
-  return D->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
+  return D->getDeclContext()->getSelfNominalTypeDecl();
 }
 
 bool IndexSwiftASTWalker::initFuncDeclIndexSymbol(FuncDecl *D,
@@ -1368,7 +1368,7 @@ canDeclProvideDefaultImplementationFor(ValueDecl* VD,
     return {};
 
   // Check if VD is from a protocol extension.
-  auto P = VD->getDeclContext()->getAsProtocolExtensionContext();
+  auto P = VD->getDeclContext()->getExtendedProtocolDecl();
   if (!P)
     return {};
 

--- a/lib/Index/IndexSymbol.cpp
+++ b/lib/Index/IndexSymbol.cpp
@@ -20,7 +20,7 @@ using namespace swift;
 using namespace swift::index;
 
 static NominalTypeDecl *getNominalParent(const ValueDecl *D) {
-  return D->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
+  return D->getDeclContext()->getSelfNominalTypeDecl();
 }
 
 /// \returns true if \c D is a subclass of 'XCTestCase'.

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -921,7 +921,7 @@ ParserResult<Pattern> Parser::parsePattern() {
   }
     
   case tok::code_complete:
-    if (!CurDeclContext->getAsNominalTypeOrNominalTypeExtensionContext()) {
+    if (!CurDeclContext->getSelfNominalTypeDecl()) {
       // This cannot be an overridden property, so just eat the token. We cannot
       // code complete anything here -- we expect an identifier.
       consumeToken(tok::code_complete);

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -449,8 +449,7 @@ public:
 
 private:
   bool validateNominalParent(NominalTypeDecl *decl, Type parent) {
-    auto parentDecl =
-      decl->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
+    auto parentDecl = decl->getDeclContext()->getSelfNominalTypeDecl();
 
     // If we don't have a parent type, fast-path.
     if (!parent) {

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -40,7 +40,7 @@ swift::getMethodDispatch(AbstractFunctionDecl *method) {
 
   auto dc = method->getDeclContext();
 
-  if (dc->getAsClassOrClassExtensionContext()) {
+  if (dc->getSelfClassDecl()) {
     if (method->isDynamic())
       return MethodDispatch::Class;
 
@@ -454,7 +454,7 @@ IsSerialized_t SILDeclRef::isSerialized() const {
     if (kind == SILDeclRef::Kind::Allocator) {
       auto *ctor = cast<ConstructorDecl>(d);
       if (ctor->isDesignatedInit() &&
-          ctor->getDeclContext()->getAsClassOrClassExtensionContext()) {
+          ctor->getDeclContext()->getSelfClassDecl()) {
         if (ctor->getEffectiveAccess() >= AccessLevel::Public &&
             !ctor->hasClangNode())
           return IsSerialized;
@@ -788,7 +788,7 @@ SubclassScope SILDeclRef::getSubclassScope() const {
   if (isDefaultArgGenerator() && !context->getASTContext().isSwiftVersion3())
     return SubclassScope::NotApplicable;
 
-  auto *classType = context->getAsClassOrClassExtensionContext();
+  auto *classType = context->getSelfClassDecl();
   if (!classType || classType->isFinal())
     return SubclassScope::NotApplicable;
 

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -780,7 +780,7 @@ static bool isPseudogeneric(SILDeclRef c) {
   dc = dc->getInnermostTypeContext();
   if (!dc) return false;
 
-  auto classDecl = dc->getAsClassOrClassExtensionContext();
+  auto classDecl = dc->getSelfClassDecl();
   return (classDecl && classDecl->usesObjCGenericsModel());
 }
 
@@ -1996,9 +1996,7 @@ getUncachedSILFunctionTypeForConstant(SILModule &M,
 
     if (extInfo.getSILRepresentation() ==
         SILFunctionTypeRepresentation::WitnessMethod) {
-      auto proto = constant.getDecl()
-                       ->getDeclContext()
-                       ->getAsProtocolOrProtocolExtensionContext();
+      auto proto = constant.getDecl()->getDeclContext()->getSelfProtocolDecl();
       witnessMethodConformance = ProtocolConformanceRef(proto);
     }
 

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -506,7 +506,7 @@ SILGenModule::getOrCreateProfilerForConstructors(DeclContext *ctx,
   if (ctx->isExtensionContext())
     decl = cd;
   else
-    decl = ctx->getAsNominalTypeOrNominalTypeExtensionContext();
+    decl = ctx->getSelfNominalTypeDecl();
   assert(decl && "No decl available for profiling in this context");
 
   SILProfiler *&profiler = constructorProfilers[decl];
@@ -765,7 +765,7 @@ void SILGenModule::emitConstructor(ConstructorDecl *decl) {
 
   bool ForCoverageMapping = doesASTRequireProfiling(M, decl);
 
-  if (declCtx->getAsClassOrClassExtensionContext()) {
+  if (declCtx->getSelfClassDecl()) {
     // Class constructors have separate entry points for allocation and
     // initialization.
     emitOrDelayFunction(

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1217,7 +1217,7 @@ public:
     // Determine whether we'll need to use an allocating constructor (vs. the
     // initializing constructor).
     auto nominal = ctorRef->getDecl()->getDeclContext()
-                     ->getAsNominalTypeOrNominalTypeExtensionContext();
+                     ->getSelfNominalTypeDecl();
     bool useAllocatingCtor;
 
     // Value types only have allocating initializers.

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -219,8 +219,7 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
   } else {
     auto *dc = ctor->getParent();
     if (isa<ExtensionDecl>(dc) &&
-        dc->getAsStructOrStructExtensionContext()->getParentModule() !=
-          dc->getParentModule()) {
+        dc->getSelfStructDecl()->getParentModule() != dc->getParentModule()) {
       MUIKind = MarkUninitializedInst::CrossModuleRootSelf;
     } else {
       MUIKind = MarkUninitializedInst::RootSelf;
@@ -288,7 +287,7 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
   // If this is not a delegating constructor, emit member initializers.
   if (!isDelegating) {
     auto *typeDC = ctor->getDeclContext();
-    auto *nominal = typeDC->getAsNominalTypeOrNominalTypeExtensionContext();
+    auto *nominal = typeDC->getSelfNominalTypeDecl();
     emitMemberInitializers(ctor, selfDecl, nominal);
   }
 
@@ -479,7 +478,7 @@ void SILGenFunction::emitClassConstructorAllocator(ConstructorDecl *ctor) {
   // Use alloc_ref to allocate the object.
   // TODO: allow custom allocation?
   // FIXME: should have a cleanup in case of exception
-  auto selfClassDecl = ctor->getDeclContext()->getAsClassOrClassExtensionContext();
+  auto selfClassDecl = ctor->getDeclContext()->getSelfClassDecl();
 
   SILValue selfValue;
 
@@ -567,7 +566,7 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
   // this behavior, we could avoid runtime overhead here.
   VarDecl *selfDecl = ctor->getImplicitSelfDecl();
   auto *dc = ctor->getDeclContext();
-  auto selfClassDecl = dc->getAsClassOrClassExtensionContext();
+  auto selfClassDecl = dc->getSelfClassDecl();
   bool NeedsBoxForSelf = isDelegating ||
     (selfClassDecl->hasSuperclass() && !ctor->hasStubImplementation());
   bool usesObjCAllocator = Lowering::usesObjCAllocator(selfClassDecl);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1088,7 +1088,7 @@ RValue SILGenFunction::emitRValueForStorageLoad(
     (void)baseMeta;
     assert(!baseMeta->is<BoundGenericType>() &&
            "generic static stored properties not implemented");
-    if (field->getDeclContext()->getAsClassOrClassExtensionContext() &&
+    if (field->getDeclContext()->getSelfClassDecl() &&
         field->hasStorage())
       // FIXME: don't need to check hasStorage, already done above
       assert(field->isFinal() && "non-final class stored properties not implemented");
@@ -2867,7 +2867,7 @@ emitKeyPathRValueBase(SILGenFunction &subSGF,
     // Use the opened archetype from the AST for a protocol member, or make a
     // new one (which we'll upcast immediately below) for a class member.
     ArchetypeType *opened;
-    if (storage->getDeclContext()->getAsClassOrClassExtensionContext()) {
+    if (storage->getDeclContext()->getSelfClassDecl()) {
       opened = ArchetypeType::getOpened(baseType);
     } else {
       opened = subs.getReplacementTypes()[0]->castTo<ArchetypeType>();
@@ -2888,8 +2888,7 @@ emitKeyPathRValueBase(SILGenFunction &subSGF,
   }
   
   // Upcast a class instance to the property's declared type if necessary.
-  if (auto propertyClass = storage->getDeclContext()
-                                  ->getAsClassOrClassExtensionContext()) {
+  if (auto propertyClass = storage->getDeclContext()->getSelfClassDecl()) {
     if (baseType->getClassOrBoundGenericClass() != propertyClass) {
       baseType = baseType->getSuperclassForDecl(propertyClass)
         ->getCanonicalType();

--- a/lib/SILGen/SILGenMaterializeForSet.cpp
+++ b/lib/SILGen/SILGenMaterializeForSet.cpp
@@ -375,7 +375,7 @@ public:
     // callback storage.)
     
     // This can happen if the witness is in a protocol extension...
-    if (Witness->getDeclContext()->getAsProtocolOrProtocolExtensionContext())
+    if (Witness->getDeclContext()->getSelfProtocolDecl())
       return true;
 
     // ...if the witness is in a constrained extension that adds protocol

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3339,7 +3339,7 @@ enum class WitnessDispatchKind {
 static WitnessDispatchKind getWitnessDispatchKind(SILDeclRef witness) {
   auto *decl = witness.getDecl();
 
-  ClassDecl *C = decl->getDeclContext()->getAsClassOrClassExtensionContext();
+  ClassDecl *C = decl->getDeclContext()->getSelfClassDecl();
   if (!C)
     return WitnessDispatchKind::Static;
 

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -122,8 +122,7 @@ static ManagedValue getNextUncurryLevelRef(SILGenFunction &SGF, SILLocation loc,
     // witness.
     if (constantInfo.SILFnType->getRepresentation()
           == SILFunctionTypeRepresentation::WitnessMethod) {
-      auto protocol =
-        func->getDeclContext()->getAsProtocolOrProtocolExtensionContext();
+      auto protocol = func->getDeclContext()->getSelfProtocolDecl();
       auto origSelfType = protocol->getSelfInterfaceType()->getCanonicalType();
       auto substSelfType = origSelfType.subst(curriedSubs)->getCanonicalType();
       auto conformance = curriedSubs.lookupConformance(origSelfType, protocol);

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -283,7 +283,7 @@ static void emitTypeMemberGlobalVariable(SILGenModule &SGM,
            && "generic static vars are not implemented yet");
   }
 
-  if (var->getDeclContext()->getAsClassOrClassExtensionContext()) {
+  if (var->getDeclContext()->getSelfClassDecl()) {
     assert(var->isFinal() && "only 'static' ('class final') stored properties are implemented in classes");
   }
 

--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -431,13 +431,13 @@ canReplaceWithCallToCollectionSwapAt(const BeginAccessInst *Access1,
   // a witness for a subscript on MutableCollection?
   bool IsSubscriptOnMutableCollection = false;
   ProtocolDecl *ProtocolForDecl =
-      Decl1->getDeclContext()->getAsProtocolOrProtocolExtensionContext();
+      Decl1->getDeclContext()->getSelfProtocolDecl();
   if (ProtocolForDecl) {
     IsSubscriptOnMutableCollection = (ProtocolForDecl == MutableCollectionDecl);
   } else {
     for (ValueDecl *Req : Decl1->getSatisfiedProtocolRequirements()) {
       DeclContext *ReqDC = Req->getDeclContext();
-      ProtocolDecl *ReqProto = ReqDC->getAsProtocolOrProtocolExtensionContext();
+      ProtocolDecl *ReqProto = ReqDC->getSelfProtocolDecl();
       assert(ReqProto && "Protocol requirement not in a protocol?");
 
       if (ReqProto == MutableCollectionDecl) {

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1486,8 +1486,7 @@ bool swift::calleesAreStaticallyKnowable(SILModule &M, SILDeclRef Decl) {
       // Constructors are special: a derived class in another module can
       // "override" a constructor if its class is "open", although the
       // constructor itself is not open.
-      auto *ND = AFD->getDeclContext()
-          ->getAsNominalTypeOrNominalTypeExtensionContext();
+      auto *ND = AFD->getDeclContext()->getSelfNominalTypeDecl();
       if (ND->getEffectiveAccess() == AccessLevel::Open)
         return false;
     }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -353,7 +353,7 @@ diagnoseInvalidDynamicConstructorReferences(ConstraintSystem &cs,
       !isStaticallyDerived &&
       !ctorDecl->hasClangNode() &&
       !(ctorDecl->isRequired() ||
-        ctorDecl->getDeclContext()->getAsProtocolOrProtocolExtensionContext())) {
+        ctorDecl->getDeclContext()->getSelfProtocolDecl())) {
     if (SuppressDiagnostics)
       return false;
 
@@ -961,7 +961,7 @@ namespace {
       // If this is a method whose result type is dynamic Self, or a
       // construction, replace the result type with the actual object type.
       Type dynamicSelfFnType;
-      if (!member->getDeclContext()->getAsProtocolOrProtocolExtensionContext()) {
+      if (!member->getDeclContext()->getSelfProtocolDecl()) {
         if (auto func = dyn_cast<AbstractFunctionDecl>(member)) {
           if ((isa<FuncDecl>(func) &&
                cast<FuncDecl>(func)->hasDynamicSelf()) ||
@@ -1043,7 +1043,7 @@ namespace {
                         member->getDescriptiveKind(),
                         member->getFullName(),
                         member->getDeclContext()
-                          ->getAsNominalTypeOrNominalTypeExtensionContext()
+                          ->getSelfNominalTypeDecl()
                           ->getName());
             tc.diagnose(member, diag::make_decl_objc,
                         member->getDescriptiveKind())
@@ -2681,8 +2681,7 @@ namespace {
           // Determine whether 'super' would have made sense as a base.
           bool hasSuper = false;
           if (auto func = cs.DC->getInnermostMethodContext()) {
-            if (auto classDecl = func->getDeclContext()
-                    ->getAsClassOrClassExtensionContext()) {
+            if (auto classDecl = func->getDeclContext()->getSelfClassDecl()) {
               hasSuper = classDecl->hasSuperclass();
             }
           }
@@ -4241,7 +4240,7 @@ namespace {
           tc.diagnose(E->getLoc(), diag::expr_selector_swift3_objc_inference,
                       foundDecl->getDescriptiveKind(), foundDecl->getFullName(),
                       foundDecl->getDeclContext()
-                        ->getAsNominalTypeOrNominalTypeExtensionContext()
+                        ->getSelfNominalTypeDecl()
                         ->getName())
             .highlight(subExpr->getSourceRange());
           tc.diagnose(foundDecl, diag::make_decl_objc,

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -132,7 +132,7 @@ bool RequirementFailure::diagnose() {
   auto *genericCtx = AffectedDecl->getAsGenericContext();
 
   if (reqDC != genericCtx) {
-    auto *NTD = reqDC->getAsNominalTypeOrNominalTypeExtensionContext();
+    auto *NTD = reqDC->getSelfNominalTypeDecl();
     emitDiagnostic(anchor->getLoc(), getDiagnosticInRereference(),
                    AffectedDecl->getDescriptiveKind(),
                    AffectedDecl->getFullName(), NTD->getDeclaredType(),
@@ -143,7 +143,7 @@ bool RequirementFailure::diagnose() {
                    AffectedDecl->getFullName(), getLHS(), getRHS());
   }
 
-  emitRequirementNote(reqDC->getAsDeclOrDeclExtensionContext());
+  emitRequirementNote(reqDC->getAsDecl());
   return true;
 }
 
@@ -479,7 +479,7 @@ static bool diagnoseUnwrap(ConstraintSystem &CS, Expr *expr, Type type) {
 
       bool singleUse = false;
       AbstractFunctionDecl *AFD = nullptr;
-      if (auto contextDecl = varDecl->getDeclContext()->getAsDeclOrDeclExtensionContext()) {
+      if (auto contextDecl = varDecl->getDeclContext()->getAsDecl()) {
         if ((AFD = dyn_cast<AbstractFunctionDecl>(contextDecl))) {
           auto checker = VarDeclMultipleReferencesChecker(varDecl);
           AFD->getBody()->walk(checker);

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2521,7 +2521,7 @@ namespace {
       assert(typeContext && "constructor without parent context?!");
 
       auto &tc = CS.getTypeChecker();
-      ClassDecl *classDecl = typeContext->getAsClassOrClassExtensionContext();
+      ClassDecl *classDecl = typeContext->getSelfClassDecl();
       if (!classDecl) {
         tc.diagnose(diagLoc, diag_not_in_class);
         return Type();
@@ -3208,8 +3208,7 @@ namespace {
             if (auto DSCE = dyn_cast<DotSyntaxCallExpr>(call->getFn())) {
               auto RefD = DSCE->getFn()->getReferencedDecl().getDecl();
               if (RefD->getBaseName() == TC.Context.Id_getBuiltinLogicValue &&
-                  RefD->getDeclContext()
-                          ->getAsNominalTypeOrNominalTypeExtensionContext() ==
+                  RefD->getDeclContext()->getSelfNominalTypeDecl() ==
                       TC.Context.getBoolDecl()) {
                 expr = DSCE->getBase();
                 continue;

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -310,13 +310,13 @@ static bool isDeclMoreConstrainedThan(ValueDecl *decl1, ValueDecl *decl2) {
 static bool isProtocolExtensionAsSpecializedAs(TypeChecker &tc,
                                                DeclContext *dc1,
                                                DeclContext *dc2) {
-  assert(dc1->getAsProtocolExtensionContext());
-  assert(dc2->getAsProtocolExtensionContext());
+  assert(dc1->getExtendedProtocolDecl());
+  assert(dc2->getExtendedProtocolDecl());
 
   // If one of the protocols being extended inherits the other, prefer the
   // more specialized protocol.
-  auto proto1 = dc1->getAsProtocolExtensionContext();
-  auto proto2 = dc2->getAsProtocolExtensionContext();
+  auto proto1 = dc1->getExtendedProtocolDecl();
+  auto proto2 = dc2->getExtendedProtocolDecl();
   if (proto1 != proto2) {
     if (proto1->inheritsFrom(proto2))
       return true;
@@ -429,10 +429,8 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
       }
 
       // Members of protocol extensions have special overloading rules.
-      ProtocolDecl *inProtocolExtension1 = outerDC1
-                                             ->getAsProtocolExtensionContext();
-      ProtocolDecl *inProtocolExtension2 = outerDC2
-                                             ->getAsProtocolExtensionContext();
+      ProtocolDecl *inProtocolExtension1 = outerDC1->getExtendedProtocolDecl();
+      ProtocolDecl *inProtocolExtension2 = outerDC2->getExtendedProtocolDecl();
       if (inProtocolExtension1 && inProtocolExtension2) {
         // Both members are in protocol extensions.
         // Determine whether the 'Self' type from the first protocol extension
@@ -927,8 +925,8 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
     // found if requested directly.
     if (!decl1->isInstanceMember() && !decl2->isInstanceMember()) {
       if (isa<VarDecl>(decl1) && isa<VarDecl>(decl2)) {
-        auto *nominal1 = dc1->getAsNominalTypeOrNominalTypeExtensionContext();
-        auto *nominal2 = dc2->getAsNominalTypeOrNominalTypeExtensionContext();
+        auto *nominal1 = dc1->getSelfNominalTypeDecl();
+        auto *nominal2 = dc2->getSelfNominalTypeDecl();
 
         if (nominal1 && nominal2 && nominal1 != nominal2) {
           auto base1 = nominal1->getDeclaredType();

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3281,8 +3281,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
     // If our base is an existential type, we can't make use of any
     // member whose signature involves associated types.
     if (instanceTy->isExistentialType()) {
-      if (auto *proto = decl->getDeclContext()
-              ->getAsProtocolOrProtocolExtensionContext()) {
+      if (auto *proto = decl->getDeclContext()->getSelfProtocolDecl()) {
         if (!proto->isAvailableInExistential(decl)) {
           result.addUnviable(candidate,
                              MemberLookupResult::UR_UnavailableInExistential);

--- a/lib/Sema/DerivedConformanceCaseIterable.cpp
+++ b/lib/Sema/DerivedConformanceCaseIterable.cpp
@@ -41,7 +41,7 @@ static bool canDeriveConformance(NominalTypeDecl *type) {
 /// Derive the implementation of allCases for a "simple" no-payload enum.
 void deriveCaseIterable_enum_getter(AbstractFunctionDecl *funcDecl) {
   auto *parentDC = funcDecl->getDeclContext();
-  auto *parentEnum = parentDC->getAsEnumOrEnumExtensionContext();
+  auto *parentEnum = parentDC->getSelfEnumDecl();
   auto enumTy = parentDC->getDeclaredTypeInContext();
   auto &C = parentDC->getASTContext();
 

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -531,8 +531,7 @@ static void deriveBodyEncodable_encode(AbstractFunctionDecl *encodeDecl) {
   // }
 
   // The enclosing type decl.
-  auto *targetDecl = encodeDecl->getDeclContext()
-                         ->getAsNominalTypeOrNominalTypeExtensionContext();
+  auto *targetDecl = encodeDecl->getDeclContext()->getSelfNominalTypeDecl();
 
   auto *funcDC = cast<DeclContext>(encodeDecl);
   auto &C = funcDC->getASTContext();
@@ -771,8 +770,7 @@ static void deriveBodyDecodable_init(AbstractFunctionDecl *initDecl) {
 
   // The enclosing type decl.
   auto conformanceDC = initDecl->getDeclContext();
-  auto *targetDecl =
-      conformanceDC->getAsNominalTypeOrNominalTypeExtensionContext();
+  auto *targetDecl = conformanceDC->getSelfNominalTypeDecl();
 
   auto *funcDC = cast<DeclContext>(initDecl);
   auto &C = funcDC->getASTContext();

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -209,7 +209,7 @@ deriveBodyCodingKey_enum_stringValue(AbstractFunctionDecl *strValDecl) {
   auto *parentDC = strValDecl->getDeclContext();
   auto &C = parentDC->getASTContext();
 
-  auto *enumDecl = parentDC->getAsEnumOrEnumExtensionContext();
+  auto *enumDecl = parentDC->getSelfEnumDecl();
   Type enumType = parentDC->getDeclaredTypeInContext();
 
   BraceStmt *body = nullptr;
@@ -276,7 +276,7 @@ deriveBodyCodingKey_init_stringValue(AbstractFunctionDecl *initDecl) {
   auto *parentDC = initDecl->getDeclContext();
   auto &C = parentDC->getASTContext();
 
-  auto *enumDecl = parentDC->getAsEnumOrEnumExtensionContext();
+  auto *enumDecl = parentDC->getSelfEnumDecl();
   Type enumType = parentDC->getDeclaredTypeInContext();
 
   auto elements = enumDecl->getAllElements();

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -868,7 +868,7 @@ deriveBodyHashable_enum_noAssociatedValues_hashInto(
   auto parentDC = hashIntoDecl->getDeclContext();
   ASTContext &C = parentDC->getASTContext();
 
-  auto enumDecl = parentDC->getAsEnumOrEnumExtensionContext();
+  auto enumDecl = parentDC->getSelfEnumDecl();
   auto selfDecl = hashIntoDecl->getImplicitSelfDecl();
 
   // generate: switch self {...}
@@ -911,7 +911,7 @@ deriveBodyHashable_enum_hasAssociatedValues_hashInto(
   auto parentDC = hashIntoDecl->getDeclContext();
   ASTContext &C = parentDC->getASTContext();
 
-  auto enumDecl = parentDC->getAsEnumOrEnumExtensionContext();
+  auto enumDecl = parentDC->getSelfEnumDecl();
   auto selfDecl = hashIntoDecl->getImplicitSelfDecl();
 
   Type enumType = selfDecl->getType();
@@ -991,7 +991,7 @@ deriveBodyHashable_struct_hashInto(AbstractFunctionDecl *hashIntoDecl) {
   auto parentDC = hashIntoDecl->getDeclContext();
   ASTContext &C = parentDC->getASTContext();
 
-  auto structDecl = parentDC->getAsStructOrStructExtensionContext();
+  auto structDecl = parentDC->getSelfStructDecl();
   SmallVector<ASTNode, 6> statements;
   auto selfDecl = hashIntoDecl->getImplicitSelfDecl();
 

--- a/lib/Sema/DerivedConformanceError.cpp
+++ b/lib/Sema/DerivedConformanceError.cpp
@@ -37,7 +37,7 @@ static void deriveBodyBridgedNSError_enum_nsErrorDomain(
   auto M = domainDecl->getParentModule();
   auto &C = M->getASTContext();
   auto TC = domainDecl->getInnermostTypeContext();
-  auto ED = TC->getAsEnumOrEnumExtensionContext();
+  auto ED = TC->getSelfEnumDecl();
 
   std::string buffer = M->getNameStr();
   buffer += ".";

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -76,7 +76,7 @@ static void deriveBodyRawRepresentable_raw(AbstractFunctionDecl *toRawDecl) {
   auto parentDC = toRawDecl->getDeclContext();
   ASTContext &C = parentDC->getASTContext();
 
-  auto enumDecl = parentDC->getAsEnumOrEnumExtensionContext();
+  auto enumDecl = parentDC->getSelfEnumDecl();
 
   Type rawTy = enumDecl->getRawType();
   assert(rawTy);
@@ -207,7 +207,7 @@ deriveBodyRawRepresentable_init(AbstractFunctionDecl *initDecl) {
   auto parentDC = initDecl->getDeclContext();
   ASTContext &C = parentDC->getASTContext();
 
-  auto nominalTypeDecl = parentDC->getAsNominalTypeOrNominalTypeExtensionContext();
+  auto nominalTypeDecl = parentDC->getSelfNominalTypeDecl();
   auto enumDecl = cast<EnumDecl>(nominalTypeDecl);
 
   Type rawTy = enumDecl->getRawType();

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -28,8 +28,7 @@ DerivedConformance::DerivedConformance(TypeChecker &tc, Decl *conformanceDecl,
                                        ProtocolDecl *protocol)
     : TC(tc), ConformanceDecl(conformanceDecl), Nominal(nominal),
       Protocol(protocol) {
-  assert(getConformanceContext()
-             ->getAsNominalTypeOrNominalTypeExtensionContext() == nominal);
+  assert(getConformanceContext()->getSelfNominalTypeDecl() == nominal);
 }
 
 DeclContext *DerivedConformance::getConformanceContext() const {
@@ -303,9 +302,8 @@ DerivedConformance::declareDerivedPropertyGetter(TypeChecker &tc,
   getterDecl->setStatic(isStatic);
 
   // If this is supposed to be a final method, mark it as such.
-  assert(isFinal || !parentDC->getAsClassOrClassExtensionContext());
-  if (isFinal && parentDC->getAsClassOrClassExtensionContext() &&
-      !getterDecl->isFinal())
+  assert(isFinal || !parentDC->getSelfClassDecl());
+  if (isFinal && parentDC->getSelfClassDecl() && !getterDecl->isFinal())
     getterDecl->getAttrs().add(new (C) FinalAttr(/*IsImplicit=*/true));
 
   // Compute the interface type of the getter.
@@ -338,9 +336,8 @@ DerivedConformance::declareDerivedProperty(Identifier name,
   propDecl->setValidationToChecked();
 
   // If this is supposed to be a final property, mark it as such.
-  assert(isFinal || !parentDC->getAsClassOrClassExtensionContext());
-  if (isFinal && parentDC->getAsClassOrClassExtensionContext() &&
-      !propDecl->isFinal())
+  assert(isFinal || !parentDC->getSelfClassDecl());
+  if (isFinal && parentDC->getSelfClassDecl() && !propDecl->isFinal())
     propDecl->getAttrs().add(new (C) FinalAttr(/*IsImplicit=*/true));
 
   Pattern *propPat = new (C) NamedPattern(propDecl, /*implicit*/ true);

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -773,7 +773,7 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
 
       const auto *VD = cast<ValueDecl>(D);
       const TypeDecl *declParent =
-          VD->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
+          VD->getDeclContext()->getSelfNominalTypeDecl();
       if (!declParent) {
         // If the declaration has been validated but not fully type-checked,
         // the attribute might be applied to something invalid.
@@ -3160,8 +3160,7 @@ class ObjCSelectorWalker : public ASTWalker {
       lookupName = lookupName.getBaseName();
 
     // Look for members with the given name.
-    auto nominal =
-      method->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
+    auto nominal = method->getDeclContext()->getSelfNominalTypeDecl();
     auto result = TC.lookupMember(const_cast<DeclContext *>(DC),
                                   nominal->getDeclaredInterfaceType(),
                                   lookupName,
@@ -3231,7 +3230,7 @@ public:
 
       // Make sure the constructor is within Selector.
       auto ctorContextType = ctor->getDeclContext()
-          ->getAsNominalTypeOrNominalTypeExtensionContext()
+          ->getSelfNominalTypeDecl()
           ->getDeclaredType();
       if (!ctorContextType || !ctorContextType->isEqual(SelectorTy))
         return { true, expr };
@@ -3361,24 +3360,20 @@ public:
       }
 
       // If this method is within a protocol...
-      if (auto proto =
-            method->getDeclContext()->getAsProtocolOrProtocolExtensionContext()) {
+      if (auto proto = method->getDeclContext()->getSelfProtocolDecl()) {
         // If the best so far is not from a protocol, or is from a
         // protocol that inherits this protocol, we have a new best.
-        auto bestProto = bestMethod->getDeclContext()
-          ->getAsProtocolOrProtocolExtensionContext();
+        auto bestProto = bestMethod->getDeclContext()->getSelfProtocolDecl();
         if (!bestProto || bestProto->inheritsFrom(proto))
           bestMethod = method;
         continue;
       }
 
       // This method is from a class.
-      auto classDecl =
-        method->getDeclContext()->getAsClassOrClassExtensionContext();
+      auto classDecl = method->getDeclContext()->getSelfClassDecl();
 
       // If the best method was from a protocol, keep it.
-      auto bestClassDecl =
-        bestMethod->getDeclContext()->getAsClassOrClassExtensionContext();
+      auto bestClassDecl = bestMethod->getDeclContext()->getSelfClassDecl();
       if (!bestClassDecl) continue;
 
       // If the best method was from a subclass of the place where
@@ -3399,8 +3394,7 @@ public:
       SmallString<32> replacement;
       {
         llvm::raw_svector_ostream out(replacement);
-        auto nominal = bestMethod->getDeclContext()
-                         ->getAsNominalTypeOrNominalTypeExtensionContext();
+        auto nominal = bestMethod->getDeclContext()->getSelfNominalTypeDecl();
         out << "#selector(";
 
         DeclName name;

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2083,7 +2083,7 @@ bool isSubscriptReturningString(const ValueDecl *D, ASTContext &Context) {
   auto *stringDecl = Context.getStringDecl();
   auto *substringDecl = Context.getSubstringDecl();
 
-  auto *typeDecl = declContext->getAsNominalTypeOrNominalTypeExtensionContext();
+  auto *typeDecl = declContext->getSelfNominalTypeDecl();
   if (!typeDecl)
     return false;
 

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -792,7 +792,7 @@ void TypeChecker::computeCaptures(AnyFunctionRef AFR) {
   // Extensions of generic ObjC functions can't use generic parameters from
   // their context.
   if (AFD && GenericParamCaptureLoc.isValid()) {
-    if (auto Clas = AFD->getParent()->getAsClassOrClassExtensionContext()) {
+    if (auto Clas = AFD->getParent()->getSelfClassDecl()) {
       if (Clas->usesObjCGenericsModel()) {
         diagnose(AFD->getLoc(),
                  diag::objc_generic_extension_using_type_parameter);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -755,8 +755,7 @@ resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC) {
       // conditional conformance for the type with the method in question
       // (NB. that type may not be the type associated with DC, for tested types
       // with static methods).
-      if (auto Proto = Value->getDeclContext()
-                           ->getAsProtocolOrProtocolExtensionContext()) {
+      if (auto Proto = Value->getDeclContext()->getSelfProtocolDecl()) {
         auto contextSelfType =
             BaseDC->getInnermostTypeContext()->getDeclaredInterfaceType();
         auto conformance = conformsToProtocol(

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -382,7 +382,7 @@ static bool checkObjCInExtensionContext(const ValueDecl *value,
     // parameters.
     // FIXME: This is a current limitation, not inherent. We don't have
     // a concrete class to attach Objective-C category metadata to.
-    if (auto classDecl = ED->getAsClassOrClassExtensionContext()) {
+    if (auto classDecl = ED->getSelfClassDecl()) {
       if (auto generic = classDecl->getGenericAncestor()) {
         if (!generic->usesObjCGenericsModel()) {
           if (diagnose) {
@@ -977,14 +977,13 @@ static bool isMemberOfObjCClassExtension(const ValueDecl *VD) {
   auto ext = dyn_cast<ExtensionDecl>(VD->getDeclContext());
   if (!ext) return false;
 
-  return ext->getAsClassOrClassExtensionContext() &&
-    ext->getAttrs().hasAttribute<ObjCAttr>();
+  return ext->getSelfClassDecl() && ext->getAttrs().hasAttribute<ObjCAttr>();
 }
 
 /// Whether this declaration is a member of a class with the `@objcMembers`
 /// attribute.
 static bool isMemberOfObjCMembersClass(const ValueDecl *VD) {
-  auto classDecl = VD->getDeclContext()->getAsClassOrClassExtensionContext();
+  auto classDecl = VD->getDeclContext()->getSelfClassDecl();
   if (!classDecl) return false;
 
   return classDecl->getAttrs().hasAttribute<ObjCMembersAttr>();
@@ -1113,7 +1112,7 @@ Optional<ObjCReason> shouldMarkAsObjC(const ValueDecl *VD, bool allowImplicit) {
   if (VD->getOverriddenDecl() && VD->getOverriddenDecl()->isObjC())
     return ObjCReason(ObjCReason::OverridesObjC);
   // A witness to an @objc protocol requirement is implicitly @objc.
-  if (VD->getDeclContext()->getAsClassOrClassExtensionContext()) {
+  if (VD->getDeclContext()->getSelfClassDecl()) {
     auto requirements =
       findWitnessedObjCRequirements(VD, /*anySingleRequirement=*/true);
     if (!requirements.empty())
@@ -1165,8 +1164,7 @@ Optional<ObjCReason> shouldMarkAsObjC(const ValueDecl *VD, bool allowImplicit) {
   // If this declaration is part of a class with implicitly @objc members,
   // make it implicitly @objc. However, if the declaration cannot be represented
   // as @objc, don't diagnose.
-  if (auto classDecl = VD->getDeclContext()
-          ->getAsClassOrClassExtensionContext()) {
+  if (auto classDecl = VD->getDeclContext()->getSelfClassDecl()) {
     // One cannot define @objc members of any foreign classes.
     if (classDecl->isForeign())
       return None;
@@ -1263,7 +1261,7 @@ llvm::Expected<bool>
 IsObjCRequest::evaluate(Evaluator &evaluator, ValueDecl *VD) const {
   auto dc = VD->getDeclContext();
   Optional<ObjCReason> isObjC;
-  if (dc->getAsClassOrClassExtensionContext() && !isa<TypeDecl>(VD)) {
+  if (dc->getSelfClassDecl() && !isa<TypeDecl>(VD)) {
     // Members of classes can be @objc.
     isObjC = shouldMarkAsObjC(VD, isa<ConstructorDecl>(VD));
   }
@@ -1532,8 +1530,7 @@ void markAsObjC(ValueDecl *D, ObjCReason reason,
   }
 
   // Record the name of this Objective-C method in its class.
-  if (auto classDecl
-        = D->getDeclContext()->getAsClassOrClassExtensionContext()) {
+  if (auto classDecl = D->getDeclContext()->getSelfClassDecl()) {
     if (auto method = dyn_cast<AbstractFunctionDecl>(D)) {
       // Determine the foreign error convention.
       if (auto baseMethod = method->getOverriddenDecl()) {

--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -343,9 +343,7 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
               Swift3ObjCInferenceWarnings::Minimal) {
           diagnose(componentNameLoc, diag::expr_keypath_swift3_objc_inference,
                    var->getFullName(),
-                   var->getDeclContext()
-                    ->getAsNominalTypeOrNominalTypeExtensionContext()
-                   ->getName());
+                   var->getDeclContext()->getSelfNominalTypeDecl()->getName());
           diagnose(var, diag::make_decl_objc, var->getDescriptiveKind())
             .fixItInsert(var->getAttributeInsertionLoc(false),
                          "@objc ");

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -187,9 +187,7 @@ Type CompleteGenericTypeResolver::resolveDependentMemberType(
   if (!concrete->hasInterfaceType())
     return ErrorType::get(tc.Context);
   if (baseTy->isTypeParameter()) {
-    if (auto proto =
-          concrete->getDeclContext()
-            ->getAsProtocolOrProtocolExtensionContext()) {
+    if (auto proto = concrete->getDeclContext()->getSelfProtocolDecl()) {
       // Fast path: if there are no type parameters in the concrete type, just
       // return it.
       if (!concrete->getDeclaredInterfaceType()->hasTypeParameter())
@@ -982,7 +980,7 @@ static void visitOuterToInner(
 
 /// Retrieve the generic parameter depth of the extended type.
 static unsigned getExtendedTypeGenericDepth(ExtensionDecl *ext) {
-  auto nominal = ext->getAsNominalTypeOrNominalTypeExtensionContext();
+  auto nominal = ext->getSelfNominalTypeDecl();
   if (!nominal) return static_cast<unsigned>(-1);
 
   auto sig = nominal->getGenericSignatureOfContext();
@@ -1073,8 +1071,7 @@ GenericEnvironment *TypeChecker::checkGenericEnvironment(
     }
   } else {
     // Re-use the signature of the type being extended.
-    sig = ext->getAsNominalTypeOrNominalTypeExtensionContext()
-            ->getGenericSignatureOfContext();
+    sig = ext->getSelfNominalTypeDecl()->getGenericSignatureOfContext();
   }
 
   CompleteGenericTypeResolver completeResolver(*this, sig);

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -417,7 +417,7 @@ bool TypeChecker::isUnsupportedMemberTypeAccess(Type type, TypeDecl *typeDecl) {
   }
 
   if (type->isExistentialType() &&
-      typeDecl->getDeclContext()->getAsProtocolOrProtocolExtensionContext()) {
+      typeDecl->getDeclContext()->getSelfProtocolDecl()) {
     // TODO: Temporarily allow typealias and associated type lookup on
     //       existential type iff it doesn't have any type parameters.
     if (isa<TypeAliasDecl>(typeDecl) || isa<AssociatedTypeDecl>(typeDecl))
@@ -475,7 +475,7 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
     // If we're looking up an associated type of a concrete type,
     // record it later for conformance checking; we might find a more
     // direct typealias with the same name later.
-    if (typeDecl->getDeclContext()->getAsProtocolOrProtocolExtensionContext()) {
+    if (typeDecl->getDeclContext()->getSelfProtocolDecl()) {
       if (auto assocType = dyn_cast<AssociatedTypeDecl>(typeDecl)) {
         if (!type->is<ArchetypeType>() &&
             !type->isTypeParameter()) {

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -60,10 +60,8 @@ extractEnumElement(TypeChecker &TC, DeclContext *DC, SourceLoc UseLoc,
 
   // If the declaration we found isn't in the same nominal type as the
   // constant, ignore it.
-  if (ctorExpr->getDecl()->getDeclContext()
-          ->getAsNominalTypeOrNominalTypeExtensionContext() != 
-        constant->getDeclContext()
-          ->getAsNominalTypeOrNominalTypeExtensionContext())
+  if (ctorExpr->getDecl()->getDeclContext()->getSelfNominalTypeDecl() !=
+        constant->getDeclContext()->getSelfNominalTypeDecl())
     return nullptr;
 
   return dyn_cast<EnumElementDecl>(ctorExpr->getDecl());

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -179,7 +179,7 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
 
     // The extension where the conformance being checked is declared.
     auto conformanceExtension = checker.Conformance->
-      getDeclContext()->getAsDeclOrDeclExtensionContext();
+      getDeclContext()->getAsDecl();
     if (extension == conformanceExtension)
       return true;
 
@@ -292,7 +292,7 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
           // on `Self`, then it may still be an interesting candidate if we find
           // an answer for that other type.
           auto witnessContext = witness->getDeclContext();
-          if (witnessContext->getAsProtocolExtensionContext()
+          if (witnessContext->getExtendedProtocolDecl()
               && witnessContext->getGenericSignatureOfContext()) {
             auto selfTy = witnessContext->getSelfInterfaceType();
             auto selfAssocTy = DependentMemberType::get(selfTy,
@@ -593,8 +593,7 @@ AssociatedTypeInference::inferTypeWitnessesViaAssociatedType(
       continue;
 
     // We only find these within a protocol extension.
-    auto defaultProto = typeDecl->getDeclContext()
-                          ->getAsProtocolOrProtocolExtensionContext();
+    auto defaultProto = typeDecl->getDeclContext()->getSelfProtocolDecl();
     if (!defaultProto)
       continue;
 
@@ -1344,11 +1343,11 @@ void AssociatedTypeInference::findSolutionsRec(
     // Record this value witness, popping it when we exit the current scope.
     valueWitnesses.push_back({inferredReq.first, witnessReq.Witness});
     if (!isa<TypeDecl>(inferredReq.first) &&
-        witnessReq.Witness->getDeclContext()->getAsProtocolExtensionContext())
+        witnessReq.Witness->getDeclContext()->getExtendedProtocolDecl())
       ++numValueWitnessesInProtocolExtensions;
     SWIFT_DEFER {
       if (!isa<TypeDecl>(inferredReq.first) &&
-          witnessReq.Witness->getDeclContext()->getAsProtocolExtensionContext())
+          witnessReq.Witness->getDeclContext()->getExtendedProtocolDecl())
         --numValueWitnessesInProtocolExtensions;
 
       valueWitnesses.pop_back();
@@ -1432,11 +1431,11 @@ compareDeclsForInference(TypeChecker &TC, DeclContext *DC,
   // that came from a protocol extension.
   if (!decl1 || !decl2) {
     if (!decl1 &&
-        decl2 && decl2->getDeclContext()->getAsProtocolExtensionContext())
+        decl2 && decl2->getDeclContext()->getExtendedProtocolDecl())
       return Comparison::Worse;
 
     if (!decl2 &&
-        decl1 && decl1->getDeclContext()->getAsProtocolExtensionContext())
+        decl1 && decl1->getDeclContext()->getExtendedProtocolDecl())
       return Comparison::Better;
 
     return Comparison::Unordered;
@@ -1450,10 +1449,8 @@ compareDeclsForInference(TypeChecker &TC, DeclContext *DC,
   if (dc1 == dc2)
     return TC.compareDeclarations(DC, decl1, decl2);
 
-  auto isProtocolExt1 =
-    (bool)dc1->getAsProtocolExtensionContext();
-  auto isProtocolExt2 =
-    (bool)dc2->getAsProtocolExtensionContext();
+  auto isProtocolExt1 = (bool)dc1->getExtendedProtocolDecl();
+  auto isProtocolExt2 = (bool)dc2->getExtendedProtocolDecl();
 
   // If one witness comes from a protocol extension, favor the one
   // from a concrete context.

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1719,8 +1719,7 @@ bool TypeChecker::typeCheckConstructorBodyUntil(ConstructorDecl *ctor,
     return HadError;
 
   // Determine whether we need to introduce a super.init call.
-  auto nominalDecl = ctor->getDeclContext()
-    ->getAsNominalTypeOrNominalTypeExtensionContext();
+  auto nominalDecl = ctor->getDeclContext()->getSelfNominalTypeDecl();
 
   // Error case.
   if (nominalDecl == nullptr)

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -622,8 +622,7 @@ NormalProtocolConformance *ModuleFile::readNormalConformance(
   uint64_t offset = conformanceEntry;
   conformanceEntry = conformance;
 
-  dc->getAsNominalTypeOrNominalTypeExtensionContext()
-    ->registerProtocolConformance(conformance);
+  dc->getSelfNominalTypeDecl()->registerProtocolConformance(conformance);
 
   // If the conformance is complete, we're done.
   if (conformance->isComplete())
@@ -1227,8 +1226,8 @@ static void filterValues(Type expectedTy, ModuleDecl *expectedModule,
     // filter by whether we expect to find something in a protocol extension or
     // not. This lets us distinguish between a protocol member and a protocol
     // extension member that have the same type.
-    if (value->getDeclContext()->getAsProtocolOrProtocolExtensionContext() &&
-        (bool)value->getDeclContext()->getAsProtocolExtensionContext()
+    if (value->getDeclContext()->getSelfProtocolDecl() &&
+        (bool)value->getDeclContext()->getExtendedProtocolDecl()
           != inProtocolExt)
       return true;
 

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1905,7 +1905,7 @@ void ModuleFile::lookupClassMember(ModuleDecl::AccessPathTy accessPath,
         auto dc = vd->getDeclContext();
         while (!dc->getParent()->isModuleScopeContext())
           dc = dc->getParent();
-        if (auto nominal = dc->getAsNominalTypeOrNominalTypeExtensionContext())
+        if (auto nominal = dc->getSelfNominalTypeDecl())
           if (nominal->getName() == accessPath.front().first)
             results.push_back(vd);
       }
@@ -1918,7 +1918,7 @@ void ModuleFile::lookupClassMember(ModuleDecl::AccessPathTy accessPath,
         auto dc = vd->getDeclContext();
         while (!dc->getParent()->isModuleScopeContext())
           dc = dc->getParent();
-        if (auto nominal = dc->getAsNominalTypeOrNominalTypeExtensionContext())
+        if (auto nominal = dc->getSelfNominalTypeDecl())
           if (nominal->getName() == accessPath.front().first)
             results.push_back(vd);
       }
@@ -1947,7 +1947,7 @@ void ModuleFile::lookupClassMembers(ModuleDecl::AccessPathTy accessPath,
         auto dc = vd->getDeclContext();
         while (!dc->getParent()->isModuleScopeContext())
           dc = dc->getParent();
-        if (auto nominal = dc->getAsNominalTypeOrNominalTypeExtensionContext())
+        if (auto nominal = dc->getSelfNominalTypeDecl())
           if (nominal->getName() == accessPath.front().first)
             consumer.foundDecl(vd, DeclVisibilityKind::DynamicLookup);
       }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1937,7 +1937,7 @@ void Serializer::writeCrossReference(const DeclContext *DC, uint32_t pathLen) {
     Type ty = SD->getInterfaceType()->getCanonicalType();
 
     abbrCode = DeclTypeAbbrCodes[XRefValuePathPieceLayout::Code];
-    bool isProtocolExt = SD->getDeclContext()->getAsProtocolExtensionContext();
+    bool isProtocolExt = SD->getDeclContext()->getExtendedProtocolDecl();
     XRefValuePathPieceLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                          addTypeRef(ty), SUBSCRIPT_ID,
                                          isProtocolExt, SD->hasClangNode(),
@@ -1952,7 +1952,7 @@ void Serializer::writeCrossReference(const DeclContext *DC, uint32_t pathLen) {
 
       Type ty = storage->getInterfaceType()->getCanonicalType();
       IdentifierID nameID = addDeclBaseNameRef(storage->getBaseName());
-      bool isProtocolExt = fn->getDeclContext()->getAsProtocolExtensionContext();
+      bool isProtocolExt = fn->getDeclContext()->getExtendedProtocolDecl();
       abbrCode = DeclTypeAbbrCodes[XRefValuePathPieceLayout::Code];
       XRefValuePathPieceLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                            addTypeRef(ty), nameID,
@@ -1981,14 +1981,14 @@ void Serializer::writeCrossReference(const DeclContext *DC, uint32_t pathLen) {
       abbrCode = DeclTypeAbbrCodes[XRefInitializerPathPieceLayout::Code];
       XRefInitializerPathPieceLayout::emitRecord(
         Out, ScratchRecord, abbrCode, addTypeRef(ty),
-        (bool)ctor->getDeclContext()->getAsProtocolExtensionContext(),
+        (bool)ctor->getDeclContext()->getExtendedProtocolDecl(),
         ctor->hasClangNode(),
         getStableCtorInitializerKind(ctor->getInitKind()));
       break;
     }
 
     abbrCode = DeclTypeAbbrCodes[XRefValuePathPieceLayout::Code];
-    bool isProtocolExt = fn->getDeclContext()->getAsProtocolExtensionContext();
+    bool isProtocolExt = fn->getDeclContext()->getExtendedProtocolDecl();
     XRefValuePathPieceLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                          addTypeRef(ty),
                                          addDeclBaseNameRef(fn->getBaseName()),
@@ -2058,7 +2058,7 @@ void Serializer::writeCrossReference(const Decl *D) {
     return;
   }
 
-  bool isProtocolExt = D->getDeclContext()->getAsProtocolExtensionContext();
+  bool isProtocolExt = D->getDeclContext()->getExtendedProtocolDecl();
   if (auto type = dyn_cast<TypeDecl>(D)) {
     abbrCode = DeclTypeAbbrCodes[XRefTypePathPieceLayout::Code];
 
@@ -4807,8 +4807,7 @@ static void collectInterestingNestedDeclarations(
 
       if (auto func = dyn_cast<AbstractFunctionDecl>(member)) {
         if (func->isObjC()) {
-          if (auto owningClass =
-                func->getDeclContext()->getAsClassOrClassExtensionContext()) {
+          if (auto owningClass = func->getDeclContext()->getSelfClassDecl()) {
             Mangle::ASTMangler mangler;
             std::string ownerName = mangler.mangleNominalType(owningClass);
             assert(!ownerName.empty() && "Mangled type came back empty!");
@@ -4843,7 +4842,7 @@ static void collectInterestingNestedDeclarations(
       if (nestedType->getEffectiveAccess() > swift::AccessLevel::FilePrivate) {
         if (!nominalParent) {
           const DeclContext *DC = member->getDeclContext();
-          nominalParent = DC->getAsNominalTypeOrNominalTypeExtensionContext();
+          nominalParent = DC->getSelfNominalTypeDecl();
           assert(nominalParent && "parent context is not a type or extension");
         }
         nestedTypeDecls[nestedType->getName()].push_back({

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -328,7 +328,7 @@ void TBDGenVisitor::visitClassDecl(ClassDecl *CD) {
 }
 
 void TBDGenVisitor::visitConstructorDecl(ConstructorDecl *CD) {
-  if (CD->getParent()->getAsClassOrClassExtensionContext()) {
+  if (CD->getParent()->getSelfClassDecl()) {
     // Class constructors come in two forms, allocating and non-allocating. The
     // default ValueDecl handling gives the allocating one, so we have to
     // manually include the non-allocating one.
@@ -342,7 +342,7 @@ void TBDGenVisitor::visitDestructorDecl(DestructorDecl *DD) {
   // like constructors above. This is the deallocating one:
   visitAbstractFunctionDecl(DD);
 
-  auto parentClass = DD->getParent()->getAsClassOrClassExtensionContext();
+  auto parentClass = DD->getParent()->getSelfClassDecl();
 
   // But the non-deallocating one doesn't apply to some @objc classes.
   if (!Lowering::usesObjCAllocator(parentClass)) {

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -277,7 +277,7 @@ static void initDocGenericParams(const Decl *D, DocEntityInfo &Info) {
 
   ProtocolDecl *proto = nullptr;
   if (auto *typeDC = DC->getInnermostTypeContext())
-    proto = typeDC->getAsProtocolOrProtocolExtensionContext();
+    proto = typeDC->getSelfProtocolDecl();
 
   for (auto &Req : GenericSig->getRequirements()) {
     // Skip protocol Self requirement.

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -479,7 +479,7 @@ void walkRelatedDecls(const ValueDecl *VD, const FnTy &Fn) {
   }
 
   // Now provide the results along with whether the name is duplicate or not.
-  ValueDecl *OriginalBase = VD->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
+  ValueDecl *OriginalBase = VD->getDeclContext()->getSelfNominalTypeDecl();
   for (auto Related : RelatedDecls) {
     ValueDecl *RelatedVD = Related.getValueDecl();
     bool SameBase = Related.getBaseDecl() && Related.getBaseDecl() == OriginalBase;

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -1656,9 +1656,8 @@ static SDKNode *constructTypeDeclNode(SDKContext &Ctx, NominalTypeDecl *NTD,
 static SDKNode *constructExternalExtensionNode(SDKContext &Ctx, SDKNode *Root,
                                                ExtensionDecl *Ext,
                                         std::set<ExtensionDecl*> &HandledExts) {
-  auto *TypeNode = SDKNodeInitInfo(Ctx,
-    Ext->getAsNominalTypeOrNominalTypeExtensionContext()).
-      createSDKNode(SDKNodeKind::DeclType);
+  auto *TypeNode = SDKNodeInitInfo(Ctx, Ext->getSelfNominalTypeDecl())
+      .createSDKNode(SDKNodeKind::DeclType);
 
   // The members of the extension are the only members of this synthesized type.
   addMembersToRoot(Ctx, TypeNode, Ext, HandledExts);


### PR DESCRIPTION
- getAsDeclOrDeclExtensionContext -> getAsDecl

This is basically the same as a dyn_cast, so it should use a 'getAs' name like TypeBase does.

- getAsNominalTypeOrNominalTypeExtensionContext -> getSelfNominalTypeDecl
- getAsClassOrClassExtensionContext -> getSelfClassDecl
- getAsEnumOrEnumExtensionContext -> getSelfEnumDecl
- getAsStructOrStructExtensionContext -> getSelfStructDecl
- getAsProtocolOrProtocolExtensionContext -> getSelfProtocolDecl
- getAsTypeOrTypeExtensionContext -> getSelfTypeDecl (private)

These do *not* return some form of `this`; instead, they get the extended types when `this` is an extension. They started off life with 'is' names, which makes sense, but changed to this at some point.  The names I went with match up with getSelfInterfaceType and getSelfTypeInContext, even though strictly speaking they're closer to what getDeclaredInterfaceType does. But it didn't seem right to claim that an extension "declares" the ClassDecl here.

- getAsProtocolExtensionContext -> getExtendedProtocolDecl

Like the above, this didn't return the ExtensionDecl; it returned its extended type.

This entire commit is a mechanical change: find-and-replace, followed by manual reformatted but no code changes.