### PR TITLE
[TBDGen] Respect app extension safety in TBD files

### DIFF
--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -423,6 +423,10 @@ convertToPacked(const version::Version &version) {
   return tapi::internal::PackedVersion(major, minor, subminor);
 }
 
+static bool isApplicationExtensionSafe(const LangOptions &LangOpts) {
+  return LangOpts.EnableAppExtensionRestrictions;
+}
+
 static void enumeratePublicSymbolsAndWrite(ModuleDecl *M, FileUnit *singleFile,
                                            StringSet *symbols,
                                            llvm::raw_ostream *os,
@@ -433,6 +437,8 @@ static void enumeratePublicSymbolsAndWrite(ModuleDecl *M, FileUnit *singleFile,
 
   tapi::internal::InterfaceFile file;
   file.setFileType(tapi::internal::FileType::TBD_V3);
+  file.setApplicationExtensionSafe(
+    isApplicationExtensionSafe(M->getASTContext().LangOpts));
   file.setInstallName(opts.InstallName);
   file.setCurrentVersion(convertToPacked(opts.CurrentVersion));
   file.setCompatibilityVersion(convertToPacked(opts.CompatibilityVersion));

--- a/test/TBD/app-extension.swift
+++ b/test/TBD/app-extension.swift
@@ -1,0 +1,9 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck %s -application-extension -emit-tbd -emit-tbd-path %t/safe.tbd
+// RUN: %target-swift-frontend -typecheck %s -emit-tbd -emit-tbd-path %t/not-safe.tbd
+
+// RUN: %FileCheck %s --check-prefix EXTENSIONSAFE < %t/safe.tbd
+// RUN: %FileCheck %s --check-prefix NOTEXTENSIONSAFE < %t/not-safe.tbd
+
+// EXTENSIONSAFE-NOT: not_app_extension_safe
+// NOTEXTENSIONSAFE: not_app_extension_safe


### PR DESCRIPTION
This patch properly passes the `not_app_extension_safe` flag to TBD files by respecting the language option.