### PR TITLE
Temporarily disable `simpleCounterLoop_ab` test on macOS to make CI pass

### DIFF
--- a/test/TensorFlowRuntime/loops.swift
+++ b/test/TensorFlowRuntime/loops.swift
@@ -29,9 +29,10 @@ LoopsTests.testAllBackends("simpleCounterLoop_a") {
     count += 1
   }
   a += a
-  expectNearlyEqual(1024.0, a.array.scalars[0])
+  expectNearlyEqual(1024.0, a.scalar!)
 }
 
+#if !os(macOS)
 LoopsTests.testAllBackends("simpleCounterLoop_ab") {
   let maxCount = 100
   var a = Tensor<Float>(0)
@@ -44,8 +45,9 @@ LoopsTests.testAllBackends("simpleCounterLoop_ab") {
     count += 1
   }
   a -= b
-  expectEqual(98, a.scalar)
+  expectEqual(98, a.scalar!)
 }
+#endif
 
 // TODO: fix the disabled GPU tests below.
 #if !CUDA

--- a/test/TensorFlowRuntime/loops.swift
+++ b/test/TensorFlowRuntime/loops.swift
@@ -32,6 +32,8 @@ LoopsTests.testAllBackends("simpleCounterLoop_a") {
   expectNearlyEqual(1024.0, a.scalar!)
 }
 
+// FIXME: This test is failing on macOS for reasons that are not likely related
+// to graph program extraction. See SR-8541.
 #if !os(macOS)
 LoopsTests.testAllBackends("simpleCounterLoop_ab") {
   let maxCount = 100


### PR DESCRIPTION
See [SR-8541](https://bugs.swift.org/browse/SR-8541) for more context.

The `simpleCounterLoop_ab` test case is failing on macOS for unknown reasons. The identical code compiled in a separate source file can run normally and produce the correct result. This could be an internal issue within `StdlibUnittests` (related to [SR-8223](https://bugs.swift.org/browse/SR-8223)?).

macOS CI has just been set up, and we'd like to get PR testing running on macOS ASAP. This patch temporarily disables `simpleCounterLoop_ab` for macOS.

There's also some minor NFC in this test file to to explicit force-unwrap scalars to validate the shape of the result tensor.