### PR TITLE
[Diagnostics] Add `superclass` requirement fix/diagnostic

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1535,6 +1535,12 @@ ERROR(types_not_equal_decl,none,
 ERROR(types_not_equal_in_decl_ref,none,
       "referencing %0 %1 on %2 requires the types %3 and %4 be equivalent",
       (DescriptiveDeclKind, DeclName, Type, Type, Type))
+ERROR(types_not_inherited_decl,none,
+      "%0 %1 requires that %2 inherit from %3",
+      (DescriptiveDeclKind, DeclName, Type, Type))
+ERROR(types_not_inherited_in_decl_ref,none,
+      "referencing %0 %1 on %2 requires that %3 inherit from %4",
+      (DescriptiveDeclKind, DeclName, Type, Type, Type))
 NOTE(where_requirement_failure_one_subst,none,
      "where %0 = %1", (Type, Type))
 NOTE(where_requirement_failure_both_subst,none,

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -262,6 +262,40 @@ protected:
   }
 };
 
+/// Diagnose failures related to superclass generic requirements, e.g.
+/// ```swift
+/// class A {
+/// }
+///
+/// class B {
+/// }
+///
+/// func foo<T>(_ t: [T]) where T: A {}
+/// foo([B()])
+/// ```
+///
+/// `A` is not the superclass of `B`, which is required by `foo<T>`.
+class SuperclassRequirementFailure final : public RequirementFailure {
+  Type LHS, RHS;
+
+public:
+  SuperclassRequirementFailure(Expr *expr, const Solution &solution, Type lhs,
+                               Type rhs, ConstraintLocator *locator)
+      : RequirementFailure(expr, solution, locator), LHS(lhs), RHS(rhs) {}
+
+  Type getLHS() const override { return LHS; }
+  Type getRHS() const override { return RHS; }
+
+protected:
+  DiagOnDecl getDiagnosticOnDecl() const override {
+    return diag::types_not_inherited_decl;
+  }
+
+  DiagInReference getDiagnosticInRereference() const override {
+    return diag::types_not_inherited_in_decl_ref;
+  }
+};
+
 /// Diagnose errors associated with missing, extraneous
 /// or incorrect labels supplied by arguments, e.g.
 /// ```swift

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -175,3 +175,15 @@ SkipSameTypeRequirement::create(ConstraintSystem &cs, Type lhs, Type rhs,
                                 ConstraintLocator *locator) {
   return new (cs.getAllocator()) SkipSameTypeRequirement(lhs, rhs, locator);
 }
+
+bool SkipSuperclassRequirement::diagnose(Expr *root,
+                                         const Solution &solution) const {
+  SuperclassRequirementFailure failure(root, solution, LHS, RHS, getLocator());
+  return failure.diagnose();
+}
+
+SkipSuperclassRequirement *
+SkipSuperclassRequirement::create(ConstraintSystem &cs, Type lhs, Type rhs,
+                                  ConstraintLocator *locator) {
+  return new (cs.getAllocator()) SkipSuperclassRequirement(lhs, rhs, locator);
+}

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -301,6 +301,26 @@ public:
                                          Type rhs, ConstraintLocator *locator);
 };
 
