### PR TITLE
[TF] Fix flaky dataset test

### DIFF
--- a/test/TensorFlowRuntime/dataset_1.swift
+++ b/test/TensorFlowRuntime/dataset_1.swift
@@ -109,7 +109,7 @@ DatasetTests.testAllBackends("MultiValue") {
     Toutput_types: outputTypes,
     output_shapes: outputShapes
   )
-  let iterator: VariantHandle = #tfop(
+  let iterator: ResourceHandle = #tfop(
     "IteratorV2", shared_name: "blah", container: "earth",
     output_types: outputTypes, output_shapes: outputShapes
   )
@@ -118,24 +118,18 @@ DatasetTests.testAllBackends("MultiValue") {
     "IteratorGetNext", iterator,
     output_types: outputTypes, output_shapes: outputShapes
   )
-  _hostOp(next.0)
-  _hostOp(next.1)
   expectEqual(0, Tensor(handle: next.0).scalarized())
   expectEqual(10, Tensor(handle: next.1).scalarized())
   next = #tfop(
     "IteratorGetNext", iterator,
     output_types: outputTypes, output_shapes: outputShapes
   )
-  _hostOp(next.0)
-  _hostOp(next.1)
   expectEqual(1, Tensor(handle: next.0).scalarized())
   expectEqual(11, Tensor(handle: next.1).scalarized())
   next = #tfop(
     "IteratorGetNext", iterator,
     output_types: outputTypes, output_shapes: outputShapes
   )
-  _hostOp(next.0)
-  _hostOp(next.1)
   expectEqual(2, Tensor(handle: next.0).scalarized())
   expectEqual(12, Tensor(handle: next.1).scalarized())
 }


### PR DESCRIPTION
In [SR-8575](https://bugs.swift.org/browse/SR-8575) @mhong found out that the execution order was undefined because `#tfop("IteratorV2", ...)` was not set up to return `ResourceHandle`, and graph lowering thereby did not add the necessary control dependencies.  This should've been caught by graph lowering, but it apparently wasn't.

This fixes the existing flaky test `TensorFlowRuntime/dataset_1.swift`.