### PR TITLE
 [Type checker] Eliminate ProtocolRequirementTypeResolver.

### DIFF
--- a/lib/Sema/GenericTypeResolver.h
+++ b/lib/Sema/GenericTypeResolver.h
@@ -103,24 +103,6 @@ public:
   virtual bool areSameType(Type type1, Type type2);
 };
 
-/// Generic type resolver that only handles what can appear in a protocol
-/// definition, i.e. Self, and Self.A.B.C dependent types.
-///
-/// This should only be used when resolving/validating where clauses in
-/// protocols.
-class ProtocolRequirementTypeResolver : public GenericTypeResolver {
-public:
-  virtual bool usesArchetypes() { return false; }
-
-  virtual Type mapTypeIntoContext(Type type);
-
-  virtual Type resolveDependentMemberType(Type baseTy, DeclContext *DC,
-                                          SourceRange baseRange,
-                                          ComponentIdentTypeRepr *ref);
-
-  virtual bool areSameType(Type type1, Type type2);
-};
-
 /// Generic type resolver that performs complete resolution of dependent
 /// types based on a given generic signature builder.
 ///

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -208,7 +208,7 @@ public:
 static void validateAttributes(TypeChecker &TC, Decl *D);
 
 void TypeChecker::resolveTrailingWhereClause(ProtocolDecl *proto) {
-  ProtocolRequirementTypeResolver resolver;
+  DependentGenericTypeResolver resolver;
   validateWhereClauses(proto, &resolver);
 }
 
@@ -4488,7 +4488,7 @@ void TypeChecker::validateDeclForNameLookup(ValueDecl *D) {
         auto helper = [&] {
           (void) typealias->getFormalAccess();
 
-          ProtocolRequirementTypeResolver resolver;
+          DependentGenericTypeResolver resolver;
           TypeResolutionOptions options(TypeResolverContext::TypeAliasDecl);
           if (validateType(typealias->getUnderlyingTypeLoc(),
                            typealias, options, &resolver)) {

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -43,11 +43,20 @@ Type DependentGenericTypeResolver::resolveDependentMemberType(
 }
 
 bool DependentGenericTypeResolver::areSameType(Type type1, Type type2) {
-  if (!type1->hasTypeParameter() && !type2->hasTypeParameter())
-    return type1->isEqual(type2);
+  if (type1->isEqual(type2))
+    return true;
 
-  // Conservative answer: they could be the same.
-  return true;
+  // If both refer to associated types with the same name, they'll implicitly
+  // be considered equivalent.
+  auto depMem1 = type1->getAs<DependentMemberType>();
+  if (!depMem1) return false;
+
+  auto depMem2 = type2->getAs<DependentMemberType>();
+  if (!depMem2) return false;
+
+  if (depMem1->getName() != depMem2->getName()) return false;
+
+  return areSameType(depMem1->getBase(), depMem2->getBase());
 }
 
 Type GenericTypeToArchetypeResolver::mapTypeIntoContext(Type type) {

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -75,33 +75,6 @@ bool GenericTypeToArchetypeResolver::areSameType(Type type1, Type type2) {
   return type1->isEqual(type2);
 }
 
-Type ProtocolRequirementTypeResolver::mapTypeIntoContext(Type type) {
-  return type;
-}
-
-Type ProtocolRequirementTypeResolver::resolveDependentMemberType(
-    Type baseTy, DeclContext *DC, SourceRange baseRange,
-    ComponentIdentTypeRepr *ref) {
-  return DependentMemberType::get(baseTy, ref->getIdentifier());
-}
-
-bool ProtocolRequirementTypeResolver::areSameType(Type type1, Type type2) {
-  if (type1->isEqual(type2))
-    return true;
-
-  // If both refer to associated types with the same name, they'll implicitly
-  // be considered equivalent.
-  auto depMem1 = type1->getAs<DependentMemberType>();
-  if (!depMem1) return false;
-
-  auto depMem2 = type2->getAs<DependentMemberType>();
-  if (!depMem2) return false;
-
-  if (depMem1->getName() != depMem2->getName()) return false;
-
-  return areSameType(depMem1->getBase(), depMem2->getBase());
-}
-
 CompleteGenericTypeResolver::CompleteGenericTypeResolver(
                                               TypeChecker &tc,
                                               GenericSignature *genericSig)

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -40,7 +40,7 @@ InheritedTypeRequest::evaluate(
     options |= TypeResolutionFlags::AllowUnavailableProtocol;
   }
 
-  ProtocolRequirementTypeResolver protoResolver;
+  DependentGenericTypeResolver protoResolver;
   GenericTypeToArchetypeResolver archetypeResolver(dc);
   GenericTypeResolver *resolver;
   if (isa<ProtocolDecl>(dc)) {


### PR DESCRIPTION
Make this generic type resolver is equivalent to `DependentGenericTypeResolver`, and use that instead.