### PR TITLE
Refactor SIL type lowering to not use FunctionType::getOld()

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2979,9 +2979,6 @@ BEGIN_CAN_TYPE_WRAPPER(AnyFunctionType, Type)
   using ExtInfo = AnyFunctionType::ExtInfo;
   using CanParamArrayRef = AnyFunctionType::CanParamArrayRef;
 
-  static CanAnyFunctionType getOld(CanGenericSignature signature,
-                                   CanType input, CanType result,
-                                   ExtInfo extInfo = ExtInfo());
   static CanAnyFunctionType get(CanGenericSignature signature,
                                 CanParamArrayRef params,
                                 CanType result,
@@ -3043,11 +3040,6 @@ private:
                ExtInfo Info);
 };
 BEGIN_CAN_TYPE_WRAPPER(FunctionType, AnyFunctionType)
-  static CanFunctionType getOld(CanType input, CanType result,
-                                ExtInfo info = ExtInfo()) {
-    auto fnType = FunctionType::getOld(input, result, info);
-    return cast<FunctionType>(fnType->getCanonicalType());
-  }
   static CanFunctionType get(CanParamArrayRef params, CanType result,
                              ExtInfo info = ExtInfo()) {
     auto fnType = FunctionType::get(params.getOriginalArray(),
@@ -3152,15 +3144,6 @@ public:
 };
 
 BEGIN_CAN_TYPE_WRAPPER(GenericFunctionType, AnyFunctionType)
-  static CanGenericFunctionType getOld(CanGenericSignature sig,
-                                       CanType input, CanType result,
-                                       ExtInfo info = ExtInfo()) {
-    // Knowing that the argument types are independently canonical is
-    // not sufficient to guarantee that the function type will be canonical.
-    auto fnType = GenericFunctionType::getOld(sig, input, result, info);
-    return cast<GenericFunctionType>(fnType->getCanonicalType());
-  }
-
   /// Create a new generic function type.
   static CanGenericFunctionType get(CanGenericSignature sig,
                                     CanParamArrayRef params,
@@ -3187,16 +3170,6 @@ BEGIN_CAN_TYPE_WRAPPER(GenericFunctionType, AnyFunctionType)
                     cast<GenericFunctionType>(getPointer()->withExtInfo(info)));
   }
 END_CAN_TYPE_WRAPPER(GenericFunctionType, AnyFunctionType)
-
-inline CanAnyFunctionType
-CanAnyFunctionType::getOld(CanGenericSignature signature,
-                           CanType input, CanType result, ExtInfo extInfo) {
-  if (signature) {
-    return CanGenericFunctionType::getOld(signature, input, result, extInfo);
-  } else {
-    return CanFunctionType::getOld(input, result, extInfo);
-  }
-}
 
 inline CanAnyFunctionType
 CanAnyFunctionType::get(CanGenericSignature signature, CanParamArrayRef params,

--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -1017,6 +1017,10 @@ public:
   /// abstraction pattern for its input type.
   AbstractionPattern getFunctionInputType() const;
 
+  /// Given that the value being abstracted is a function type, return
+  /// the abstraction pattern for one of its parameter types.
+  AbstractionPattern getFunctionParamType(unsigned index) const;
+
   /// Given that the value being abstracted is optional, return the
   /// abstraction pattern for its object type.
   AbstractionPattern getOptionalObjectType() const;

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -1015,9 +1015,15 @@ private:
                               bool canBridgeBool,
                               bool bridgedCollectionsAreOptional);
 
-  CanType getBridgedInputType(SILFunctionTypeRepresentation rep,
-                              AbstractionPattern pattern,
-                              CanType input);
+  AnyFunctionType::Param
+  getBridgedParam(SILFunctionTypeRepresentation rep,
+                  AbstractionPattern pattern,
+                  AnyFunctionType::Param param);
+
+  void getBridgedParams(SILFunctionTypeRepresentation rep,
+                        AbstractionPattern pattern,
+                        ArrayRef<AnyFunctionType::Param> params,
+                        SmallVectorImpl<AnyFunctionType::Param> &bridged);
 
   CanType getBridgedResultType(SILFunctionTypeRepresentation rep,
                                AbstractionPattern pattern,

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1029,10 +1029,13 @@ public:
       bool resugarNSErrorPointer = true);
 
   /// \brief Import the given Clang type into Swift, returning the
