### PR TITLE
[Type checker] Finalize witnesses when we finish checking a conformance.

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3486,6 +3486,10 @@ void ConformanceChecker::checkConformance(MissingWitnessDiagnosisKind Kind) {
       auto witness = Conformance->getWitness(requirement, nullptr).getDecl();
       if (!witness) return;
 
+      // Make sure that we finalize the witness, so we can emit this
+      // witness table.
+      TC.DeclsToFinalize.insert(witness);
+
       // Objective-C checking for @objc requirements.
       if (requirement->isObjC() &&
           requirement->getFullName() == witness->getFullName() &&

--- a/test/multifile/Inputs/require-finalize-witness-other.swift
+++ b/test/multifile/Inputs/require-finalize-witness-other.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+extension C {
+  @objc func foo(_: String) { }
+}

--- a/test/multifile/require-finalize-witness.swift
+++ b/test/multifile/require-finalize-witness.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -module-name test -emit-ir -primary-file %s %S/Inputs/require-finalize-witness-other.swift -sdk %sdk -o - | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+@objc class C: NSObject { }
+
+protocol P {
+  func foo(_: String)
+}
+
+// CHECK: define {{.*}} @"$S4test1CCAA1PA2aDP3fooyySSFTW"
+extension C: P { }


### PR DESCRIPTION
This ensures that SILGen can build the witness table. Fixes SR-8531.