### PR TITLE
[libSyntax] Fix places in which RawSyntax nodes were created without an arena

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1259,7 +1259,8 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
       if (SyntaxContext->isEnabled()) {
         // Add dummy blank argument list to the call expression syntax.
         SyntaxContext->addSyntax(
-            SyntaxFactory::makeBlankFunctionCallArgumentList());
+            SyntaxFactory::makeBlankFunctionCallArgumentList(
+                &SyntaxContext->getArena()));
       }
 
       ParserResult<Expr> closure =
@@ -1547,10 +1548,10 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
                      : VarDecl::Specifier::Var;
       auto pattern = createBindingFromPattern(loc, name, specifier);
       if (SyntaxContext->isEnabled()) {
-        PatternSyntax PatternNode =
-            SyntaxFactory::makeIdentifierPattern(SyntaxContext->popToken());
-        ExprSyntax ExprNode =
-            SyntaxFactory::makeUnresolvedPatternExpr(PatternNode);
+        PatternSyntax PatternNode = SyntaxFactory::makeIdentifierPattern(
+            SyntaxContext->popToken(), &SyntaxContext->getArena());
+        ExprSyntax ExprNode = SyntaxFactory::makeUnresolvedPatternExpr(
+            PatternNode, &SyntaxContext->getArena());
         SyntaxContext->addSyntax(ExprNode);
       }
       return makeParserResult(new (Context) UnresolvedPatternExpr(pattern));
@@ -1658,7 +1659,8 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
       if (SyntaxContext->isEnabled()) {
         // Add dummy blank argument list to the call expression syntax.
         SyntaxContext->addSyntax(
-            SyntaxFactory::makeBlankFunctionCallArgumentList());
+            SyntaxFactory::makeBlankFunctionCallArgumentList(
+                &SyntaxContext->getArena()));
       }
 
       ParserResult<Expr> closure =
@@ -2028,7 +2030,8 @@ DeclName Parser::parseUnqualifiedDeclName(bool afterDot,
     SyntaxParsingContext ArgsCtxt(SyntaxContext, SyntaxKind::DeclNameArguments);
     consumeToken(tok::l_paren);
     if (SyntaxContext->isEnabled())
-      SyntaxContext->addSyntax(SyntaxFactory::makeBlankDeclNameArgumentList());
+      SyntaxContext->addSyntax(SyntaxFactory::makeBlankDeclNameArgumentList(
+          &SyntaxContext->getArena()));
     consumeToken(tok::r_paren);
     loc = DeclNameLoc(baseNameLoc);
     SmallVector<Identifier, 2> argumentLabels;

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -438,8 +438,8 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
           .useArguments(TupleTypeNode->getElements())
           .useRightParen(TupleTypeNode->getRightParen());
       } else {
-        Builder
-          .addTupleTypeElement(SyntaxFactory::makeTupleTypeElement(InputNode));
+        Builder.addTupleTypeElement(SyntaxFactory::makeTupleTypeElement(
+            InputNode, /*TrailingComma=*/None, &Context.getSyntaxArena()));
       }
       SyntaxContext->addSyntax(Builder.build());
     }
@@ -719,7 +719,8 @@ Parser::parseTypeSimpleOrComposition(Diag<> MessageID,
 
   if (SyntaxContext->isEnabled() && Status.isSuccess()) {
     auto LastNode = SyntaxFactory::makeCompositionTypeElement(
-        SyntaxContext->popIf<TypeSyntax>().getValue(), None);
+        SyntaxContext->popIf<TypeSyntax>().getValue(), None,
+        &SyntaxContext->getArena());
     SyntaxContext->addSyntax(LastNode);
   }
   SyntaxContext->collectNodesInPlace(SyntaxKind::CompositionTypeElementList);


### PR DESCRIPTION
We were failing to pass the `SyntaxArena` to the creation of `RawSyntax` nodes in some places and thus allocating the nodes using `malloc` instead of the bump allocator. With this PR we correctly pass the arena.