### PR TITLE
[stdlib] Prepare sorting for move only types

### DIFF
--- a/stdlib/public/core/Sort.swift
+++ b/stdlib/public/core/Sort.swift
@@ -402,17 +402,16 @@ extension MutableCollection where Self: RandomAccessCollection {
     let half = distance(from: lo, to: hi) / 2
     let mid = index(lo, offsetBy: half)
     try _sort3(lo, mid, hi, by: areInIncreasingOrder)
-    let pivot = self[mid]
 
     // Loop invariants:
     // * lo < hi
-    // * self[i] < pivot, for i in range.lowerBound..<lo
-    // * pivot <= self[i] for i in hi..<range.upperBound
+    // * self[i] < self[mid], for i in range.lowerBound..<lo
+    // * self[mid] <= self[i] for i in hi..<range.upperBound
     Loop: while true {
       FindLo: do {
         formIndex(after: &lo)
         while lo != hi {
-          if try !areInIncreasingOrder(self[lo], pivot) { break FindLo }
+          if try !areInIncreasingOrder(self[lo], self[mid]) { break FindLo }
           formIndex(after: &lo)
         }
         break Loop
@@ -421,7 +420,7 @@ extension MutableCollection where Self: RandomAccessCollection {
       FindHi: do {
         formIndex(before: &hi)
         while hi != lo {
-          if try areInIncreasingOrder(self[hi], pivot) { break FindHi }
+          if try areInIncreasingOrder(self[hi], self[mid]) { break FindHi }
           formIndex(before: &hi)
         }
         break Loop

--- a/stdlib/public/core/Sort.swift
+++ b/stdlib/public/core/Sort.swift
@@ -265,7 +265,7 @@ extension Collection where Self: BidirectionalCollection {
   internal func _findUpperBound(
     forKey key: Element,
     within range: Range<Index>,
-    by areInIncreasingOreder: (Element, Element) throws -> Bool
+    by areInIncreasingOrder: (Element, Element) throws -> Bool
   ) rethrows -> Index {
     
     var start = range.lowerBound
@@ -274,14 +274,14 @@ extension Collection where Self: BidirectionalCollection {
     while start < end {
       let half = distance(from: start, to: end) &>> 1
       let mid  = index(start, offsetBy: half)
-      // the following if statement equals to self[mid] <= key
+      // The following if statement equals to self[mid] <= key.
       // <= is necessary for picking the first element that is greater
-      // than key
-      if try !areInIncreasingOreder(key, self[mid]) {
-        // move left bound closer to right
+      // than key.
+      if try !areInIncreasingOrder(key, self[mid]) {
+        // Move left bound closer to the right.
         start = index(after: mid)
       } else {
-        // move right bound closer to left
+        // Move right bound closer to the left.
         end = mid
       }
     }
@@ -307,14 +307,14 @@ extension MutableCollection where Self: BidirectionalCollection {
 
     while sortedEnd != range.upperBound {
 
-      // Find the position where should we put the left most element
+      // Find the position where should we put the leftmost element
       // of unsorted part of our range.
       let insertionPoint = try _findUpperBound(
         forKey: self[sortedEnd],
         within: start..<sortedEnd,
         by: areInIncreasingOrder)
 
-      // swap elements forward until insertion point is reached.
+      // Swap elements forward until insertion point is reached.
       var i = sortedEnd
 
       while i != insertionPoint {
@@ -442,8 +442,8 @@ extension MutableCollection where Self: RandomAccessCollection {
         }
         break Loop
       }
-      
-      // we must update mid to keep pivot reference valid
+
+      // We must update mid to keep reference to pivot element valid.
       if lo == mid {
         mid = hi
       } else if hi == mid {

--- a/stdlib/public/core/Sort.swift
+++ b/stdlib/public/core/Sort.swift
@@ -266,14 +266,14 @@ extension Collection where Self: BidirectionalCollection {
     forKey key: Element,
     within range: Range<Index>,
     by areInIncreasingOreder: (Element, Element) throws -> Bool
-    ) rethrows -> Index {
+  ) rethrows -> Index {
     
     var start = range.lowerBound
     var end   = range.upperBound
     
     while start < end {
-      let mid = index(start,
-                      offsetBy: distance(from: start, to: end) &>> 1)
+      let half = distance(from: start, to: end) &>> 1
+      let mid  = index(start, offsetBy: half)
       // the following if statement equals to self[mid] <= key
       // <= is necessary for picking the first element that is greater
       // than key
@@ -314,17 +314,14 @@ extension MutableCollection where Self: BidirectionalCollection {
         within: start..<sortedEnd,
         by: areInIncreasingOrder)
 
-      // Move elements forward until insertion point is reached.
+      // swap elements forward until insertion point is reached.
       var i = sortedEnd
-      let tmp = self[i]
 
       while i != insertionPoint {
         let j = index(before: i)
-        self[i] = self[j]
+        swapAt(i,j)
         i = j
       }
-      
-      self[insertionPoint] = tmp
 
       formIndex(after: &sortedEnd)
     }
@@ -420,7 +417,7 @@ extension MutableCollection where Self: RandomAccessCollection {
     // Sort the first, middle, and last elements, then use the middle value
     // as the pivot for the partition.
     let half = distance(from: lo, to: hi) / 2
-    let mid = index(lo, offsetBy: half)
+    var mid = index(lo, offsetBy: half)
     try _sort3(lo, mid, hi, by: areInIncreasingOrder)
 
     // Loop invariants:
@@ -445,7 +442,13 @@ extension MutableCollection where Self: RandomAccessCollection {
         }
         break Loop
       }
-
+      
+      // we can swap mid, so we should keep pivot valid
+      if lo == mid {
+        mid = hi
+      } else if hi == mid {
+        mid = lo
+      }
       swapAt(lo, hi)
     }
 

--- a/stdlib/public/core/Sort.swift
+++ b/stdlib/public/core/Sort.swift
@@ -443,7 +443,7 @@ extension MutableCollection where Self: RandomAccessCollection {
         break Loop
       }
       
-      // we can swap mid, so we should keep pivot valid
+      // we must update mid to keep pivot reference valid
       if lo == mid {
         mid = hi
       } else if hi == mid {


### PR DESCRIPTION
Also I've decided to test binary search for finding insertion point.  Binary search will reduce number of comparisons from O(n^2) to O(n log n ) which should be good for performance if comparator is slow (e. g. a lot of long strings with same prefixes), but it will increase binary size so linear search with some index magic and swapAt can be used instead. 