### PR TITLE
[Type checker] Marking a class as @objc doesn’t require an interface type.

### DIFF
--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -1520,11 +1520,11 @@ void markAsObjC(ValueDecl *D, ObjCReason reason,
     attr->setInvalid();
   }
 
-  if (!D->hasInterfaceType()) {
+  if (!isa<TypeDecl>(D) && !D->hasInterfaceType()) {
     ctx.getLazyResolver()->resolveDeclSignature(D);
   }
 
-  if (!isa<AccessorDecl>(D)) {
+  if (!isa<AccessorDecl>(D) && !isa<TypeDecl>(D)) {
     useObjectiveCBridgeableConformances(D->getInnermostDeclContext(),
                                         D->getInterfaceType());
   }

--- a/test/multifile/Inputs/objc-protocol-bridging.h
+++ b/test/multifile/Inputs/objc-protocol-bridging.h
@@ -1,0 +1,7 @@
+@import Foundation;
+
+@class SwiftClass;
+@protocol ObjCProtocol
+@optional
+-(void)method:(nullable SwiftClass *)object;
+@end

--- a/test/multifile/Inputs/objc-protocol-other.swift
+++ b/test/multifile/Inputs/objc-protocol-other.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+@objc class SwiftClass : NSObject { }

--- a/test/multifile/objc-protocol.swift
+++ b/test/multifile/objc-protocol.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend -module-name test -emit-ir -primary-file %s %S/Inputs/objc-protocol-other.swift -import-objc-header %S/Inputs/objc-protocol-bridging.h -sdk %sdk -o %t.o
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+@objc class Foo : NSObject, ObjCProtocol { }


### PR DESCRIPTION
Fixes the crash in SR-8540 / rdar://problem/43383512.
