### PR TITLE
[Sema] Validate Swift.Dictionary when resolving '[K: V]' sugar

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2533,6 +2533,7 @@ Type TypeResolver::resolveDictionaryType(DictionaryTypeRepr *repr,
   if (auto dictTy = TC.getDictionaryType(repr->getBrackets().Start, keyTy, 
                                          valueTy)) {
     // Check the requirements on the generic arguments.
+    TC.validateDecl(dictDecl);
     auto unboundTy = dictDecl->getDeclaredType()->castTo<UnboundGenericType>();
 
     Type args[] = {keyTy, valueTy};

--- a/test/Sema/stdlib_sugar_types.swift
+++ b/test/Sema/stdlib_sugar_types.swift
@@ -1,0 +1,19 @@
+// Test using type sugar before the types are defined.
+
+// RUN: %target-swift-frontend -typecheck -parse-stdlib -module-name Swift -parse-as-library %s
+
+struct Dummy {}
+
+let a: Dummy? = .none
+let b: Dummy! = .none
+let c: [Dummy] = .init()
+let d: [Dummy: Dummy] = .init()
+
+enum Optional<Wrapped> {
+  case none
+  case some(Wrapped)
+}
+
+struct Array<Element> {}
+
+struct Dictionary<Key, Value> {}


### PR DESCRIPTION
Otherwise we'll try to use its generic signature before it's been computed.