### PR TITLE
[passmanager] Add the ability to verify before/after/around a specifi…

### DIFF
--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -86,6 +86,21 @@ llvm::cl::list<std::string>
                      llvm::cl::desc("Disable passes "
                                     "which contain a string from this list"));
 
+llvm::cl::list<std::string> SILVerifyBeforePass(
+    "sil-verify-before-pass",
+    llvm::cl::desc("Verify the module/analyses before we run "
+                   "a pass from this list"));
+
+llvm::cl::list<std::string> SILVerifyAroundPass(
+    "sil-verify-around-pass",
+    llvm::cl::desc("Verify the module/analyses before/after we run "
+                   "a pass from this list"));
+
+llvm::cl::list<std::string>
+    SILVerifyAfterPass("sil-verify-after-pass",
+                       llvm::cl::desc("Verify the module/analyses after we run "
+                                      "a pass from this list"));
+
 llvm::cl::opt<bool> SILVerifyWithoutInvalidation(
     "sil-verify-without-invalidation", llvm::cl::init(false),
     llvm::cl::desc("Verify after passes even if the pass has not invalidated"));
@@ -365,6 +380,20 @@ void SILPassManager::runPassOnFunction(unsigned TransIdx, SILFunction *F) {
 
   CurrentPassHasInvalidated = false;
 
+  auto MatchFun = [&](const std::string &Str) -> bool {
+    return SFT->getTag().find(Str) != StringRef::npos ||
+           SFT->getID().find(Str) != StringRef::npos;
+  };
+  if ((SILVerifyBeforePass.end() != std::find_if(SILVerifyBeforePass.begin(),
+                                                 SILVerifyBeforePass.end(),
+                                                 MatchFun)) ||
+      (SILVerifyAroundPass.end() != std::find_if(SILVerifyAroundPass.begin(),
+                                                 SILVerifyAroundPass.end(),
+                                                 MatchFun))) {
+    F->verify();
+    verifyAnalyses();
+  }
+
   if (SILPrintPassName)
     dumpPassInfo("Run", TransIdx, F);
 
@@ -404,6 +433,16 @@ void SILPassManager::runPassOnFunction(unsigned TransIdx, SILFunction *F) {
       (CurrentPassHasInvalidated || SILVerifyWithoutInvalidation)) {
     F->verify();
     verifyAnalyses(F);
+  } else {
+    if ((SILVerifyAfterPass.end() != std::find_if(SILVerifyAfterPass.begin(),
+                                                  SILVerifyAfterPass.end(),
+                                                  MatchFun)) ||
+        (SILVerifyAroundPass.end() != std::find_if(SILVerifyAroundPass.begin(),
+                                                   SILVerifyAroundPass.end(),
+                                                   MatchFun))) {
+      F->verify();
+      verifyAnalyses();
+    }
   }
 
   ++NumPassesRun;
@@ -497,6 +536,20 @@ void SILPassManager::runModulePass(unsigned TransIdx) {
     printModule(Mod, Options.EmitVerboseSIL);
   }
 
+  auto MatchFun = [&](const std::string &Str) -> bool {
+    return SMT->getTag().find(Str) != StringRef::npos ||
+           SMT->getID().find(Str) != StringRef::npos;
+  };
+  if ((SILVerifyBeforePass.end() != std::find_if(SILVerifyBeforePass.begin(),
+                                                 SILVerifyBeforePass.end(),
+                                                 MatchFun)) ||
+      (SILVerifyAroundPass.end() != std::find_if(SILVerifyAroundPass.begin(),
+                                                 SILVerifyAroundPass.end(),
+                                                 MatchFun))) {
+    Mod->verify();
+    verifyAnalyses();
+  }
+
   llvm::sys::TimePoint<> StartTime = std::chrono::system_clock::now();
   assert(analysesUnlocked() && "Expected all analyses to be unlocked!");
   Mod->registerDeleteNotificationHandler(SMT);
@@ -522,6 +575,16 @@ void SILPassManager::runModulePass(unsigned TransIdx) {
       (CurrentPassHasInvalidated || !SILVerifyWithoutInvalidation)) {
     Mod->verify();
     verifyAnalyses();
+  } else {
+    if ((SILVerifyAfterPass.end() != std::find_if(SILVerifyAfterPass.begin(),
+                                                  SILVerifyAfterPass.end(),
+                                                  MatchFun)) ||
+        (SILVerifyAroundPass.end() != std::find_if(SILVerifyAroundPass.begin(),
+                                                   SILVerifyAroundPass.end(),
+                                                   MatchFun))) {
+      Mod->verify();
+      verifyAnalyses();
+    }
   }
 }
 


### PR DESCRIPTION
…c transform.

This helps speed up triaging failures caught by -sil-verify-all since this
allows one to trigger the -sil-verify-all verification around specific passes in
the pipeline rather than after every pass run. Was useful for me when tracking
down missing pass manager notification.
