### PR TITLE
Small improvements to AST printing in service of textual interfaces

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -110,9 +110,7 @@ PrintOptions PrintOptions::printTextualInterfaceFile() {
   // the default to 'public' and mark the 'internal' things.
   result.PrintAccess = true;
 
-  result.ExcludeAttrList.push_back(DAK_AccessControl);
-
-  // FIXME: We'll need the actual default parameter expression.
+  result.ExcludeAttrList = {DAK_ImplicitlyUnwrappedOptional, DAK_AccessControl};
   result.PrintDefaultParameterPlaceholder = false;
 
   return result;

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -610,15 +610,15 @@ StringRef DeclAttribute::getAttrName() const {
   case DAK_Effects:
     switch (cast<EffectsAttr>(this)->getKind()) {
       case EffectsKind::ReadNone:
-        return "effects(readnone)";
+        return "_effects(readnone)";
       case EffectsKind::ReadOnly:
-        return "effects(readonly)";
+        return "_effects(readonly)";
       case EffectsKind::ReleaseNone:
-        return "effects(releasenone)";
+        return "_effects(releasenone)";
       case EffectsKind::ReadWrite:
-        return "effects(readwrite)";
+        return "_effects(readwrite)";
       case EffectsKind::Unspecified:
-        return "effects(unspecified)";
+        return "_effects(unspecified)";
     }
   case DAK_AccessControl:
   case DAK_SetterAccess: {

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -572,10 +572,10 @@ void SpecifierTypeRepr::printImpl(ASTPrinter &Printer,
     Printer.printKeyword("inout");
     break;
   case TypeReprKind::Shared:
-    Printer.printKeyword("shared");
+    Printer.printKeyword("__shared");
     break;
   case TypeReprKind::Owned:
-    Printer.printKeyword("owned");
+    Printer.printKeyword("__owned");
     break;
   default:
     llvm_unreachable("unknown specifier type repr");

--- a/test/ModuleInterface/attrs.swift
+++ b/test/ModuleInterface/attrs.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -emit-interface-path %t.swiftinterface -enable-resilience -emit-module -o /dev/null %s
+// RUN: %FileCheck %s < %t.swiftinterface
+
+// CHECK: @_transparent public func glass() -> Int{{$}}
+@_transparent public func glass() -> Int { return 0 }
+
+// CHECK: @_effects(readnone) public func illiterate(){{$}}
+@_effects(readnone) public func illiterate() {}
+
+// CHECK-LABEL: @_fixed_layout public struct Point {
+@_fixed_layout public struct Point {
+  // CHECK-NEXT: public var x: Int
+  public var x: Int
+  // CHECK-NEXT: public var y: Int
+  public var y: Int
+} // CHECK-NEXT: {{^}$}}

--- a/test/ModuleInterface/smoke-test.swift
+++ b/test/ModuleInterface/smoke-test.swift
@@ -1,8 +1,10 @@
 // RUN: %target-swift-frontend -emit-interface-path - -emit-module -o /dev/null %s | %FileCheck %s
-// RUN: %target-swift-frontend -emit-interface-path - -emit-module -o /dev/null %s %S/Inputs/other.swift | %FileCheck -check-prefix CHECK-MULTI-FILE %s
+// RUN: %target-swift-frontend -emit-interface-path - -emit-module -o /dev/null %s %S/Inputs/other.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-MULTI-FILE %s
 
 // CHECK: public func verySimpleFunction(){{$}}
-// CHECK-MULTI-FILE: public func verySimpleFunction(){{$}}
 public func verySimpleFunction() {}
+
+// CHECK: public func ownership(_ x: __shared AnyObject){{$}}
+public func ownership(_ x: __shared AnyObject) {}
 
 // CHECK-MULTI-FILE: public func otherFileFunction(){{$}}


### PR DESCRIPTION
- Print "__owned" and "__shared" with leading underscores
- Print the '_effects' attribute with its underscore
- Print normally unprinted attributes when generating a swiftinterface file