### PR TITLE
Partition all functions with tensorflow convention even if private

### DIFF
--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -377,10 +377,8 @@ protected:
           // it. This should be removed once partition is moved into the
           // deabstraction pass.
           for (const auto &attr : graphOp->getAttributes()) {
-            if (attr.value.getKind() != SymbolicValue::Function) {
-              continue;
-            }
-            ensureAlive(attr.value.getFunctionValue());
+            if (attr.value.getKind() == SymbolicValue::Function)
+              ensureAlive(attr.value.getFunctionValue());
           }
         }
       }

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -16,6 +16,9 @@
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SIL/PatternMatch.h"
 #include "swift/SIL/SILBuilder.h"
+// SWIFT_ENABLE_TENSORFLOW
+#include "swift/SIL/SILConstants.h"
+// SWIFT_ENABLE_TENSORFLOW end
 #include "swift/SIL/SILVisitor.h"
 #include "swift/SIL/InstructionUtils.h"
 #include "swift/SILOptimizer/Utils/Local.h"
@@ -25,6 +28,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 using namespace swift;
+
 
 STATISTIC(NumDeadFunc, "Number of dead functions eliminated");
 
@@ -365,6 +369,19 @@ protected:
         } else if (auto *KPI = dyn_cast<KeyPathInst>(&I)) {
           for (auto &component : KPI->getPattern()->getComponents())
             ensureKeyPathComponentIsAlive(component);
+        } else if (auto *graphOp = dyn_cast<GraphOperationInst>(&I)) {
+          // SWIFT_ENABLE_TENSORFLOW
+          //
+          // Mark function attributes as live so that it is not eliminated
+          // before partitioning and graph lowering has a chance to look at
+          // it. This should be removed once partition is moved into the
+          // deabstraction pass.
+          for (const auto &attr : graphOp->getAttributes()) {
+            if (attr.value.getKind() != SymbolicValue::Function) {
+              continue;
+            }
+            ensureAlive(attr.value.getFunctionValue());
+          }
         }
       }
     }

--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -670,6 +670,12 @@ bool TensorFunctionClassifier::shouldBePartitioned(SILFunction *fn) {
     }
   }
 
+  // Graph functions always get partitioned because they can be used as
+  // attributes.
+  if (fn->getLoweredFunctionType()->getRepresentation() ==
+      SILFunctionType::Representation::TensorFlow)
+    return true;
+
   // If the function is marked public, but it isn't marked inlinable, then it is
   // a public entrypoint that cannot be deabstracted through, so we must
   // transform it.


### PR DESCRIPTION
This patch has a temporary fix to not throw away private functions in DeadFunctionElimination if they only appear as attributes of graph ops. This can be removed as soon as we move partitioning to the deabstraction pass. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-8550](https://bugs.swift.org/browse/SR-8550).

