### PR TITLE
[CodeCompletion] Remove a wrong assert()

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2254,7 +2254,6 @@ bool TypeChecker::typeCheckCompletionSequence(Expr *&expr, DeclContext *DC) {
   auto &solutionCS = solution.getConstraintSystem();
   expr->setType(solution.simplifyType(solutionCS.getType(expr)));
   auto completionType = solution.simplifyType(solutionCS.getType(CCE));
-  assert(!completionType->hasUnresolvedType());
   CCE->setType(completionType);
   return false;
 }

--- a/validation-test/IDE/crashers_2_fixed/sr8568.swift
+++ b/validation-test/IDE/crashers_2_fixed/sr8568.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=COMPLETE -source-filename=%s
+
+
+struct S<T> {}
+func use<T>(x: (S<T>) -> Void) {}
+
+func test() {
+  use { $0 #^COMPLETE^# }
+}


### PR DESCRIPTION
`CS.solve()` with `FreeTypeVariableBinding::Disallow` still may emit unresolved type. e.g. `DeclRefExpr` to decl with unresolved type.

https://bugs.swift.org/browse/SR-8568
rdar://problem/43433253
