### PR TITLE
[overlays] Clean up some sources of undefined behaviour

### DIFF
--- a/stdlib/public/SDK/CoreGraphics/CoreGraphics.swift
+++ b/stdlib/public/SDK/CoreGraphics/CoreGraphics.swift
@@ -517,7 +517,7 @@ extension CGAffineTransform : Codable {
 
 extension CGImage {
   public func copy(maskingColorComponents components: [CGFloat]) -> CGImage? {
-    return self.__copy(maskingColorComponents: UnsafePointer(components))
+    return self.__copy(maskingColorComponents: components)
   }
 }
 

--- a/stdlib/public/SDK/Metal/Metal.swift
+++ b/stdlib/public/SDK/Metal/Metal.swift
@@ -100,10 +100,11 @@ extension MTLDevice {
 @available(swift 4)
 @available(macOS 10.13, *)
 public func MTLCopyAllDevicesWithObserver(handler: @escaping MTLDeviceNotificationHandler) -> (devices:[MTLDevice], observer:NSObject) {
-    var resultTuple: (devices:[MTLDevice], observer:NSObject)
-    resultTuple.observer = NSObject()
-    resultTuple.devices = __MTLCopyAllDevicesWithObserver(AutoreleasingUnsafeMutablePointer<NSObjectProtocol?>(&resultTuple.observer), handler)
-    return resultTuple
+    var observer: NSObjectProtocol?
+    let devices = __MTLCopyAllDevicesWithObserver(&observer, handler)
+    // FIX-ME: The force cast here isn't great – ideally we would return the
+    // observer as an NSObjectProtocol.
+    return (devices, observer as! NSObject)
 }
 #endif
 

--- a/stdlib/public/SDK/Metal/Metal.swift
+++ b/stdlib/public/SDK/Metal/Metal.swift
@@ -102,7 +102,7 @@ extension MTLDevice {
 public func MTLCopyAllDevicesWithObserver(handler: @escaping MTLDeviceNotificationHandler) -> (devices:[MTLDevice], observer:NSObject) {
     var observer: NSObjectProtocol?
     let devices = __MTLCopyAllDevicesWithObserver(&observer, handler)
-    // FIX-ME: The force cast here isn't great – ideally we would return the
+    // FIXME: The force cast here isn't great – ideally we would return the
     // observer as an NSObjectProtocol.
     return (devices, observer as! NSObject)
 }

--- a/stdlib/public/SDK/SceneKit/SceneKit.swift.gyb
+++ b/stdlib/public/SDK/SceneKit/SceneKit.swift.gyb
@@ -179,15 +179,15 @@ extension SCNGeometryElement {
 extension SCNGeometrySource {
   @nonobjc
   public convenience init(vertices: [SCNVector3]) {
-    self.init(vertices: UnsafePointer(vertices), count: vertices.count)
+    self.init(vertices: vertices, count: vertices.count)
   }
   @nonobjc
   public convenience init(normals: [SCNVector3]) {
-    self.init(normals: UnsafePointer(normals), count: normals.count)
+    self.init(normals: normals, count: normals.count)
   }
   @nonobjc
   public convenience init(textureCoordinates: [CGPoint]) {
-    self.init(textureCoordinates: UnsafePointer(textureCoordinates), count: textureCoordinates.count)
+    self.init(textureCoordinates: textureCoordinates, count: textureCoordinates.count)
   }
 }
 


### PR DESCRIPTION
While experimenting with forbidding temporary argument conversions for `UnsafePointer` initialiser parameters (amongst others), I found a few cases where we're currently making such unsound calls in the SDK overlays (unsound because such temporary argument conversions produce pointers valid only for the duration of the call).

This PR removes such usages by performing the temporary argument conversions directly without going through any `UnsafePointer` initialiser calls first.

In the case of `MTLCopyAllDevicesWithObserver`, such usage led to us over-releasing the observer, as the call to `AutoreleasingUnsafeMutablePointer`'s initialiser:

```swift
AutoreleasingUnsafeMutablePointer<NSObjectProtocol?>(&resultTuple.observer)
```

treats the +1 memory as having +0 semantics, leading to an unbalanced autorelease (this didn't appear to cause issues for users though as Metal itself keeps the observer retained).
