### PR TITLE
[AutoDiff] Add a code path for loadable types in AdjointEmitter

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -43,6 +43,7 @@
 #include "swift/SILOptimizer/Utils/Local.h"
 #include "swift/SILOptimizer/Utils/LoopUtils.h"
 #include "swift/Serialization/SerializedSILLoader.h"
+#include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/BreadthFirstIterator.h"
 #include "llvm/ADT/DenseSet.h"
 
@@ -1520,127 +1521,156 @@ reapplyFunctionConversion(SILValue newFunc, SILValue oldFunc,
   llvm_unreachable("Unhandled function convertion instruction");
 }
 
+/// Create a builtin floating point value. The specified type must be a builtin
+/// float type.
+static SILValue createBuiltinFPScalar(APFloat scalar, CanType type,
+                                      SILLocation loc, SILBuilder &builder) {
+  auto *fpType = type->castTo<BuiltinFloatType>();
+  // If the scalar is a floating point where the FP semantics are different from
+  // the specified FP type, perform a rounding conversion.
+  if (!scalar.isInteger() &&
+      &scalar.getSemantics() != &fpType->getAPFloatSemantics()) {
+    bool losesInfo = false;
+    scalar.convert(fpType->getAPFloatSemantics(),
+                   APFloat::rmNearestTiesToAway, &losesInfo);
+  }
+  // If the scalar is effectively an integer, just coerce it to the right FP
+  // semantics.
+  if (scalar.isInteger()) {
+    bool isExact = false;
+    llvm::APSInt integer;
+    scalar.convertToInteger(integer, APFloat::rmTowardZero, &isExact);
+    integer = integer.extOrTrunc(32);
+    scalar = APFloat(fpType->getAPFloatSemantics(), integer);
+  }
+  return builder.createFloatLiteral(
+      loc, SILType::getPrimitiveObjectType(type), scalar);
+}
+
 /// Convert an integer literal to a type that is expressible by integer literal.
