### PR TITLE
Basic: guard inclusion of unistd.h on non-Unices

### DIFF
--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -27,8 +27,12 @@
 #include "llvm/Support/raw_ostream.h"
 #include <chrono>
 #include <limits>
-#include <unistd.h>
 
+#if LLVM_ON_UNIX
+#if HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#endif
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif


### PR DESCRIPTION
unistd.h is a Unix specific header.  Ensure that we do not try to include it on
non-unix environments (i.e. Windows).  This attempts to restore the Windows
build once again.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
