### PR TITLE
[stdlib] Use RRC.filter in removeAll(where: _)

### DIFF
--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -1136,8 +1136,6 @@ extension RangeReplaceableCollection {
   public mutating func removeAll(
     where shouldBeRemoved: (Element) throws -> Bool
   ) rethrows {
-    // FIXME: Switch to using RRC.filter once stdlib is compiled for 4.0
-    // self = try filter { try !predicate($0) }
-    self = try Self(self.lazy.filter { try !shouldBeRemoved($0) })
+    self = try filter { try !shouldBeRemoved($0) }
   }
 }


### PR DESCRIPTION
Resolved FIXME.
`RangeReplaceableCollection.filter` is now available.