### PR TITLE
[Type checker] Move TypeChecker::resolveType() into TypeResolution.

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1420,8 +1420,8 @@ namespace {
     Type resolveTypeReferenceInExpression(TypeRepr *rep) {
       TypeResolutionOptions options(TypeResolverContext::InExpression);
       options |= TypeResolutionFlags::AllowUnboundGenerics;
-      return CS.TC.resolveType(rep, TypeResolution::forContextual(CS.DC),
-                               options);
+      return TypeResolution::forContextual(CS.DC).resolveType(rep,
+                                                              options);
     }
 
     Type visitTypeExpr(TypeExpr *E) {

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1199,9 +1199,9 @@ void ConstraintSystem::shrink(Expr *expr) {
             // instead of cloning representative.
             auto coercionRepr = typeRepr->clone(CS.getASTContext());
             // Let's try to resolve coercion type from cloned representative.
+            auto resolution = TypeResolution::forContextual(CS.DC);
             auto coercionType =
-              CS.TC.resolveType(coercionRepr,
-                                TypeResolution::forContextual(CS.DC), None);
+              resolution.resolveType(coercionRepr, None);
 
             // Looks like coercion type is invalid, let's skip this sub-tree.
             if (coercionType->hasError())

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1848,8 +1848,8 @@ static void maybeAddAccessorsToBehaviorStorage(TypeChecker &TC, VarDecl *var) {
   };
 
   // Try to resolve the behavior to a protocol.
-  auto behaviorType = TC.resolveType(behavior->ProtocolName,
-                                     TypeResolution::forContextual(dc), None);
+  auto resolution = TypeResolution::forContextual(dc);
+  auto behaviorType = resolution.resolveType(behavior->ProtocolName, None);
   if (!behaviorType) {
     return makeBehaviorAccessors();
   }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -475,7 +475,7 @@ Type ConstraintSystem::openUnboundGenericType(UnboundGenericType *unbound,
   // pointing at a generic TypeAliasDecl here. If we find a way to
   // handle generic TypeAliases elsewhere, this can just become a
   // call to BoundGenericType::get().
-  return TC.applyUnboundGenericArguments(
+  return TypeChecker::applyUnboundGenericArguments(
       unbound, unboundDecl,
       SourceLoc(), TypeResolution::forContextual(DC), arguments);
 }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -980,10 +980,11 @@ ConstraintSystem::getTypeOfReference(ValueDecl *value,
   // Unqualified reference to a type.
   if (auto typeDecl = dyn_cast<TypeDecl>(value)) {
     // Resolve the reference to this type declaration in our current context.
-    auto type = TC.resolveTypeInContext(typeDecl, nullptr,
-                                        TypeResolution::forContextual(useDC),
-                                        TypeResolverContext::InExpression,
-                                        /*isSpecialized=*/false);
+    auto type = TypeChecker::resolveTypeInContext(
+                                      typeDecl, nullptr,
+                                      TypeResolution::forContextual(useDC),
+                                      TypeResolverContext::InExpression,
+                                      /*isSpecialized=*/false);
 
     // Open the type.
     type = openUnboundGenericType(type, locator);

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -47,8 +47,7 @@ Type DerivedConformance::getProtocolType() const {
   return Protocol->getDeclaredType();
 }
 
-bool DerivedConformance::derivesProtocolConformance(TypeChecker &TC,
-                                                    DeclContext *DC,
+bool DerivedConformance::derivesProtocolConformance(DeclContext *DC,
                                                     NominalTypeDecl *Nominal,
                                                     ProtocolDecl *Protocol) {
   // Only known protocols can be derived.
@@ -73,7 +72,7 @@ bool DerivedConformance::derivesProtocolConformance(TypeChecker &TC,
         // Enums without associated values can implicitly derive Equatable
         // conformance.
       case KnownProtocolKind::Equatable:
-        return canDeriveEquatable(TC, DC, Nominal);
+        return canDeriveEquatable(DC, Nominal);
 
         // "Simple" enums without availability attributes can explicitly derive
         // a CaseIterable conformance.
@@ -129,7 +128,7 @@ bool DerivedConformance::derivesProtocolConformance(TypeChecker &TC,
     if (auto structDecl = dyn_cast<StructDecl>(Nominal)) {
       switch (*knownProtocol) {
         case KnownProtocolKind::Equatable:
-          return canDeriveEquatable(TC, DC, Nominal);
+          return canDeriveEquatable(DC, Nominal);
         default:
           return false;
       }
@@ -158,8 +157,7 @@ ValueDecl *DerivedConformance::getDerivableRequirement(TypeChecker &tc,
             ConformanceCheckFlags::SkipConditionalRequirements)) {
       auto DC = conformance->getConcrete()->getDeclContext();
       // Check whether this nominal type derives conformances to the protocol.
-      if (!DerivedConformance::derivesProtocolConformance(tc, DC, nominal,
-                                                          proto))
+      if (!DerivedConformance::derivesProtocolConformance(DC, nominal, proto))
         return nullptr;
     }
 

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -58,8 +58,6 @@ public:
   /// declarations for requirements of the protocol that are not satisfied by
   /// the type's explicit members.
   ///
-  /// \param tc The type checker.
-  ///
   /// \param nominal The nominal type for which we are determining whether to
   /// derive a witness.
   ///
@@ -67,7 +65,7 @@ public:
   ///
   /// \return True if the type can implicitly derive a conformance for the
   /// given protocol.
-  static bool derivesProtocolConformance(TypeChecker &tc, DeclContext *DC,
+  static bool derivesProtocolConformance(DeclContext *DC,
                                          NominalTypeDecl *nominal,
                                          ProtocolDecl *protocol);
 
@@ -120,8 +118,7 @@ public:
   /// associated values, and for structs with all-Equatable stored properties.
   ///
   /// \returns True if the requirement can be derived.
-  static bool canDeriveEquatable(TypeChecker &tc, DeclContext *DC,
-                                 NominalTypeDecl *type);
+  static bool canDeriveEquatable(DeclContext *DC, NominalTypeDecl *type);
 
   /// Derive an Equatable requirement for a type.
   ///

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1777,12 +1777,13 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
   SmallPtrSet<TypeBase *, 4> constrainedGenericParams;
 
   // Go over the set of requirements and resolve their types.
+  auto resolution = TypeResolution::forContextual(FD);
   for (auto &req : trailingWhereClause->getRequirements()) {
     if (req.getKind() == RequirementReprKind::SameType) {
-      auto firstType = TC.resolveType(req.getFirstTypeRepr(),
-                                      TypeResolution::forContextual(FD), None);
-      auto secondType = TC.resolveType(req.getSecondTypeRepr(),
-                                       TypeResolution::forContextual(FD), None);
+      auto firstType = resolution.resolveType(req.getFirstTypeRepr(),
+                                              None);
+      auto secondType = resolution.resolveType(req.getSecondTypeRepr(),
+                                               None);
       Type interfaceFirstType;
       Type interfaceSecondType;
 
@@ -1832,9 +1833,8 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
     }
 
     if (req.getKind() == RequirementReprKind::LayoutConstraint) {
-      auto subjectType = TC.resolveType(req.getSubjectRepr(),
-                                        TypeResolution::forContextual(FD),
-                                        None);
+      auto subjectType = resolution.resolveType(req.getSubjectRepr(),
+                                                None);
       Type interfaceSubjectType;
 
       // Map types to their interface types.
@@ -1870,12 +1870,8 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
     }
 
     if (req.getKind() == RequirementReprKind::TypeConstraint) {
-      auto subjectType = TC.resolveType(req.getSubjectRepr(),
-                                        TypeResolution::forContextual(FD),
-                                        None);
-      auto constraint = TC.resolveType(req.getConstraintLoc().getTypeRepr(),
-                                       TypeResolution::forContextual(FD),
-                                       None);
+      auto subjectType = resolution.resolveType(req.getSubjectRepr(), None);
+      auto constraint = resolution.resolveType(req.getConstraintLoc().getTypeRepr(), None);
 
       Type interfaceSubjectType;
 
@@ -2043,8 +2039,8 @@ void AttributeChecker::visitImplementsAttr(ImplementsAttr *attr) {
   options |= TypeResolutionFlags::AllowUnboundGenerics;
 
   DeclContext *DC = D->getDeclContext();
-  Type T = TC.resolveType(ProtoTypeLoc.getTypeRepr(),
-                          TypeResolution::forContextual(DC), options);
+  auto resolution = TypeResolution::forContextual(DC);
+  Type T = resolution.resolveType(ProtoTypeLoc.getTypeRepr(), options);
   ProtoTypeLoc.setType(T);
 
   // Definite error-types were already diagnosed in resolveType.

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1036,7 +1036,7 @@ namespace {
       if (auto PlaceholderE = dyn_cast<EditorPlaceholderExpr>(expr)) {
         if (!PlaceholderE->getTypeLoc().isNull()) {
           if (!TC.validateType(PlaceholderE->getTypeLoc(),
-                               TypeResolution::forContextual(DC)))
+                               TypeResolution::forContextual(DC), None))
             expr->setType(PlaceholderE->getTypeLoc().getType());
         }
         return finish(true, expr);
@@ -1347,7 +1347,7 @@ TypeExpr *PreCheckExpression::simplifyNestedTypeExpr(UnresolvedDotExpr *UDE) {
     options |= TypeResolutionFlags::AllowUnboundGenerics;
     options |= TypeResolutionFlags::AllowUnavailable;
     auto resolution = TypeResolution::forContextual(DC);
-    auto BaseTy = TC.resolveType(InnerTypeRepr, resolution, options);
+    auto BaseTy = resolution.resolveType(InnerTypeRepr, options);
 
     if (BaseTy && BaseTy->mayHaveMembers()) {
       auto lookupOptions = defaultMemberLookupOptions;
@@ -1864,7 +1864,7 @@ Expr *PreCheckExpression::simplifyTypeConstructionWithLiteralArg(Expr *E) {
     TypeResolutionOptions options(TypeResolverContext::InExpression);
     options |= TypeResolutionFlags::AllowUnboundGenerics;
     auto resolution = TypeResolution::forContextual(DC);
-    type = TC.resolveType(rep, resolution, options);
+    type = resolution.resolveType(rep, options);
     typeExpr->getTypeLoc().setType(type);
   }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3818,8 +3818,10 @@ void TypeChecker::validateDecl(ValueDecl *D) {
     TypeLoc &defaultDefinition = assocType->getDefaultDefinitionLoc();
     if (!defaultDefinition.isNull()) {
       if (validateType(
-                defaultDefinition,
-                TypeResolution::forContextual(assocType->getDeclContext()))) {
+            defaultDefinition,
+            TypeResolution::forContextual(
+              assocType->getDeclContext()),
+            None)) {
         defaultDefinition.setInvalidType(Context);
       } else {
         // associatedtype X = X is invalid

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -1068,14 +1068,17 @@ RequirementCheckResult TypeChecker::checkGenericArguments(
         }
         break;
 
-      case RequirementKind::Superclass:
+      case RequirementKind::Superclass: {
         // Superclass requirements.
-        if (!isSubclassOf(firstType, secondType, dc)) {
+        // FIXME: Don't use the type checker instance here?
+        TypeChecker &tc = static_cast<TypeChecker &>(*ctx.getLazyResolver());
+        if (!tc.isSubclassOf(firstType, secondType, dc)) {
           diagnostic = diag::type_does_not_inherit;
           diagnosticNote = diag::type_does_not_inherit_or_conform_requirement;
           requirementFailure = true;
         }
         break;
+      }
 
       case RequirementKind::SameType:
         if (!firstType->isEqual(secondType)) {

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -447,7 +447,7 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
   if (options.contains(NameLookupFlags::IgnoreAccessControl))
     subOptions |= NL_IgnoreAccessControl;
 
-  if (!dc->lookupQualified(type, name, subOptions, this, decls))
+  if (!dc->lookupQualified(type, name, subOptions, nullptr, decls))
     return result;
 
   // Look through the declarations, keeping only the unique type declarations.
@@ -457,9 +457,11 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
     auto *typeDecl = cast<TypeDecl>(decl);
 
     // FIXME: This should happen before we attempt shadowing checks.
-    validateDecl(typeDecl);
-    if (!typeDecl->hasInterfaceType()) // FIXME: recursion-breaking hack
-      continue;
+    if (!typeDecl->hasInterfaceType()) {
+      dc->getASTContext().getLazyResolver()->resolveDeclSignature(typeDecl);
+      if (!typeDecl->hasInterfaceType()) // FIXME: recursion-breaking hack
+        continue;
+    }
 
     auto memberType = typeDecl->getDeclaredInterfaceType();
 
@@ -548,7 +550,9 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
           ProtocolConformanceState::CheckingTypeWitnesses)
         continue;
 
-      auto typeDecl = concrete->getTypeWitnessAndDecl(assocType, this).second;
+      auto lazyResolver = dc->getASTContext().getLazyResolver();
+      auto typeDecl =
+        concrete->getTypeWitnessAndDecl(assocType, lazyResolver).second;
 
       assert(typeDecl && "Missing type witness?");
 

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -886,7 +886,7 @@ Type AssociatedTypeInference::computeDerivedTypeWitness(
 
   // Can we derive conformances for this protocol and adoptee?
   NominalTypeDecl *derivingTypeDecl = adoptee->getAnyNominal();
-  if (!DerivedConformance::derivesProtocolConformance(tc, dc, derivingTypeDecl,
+  if (!DerivedConformance::derivesProtocolConformance(dc, derivingTypeDecl,
                                                       proto))
     return Type();
 
@@ -1117,7 +1117,7 @@ bool AssociatedTypeInference::checkCurrentTypeWitnesses(
                              { Type(proto->getProtocolSelfType()) },
                              sanitizedRequirements,
                              QuerySubstitutionMap{substitutions},
-                             TypeChecker::LookUpConformance(tc, dc),
+                             TypeChecker::LookUpConformance(dc),
                              None, nullptr, options);
   switch (result) {
   case RequirementCheckResult::Failure:

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -45,17 +45,13 @@ InheritedTypeRequest::evaluate(
     isa<ProtocolDecl>(dc) ? TypeResolution::forStructural(dc)
                           : TypeResolution::forContextual(dc);
 
-  auto lazyResolver = dc->getASTContext().getLazyResolver();
-  assert(lazyResolver && "Cannot resolve inherited type at this point");
-
-  TypeChecker &tc = *static_cast<TypeChecker *>(lazyResolver);
   TypeLoc &typeLoc = getTypeLoc(decl, index);
 
   Type inheritedType =
-    tc.resolveType(typeLoc.getTypeRepr(), resolution, options);
+    resolution.resolveType(typeLoc.getTypeRepr(), options);
   if (inheritedType && !isa<ProtocolDecl>(dc))
     inheritedType = inheritedType->mapTypeOutOfContext();
-  return inheritedType ? inheritedType : ErrorType::get(tc.Context);
+  return inheritedType ? inheritedType : ErrorType::get(dc->getASTContext());
 }
 
 llvm::Expected<Type>

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -18,6 +18,243 @@
 
 namespace swift {
 
+/// Flags that describe the context of type checking a pattern or
+/// type.
+enum class TypeResolutionFlags : uint16_t {
+  /// Whether to allow unspecified types within a pattern.
+  AllowUnspecifiedTypes = 1 << 0,
+
+  /// Whether to allow unbound generic types.
+  AllowUnboundGenerics = 1 << 1,
+
+  /// Whether an unavailable protocol can be referenced.
+  AllowUnavailableProtocol = 1 << 2,
+
+  /// Whether we should allow references to unavailable types.
+  AllowUnavailable = 1 << 3,
+
+  /// Whether the given type can override the type of a typed pattern.
+  OverrideType = 1 << 4,
+
+  /// Whether we are validating the type for SIL.
+  // FIXME: Move this flag to TypeResolverContext.
+  SILType = 1 << 5,
+
+  /// Whether we are parsing a SIL file.  Not the same as SILType,
+  /// because the latter is not set if we're parsing an AST type.
+  SILMode = 1 << 6,
+
+  /// Whether this is a resolution based on a non-inferred type pattern.
+  FromNonInferredPattern = 1 << 7,
+
+  /// Whether this type resolution is guaranteed not to affect downstream files.
+  KnownNonCascadingDependency = 1 << 8,
+
+  /// Whether we are at the direct base of a type expression.
+  Direct = 1 << 9,
+
+  /// Whether we should not produce diagnostics if the type is invalid.
+  SilenceErrors = 1 << 10,
+};
+
+/// Type resolution contexts that require special handling.
+enum class TypeResolverContext : uint8_t {
+  /// No special type handling is required.
+  None,
+
+  /// Whether we are checking the parameter list of a function.
+  AbstractFunctionDecl,
+
+  /// Whether we are checking the parameter list of a subscript.
+  SubscriptDecl,
+
+  /// Whether we are checking the parameter list of a closure.
+  ClosureExpr,
+
+  /// Whether we are in the input type of a function, or under one level of
+  /// tuple type.  This is not set for multi-level tuple arguments.
+  /// See also: TypeResolutionFlags::Direct
+  FunctionInput,
+
+  /// Whether this is a variadic function input.
+  VariadicFunctionInput,
+
+  /// Whether we are in the result type of a function, including multi-level
+  /// tuple return values. See also: TypeResolutionFlags::Direct
+  FunctionResult,
+
+  /// Whether we are in the result type of a function body that is
+  /// known to produce dynamic Self.
+  DynamicSelfResult,
+
+  /// Whether we are in a protocol's where clause
+  ProtocolWhereClause,
+
+  /// Whether this is a pattern binding entry.
+  PatternBindingDecl,
+
+  /// Whether we are the variable type in a for/in statement.
+  ForEachStmt,
+
+  /// Whether we are binding an extension declaration, which limits
+  /// the lookup.
+  ExtensionBinding,
+
+  /// Whether this type is being used in an expression or local declaration.
+  ///
+  /// This affects what sort of dependencies are recorded when resolving the
+  /// type.
+  InExpression,
+
+  /// Whether this type is being used in a cast or coercion expression.
+  ExplicitCastExpr,
+
+  /// Whether this type is the value carried in an enum case.
+  EnumElementDecl,
+
+  /// Whether this is the payload subpattern of an enum pattern.
+  EnumPatternPayload,
+
+  /// Whether we are checking the underlying type of a typealias.
+  TypeAliasDecl,
+
+  /// Whether we are in a requirement of a generic declaration
+  GenericRequirement,
+
+  /// Whether we are in a type argument for an optional
+  ImmediateOptionalTypeArgument,
+
+  /// Whether this is the type of an editor placeholder.
+  EditorPlaceholderExpr,
+};
+
+/// Options that determine how type resolution should work.
+class TypeResolutionOptions {
+  using Context = TypeResolverContext;
+
+  // The "base" type resolution context. This never changes.
+  Context base = Context::None;
+  // The current type resolution context.
+  Context context = Context::None;
+  // TypeResolutionFlags
+  uint16_t flags = 0;
+  static_assert(sizeof(flags) == sizeof(TypeResolutionFlags),
+      "Flags size error");
+
+public:
+  ~TypeResolutionOptions() = default;
+  TypeResolutionOptions(const TypeResolutionOptions &) = default;
+  TypeResolutionOptions(TypeResolutionOptions &&) = default;
+  TypeResolutionOptions &operator =(const TypeResolutionOptions &) = default;
+  TypeResolutionOptions &operator =(TypeResolutionOptions &&) = default;
+
+  // NOTE: Use either setContext() or explicit construction and assignment.
+  void operator =(const Context &) = delete;
+  void operator =(Context &&) = delete;
+
+  // NOTE: "None" might be more permissive than one wants, therefore no
+  // reasonable default context is possible.
+  TypeResolutionOptions() = delete;
+
+  TypeResolutionOptions(Context context) : base(context), context(context),
+      flags(unsigned(TypeResolutionFlags::Direct)) {}
+  // Helper forwarding constructors:
+  TypeResolutionOptions(llvm::NoneType) : TypeResolutionOptions(Context::None){}
+
+  /// Test the current type resolution base context.
+  bool hasBase(Context context) const { return base == context; }
+
+  /// Get the base type resolution context.
+  Context getBaseContext() const { return base; }
+
+  /// Test the current type resolution context.
+  bool is(Context context) const { return this->context == context; }
+
+  /// Get the current type resolution context.
+  Context getContext() const { return context; }
+  /// Set the current type resolution context.
+  void setContext(Context newContext) {
+    context = newContext;
+    flags &= ~unsigned(TypeResolutionFlags::Direct);
+  }
+  void setContext(llvm::NoneType) { setContext(Context::None); }
+
+  /// Get the current flags.
+  TypeResolutionFlags getFlags() const { return TypeResolutionFlags(flags); }
+
+  /// Is this type resolution context an expression.
+  bool isAnyExpr() const {
+    switch (base) {
+    case Context::InExpression:
+    case Context::ExplicitCastExpr:
+    case Context::ForEachStmt:
+    case Context::PatternBindingDecl:
+    case Context::EditorPlaceholderExpr:
+    case Context::ClosureExpr:
+      return true;
+    case Context::None:
+    case Context::FunctionInput:
+    case Context::VariadicFunctionInput:
+    case Context::FunctionResult:
+    case Context::DynamicSelfResult:
+    case Context::ProtocolWhereClause:
+    case Context::ExtensionBinding:
+    case Context::SubscriptDecl:
+    case Context::EnumElementDecl:
+    case Context::EnumPatternPayload:
+    case Context::TypeAliasDecl:
+    case Context::GenericRequirement:
+    case Context::ImmediateOptionalTypeArgument:
+    case Context::AbstractFunctionDecl:
+      return false;
+    }
+  }
+
+  /// Determine whether all of the given options are set.
+  bool contains(TypeResolutionFlags set) const {
+    return !static_cast<bool>(unsigned(set) & ~unsigned(flags));
+  }
+
+  /// Produce type resolution options with additional flags.
+  friend TypeResolutionOptions operator|(TypeResolutionOptions lhs,
+                                         TypeResolutionFlags rhs) {
+    return lhs |= rhs;
+  }
+
+  /// Merge additional flags into type resolution options.
+  friend TypeResolutionOptions &operator|=(TypeResolutionOptions &lhs,
+                                           TypeResolutionFlags rhs) {
+    lhs.flags |= unsigned(rhs);
+    return lhs;
+  }
+
+  /// Test whether any given flag is set in the type resolution options.
+  friend bool operator&(TypeResolutionOptions lhs, TypeResolutionFlags rhs) {
+    return lhs.flags & unsigned(rhs);
+  }
+
+  /// Produce type resolution options with removed flags.
+  friend TypeResolutionOptions operator-(TypeResolutionOptions lhs,
+                                         TypeResolutionFlags rhs) {
+    return lhs -= rhs;
+  }
+
+  /// Remove the flags from the type resolution options.
+  friend TypeResolutionOptions &operator-=(TypeResolutionOptions &lhs,
+                                           TypeResolutionFlags rhs) {
+    lhs.flags &= ~unsigned(rhs);
+    return lhs;
+  }
+  /// Strip the contextual options from the given type resolution options.
+  inline TypeResolutionOptions withoutContext(bool preserveSIL = false) const {
+    auto copy = *this;
+    copy.setContext(None);
+    // FIXME: Move SILType to TypeResolverContext.
+    if (!preserveSIL) copy -= TypeResolutionFlags::SILType;
+    return copy;
+  }
+};
+
 /// Handles the resolution of types within a given declaration context,
 /// which might involve resolving generic parameters to a particular
 /// stage.
@@ -78,16 +315,32 @@ public:
   /// no generic signature to resolve types.
   GenericSignature *getGenericSignature() const;
 
+  /// \brief Resolves a TypeRepr to a type.
+  ///
+  /// Performs name binding, checking of generic arguments, and so on in order
+  /// to create a well-formed type.
+  ///
+  /// \param TyR The type representation to check.
+  ///
+  /// \param options Options that alter type resolution.
+  ///
+  /// \returns a well-formed type or an ErrorType in case of an error.
+  Type resolveType(TypeRepr *TyR, TypeResolutionOptions options);
+
   /// Whether this type resolution uses archetypes (vs. generic parameters).
   bool usesArchetypes() const;
 
   /// Map the given type (that involves generic parameters)
   Type mapTypeIntoContext(Type type) const;
 
+  /// Resolve a reference to a member type of the given (dependent) base and
+  /// name.
   Type resolveDependentMemberType(Type baseTy, DeclContext *DC,
                                   SourceRange baseRange,
                                   ComponentIdentTypeRepr *ref) const;
 
+  /// Determine whether the given two types are equivalent within this
+  /// type resolution context.
   bool areSameType(Type type1, Type type2) const;
 };
 

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -67,6 +67,9 @@ public:
   static TypeResolution forContextual(DeclContext *dc,
                                       GenericEnvironment *genericEnv);
 
+  /// Retrieve the ASTContext in which this resolution occurs.
+  ASTContext &getASTContext() const { return dc->getASTContext(); }
+
   /// Retrieve the declaration context in which type resolution will be
   /// performed.
   DeclContext *getDeclContext() const { return dc; }

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -988,24 +988,6 @@ OwnedResolver swift::createLazyResolver(ASTContext &Ctx) {
                        &deleteTypeCheckerAndDiags);
 }
 
-void TypeChecker::diagnoseAmbiguousMemberType(Type baseTy,
-                                              SourceRange baseRange,
-                                              Identifier name,
-                                              SourceLoc nameLoc,
-                                              LookupTypeResult &lookup) {
-  if (auto moduleTy = baseTy->getAs<ModuleType>()) {
-    diagnose(nameLoc, diag::ambiguous_module_type, name,
-             moduleTy->getModule()->getName())
-      .highlight(baseRange);
-  } else {
-    diagnose(nameLoc, diag::ambiguous_member_type, name, baseTy)
-      .highlight(baseRange);
-  }
-  for (const auto &member : lookup) {
-    diagnose(member.Member, diag::found_candidate_type, member.MemberType);
-  }
-}
-
 // checkForForbiddenPrefix is for testing purposes.
 
 void TypeChecker::checkForForbiddenPrefix(const Decl *D) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1064,9 +1064,9 @@ public:
   
   /// \brief Try to resolve an IdentTypeRepr, returning either the referenced
   /// Type or an ErrorType in case of error.
-  Type resolveIdentifierType(TypeResolution resolution,
-                             IdentTypeRepr *IdType,
-                             TypeResolutionOptions options);
+  static Type resolveIdentifierType(TypeResolution resolution,
+                                    IdentTypeRepr *IdType,
+                                    TypeResolutionOptions options);
 
   /// Bind an UnresolvedDeclRefExpr by performing name lookup and
   /// returning the resultant expression.  Context is the DeclContext used
@@ -1112,8 +1112,8 @@ public:
   /// \param options Options that alter type resolution.
   ///
   /// \returns a well-formed type or an ErrorType in case of an error.
-  Type resolveType(TypeRepr *TyR, TypeResolution resolution,
-                   TypeResolutionOptions options);
+  static Type resolveType(TypeRepr *TyR, TypeResolution resolution,
+                          TypeResolutionOptions options);
 
   void validateDecl(ValueDecl *D);
   void validateDecl(OperatorDecl *decl);
@@ -1179,10 +1179,10 @@ public:
   /// error.
   ///
   /// \see applyUnboundGenericArguments
-  Type applyGenericArguments(Type type, SourceLoc loc,
-                             TypeResolution resolution,
-                             GenericIdentTypeRepr *generic,
-                             TypeResolutionOptions options);
+  static Type applyGenericArguments(Type type, SourceLoc loc,
+                                    TypeResolution resolution,
+                                    GenericIdentTypeRepr *generic,
+                                    TypeResolutionOptions options);
 
   /// Apply generic arguments to the given type.
   ///
@@ -1200,11 +1200,11 @@ public:
   /// error.
   ///
   /// \see applyGenericArguments
-  Type applyUnboundGenericArguments(UnboundGenericType *unboundType,
-                                    GenericTypeDecl *decl,
-                                    SourceLoc loc,
-                                    TypeResolution resolution,
-                                    ArrayRef<Type> genericArgs);
+  static Type applyUnboundGenericArguments(UnboundGenericType *unboundType,
+                                           GenericTypeDecl *decl,
+                                           SourceLoc loc,
+                                           TypeResolution resolution,
+                                           ArrayRef<Type> genericArgs);
 
   /// \brief Substitute the given base type into the type of the given nested type,
   /// producing the effective type that the nested type will have.
@@ -2161,11 +2161,6 @@ public:
 
   /// \brief Look up the Bool type in the standard library.
   Type lookupBoolType(const DeclContext *dc);
-
-  /// Diagnose an ambiguous member type lookup result.
-  void diagnoseAmbiguousMemberType(Type baseTy, SourceRange baseRange,
-                                   Identifier name, SourceLoc nameLoc,
-                                   LookupTypeResult &lookup);
 
   /// @}
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -41,6 +41,7 @@ class NormalProtocolConformance;
 class TopLevelContext;
 class TypeChecker;
 class TypeResolution;
+class TypeResolutionOptions;
 class TypoCorrectionResults;
 class ExprPattern;
 class SynthesizedFunction;
@@ -457,243 +458,6 @@ enum class RequirementCheckResult {
   Success, Failure, SubstitutionFailure
 };
 
-/// Flags that describe the context of type checking a pattern or
-/// type.
-enum class TypeResolutionFlags : uint16_t {
-  /// Whether to allow unspecified types within a pattern.
-  AllowUnspecifiedTypes = 1 << 0,
-
-  /// Whether to allow unbound generic types.
-  AllowUnboundGenerics = 1 << 1,
-
-  /// Whether an unavailable protocol can be referenced.
-  AllowUnavailableProtocol = 1 << 2,
-
-  /// Whether we should allow references to unavailable types.
-  AllowUnavailable = 1 << 3,
-
-  /// Whether the given type can override the type of a typed pattern.
-  OverrideType = 1 << 4,
-
-  /// Whether we are validating the type for SIL.
-  // FIXME: Move this flag to TypeResolverContext.
-  SILType = 1 << 5,
-
-  /// Whether we are parsing a SIL file.  Not the same as SILType,
-  /// because the latter is not set if we're parsing an AST type.
-  SILMode = 1 << 6,
-
-  /// Whether this is a resolution based on a non-inferred type pattern.
-  FromNonInferredPattern = 1 << 7,
-
-  /// Whether this type resolution is guaranteed not to affect downstream files.
-  KnownNonCascadingDependency = 1 << 8,
-
-  /// Whether we are at the direct base of a type expression.
-  Direct = 1 << 9,
-
-  /// Whether we should not produce diagnostics if the type is invalid.
-  SilenceErrors = 1 << 10,
-};
-
-/// Type resolution contexts that require special handling.
-enum class TypeResolverContext : uint8_t {
-  /// No special type handling is required.
-  None,
-
-  /// Whether we are checking the parameter list of a function.
-  AbstractFunctionDecl,
-
-  /// Whether we are checking the parameter list of a subscript.
-  SubscriptDecl,
-
-  /// Whether we are checking the parameter list of a closure.
-  ClosureExpr,
-
-  /// Whether we are in the input type of a function, or under one level of
-  /// tuple type.  This is not set for multi-level tuple arguments.
-  /// See also: TypeResolutionFlags::Direct
-  FunctionInput,
-
-  /// Whether this is a variadic function input.
-  VariadicFunctionInput,
-
-  /// Whether we are in the result type of a function, including multi-level
-  /// tuple return values. See also: TypeResolutionFlags::Direct
-  FunctionResult,
-
-  /// Whether we are in the result type of a function body that is
-  /// known to produce dynamic Self.
-  DynamicSelfResult,
-
-  /// Whether we are in a protocol's where clause
-  ProtocolWhereClause,
-
-  /// Whether this is a pattern binding entry.
-  PatternBindingDecl,
-
-  /// Whether we are the variable type in a for/in statement.
-  ForEachStmt,
-
-  /// Whether we are binding an extension declaration, which limits
-  /// the lookup.
-  ExtensionBinding,
-
-  /// Whether this type is being used in an expression or local declaration.
-  ///
-  /// This affects what sort of dependencies are recorded when resolving the
-  /// type.
-  InExpression,
-
-  /// Whether this type is being used in a cast or coercion expression.
-  ExplicitCastExpr,
-
-  /// Whether this type is the value carried in an enum case.
-  EnumElementDecl,
-
-  /// Whether this is the payload subpattern of an enum pattern.
-  EnumPatternPayload,
-
-  /// Whether we are checking the underlying type of a typealias.
-  TypeAliasDecl,
-
-  /// Whether we are in a requirement of a generic declaration
-  GenericRequirement,
-
-  /// Whether we are in a type argument for an optional
-  ImmediateOptionalTypeArgument,
-
-  /// Whether this is the type of an editor placeholder.
-  EditorPlaceholderExpr,
-};
-
-/// Options that determine how type resolution should work.
-class TypeResolutionOptions {
-  using Context = TypeResolverContext;
-
-  // The "base" type resolution context. This never changes.
-  Context base = Context::None;
-  // The current type resolution context.
-  Context context = Context::None;
-  // TypeResolutionFlags
-  uint16_t flags = 0;
-  static_assert(sizeof(flags) == sizeof(TypeResolutionFlags),
-      "Flags size error");
-
-public:
-  ~TypeResolutionOptions() = default;
-  TypeResolutionOptions(const TypeResolutionOptions &) = default;
-  TypeResolutionOptions(TypeResolutionOptions &&) = default;
-  TypeResolutionOptions &operator =(const TypeResolutionOptions &) = default;
-  TypeResolutionOptions &operator =(TypeResolutionOptions &&) = default;
-
-  // NOTE: Use either setContext() or explicit construction and assignment.
-  void operator =(const Context &) = delete;
-  void operator =(Context &&) = delete;
-
-  // NOTE: "None" might be more permissive than one wants, therefore no
-  // reasonable default context is possible.
-  TypeResolutionOptions() = delete;
-
-  TypeResolutionOptions(Context context) : base(context), context(context),
-      flags(unsigned(TypeResolutionFlags::Direct)) {}
-  // Helper forwarding constructors:
-  TypeResolutionOptions(llvm::NoneType) : TypeResolutionOptions(Context::None){}
-
-  /// Test the current type resolution base context.
-  bool hasBase(Context context) const { return base == context; }
-
-  /// Get the base type resolution context.
-  Context getBaseContext() const { return base; }
-
-  /// Test the current type resolution context.
-  bool is(Context context) const { return this->context == context; }
-
-  /// Get the current type resolution context.
-  Context getContext() const { return context; }
-  /// Set the current type resolution context.
-  void setContext(Context newContext) {
-    context = newContext;
-    flags &= ~unsigned(TypeResolutionFlags::Direct);
-  }
-  void setContext(llvm::NoneType) { setContext(Context::None); }
-
-  /// Get the current flags.
-  TypeResolutionFlags getFlags() const { return TypeResolutionFlags(flags); }
-
-  /// Is this type resolution context an expression.
-  bool isAnyExpr() const {
-    switch (base) {
-    case Context::InExpression:
-    case Context::ExplicitCastExpr:
-    case Context::ForEachStmt:
-    case Context::PatternBindingDecl:
-    case Context::EditorPlaceholderExpr:
-    case Context::ClosureExpr:
-      return true;
-    case Context::None:
-    case Context::FunctionInput:
-    case Context::VariadicFunctionInput:
-    case Context::FunctionResult:
-    case Context::DynamicSelfResult:
-    case Context::ProtocolWhereClause:
-    case Context::ExtensionBinding:
-    case Context::SubscriptDecl:
-    case Context::EnumElementDecl:
-    case Context::EnumPatternPayload:
-    case Context::TypeAliasDecl:
-    case Context::GenericRequirement:
-    case Context::ImmediateOptionalTypeArgument:
-    case Context::AbstractFunctionDecl:
-      return false;
-    }
-  }
-
-  /// Determine whether all of the given options are set.
-  bool contains(TypeResolutionFlags set) const {
-    return !static_cast<bool>(unsigned(set) & ~unsigned(flags));
-  }
-
-  /// Produce type resolution options with additional flags.
-  friend TypeResolutionOptions operator|(TypeResolutionOptions lhs,
-                                         TypeResolutionFlags rhs) {
-    return lhs |= rhs;
-  }
-
-  /// Merge additional flags into type resolution options.
-  friend TypeResolutionOptions &operator|=(TypeResolutionOptions &lhs,
-                                           TypeResolutionFlags rhs) {
-    lhs.flags |= unsigned(rhs);
-    return lhs;
-  }
-
-  /// Test whether any given flag is set in the type resolution options.
-  friend bool operator&(TypeResolutionOptions lhs, TypeResolutionFlags rhs) {
-    return lhs.flags & unsigned(rhs);
-  }
-
-  /// Produce type resolution options with removed flags.
-  friend TypeResolutionOptions operator-(TypeResolutionOptions lhs,
-                                         TypeResolutionFlags rhs) {
-    return lhs -= rhs;
-  }
-
-  /// Remove the flags from the type resolution options.
-  friend TypeResolutionOptions &operator-=(TypeResolutionOptions &lhs,
-                                           TypeResolutionFlags rhs) {
-    lhs.flags &= ~unsigned(rhs);
-    return lhs;
-  }
-  /// Strip the contextual options from the given type resolution options.
-  inline TypeResolutionOptions withoutContext(bool preserveSIL = false) const {
-    auto copy = *this;
-    copy.setContext(None);
-    // FIXME: Move SILType to TypeResolverContext.
-    if (!preserveSIL) copy -= TypeResolutionFlags::SILType;
-    return copy;
-  }
-};
-
 /// Flags that control protocol conformance checking.
 enum class ConformanceCheckFlags {
   /// Whether we're performing the check from within an expression.
@@ -1088,7 +852,7 @@ public:
   ///
   /// \returns true if type validation failed, or false otherwise.
   bool validateType(TypeLoc &Loc, TypeResolution resolution,
-                    TypeResolutionOptions options = None);
+                    TypeResolutionOptions options);
 
   /// Check for unsupported protocol types in the given declaration.
   void checkUnsupportedProtocolType(Decl *decl);
@@ -1099,21 +863,6 @@ public:
   /// Expose TypeChecker's handling of GenericParamList to SIL parsing.
   GenericEnvironment *handleSILGenericParams(GenericParamList *genericParams,
                                              DeclContext *DC);
-
-  /// \brief Resolves a TypeRepr to a type.
-  ///
-  /// Performs name binding, checking of generic arguments, and so on in order
-  /// to create a well-formed type.
-  ///
-  /// \param TyR The type representation to check.
-  ///
-  /// \param resolution The type resolution to perform.
-  ///
-  /// \param options Options that alter type resolution.
-  ///
-  /// \returns a well-formed type or an ErrorType in case of an error.
-  static Type resolveType(TypeRepr *TyR, TypeResolution resolution,
-                          TypeResolutionOptions options);
 
   void validateDecl(ValueDecl *D);
   void validateDecl(OperatorDecl *decl);
@@ -1456,7 +1205,7 @@ public:
 
   bool validateRequirement(SourceLoc whereLoc, RequirementRepr &req,
                            TypeResolution resolution,
-                           TypeResolutionOptions options = None);
+                           TypeResolutionOptions options);
 
   /// Validate the given requirements.
   void validateRequirements(SourceLoc whereLoc,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1156,11 +1156,11 @@ public:
   /// \param resolution The resolution to perform.
   ///
   /// \returns the resolved type.
-  Type resolveTypeInContext(TypeDecl *typeDecl,
-                            DeclContext *foundDC,
-                            TypeResolution resolution,
-                            TypeResolutionOptions options,
-                            bool isSpecialized);
+  static Type resolveTypeInContext(TypeDecl *typeDecl,
+                                   DeclContext *foundDC,
+                                   TypeResolution resolution,
+                                   TypeResolutionOptions options,
+                                   bool isSpecialized);
 
   /// Apply generic arguments to the given type.
   ///
@@ -1498,7 +1498,7 @@ public:
   /// requirement.
   /// \param listener The generic check listener used to pick requirements and
   /// notify callers about diagnosed errors.
-  RequirementCheckResult checkGenericArguments(
+  static RequirementCheckResult checkGenericArguments(
       DeclContext *dc, SourceLoc loc, SourceLoc noteLoc, Type owner,
       TypeArrayView<GenericTypeParamType> genericParams,
       ArrayRef<Requirement> requirements,
@@ -1985,10 +1985,10 @@ public:
   ///
   /// \returns the conformance, if \c T conforms to the protocol \c Proto, or
   /// an empty optional.
-  Optional<ProtocolConformanceRef> containsProtocol(
-                                     Type T, ProtocolDecl *Proto,
-                                     DeclContext *DC,
-                                     ConformanceCheckOptions options);
+  static Optional<ProtocolConformanceRef> containsProtocol(
+                                             Type T, ProtocolDecl *Proto,
+                                             DeclContext *DC,
+                                             ConformanceCheckOptions options);
 
   /// \brief Determine whether the given type conforms to the given protocol.
   ///
@@ -2007,12 +2007,12 @@ public:
   ///
   /// \returns The protocol conformance, if \c T conforms to the
   /// protocol \c Proto, or \c None.
-  Optional<ProtocolConformanceRef> conformsToProtocol(
-                                     Type T,
-                                     ProtocolDecl *Proto,
-                                     DeclContext *DC,
-                                     ConformanceCheckOptions options,
-                                     SourceLoc ComplainLoc = SourceLoc());
+  static Optional<ProtocolConformanceRef> conformsToProtocol(
+                                           Type T,
+                                           ProtocolDecl *Proto,
+                                           DeclContext *DC,
+                                           ConformanceCheckOptions options,
+                                           SourceLoc ComplainLoc = SourceLoc());
 
   /// Mark the given protocol conformance as "used" from the given declaration
   /// context.
@@ -2023,12 +2023,10 @@ public:
   /// conformance through a particular declaration context using the given
   /// type checker.
   class LookUpConformance {
-    TypeChecker &tc;
     DeclContext *dc;
 
   public:
-    explicit LookUpConformance(TypeChecker &tc, DeclContext *dc)
-      : tc(tc), dc(dc) { }
+    explicit LookUpConformance(DeclContext *dc) : dc(dc) { }
 
     Optional<ProtocolConformanceRef>
     operator()(CanType dependentType,
@@ -2124,8 +2122,7 @@ public:
 
   /// \brief Check whether the given declaration can be written as a
   /// member of the given base type.
-  bool isUnsupportedMemberTypeAccess(Type type,
-                                     TypeDecl *typeDecl);
+  static bool isUnsupportedMemberTypeAccess(Type type, TypeDecl *typeDecl);
 
   /// \brief Look up a member type within the given type.
   ///
@@ -2138,10 +2135,10 @@ public:
   /// \param options Options that control name lookup.
   ///
   /// \returns The result of name lookup.
-  LookupTypeResult lookupMemberType(DeclContext *dc, Type type,
-                                    Identifier name,
-                                    NameLookupOptions options
-                                      = defaultMemberTypeLookupOptions);
+  static LookupTypeResult lookupMemberType(DeclContext *dc, Type type,
+                                           Identifier name,
+                                           NameLookupOptions options
+                                             = defaultMemberTypeLookupOptions);
 
   /// \brief Look up the constructors of the given type.
   ///
@@ -2411,7 +2408,7 @@ public:
   ///
   /// Returns true if the arguments list could be constructed, false if for
   /// some reason it could not.
-  bool getDefaultGenericArgumentsString(
+  static bool getDefaultGenericArgumentsString(
       SmallVectorImpl<char> &buf,
       const GenericTypeDecl *typeDecl,
       llvm::function_ref<Type(const GenericTypeParamDecl *)> getPreferredType =

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1047,9 +1047,9 @@ public:
     return Diags.diagnose(std::forward<ArgTypes>(Args)...);
   }
 
-  Type getArraySliceType(SourceLoc loc, Type elementType);
-  Type getDictionaryType(SourceLoc loc, Type keyType, Type valueType);
-  Type getOptionalType(SourceLoc loc, Type elementType);
+  static Type getArraySliceType(SourceLoc loc, Type elementType);
+  static Type getDictionaryType(SourceLoc loc, Type keyType, Type valueType);
+  static Type getOptionalType(SourceLoc loc, Type elementType);
   Type getUnsafePointerType(SourceLoc loc, Type pointeeType);
   Type getUnsafeMutablePointerType(SourceLoc loc, Type pointeeType);
   Type getStringType(DeclContext *dc);

--- a/test/decl/protocol/req/recursion.swift
+++ b/test/decl/protocol/req/recursion.swift
@@ -25,12 +25,13 @@ protocol CircularAssocTypeDefault {
   associatedtype Z3 = Z2
   // expected-note@-1{{protocol requires nested type 'Z3'; do you want to add it?}}
 
-  associatedtype Z4 = Self.Z4 // expected-error{{associated type 'Z4' is not a member type of 'Self'}}
-  // expected-note@-1{{protocol requires nested type 'Z4'; do you want to add it?}}
+  associatedtype Z4 = Self.Z4 // expected-error{{associated type 'Z4' references itself}}
+  // expected-note@-1{{type declared here}}
+  // expected-note@-2{{protocol requires nested type 'Z4'; do you want to add it?}}
 
   associatedtype Z5 = Self.Z6
   // expected-note@-1{{protocol requires nested type 'Z5'; do you want to add it?}}
-  associatedtype Z6 = Self.Z5 // expected-error{{associated type 'Z5' is not a member type of 'Self'}}
+  associatedtype Z6 = Self.Z5
   // expected-note@-1{{protocol requires nested type 'Z6'; do you want to add it?}}
 }
 


### PR DESCRIPTION
Separate type resolution *almost* completely from the `TypeChecker` instance, and move the primary entry point (`TypeChecker::resolveType()`) into `TypeResolution`.