### PR TITLE
[Diagnostics] NFC: refactor `getRequirementDC` to use `getGenericSign…

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -107,18 +107,11 @@ const DeclContext *RequirementFailure::getRequirementDC() const {
   auto *DC = AffectedDecl->getDeclContext();
 
   do {
-    auto *D = DC->getInnermostDeclarationDeclContext();
-    if (!D)
-      break;
-
-    if (auto *GC = D->getAsGenericContext()) {
-      auto *sig = GC->getGenericSignature();
-      if (sig && sig->isRequirementSatisfied(req))
+    if (auto *sig = DC->getGenericSignatureOfContext()) {
+      if (sig->isRequirementSatisfied(req))
         return DC;
     }
-
-    DC = DC->getParent();
-  } while (DC);
+  } while ((DC = DC->getParent()));
 
   return AffectedDecl->getAsGenericContext();
 }


### PR DESCRIPTION
…atureOfContext`

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