-static void convertIntToIndirectExpressible(intmax_t value,
-                                            NominalTypeDecl *targetTypeDecl,
-                                            SILValue resultBuf, SILLocation loc,
-                                            SILBuilder &builder,
-                                            ADContext &context) {
+static void convertFloatToIndirectExpressible(APFloat scalar,
+                                              NominalTypeDecl *targetTypeDecl,
+                                              SILValue resultBuf,
+                                              SILLocation loc,
+                                              SILBuilder &builder,
+                                              ADContext &context) {
   auto &module = builder.getModule();
   auto &astCtx = module.getASTContext();
   auto targetTy =
       targetTypeDecl->getDeclaredInterfaceType()->getCanonicalType();
-  // Step 1. Initialize a value of type `<target type>.IntegerLiteralType` from
+  // Step 1. Initialize a value of type `<target type>.FloatLiteralType` from
   // the given value.
-  DeclName intLitTypeName(astCtx.Id_IntegerLiteralType);
-  SmallVector<ValueDecl *, 1> intLitTypeLookupResults;
-  targetTypeDecl->lookupQualified(targetTy, intLitTypeName, NL_OnlyTypes,
+  DeclName floatLitTypeName(astCtx.Id_FloatLiteralType);
+  SmallVector<ValueDecl *, 1> floatLitTypeLookupResults;
+  targetTypeDecl->lookupQualified(targetTy, floatLitTypeName, NL_OnlyTypes,
                                   /*typeResolver*/ nullptr,
-                                  intLitTypeLookupResults);
-  assert(intLitTypeLookupResults.size() == 1);
-  auto intLitTypeAliasDecl = cast<TypeAliasDecl>(intLitTypeLookupResults[0]);
-  // Now we have the IntegerLiteralType type.
-  auto intLitTy =
-      intLitTypeAliasDecl->getUnderlyingTypeLoc().getType()->getCanonicalType();
-  auto *intLitTypeDecl = intLitTy->getAnyNominal();
-  assert(intLitTypeDecl);
-  // %1 = integer_literal $Builtin.Int2048, <value>
-  auto builtinIntTy = SILType::getBuiltinIntegerType(2048, astCtx);
-  auto *builtinInt = builder.createIntegerLiteral(loc, builtinIntTy, value);
-  // %2 = metatype $@thin <target type>.IntegerLiteralType.Type
-  auto intLitMetatypeTy = SILType::getPrimitiveObjectType(
-      CanMetatypeType::get(intLitTy, MetatypeRepresentation::Thick));
-  auto *intLitMetatype = builder.createMetatype(loc, intLitMetatypeTy);
+                                  floatLitTypeLookupResults);
+  assert(floatLitTypeLookupResults.size() == 1);
+  auto floatLitTypeAliasDecl =
+      cast<TypeAliasDecl>(floatLitTypeLookupResults[0]);
+  // Now we have the FloatLiteralType type.
+  auto floatLitTy = floatLitTypeAliasDecl
+      ->getUnderlyingTypeLoc().getType()->getCanonicalType();
+  auto *floatLitTypeDecl = floatLitTy->getAnyNominal();
+  assert(floatLitTypeDecl);
+  // %1 = float_literal $Builtin.FPIEEE80, <value>
+  auto builtinFloatTy =
+      SILType::getBuiltinFloatType(BuiltinFloatType::FPKind::IEEE80, astCtx);
+  auto builtinFloat =
+      createBuiltinFPScalar(scalar, builtinFloatTy.getASTType(), loc, builder);
+  // %2 = metatype $@thin <target type>.FloatLiteralType.Type
+  auto floatLitMetatypeTy = SILType::getPrimitiveObjectType(
+      CanMetatypeType::get(floatLitTy, MetatypeRepresentation::Thick));
+  auto *floatLitMetatype = builder.createMetatype(loc, floatLitMetatypeTy);
   // ExpressibleByBuiltinIntegerLiteral
-  auto *ebilProto =
-      astCtx.getProtocol(KnownProtocolKind::ExpressibleByBuiltinIntegerLiteral);
-  // `init(_builtinIntegerLiteral:)`
+  auto *ebflProto =
+      astCtx.getProtocol(KnownProtocolKind::ExpressibleByBuiltinFloatLiteral);
+  // `init(_builtinFloatLiteral:)`
   DeclName builtinLitInitName(astCtx, DeclBaseName::createConstructor(),
-                              {astCtx.getIdentifier("_builtinIntegerLiteral")});
-  auto *initBILDecl =
-      cast<ConstructorDecl>(ebilProto->lookupDirect(builtinLitInitName)[0]);
-  SILDeclRef initBILDeclRef(initBILDecl);
-  auto initBILType = context.getTypeConverter().getConstantType(initBILDeclRef);
-  // Look up `IntegerLiteralType : _ExpressibleByBuiltinIntegerLiteral`. This is
+                              {astCtx.Id_builtinFloatLiteral});
+  auto *initBFLDecl =
+      cast<ConstructorDecl>(ebflProto->lookupDirect(builtinLitInitName)[0]);
+  SILDeclRef initBFLDeclRef(initBFLDecl);
+  auto initBFLType = context.getTypeConverter().getConstantType(initBFLDeclRef);
+  // Look up `FloatLiteralType : _ExpressibleByBuiltinFloatLiteral`. This is
   // guaranteed to be a normal conformance.
-  auto *ebilConf =
-      astCtx.getConformance(intLitTy, ebilProto, intLitTypeDecl->getLoc(),
-                            intLitTypeDecl, ProtocolConformanceState::Complete);
-  ProtocolConformanceRef ebilConfRef(ebilConf);
+  auto *ebflConf = astCtx.getConformance(floatLitTy, ebflProto,
+                                         floatLitTypeDecl->getLoc(),
+                                         floatLitTypeDecl,
+                                         ProtocolConformanceState::Complete);
+  ProtocolConformanceRef ebflConfRef(ebflConf);
   // Link witness table.
-  context.lookupOrLinkWitnessTable(ebilConfRef);
+  context.lookupOrLinkWitnessTable(ebflConfRef);
   // %3 = witness_method ...
-  auto initBILFn = builder.createWitnessMethod(loc, intLitTy, ebilConfRef,
-                                               initBILDeclRef, initBILType);
+  auto initBFLFn = builder.createWitnessMethod(loc, floatLitTy, ebflConfRef,
+                                               initBFLDeclRef, initBFLType);
   // Get substitutions.
-  auto intLitSubMap = SubstitutionMap::getProtocolSubstitutions(
-      ebilProto, intLitTy, ebilConfRef);
+  auto floatLitSubMap = SubstitutionMap::getProtocolSubstitutions(
+      ebflProto, floatLitTy, ebflConfRef);
   // Allocate result buffer.
-  // %intLitBuf = alloc_stack $IntegerLiteralType
-  auto *intLitBuf =
-      builder.createAllocStack(loc, SILType::getPrimitiveObjectType(intLitTy));
+  // %floatLitBuf = alloc_stack $FloatLiteralType
+  auto *floatLitBuf = builder.createAllocStack(
+      loc, SILType::getPrimitiveObjectType(floatLitTy));
   SWIFT_DEFER {
-    // dealloc_stack %intLitBuf : $*IntegerLiteralType
-    builder.createDeallocStack(loc, intLitBuf);
+    // dealloc_stack %floatLitBuf : $*FloatLiteralType
+    builder.createDeallocStack(loc, floatLitBuf);
   };
-  // %4 = apply %3 <...>(%intLitBuf, %1, %2)
-  builder.createApply(loc, initBILFn, intLitSubMap,
-                      {intLitBuf, builtinInt, intLitMetatype},
+  // %4 = apply %3 <...>(%floatLitBuf, %1, %2)
+  builder.createApply(loc, initBFLFn, floatLitSubMap,
+                      {floatLitBuf, builtinFloat, floatLitMetatype},
                       /*isNonThrowing*/ false);
 
   // Step 2. Initialize a value of type `<target type>` by calling
-  // %5 = metatype $@thin <target type>.IntegerLiteralType.Type
+  // %5 = metatype $@thin <target type>.FloatLiteralType.Type
   auto targetMetatypeTy = SILType::getPrimitiveObjectType(
       CanMetatypeType::get(targetTy, MetatypeRepresentation::Thick));
   auto *targetMetatype = builder.createMetatype(loc, targetMetatypeTy);
-  // `ExpressibleByIntegerLiteral.init(integerLiteral: %4)`.
-  auto *eilProto =
-      astCtx.getProtocol(KnownProtocolKind::ExpressibleByIntegerLiteral);
-  DeclName intLitInitName(astCtx, DeclBaseName::createConstructor(),
-                          {astCtx.getIdentifier("integerLiteral")});
-  auto *initILDecl =
-      cast<ConstructorDecl>(eilProto->lookupDirect(intLitInitName)[0]);
-  SILDeclRef initILDeclRef(initILDecl);
-  auto initILType = context.getTypeConverter().getConstantType(initILDeclRef);
-  // Lookup `<target type> : ExpressibleByIntegerLiteral` (could be specialized
-  // or inherited).
+  // `ExpressibleByIntegerLiteral.init(floatLiteral: %4)`.
+  auto *eflProto =
+      astCtx.getProtocol(KnownProtocolKind::ExpressibleByFloatLiteral);
+  DeclName floatLitInitName(astCtx, DeclBaseName::createConstructor(),
+                          {astCtx.Id_integerLiteral});
+  auto *initFLDecl =
+      cast<ConstructorDecl>(eflProto->lookupDirect(floatLitInitName)[0]);
+  SILDeclRef initFLDeclRef(initFLDecl);
+  auto initFLType = context.getTypeConverter().getConstantType(initFLDeclRef);
+  // Lookup `<target type> : ExpressibleByFloatLiteral`.
   auto *parentModule = targetTypeDecl->getModuleContext();
-  auto eilConf = *parentModule->lookupConformance(targetTy, eilProto);
-  ProtocolConformanceRef eilConfRef(eilConf);
-  context.lookupOrLinkWitnessTable(eilConfRef);
+  auto eflConf = *parentModule->lookupConformance(targetTy, eflProto);
+  ProtocolConformanceRef eflConfRef(eflConf);
+  context.lookupOrLinkWitnessTable(eflConfRef);
   // %6 = witness_method ...
-  auto initILFn = builder.createWitnessMethod(loc, targetTy, eilConfRef,
-                                              initILDeclRef, initILType);
+  auto initFLFn = builder.createWitnessMethod(loc, targetTy, eflConfRef,
+                                              initFLDeclRef, initFLType);
   // Get substitutions.
   auto targetSubMap =
-      SubstitutionMap::getProtocolSubstitutions(eilProto, targetTy, eilConfRef);
-  // %7 = apply %6 <...>(%resultBuf, %intLitBuf, %5)
-  builder.createApply(loc, initILFn, targetSubMap,
-                      {resultBuf, intLitBuf, targetMetatype},
+      SubstitutionMap::getProtocolSubstitutions(eflProto, targetTy, eflConfRef);
+  // %7 = apply %6 <...>(%resultBuf, %floatLitBuf, %5)
+  builder.createApply(loc, initFLFn, targetSubMap,
+                      {resultBuf, floatLitBuf, targetMetatype},
                       /*isNonThrowing*/ false);
 }
 
-/// Create a seed value.
+/// Create a scalar value in the specified type indirectly in a buffer.
 ///
-/// NOTE: This will be reduced to only support scalar AD when vector AD supports
-/// optional seeds, because a vector of 1s as seed doesn't make mathematical
-/// sense in vector AD.
-static void convertToIndirectSeed(intmax_t value, CanType type,
-                                  SILValue seedBuf, SILLocation loc,
-                                  SILBuilder &builder, ADContext &context) {
+/// The specified type must satisfy **one** of these requirements:
+/// - It is a builtin floating point type like `Builtin.FPIEEE32`.
+/// - It conforms to `FloatingPoint`.
+/// - It conforms `VectorNumeric` and its nested type `ScalarElement` conforms
+///   to `FloatingPoint`.
+///
+/// The root address derivation of `seedBufAccess` must be the result of
+/// `begin_access`.
+static void createScalarValueIndirect(APFloat scalar, CanType type,
+                                      SILValue seedBufAccess, SILLocation loc,
+                                      SILBuilder &builder, ADContext &context) {
   // See if the type is a builtin float. If so, we don't do protocol
   // conformance-based conversion.
-  if (auto fpType = type->getAs<BuiltinFloatType>()) {
-    auto one = builder.createFloatLiteral(
-        loc, SILType::getPrimitiveObjectType(type),
-        APFloat(fpType->getAPFloatSemantics(), value));
-    auto access = builder.createBeginAccess(loc, seedBuf, SILAccessKind::Init,
-                                            SILAccessEnforcement::Static,
-                                            /*noNestedConflict*/ true,
-                                            /*fromBuiltin*/ false);
-    builder.createStore(loc, one, access,
+  if (auto *fpType = type->getAs<BuiltinFloatType>()) {
+    auto scalarVal =
+        createBuiltinFPScalar(scalar, fpType->getCanonicalType(), loc, builder);
+    builder.createStore(loc, scalarVal, seedBufAccess,
                         getBufferSOQ(type, builder.getFunction()));
-    builder.createEndAccess(loc, access, /*aborted*/ false);
     return;
   }
 
@@ -1652,8 +1682,8 @@ static void convertToIndirectSeed(intmax_t value, CanType type,
   // If it's scalar differentiation, just convert the literal to the requested
   // type.
   if (context.supportsScalarDifferentiation(type)) {
-    convertIntToIndirectExpressible(value, targetTypeDecl, seedBuf, loc,
-                                    builder, context);
+    convertFloatToIndirectExpressible(scalar, targetTypeDecl, seedBufAccess,
+                                      loc, builder, context);
     return;
   }
   // Otherwise it must be vector differentiation, call
@@ -1673,8 +1703,8 @@ static void convertToIndirectSeed(intmax_t value, CanType type,
   // %0 = ... : $<scalar type>
   auto scalarBuf =
       builder.createAllocStack(loc, SILType::getPrimitiveObjectType(scalarTy));
-  convertIntToIndirectExpressible(value, scalarTyDecl, scalarBuf, loc, builder,
-                                  context);
+  convertFloatToIndirectExpressible(scalar, scalarTyDecl, scalarBuf, loc,
+                                    builder, context);
   auto scalarLOQ = getBufferLOQ(scalarTy, builder.getFunction());
   auto loadAccess = builder.createBeginAccess(
       loc, scalarBuf, SILAccessKind::Read, SILAccessEnforcement::Static,
@@ -1723,8 +1753,46 @@ static void convertToIndirectSeed(intmax_t value, CanType type,
       SubstitutionMap::getProtocolSubstitutions(vecNumProto, type, confRef);
   // %5 = apply %4(%3, %2, %1)
   builder.createApply(loc, initFnRef, initSubMap,
-                      {seedBuf, scalarValBuf, metatype},
+                      {seedBufAccess, scalarValBuf, metatype},
                       /*isNonThrowing*/ false);
+}
+
+/// Creates and returns a scalar value in the specified type.
+///
+/// The specified type must satisfy **one** of these requirements:
+/// - It is a builtin floating point type like `Builtin.FPIEEE32`.
+/// - It conforms to `FloatingPoint`.
+/// - It conforms `VectorNumeric` and its nested type `ScalarElement` conforms
+///   to `FloatingPoint`.
+///
+/// The specified type must be a loadable type.
+static SILValue createScalarValueDirect(APFloat scalar, CanType type,
+                                        SILLocation loc,
+                                        SILBuilder &builder,
+                                        ADContext &context) {
+  // Builtin values can be trivially created.
+  if (auto *fpType = type->getAs<BuiltinFloatType>())
+    return createBuiltinFPScalar(scalar, fpType->getCanonicalType(),
+                                 loc, builder);
+  // Otherwise, initiailize the value through protocol calls.
+  auto *buffer =
+      builder.createAllocStack(loc, SILType::getPrimitiveObjectType(type));
+  auto *access =
+      builder.createBeginAccess(loc, buffer, SILAccessKind::Init,
+                                SILAccessEnforcement::Static,
+                                /*noNestedConflict*/ true,
+                                /*fromBuiltin*/ false);
+  createScalarValueIndirect(scalar, type, access, loc, builder, context);
+  builder.createEndAccess(loc, access, /*aborted*/ false);
+  access = builder.createBeginAccess(loc, buffer, SILAccessKind::Read,
+                                     SILAccessEnforcement::Static,
+                                     /*noNestedConflict*/ true,
+                                     /*fromBuiltin*/ false);
+  auto *loadedValue = builder.createLoad(
+      loc, access, getBufferLOQ(type, builder.getFunction()));
+  builder.createEndAccess(loc, access, /*aborted*/ false);
+  builder.createDeallocStack(loc, buffer);
+  return loadedValue;
 }
 
 //===----------------------------------------------------------------------===//
@@ -2576,7 +2644,7 @@ public:
 
   Kind getKind() const { return kind; }
   SILType getType() const { return type; }
-  Type getSwiftType() const { return type.getASTType(); }
+  CanType getSwiftType() const { return type.getASTType(); }
 
   NominalTypeDecl *getNominalType() const {
     return getSwiftType()->getAnyNominal();
@@ -2769,7 +2837,7 @@ protected:
 
   /// Materialize an adjoint value. The type of the given adjoint value must be
   /// loadable.
-  SILValue materializeAdjoint(AdjointValue val, SILLocation loc);
+  SILValue materializeAdjointDirect(AdjointValue val, SILLocation loc);
 
   /// Materialize an adjoint value indirectly to a SIL buffer.
   void materializeAdjointIndirect(AdjointValue val, SILValue destBuffer);
@@ -2894,7 +2962,7 @@ public:
       auto adjParam = std::get<1>(paramPair);
       auto adjVal = getAdjointValue(origParam);
       if (adjParam->getType().isObject())
-        retElts.push_back(materializeAdjoint(adjVal, adjLoc));
+        retElts.push_back(materializeAdjointDirect(adjVal, adjLoc));
       else
         materializeAdjointIndirect(adjVal, adjParam);
     }
@@ -3161,7 +3229,7 @@ public:
     case AdjointValue::Kind::Materialized:
     case AdjointValue::Kind::Tuple:
       SmallVector<SILValue, 8> eltVals;
-      auto adj = materializeAdjoint(av, sei->getLoc());
+      auto adj = materializeAdjointDirect(av, sei->getLoc());
       auto *structBuf =
           getBuilder().createAllocStack(sei->getLoc(), structDeclSILTy);
       auto *bufAccess = builder.createBeginAccess(
@@ -3267,7 +3335,7 @@ public:
       addAdjointValue(bi->getOperand(1), adj);
       break;
     case BuiltinValueKind::FSub: {
-      auto adjVal = materializeAdjoint(adj, opLoc);
+      auto adjVal = materializeAdjointDirect(adj, opLoc);
       addAdjointValue(bi->getOperand(0), adjVal);
       // NOTE: `createBuiltinBinaryFunction` is general enough to work on
       // builtin functions with arbitrary arity.
@@ -3277,14 +3345,14 @@ public:
       break;
     }
     case BuiltinValueKind::FNeg: {
-      auto adjVal = materializeAdjoint(adj, opLoc);
+      auto adjVal = materializeAdjointDirect(adj, opLoc);
       auto *neg = builder.createBuiltinBinaryFunction(opLoc, "fneg", opType,
                                                       opType, {adjVal});
       addAdjointValue(bi->getOperand(0), neg);
       break;
     }
     case BuiltinValueKind::FMul: {
-      auto adjVal = materializeAdjoint(adj, opLoc);
+      auto adjVal = materializeAdjointDirect(adj, opLoc);
       auto *adjLHS = builder.createBuiltinBinaryFunction(
           opLoc, "fmul", opType, opType,
           {adjVal, remapValue(bi->getOperand(1))});
@@ -3296,7 +3364,7 @@ public:
       break;
     }
     case BuiltinValueKind::FDiv: {
-      auto adjVal = materializeAdjoint(adj, opLoc);
+      auto adjVal = materializeAdjointDirect(adj, opLoc);
       auto lhs = remapValue(bi->getOperand(0));
       auto rhs = remapValue(bi->getOperand(1));
       // x' = seed / y
@@ -3346,21 +3414,35 @@ void AdjointEmitter::rematerializeOriginalInstruction(SILInstruction *inst) {
   rematCloner.visit(inst);
 }
 
-// TODO: What if value was not loadable? Consider removing this functon entirely
-// and force indirect for all cases for the ease of implementation.
-SILValue AdjointEmitter::materializeAdjoint(AdjointValue value,
-                                            SILLocation loc) {
-  auto valueBuf = getBuilder().createAllocStack(loc, value.getType());
-  SWIFT_DEFER { getBuilder().createDeallocStack(loc, valueBuf); };
-  materializeAdjointIndirect(value, valueBuf);
-  auto access = getBuilder().createBeginAccess(
-      loc, valueBuf, SILAccessKind::Read, SILAccessEnforcement::Static,
-      /*noNestedConflict*/ true,
-      /*fromBuiltin*/ false);
-  auto loq = getBufferLOQ(value.getType().getASTType(), getAdjoint());
-  auto val = getBuilder().createLoad(loc, valueBuf, loq);
-  getBuilder().createEndAccess(loc, access, /*aborted*/ false);
-  return val;
+SILValue AdjointEmitter::materializeAdjointDirect(AdjointValue val,
+                                                  SILLocation loc) {
+  auto &builder = getBuilder();
+  auto &ctx = getContext();
+  switch (val.getKind()) {
+  case AdjointValue::Kind::Zero: {
+    if (auto tupleTy = val.getType().getAs<TupleType>()) {
+      auto elts = map<SmallVector<SILValue, 8>>(tupleTy->getElementTypes(),
+          [&](Type eltTy) {
+            return createScalarValueDirect(APFloat(0.0),
+                                           eltTy->getCanonicalType(),
+                                           loc, builder, ctx);
+          });
+      return builder.createTuple(loc, elts);
+    }
+    return createScalarValueDirect(
+        APFloat(0.0), val.getType().getASTType(), loc, builder, ctx);
+  }
+  case AdjointValue::Kind::Tuple: {
+    auto elts = map<SmallVector<SILValue, 8>>(
+        val.getTupleElements(),
+        [&](const AdjointValue &elt) {
+          return materializeAdjointDirect(elt, loc);
+        });
+    return builder.createTuple(loc, elts);
+  }
+  case AdjointValue::Kind::Materialized:
+    return val.getMaterializedValue();
+  }
 }
 
 void AdjointEmitter::materializeAdjointIndirect(AdjointValue val,
@@ -3383,24 +3465,24 @@ void AdjointEmitter::materializeAdjointIndirect(AdjointValue val,
       for (unsigned i : range(tupleTy->getNumElements())) {
         auto eltAddr = getBuilder().createTupleElementAddr(loc, destBuffer, i);
         auto elt = tupleTy->getElement(i);
-        convertIntToIndirectExpressible(0, elt.getType()->getAnyNominal(),
-                                        eltAddr, loc, getBuilder(),
-                                        getContext());
+        convertFloatToIndirectExpressible(APFloat(0.0),
+                                          elt.getType()->getAnyNominal(),
+                                          eltAddr, loc, getBuilder(),
+                                          getContext());
       }
     } else if (auto builtinFP = val.getType().getAs<BuiltinFloatType>()) {
       auto *access = getBuilder().createBeginAccess(
           loc, destBuffer, SILAccessKind::Init, SILAccessEnforcement::Static,
           /*noNestedConflict*/ true, /*fromBuiltin*/ false);
-      auto *zero = getBuilder().createFloatLiteral(
-          loc, val.getType(), APFloat(builtinFP->getAPFloatSemantics(), 0));
+      auto zero = createBuiltinFPScalar(APFloat(0.0), builtinFP, loc, builder);
       getBuilder().createStore(loc, zero, access,
                                getBufferSOQ(builtinFP, getAdjoint()));
       getBuilder().createEndAccess(loc, access, /*aborted*/ false);
     } else {
       auto *nomTy = val.getSwiftType()->getAnyNominal();
       assert(nomTy);
-      convertIntToIndirectExpressible(0, nomTy, destBuffer, loc, getBuilder(),
-                                      getContext());
+      convertFloatToIndirectExpressible(APFloat(0.0), nomTy, destBuffer, loc,
+                                        getBuilder(), getContext());
     }
     break;
   /// Given a `%buf : *(T0, T1, T2, ...)`, recursively emit instructions to
@@ -3674,7 +3756,8 @@ static SILFunction *lookupOrSynthesizeGradient(ADContext &context,
       // Call `<seed type>.init(1)` to create a default
       // seed to feed into the canonical gradient.
       auto *seedBuf = builder.createAllocStack(loc, seedSILTy);
-      convertToIndirectSeed(1, seedTy, seedBuf, loc, builder, context);
+      createScalarValueIndirect(
+          APFloat(1.0), seedTy, seedBuf, loc, builder, context);
       // If seed is address only, we'll clean up the buffer after calling the
       // canonical gradient Otherwise, we just load the seed and deallocate the
       // buffer.

--- a/test/AutoDiff/builtin_math.sil
+++ b/test/AutoDiff/builtin_math.sil
@@ -11,6 +11,12 @@ bb0(%0 : @trivial $Builtin.FPIEEE32, %1 : @trivial $Builtin.FPIEEE32):
   return %2 : $Builtin.FPIEEE32
 }
 
+sil @simple_div : $@convention(thin) (Builtin.FPIEEE32, Builtin.FPIEEE32) -> Builtin.FPIEEE32 {
+bb0(%0 : @trivial $Builtin.FPIEEE32, %1 : @trivial $Builtin.FPIEEE32):
+  %2 = builtin "fdiv_FPIEEE32"(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
+  return %2 : $Builtin.FPIEEE32
+}
+
 sil @chain_rule : $@convention(thin) (Builtin.FPIEEE32, Builtin.FPIEEE32) -> Builtin.FPIEEE32 {
 bb0(%0 : @trivial $Builtin.FPIEEE32, %1 : @trivial $Builtin.FPIEEE32):
   %2 = builtin "fneg_FPIEEE32"(%0 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
@@ -26,6 +32,7 @@ bb0(%0 : @trivial $Builtin.FPIEEE32, %1 : @trivial $Builtin.FPIEEE32):
   %5 = builtin "fsub_FPIEEE32"(%4 : $Builtin.FPIEEE32, %3 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
   return %5 : $Builtin.FPIEEE32
 }
+
 sil @fanout : $@convention(thin) (Builtin.FPIEEE32, Builtin.FPIEEE32) -> Builtin.FPIEEE32 {
 bb0(%0 : @trivial $Builtin.FPIEEE32, %1 : @trivial $Builtin.FPIEEE32):
   // f(x, y) =
@@ -44,6 +51,11 @@ bb0(%0 : @trivial $Builtin.FPIEEE32):
   %simple_mul = function_ref @simple_mul : $@convention(thin) (Builtin.FPIEEE32, Builtin.FPIEEE32) -> Builtin.FPIEEE32
   %simple_mul_grad = gradient [source 0] [wrt 0, 1] %simple_mul : $@convention(thin) (Builtin.FPIEEE32, Builtin.FPIEEE32) -> Builtin.FPIEEE32
 
+  // FIXME(SR-8584): Uncomment this test when the crasher gets fixed.
+  //
+  // %simple_div = function_ref @simple_div : $@convention(thin) (Builtin.FPIEEE32, Builtin.FPIEEE32) -> Builtin.FPIEEE32
+  // %simple_div_grad = gradient [source 0] [wrt 0, 1] %simple_div : $@convention(thin) (Builtin.FPIEEE32, Builtin.FPIEEE32) -> Builtin.FPIEEE32
+
   %chain_rule = function_ref @chain_rule : $@convention(thin) (Builtin.FPIEEE32, Builtin.FPIEEE32) -> Builtin.FPIEEE32
   %chain_rule_grad = gradient [source 0] [wrt 0, 1] %chain_rule : $@convention(thin) (Builtin.FPIEEE32, Builtin.FPIEEE32) -> Builtin.FPIEEE32
 
@@ -58,6 +70,10 @@ bb0(%0 : @trivial $Builtin.FPIEEE32):
 }
 
 // CHECK-LABEL: struct simple_mul__Type {
+// CHECK:   @sil_stored var v_0: Builtin.FPIEEE32
+// CHECK: }
+
+// CHECK-LABEL: struct simple_div__Type {
 // CHECK:   @sil_stored var v_0: Builtin.FPIEEE32
 // CHECK: }
 


### PR DESCRIPTION
* Add a code path for loadable types in AdjointEmitter.
* Switch to floating point scalar initialization.
* Add division test (pending [SR-8584](https://bugs.swift.org/browse/SR-8584)).