### PR TITLE
Fix and improve DI diagnostics around inout uses of constants

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -199,8 +199,15 @@ ERROR(immutable_property_already_initialized,none,
       (StringRef))
 NOTE(initial_value_provided_in_let_decl,none,
      "initial value already provided in 'let' declaration", ())
+ERROR(mutation_of_property_of_immutable_value,none,
+      "cannot mutate %select{property %0|subscript}1 of immutable value '%2'",
+      (DeclBaseName, bool, StringRef))
+ERROR(using_mutating_accessor_on_immutable_value,none,
+      "mutating accessor for %select{property %0|subscript}1 may not"
+      " be used on immutable value '%2'",
+      (DeclBaseName, bool, StringRef))
 ERROR(mutating_method_called_on_immutable_value,none,
-      "mutating %select{method|property access|subscript|operator}1 %0 may not"
+      "mutating %select{method|operator}1 %0 may not"
       " be used on immutable value '%2'",
       (DeclBaseName, unsigned, StringRef))
 ERROR(immutable_value_passed_inout,none,
@@ -208,9 +215,6 @@ ERROR(immutable_value_passed_inout,none,
       (StringRef))
 ERROR(assignment_to_immutable_value,none,
       "immutable value '%0' must not be assigned to",
-      (StringRef))
-ERROR(mutating_protocol_witness_method_on_let_constant,none,
-      "cannot perform mutating operation: '%0' is a 'let' constant",
       (StringRef))
 
 WARNING(designated_init_in_cross_module_extension,none,

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollectorOwnership.h
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollectorOwnership.h
@@ -211,8 +211,11 @@ enum DIUseKind {
   /// The instruction is a store to a member of a larger struct value.
   PartialStore,
 
-  /// An indirect 'inout' parameter of an Apply instruction.
-  InOutUse,
+  /// An 'inout' argument of a function application.
+  InOutArgument,
+
+  /// An 'inout' self argument of a function application.
+  InOutSelfArgument,
 
   /// An indirect 'in' parameter of an Apply instruction.
   IndirectIn,

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -780,7 +780,8 @@ void LifetimeChecker::doIt() {
     case DIUseKind::Load:
       handleLoadUse(i);
       break;
-    case DIUseKind::InOutUse:
+    case DIUseKind::InOutArgument:
+    case DIUseKind::InOutSelfArgument:
       handleInOutUse(Use);
       break;
     case DIUseKind::Escape:
@@ -818,54 +819,11 @@ void LifetimeChecker::doIt() {
 
 void LifetimeChecker::handleLoadUse(unsigned UseID) {
   DIMemoryUse &Use = Uses[UseID];
-  SILInstruction *LoadInst = Use.Inst;
 
   bool IsSuperInitComplete, FailedSelfUse;
   // If the value is not definitively initialized, emit an error.
   if (!isInitializedAtUse(Use, &IsSuperInitComplete, &FailedSelfUse))
     return handleLoadUseFailure(Use, IsSuperInitComplete, FailedSelfUse);
-
-  // If this is an OpenExistentialAddrInst in preparation for applying
-  // a witness method, analyze its use to make sure, that no mutation of
-  // lvalue let constants occurs.
-  auto *OEAI = dyn_cast<OpenExistentialAddrInst>(LoadInst);
-  if (OEAI != nullptr && TheMemory.isElementLetProperty(Use.FirstElement)) {
-    for (auto OEAUse : OEAI->getUses()) {
-      auto *AI = dyn_cast<ApplyInst>(OEAUse->getUser());
-
-      if (AI == nullptr)
-        // User is not an ApplyInst
-        continue;
-
-      unsigned OperandNumber = OEAUse->getOperandNumber();
-      auto OptArgumentNumber =
-        AI->getArgumentIndexForOperandIndex(OperandNumber);
-      if (!OptArgumentNumber)
-        // Not used as a call argument
-        continue;
-
-      unsigned ArgumentNumber = *OptArgumentNumber;
-
-      CanSILFunctionType calleeType = AI->getSubstCalleeType();
-      SILParameterInfo parameterInfo = calleeType->getParameters()[ArgumentNumber];
-
-      if (!parameterInfo.isIndirectMutating() ||
-          parameterInfo.getType().isAnyClassReferenceType())
-        continue;
-
-      if (!shouldEmitError(LoadInst))
-        continue;
-
-      std::string PropertyName;
-      auto *VD = TheMemory.getPathStringToElement(Use.FirstElement, PropertyName);
-      diagnose(Module, LoadInst->getLoc(),
-               diag::mutating_protocol_witness_method_on_let_constant, PropertyName);
-
-      if (auto *Var = dyn_cast<VarDecl>(VD)) {
-        Var->emitLetToVarNoteIfSimple(nullptr);
-      }
-    }
-  }
 }
 
 void LifetimeChecker::emitSelfConsumedDiagnostic(SILInstruction *Inst) {
@@ -1051,6 +1009,38 @@ void LifetimeChecker::handleStoreUse(unsigned UseID) {
   updateInstructionForInitState(Use);
 }
 
+/// Check whether the instruction is an application.
+///
+/// Looks through certain projections to find the application.
+/// If this is done, updates isSelfParameter as appropriate; otherwise,
+/// assumes it was properly set by the caller based on which operand
+/// was accessed.
+static FullApplySite findApply(SILInstruction *I, bool &isSelfParameter) {
+  if (auto apply = FullApplySite::isa(I))
+    return apply;
+
+  // If this is an OpenExistentialAddrInst in preparation for applying
+  // a witness method, analyze its use to make sure, that no mutation of
+  // lvalue let constants occurs.
+  if (auto *open = dyn_cast<OpenExistentialAddrInst>(I)) {
+    for (auto use : open->getUses()) {
+      // Stop at the first use in an apply we find.  We assume that we
+      // won't find multiple interesting calls.
+      if (auto apply = FullApplySite::isa(use->getUser())) {
+        // The 'open' could also be a type dependency of the apply, so
+        // instead of checking whether 'use' is exactly the self argument,
+        // just check whether the self argument is the opened value.
+        isSelfParameter =
+          apply.hasSelfArgument() &&
+          apply.getSelfArgument() == open;
+        return apply;
+      }
+    }
+  }
+
+  return FullApplySite();
+}
+
 void LifetimeChecker::handleInOutUse(const DIMemoryUse &Use) {
   bool IsSuperInitDone, FailedSelfUse;
 
@@ -1080,15 +1070,16 @@ void LifetimeChecker::handleInOutUse(const DIMemoryUse &Use) {
       continue;
 
     std::string PropertyName;
-    (void)TheMemory.getPathStringToElement(i, PropertyName);
+    auto VD = TheMemory.getPathStringToElement(i, PropertyName);
     
     // Try to produce a specific error message about the inout use.  If this is
     // a call to a method or a mutating property access, indicate that.
     // Otherwise, we produce a generic error.
     FuncDecl *FD = nullptr;
     bool isAssignment = false;
+    bool isSelfParameter = (Use.Kind == DIUseKind::InOutSelfArgument);
 
-    auto Apply = FullApplySite::isa(Use.Inst);
+    auto Apply = findApply(Use.Inst, isSelfParameter);
     if (Apply) {
       // If this is a method application, produce a nice, specific, error.
       if (auto *WMI = dyn_cast<MethodInst>(Apply.getCallee()))
@@ -1101,7 +1092,7 @@ void LifetimeChecker::handleInOutUse(const DIMemoryUse &Use) {
           FD = SILLoc.getAsASTNode<FuncDecl>();
         }
       }
-      
+
       // If we failed to find the decl a clean and principled way, try hacks:
       // map back to the AST and look for some common patterns.
       if (!FD) {
@@ -1122,29 +1113,49 @@ void LifetimeChecker::handleInOutUse(const DIMemoryUse &Use) {
     // If we were able to find a method or function call, emit a diagnostic
     // about the method.  The magic numbers used by the diagnostic are:
     // 0 -> method, 1 -> property, 2 -> subscript, 3 -> operator.
-    unsigned Case = ~0;
-    DeclBaseName MethodName;
-    if (auto accessor = dyn_cast_or_null<AccessorDecl>(FD)) {
-      MethodName = accessor->getStorage()->getBaseName();
-      Case = isa<SubscriptDecl>(accessor->getStorage()) ? 2 : 1;
+    auto accessor = dyn_cast_or_null<AccessorDecl>(FD);
+    if (accessor && isSelfParameter) {
+      bool isMutator = [&] {
+        switch (accessor->getAccessorKind()) {
+        case AccessorKind::Get:
+        case AccessorKind::Read:
+        case AccessorKind::Address:
+          return false;
+        case AccessorKind::Set:
+        case AccessorKind::Modify:
+        case AccessorKind::MutableAddress:
+        case AccessorKind::DidSet:
+        case AccessorKind::WillSet:
+        case AccessorKind::MaterializeForSet:
+          return true;
+        }
+        llvm_unreachable("bad kind");
+      }();
+      diagnose(Module, Use.Inst->getLoc(),
+               isMutator
+                 ? diag::mutation_of_property_of_immutable_value
+                 : diag::using_mutating_accessor_on_immutable_value,
+               accessor->getStorage()->getBaseName(),
+               isa<SubscriptDecl>(accessor->getStorage()),
+               PropertyName);
     } else if (FD && FD->isOperator()) {
-      MethodName = FD->getName();
-      Case = 3;
-    } else if (FD && FD->isInstanceMember()) {
-      MethodName = FD->getName();
-      Case = 0;
-    }
-    
-    if (Case != ~0U) {
       diagnose(Module, Use.Inst->getLoc(),
                diag::mutating_method_called_on_immutable_value,
-               MethodName, Case, PropertyName);
+               FD->getName(), /*operator*/ 1, PropertyName);
+    } else if (FD && isSelfParameter) {
+      diagnose(Module, Use.Inst->getLoc(),
+               diag::mutating_method_called_on_immutable_value,
+               FD->getName(), /*method*/ 0, PropertyName);
     } else if (isAssignment) {
       diagnose(Module, Use.Inst->getLoc(),
                diag::assignment_to_immutable_value, PropertyName);
     } else {
       diagnose(Module, Use.Inst->getLoc(),
                diag::immutable_value_passed_inout, PropertyName);
+    }
+
+    if (auto *Var = dyn_cast<VarDecl>(VD)) {
+      Var->emitLetToVarNoteIfSimple(nullptr);
     }
     return;
   }

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -757,14 +757,23 @@ extension Int {
   func inspect() {}
 }
 
+extension Array {
+  subscript(replacing index: Int, with newValue: Element) -> Element {
+    mutating get {
+      let oldValue = self[index]
+      self[index] = newValue
+      return oldValue
+    }
+  }
+}
 
 func throwingSwap<T>(_ a: inout T, _ b: inout T) throws {}
 
 // <rdar://problem/19035287> let properties should only be initializable, not reassignable
 struct LetProperties {
-  // expected-note @+1 {{change 'let' to 'var' to make it mutable}} {{3-6=var}}
+  // expected-note @+1 5 {{change 'let' to 'var' to make it mutable}} {{3-6=var}}
   let arr : [Int]
-  // expected-note @+1 2 {{change 'let' to 'var' to make it mutable}} {{3-6=var}} {{3-6=var}}
+  // expected-note @+1 7 {{change 'let' to 'var' to make it mutable}} {{3-6=var}} {{3-6=var}}
   let (u, v) : (Int, Int)
   // expected-note @+1 2 {{change 'let' to 'var' to make it mutable}} {{3-6=var}} {{3-6=var}}
   let w : (Int, Int)
@@ -828,10 +837,11 @@ struct LetProperties {
     arr = []
     arr += []      // expected-error {{mutating operator '+=' may not be used on immutable value 'self.arr'}}
     arr.append(4)  // expected-error {{mutating method 'append' may not be used on immutable value 'self.arr'}}
-    arr[12] = 17   // expected-error {{mutating subscript 'subscript' may not be used on immutable value 'self.arr'}}
+    arr[12] = 17   // expected-error {{cannot mutate subscript of immutable value 'self.arr'}}
+    let _ = arr[replacing: 12, with: 17] // expected-error {{mutating accessor for subscript may not be used on immutable value 'self.arr'}}
 
-    methodTakesInOut(&u)  // expected-error {{mutating method 'methodTakesInOut' may not be used on immutable value 'self.u'}}
-    try throwingMethodTakesInOut(&u)  // expected-error {{mutating method 'throwingMethodTakesInOut' may not be used on immutable value 'self.u'}}
+    methodTakesInOut(&u)  // expected-error {{immutable value 'self.u' must not be passed inout}}
+    try throwingMethodTakesInOut(&u)  // expected-error {{immutable value 'self.u' must not be passed inout}}
   }
 }
 
@@ -844,7 +854,7 @@ protocol TestMutabilityProtocol {
  
 class C<T : TestMutabilityProtocol> {
   let x : T
-  let y : T
+  let y : T // expected-note {{change 'let' to 'var' to make it mutable}}
   
   init(a : T) {
     x = a; y = a
@@ -886,7 +896,7 @@ func testLocalProperties(_ b : Int) -> Int {
 // Should be rejected as multiple assignment.
 func testAddressOnlyProperty<T>(_ b : T) -> T {
   // expected-note @+1 {{change 'let' to 'var' to make it mutable}} {{3-6=var}}
-  let x : T
+  let x : T  // expected-note {{change 'let' to 'var' to make it mutable}}
   let y : T
   let z : T   // never assigned is ok.  expected-warning {{immutable value 'z' was never used}} {{7-8=_}}
   x = b
@@ -938,8 +948,8 @@ struct StructMutatingMethodTest {
 
  // <rdar://problem/19268443> DI should reject this call to transparent function
  class TransparentFunction {
-  let x : Int
-  let y : Int
+  let x : Int  // expected-note {{change 'let' to 'var' to make it mutable}}
+  let y : Int  // expected-note {{change 'let' to 'var' to make it mutable}}
   init() {
     x = 42
     x += 1     // expected-error {{mutating operator '+=' may not be used on immutable value 'self.x'}}
@@ -1082,7 +1092,7 @@ extension ProtocolInitTest {
 // <rdar://problem/22436880> Function accepting UnsafeMutablePointer is able to change value of immutable value
 func bug22436880(_ x: UnsafeMutablePointer<Int>) {}
 func test22436880() {
-  let x: Int
+  let x: Int // expected-note {{change 'let' to 'var' to make it mutable}}
   x = 1
   bug22436880(&x) // expected-error {{immutable value 'x' must not be passed inout}}
 }

--- a/test/SILOptimizer/definite_init_inout_super_init.swift
+++ b/test/SILOptimizer/definite_init_inout_super_init.swift
@@ -5,7 +5,7 @@ class B {
 }
 
 class A : B {
-  let x: Int
+  let x: Int // expected-note {{change 'let' to 'var' to make it mutable}}
 
   init() {
     self.x = 12

--- a/test/SILOptimizer/definite_init_lvalue_let_witness_methods.swift
+++ b/test/SILOptimizer/definite_init_lvalue_let_witness_methods.swift
@@ -20,7 +20,7 @@ class TestClass {
     let testObject: TestProtocol // expected-note {{change 'let' to 'var' to make it mutable}}
     init() {
         testObject = TestStruct(foo: 42)
-        testObject.foo = 666 // expected-error {{cannot perform mutating operation: 'self.testObject' is a 'let' constant}}
+        testObject.foo = 666 // expected-error {{cannot mutate property 'foo' of immutable value 'self.testObject'}}
     }
 }
 
@@ -29,25 +29,29 @@ class TestClass {
 let testObject: TestProtocol  // expected-note {{change 'let' to 'var' to make it mutable}}
 testObject = TestStruct(foo: 42)
 
-testObject.foo = 666 // expected-error {{cannot perform mutating operation: 'testObject' is a 'let' constant}}
+testObject.foo = 666 // expected-error {{cannot mutate property 'foo' of immutable value 'testObject'}}
 
 extension TestProtocol {
     mutating func messThingsUp() {
         foo = 666
     }
+    mutating func messThingsUpAndThenThrow() throws {
+        foo = 616
+    }
 }
 
 // Mark: - Case3: Illegally muatating let constant in a function scope
 
-let testObject2: TestProtocol  // expected-note {{change 'let' to 'var' to make it mutable}}
+let testObject2: TestProtocol  // expected-note 2 {{change 'let' to 'var' to make it mutable}}
 testObject2 = TestStruct(foo: 42)
-testObject2.messThingsUp() // expected-error {{cannot perform mutating operation: 'testObject2' is a 'let' constant}}
+testObject2.messThingsUp() // expected-error {{mutating method 'messThingsUp' may not be used on immutable value 'testObject2'}}
+try! testObject2.messThingsUpAndThenThrow() // expected-error {{mutating method 'messThingsUpAndThenThrow' may not be used on immutable value 'testObject2'}}
 
 func testFunc() {
     let testObject: TestProtocol // expected-note {{change 'let' to 'var' to make it mutable}}
 
     testObject = TestStruct(foo: 42)
-    testObject.foo = 666 // expected-error {{cannot perform mutating operation: 'testObject' is a 'let' constant}}
+    testObject.foo = 666 // expected-error {{cannot mutate property 'foo' of immutable value 'testObject'}}
 }
 
 // Mark: - Case4: Illegally passing a let constants property as an inout parameter
@@ -58,4 +62,5 @@ testObject3 = TestStruct(foo: 42)
 func mutateThis(mutatee: inout Int) {
     mutatee = 666
 }
-mutateThis(mutatee: &testObject3.foo) // expected-error {{cannot perform mutating operation: 'testObject3' is a 'let' constant}}
+// FIXME: should be {{cannot mutate property 'foo' of immutable value 'testObject3'}}
+mutateThis(mutatee: &testObject3.foo) // expected-error {{immutable value 'testObject3' must not be passed inout}}


### PR DESCRIPTION
The only real bug here is that we were looking specifically for `apply` instructions, so we failed to diagnose `try_apply` calls to mutating throwing functions on immutable existentials.  Fixing this is a source-compatibility break, but it's clearly in the "obvious bug" category rather than something we need to emulate.  (I found this bug because DI stopped diagnosing a modification of a property of a `let` existential when it started being done with `modify`, which of course is called with `begin_apply`.)