### PR TITLE
[Frontend] -e and -M switches

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -199,6 +199,10 @@ ERROR(verify_encountered_fatal,none,
 ERROR(error_parse_input_file,none,
       "error parsing input file '%0' (%1)", (StringRef, StringRef))
 
+ERROR(error_m_switch_without_e_switch,none,
+      "cannot use -M arguments to import modules without -e arguments "
+      "to use them", ())
+
 ERROR(error_write_index_unit,none,
       "writing index unit file: %0", (StringRef))
 ERROR(error_create_index_dir,none,

--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -280,7 +280,8 @@ public:
   }
 
   const llvm::opt::DerivedArgList &getArgs() const { return *TranslatedArgs; }
-  ArrayRef<InputPair> getInputFiles() const { return InputFilesWithTypes; }
+  ArrayRef<InputPair> getInputFiles() const { return InputFilesWithTypes.typesAndArgs; }
+  bool hasInputs() const { return !InputFilesWithTypes.empty(); }
 
   OutputFileMap &getDerivedOutputFileMap() { return DerivedOutputFileMap; }
   const OutputFileMap &getDerivedOutputFileMap() const {

--- a/include/swift/Driver/Util.h
+++ b/include/swift/Driver/Util.h
@@ -31,7 +31,10 @@ namespace driver {
   /// Type used for a list of input arguments.
   struct InputFileList {
     SmallVector<InputPair, 16> typesAndArgs;
-    bool empty() const { return typesAndArgs.empty(); }
+    bool hasLinesToExecute = false;
+    bool empty() const {
+      return !hasLinesToExecute && typesAndArgs.empty();
+    }
   };
 
   enum class LinkKind {

--- a/include/swift/Driver/Util.h
+++ b/include/swift/Driver/Util.h
@@ -29,7 +29,10 @@ namespace driver {
   /// An input argument from the command line and its inferred type.
   using InputPair = std::pair<file_types::ID, const llvm::opt::Arg *>;
   /// Type used for a list of input arguments.
-  using InputFileList = SmallVector<InputPair, 16>;
+  struct InputFileList {
+    SmallVector<InputPair, 16> typesAndArgs;
+    bool empty() const { return typesAndArgs.empty(); }
+  };
 
   enum class LinkKind {
     None,

--- a/include/swift/Frontend/FrontendInputsAndOutputs.h
+++ b/include/swift/Frontend/FrontendInputsAndOutputs.h
@@ -46,6 +46,10 @@ class FrontendInputsAndOutputs {
   /// Punt where needed to enable batch mode experiments.
   bool AreBatchModeChecksBypassed = false;
 
+  /// Contents of -e switches (empty if none). (Used for lifetime
+  /// management; the buffer is accessed through an InputFile.)
+  std::shared_ptr<llvm::MemoryBuffer> LinesToExecute;
+
 public:
   bool areBatchModeChecksBypassed() const { return AreBatchModeChecksBypassed; }
   void setBypassBatchModeChecks(bool bbc) { AreBatchModeChecksBypassed = bbc; }

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -381,9 +381,6 @@ def enable_source_import : Flag<["-"], "enable-source-import">,
 def enable_throw_without_try : Flag<["-"], "enable-throw-without-try">,
   HelpText<"Allow throwing function calls without 'try'">;
 
-def import_module : Separate<["-"], "import-module">,
-  HelpText<"Implicitly import the specified module">;
-
 def print_stats : Flag<["-"], "print-stats">,
   HelpText<"Print various statistics">;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -381,6 +381,10 @@ def enable_source_import : Flag<["-"], "enable-source-import">,
 def enable_throw_without_try : Flag<["-"], "enable-throw-without-try">,
   HelpText<"Allow throwing function calls without 'try'">;
 
+def import_module : Separate<["-"], "import-module">,
+  HelpText<"Implicitly import <module_name> in code being compiled">,
+  MetaVarName<"<module_name>">;
+
 def print_stats : Flag<["-"], "print-stats">,
   HelpText<"Print various statistics">;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -171,6 +171,9 @@ def tools_directory : Separate<["-"], "tools-directory">,
 def D : JoinedOrSeparate<["-"], "D">, Flags<[FrontendOption]>,
   HelpText<"Marks a conditional compilation flag as true">;
 
+def e : Separate<["-"], "e">, Flags<[FrontendOption]>,
+  HelpText<"Specify a line of source code in the command line itself (usable multiple times)">;
+
 def F : JoinedOrSeparate<["-"], "F">, Flags<[FrontendOption, ArgumentIsPath]>,
   HelpText<"Add directory to framework search path">;
 def F_EQ : Joined<["-"], "F=">, Flags<[FrontendOption, ArgumentIsPath]>,

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -188,6 +188,11 @@ def I : JoinedOrSeparate<["-"], "I">, Flags<[FrontendOption, ArgumentIsPath]>,
 def I_EQ : Joined<["-"], "I=">, Flags<[FrontendOption, ArgumentIsPath]>,
   Alias<I>;
 
+def import_module : Joined<["-"], "M">, Flags<[FrontendOption]>,
+  HelpText<"Implicitly import <module_name> in code being compiled">, MetaVarName<"<module_name>">;
+def import_module_long : Separate<["-"], "import-module">, Flags<[FrontendOption]>,
+  Alias<import_module>;
+
 def import_underlying_module : Flag<["-"], "import-underlying-module">,
   Flags<[FrontendOption, NoInteractiveOption]>,
   HelpText<"Implicitly imports the Objective-C half of a module">;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -188,10 +188,8 @@ def I : JoinedOrSeparate<["-"], "I">, Flags<[FrontendOption, ArgumentIsPath]>,
 def I_EQ : Joined<["-"], "I=">, Flags<[FrontendOption, ArgumentIsPath]>,
   Alias<I>;
 
-def import_module : Joined<["-"], "M">, Flags<[FrontendOption]>,
-  HelpText<"Implicitly import <module_name> in code being compiled">, MetaVarName<"<module_name>">;
-def import_module_long : Separate<["-"], "import-module">, Flags<[FrontendOption]>,
-  Alias<import_module>;
+def M : Joined<["-"], "M">, Flags<[FrontendOption]>,
+  HelpText<"Import <module_name> in code provided by -e arguments">, MetaVarName<"<module_name>">;
 
 def import_underlying_module : Flag<["-"], "import-underlying-module">,
   Flags<[FrontendOption, NoInteractiveOption]>,

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1184,7 +1184,8 @@ void Driver::buildInputs(const ToolChain &TC,
   llvm::StringMap<StringRef> SourceFileNames;
 
   for (Arg *A : Args) {
-    if (A->getOption().matches(options::OPT_e)) {
+    if (A->getOption().matches(options::OPT_e) ||
+        A->getOption().matches(options::OPT_M)) {
       Inputs.hasLinesToExecute = true;
     } else if (A->getOption().getKind() == Option::InputClass) {
       StringRef Value = A->getValue();

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1184,7 +1184,9 @@ void Driver::buildInputs(const ToolChain &TC,
   llvm::StringMap<StringRef> SourceFileNames;
 
   for (Arg *A : Args) {
-    if (A->getOption().getKind() == Option::InputClass) {
+    if (A->getOption().matches(options::OPT_e)) {
+      Inputs.hasLinesToExecute = true;
+    } else if (A->getOption().getKind() == Option::InputClass) {
       StringRef Value = A->getValue();
       file_types::ID Ty = file_types::TY_INVALID;
 

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -172,6 +172,7 @@ static void addCommonFrontendArgs(const ToolChain &TC, const OutputInfo &OI,
     arguments.push_back(inputArgs.MakeArgString(OI.SDKPath));
   }
 
+  inputArgs.AddAllArgs(arguments, options::OPT_e);
   inputArgs.AddAllArgs(arguments, options::OPT_I);
   inputArgs.AddAllArgs(arguments, options::OPT_F, options::OPT_Fsystem);
 

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -175,6 +175,7 @@ static void addCommonFrontendArgs(const ToolChain &TC, const OutputInfo &OI,
   inputArgs.AddAllArgs(arguments, options::OPT_e);
   inputArgs.AddAllArgs(arguments, options::OPT_I);
   inputArgs.AddAllArgs(arguments, options::OPT_F, options::OPT_Fsystem);
+  inputArgs.AddAllArgs(arguments, options::OPT_import_module);
 
   inputArgs.AddLastArg(arguments, options::OPT_AssertConfig);
   inputArgs.AddLastArg(arguments, options::OPT_autolink_force_load);

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -172,7 +172,7 @@ static void addCommonFrontendArgs(const ToolChain &TC, const OutputInfo &OI,
     arguments.push_back(inputArgs.MakeArgString(OI.SDKPath));
   }
 
-  inputArgs.AddAllArgs(arguments, options::OPT_e);
+  inputArgs.AddAllArgs(arguments, options::OPT_e, options::OPT_M);
   inputArgs.AddAllArgs(arguments, options::OPT_I);
   inputArgs.AddAllArgs(arguments, options::OPT_F, options::OPT_Fsystem);
   inputArgs.AddAllArgs(arguments, options::OPT_import_module);

--- a/lib/Frontend/ArgsToFrontendInputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendInputsConverter.cpp
@@ -99,11 +99,22 @@ bool ArgsToFrontendInputsConverter::readInputFilesFromCommandLine() {
   }
   if (Args.hasArgNoClaim(options::OPT_e)) {
     SmallString<256> lines;
+    if (Args.hasArgNoClaim(options::OPT_M)) {
+      lines += "#sourceLocation(file: \"-M\", line: 1)\n";
+      for (StringRef module : Args.getAllArgValues(options::OPT_M)) {
+        lines += "import ";
+        lines += module;
+        lines += "\n";
+      }
+      lines += "#sourceLocation(file: \"-e\", line: 1)\n";
+    }
     for (StringRef line : Args.getAllArgValues(options::OPT_e)) {
       lines += line;
       lines += "\n";
     }
     LinesToExecute = llvm::MemoryBuffer::getMemBufferCopy(lines, "-e");
+  } else if (Args.hasArgNoClaim(options::OPT_M)) {
+    Diags.diagnose(SourceLoc(), diag::error_m_switch_without_e_switch);
   }
   return false; // FIXME: Don't bail out for duplicates, too many tests depend
   // on it.

--- a/lib/Frontend/ArgsToFrontendInputsConverter.h
+++ b/lib/Frontend/ArgsToFrontendInputsConverter.h
@@ -45,6 +45,9 @@ class ArgsToFrontendInputsConverter {
   DiagnosticEngine &Diags;
   const llvm::opt::ArgList &Args;
 
+  /// The code provided in -e switches.
+  std::shared_ptr<llvm::MemoryBuffer> LinesToExecute;
+
   llvm::opt::Arg const *const FilelistPathArg;
   llvm::opt::Arg const *const PrimaryFilelistPathArg;
 

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -183,7 +183,7 @@ OutputFilesComputer::computeOutputFile(StringRef outputArg,
 
 Optional<std::string>
 OutputFilesComputer::deriveOutputFileFromInput(const InputFile &input) const {
-  if (input.file() == "-" || HasTextualOutput)
+  if (input.file() == "-" || input.file() == "-e" || HasTextualOutput)
     return std::string("-");
 
   std::string baseName = determineBaseNameOfOutput(input);
@@ -429,7 +429,7 @@ StringRef SupplementaryOutputPathsComputer::
   if (!outputFilename.empty() && outputFilename != "-")
     return outputFilename;
 
-  if (input.isPrimary() && input.file() != "-")
+  if (input.isPrimary() && input.file() != "-" && input.file() != "-e")
     return llvm::sys::path::filename(input.file());
 
   return ModuleName;

--- a/lib/Frontend/FrontendInputsAndOutputs.cpp
+++ b/lib/Frontend/FrontendInputsAndOutputs.cpp
@@ -37,6 +37,7 @@ FrontendInputsAndOutputs::FrontendInputsAndOutputs(
   for (InputFile input : other.AllInputs)
     addInput(input);
   IsSingleThreadedWMO = other.IsSingleThreadedWMO;
+  LinesToExecute = other.LinesToExecute;
 }
 
 FrontendInputsAndOutputs &FrontendInputsAndOutputs::
@@ -45,6 +46,7 @@ operator=(const FrontendInputsAndOutputs &other) {
   for (InputFile input : other.AllInputs)
     addInput(input);
   IsSingleThreadedWMO = other.IsSingleThreadedWMO;
+  LinesToExecute = other.LinesToExecute;
   return *this;
 }
 

--- a/test/Driver/lines_to_execute.swift
+++ b/test/Driver/lines_to_execute.swift
@@ -12,15 +12,15 @@
 // CHECK-4: -e:2:1: error: use of unresolved identifier 'foo'
 // CHECK-4-NOT: Hello, world!
 
-// RUN: %swift_driver_plain -MFoundation -e 'NSLog("Hello, world!")' 2>&1 | %FileCheck -check-prefix CHECK-5 %s
-// CHECK-5: swift[{{.*}}] Hello, world!
+// RUN: %swift_driver_plain -MSwiftShims -e '_stdlib_write(1, "Hello, world!", 13)' 2>&1 | %FileCheck -check-prefix CHECK-5 %s
+// CHECK-5: Hello, world!
 
 // RUN: not %swift_driver_plain -MFnord -e 'fnord' 2>&1 | %FileCheck -check-prefix CHECK-6 %s
 // CHECK-6: -M:1:8: error: no such module 'Fnord'
 // CHECK-6-NOT: -e:1:1: error: use of unresolved identifier 'fnord'
 
-// RUN: not %swift_driver_plain -MFoundation -e 'fnord' 2>&1 | %FileCheck -check-prefix CHECK-7 %s
+// RUN: not %swift_driver_plain -MSwiftShims -e 'fnord' 2>&1 | %FileCheck -check-prefix CHECK-7 %s
 // CHECK-7: -e:1:1: error: use of unresolved identifier 'fnord'
 
-// RUN: not %swift_driver_plain -MFoundation 2>&1 | %FileCheck -check-prefix CHECK-8 %s
+// RUN: not %swift_driver_plain -MSwiftShims 2>&1 | %FileCheck -check-prefix CHECK-8 %s
 // CHECK-8: error: cannot use -M arguments to import modules without -e arguments to use them

--- a/test/Driver/lines_to_execute.swift
+++ b/test/Driver/lines_to_execute.swift
@@ -14,3 +14,13 @@
 
 // RUN: %swift_driver_plain -MFoundation -e 'NSLog("Hello, world!")' 2>&1 | %FileCheck -check-prefix CHECK-5 %s
 // CHECK-5: swift[{{.*}}] Hello, world!
+
+// RUN: not %swift_driver_plain -MFnord -e 'fnord' 2>&1 | %FileCheck -check-prefix CHECK-6 %s
+// CHECK-6: -M:1:8: error: no such module 'Fnord'
+// CHECK-6-NOT: -e:1:1: error: use of unresolved identifier 'fnord'
+
+// RUN: not %swift_driver_plain -MFoundation -e 'fnord' 2>&1 | %FileCheck -check-prefix CHECK-7 %s
+// CHECK-7: -e:1:1: error: use of unresolved identifier 'fnord'
+
+// RUN: not %swift_driver_plain -MFoundation 2>&1 | %FileCheck -check-prefix CHECK-8 %s
+// CHECK-8: error: cannot use -M arguments to import modules without -e arguments to use them

--- a/test/Driver/lines_to_execute.swift
+++ b/test/Driver/lines_to_execute.swift
@@ -12,3 +12,5 @@
 // CHECK-4: -e:2:1: error: use of unresolved identifier 'foo'
 // CHECK-4-NOT: Hello, world!
 
+// RUN: %swift_driver_plain -MFoundation -e 'NSLog("Hello, world!")' 2>&1 | %FileCheck -check-prefix CHECK-5 %s
+// CHECK-5: swift[{{.*}}] Hello, world!

--- a/test/Driver/lines_to_execute.swift
+++ b/test/Driver/lines_to_execute.swift
@@ -1,0 +1,14 @@
+// RUN: %swift_driver_plain -e 'print("Hello, world!")' 2>&1 | %FileCheck -check-prefix CHECK-1 %s
+// CHECK-1: Hello, world!
+
+// RUN: not %swift_driver_plain -e 'foo' 2>&1 | %FileCheck -check-prefix CHECK-2 %s
+// CHECK-2: -e:1:1: error: use of unresolved identifier 'foo'
+
+// RUN: %swift_driver_plain -e 'print("Hello, world!")' -e 'print("Hi, land!")' 2>&1 | %FileCheck -check-prefix CHECK-3 %s
+// CHECK-3: Hello, world!
+// CHECK-3: Hi, land!
+
+// RUN: not %swift_driver_plain -e 'print("Hello, world!")' -e 'foo' 2>&1 | %FileCheck -check-prefix CHECK-4 %s
+// CHECK-4: -e:2:1: error: use of unresolved identifier 'foo'
+// CHECK-4-NOT: Hello, world!
+


### PR DESCRIPTION
Adds two switches to the frontend. `-e <line>` adds `<line>` to a virtual file of code which it can run. `-M<module_name>` adds `<module_name>` to the implicit imported modules list. Together, they ~~fight crime~~ let you write Swift one-liners.

Resolves [SR-5860](https://bugs.swift.org/browse/SR-5860). Unlike #18303, this implementation keeps the code in memory, rather than writing it to a temporary file.