### PR TITLE
Fix some edge cases when inlining coroutines

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7828,6 +7828,21 @@ public:
     }
   }
 
+  /// Return whether the given apply is of a formally-throwing function
+  /// which is statically known not to throw.
+  bool isNonThrowing() const {
+    switch (getInstruction()->getKind()) {
+    case SILInstructionKind::ApplyInst:
+      return cast<ApplyInst>(Inst)->isNonThrowing();
+    case SILInstructionKind::BeginApplyInst:
+      return cast<BeginApplyInst>(Inst)->isNonThrowing();
+    case SILInstructionKind::TryApplyInst:
+      return false;
+    default:
+      llvm_unreachable("not implemented for this instruction!");
+    }
+  }
+
   static ApplySite getFromOpaqueValue(void *p) {
     return ApplySite(p);
   }

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -103,6 +103,10 @@ static bool canSpecializeFunction(SILFunction *F,
   if (F->getConventions().hasIndirectSILResults())
     return false;
 
+  // For now ignore coroutines.
+  if (F->getLoweredFunctionType()->isCoroutine())
+    return false;
+
   // Do not specialize the signature of always inline functions. We
   // will just inline them and specialize each one of the individual
   // functions that these sorts of functions are inlined into.

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -19,18 +19,49 @@
 #include "llvm/Support/Debug.h"
 using namespace swift;
 
-bool SILInliner::canInlineBeginApply(FullApplySite AI) {
-  // Don't inline a coroutine with multiple yields. We are not yet able to do
-  // so. The current implementation cannot handle values that are live across
-  // only some yields.
-  unsigned NumYields = 0;
-  if (auto BA = dyn_cast<BeginApplyInst>(AI)) {
-    for (auto &B : BA->getReferencedFunction()->getBlocks()) {
-      if (isa<YieldInst>(B.getTerminator()))
-        NumYields++;
-      if (NumYields > 1)
-        return false;
+static bool canInlineBeginApply(BeginApplyInst *BA) {
+  // Don't inline if we have multiple resumption sites (i.e. end_apply or
+  // abort_apply instructions).  The current implementation clones a single
+  // copy of the end_apply and abort_apply paths, so it can't handle values
+  // that might be live in the caller across different resumption sites.  To
+  // handle this in general, we'd need to separately clone the resume/unwind
+  // paths into each end/abort.
+  bool hasEndApply = false, hasAbortApply = false;
+  for (auto tokenUse : BA->getTokenResult()->getUses()) {
+    auto user = tokenUse->getUser();
+    if (isa<EndApplyInst>(user)) {
+      if (hasEndApply) return false;
+      hasEndApply = true;
+    } else {
+      assert(isa<AbortApplyInst>(user));
+      if (hasAbortApply) return false;
+      hasAbortApply = true;
     }
+  }
+
+  // Don't inline a coroutine with multiple yields.  The current
+  // implementation doesn't clone code from the caller, so it can't handle
+  // values that might be live in the callee across different yields.
+  // To handle this in general, we'd need to clone code in the caller,
+  // both between the begin_apply and the resumption site and then
+  // potentially after the resumption site when there are un-mergeable
+  // values alive across it.
+  bool hasYield = false;
+  for (auto &B : BA->getReferencedFunction()->getBlocks()) {
+    if (isa<YieldInst>(B.getTerminator())) {
+      if (hasYield) return false;
+      hasYield = true;
+    }
+  }
+  // Note that zero yields is fine; it just means the begin_apply is
+  // basically noreturn.
+
+  return true;
+}
+
+bool SILInliner::canInlineBeginApply(FullApplySite AI) {
+  if (auto BA = dyn_cast<BeginApplyInst>(AI)) {
+    return ::canInlineBeginApply(BA);
   }
   return true;
 }
@@ -43,46 +74,25 @@ bool SILInliner::canInlineFunction(FullApplySite AI) {
 
 /// Utility class for rewiring control-flow of inlined begin_apply functions.
 class BeginApplySite {
-  SmallVector<SILBasicBlock *, 4> ExitingBlocks;
-  SmallVector<SILValue, 8> YieldedIndirectValues;
   SILLocation Loc;
   SILBuilder &Builder;
   BeginApplyInst *BeginApply;
-  SILFunction *F;
+  bool HasYield = false;
+
   EndApplyInst *EndApply = nullptr;
   SILBasicBlock *EndApplyBB = nullptr;
-  SILBasicBlock *EndApplyBBMerge = nullptr;
+  SILBasicBlock *EndApplyReturnBB = nullptr;
+
   AbortApplyInst *AbortApply = nullptr;
   SILBasicBlock *AbortApplyBB = nullptr;
-  SILBasicBlock *AbortApplyBBMerge = nullptr;
-  SILArgument *IntToken = nullptr;
-
-  unsigned YieldNum = 0;
-  SmallVector<SILBasicBlock*, 8> YieldResumes;
-  SmallVector<SILBasicBlock*, 8> YieldUnwinds;
-
-  void
-  getYieldCaseBBs(SmallVectorImpl<std::pair<SILValue, SILBasicBlock *>> &Result,
-                  SmallVectorImpl<SILBasicBlock *> &Dests) {
-    unsigned Token = 0;
-    for (auto *Blk : Dests) {
-      Result.push_back(std::make_pair(
-          SILValue(Builder.createIntegerLiteral(
-              Loc,
-              SILType::getBuiltinIntegerType(
-                  32, Builder.getFunction().getModule().getASTContext()),
-              Token++)),
-          Blk));
-    }
-  }
+  SILBasicBlock *AbortApplyReturnBB = nullptr;
 
 public:
   BeginApplySite(BeginApplyInst *BeginApply, SILLocation Loc,
                  SILBuilder &Builder)
-      : Loc(Loc), Builder(Builder), BeginApply(BeginApply),
-        F(BeginApply->getFunction()) {}
+      : Loc(Loc), Builder(Builder), BeginApply(BeginApply) {}
 
-  static Optional<BeginApplySite> isa(FullApplySite AI, SILLocation Loc,
+  static Optional<BeginApplySite> get(FullApplySite AI, SILLocation Loc,
                                       SILBuilder &Builder) {
     auto *BeginApply = dyn_cast<BeginApplyInst>(AI);
     if (!BeginApply)
@@ -90,118 +100,129 @@ public:
     return BeginApplySite(BeginApply, Loc, Builder);
   }
 
-  void collectCallerExitingBlocks() {
-    F->findExitingBlocks(ExitingBlocks);
-  }
-
-  void processApply(SILBasicBlock *ReturnToBB) {
-    // Handle direct and indirect results.
-    for (auto YieldedValue : BeginApply->getYieldedValues()) {
-      // Store the addresses of indirect results so that we can replace them by
-      // the yielded address value later.
-      if (YieldedValue->getType().isAddress()) {
-        YieldedIndirectValues.push_back(YieldedValue);
-        continue;
-      }
-      // Insert a phi for direct results.
-      auto *RetArg = ReturnToBB->createPHIArgument(YieldedValue->getType(),
-                                                   ValueOwnershipKind::Owned);
-      // Replace all uses of the ApplyInst with the new argument.
-      YieldedValue->replaceAllUsesWith(RetArg);
-    }
-
-    // Add a trailing phi argument for the token integer (tells us which yield
-    // we came from).
-    IntToken = ReturnToBB->createPHIArgument(
-        SILType::getBuiltinIntegerType(32, F->getModule().getASTContext()),
-        ValueOwnershipKind::Owned);
-
+  void preprocess(SILBasicBlock *ReturnToBB) {
     // Get the end_apply, abort_apply instructions.
     auto Token = BeginApply->getTokenResult();
     for (auto *TokenUse : Token->getUses()) {
-      EndApply = dyn_cast<EndApplyInst>(TokenUse->getUser());
-      if (EndApply)
-        continue;
-      AbortApply = cast<AbortApplyInst>(TokenUse->getUser());
-    }
-
-    // Split the basic block before the end/abort_apply. We will insert code
-    // to jump to the resume/unwind blocks depending on the integer token
-    // later. And the inlined resume/unwind return blocks will jump back to
-    // the merge blocks.
-    EndApplyBB = EndApply->getParent();
-    EndApplyBBMerge = EndApplyBB->split(SILBasicBlock::iterator(EndApply));
-    if (AbortApply) {
-      AbortApplyBB = AbortApply->getParent();
-      AbortApplyBBMerge =
-          AbortApplyBB->split(SILBasicBlock::iterator(AbortApply));
+      if (auto End = dyn_cast<EndApplyInst>(TokenUse->getUser())) {
+        collectEndApply(End);
+      } else {
+        collectAbortApply(cast<AbortApplyInst>(TokenUse->getUser()));
+      }
     }
   }
 
-  void processTerminator(
-      TermInst *Terminator, SILBasicBlock *ReturnToBB,
+  // Split the basic block before the end/abort_apply. We will insert code
+  // to jump to the resume/unwind blocks depending on the integer token
+  // later. And the inlined resume/unwind return blocks will jump back to
+  // the merge blocks.
+  void collectEndApply(EndApplyInst *End) {
+    assert(!EndApply);
+    EndApply = End;
+    EndApplyBB = EndApply->getParent();
+    EndApplyReturnBB = EndApplyBB->split(SILBasicBlock::iterator(EndApply));
+  }
+  void collectAbortApply(AbortApplyInst *Abort) {
+    assert(!AbortApply);
+    AbortApply = Abort;
+    AbortApplyBB = AbortApply->getParent();
+    AbortApplyReturnBB = AbortApplyBB->split(SILBasicBlock::iterator(Abort));
+  }
+
+  /// Perform special processing for the given terminator if necessary.
+  ///
+  /// \return false to use the normal inlining logic
+  bool processTerminator(
+      TermInst *terminator, SILBasicBlock *returnToBB,
       llvm::function_ref<SILBasicBlock *(SILBasicBlock *)> remapBlock,
-      llvm::function_ref<SILValue(SILValue)> remapValue,
-      llvm::function_ref<void(TermInst *)> mapTerminator) {
+      llvm::function_ref<SILValue(SILValue)> remapValue) {
     // A yield branches to the begin_apply return block passing the yielded
     // results as branch arguments. Collect the yields target block for
     // resuming later. Pass an integer token to the begin_apply return block
     // to mark the yield we came from.
-    if (auto *Yield = dyn_cast<YieldInst>(Terminator)) {
-      YieldResumes.push_back(remapBlock(Yield->getResumeBB()));
-      YieldUnwinds.push_back(remapBlock(Yield->getUnwindBB()));
-      auto ContextToken = Builder.createIntegerLiteral(
-          Loc,
-          SILType::getBuiltinIntegerType(32, F->getModule().getASTContext()),
-          YieldNum++);
+    if (auto *yield = dyn_cast<YieldInst>(terminator)) {
+      assert(!HasYield);
+      HasYield = true;
 
-      SmallVector<SILValue, 8> BrResults;
-      unsigned IndirectIdx = 0;
-      for (auto CalleeYieldedVal : Yield->getYieldedValues()) {
-        auto YieldedVal = remapValue(CalleeYieldedVal);
-        if (YieldedVal->getType().isAddress()) {
-          auto YieldedDestAddr = YieldedIndirectValues[IndirectIdx++];
-          YieldedDestAddr->replaceAllUsesWith(YieldedVal);
-        } else
-          BrResults.push_back(YieldedVal);
+      // Pairwise replace the yielded values of the BeginApply with the
+      // values that were yielded.
+      auto calleeYields = yield->getYieldedValues();
+      auto callerYields = BeginApply->getYieldedValues();
+      assert(calleeYields.size() == callerYields.size());
+      for (auto i : indices(calleeYields)) {
+        auto remappedYield = remapValue(calleeYields[i]);
+        callerYields[i]->replaceAllUsesWith(remappedYield);
       }
-      BrResults.push_back(SILValue(ContextToken));
-      Builder.createBranch(Loc, ReturnToBB, BrResults);
-      return;
+      Builder.createBranch(Loc, returnToBB);
+
+      // Add branches at the resumption sites to the resume/unwind block.
+      if (EndApply) {
+        SavedInsertionPointRAII savedIP(Builder, EndApplyBB);
+        auto resumeBB = remapBlock(yield->getResumeBB());
+        Builder.createBranch(EndApply->getLoc(), resumeBB);
+      }
+      if (AbortApply) {
+        SavedInsertionPointRAII savedIP(Builder, AbortApplyBB);
+        auto unwindBB = remapBlock(yield->getUnwindBB());
+        Builder.createBranch(AbortApply->getLoc(), unwindBB);
+      }
+      return true;
     }
 
-    // Return and unwind terminators branch to the end_apply/abort_apply merge
-    // block respectively.
-    if (auto *RI = dyn_cast<ReturnInst>(Terminator)) {
-      Builder.createBranch(Loc, EndApplyBBMerge);
-      return;
-    }
-    if (auto *Unwind = dyn_cast<UnwindInst>(Terminator)) {
-      Builder.createBranch(Loc, AbortApplyBBMerge);
-      return;
+    // 'return' and 'unwind' instructions turn into branches to the
+    // end_apply/abort_apply return blocks, respectively.  If those blocks
+    // are null, it's because there weren't any of the corresponding
+    // instructions in the caller.  That means this entire path is
+    // unreachable.
+    if (isa<ReturnInst>(terminator) || isa<UnwindInst>(terminator)) {
+      bool isNormal = isa<ReturnInst>(terminator);
+      auto returnBB = isNormal ? EndApplyReturnBB : AbortApplyReturnBB;
+      if (returnBB) {
+        Builder.createBranch(Loc, returnBB);
+      } else {
+        Builder.createUnreachable(Loc);
+      }
+      return true;
     }
 
-    // Otherwise, we just map the branch instruction.
-    assert(!::isa<ThrowInst>(Terminator) &&
+    assert(!isa<ThrowInst>(terminator) &&
            "Unexpected throw instruction in yield_once function");
-    mapTerminator(Terminator);
+
+    // Otherwise, we just map the instruction normally.
+    return false;
   }
 
-  void dispatchToResumeUnwindBlocks() {
-    // Resume edge.
-    Builder.setInsertionPoint(EndApplyBB);
-    SmallVector<std::pair<SILValue, SILBasicBlock *>, 8> CaseBBs;
-    getYieldCaseBBs(CaseBBs, YieldResumes);
-    Builder.createSwitchValue(Loc, IntToken, nullptr, CaseBBs);
-    EndApply->eraseFromParent();
-    // Unwind edge.
-    if (AbortApplyBB) {
-      Builder.setInsertionPoint(AbortApplyBB);
-      SmallVector<std::pair<SILValue, SILBasicBlock *>, 8> CaseBBs;
-      getYieldCaseBBs(CaseBBs, YieldUnwinds);
-      Builder.createSwitchValue(Loc, IntToken, nullptr, CaseBBs);
-      AbortApply->eraseFromParent();
+  /// Complete the begin_apply-specific inlining work.
+  void complete() {
+    // If there was no yield in the coroutine, then control never reaches
+    // the end of the begin_apply, so all the downstream code is unreachable.
+    // Make sure the function is well-formed, since we otherwise rely on
+    // having visited a yield instruction.
+    if (!HasYield) {
+      // Make sure the split resumption blocks have terminators.
+      if (EndApplyBB) {
+        SavedInsertionPointRAII savedIP(Builder, EndApplyBB);
+        Builder.createUnreachable(Loc);
+      }
+      if (AbortApplyBB) {
+        SavedInsertionPointRAII savedIP(Builder, AbortApplyBB);
+        Builder.createUnreachable(Loc);
+      }
+
+      // Replace all the yielded values in the callee with undef.
+      for (auto calleeYield : BeginApply->getYieldedValues()) {
+        calleeYield->replaceAllUsesWith(SILUndef::get(calleeYield->getType(),
+                                                      Builder.getModule()));
+      }
     }
+
+    // Remove the resumption sites.
+    if (EndApply)
+      EndApply->eraseFromParent();
+    if (AbortApply)
+      AbortApply->eraseFromParent();
+
+    assert(!BeginApply->hasUsesOfAnyResult());
   }
 };
 
@@ -290,11 +311,8 @@ void SILInliner::inlineFunction(FullApplySite AI, ArrayRef<SILValue> Args) {
     ValueMap.insert(std::make_pair(calleeArg, callArg));
   }
 
-  // Find the existing blocks. We will need them for inlining the co-routine
-  // call.
-  auto BeginApply = BeginApplySite::isa(AI, Loc.getValue(), getBuilder());
-  if (BeginApply)
-    BeginApply->collectCallerExitingBlocks();
+  // Set up the coroutine-specific inliner if applicable.
+  auto BeginApply = BeginApplySite::get(AI, Loc.getValue(), getBuilder());
 
   // Recursively visit callee's BB in depth-first preorder, starting with the
   // entry block, cloning all instructions other than terminators.
@@ -339,7 +357,7 @@ void SILInliner::inlineFunction(FullApplySite AI, ArrayRef<SILValue> Args) {
       apply->replaceAllUsesWith(RetArg);
     } else {
       // Handle begin_apply.
-      BeginApply->processApply(ReturnToBB);
+      BeginApply->preprocess(ReturnToBB);
     }
   }
 
@@ -349,16 +367,15 @@ void SILInliner::inlineFunction(FullApplySite AI, ArrayRef<SILValue> Args) {
 
     // Coroutine terminators need special handling.
     if (BeginApply) {
-      BeginApply->processTerminator(
-          BI->first->getTerminator(), ReturnToBB,
-          [=](SILBasicBlock *Block) -> SILBasicBlock * {
-            return this->remapBasicBlock(Block);
-          },
-          [=](SILValue Val) -> SILValue {
-            return this->remapValue(Val);
-          },
-          [=](TermInst *Term) { this->visit(Term); });
-      continue;
+      if (BeginApply->processTerminator(
+            BI->first->getTerminator(), ReturnToBB,
+            [=](SILBasicBlock *Block) -> SILBasicBlock * {
+              return this->remapBasicBlock(Block);
+            },
+            [=](SILValue Val) -> SILValue {
+              return this->remapValue(Val);
+            }))
+        continue;
     }
 
     // Modify return terminators to branch to the return-to BB, rather than
@@ -373,14 +390,16 @@ void SILInliner::inlineFunction(FullApplySite AI, ArrayRef<SILValue> Args) {
     // Modify throw terminators to branch to the error-return BB, rather than
     // trying to clone the ThrowInst.
     if (auto *TI = dyn_cast<ThrowInst>(BI->first->getTerminator())) {
-      if (auto *A = dyn_cast<ApplyInst>(AI)) {
-        (void)A;
-        assert(A->isNonThrowing() &&
+      auto tryAI = dyn_cast<TryApplyInst>(AI);
+      if (!tryAI) {
+        assert((isa<ApplyInst>(AI)
+                  ? cast<ApplyInst>(AI)->isNonThrowing()
+                  : cast<BeginApplyInst>(AI)->isNonThrowing()) &&
                "apply of a function with error result must be non-throwing");
         getBuilder().createUnreachable(Loc.getValue());
         continue;
       }
-      auto tryAI = cast<TryApplyInst>(AI);
+
       auto returnedValue = remapValue(TI->getOperand());
       getBuilder().createBranch(Loc.getValue(), tryAI->getErrorBB(),
                                 returnedValue);
@@ -392,9 +411,9 @@ void SILInliner::inlineFunction(FullApplySite AI, ArrayRef<SILValue> Args) {
     visit(BI->first->getTerminator());
   }
 
-  // Insert dispatch code at end/abort_apply to the resume/unwind target blocks.
+  // Clean up after inlining into a begin_apply.
   if (BeginApply)
-    BeginApply->dispatchToResumeUnwindBlocks();
+    BeginApply->complete();
 }
 
 SILValue SILInliner::borrowFunctionArgument(SILValue callArg,

--- a/test/SILOptimizer/inline_begin_apply.sil
+++ b/test/SILOptimizer/inline_begin_apply.sil
@@ -53,8 +53,7 @@ unwind:
 // CHECK:  [[TEMP:%.*]] = alloc_stack $Indirect<SomeSubclass>
 // CHECK:  [[MK_IND:%.*]] = function_ref @make_indirect
 // CHECK:  apply [[MK_IND]]<SomeSubclass>([[TEMP]])
-// CHECK:  [[INTTOKEN:%.*]] = integer_literal $Builtin.Int32, 0
-// CHECK:  br bb3([[INTTOKEN]] : $Builtin.Int32)
+// CHECK:  br bb3
 
 // CHECK:bb1:
 // CHECK:  [[I2:%.*]] = integer_literal $Builtin.Int32, 2000
@@ -68,15 +67,14 @@ unwind:
 // CHECK:  dealloc_stack [[TEMP]] : $*Indirect<SomeSubclass>
 // CHECK:  br bb7
 
-// CHECK: bb3([[WHICH_YIELD:%.*]] : @trivial $Builtin.Int32):
+// CHECK: bb3:
 // CHECK:  destroy_addr [[TEMP]] : $*Indirect<SomeSubclass>
 // CHECK:  cond_br %0, bb4, bb6
 
 // CHECK: bb4:
 // CHECK:   [[I4:%.*]] = integer_literal $Builtin.Int32, 10
 // CHECK:   apply [[MARKER]]([[I4]])
-// CHECK:   [[ZERO:%.*]] = integer_literal $Builtin.Int32, 0
-// CHECK:   switch_value [[WHICH_YIELD]] : $Builtin.Int32, case [[ZERO]]: bb1
+// CHECK:   br bb1
 
 // CHECK: bb5:
 // CHECK:   [[I5:%.*]] = integer_literal $Builtin.Int32, 20
@@ -86,8 +84,7 @@ unwind:
 // CHECK: bb6:
 // CHECK:   [[I6:%.*]] = integer_literal $Builtin.Int32, 11
 // CHECK:   apply [[MARKER]]([[I6]])
-// CHECK:   [[ZERO:%.*]] = integer_literal $Builtin.Int32, 0
-// CHECK:   switch_value [[WHICH_YIELD]] : $Builtin.Int32, case [[ZERO]]: bb2
+// CHECK:   br bb2
 
 // CHECK: bb7:
 // CHECK:   [[I7:%.*]] = integer_literal $Builtin.Int32, 21
@@ -197,46 +194,45 @@ cont:
   return %ret : $()
 }
 
-// CHECK: sil @test_simple_call_yield_owned : $@convention(thin) (Builtin.Int1, @owned SomeClass) -> () {
-// CHECK: bb0(%0 : @trivial $Builtin.Int1, %1 : @owned $SomeClass):
-// CHECK:   %2 = function_ref @marker
-// CHECK:   %3 = integer_literal $Builtin.Int32, 1000
-// CHECK:   %4 = apply %2(%3)
-// CHECK:   %5 = integer_literal $Builtin.Int32, 0
-// CHECK:   br bb3(%1 : $SomeClass, %5 : $Builtin.Int32)
+// CHECK-LABEL: sil @test_simple_call_yield_owned : $@convention(thin) (Builtin.Int1, @owned SomeClass) -> () {
+// CHECK:      bb0(%0 : @trivial $Builtin.Int1, %1 : @owned $SomeClass):
+// CHECK-NEXT:   // function_ref
+// CHECK-NEXT:   %2 = function_ref @marker
+// CHECK-NEXT:   %3 = integer_literal $Builtin.Int32, 1000
+// CHECK-NEXT:   %4 = apply %2(%3)
+// CHECK-NEXT:   br bb3
 
-// CHECK: bb1:
-// CHECK:   %7 = integer_literal $Builtin.Int32, 2000
-// CHECK:   %8 = apply %2(%7)
-// CHECK:   destroy_value %1 : $SomeClass
-// CHECK:   br bb5
+// CHECK:      bb1:
+// CHECK-NEXT:   [[T0:%.*]] = integer_literal $Builtin.Int32, 2000
+// CHECK-NEXT:   apply %2([[T0]])
+// CHECK-NEXT:   destroy_value %1 : $SomeClass
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   br bb5
 
-// CHECK: bb2:
-// CHECK:   %12 = integer_literal $Builtin.Int32, 3000
-// CHECK:   %13 = apply %2(%12)
-// CHECK:   destroy_value %1 : $SomeClass
-// CHECK:   br bb7
+// CHECK:      bb2:
+// CHECK-NEXT:   [[T1:%.*]] = integer_literal $Builtin.Int32, 3000
+// CHECK-NEXT:   apply %2([[T1]])
+// CHECK-NEXT:   destroy_value %1 : $SomeClass
+// CHECK-NEXT:   br bb7
 
-// CHECK: bb3(%16 : @owned $SomeClass, %17 : @trivial $Builtin.Int32):
-// CHECK:   cond_br %0, bb4, bb6
+// CHECK:      bb3:
+// CHECK-NEXT:   cond_br %0, bb4, bb6
 
-// CHECK: bb4:
-// CHECK:   %19 = integer_literal $Builtin.Int32, 0
-// CHECK:   switch_value %17 : $Builtin.Int32, case %19: bb1
+// CHECK:      bb4:
+// CHECK-NEXT:   br bb1
 
-// CHECK: bb5:
-// CHECK:   br bb8
+// CHECK:      bb5:
+// CHECK-NEXT:   br bb8
 
-// CHECK: bb6:
-// CHECK:   %22 = integer_literal $Builtin.Int32, 0
-// CHECK:   switch_value %17 : $Builtin.Int32, case %22: bb2
+// CHECK:      bb6:
+// CHECK-NEXT:   br bb2
 
-// CHECK: bb7:
-// CHECK:   br bb8
+// CHECK:      bb7:
+// CHECK-NEXT:   br bb8
 
-// CHECK: bb8:
-// CHECK:   %25 = tuple ()
-// CHECK:   return %25 : $()
+// CHECK:      bb8:
+// CHECK-NEXT:   [[T0:%.*]] = tuple ()
+// CHECK-NEXT:   return [[T0]] : $()
 
 sil [transparent] @yield_owned : $@yield_once(@owned SomeClass) -> (@yields @owned SomeClass) {
 entry(%0 : @owned $SomeClass):
@@ -303,51 +299,50 @@ unwind:
 }
 
 
-// CHECK: sil @test_simple_call_yield_inout : $@convention(thin) (Builtin.Int1) -> () {
-// CHECK: bb0(%0 : @trivial $Builtin.Int1):
-// CHECK:   %1 = alloc_stack $Builtin.Int8
-// CHECK:   %2 = integer_literal $Builtin.Int8, 8
-// CHECK:   store %2 to [trivial] %1 : $*Builtin.Int8
-// CHECK:   %4 = integer_literal $Builtin.Int32, 0
-// CHECK:   br bb3(%4 : $Builtin.Int32)
+// CHECK-LABEL: sil @test_simple_call_yield_inout : $@convention(thin) (Builtin.Int1) -> () {
+// CHECK:      bb0(%0 : @trivial $Builtin.Int1):
+// CHECK-NEXT:   %1 = alloc_stack $Builtin.Int8
+// CHECK-NEXT:   %2 = integer_literal $Builtin.Int8, 8
+// CHECK-NEXT:   store %2 to [trivial] %1 : $*Builtin.Int8
+// CHECK-NEXT:   br bb3
 
-// CHECK: bb1:
-// CHECK:   %6 = function_ref @use : $@convention(thin) (@in Builtin.Int8) -> ()
-// CHECK:   %7 = apply %6(%1) : $@convention(thin) (@in Builtin.Int8) -> ()
-// CHECK:   dealloc_stack %1 : $*Builtin.Int8
-// CHECK:   %9 = tuple ()
-// CHECK:   br bb5
+// CHECK:      bb1:
+// CHECK-NEXT:   // function_ref
+// CHECK-NEXT:   [[USE:%.*]] = function_ref @use : $@convention(thin) (@in Builtin.Int8) -> ()
+// CHECK-NEXT:   apply [[USE]](%1) : $@convention(thin) (@in Builtin.Int8) -> ()
+// CHECK-NEXT:   dealloc_stack %1 : $*Builtin.Int8
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   br bb5
 
-// CHECK: bb2:
-// CHECK:   %11 = integer_literal $Builtin.Int32, 3000
-// CHECK:   %12 = function_ref @marker : $@convention(thin) (Builtin.Int32) -> ()
-// CHECK:   %13 = apply %12(%11) : $@convention(thin) (Builtin.Int32) -> ()
-// CHECK:   dealloc_stack %1 : $*Builtin.Int8
-// CHECK:   br bb7
+// CHECK:      bb2:
+// CHECK-NEXT:   [[T0:%.*]] = integer_literal $Builtin.Int32, 3000
+// CHECK-NEXT:   // function_ref
+// CHECK-NEXT:   [[MARKER:%.*]] = function_ref @marker : $@convention(thin) (Builtin.Int32) -> ()
+// CHECK-NEXT:   apply [[MARKER]]([[T0]]) : $@convention(thin) (Builtin.Int32) -> ()
+// CHECK-NEXT:   dealloc_stack %1 : $*Builtin.Int8
+// CHECK-NEXT:   br bb7
 
-// CHECK: bb3(%16 : @trivial $Builtin.Int32):
-// CHECK:   cond_br %0, bb4, bb6
+// CHECK:      bb3:
+// CHECK-NEXT:   cond_br %0, bb4, bb6
 
-// CHECK: bb4:
-// CHECK:   %18 = integer_literal $Builtin.Int8, 8
-// CHECK:   store %18 to [trivial] %1 : $*Builtin.Int8
-// CHECK:   %20 = integer_literal $Builtin.Int32, 0
-// CHECK:   switch_value %16 : $Builtin.Int32, case %20: bb1
+// CHECK:      bb4:
+// CHECK-NEXT:   [[T0:%.*]] = integer_literal $Builtin.Int8, 8
+// CHECK-NEXT:   store [[T0]] to [trivial] %1 : $*Builtin.Int8
+// CHECK-NEXT:   br bb1
 
-// CHECK: bb5:
-// CHECK:   br bb8
+// CHECK:      bb5:
+// CHECK-NEXT:   br bb8
 
-// CHECK: bb6:
-// CHECK:   %23 = integer_literal $Builtin.Int32, 0
-// CHECK:   switch_value %16 : $Builtin.Int32, case %23: bb2
+// CHECK:      bb6:
+// CHECK-NEXT:   br bb2
 
-// CHECK: bb7:
-// CHECK:   br bb8
+// CHECK:      bb7:
+// CHECK-NEXT:   br bb8
 
-// CHECK: bb8:
-// CHECK:   %26 = tuple ()
-// CHECK:   return %26 : $()
-// CHECK: }
+// CHECK:      bb8:
+// CHECK-NEXT:   [[T0:%.*]] = tuple ()
+// CHECK-NEXT:   return [[T0]] : $()
+// CHECK:      }
 
 sil @test_simple_call_yield_inout : $(Builtin.Int1) -> () {
 entry(%flag : @trivial $Builtin.Int1):
@@ -366,6 +361,87 @@ no:
   br cont
 
 cont:
+  %ret = tuple ()
+  return %ret : $()
+}
+
+//   We can't inline yet if there are multiple ends.
+// CHECK-LABEL: sil @test_multi_end_yield_inout : $@convention(thin) (Builtin.Int1) -> () {
+// CHECK:       [[T0:%.*]] = function_ref @yield_inout
+// CHECK:       begin_apply [[T0]]
+sil @test_multi_end_yield_inout : $(Builtin.Int1) -> () {
+entry(%flag : @trivial $Builtin.Int1):
+  %0 = function_ref @yield_inout : $@convention(thin) @yield_once() -> (@yields @inout Builtin.Int8)
+  (%addr, %token) = begin_apply %0() : $@convention(thin) @yield_once() -> (@yields @inout Builtin.Int8)
+  cond_br %flag, yes, no
+
+yes:
+  end_apply %token
+  br cont
+
+no:
+  end_apply %token
+  br cont
+
+cont:
+  %ret = tuple ()
+  return %ret : $()
+}
+
+//   We can't inline yet if there are multiple aborts.
+// CHECK-LABEL: sil @test_multi_abort_yield_inout : $@convention(thin) (Builtin.Int1) -> () {
+// CHECK:       [[T0:%.*]] = function_ref @yield_inout
+// CHECK:       begin_apply [[T0]]
+sil @test_multi_abort_yield_inout : $(Builtin.Int1) -> () {
+entry(%flag : @trivial $Builtin.Int1):
+  %0 = function_ref @yield_inout : $@convention(thin) @yield_once() -> (@yields @inout Builtin.Int8)
+  (%addr, %token) = begin_apply %0() : $@convention(thin) @yield_once() -> (@yields @inout Builtin.Int8)
+  cond_br %flag, yes, no
+
+yes:
+  abort_apply %token
+  br cont
+
+no:
+  abort_apply %token
+  br cont
+
+cont:
+  %ret = tuple ()
+  return %ret : $()
+}
+
+sil [transparent] @no_yields : $@yield_once () -> (@yields @inout Builtin.Int8) {
+entry:
+  %3000 = integer_literal $Builtin.Int32, 3000
+  %marker = function_ref @marker : $@convention(thin) (Builtin.Int32) -> ()
+  apply %marker(%3000) : $@convention(thin) (Builtin.Int32) -> ()
+  unreachable
+}
+
+// CHECK-LABEL: sil @test_simple_call_no_yields : $@convention(thin) () -> () {
+// CHECK:      bb0:
+// CHECK-NEXT:   [[T0:%.*]] = integer_literal $Builtin.Int32, 3000
+// CHECK-NEXT:   // function_ref
+// CHECK-NEXT:   [[MARKER:%.*]] = function_ref @marker : $@convention(thin) (Builtin.Int32) -> ()
+// CHECK-NEXT:   apply [[MARKER]]([[T0]]) : $@convention(thin) (Builtin.Int32) -> ()
+// CHECK-NEXT:   unreachable
+// CHECK:      bb1:
+// CHECK-NEXT:   // function_ref
+// CHECK-NEXT:   [[USE:%.*]] = function_ref @use : $@convention(thin) (@in Builtin.Int8) -> ()
+// CHECK-NEXT:   apply [[USE]](undef) : $@convention(thin) (@in Builtin.Int8) -> ()
+// CHECK-NEXT:   unreachable
+// CHECK:      bb2:
+// CHECK-NEXT:   [[T0:%.*]] = tuple ()
+// CHECK-NEXT:   return [[T0]] : $()
+// CHECK:      }
+sil @test_simple_call_no_yields : $() -> () {
+entry:
+  %0 = function_ref @no_yields : $@convention(thin) @yield_once () -> (@yields @inout Builtin.Int8)
+  (%addr, %token) = begin_apply %0() : $@convention(thin) @yield_once () -> (@yields @inout Builtin.Int8)
+  %use = function_ref @use : $@convention(thin) (@in Builtin.Int8) -> ()
+  apply %use(%addr) : $@convention(thin) (@in Builtin.Int8) -> ()
+  end_apply %token
   %ret = tuple ()
   return %ret : $()
 }


### PR DESCRIPTION
The current inlining strategy doesn't support inlining coroutines when there are multiple `end_apply` or `abort_apply` instructions in the caller, so refuse to inline such cases.  Also, handle the case where there are no `yield` instructions in the callee, which can happen if e.g. the callee calls a no-return function.

I also simplified the code somewhat by removing the vestiges of the code that tried to unify control flow with switches.

As an unrelated fix, suppress function signature optimization for coroutines for now.