+/// Skip 'superclass' generic requirement constraint,
+/// and assume that types are equal.
+class SkipSuperclassRequirement final : public ConstraintFix {
+  Type LHS, RHS;
+
+  SkipSuperclassRequirement(Type lhs, Type rhs, ConstraintLocator *locator)
+      : ConstraintFix(FixKind::SkipSameTypeRequirement, locator), LHS(lhs),
+        RHS(rhs) {}
+
+public:
+  std::string getName() const override {
+    return "skip superclass generic requirement";
+  }
+
+  bool diagnose(Expr *root, const Solution &solution) const override;
+
+  static SkipSuperclassRequirement *
+  create(ConstraintSystem &cs, Type lhs, Type rhs, ConstraintLocator *locator);
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1662,8 +1662,11 @@ static void attemptToFixRequirementFailure(
     return;
   }
 
-  case RequirementKind::Superclass:
-    break; // Not yet supported
+  case RequirementKind::Superclass: {
+    auto *fix = SkipSuperclassRequirement::create(cs, type1, type2, reqLoc);
+    conversionsOrFixes.push_back(fix);
+    return;
+  }
 
   case RequirementKind::Conformance:
   case RequirementKind::Layout:

--- a/test/Generics/inheritance.swift
+++ b/test/Generics/inheritance.swift
@@ -12,7 +12,7 @@ class Other { }
 
 func acceptA(_ a: A) { }
 
-func f0<T : A>(_ obji: T, _ ai: A, _ bi: B) {
+func f0<T : A>(_ obji: T, _ ai: A, _ bi: B) { // expected-note {{where 'T' = 'Other'}}
   var obj = obji, a = ai, b = bi
   // Method access
   obj.foo()
@@ -39,7 +39,7 @@ func f0<T : A>(_ obji: T, _ ai: A, _ bi: B) {
 func call_f0(_ a: A, b: B, other: Other) {
   f0(a, a, b)
   f0(b, a, b)
-  f0(other, a, b) // expected-error{{cannot convert value of type 'Other' to expected argument type 'A'}}
+  f0(other, a, b) // expected-error{{global function 'f0' requires that 'Other' inherit from 'A'}}
 }
 
 class X<T> {

--- a/test/type/subclass_composition.swift
+++ b/test/type/subclass_composition.swift
@@ -300,9 +300,13 @@ func dependentMemberTypes<T : BaseIntAndP2>(
 func conformsToAnyObject<T : AnyObject>(_: T) {}
 func conformsToP1<T : P1>(_: T) {}
 func conformsToP2<T : P2>(_: T) {}
-func conformsToBaseIntAndP2<T : Base<Int> & P2>(_: T) {} // expected-note 3 {{where 'T' = 'Base<Int>'}}
+func conformsToBaseIntAndP2<T : Base<Int> & P2>(_: T) {}
+// expected-note@-1 2 {{where 'T' = 'Base<String>'}}
+// expected-note@-2   {{where 'T' = 'Base<Int>'}}
 
-func conformsToBaseIntAndP2WithWhereClause<T>(_: T) where T : Base<Int> & P2 {} // expected-note 2 {{where 'T' = 'Base<Int>'}}
+func conformsToBaseIntAndP2WithWhereClause<T>(_: T) where T : Base<Int> & P2 {}
+// expected-note@-1 {{where 'T' = 'Base<String>'}}
+// expected-note@-2 {{where 'T' = 'Base<Int>'}}
 
 class FakeDerived : Base<String>, P2 {
   required init(classInit: ()) {
@@ -417,13 +421,14 @@ func conformsTo<T1 : P2, T2 : Base<Int> & P2>(
   // expected-error@-1 {{argument type 'Base<Int>' does not conform to expected type 'P2'}}
 
   conformsToBaseIntAndP2(badBase)
-  // expected-error@-1 {{global function 'conformsToBaseIntAndP2' requires that 'Base<Int>' conform to 'P2'}}
+  // expected-error@-1 {{global function 'conformsToBaseIntAndP2' requires that 'Base<String>' inherit from 'Base<Int>'}}
+  // expected-error@-2 {{argument type 'Base<String>' does not conform to expected type 'P2'}}
 
   conformsToBaseIntAndP2(fakeDerived)
-  // expected-error@-1 {{global function 'conformsToBaseIntAndP2' requires that 'Base<Int>' conform to 'P2'}}
+  // expected-error@-1 {{global function 'conformsToBaseIntAndP2' requires that 'Base<String>' inherit from 'Base<Int>'}}
 
   conformsToBaseIntAndP2WithWhereClause(fakeDerived)
-  // expected-error@-1 {{global function 'conformsToBaseIntAndP2WithWhereClause' requires that 'Base<Int>' conform to 'P2'}}
+  // expected-error@-1 {{global function 'conformsToBaseIntAndP2WithWhereClause' requires that 'Base<String>' inherit from 'Base<Int>'}}
 
   conformsToBaseIntAndP2(p2Archetype)
   // expected-error@-1 {{global function 'conformsToBaseIntAndP2' requires that 'Base<Int>' conform to 'P2'}}

--- a/test/type/subclass_composition_objc.swift
+++ b/test/type/subclass_composition_objc.swift
@@ -24,13 +24,13 @@ class SomeMethods {
 
 // Test self-conformance
 
-func takesObjCClass<T : ObjCClass>(_: T) {}
+func takesObjCClass<T : ObjCClass>(_: T) {} // expected-note {{where 'T' = 'ObjCProtocol'}}
 func takesObjCProtocol<T : ObjCProtocol>(_: T) {}
-func takesObjCClassAndProtocol<T : ObjCClass & ObjCProtocol>(_: T) {} // expected-note {{where 'T' = 'ObjCClass'}}
+func takesObjCClassAndProtocol<T : ObjCClass & ObjCProtocol>(_: T) {} // expected-note {{where 'T' = 'ObjCProtocol'}}
 
 func testSelfConformance(c: ObjCClass, p: ObjCProtocol, cp: ObjCClass & ObjCProtocol) {
   takesObjCClass(c)
-  takesObjCClass(p) // expected-error {{cannot convert value of type 'ObjCProtocol' to expected argument type 'ObjCClass'}}
+  takesObjCClass(p) // expected-error {{global function 'takesObjCClass' requires that 'ObjCProtocol' inherit from 'ObjCClass'}}
   takesObjCClass(cp)
 
   takesObjCProtocol(c) // expected-error {{argument type 'ObjCClass' does not conform to expected type 'ObjCProtocol'}}
@@ -39,7 +39,7 @@ func testSelfConformance(c: ObjCClass, p: ObjCProtocol, cp: ObjCClass & ObjCProt
 
   // FIXME: Bad diagnostics
   takesObjCClassAndProtocol(c) // expected-error {{argument type 'ObjCClass' does not conform to expected type 'ObjCProtocol'}}
-  takesObjCClassAndProtocol(p) // expected-error {{global function 'takesObjCClassAndProtocol' requires that 'ObjCClass' conform to 'ObjCProtocol'}}
+  takesObjCClassAndProtocol(p) // expected-error {{global function 'takesObjCClassAndProtocol' requires that 'ObjCProtocol' inherit from 'ObjCClass'}}
   takesObjCClassAndProtocol(cp)
 }
 


### PR DESCRIPTION
Extend new requirement failure diagnostics by adding "superclass"
generic requirement failures.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
