### PR TITLE
[ConstraintSystem] Add same-type requirement fix/diagnostic

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1529,6 +1529,12 @@ ERROR(type_does_not_conform_in_decl_ref,none,
 ERROR(type_does_not_conform_decl_owner,none,
       "%0 %1 requires that %2 conform to %3",
       (DescriptiveDeclKind, DeclName, Type, Type))
+ERROR(types_not_equal_decl,none,
+      "%0 %1 requires the types %2 and %3 be equivalent",
+      (DescriptiveDeclKind, DeclName, Type, Type))
+ERROR(types_not_equal_in_decl_ref,none,
+      "referencing %0 %1 on %2 requires the types %3 and %4 be equivalent",
+      (DescriptiveDeclKind, DeclName, Type, Type, Type))
 NOTE(where_requirement_failure_one_subst,none,
      "where %0 = %1", (Type, Type))
 NOTE(where_requirement_failure_both_subst,none,

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -163,3 +163,15 @@ MissingConformance *MissingConformance::create(ConstraintSystem &cs, Type type,
                                                ConstraintLocator *locator) {
   return new (cs.getAllocator()) MissingConformance(type, protocol, locator);
 }
+
+bool SkipSameTypeRequirement::diagnose(Expr *root,
+                                       const Solution &solution) const {
+  SameTypeRequirementFailure failure(root, solution, LHS, RHS, getLocator());
+  return failure.diagnose();
+}
+
+SkipSameTypeRequirement *
+SkipSameTypeRequirement::create(ConstraintSystem &cs, Type lhs, Type rhs,
+                                ConstraintLocator *locator) {
+  return new (cs.getAllocator()) SkipSameTypeRequirement(lhs, rhs, locator);
+}

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -66,11 +66,15 @@ enum class FixKind : uint8_t {
   /// labels attached to the, fix it by suggesting proper labels.
   RelabelArguments,
 
+  /// Treat rvalue as lvalue
+  TreatRValueAsLValue,
+
   /// Add a new conformance to the type to satisfy a requirement.
   AddConformance,
 
-  /// Treat rvalue as lvalue
-  TreatRValueAsLValue,
+  /// Skip same-type generic requirement constraint,
+  /// and assume that types are equal.
+  SkipSameTypeRequirement,
 };
 
 class ConstraintFix {
@@ -275,6 +279,26 @@ public:
   static MissingConformance *create(ConstraintSystem &cs, Type type,
                                     ProtocolDecl *protocol,
                                     ConstraintLocator *locator);
+};
+
+/// Skip same-type generic requirement constraint,
+/// and assume that types are equal.
+class SkipSameTypeRequirement final : public ConstraintFix {
+  Type LHS, RHS;
+
+  SkipSameTypeRequirement(Type lhs, Type rhs, ConstraintLocator *locator)
+      : ConstraintFix(FixKind::SkipSameTypeRequirement, locator), LHS(lhs),
+        RHS(rhs) {}
+
+public:
+  std::string getName() const override {
+    return "skip same-type generic requirement";
+  }
+
+  bool diagnose(Expr *root, const Solution &solution) const override;
+
+  static SkipSameTypeRequirement *create(ConstraintSystem &cs, Type lhs,
+                                         Type rhs, ConstraintLocator *locator);
 };
 
 } // end namespace constraints

--- a/test/Constraints/conditionally_defined_types.swift
+++ b/test/Constraints/conditionally_defined_types.swift
@@ -15,7 +15,7 @@ struct Z2: AssociatedType {
 }
 
 struct SameType<T> {}
-extension SameType where T == X {
+extension SameType where T == X { // expected-note 5 {{where 'T' = 'Y'}}
     typealias TypeAlias1 = T
     typealias TypeAlias2 = Y
     typealias TypeAlias3<U> = (T, U) // expected-note {{requirement specified as 'T' == 'X' [with T = Y]}}
@@ -36,20 +36,20 @@ let _ = SameType<X>.Decl3.self
 let _ = SameType<X>.Decl4<X>.self
 let _ = SameType<X>.Decl5<X>.self
 
-let _ = SameType<Y>.TypeAlias1.self // expected-error {{'SameType<Y>.TypeAlias1.Type' (aka 'X.Type') requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.TypeAlias2.self // expected-error {{'SameType<Y>.TypeAlias2.Type' (aka 'Y.Type') requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.TypeAlias1.self // expected-error {{referencing type alias 'TypeAlias1' on 'SameType' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.TypeAlias2.self // expected-error {{referencing type alias 'TypeAlias2' on 'SameType' requires the types 'Y' and 'X' be equivalent}}
 let _ = SameType<Y>.TypeAlias3<X>.self // expected-error {{'SameType<Y>.TypeAlias3' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.Decl1.self // expected-error {{'SameType<Y>.Decl1.Type' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.Decl2.self // expected-error {{'SameType<Y>.Decl2.Type' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.Decl3.self // expected-error {{'SameType<Y>.Decl3.Type' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl1.self // expected-error {{referencing struct 'Decl1' on 'SameType' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl2.self // expected-error {{referencing enum 'Decl2' on 'SameType' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl3.self // expected-error {{referencing class 'Decl3' on 'SameType' requires the types 'Y' and 'X' be equivalent}}
 let _ = SameType<Y>.Decl4<X>.self // expected-error {{'SameType<Y>.Decl4' requires the types 'Y' and 'X' be equivalent}}
 let _ = SameType<Y>.Decl5<X>.self // expected-error {{'SameType<Y>.Decl5' requires the types 'Y' and 'X' be equivalent}}
 
-extension SameType: AssociatedType where T == X {}
+extension SameType: AssociatedType where T == X {} // expected-note {{where 'T' = 'Y'}}
 
 // (Y first here, because there were issues caused by running associated type
 // inference for the first time)
-let _ = SameType<Y>.T.self // expected-error {{'SameType<Y>.T.Type' (aka 'X.Type') requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.T.self // expected-error {{referencing type alias 'T' on 'SameType' requires the types 'Y' and 'X' be equivalent}}
 
 let _ = SameType<X>.T.self
 
@@ -92,7 +92,7 @@ let _ = Conforms<X>.T.self
 
 // Now, even more nesting!
 
-extension SameType.Decl1 {
+extension SameType.Decl1 { // expected-note 5 {{where 'T' = 'Y'}}
     typealias TypeAlias1 = T
     typealias TypeAlias2 = Y
     typealias TypeAlias3<U> = (T, U) // expected-note {{requirement specified as 'T' == 'X' [with T = Y]}}
@@ -113,16 +113,16 @@ let _ = SameType<X>.Decl1.Decl3.self
 let _ = SameType<X>.Decl1.Decl4<X>.self
 let _ = SameType<X>.Decl1.Decl5<X>.self
 
-let _ = SameType<Y>.Decl1.TypeAlias1.self // expected-error {{'SameType<Y>.Decl1.TypeAlias1.Type' (aka 'X.Type') requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.Decl1.TypeAlias2.self // expected-error {{'SameType<Y>.Decl1.TypeAlias2.Type' (aka 'Y.Type') requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl1.TypeAlias1.self // expected-error {{referencing type alias 'TypeAlias1' on 'SameType.Decl1' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl1.TypeAlias2.self // expected-error {{referencing type alias 'TypeAlias2' on 'SameType.Decl1' requires the types 'Y' and 'X' be equivalent}}
 let _ = SameType<Y>.Decl1.TypeAlias3<X>.self // expected-error {{'SameType<Y>.Decl1.TypeAlias3' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.Decl1.Decl1.self // expected-error {{'SameType<Y>.Decl1.Decl1.Type' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.Decl1.Decl2.self // expected-error {{'SameType<Y>.Decl1.Decl2.Type' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<Y>.Decl1.Decl3.self // expected-error {{'SameType<Y>.Decl1.Decl3.Type' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl1.Decl1.self // expected-error {{referencing struct 'Decl1' on 'SameType.Decl1' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl1.Decl2.self // expected-error {{referencing enum 'Decl2' on 'SameType.Decl1' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.Decl1.Decl3.self // expected-error {{referencing class 'Decl3' on 'SameType.Decl1' requires the types 'Y' and 'X' be equivalent}}
 let _ = SameType<Y>.Decl1.Decl4<X>.self // expected-error {{'SameType<Y>.Decl1.Decl4' requires the types 'Y' and 'X' be equivalent}}
 let _ = SameType<Y>.Decl1.Decl5<X>.self // expected-error {{'SameType<Y>.Decl1.Decl5' requires the types 'Y' and 'X' be equivalent}}
 
-extension SameType.Decl4 where U == X {
+extension SameType.Decl4 where U == X { // expected-note 5 {{where 'U' = 'Y'}}
     typealias TypeAlias1 = T
     typealias TypeAlias2 = Y
     typealias TypeAlias3<V> = (T, U, V) // expected-note {{requirement specified as 'U' == 'X' [with U = Y]}}
@@ -145,12 +145,12 @@ let _ = SameType<X>.Decl4<X>.Decl3.self
 let _ = SameType<X>.Decl4<X>.Decl4<X>.self
 let _ = SameType<X>.Decl4<X>.Decl5<X>.self
 
-let _ = SameType<X>.Decl4<Y>.TypeAlias1.self // expected-error {{'SameType<X>.Decl4<Y>.TypeAlias1.Type' (aka 'X.Type') requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<X>.Decl4<Y>.TypeAlias2.self // expected-error {{'SameType<X>.Decl4<Y>.TypeAlias2.Type' (aka 'Y.Type') requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<X>.Decl4<Y>.TypeAlias1.self // expected-error {{referencing type alias 'TypeAlias1' on 'SameType.Decl4' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<X>.Decl4<Y>.TypeAlias2.self // expected-error {{referencing type alias 'TypeAlias2' on 'SameType.Decl4' requires the types 'Y' and 'X' be equivalent}}
 let _ = SameType<X>.Decl4<Y>.TypeAlias3<X>.self // expected-error {{'SameType<X>.Decl4<Y>.TypeAlias3' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<X>.Decl4<Y>.Decl1.self // expected-error {{'SameType<X>.Decl4<Y>.Decl1.Type' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<X>.Decl4<Y>.Decl2.self // expected-error {{'SameType<X>.Decl4<Y>.Decl2.Type' requires the types 'Y' and 'X' be equivalent}}
-let _ = SameType<X>.Decl4<Y>.Decl3.self // expected-error {{'SameType<X>.Decl4<Y>.Decl3.Type' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<X>.Decl4<Y>.Decl1.self // expected-error {{referencing struct 'Decl1' on 'SameType.Decl4' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<X>.Decl4<Y>.Decl2.self // expected-error {{referencing enum 'Decl2' on 'SameType.Decl4' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<X>.Decl4<Y>.Decl3.self // expected-error {{referencing class 'Decl3' on 'SameType.Decl4' requires the types 'Y' and 'X' be equivalent}}
 let _ = SameType<X>.Decl4<Y>.Decl4<X>.self // expected-error {{'SameType<X>.Decl4<Y>.Decl4' requires the types 'Y' and 'X' be equivalent}}
 let _ = SameType<X>.Decl4<Y>.Decl5<X>.self // expected-error {{'SameType<X>.Decl4<Y>.Decl5' requires the types 'Y' and 'X' be equivalent}}
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1198,8 +1198,7 @@ func platypus<T>(a: [T]) {
 func badTypes() {
   let sequence:AnySequence<[Int]> = AnySequence() { AnyIterator() { [3] }}
   let array = [Int](sequence)
-  // expected-error@-1 {{type of expression is ambiguous without more context}}
-  // FIXME: terrible diagnostic
+  // expected-error@-1 {{initializer 'init' requires the types 'Int' and '[Int]' be equivalent}}
 }
 
 // rdar://34357545

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -248,12 +248,12 @@ struct S27515965 : P27515965 {
 
 struct V27515965 {
   init<T : P27515965>(_ tp: T) where T.R == Float {}
-  // expected-note@-1 {{candidate requires that the types 'Any' and 'Float' be equivalent (requirement specified as 'T.R' == 'Float' [with T = S27515965])}}
+  // expected-note@-1 {{where 'T.R' = 'Any'}}
 }
 
 func test(x: S27515965) -> V27515965 {
   return V27515965(x)
-  // expected-error@-1 {{cannot invoke initializer for type 'init(_:)' with an argument list of type '(S27515965)'}}
+  // expected-error@-1 {{initializer 'init' requires the types 'Any' and 'Float' be equivalent}}
 }
 
 protocol BaseProto {}

--- a/test/Constraints/rdar39931339.swift
+++ b/test/Constraints/rdar39931339.swift
@@ -13,7 +13,7 @@ extension S where T : P {
   typealias B<U> = S<U>
 }
 
-extension S where T == Float {
+extension S where T == Float { // expected-note {{where 'T' = 'Int'}}
   typealias C = Int
 }
 
@@ -24,6 +24,8 @@ extension A where T == [U], U: P { // expected-note {{where 'U' = 'Float'}}
 }
 
 extension A where T == [U], U == Int {
+// expected-note@-1 {{where 'U' = 'String'}}
+// expected-note@-2 {{where 'T' = '[String]'}}
   typealias S2 = Int
 }
 
@@ -32,12 +34,14 @@ class B<U> : A<[U], U> {}
 _ = B<C>.S1()          // Ok
 _ = B<Int>.S2()        // Ok
 _ = B<Float>.S1()      // expected-error {{referencing type alias 'S1' on 'A' requires that 'Float' conform to 'P'}}
-_ = B<String>.S2()     // expected-error {{'B<String>.S2.Type' (aka 'Int.Type') requires the types '[String]' and '[Int]' be equivalent}}
+_ = B<String>.S2()
+// expected-error@-1 {{referencing type alias 'S2' on 'A' requires the types '[String]' and '[Int]' be equivalent}}
+// expected-error@-2 {{referencing type alias 'S2' on 'A' requires the types 'String' and 'Int' be equivalent}}
 
 _ = S<C>.A()           // Ok
 _ = S<Int>.A()         // expected-error {{referencing type alias 'A' on 'S' requires that 'Int' conform to 'P'}}
 _ = S<String>.B<Int>() // expected-error {{type 'String' does not conform to protocol 'P'}}
-_ = S<Int>.C()         // expected-error {{'S<Int>.C.Type' (aka 'Int.Type') requires the types 'Int' and 'Float' be equivalent}}
+_ = S<Int>.C()         // expected-error {{referencing type alias 'C' on 'S' requires the types 'Int' and 'Float' be equivalent}}
 
 func foo<T>(_ s: S<T>.Type) {
   _ = s.A() // expected-error {{referencing type alias 'A' on 'S' requires that 'T' conform to 'P'}}

--- a/test/Constraints/tuple.swift
+++ b/test/Constraints/tuple.swift
@@ -162,14 +162,14 @@ protocol Kingdom {
   associatedtype King
 }
 struct Victory<General> {
-  init<K: Kingdom>(_ king: K) where K.King == General {}
+  init<K: Kingdom>(_ king: K) where K.King == General {} // expected-note {{where 'General' = '(x: Int, y: Int)', 'K.King' = '(Int, Int)'}}
 }
 struct MagicKingdom<K> : Kingdom {
   typealias King = K
 }
 func magify<T>(_ t: T) -> MagicKingdom<T> { return MagicKingdom() }
 func foo(_ pair: (Int, Int)) -> Victory<(x: Int, y: Int)> {
-  return Victory(magify(pair)) // expected-error {{cannot convert return expression of type 'Victory<(Int, Int)>' to return type 'Victory<(x: Int, y: Int)>'}}
+  return Victory(magify(pair)) // expected-error {{initializer 'init' requires the types '(x: Int, y: Int)' and '(Int, Int)' be equivalent}}
 }
 
 

--- a/test/Generics/deduction.swift
+++ b/test/Generics/deduction.swift
@@ -218,12 +218,12 @@ func callRangeOfIsBefore(_ ia: [Int], da: [Double]) {
 }
 
 func testEqualIterElementTypes<A: IteratorProtocol, B: IteratorProtocol>(_ a: A, _ b: B) where A.Element == B.Element {}
-// expected-note@-1 {{candidate requires that the types 'Int' and 'Double' be equivalent (requirement specified as 'A.Element' == 'B.Element' [with A = IndexingIterator<[Int]>, B = IndexingIterator<[Double]>])}}
+// expected-note@-1 {{where 'A.Element' = 'Int', 'B.Element' = 'Double'}}
 func compareIterators() {
   var a: [Int] = []
   var b: [Double] = []
   testEqualIterElementTypes(a.makeIterator(), b.makeIterator())
-  // expected-error@-1 {{cannot invoke 'testEqualIterElementTypes(_:_:)' with an argument list of type '(IndexingIterator<[Int]>, IndexingIterator<[Double]>)'}}
+  // expected-error@-1 {{global function 'testEqualIterElementTypes' requires the types 'Int' and 'Double' be equivalent}}
 }
 
 protocol P_GI {

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -180,9 +180,7 @@ extension S1 {
 // Protocol extensions with additional requirements
 // ----------------------------------------------------------------------------
 extension P4 where Self.AssocP4 : P1 {
-// expected-note@-1 {{where 'Self.AssocP4' = 'S4aHelper'}}
-// expected-note@-2 {{'Self.AssocP4' = 'Int'}}
-  func extP4a() {
+  func extP4a() { // expected-note 2 {{found this candidate}}
     acceptsP1(reqP4a())
   }
 }
@@ -213,13 +211,17 @@ extension P4 where Self.AssocP4 == Int {
 }
 
 extension P4 where Self.AssocP4 == Bool {
-  func extP4a() -> Bool { return reqP4a() }
+  func extP4a() -> Bool { return reqP4a() } // expected-note 2 {{found this candidate}}
 }
 
 func testP4(_ s4a: S4a, s4b: S4b, s4c: S4c, s4d: S4d) {
-  s4a.extP4a() // expected-error{{referencing instance method 'extP4a()' on 'P4' requires that 'S4aHelper' conform to 'P1'}}
+  // FIXME: Both of the 'ambiguous' examples below are indeed ambiguous,
+  //        because they don't match on conformance and same-type
+  //        requirement of different overloads, but diagnostic
+  //        could be improved to point out exactly what is missing in each case.
+  s4a.extP4a() // expected-error{{ambiguous reference to member 'extP4a()'}}
   s4b.extP4a() // ok
-  s4c.extP4a() // expected-error{{referencing instance method 'extP4a()' on 'P4' requires that 'Int' conform to 'P1'}}
+  s4c.extP4a() // expected-error{{ambiguous reference to member 'extP4a()'}}
   s4c.extP4Int() // okay
   var b1 = s4d.extP4a() // okay, "Bool" version
   b1 = true // checks type above


### PR DESCRIPTION
Extend new requirement failure diagnostics by adding "same-type"
generic requirement failures.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
