### PR TITLE
[stdlib] Mark two types @usableFromInline; they satisfy requirements

### DIFF
--- a/stdlib/public/core/UnmanagedOpaqueString.swift
+++ b/stdlib/public/core/UnmanagedOpaqueString.swift
@@ -223,8 +223,8 @@ extension _UnmanagedOpaqueString : RandomAccessCollection {
 }
 
 extension _UnmanagedOpaqueString : _StringVariant {
-  internal typealias Encoding = Unicode.UTF16
-  internal typealias CodeUnit = Encoding.CodeUnit
+  @usableFromInline internal typealias Encoding = Unicode.UTF16
+  @usableFromInline internal typealias CodeUnit = Encoding.CodeUnit
 
   @inlinable
   var isASCII: Bool {


### PR DESCRIPTION
Otherwise, the textual interface won't see them, and any inlinable code that wants to make use of the protocol might get confused. We should have a check for this in the compiler itself, but for now I'm just providing this change to get unblocked.

(Okay, strictly speaking Encoding isn't a requirement right now, but it ought to be, right?)