### PR TITLE
[Type checker] Request nominal layout for all potential metadata sources

### DIFF
--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -792,6 +792,20 @@ static bool validateParameterType(ParamDecl *decl, DeclContext *DC,
   return hadError;
 }
 
+/// Given a type of a function parameter, request layout for any
+/// nominal types that IRGen could use as metadata sources.
+static void requestLayoutForMetadataSources(TypeChecker &tc, Type type) {
+  type->getCanonicalType().visit([&tc](CanType type) {
+    // Generic types are sources for typemetadata and conformances. If a
+    // parameter is of dependent type then the body of a function with said
+    // parameter could potentially require the generic type's layout to
+    // recover them.
+    if (auto *nominalDecl = type->getAnyNominal()) {
+      tc.requestNominalLayout(nominalDecl);
+    }
+  });
+}
+
 /// Request nominal layout for any types that could be sources of type metadata
 /// or conformances.
 void TypeChecker::requestRequiredNominalTypeLayoutForParameters(
@@ -800,13 +814,7 @@ void TypeChecker::requestRequiredNominalTypeLayoutForParameters(
     if (!param->hasInterfaceType())
       continue;
 
-    // Generic types are sources for typemetadata and conformances. If a
-    // parameter is of dependent type then the body of a function with said
-    // parameter could potentially require the generic type's layout to
-    // recover them.
-    if (auto *nominalDecl = param->getInterfaceType()->getAnyNominal()) {
-      requestNominalLayout(nominalDecl);
-    }
+    requestLayoutForMetadataSources(*this, param->getInterfaceType());
   }
 }
 

--- a/test/multifile/Inputs/require-layout-generic-class.swift
+++ b/test/multifile/Inputs/require-layout-generic-class.swift
@@ -8,6 +8,6 @@ public class Base<T> {
 public class Sub<T> : Base<T> {
 }
 
-public func requestTypeThrough<T>(closure: (Sub<T>) -> (), arg: T) {
-  closure(Sub(arg))
+public func requestTypeThrough<T>(closure: ((Sub<T>, Int)) -> (), arg: T) {
+  closure((Sub(arg), 0))
 }

--- a/test/multifile/require-layout-generic-arg-closure.swift
+++ b/test/multifile/require-layout-generic-arg-closure.swift
@@ -5,14 +5,14 @@
 
 // The offset of the typemetadata in the class typemetadata must match.
 
-// FILE1-LABEL: define internal swiftcc void @"$S4test12requestType21xyx_tlFyAA3SubCyxGXEfU_"(%T4test3SubC*)
+// FILE1-LABEL: define internal swiftcc void @"$S4test12requestType21xyx_tlFyAA3SubCyxG_Sit_tXEfU_
 // FILE1: entry:
 // FILE1:   [[T1:%.*]] = bitcast %T4test3SubC* %0 to %swift.type**
 // FILE1:   [[TYPEMETADATA:%.*]] = load %swift.type*, %swift.type** [[T1]]
 // FILE1:   [[T2:%.*]] = bitcast %swift.type* [[TYPEMETADATA]] to %swift.type**
 // FILE1:   [[T_PTR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T2]], i64 16
 // FILE1:   [[T:%.*]] = load %swift.type*, %swift.type** [[T_PTR]]
-// FILE1:   call swiftcc %swift.metadata_response @"$S4test3SubCMa"(i64 0, %swift.type* [[T]])
+// FILE1:   call swiftcc %swift.metadata_response @"$S4test3SubCMa"(i64 255, %swift.type* [[T]])
 
 public func requestType2<T>(x: T) {
   requestTypeThrough(closure: { x in print(x) }, arg: x)


### PR DESCRIPTION
Fixes the non-WMO crash in ReactiveCocoa (SR-8530), where IRGen was
attempting to fulfill a metadata request based on a nominal type whose
layout was not checked.
