### PR TITLE
[Sema] Pare down operator candidates during protocol type checking

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3554,38 +3554,44 @@ void bindFuncDeclToOperator(TypeChecker &TC, FuncDecl *FD) {
   FD->setOperatorDecl(op);
 }
 
-void checkMemberOperator(TypeChecker &TC, FuncDecl *FD) {
+bool swift::isMemberOperator(FuncDecl *decl, Type type) {
   // Check that member operators reference the type of 'Self'.
-  if (FD->isInvalid()) return;
+  if (decl->isInvalid())
+    return true;
 
-  auto *DC = FD->getDeclContext();
+  auto *DC = decl->getDeclContext();
   auto selfNominal = DC->getSelfNominalTypeDecl();
-  if (!selfNominal) return;
 
   // Check the parameters for a reference to 'Self'.
-  bool isProtocol = isa<ProtocolDecl>(selfNominal);
-  for (auto param : *FD->getParameters()) {
+  bool isProtocol = selfNominal && isa<ProtocolDecl>(selfNominal);
+  for (auto param : *decl->getParameters()) {
     auto paramType = param->getInterfaceType();
     if (!paramType) break;
 
     // Look through a metatype reference, if there is one.
     paramType = paramType->getMetatypeInstanceType();
 
-    // Is it the same nominal type?
-    if (paramType->getAnyNominal() == selfNominal) return;
+    auto nominal = paramType->getAnyNominal();
+    if (type.isNull()) {
+      // Is it the same nominal type?
+      if (selfNominal && nominal == selfNominal)
+        return true;
+    } else {
+      // Is it the same nominal type? Or a generic (which may or may not match)?
+      if (paramType->is<GenericTypeParamType>() ||
+          nominal == type->getAnyNominal())
+        return true;
+    }
 
     if (isProtocol) {
       // For a protocol, is it the 'Self' type parameter?
       if (auto genericParam = paramType->getAs<GenericTypeParamType>())
         if (genericParam->isEqual(DC->getSelfInterfaceType()))
-          return;
+          return true;
     }
   }
 
-  // We did not find 'Self'. Complain.
-  TC.diagnose(FD, diag::operator_in_unrelated_type,
-              FD->getDeclContext()->getDeclaredInterfaceType(),
-              isProtocol, FD->getFullName());
+  return false;
 }
 
 bool checkDynamicSelfReturn(FuncDecl *func,
@@ -4174,8 +4180,14 @@ void TypeChecker::validateDecl(ValueDecl *D) {
 
     // Member functions need some special validation logic.
     if (FD->getDeclContext()->isTypeContext()) {
-      if (FD->isOperator())
-        checkMemberOperator(*this, FD);
+      if (FD->isOperator() && !isMemberOperator(FD, nullptr)) {
+        auto selfNominal = FD->getDeclContext()->getSelfNominalTypeDecl();
+        auto isProtocol = selfNominal && isa<ProtocolDecl>(selfNominal);
+        // We did not find 'Self'. Complain.
+        diagnose(FD, diag::operator_in_unrelated_type,
+                 FD->getDeclContext()->getDeclaredInterfaceType(), isProtocol,
+                 FD->getFullName());
+      }
 
       auto accessor = dyn_cast<AccessorDecl>(FD);
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -930,7 +930,7 @@ WitnessChecker::lookupValueWitnessesViaImplementsAttr(
   }
 }
 
-SmallVector<ValueDecl *, 4> 
+SmallVector<ValueDecl *, 4>
 WitnessChecker::lookupValueWitnesses(ValueDecl *req, bool *ignoringNames) {
   assert(!isa<AssociatedTypeDecl>(req) && "Not for lookup for type witnesses*");
   
@@ -950,7 +950,10 @@ WitnessChecker::lookupValueWitnesses(ValueDecl *req, bool *ignoringNames) {
                                        SourceLoc(),
                                        lookupOptions);
     for (auto candidate : lookup) {
-      witnesses.push_back(candidate.getValueDecl());
+      auto decl = candidate.getValueDecl();
+      if (swift::isMemberOperator(cast<FuncDecl>(decl), Adoptee)) {
+        witnesses.push_back(decl);
+      }
     }
   } else {
     // Variable/function/subscript requirements.

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -33,6 +33,7 @@ class AccessScope;
 class AssociatedTypeDecl;
 class AvailabilityContext;
 class DeclContext;
+class FuncDecl;
 class NormalProtocolConformance;
 class ProtocolDecl;
 class TypeChecker;
@@ -451,6 +452,8 @@ protected:
 
   WitnessChecker(TypeChecker &tc, ProtocolDecl *proto,
                  Type adoptee, DeclContext *dc);
+
+  bool isMemberOperator(FuncDecl *decl, Type type);
 
   /// Gather the value witnesses for the given requirement.
   ///

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -230,8 +230,8 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
   auto typeInContext =
     conformance->getDeclContext()->mapTypeIntoContext(conformance->getType());
 
-  for (auto witness : checker.lookupValueWitnesses(req,
-                                                   /*ignoringNames=*/nullptr)) {
+  for (auto witness :
+       checker.lookupValueWitnesses(req, /*ignoringNames=*/nullptr)) {
     LLVM_DEBUG(llvm::dbgs() << "Inferring associated types from decl:\n";
                witness->dump(llvm::dbgs()));
 
@@ -399,7 +399,7 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
 
     result.push_back(std::move(witnessResult));
 next_witness:;
-  }
+}
 
   return result;
 }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -2209,6 +2209,11 @@ Type getMemberTypeForComparison(ASTContext &ctx, ValueDecl *member,
 bool isOverrideBasedOnType(ValueDecl *decl, Type declTy,
                            ValueDecl *parentDecl, Type parentDeclTy);
 
+/// Determine whether the given declaration is an operator defined in a
+/// protocol. If \p type is not null, check specifically whether \p decl
+/// could fulfill a protocol requirement for it.
+bool isMemberOperator(FuncDecl *decl, Type type);
+
 } // end namespace swift
 
 #endif

--- a/test/Compatibility/accessibility.swift
+++ b/test/Compatibility/accessibility.swift
@@ -641,12 +641,10 @@ fileprivate struct EquatablishOuter {
   internal struct Inner : Equatablish {}
 }
 private func ==(lhs: EquatablishOuter.Inner, rhs: EquatablishOuter.Inner) {}
-// expected-note@-1 {{candidate has non-matching type}}
 
 fileprivate struct EquatablishOuter2 {
   internal struct Inner : Equatablish {
     fileprivate static func ==(lhs: Inner, rhs: Inner) {}
-    // expected-note@-1 {{candidate has non-matching type}}
   }
 }
 
@@ -660,7 +658,6 @@ internal struct EquatablishOuterProblem2 {
   public struct Inner : Equatablish {
     fileprivate static func ==(lhs: Inner, rhs: Inner) {} // expected-error {{method '==' must be as accessible as its enclosing type because it matches a requirement in protocol 'Equatablish'}} {{none}}
     // expected-note@-1 {{mark the operator function as 'internal' to satisfy the requirement}} {{5-16=internal}}
-    // expected-note@-2 {{candidate has non-matching type}}
   }
 }
 
@@ -671,7 +668,6 @@ internal struct EquatablishOuterProblem3 {
 }
 private func ==(lhs: EquatablishOuterProblem3.Inner, rhs: EquatablishOuterProblem3.Inner) {}
 // expected-note@-1 {{mark the operator function as 'internal' to satisfy the requirement}} {{1-8=internal}}
-// expected-note@-2 {{candidate has non-matching type}}
 
 
 public protocol AssocTypeProto {

--- a/test/Sema/accessibility.swift
+++ b/test/Sema/accessibility.swift
@@ -650,12 +650,10 @@ fileprivate struct EquatablishOuter {
   internal struct Inner : Equatablish {}
 }
 private func ==(lhs: EquatablishOuter.Inner, rhs: EquatablishOuter.Inner) {}
-// expected-note@-1 {{candidate has non-matching type}}
 
 fileprivate struct EquatablishOuter2 {
   internal struct Inner : Equatablish {
     fileprivate static func ==(lhs: Inner, rhs: Inner) {}
-    // expected-note@-1 {{candidate has non-matching type}}
   }
 }
 
@@ -669,7 +667,6 @@ internal struct EquatablishOuterProblem2 {
   public struct Inner : Equatablish {
     fileprivate static func ==(lhs: Inner, rhs: Inner) {} // expected-error {{method '==' must be as accessible as its enclosing type because it matches a requirement in protocol 'Equatablish'}} {{none}}
     // expected-note@-1 {{mark the operator function as 'internal' to satisfy the requirement}} {{5-16=internal}}
-    // expected-note@-2 {{candidate has non-matching type}}
   }
 }
 
@@ -679,7 +676,6 @@ internal struct EquatablishOuterProblem3 {
 }
 private func ==(lhs: EquatablishOuterProblem3.Inner, rhs: EquatablishOuterProblem3.Inner) {}
 // expected-note@-1 {{mark the operator function as 'internal' to satisfy the requirement}} {{1-8=internal}}
-// expected-note@-2 {{candidate has non-matching type}}
 
 
 public protocol AssocTypeProto {

--- a/test/Sema/enum_conformance_synthesis.swift
+++ b/test/Sema/enum_conformance_synthesis.swift
@@ -45,7 +45,7 @@ enum CustomHashable {
 
   var hashValue: Int { return 0 }
 }
-func ==(x: CustomHashable, y: CustomHashable) -> Bool { // expected-note 4 {{non-matching type}}
+func ==(x: CustomHashable, y: CustomHashable) -> Bool {
   return true
 }
 
@@ -63,7 +63,7 @@ enum InvalidCustomHashable {
 
   var hashValue: String { return "" } // expected-note{{previously declared here}}
 }
-func ==(x: InvalidCustomHashable, y: InvalidCustomHashable) -> String { // expected-note 4 {{non-matching type}}
+func ==(x: InvalidCustomHashable, y: InvalidCustomHashable) -> String {
   return ""
 }
 func invalidCustomHashable() {
@@ -213,7 +213,7 @@ public enum Medicine {
 
 extension Medicine : Equatable {}
 
-public func ==(lhs: Medicine, rhs: Medicine) -> Bool { // expected-note 4 {{non-matching type}}
+public func ==(lhs: Medicine, rhs: Medicine) -> Bool {
   return true
 }
 
@@ -236,7 +236,7 @@ extension NotExplicitlyHashableAndCannotDerive : CaseIterable {} // expected-err
 // Verify that conformance (albeit manually implemented) can still be added to
 // a type in a different file.
 extension OtherFileNonconforming: Hashable {
-  static func ==(lhs: OtherFileNonconforming, rhs: OtherFileNonconforming) -> Bool { // expected-note 4 {{non-matching type}}
+  static func ==(lhs: OtherFileNonconforming, rhs: OtherFileNonconforming) -> Bool {
     return true
   }
   var hashValue: Int { return 0 }

--- a/test/Sema/struct_equatable_hashable.swift
+++ b/test/Sema/struct_equatable_hashable.swift
@@ -50,7 +50,7 @@ struct CustomHashValue: Hashable {
 
   var hashValue: Int { return 0 }
 
-  static func ==(x: CustomHashValue, y: CustomHashValue) -> Bool { return true } // expected-note 3 {{non-matching type}}
+  static func ==(x: CustomHashValue, y: CustomHashValue) -> Bool { return true }
 }
 
 func customHashValue() {
@@ -72,7 +72,7 @@ struct CustomHashInto: Hashable {
     hasher.combine(y)
   }
 
-  static func ==(x: CustomHashInto, y: CustomHashInto) -> Bool { return true } // expected-note 3 {{non-matching type}}
+  static func ==(x: CustomHashInto, y: CustomHashInto) -> Bool { return true }
 }
 
 func customHashInto() {
@@ -172,9 +172,9 @@ public struct StructConformsAndImplementsInExtension {
   let v: Int
 }
 extension StructConformsAndImplementsInExtension : Equatable {
-  public static func ==(lhs: StructConformsAndImplementsInExtension, rhs: StructConformsAndImplementsInExtension) -> Bool {  // expected-note 3 {{non-matching type}}
+  public static func ==(lhs: StructConformsAndImplementsInExtension, rhs: StructConformsAndImplementsInExtension) -> Bool {
     return true
-  }  
+  }
 }
 
 // No explicit conformance and it cannot be derived.
@@ -189,7 +189,7 @@ struct NoStoredProperties: Hashable {}
 // Verify that conformance (albeit manually implemented) can still be added to
 // a type in a different file.
 extension OtherFileNonconforming: Hashable {
-  static func ==(lhs: OtherFileNonconforming, rhs: OtherFileNonconforming) -> Bool { // expected-note 3 {{non-matching type}}
+  static func ==(lhs: OtherFileNonconforming, rhs: OtherFileNonconforming) -> Bool {
     return true
   }
   var hashValue: Int { return 0 }

--- a/test/decl/protocol/req/func.swift
+++ b/test/decl/protocol/req/func.swift
@@ -96,7 +96,7 @@ struct X3a : P3 {
   typealias Assoc = X1a
 }
 
-prefix func ~~(_: X3a) -> X1a {} // expected-note{{candidate has non-matching type '(X3a) -> X1a'}} expected-note{{candidate is prefix, not postfix as required}}
+prefix func ~~(_: X3a) -> X1a {}
 
 // FIXME: Add example with overloaded prefix/postfix
 
@@ -105,7 +105,7 @@ struct X3z : P3 { // expected-error{{type 'X3z' does not conform to protocol 'P3
   typealias Assoc = X1a
 }
 
-postfix func ~~(_: X3z) -> X1a {} // expected-note{{candidate is postfix, not prefix as required}} expected-note{{candidate has non-matching type '(X3z) -> X1a'}}
+postfix func ~~(_: X3z) -> X1a {} // expected-note{{candidate is postfix, not prefix as required}}
 
 // Protocol with postfix unary function
 postfix operator ~~
@@ -119,14 +119,14 @@ struct X4a : P4 {
   typealias Assoc = X1a
 }
 
-postfix func ~~(_: X4a) -> X1a {} // expected-note{{candidate has non-matching type '(X4a) -> X1a'}} expected-note{{candidate is postfix, not prefix as required}}
+postfix func ~~(_: X4a) -> X1a {}
 
 // Prefix/postfix mismatch.
 struct X4z : P4 { // expected-error{{type 'X4z' does not conform to protocol 'P4'}}
   typealias Assoc = X1a
 }
 
-prefix func ~~(_: X4z) -> X1a {} // expected-note{{candidate has non-matching type '(X4z) -> X1a'}} expected-note{{candidate is prefix, not postfix as required}}
+prefix func ~~(_: X4z) -> X1a {} // expected-note{{candidate is prefix, not postfix as required}}
 
 // Objective-C protocol
 @objc protocol P5 {
@@ -270,3 +270,10 @@ struct X12 : P12 { // expected-error{{type 'X12' does not conform to protocol 'P
 }
 
 func ==(x: X12.Index, y: X12.Index) -> Bool { return true }
+
+protocol P13 {}
+protocol P14 {
+  static prefix func %%%(_: Self.Type)
+}
+prefix func %%%<P: P13>(_: P.Type) { }
+struct X13: P14, P13 { }


### PR DESCRIPTION
This cuts down the number of witnesses returned when looking up a protocol's member operator.

It does this by excluding operators that couldn't be valid—i.e. that only use nominal types that aren't the conforming type.

The end goal of this was to reduce the number of `candidate has non-matching type` diagnostics when you're missing a `==` implementation. This is a first step towards providing an improved diagnostic when a `==` can't be synthesized.

This code:

```swift
struct Nope {}

struct B: Equatable {
	let a: Nope
	
	static func == (_: B, _: Int) -> Bool { return false }
}
```

would return these diagnostics before:

```
equatable.swift:3:8: error: type 'B' does not conform to protocol 'Equatable'
struct B: Equatable {
       ^
equatable.swift:6:14: note: candidate has non-matching type '(B, Int) -> Bool'
        static func == (_: B, _: Int) -> Bool { return false }
                    ^
Swift.==:1:13: note: candidate has non-matching type '(Any.Type?, Any.Type?) -> Bool'
public func == (t0: Any.Type?, t1: Any.Type?) -> Bool
            ^
Swift.==:1:13: note: candidate has non-matching type '<T where T : RawRepresentable, T.RawValue : Equatable> (T, T) -> Bool'
public func == <T>(lhs: T, rhs: T) -> Bool where T : RawRepresentable, T.RawValue : Equatable
            ^
Swift.==:1:13: note: candidate has non-matching type '((), ()) -> Bool'
public func == (lhs: (), rhs: ()) -> Bool
            ^
Swift.==:1:13: note: candidate has non-matching type '<A, B where A : Equatable, B : Equatable> ((A, B), (A, B)) -> Bool'
public func == <A, B>(lhs: (A, B), rhs: (A, B)) -> Bool where A : Equatable, B : Equatable
            ^
Swift.==:1:13: note: candidate has non-matching type '<A, B, C where A : Equatable, B : Equatable, C : Equatable> ((A, B, C), (A, B, C)) -> Bool'
public func == <A, B, C>(lhs: (A, B, C), rhs: (A, B, C)) -> Bool where A : Equatable, B : Equatable, C : Equatable
            ^
Swift.==:1:13: note: candidate has non-matching type '<A, B, C, D where A : Equatable, B : Equatable, C : Equatable, D : Equatable> ((A, B, C, D), (A, B, C, D)) -> Bool'
public func == <A, B, C, D>(lhs: (A, B, C, D), rhs: (A, B, C, D)) -> Bool where A : Equatable, B : Equatable, C : Equatable, D : Equatable
            ^
Swift.==:1:13: note: candidate has non-matching type '<A, B, C, D, E where A : Equatable, B : Equatable, C : Equatable, D : Equatable, E : Equatable> ((A, B, C, D, E), (A, B, C, D, E)) -> Bool'
public func == <A, B, C, D, E>(lhs: (A, B, C, D, E), rhs: (A, B, C, D, E)) -> Bool where A : Equatable, B : Equatable, C : Equatable, D : Equatable, E : Equatable
            ^
Swift.==:1:13: note: candidate has non-matching type '<A, B, C, D, E, F where A : Equatable, B : Equatable, C : Equatable, D : Equatable, E : Equatable, F : Equatable> ((A, B, C, D, E, F), (A, B, C, D, E, F)) -> Bool'
public func == <A, B, C, D, E, F>(lhs: (A, B, C, D, E, F), rhs: (A, B, C, D, E, F)) -> Bool where A : Equatable, B : Equatable, C : Equatable, D : Equatable, E : Equatable, F : Equatable
            ^
Swift.ContiguousArray<Element>:2:24: note: candidate has non-matching type '<Element> (ContiguousArray<ContiguousArray<Element>.Element>, ContiguousArray<ContiguousArray<Element>.Element>) -> Bool' (aka '<τ_0_0> (ContiguousArray<τ_0_0>, ContiguousArray<τ_0_0>) -> Bool')
    public static func == (lhs: ContiguousArray<ContiguousArray<Element>.Element>, rhs: ContiguousArray<ContiguousArray<Element>.Element>) -> Bool
                       ^
Swift.ArraySlice<Element>:2:24: note: candidate has non-matching type '<Element> (ArraySlice<ArraySlice<Element>.Element>, ArraySlice<ArraySlice<Element>.Element>) -> Bool' (aka '<τ_0_0> (ArraySlice<τ_0_0>, ArraySlice<τ_0_0>) -> Bool')
    public static func == (lhs: ArraySlice<ArraySlice<Element>.Element>, rhs: ArraySlice<ArraySlice<Element>.Element>) -> Bool
                       ^
Swift.Array<Element>:2:24: note: candidate has non-matching type '<Element> (Array<Array<Element>.Element>, Array<Array<Element>.Element>) -> Bool' (aka '<τ_0_0> (Array<τ_0_0>, Array<τ_0_0>) -> Bool')
    public static func == (lhs: [[Element].Element], rhs: [[Element].Element]) -> Bool
                       ^
Swift.Bool:3:24: note: candidate has non-matching type '(Bool, Bool) -> Bool'
    public static func == (lhs: Bool, rhs: Bool) -> Bool
                       ^
Swift.AutoreleasingUnsafeMutablePointer<Pointee>:2:24: note: candidate has non-matching type '<Pointee> (AutoreleasingUnsafeMutablePointer<Pointee>, AutoreleasingUnsafeMutablePointer<Pointee>) -> Bool'
    public static func == (lhs: AutoreleasingUnsafeMutablePointer<Pointee>, rhs: AutoreleasingUnsafeMutablePointer<Pointee>) -> Bool
                       ^
Swift.Character:2:24: note: candidate has non-matching type '(Character, Character) -> Bool'
    public static func == (lhs: Character, rhs: Character) -> Bool
                       ^
Swift.Character.UnicodeScalarView.Index:2:24: note: candidate has non-matching type '(Character.UnicodeScalarView.Index, Character.UnicodeScalarView.Index) -> Bool'
    public static func == (lhs: Character.UnicodeScalarView.Index, rhs: Character.UnicodeScalarView.Index) -> Bool
                       ^
Swift.CodingUserInfoKey:5:24: note: candidate has non-matching type '(CodingUserInfoKey, CodingUserInfoKey) -> Bool'
    public static func == (lhs: CodingUserInfoKey, rhs: CodingUserInfoKey) -> Bool
                       ^
Swift.ClosedRange<Bound>.Index:2:24: note: candidate has non-matching type '<Bound> (ClosedRange<Bound>.Index, ClosedRange<Bound>.Index) -> Bool'
    public static func == (lhs: ClosedRange<Bound>.Index, rhs: ClosedRange<Bound>.Index) -> Bool
                       ^
Swift.ClosedRange<Bound>:2:24: note: candidate has non-matching type '<Bound> (ClosedRange<Bound>, ClosedRange<Bound>) -> Bool'
    public static func == (lhs: ClosedRange<Bound>, rhs: ClosedRange<Bound>) -> Bool
                       ^
Swift.OpaquePointer:2:24: note: candidate has non-matching type '(OpaquePointer, OpaquePointer) -> Bool'
    public static func == (lhs: OpaquePointer, rhs: OpaquePointer) -> Bool
                       ^
Swift.Dictionary<Key, Value>:17:28: note: candidate has non-matching type '<Key, Value> (Dictionary<Key, Value>.Keys, Dictionary<Key, Value>.Keys) -> Bool'
        public static func == (lhs: Dictionary<Key, Value>.Keys, rhs: Dictionary<Key, Value>.Keys) -> Bool
                           ^
Swift.Dictionary<Key, Value>:2:24: note: candidate has non-matching type '<Key, Value> ([Key : Value], [Key : Value]) -> Bool'
    public static func == (lhs: [Key : Value], rhs: [Key : Value]) -> Bool
                       ^
Swift.Dictionary<Key, Value>.Index:2:24: note: candidate has non-matching type '<Key, Value> (Dictionary<Key, Value>.Index, Dictionary<Key, Value>.Index) -> Bool'
    public static func == (lhs: Dictionary<Key, Value>.Index, rhs: Dictionary<Key, Value>.Index) -> Bool
                       ^
Swift.LazyDropWhileCollection<Base>.Index:2:24: note: candidate has non-matching type '<Base> (LazyDropWhileCollection<Base>.Index, LazyDropWhileCollection<Base>.Index) -> Bool'
    public static func == (lhs: LazyDropWhileCollection<Base>.Index, rhs: LazyDropWhileCollection<Base>.Index) -> Bool
                       ^
Swift.EmptyCollection<Element>:2:24: note: candidate has non-matching type '<Element> (EmptyCollection<Element>, EmptyCollection<Element>) -> Bool'
    public static func == (lhs: EmptyCollection<Element>, rhs: EmptyCollection<Element>) -> Bool
                       ^
Swift.FlattenCollection<Base>.Index:2:24: note: candidate has non-matching type '<Base> (FlattenCollection<Base>.Index, FlattenCollection<Base>.Index) -> Bool'
    public static func == (lhs: FlattenCollection<Base>.Index, rhs: FlattenCollection<Base>.Index) -> Bool
                       ^
Swift.FloatingPointSign:6:24: note: candidate has non-matching type '(FloatingPointSign, FloatingPointSign) -> Bool'
    public static func == (a: FloatingPointSign, b: FloatingPointSign) -> Bool
                       ^
Swift.FloatingPoint:2:24: note: candidate has non-matching type '<Self> (Self, Self) -> Bool'
    public static func == (lhs: Self, rhs: Self) -> Bool
                       ^
Swift.AnyHashable:2:24: note: candidate has non-matching type '(AnyHashable, AnyHashable) -> Bool'
    public static func == (lhs: AnyHashable, rhs: AnyHashable) -> Bool
                       ^
Swift.BinaryInteger:2:24: note: candidate has non-matching type '<Self, Other> (Self, Other) -> Bool'
    public static func == <Other>(lhs: Self, rhs: Other) -> Bool where Other : BinaryInteger
                       ^
Swift.UInt8:11:24: note: candidate has non-matching type '(UInt8, UInt8) -> Bool'
    public static func == (lhs: UInt8, rhs: UInt8) -> Bool
                       ^
Swift.Int8:11:24: note: candidate has non-matching type '(Int8, Int8) -> Bool'
    public static func == (lhs: Int8, rhs: Int8) -> Bool
                       ^
Swift.UInt16:11:24: note: candidate has non-matching type '(UInt16, UInt16) -> Bool'
    public static func == (lhs: UInt16, rhs: UInt16) -> Bool
                       ^
Swift.Int16:11:24: note: candidate has non-matching type '(Int16, Int16) -> Bool'
    public static func == (lhs: Int16, rhs: Int16) -> Bool
                       ^
Swift.UInt32:11:24: note: candidate has non-matching type '(UInt32, UInt32) -> Bool'
    public static func == (lhs: UInt32, rhs: UInt32) -> Bool
                       ^
Swift.Int32:13:24: note: candidate has non-matching type '(Int32, Int32) -> Bool'
    public static func == (lhs: Int32, rhs: Int32) -> Bool
                       ^
Swift.UInt64:11:24: note: candidate has non-matching type '(UInt64, UInt64) -> Bool'
    public static func == (lhs: UInt64, rhs: UInt64) -> Bool
                       ^
Swift.Int64:13:24: note: candidate has non-matching type '(Int64, Int64) -> Bool'
    public static func == (lhs: Int64, rhs: Int64) -> Bool
                       ^
Swift.UInt:11:24: note: candidate has non-matching type '(UInt, UInt) -> Bool'
    public static func == (lhs: UInt, rhs: UInt) -> Bool
                       ^
Swift.Int:11:24: note: candidate has non-matching type '(Int, Int) -> Bool'
    public static func == (lhs: Int, rhs: Int) -> Bool
                       ^
Swift.AnyKeyPath:6:24: note: candidate has non-matching type '(AnyKeyPath, AnyKeyPath) -> Bool'
    public static func == (a: AnyKeyPath, b: AnyKeyPath) -> Bool
                       ^
Swift.ManagedBufferPointer:12:24: note: candidate has non-matching type '<Header, Element> (ManagedBufferPointer<Header, Element>, ManagedBufferPointer<Header, Element>) -> Bool'
    public static func == (lhs: ManagedBufferPointer<Header, Element>, rhs: ManagedBufferPointer<Header, Element>) -> Bool
                       ^
Swift.Unicode.Scalar:2:24: note: candidate has non-matching type '(Unicode.Scalar, Unicode.Scalar) -> Bool'
    public static func == (lhs: Unicode.Scalar, rhs: Unicode.Scalar) -> Bool
                       ^
Swift.ObjectIdentifier:2:24: note: candidate has non-matching type '(ObjectIdentifier, ObjectIdentifier) -> Bool'
    public static func == (x: ObjectIdentifier, y: ObjectIdentifier) -> Bool
                       ^
Swift.Optional<Wrapped>:2:24: note: candidate has non-matching type '<Wrapped> (Wrapped?, Wrapped?) -> Bool'
    public static func == (lhs: Wrapped?, rhs: Wrapped?) -> Bool
                       ^
Swift.Optional<Wrapped>:3:24: note: candidate has non-matching type '<Wrapped> (Wrapped?, _OptionalNilComparisonType) -> Bool'
    public static func == (lhs: Wrapped?, rhs: _OptionalNilComparisonType) -> Bool
                       ^
Swift.Optional<Wrapped>:5:24: note: candidate has non-matching type '<Wrapped> (_OptionalNilComparisonType, Wrapped?) -> Bool'
    public static func == (lhs: _OptionalNilComparisonType, rhs: Wrapped?) -> Bool
                       ^
Swift.LazyPrefixWhileCollection<Base>.Index:2:24: note: candidate has non-matching type '<Base> (LazyPrefixWhileCollection<Base>.Index, LazyPrefixWhileCollection<Base>.Index) -> Bool'
    public static func == (lhs: LazyPrefixWhileCollection<Base>.Index, rhs: LazyPrefixWhileCollection<Base>.Index) -> Bool
                       ^
Swift.Range<Bound>:2:24: note: candidate has non-matching type '<Bound> (Range<Range<Bound>.Bound>, Range<Range<Bound>.Bound>) -> Bool' (aka '<τ_0_0> (Range<τ_0_0>, Range<τ_0_0>) -> Bool')
    public static func == (lhs: Range<Range<Bound>.Bound>, rhs: Range<Range<Bound>.Bound>) -> Bool
                       ^
Swift.ReversedCollection<Base>.Index:2:24: note: candidate has non-matching type '<Base> (ReversedCollection<Base>.Index, ReversedCollection<Base>.Index) -> Bool'
    public static func == (lhs: ReversedCollection<Base>.Index, rhs: ReversedCollection<Base>.Index) -> Bool
                       ^
Swift.Set<Element>:2:24: note: candidate has non-matching type '<Element> (Set<Element>, Set<Element>) -> Bool'
    public static func == (lhs: Set<Element>, rhs: Set<Element>) -> Bool
                       ^
Swift.Set<Element>.Index:2:24: note: candidate has non-matching type '<Element> (Set<Element>.Index, Set<Element>.Index) -> Bool'
    public static func == (lhs: Set<Element>.Index, rhs: Set<Element>.Index) -> Bool
                       ^
Swift.Strideable:3:24: note: candidate has non-matching type '<Self> (Self, Self) -> Bool'
    public static func == (x: Self, y: Self) -> Bool
                       ^
Swift.StringProtocol:2:24: note: candidate has non-matching type '<Self, S> (Self, S) -> Bool'
    public static func == <S>(lhs: Self, rhs: S) -> Bool where S : StringProtocol
                       ^
Swift.String:2:24: note: candidate has non-matching type '(String, String) -> Bool'
    public static func == (lhs: String, rhs: String) -> Bool
                       ^
Swift.String.Index:2:24: note: candidate has non-matching type '(String.Index, String.Index) -> Bool'
    public static func == (lhs: String.Index, rhs: String.Index) -> Bool
                       ^
Swift._UIntBuffer<Storage, Element>:3:28: note: candidate has non-matching type '<Storage, Element> (_UIntBuffer<Storage, Element>.Index, _UIntBuffer<Storage, Element>.Index) -> Bool'
        public static func == (lhs: _UIntBuffer<Storage, Element>.Index, rhs: _UIntBuffer<Storage, Element>.Index) -> Bool
                           ^
Swift.UnsafeMutablePointer<Pointee>:2:24: note: candidate has non-matching type '<Pointee> (UnsafeMutablePointer<Pointee>, UnsafeMutablePointer<Pointee>) -> Bool'
    public static func == (lhs: UnsafeMutablePointer<Pointee>, rhs: UnsafeMutablePointer<Pointee>) -> Bool
                       ^
Swift.UnsafePointer<Pointee>:2:24: note: candidate has non-matching type '<Pointee> (UnsafePointer<Pointee>, UnsafePointer<Pointee>) -> Bool'
    public static func == (lhs: UnsafePointer<Pointee>, rhs: UnsafePointer<Pointee>) -> Bool
                       ^
Swift.UnsafeMutableRawPointer:2:24: note: candidate has non-matching type '(UnsafeMutableRawPointer, UnsafeMutableRawPointer) -> Bool'
    public static func == (lhs: UnsafeMutableRawPointer, rhs: UnsafeMutableRawPointer) -> Bool
                       ^
Swift.UnsafeRawPointer:2:24: note: candidate has non-matching type '(UnsafeRawPointer, UnsafeRawPointer) -> Bool'
    public static func == (lhs: UnsafeRawPointer, rhs: UnsafeRawPointer) -> Bool
                       ^
Swift.UnicodeDecodingResult:5:24: note: candidate has non-matching type '(UnicodeDecodingResult, UnicodeDecodingResult) -> Bool'
    public static func == (lhs: UnicodeDecodingResult, rhs: UnicodeDecodingResult) -> Bool
                       ^
Swift._ValidUTF8Buffer<Storage>:3:28: note: candidate has non-matching type '<Storage> (_ValidUTF8Buffer<Storage>.Index, _ValidUTF8Buffer<Storage>.Index) -> Bool'
        public static func == (lhs: _ValidUTF8Buffer<Storage>.Index, rhs: _ValidUTF8Buffer<Storage>.Index) -> Bool
                           ^
Swift._SwiftNSOperatingSystemVersion:2:24: note: candidate has non-matching type '(_SwiftNSOperatingSystemVersion, _SwiftNSOperatingSystemVersion) -> Bool'
    public static func == (lhs: _SwiftNSOperatingSystemVersion, rhs: _SwiftNSOperatingSystemVersion) -> Bool
                       ^
Swift.AnyIndex:2:24: note: candidate has non-matching type '(AnyIndex, AnyIndex) -> Bool'
    public static func == (lhs: AnyIndex, rhs: AnyIndex) -> Bool
                       ^
Swift.Equatable:2:24: note: protocol requires function '==' with type '(B, B) -> Bool'; do you want to add a stub?
    public static func == (lhs: Self, rhs: Self) -> Bool
                       ^
```

Now it returns these diagnostics:

```
/Users/mdiep/Repositories/apple/bugs/equatable.swift:3:8: error: type 'B' does not conform to protocol 'Equatable'
struct B: Equatable {
       ^
equatable.swift:6:14: note: candidate has non-matching type '(B, Int) -> Bool'
        static func == (_: B, _: Int) -> Bool { return false }
                    ^
Swift.==:1:24: note: candidate has non-matching type '<T where T : RawRepresentable, T.RawValue : Equatable> (T, T) -> Bool'
@inlinable public func == <T>(lhs: T, rhs: T) -> Bool where T : RawRepresentable, T.RawValue : Equatable
                       ^
Swift.FloatingPoint:2:24: note: candidate has non-matching type '<Self> (Self, Self) -> Bool'
    public static func == (lhs: Self, rhs: Self) -> Bool
                       ^
Swift.BinaryInteger:2:35: note: candidate has non-matching type '<Self, Other> (Self, Other) -> Bool'
    @inlinable public static func == <Other>(lhs: Self, rhs: Other) -> Bool where Other : BinaryInteger
                                  ^
Swift._Pointer:2:24: note: candidate has non-matching type '<Self> (Self, Self) -> Bool'
    public static func == (lhs: Self, rhs: Self) -> Bool
                       ^
Swift.Strideable:3:35: note: candidate has non-matching type '<Self> (Self, Self) -> Bool'
    @inlinable public static func == (x: Self, y: Self) -> Bool
                                  ^
Swift.StringProtocol:2:35: note: candidate has non-matching type '<Self, S> (Self, S) -> Bool'
    @inlinable public static func == <S>(lhs: Self, rhs: S) -> Bool where S : StringProtocol
                                  ^
Swift.Equatable:2:24: note: protocol requires function '==' with type '(B, B) -> Bool'; do you want to add a stub?
    public static func == (lhs: Self, rhs: Self) -> Bool
                       ^
```

There's some more room for improvement here, but I'm not sure (1) how to properly check to exclude unbound generics that wouldn't be valid or (2) if this is desirable, since you might have forgotten to declare conformance to a protocol.