### PR TITLE
[stdlib] Remove some FIXME(ABI) redundant entries from the Collection hierarchy

### DIFF
--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -38,15 +38,6 @@
 public protocol BidirectionalCollection: Collection
 where SubSequence: BidirectionalCollection, Indices: BidirectionalCollection {
   // FIXME(ABI): Associated type inference requires this.
-  associatedtype Element
-
-  // FIXME(ABI): Associated type inference requires this.
-  associatedtype Index
-
-  // FIXME(ABI): Associated type inference requires this.
-  associatedtype SubSequence
-
-  // FIXME(ABI): Associated type inference requires this.
   associatedtype Indices
 
   /// Returns the position immediately before the given index.
@@ -61,23 +52,6 @@ where SubSequence: BidirectionalCollection, Indices: BidirectionalCollection {
   /// - Parameter i: A valid index of the collection. `i` must be greater than
   ///   `startIndex`.
   func formIndex(before i: inout Index)
-
-  /// Returns the position immediately after the given index.
-  ///
-  /// The successor of an index must be well defined. For an index `i` into a
-  /// collection `c`, calling `c.index(after: i)` returns the same index every
-  /// time.
-  ///
-  /// - Parameter i: A valid index of the collection. `i` must be less than
-  ///   `endIndex`.
-  /// - Returns: The index value immediately after `i`.
-  func index(after i: Index) -> Index
-
-  /// Replaces the given index with its successor.
-  ///
-  /// - Parameter i: A valid index of the collection. `i` must be less than
-  ///   `endIndex`.
-  func formIndex(after i: inout Index)
 
   /// Returns an index that is the specified distance from the given index.
   ///
@@ -172,25 +146,6 @@ where SubSequence: BidirectionalCollection, Indices: BidirectionalCollection {
   ///   resulting distance.
   func distance(from start: Index, to end: Index) -> Int
 
-  /// The indices that are valid for subscripting the collection, in ascending
-  /// order.
-  ///
-  /// A collection's `indices` property can hold a strong reference to the
-  /// collection itself, causing the collection to be non-uniquely referenced.
-  /// If you mutate the collection while iterating over its indices, a strong
-  /// reference can cause an unexpected copy of the collection. To avoid the
-  /// unexpected copy, use the `index(after:)` method starting with
-  /// `startIndex` to produce indices instead.
-  ///
-  ///     var c = MyFancyCollection([10, 20, 30, 40, 50])
-  ///     var i = c.startIndex
-  ///     while i != c.endIndex {
-  ///         c[i] /= 5
-  ///         i = c.index(after: i)
-  ///     }
-  ///     // c == MyFancyCollection([2, 4, 6, 8, 10])
-  var indices: Indices { get }
-  
   // TODO: swift-3-indexing-model: tests.
   /// The last element of the collection.
   ///
@@ -204,40 +159,6 @@ where SubSequence: BidirectionalCollection, Indices: BidirectionalCollection {
   ///     
   /// - Complexity: O(1)
   var last: Element? { get }
-
-  /// Accesses a contiguous subrange of the collection's elements.
-  ///
-  /// The accessed slice uses the same indices for the same elements as the
-  /// original collection uses. Always use the slice's `startIndex` property
-  /// instead of assuming that its indices start at a particular value.
-  ///
-  /// This example demonstrates getting a slice of an array of strings, finding
-  /// the index of one of the strings in the slice, and then using that index
-  /// in the original array.
-  ///
-  ///     let streets = ["Adams", "Bryant", "Channing", "Douglas", "Evarts"]
-  ///     let streetsSlice = streets[2 ..< streets.endIndex]
-  ///     print(streetsSlice)
-  ///     // Prints "["Channing", "Douglas", "Evarts"]"
-  ///
-  ///     let index = streetsSlice.firstIndex(of: "Evarts")    // 4
-  ///     print(streets[index!])
-  ///     // Prints "Evarts"
-  ///
-  /// - Parameter bounds: A range of the collection's indices. The bounds of
-  ///   the range must be valid indices of the collection.
-  ///
-  /// - Complexity: O(1)
-  subscript(bounds: Range<Index>) -> SubSequence { get }
-
-  // FIXME(ABI): Associated type inference requires this.
-  subscript(position: Index) -> Element { get }
-
-  // FIXME(ABI): Associated type inference requires this.
-  var startIndex: Index { get }
-
-  // FIXME(ABI): Associated type inference requires this.
-  var endIndex: Index { get }
 }
 
 /// Default implementation for bidirectional collections.

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -58,17 +58,7 @@
 ///     a[i] = x
 ///     let y = x
 public protocol MutableCollection: Collection
-where SubSequence: MutableCollection
-{
-  // FIXME(ABI): Associated type inference requires this.
-  associatedtype Element
-
-  // FIXME(ABI): Associated type inference requires this.
-  associatedtype Index
-
-  // FIXME(ABI): Associated type inference requires this.
-  associatedtype SubSequence
-
+where SubSequence: MutableCollection {
   /// Accesses the element at the specified position.
   ///
   /// For example, you can replace an element of an array by using its

--- a/stdlib/public/core/RandomAccessCollection.swift
+++ b/stdlib/public/core/RandomAccessCollection.swift
@@ -31,39 +31,7 @@
 /// `Strideable` protocol or you must implement the `index(_:offsetBy:)` and
 /// `distance(from:to:)` methods with O(1) efficiency.
 public protocol RandomAccessCollection: BidirectionalCollection
-where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection
-{
-  // FIXME(ABI): Associated type inference requires this.
-  associatedtype Element
-
-  // FIXME(ABI): Associated type inference requires this.
-  associatedtype Index
-
-  // FIXME(ABI): Associated type inference requires this.
-  associatedtype SubSequence
-
-  // FIXME(ABI): Associated type inference requires this.
-  associatedtype Indices
-
-  /// The indices that are valid for subscripting the collection, in ascending
-  /// order.
-  ///
-  /// A collection's `indices` property can hold a strong reference to the
-  /// collection itself, causing the collection to be nonuniquely referenced.
-  /// If you mutate the collection while iterating over its indices, a strong
-  /// reference can result in an unexpected copy of the collection. To avoid
-  /// the unexpected copy, use the `index(after:)` method starting with
-  /// `startIndex` to produce indices instead.
-  ///
-  ///     var c = MyFancyCollection([10, 20, 30, 40, 50])
-  ///     var i = c.startIndex
-  ///     while i != c.endIndex {
-  ///         c[i] /= 5
-  ///         i = c.index(after: i)
-  ///     }
-  ///     // c == MyFancyCollection([2, 4, 6, 8, 10])
-  var indices: Indices { get }
-
+where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection {
   /// Accesses a contiguous subrange of the collection's elements.
   ///
   /// The accessed slice uses the same indices for the same elements as the
@@ -88,45 +56,6 @@ where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection
   ///
   /// - Complexity: O(1)
   subscript(bounds: Range<Index>) -> SubSequence { get }
-
-  // FIXME(ABI): Associated type inference requires this.
-  subscript(position: Index) -> Element { get }
-
-  // FIXME(ABI): Associated type inference requires this.
-  var startIndex: Index { get }
-
-  // FIXME(ABI): Associated type inference requires this.
-  var endIndex: Index { get }
-
-  /// Returns the position immediately before the given index.
-  ///
-  /// - Parameter i: A valid index of the collection. `i` must be greater than
-  ///   `startIndex`.
-  /// - Returns: The index value immediately before `i`.
-  func index(before i: Index) -> Index
-
-  /// Replaces the given index with its predecessor.
-  ///
-  /// - Parameter i: A valid index of the collection. `i` must be greater than
-  ///   `startIndex`.
-  func formIndex(before i: inout Index)
-
-  /// Returns the position immediately after the given index.
-  ///
-  /// The successor of an index must be well defined. For an index `i` into a
-  /// collection `c`, calling `c.index(after: i)` returns the same index every
-  /// time.
-  ///
-  /// - Parameter i: A valid index of the collection. `i` must be less than
-  ///   `endIndex`.
-  /// - Returns: The index value immediately after `i`.
-  func index(after i: Index) -> Index
-
-  /// Replaces the given index with its successor.
-  ///
-  /// - Parameter i: A valid index of the collection. `i` must be less than
-  ///   `endIndex`.
-  func formIndex(after i: inout Index)
 
   /// Returns an index that is the specified distance from the given index.
   ///

--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -62,9 +62,7 @@
 /// parameter. You can override any of the protocol's required methods to
 /// provide your own custom implementation.
 public protocol RangeReplaceableCollection : Collection
-  where SubSequence : RangeReplaceableCollection {
-  // FIXME(ABI): Associated type inference requires this.
-  associatedtype SubSequence
+where SubSequence : RangeReplaceableCollection {
 
   //===--- Fundamental Requirements ---------------------------------------===//
 
@@ -147,8 +145,7 @@ public protocol RangeReplaceableCollection : Collection
   ///
   /// - Parameter elements: The sequence of elements for the new collection.
   ///   `elements` must be finite.
-  init<S : Sequence>(_ elements: S)
-    where S.Element == Element
+  init<S : Sequence>(_ elements: S) where S.Element == Element
 
   /// Adds an element to the end of the collection.
   ///
@@ -361,12 +358,6 @@ public protocol RangeReplaceableCollection : Collection
   /// - Complexity: O(*n*), where *n* is the length of the collection.
   mutating func removeAll(
     where shouldBeRemoved: (Element) throws -> Bool) rethrows
-
-  // FIXME(ABI): Associated type inference requires this.
-  subscript(bounds: Index) -> Element { get }
-
-  // FIXME(ABI): Associated type inference requires this.
-  subscript(bounds: Range<Index>) -> SubSequence { get }
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/api-digester/source-stability.swift.expected
+++ b/test/api-digester/source-stability.swift.expected
@@ -14,7 +14,13 @@ TypeAlias StringProtocol.UTF16Index has been removed (deprecated)
 TypeAlias StringProtocol.UTF8Index has been removed (deprecated)
 TypeAlias StringProtocol.UnicodeScalarIndex has been removed (deprecated)
 TypeAlias UIntMax has been removed
+Var BidirectionalCollection.endIndex has been removed
+Var BidirectionalCollection.indices has been removed
+Var BidirectionalCollection.startIndex has been removed
 Var FixedWidthInteger.allZeros has been removed (deprecated)
+Var RandomAccessCollection.endIndex has been removed
+Var RandomAccessCollection.indices has been removed
+Var RandomAccessCollection.startIndex has been removed
 Constructor Int.init(truncatingBitPattern:) has been removed
 Constructor Int16.init(truncatingBitPattern:) has been removed
 Constructor Int32.init(truncatingBitPattern:) has been removed
@@ -24,6 +30,8 @@ Constructor UInt.init(truncatingBitPattern:) has been removed
 Constructor UInt16.init(truncatingBitPattern:) has been removed
 Constructor UInt32.init(truncatingBitPattern:) has been removed
 Constructor UInt8.init(truncatingBitPattern:) has been removed
+Func BidirectionalCollection.formIndex(after:) has been removed
+Func BidirectionalCollection.index(after:) has been removed
 Func BinaryInteger.toIntMax() has been removed
 Func FixedWidthInteger.addWithOverflow(_:_:) has been removed
 Func FixedWidthInteger.divideWithOverflow(_:_:) has been removed
@@ -45,6 +53,10 @@ Func Int16.toUIntMax() has been removed
 Func Int32.toUIntMax() has been removed
 Func Int64.toUIntMax() has been removed
 Func Int8.toUIntMax() has been removed
+Func RandomAccessCollection.formIndex(after:) has been removed
+Func RandomAccessCollection.formIndex(before:) has been removed
+Func RandomAccessCollection.index(after:) has been removed
+Func RandomAccessCollection.index(before:) has been removed
 Func Sequence.flatMap(_:) has been removed
 Func SignedNumeric.abs(_:) has been removed
 Func String.UTF16View.distance(from:to:) has been removed


### PR DESCRIPTION
Some are still needed to make inference work, but these ones seem like they can safely be removed (unless the compatibility suite says otherwise).