-  /// Swift type and whether we should treat it as an optional that is
-  /// implicitly unwrapped.
+  /// Swift parameters and result type and whether we should treat it
+  /// as an optional that is implicitly unwrapped.
   ///
-  /// \returns A pair of the imported type and whether we should treat
+  /// The parameters are returned via \c parameterList, and the result type is
+  /// the return type of this method.
+  ///
+  /// \returns A pair of the imported result type and whether we should treat
   /// it as an optional that is implicitly unwrapped. The returned
   /// type is null if it cannot be represented in Swift.
 
@@ -1052,9 +1055,6 @@ public:
   ///   to system APIs.
   /// \param name The name of the function.
   /// \param[out] parameterList The parameters visible inside the function body.
-  ///
-  /// \returns the imported function type, or null if the type cannot be
-  /// imported.
   ImportedType importFunctionType(DeclContext *dc,
                                   const clang::FunctionDecl *clangDecl,
                                   ArrayRef<const clang::ParmVarDecl *> params,
@@ -1104,7 +1104,10 @@ public:
                        StringRef argumentLabel, bool isFirstParameter,
                        bool isLastParameter, importer::NameImporter &);
 
-  /// Import the type of an Objective-C method.
+  /// Import the parameter and return types of an Objective-C method.
+  ///
+  /// The parameters are returned via \c bodyParams, and the result type is
+  /// the return type of this method.
   ///
   /// Note that this is not appropriate to use for property accessor methods.
   /// Use #importAccessorMethodType instead.
@@ -1122,7 +1125,7 @@ public:
   /// \param kind Controls whether we're building a type for a method that
   ///   needs special handling.
   ///
