### PR TITLE
[TF] Implement _TensorFlowDataTypeCompatible protocol

### DIFF
--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -104,7 +104,7 @@ public enum _RuntimeConfig {
   /// needed. Otherwise, The entire GPU memory region is pre-allocated.
   // TODO: assess whether we should default to true.
   static public var gpuMemoryAllowGrowth = false
-  
+
   /// When non-nil, run metadata (with full trace) of each session execution
   /// will be dumped to the give path.
   static public var runMetadataOutputPath: String? = nil
@@ -183,7 +183,7 @@ private func configureRuntimeFromEnvironment() {
     _RuntimeConfig.session = .remote(grpcAddress: address)
     debugLog("Setting TF server address to \(address) from env.")
   }
-  
+
   if let value = getenv("SWIFT_TENSORFLOW_RUN_METADATA_OUTPUT") {
     let path = String(cString: value)
     _RuntimeConfig.runMetadataOutputPath = path
@@ -215,7 +215,7 @@ public final class _ExecutionContext {
   public static let global: _ExecutionContext = _ExecutionContext()
 
   public let cpuDeviceName: String
- 
+
   /// Only set when there is a usable GPU.
   public let gpuDeviceName: String?
 
@@ -577,7 +577,7 @@ extension TFState {
       exit(-1)
     }
     debugLog("Done running TF computation.")
-    
+
     // If run metadata path was set, dump the run metadata proto to a file.
     if let path = _RuntimeConfig.runMetadataOutputPath {
       TF_DeleteBuffer(runOptions)
@@ -871,7 +871,7 @@ public func _TFCStartTensorComputation(
     """)
 
   internalConsistencyCheck(programByteCount > 0, "Cannot run an empty graph!")
-  
+
   return _TensorComputation(programByteAddress: programByteAddress,
                             programByteCount: programByteCount,
                             entryFunctionBaseNameAddress: entryFunctionBaseNameAddress,

--- a/stdlib/public/TensorFlow/DataTypes.swift
+++ b/stdlib/public/TensorFlow/DataTypes.swift
@@ -30,9 +30,6 @@ public struct _TensorDataType {
 }
 
 /// A scalar data type compatible with TensorFlow.
-///
-/// Types that conform to `AccelerableByTensorFlow` can be used as the `Scalar`
-/// associated type of `Tensor`, `Tensor1D`, `Tensor2D`, etc.
 public protocol _TensorFlowDataTypeCompatible {
   /// The underlying TensorFlow data type.
   /// - Note: This is not intended for general use.

--- a/stdlib/public/TensorFlow/DataTypes.swift
+++ b/stdlib/public/TensorFlow/DataTypes.swift
@@ -33,7 +33,7 @@ public struct _TensorDataType {
 ///
 /// Types that conform to `AccelerableByTensorFlow` can be used as the `Scalar`
 /// associated type of `Tensor`, `Tensor1D`, `Tensor2D`, etc.
-public protocol AccelerableByTensorFlow {
+public protocol _TensorFlowDataTypeCompatible {
   /// The underlying TensorFlow data type.
   /// - Note: This is not intended for general use.
   static var _tensorFlowDataType: _TensorDataType { get }
@@ -41,6 +41,14 @@ public protocol AccelerableByTensorFlow {
   // Hooks used by the TFPartition pass for primitive operations on tensors.
   // These should not be called directly or implemented.
 
+  /// This indicates that it is safe to hoist the specified computation that
+  /// creates a tensor to being a parameter that is passed in from outside of
+  /// the tensor program.
+  static func _hoistableClosure(_ fn: () -> TensorHandle<Self>)
+    -> TensorHandle<Self>
+}
+
+public protocol AccelerableByTensorFlow : _TensorFlowDataTypeCompatible {
   /// This converts a TensorHandle that is known to have a 0d value into
   /// the scalar that it produces.  Users should call the _TFGetScalarOrDie
   /// wrapper function.
@@ -53,12 +61,6 @@ public protocol AccelerableByTensorFlow {
   /// This converts a scalar to a 0d TensorHandle that contains the value.
   /// Users should call the _TFMakeScalarTensor wrapper function.
   static func _makeScalarTensor(_ scalar: Self) -> TensorHandle<Self>
-
-  /// This indicates that it is safe to hoist the specified computation that
-  /// creates a tensor to being a parameter that is passed in from outside of
-  /// the tensor program.
-  static func _hoistableClosure(_ fn: () -> TensorHandle<Self>)
-    -> TensorHandle<Self>
 }
 
 // This is the implementation of the _getScalarOrDie requirement for each
@@ -66,7 +68,7 @@ public protocol AccelerableByTensorFlow {
 // global _TFGetScalarOrDie function in order to ensure that the noinline
 // SIL functions below have non-generic type signatures.  This is important for
 // the inner workings of the partitioning pass.
-private func _TFGetScalarOrDieImpl<Scalar>(
+private func _TFGetScalarOrDieImpl<Scalar : AccelerableByTensorFlow>(
   _ handle: TensorHandle<Scalar>
 ) -> Scalar {
   return handle.makeHostCopy().scalar!
@@ -77,13 +79,13 @@ private func _TFGetScalarOrDieImpl<Scalar>(
 // global _TFGetScalar function in order to ensure that the noinline
 // SIL functions below have non-generic type signatures.  This is important for
 // the inner workings of the partitioning pass.
-private func _TFGetScalarImpl<Scalar>(
+private func _TFGetScalarImpl<Scalar : AccelerableByTensorFlow>(
   _ handle: TensorHandle<Scalar>
 ) -> Scalar? {
   return handle.makeHostCopy().scalar
 }
 
-internal extension AccelerableByTensorFlow {
+internal extension _TensorFlowDataTypeCompatible {
   @usableFromInline
   static var cDataType: TF_DataType {
     return _tensorFlowDataType.cDataType
@@ -381,22 +383,9 @@ extension Double : AccelerableByTensorFlow {
   }
 }
 
-extension String : AccelerableByTensorFlow {
+extension String : _TensorFlowDataTypeCompatible {
   public static var _tensorFlowDataType: _TensorDataType {
     return _TensorDataType(TF_STRING)
-  }
-  @_silgen_name("__tf_get_scalar_or_die_String") @inline(never)
-  public static func _getScalarOrDie(_ handle: TensorHandle<String>) -> String {
-    return _TFGetScalarOrDieImpl(handle)
-  }
-  @_silgen_name("__tf_get_scalar_String") @inline(never)
-  public static func _getScalar(_ handle: TensorHandle<String>) -> String? {
-    return _TFGetScalarImpl(handle)
-  }
-  @inlinable @inline(__always)
-  public static func _makeScalarTensor(_ scalar: String)
-    -> TensorHandle<String> {
-    return #tfop("tfc.scalarToTensor", scalar)
   }
   @_silgen_name("__tf_hoistable_String") @_optimize(none) @inline(never)
   public static func _hoistableClosure(_ fn: () -> TensorHandle<String>)

--- a/stdlib/public/TensorFlow/Tensor.swift
+++ b/stdlib/public/TensorFlow/Tensor.swift
@@ -93,7 +93,7 @@ func _TFGetScalar<Scalar : AccelerableByTensorFlow>(
 /// designed to align with the requirements of the `Const` TensorFlow operation.
 @usableFromInline @inline(never)
 @_silgen_name("__tf_tensor_from_scalars")
-func _TFTensorFromScalars<Scalar>(
+func _TFTensorFromScalars<Scalar : AccelerableByTensorFlow>(
   _ scalars: [Scalar], shape: [Int32]
 ) -> TensorHandle<Scalar> {
   let contiguousSize = shape.map(Int.init).reduce(1, *)
@@ -118,7 +118,7 @@ func _TFMakeScalarTensor<Scalar : AccelerableByTensorFlow>(
 
 @usableFromInline @inline(never)
 @_silgen_name("__tf_tensor_from_scalars_1d")
-func _TFTensorFromScalars1D<Scalar>(_ scalars: [Scalar])
+func _TFTensorFromScalars1D<Scalar : AccelerableByTensorFlow>(_ scalars: [Scalar])
   -> TensorHandle<Scalar> {
   return _TFTensorFromScalars(scalars, shape: [Int32(scalars.count)])
 }

--- a/stdlib/public/TensorFlow/Tensor.swift
+++ b/stdlib/public/TensorFlow/Tensor.swift
@@ -73,14 +73,18 @@ func _TFReceive<Scalar>(_ handle: TensorHandle<Scalar>)
 /// where it is known that the op always returns a 0-d tensor. It is not for use
 /// in general code.
 @inlinable @inline(__always)
-func _TFGetScalarOrDie<Scalar>(_ handle: TensorHandle<Scalar>) -> Scalar {
+func _TFGetScalarOrDie<Scalar : AccelerableByTensorFlow>(
+  _ handle: TensorHandle<Scalar>
+) -> Scalar {
   return Scalar._getScalarOrDie(handle)
 }
 
 /// This function converts a `TensorHandle` into a scalar if it is 0-d, or
 /// returns nil otherwise.
 @inlinable @inline(__always)
-func _TFGetScalar<Scalar>(_ handle: TensorHandle<Scalar>) -> Scalar? {
+func _TFGetScalar<Scalar : AccelerableByTensorFlow>(
+  _ handle: TensorHandle<Scalar>
+) -> Scalar? {
   return Scalar._getScalar(handle)
 }
 
@@ -106,7 +110,9 @@ func _TFTensorFromScalars<Scalar>(
 }
 
 @inlinable @inline(__always)
-func _TFMakeScalarTensor<Scalar>(_ scalar: Scalar) -> TensorHandle<Scalar> {
+func _TFMakeScalarTensor<Scalar : AccelerableByTensorFlow>(
+  _ scalar: Scalar
+) -> TensorHandle<Scalar> {
   return Scalar._makeScalarTensor(scalar)
 }
 

--- a/stdlib/public/TensorFlow/TensorHandle.swift
+++ b/stdlib/public/TensorFlow/TensorHandle.swift
@@ -90,8 +90,8 @@ internal extension TensorHandle where Scalar : AccelerableByTensorFlow {
   }
 }
 
-extension TensorHandle : TensorSendableReceivable where
-  Scalar : AccelerableByTensorFlow {
+extension TensorHandle : TensorSendableReceivable
+  where Scalar : AccelerableByTensorFlow {
   @inlinable
   static func receiveFromAccelerator(_ computation: _TensorComputation,
                                      _ tensorId: Int

--- a/stdlib/public/TensorFlow/TensorHandle.swift
+++ b/stdlib/public/TensorFlow/TensorHandle.swift
@@ -21,7 +21,7 @@ import CTensorFlow
 /// on to determine the datatypes of parameters when they are extracted
 /// into a tensor program.
 @_fixed_layout // required because the compiler accesses cTensorHandle directly.
-public final class TensorHandle<Scalar : AccelerableByTensorFlow> {
+public final class TensorHandle<Scalar : _TensorFlowDataTypeCompatible> {
   /// The underlying `TF_TensorHandle *`.
   ///
   /// - Note: The compiler knows that `TensorHandle` has a single stored
@@ -79,7 +79,7 @@ public final class TensorHandle<Scalar : AccelerableByTensorFlow> {
   }
 }
 
-internal extension TensorHandle {
+internal extension TensorHandle where Scalar : AccelerableByTensorFlow {
   /// Create a `ShapedArray` with contents of the underlying `TensorHandle`. If
   /// the `TensorHandle` is on the accelerator, it will be copied to the host.
   /// - Returns: A `ShapedArray`.
@@ -108,7 +108,7 @@ extension TensorHandle : TensorSendableReceivable {
     TF_DeleteTensor(cTensor!)
     if _RuntimeConfig.printsDebugLog {
       debugLog("The received tensor of id \(tensorId) has content:")
-      dumpTensorContent(tensorHandle.cTensorHandle, Scalar.self)
+      // dumpTensorContent(tensorHandle.cTensorHandle, Scalar.self)
     }
     return tensorHandle
   }
@@ -118,7 +118,7 @@ extension TensorHandle : TensorSendableReceivable {
                          _ tensorId: Int) {
     if _RuntimeConfig.printsDebugLog {
       debugLog("Sending tensor of id \(tensorId) and type \(Scalar.self) with:")
-      dumpTensorContent(self.cTensorHandle, Scalar.self)
+      // dumpTensorContent(self.cTensorHandle, Scalar.self)
     }
     let status = TF_NewStatus()
     let cTensor = TFE_TensorHandleResolve(self.cTensorHandle, status)

--- a/stdlib/public/TensorFlow/TensorHandle.swift
+++ b/stdlib/public/TensorFlow/TensorHandle.swift
@@ -109,7 +109,7 @@ extension TensorHandle : TensorSendableReceivable where
     TF_DeleteTensor(cTensor!)
     if _RuntimeConfig.printsDebugLog {
       debugLog("The received tensor of id \(tensorId) has content:")
-      // dumpTensorContent(tensorHandle.cTensorHandle, Scalar.self)
+      dumpTensorContent(tensorHandle.cTensorHandle, Scalar.self)
     }
     return tensorHandle
   }
@@ -119,7 +119,7 @@ extension TensorHandle : TensorSendableReceivable where
                          _ tensorId: Int) {
     if _RuntimeConfig.printsDebugLog {
       debugLog("Sending tensor of id \(tensorId) and type \(Scalar.self) with:")
-      // dumpTensorContent(self.cTensorHandle, Scalar.self)
+      dumpTensorContent(self.cTensorHandle, Scalar.self)
     }
     let status = TF_NewStatus()
     let cTensor = TFE_TensorHandleResolve(self.cTensorHandle, status)

--- a/stdlib/public/TensorFlow/Utilities.swift
+++ b/stdlib/public/TensorFlow/Utilities.swift
@@ -290,7 +290,8 @@ public func _hostOp<Scalar>(_ x: Tensor<Scalar>) {
 }
 
 @inline(never)
-public func _hostOp<Scalar : AccelerableByTensorFlow>(_ x: TensorHandle<Scalar>) {
+public func _hostOp<Scalar>(_ x: TensorHandle<Scalar>)
+  where Scalar : AccelerableByTensorFlow {
   print(Tensor(handle: x))
 }
 

--- a/stdlib/public/TensorFlow/Utilities.swift
+++ b/stdlib/public/TensorFlow/Utilities.swift
@@ -290,7 +290,7 @@ public func _hostOp<Scalar>(_ x: Tensor<Scalar>) {
 }
 
 @inline(never)
-public func _hostOp<Scalar>(_ x: TensorHandle<Scalar>) {
+public func _hostOp<Scalar : AccelerableByTensorFlow>(_ x: TensorHandle<Scalar>) {
   print(Tensor(handle: x))
 }
 


### PR DESCRIPTION
This patch implements a new protocol `_TensorFlowDataTypeCompatible` which `AccelerableByTensorFlow` refines. 
