### PR TITLE
bumping Swift version from 4.2 to 4.2.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ set_property(CACHE SWIFT_ANALYZE_CODE_COVERAGE PROPERTY
 # SWIFT_VERSION is deliberately /not/ cached so that an existing build directory
 # can be reused when a new version of Swift comes out (assuming the user hasn't
 # manually set it as part of their own CMake configuration).
-set(SWIFT_VERSION "4.2")
+set(SWIFT_VERSION "4.2.1")
 
 set(SWIFT_VENDOR "" CACHE STRING
     "The vendor name of the Swift compiler")

--- a/test/Parse/ConditionalCompilation/language_version_explicit.swift
+++ b/test/Parse/ConditionalCompilation/language_version_explicit.swift
@@ -22,7 +22,7 @@
 #endif
 
 // NOTE: Please modify this condition...
-#if swift(>=4.2)
+#if swift(>=4.2.1)
   let b = 1
 #else
   // This shouldn't emit any diagnostics.
@@ -30,7 +30,7 @@
 #endif
 
 // NOTE: ...and modify this condition...
-#if swift(>=4.2.1)
+#if swift(>=4.2.2)
   // This shouldn't emit any diagnostics.
   asdf asdf asdf asdf
 #else

--- a/test/Serialization/Recovery/crash-recovery.swift
+++ b/test/Serialization/Recovery/crash-recovery.swift
@@ -14,7 +14,7 @@ public class Sub: Base {
 
 // CHECK-CRASH: error: fatal error encountered while reading from module 'Lib'; please file a bug report with your project and the crash log
 // CHECK-CRASH-3-NOT: note
-// CHECK-CRASH-4: note: compiling as Swift 4.2, with 'Lib' built as Swift 3.4
+// CHECK-CRASH-4: note: compiling as Swift 4.2.1, with 'Lib' built as Swift 3.4
 // CHECK-CRASH-LABEL: *** DESERIALIZATION FAILURE (please include this section in any bug report) ***
 // CHECK-CRASH: could not find 'disappearingMethod()' in parent class
 // CHECK-CRASH: While loading members for 'Sub' in module 'Lib'

--- a/test/Serialization/Recovery/types-4-to-3.swift
+++ b/test/Serialization/Recovery/types-4-to-3.swift
@@ -16,8 +16,8 @@ import Lib
 func requiresConformance(_: B_RequiresConformance<B_ConformsToProto>) {}
 func requiresConformance(_: B_RequiresConformance<C_RelyOnConformanceImpl.Assoc>) {}
 
-class Sub: Base {} // expected-error {{cannot inherit from class 'Base' (compiled with Swift 4.2.1) because it has overridable members that could not be loaded in Swift 3.4}}
-class Impl: Proto {} // expected-error {{type 'Impl' cannot conform to protocol 'Proto' (compiled with Swift 4.2.1) because it has requirements that could not be loaded in Swift 3.4}}
+class Sub: Base {} // expected-error {{cannot inherit from class 'Base' (compiled with Swift 4.1.50) because it has overridable members that could not be loaded in Swift 3.4}}
+class Impl: Proto {} // expected-error {{type 'Impl' cannot conform to protocol 'Proto' (compiled with Swift 4.1.50) because it has requirements that could not be loaded in Swift 3.4}}
 
 #else // TEST
 

--- a/test/Serialization/Recovery/types-4-to-3.swift
+++ b/test/Serialization/Recovery/types-4-to-3.swift
@@ -16,8 +16,8 @@ import Lib
 func requiresConformance(_: B_RequiresConformance<B_ConformsToProto>) {}
 func requiresConformance(_: B_RequiresConformance<C_RelyOnConformanceImpl.Assoc>) {}
 
-class Sub: Base {} // expected-error {{cannot inherit from class 'Base' (compiled with Swift 4.1.50) because it has overridable members that could not be loaded in Swift 3.4}}
-class Impl: Proto {} // expected-error {{type 'Impl' cannot conform to protocol 'Proto' (compiled with Swift 4.1.50) because it has requirements that could not be loaded in Swift 3.4}}
+class Sub: Base {} // expected-error {{cannot inherit from class 'Base' (compiled with Swift 4.2.1) because it has overridable members that could not be loaded in Swift 3.4}}
+class Impl: Proto {} // expected-error {{type 'Impl' cannot conform to protocol 'Proto' (compiled with Swift 4.2.1) because it has requirements that could not be loaded in Swift 3.4}}
 
 #else // TEST
 


### PR DESCRIPTION

This PR bumps the swift version number to 4.2.1 now that the branch is open for post-4.2 changes.

Resolves rdar://problem/43124673