-  /// \returns the imported function type, or null if the type cannot be
+  /// \returns the imported result type, or null if the type cannot be
   /// imported.
   ImportedType
   importMethodType(const DeclContext *dc,
@@ -1136,6 +1139,9 @@ public:
   /// Import the type of an Objective-C method that will be imported as an
   /// accessor for \p property.
   ///
+  /// The parameters are returned via \c bodyParams, and the result type is
+  /// the return type of this method.
+  ///
   /// \param dc The context the method is being imported into.
   /// \param property The property the method will be an accessor for.
   /// \param clangDecl The underlying declaration.
@@ -1146,7 +1152,7 @@ public:
   ///   accessor.
   /// \param[out] params The patterns visible inside the function body.
   ///
-  /// \returns the imported function type, or null if the type cannot be
+  /// \returns the imported result type, or null if the type cannot be
   /// imported.
   ImportedType importAccessorMethodType(const DeclContext *dc,
                                         const clang::ObjCPropertyDecl *property,

--- a/lib/SIL/AbstractionPattern.cpp
+++ b/lib/SIL/AbstractionPattern.cpp
@@ -1027,9 +1027,18 @@ bool AbstractionPattern::hasSameBasicTypeStructure(CanType l, CanType r) {
   auto lFunction = dyn_cast<AnyFunctionType>(l);
   auto rFunction = dyn_cast<AnyFunctionType>(r);
   if (lFunction && rFunction) {
-    return hasSameBasicTypeStructure(lFunction.getInput(),
-                                     rFunction.getInput())
-        && hasSameBasicTypeStructure(lFunction.getResult(),
+    auto lParam = lFunction.getParams();
+    auto rParam = rFunction.getParams();
+    if (lParam.size() != rParam.size())
+      return false;
+
+    for (unsigned i : indices(lParam)) {
+      if (!hasSameBasicTypeStructure(lParam[i].getPlainType(),
+                                     rParam[i].getPlainType()))
+        return false;
+    }
+
+    return hasSameBasicTypeStructure(lFunction.getResult(),
                                      rFunction.getResult());
   } else if (lFunction || rFunction) {
     return false;

--- a/lib/SIL/Bridging.cpp
+++ b/lib/SIL/Bridging.cpp
@@ -35,50 +35,35 @@ SILType TypeConverter::getLoweredTypeOfGlobal(VarDecl *var) {
   return getLoweredType(origType, origType.getType()).getObjectType();
 }
 
-CanType TypeConverter::getBridgedInputType(SILFunctionTypeRepresentation rep,
-                                           AbstractionPattern pattern,
-                                           CanType input) {
-  if (auto tuple = dyn_cast<TupleType>(input)) {
-    SmallVector<TupleTypeElt, 4> bridgedFields;
-    bool changed = false;
+AnyFunctionType::Param
+TypeConverter::getBridgedParam(SILFunctionTypeRepresentation rep,
+                               AbstractionPattern pattern,
+                               AnyFunctionType::Param param) {
+  assert(!param.getParameterFlags().isInOut() &&
+         !param.getParameterFlags().isVariadic());
 
-    for (unsigned i : indices(tuple->getElements())) {
-      auto &elt = tuple->getElement(i);
-      Type bridged = getLoweredBridgedType(pattern.getTupleElementType(i),
-                                           elt.getType(), rep,
-                                           TypeConverter::ForArgument);
-      if (!bridged) {
-        Context.Diags.diagnose(SourceLoc(), diag::could_not_find_bridge_type,
-                               elt.getType());
-
-        llvm::report_fatal_error("unable to set up the ObjC bridge!");
-      }
-
-      CanType canBridged = bridged->getCanonicalType();
-      if (canBridged != CanType(elt.getType())) {
-        changed = true;
-        bridgedFields.push_back(elt.getWithType(canBridged));
-      } else {
-        bridgedFields.push_back(elt);
-      }
-    }
-
-    if (!changed)
-      return input;
-    return CanType(TupleType::get(bridgedFields, input->getASTContext()));
-  }
-
-  auto loweredBridgedType = getLoweredBridgedType(pattern, input, rep,
-                                                  TypeConverter::ForArgument);
-
-  if (!loweredBridgedType) {
+  auto bridged = getLoweredBridgedType(pattern, param.getPlainType(), rep,
+                                       TypeConverter::ForArgument);
+  if (!bridged) {
     Context.Diags.diagnose(SourceLoc(), diag::could_not_find_bridge_type,
-                           input);
-
-    llvm::report_fatal_error("unable to set up the ObjC bridge!");
+                           param.getPlainType());
+     llvm::report_fatal_error("unable to set up the ObjC bridge!");
   }
 
-  return loweredBridgedType->getCanonicalType();
+  return AnyFunctionType::Param(bridged->getCanonicalType(),
+                                param.getLabel(),
+                                param.getParameterFlags());
+}
+
+void TypeConverter::
+getBridgedParams(SILFunctionTypeRepresentation rep,
+                 AbstractionPattern pattern,
+                 ArrayRef<AnyFunctionType::Param> params,
+                 SmallVectorImpl<AnyFunctionType::Param> &bridgedParams) {
+  for (unsigned i : indices(params)) {
+    auto paramPattern = pattern.getFunctionParamType(i);
+    bridgedParams.push_back(getBridgedParam(rep, paramPattern, params[i]));
+  }
 }
 
 /// Bridge a result type.
@@ -195,18 +180,18 @@ Type TypeConverter::getLoweredCBridgedType(AbstractionPattern pattern,
       // Thick functions (TODO: conditionally) get bridged to blocks.
       // This bridging is more powerful than usual block bridging, however,
       // so we use the ObjCMethod representation.
-      Type newInput =
-          getBridgedInputType(SILFunctionType::Representation::ObjCMethod,
-                              pattern.getFunctionInputType(),
-                              funTy->getInput()->getCanonicalType());
+      SmallVector<AnyFunctionType::Param, 8> newParams;
+      getBridgedParams(SILFunctionType::Representation::ObjCMethod,
+                       pattern, funTy->getParams(), newParams);
+
       Type newResult =
           getBridgedResultType(SILFunctionType::Representation::ObjCMethod,
                                pattern.getFunctionResultType(),
                                funTy->getResult()->getCanonicalType(),
                                /*non-optional*/false);
 
-      return FunctionType::getOld(newInput, newResult,
-                                  funTy->getExtInfo().withSILRepresentation(
+      return FunctionType::get(newParams, newResult,
+                               funTy->getExtInfo().withSILRepresentation(
                                        SILFunctionType::Representation::Block));
     }
     }

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -2259,15 +2259,31 @@ static CanType copyOptionalityFromDerivedToBase(TypeConverter &tc,
   // (T1 -> T2) +> (S1 -> S2) = (T1 +> S1) -> (T2 +> S2)
   if (auto derivedFunc = dyn_cast<AnyFunctionType>(derived)) {
     if (auto baseFunc = dyn_cast<AnyFunctionType>(base)) {
-      return CanAnyFunctionType::getOld(
-        baseFunc.getOptGenericSignature(),
-        copyOptionalityFromDerivedToBase(tc,
-                                         derivedFunc.getInput(),
-                                         baseFunc.getInput()),
-        copyOptionalityFromDerivedToBase(tc,
-                                         derivedFunc.getResult(),
-                                         baseFunc.getResult()),
-        baseFunc->getExtInfo());
+      SmallVector<FunctionType::Param, 8> params;
+
+      auto derivedParams = derivedFunc.getParams();
+      auto baseParams = baseFunc.getParams();
+      assert(derivedParams.size() == baseParams.size());
+      for (unsigned i = 0, e = derivedParams.size(); i < e; i++) {
+        // FIXME: Why are 'escaping' flags set inconsistently?
+        assert(derivedParams[i].getParameterFlags().withEscaping(false) ==
+               baseParams[i].getParameterFlags().withEscaping(false));
+
+        params.emplace_back(
+          copyOptionalityFromDerivedToBase(
+            tc,
+            derivedParams[i].getPlainType(),
+            baseParams[i].getPlainType()),
+          Identifier(),
+          baseParams[i].getParameterFlags());
+      }
+
+      auto result = copyOptionalityFromDerivedToBase(tc,
+                                                     derivedFunc.getResult(),
+                                                     baseFunc.getResult());
+      return CanAnyFunctionType::get(baseFunc.getOptGenericSignature(),
+                                     llvm::makeArrayRef(params), result,
+                                     baseFunc->getExtInfo());
     }
   }
 
@@ -2576,29 +2592,34 @@ TypeConverter::getBridgedFunctionType(AbstractionPattern pattern,
   // Pull out the generic signature.
   CanGenericSignature genericSig = t.getOptGenericSignature();
 
-  auto rebuild = [&](CanType input, CanType result) -> CanAnyFunctionType {
-    return CanAnyFunctionType::getOld(genericSig, input, result, extInfo);
-  };
-
   switch (auto rep = t->getExtInfo().getSILRepresentation()) {
   case SILFunctionTypeRepresentation::Thick:
   case SILFunctionTypeRepresentation::Thin:
   case SILFunctionTypeRepresentation::Method:
   case SILFunctionTypeRepresentation::Closure:
-  case SILFunctionTypeRepresentation::WitnessMethod:
+  case SILFunctionTypeRepresentation::WitnessMethod: {
     // No bridging needed for native functions.
     if (t->getExtInfo() == extInfo)
       return t;
-    return rebuild(t.getInput(), t.getResult());
+    return CanAnyFunctionType::get(genericSig, t.getParams(), t.getResult(),
+                                   extInfo);
+  }
 
   case SILFunctionTypeRepresentation::CFunctionPointer:
   case SILFunctionTypeRepresentation::Block:
-  case SILFunctionTypeRepresentation::ObjCMethod:
-    return rebuild(getBridgedInputType(rep, pattern.getFunctionInputType(),
-                                       t.getInput()),
-                   getBridgedResultType(rep, pattern.getFunctionResultType(),
-                                        t.getResult(),
-                        pattern.hasForeignErrorStrippingResultOptionality()));
+  case SILFunctionTypeRepresentation::ObjCMethod: {
+    SmallVector<AnyFunctionType::Param, 8> params;
+    getBridgedParams(rep, pattern, t->getParams(), params);
+
+    bool suppressOptional = pattern.hasForeignErrorStrippingResultOptionality();
+    auto result = getBridgedResultType(rep,
+                                       pattern.getFunctionResultType(),
+                                       t.getResult(),
+                                       suppressOptional);
+
+    return CanAnyFunctionType::get(genericSig, llvm::makeArrayRef(params),
+                                   result, extInfo);
+  }
   }
   llvm_unreachable("bad calling convention");
 }
@@ -2628,7 +2649,7 @@ static AbstractFunctionDecl *getBridgedFunction(SILDeclRef declRef) {
 static AbstractionPattern
 getAbstractionPatternForConstant(ASTContext &ctx, SILDeclRef constant,
                                  CanAnyFunctionType fnType,
-                                 unsigned uncurryLevel) {
+                                 unsigned numParameterLists) {
   if (!constant.isForeign)
     return AbstractionPattern(fnType);
 
@@ -2643,17 +2664,17 @@ getAbstractionPatternForConstant(ASTContext &ctx, SILDeclRef constant,
   // we're going to apply a foreign error convention that checks
   // for nil results.
   if (auto method = dyn_cast<clang::ObjCMethodDecl>(clangDecl)) {
-    assert(uncurryLevel == 1 && "getting curried ObjC method type?");
+    assert(numParameterLists == 2 && "getting curried ObjC method type?");
     auto foreignError = bridgedFn->getForeignErrorConvention();
     return AbstractionPattern::getCurriedObjCMethod(fnType, method,
                                                     foreignError);
   } else if (auto value = dyn_cast<clang::ValueDecl>(clangDecl)) {
-    if (uncurryLevel == 0) {
+    if (numParameterLists == 1) {
       // C function imported as a function.
       return AbstractionPattern(fnType, value->getType().getTypePtr());
     } else {
       // C function imported as a method.
-      assert(uncurryLevel == 1);
+      assert(numParameterLists == 2);
       return AbstractionPattern::getCurriedCFunctionAsMethod(fnType, bridgedFn);
     }
   }
@@ -2664,16 +2685,16 @@ getAbstractionPatternForConstant(ASTContext &ctx, SILDeclRef constant,
 TypeConverter::LoweredFormalTypes
 TypeConverter::getLoweredFormalTypes(SILDeclRef constant,
                                      CanAnyFunctionType fnType) {
-  unsigned uncurryLevel = constant.getParameterListCount() - 1;
+  unsigned numParameterLists = constant.getParameterListCount();
   auto extInfo = fnType->getExtInfo();
 
   // Form an abstraction pattern for bridging purposes.
-  // Foreign functions are only available at very specific uncurry levels.
   AbstractionPattern bridgingFnPattern =
-    getAbstractionPatternForConstant(Context, constant, fnType, uncurryLevel);
+    getAbstractionPatternForConstant(Context, constant, fnType,
+                                     numParameterLists);
 
   // Fast path: no uncurrying required.
-  if (uncurryLevel == 0) {
+  if (numParameterLists == 1) {
     auto bridgedFnType =
       getBridgedFunctionType(bridgingFnPattern, fnType, extInfo);
     bridgingFnPattern.rewriteType(bridgingFnPattern.getGenericSignature(),
@@ -2689,31 +2710,23 @@ TypeConverter::getLoweredFormalTypes(SILDeclRef constant,
   // The dependent generic signature.
   CanGenericSignature genericSig = fnType.getOptGenericSignature();
 
-  // The uncurried input types.
-  SmallVector<TupleTypeElt, 4> inputs;
+  // The 'self' parameter.
+  assert(fnType.getParams().size() == 1);
+  AnyFunctionType::Param selfParam = fnType.getParams()[0];
 
-  // Merge inputs and generic parameters from the uncurry levels.
-  for (;;) {
-    auto canInput = fnType->getInput()->getCanonicalType();
-    auto inputFlags = ParameterTypeFlags().withInOut(isa<InOutType>(canInput));
-    inputs.push_back(TupleTypeElt(canInput->getInOutObjectType(), Identifier(),
-                                  inputFlags));
+  // The formal method parameters.
+  fnType = cast<FunctionType>(fnType.getResult());
+  auto innerExtInfo = fnType->getExtInfo();
+  auto methodParams = fnType->getParams();
 
-    // The uncurried function calls all of the intermediate function
-    // levels and so throws if any of them do.
-    if (fnType->getExtInfo().throws())
-      extInfo = extInfo.withThrows();
-
-    if (uncurryLevel-- == 0)
-      break;
-    fnType = cast<AnyFunctionType>(fnType.getResult());
-  }
-
-  CanType resultType = fnType.getResult();
+  auto resultType = fnType.getResult();
   bool suppressOptionalResult =
     bridgingFnPattern.hasForeignErrorStrippingResultOptionality();
 
   // Bridge input and result types.
+  SmallVector<AnyFunctionType::Param, 8> bridgedParams;
+  CanType bridgedResultType;
+
   switch (rep) {
   case SILFunctionTypeRepresentation::Thin:
   case SILFunctionTypeRepresentation::Thick:
@@ -2721,41 +2734,27 @@ TypeConverter::getLoweredFormalTypes(SILDeclRef constant,
   case SILFunctionTypeRepresentation::Closure:
   case SILFunctionTypeRepresentation::WitnessMethod:
     // Native functions don't need bridging.
+    bridgedParams.append(methodParams.begin(), methodParams.end());
+    bridgedResultType = resultType;
     break;
 
-  case SILFunctionTypeRepresentation::ObjCMethod: {
-    assert(inputs.size() == 2);
-    // The "self" parameter should not get bridged unless it's a metatype.
-    if (inputs.front().getType()->is<AnyMetatypeType>()) {
-      auto inputPattern = bridgingFnPattern.getFunctionInputType();
-      inputs[0] = inputs[0].getWithType(
-        getBridgedInputType(rep, inputPattern, CanType(inputs[0].getType())));
+  case SILFunctionTypeRepresentation::ObjCMethod:
+  case SILFunctionTypeRepresentation::CFunctionPointer: {
+    if (rep == SILFunctionTypeRepresentation::ObjCMethod) {
+      // The "self" parameter should not get bridged unless it's a metatype.
+      if (selfParam.getPlainType()->is<AnyMetatypeType>()) {
+        auto selfPattern = bridgingFnPattern.getFunctionParamType(0);
+        selfParam = getBridgedParam(rep, selfPattern, selfParam);
+      }
     }
 
     auto partialFnPattern = bridgingFnPattern.getFunctionResultType();
-    inputs[1] = inputs[1].getWithType(
-        getBridgedInputType(rep, partialFnPattern.getFunctionInputType(),
-                            CanType(inputs[1].getType())));
+    getBridgedParams(rep, partialFnPattern, methodParams, bridgedParams);
 
-    resultType = getBridgedResultType(rep,
-                                   partialFnPattern.getFunctionResultType(),
-                                   resultType, suppressOptionalResult);
-    break;
-  }
-
-  case SILFunctionTypeRepresentation::CFunctionPointer: {
-    // A C function imported as a method.
-    assert(inputs.size() == 2);
-
-    // Bridge the parameters.
-    auto partialFnPattern = bridgingFnPattern.getFunctionResultType();
-    inputs[1] = inputs[1].getWithType(
-                getBridgedInputType(rep, partialFnPattern.getFunctionInputType(),
-                                    CanType(inputs[1].getType())));
-    
-    resultType = getBridgedResultType(rep,
-                                      partialFnPattern.getFunctionResultType(),
-                                      resultType, suppressOptionalResult);
+    bridgedResultType =
+      getBridgedResultType(rep,
+                           partialFnPattern.getFunctionResultType(),
+                           resultType, suppressOptionalResult);
     break;
   }
 
@@ -2763,30 +2762,40 @@ TypeConverter::getLoweredFormalTypes(SILDeclRef constant,
     llvm_unreachable("Cannot uncurry native representation");
   }
 
-  // Put the inputs in the order expected by the calling convention.
-  std::reverse(inputs.begin(), inputs.end());
-
-  auto buildFinalFunctionType =
-      [&](CanType inputType, CanType resultType) -> CanAnyFunctionType {
-    return CanAnyFunctionType::getOld(genericSig, inputType, resultType, extInfo);
-  };
-
   // Build the curried function type.
-  CanType curriedResultType = resultType;
-  for (auto input : llvm::makeArrayRef(inputs).drop_back()) {
-    curriedResultType = CanFunctionType::getOld(CanType(input.getType()),
-                                                curriedResultType);
-  }
-  auto curried = buildFinalFunctionType(CanType(inputs.back().getType()),
-                                        curriedResultType);
+  auto inner =
+    CanFunctionType::get(llvm::makeArrayRef(bridgedParams),
+                         bridgedResultType);
 
-  // Replace the type in the abstraction pattern with the type we just built.
+  auto curried =
+    CanAnyFunctionType::get(genericSig, {selfParam}, inner, extInfo);
+
+  // Replace the type in the abstraction pattern with the curried type.
   bridgingFnPattern.rewriteType(genericSig, curried);
 
+  // Implode non-self parameters.
+  //
+  // FIXME: Remove this once AbstractionPattern is ported to the new
+  // function type representation.
+  if (bridgedParams.size() != 1 ||
+      bridgedParams[0].isVariadic()) {
+    auto implodedParams = AnyFunctionType::composeInput(
+      Context, bridgedParams, true);
+    bridgedParams.clear();
+    bridgedParams.emplace_back(implodedParams);
+  }
+
   // Build the uncurried function type.
-  CanType uncurriedInputType =
-    TupleType::get(inputs, Context)->getCanonicalType();
-  auto uncurried = buildFinalFunctionType(uncurriedInputType, resultType);
+  if (innerExtInfo.throws())
+    extInfo = extInfo.withThrows(true);
+
+  bridgedParams.push_back(selfParam);
+
+  auto uncurried =
+    CanAnyFunctionType::get(genericSig,
+                            llvm::makeArrayRef(bridgedParams),
+                            bridgedResultType,
+                            extInfo);
 
   return { bridgingFnPattern, uncurried };
 }

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -129,7 +129,7 @@ emitBridgeNativeToObjectiveC(SILGenFunction &SGF,
   // We might have to re-abstract the 'self' value if it is an
   // Optional.
   AbstractionPattern origSelfType(witness->getInterfaceType());
-  origSelfType = origSelfType.getFunctionInputType();
+  origSelfType = origSelfType.getFunctionParamType(0);
 
   swiftValue = SGF.emitSubstToOrigValue(loc, swiftValue,
                                         origSelfType,

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -5587,7 +5587,7 @@ RValue RValueEmitter::visitPointerToPointerExpr(PointerToPointerExpr *E,
   // Get the original pointer value, abstracted to the converter function's
   // expected level.
   AbstractionPattern origTy(converter->getInterfaceType());
-  origTy = origTy.getFunctionInputType();
+  origTy = origTy.getFunctionParamType(0);
 
   CanType inputTy = E->getSubExpr()->getType()->getCanonicalType();
   auto &origTL = SGF.getTypeLowering(origTy, inputTy);


### PR DESCRIPTION
There are still some hacks in there, because clients of AbstractionPattern ask for a function type's _inputs_ as a single tuple type.

Remaining uses of `FunctionType::getOld()`:

```
lib/IDE/TypeReconstruction.cpp:        FunctionType::getOld(arg_clang_type, return_clang_type,
lib/Sema/CSDiag.cpp:      auto fTy = FunctionType::getOld(tv, contextualType, extInfo);
lib/Sema/CSDiag.cpp:          auto expectedType = FunctionType::getOld(InputType, ResultType);
lib/Sema/CSGen.cpp:      auto fnTy = FunctionType::getOld(inputTv, outputTy);
lib/Sema/CSGen.cpp:        auto funcTy = FunctionType::getOld(CS.getType(arg), outputTy);
lib/Sema/CSGen.cpp:        auto methodTy = FunctionType::getOld(argsTy, resultTy);
lib/Sema/CSGen.cpp:      auto funcTy = FunctionType::getOld(CS.getType(expr->getArg()), outputTy,
lib/Sema/CSSimplify.cpp:                           FunctionType::getOld(tv, resultType),
```