### PR TITLE
[TF API] Implement DoubleValueDataset and and random dataset ops

### DIFF
--- a/stdlib/public/TensorFlow/Dataset.swift
+++ b/stdlib/public/TensorFlow/Dataset.swift
@@ -174,7 +174,8 @@ public extension SingleValueDataset {
       _handle: #tfop(
         "BatchDataset", _handle, Tensor<Int64>(batchSize),
         output_types: [ScalarOfElement.self], output_shapes: [elementShape]
-      )
+      ),
+      elementShape: elementShape
     )
   }
 }
@@ -348,7 +349,8 @@ public extension DoubleValueDataset {
         "ShuffleDataset", _handle, Tensor<Int64>(sampleCount), seed1, seed2,
         output_types: [ScalarOfFirstElement.self, ScalarOfSecondElement.self],
         output_shapes: [elementShapes.0, elementShapes.1]
-      )
+      ),
+      elementShapes: elementShapes
     )
   }
 
@@ -359,7 +361,8 @@ public extension DoubleValueDataset {
         "BatchDataset", _handle, Tensor<Int64>(batchSize),
         output_types: [ScalarOfFirstElement.self, ScalarOfSecondElement.self],
         output_shapes: [elementShapes.0, elementShapes.1]
-      )
+      ),
+      elementShapes: elementShapes
     )
   }
 }

--- a/stdlib/public/TensorFlow/Dataset.swift
+++ b/stdlib/public/TensorFlow/Dataset.swift
@@ -12,6 +12,40 @@
 //
 // The dataset API.
 //
+// NOTE: `SingleValueDataset`, `DoubleValueDataset`, etc are interfaces
+// duplicated for different arities, and they are so because of limitations of
+// the type system and the `#tfop` interface. While the future direction is to
+// have one `Dataset<Element>` type to unify all datasets, e.g.
+// `Dataset<(Tensor<Float>, Tensor<Int32>)>`, Arbitrary arity Dataset types are
+// not possible until two new features of `#tfop` are implemented. Please refer
+// to SR-8573 and SR-8574 for more details.
+//
+//===----------------------------------------------------------------------===//
+
+/// The default graph seed.
+///
+/// - Note: See TensorFlow's `python.framework.random_seed.DEFAULT_GRAPH_SEED`.
+@usableFromInline let _defaultGraphSeed: Int64 = 87654321
+
+/// Returns the local seeds an operation should use given an op-specific seed.
+///
+/// Given operation-specific seed, `seed`, this helper function returns two
+/// seeds derived from graph-level and op-level seeds. Many random operations
+/// internally use the two seeds to allow user to change the seed globally for a
+/// graph, or for only specific operations.
+///
+/// - Note: See TensorFlow's `python.framework.random_seed.get_seed`.
+///
+// TODO: There's no support for TF's "global seed" yet, so we always use the
+// default graph seed as the first seed. Need to investigate the best way to
+// model TF's "global seed".
+@usableFromInline
+func _tensorSeeds(_ seed: Tensor<Int64>) -> (Tensor<Int64>, Tensor<Int64>) {
+  return (Tensor(_defaultGraphSeed), seed)
+}
+
+//===----------------------------------------------------------------------===//
+// Single value dataset
 //===----------------------------------------------------------------------===//
 
 /// Represents a potentially large set of elements.
@@ -27,6 +61,19 @@ public struct SingleValueDataset<ScalarOfElement : AccelerableByTensorFlow> {
   internal init(_handle: VariantHandle, elementShape: TensorShape) {
     self._handle = _handle
     self.elementShape = elementShape
+  }
+}
+
+public extension SingleValueDataset {
+  init(randomSeed: Int64, elementShape: TensorShape) {
+    let (seed1, seed2) = _tensorSeeds(Tensor(randomSeed))
+    enableCPU()
+    self.init(
+      _handle: #tfop("RandomDataset", seed1, seed2,
+                     output_types: [ScalarOfElement.self],
+                     output_shapes: [elementShape]),
+      elementShape: elementShape
+    )
   }
 }
 
@@ -54,7 +101,7 @@ public extension SingleValueDataset {
 extension SingleValueDataset : Sequence {
   public typealias Element = Tensor<ScalarOfElement>
 
-  public typealias Iterator = SingleValueDatasetIterator
+  public typealias Iterator = SingleValueDatasetIterator<ScalarOfElement>
 
   /// Returns an iterator over the elements of this dataset.
   @inlinable @inline(__always)
@@ -73,9 +120,9 @@ public extension SingleValueDataset {
   func map<T : AccelerableByTensorFlow>(
     _ transform: @convention(tensorflow) (Tensor<ScalarOfElement>) -> Tensor<T>
   ) -> SingleValueDataset<T> {
-    // FIXME: If we pass an empty Array<TensorHandle<T>> as other_arguments and
-    // an empty Array<Any.Type> as Targuments, partitioning won't recognize the
-    // attribute:
+    // FIXME(SR-8570): If we pass an empty Array<TensorHandle<T>> as
+    // other_arguments and an empty Array<Any.Type> as Targuments, partitioning
+    // won't recognize the attribute:
     //    error: unknown array attribute
     return SingleValueDataset<T>(
       _handle: #tfop(
@@ -92,9 +139,9 @@ public extension SingleValueDataset {
     _ isIncluded:
       @convention(tensorflow) (Tensor<ScalarOfElement>) -> Tensor<Bool>
   ) -> SingleValueDataset {
-    // FIXME: If we pass an empty Array<TensorHandle<T>> as other_arguments and
-    // an empty Array<Any.Type> as Targuments, partitioning won't recognize the
-    // attribute:
+    // FIXME(SR-8570): If we pass an empty Array<TensorHandle<T>> as
+    // other_arguments and an empty Array<Any.Type> as Targuments, partitioning
+    // won't recognize the attribute:
     //    error: unknown array attribute
     return SingleValueDataset(
       _handle: #tfop(
@@ -103,6 +150,31 @@ public extension SingleValueDataset {
         output_types: [ScalarOfElement.self], output_shapes: [elementShape]
       ),
       elementShape: elementShape
+    )
+  }
+
+  // TODO: Make default seeds consistent with TensorFlow Python API.
+  @inlinable @inline(__always)
+  func shuffled(
+    sampleCount: Int64, randomSeed: Int64 = 42
+  ) -> SingleValueDataset {
+    let (seed1, seed2) = _tensorSeeds(Tensor(randomSeed))
+    return SingleValueDataset(
+      _handle: #tfop(
+        "ShuffleDataset", _handle, Tensor<Int64>(sampleCount), seed1, seed2,
+        output_types: [ScalarOfElement.self], output_shapes: [elementShape]
+      ),
+      elementShape: elementShape
+    )
+  }
+
+  @inlinable @inline(__always)
+  func batched(_ batchSize: Int64) -> SingleValueDataset {
+    return SingleValueDataset(
+      _handle: #tfop(
+        "BatchDataset", _handle, Tensor<Int64>(batchSize),
+        output_types: [ScalarOfElement.self], output_shapes: [elementShape]
+      )
     )
   }
 }
@@ -127,7 +199,7 @@ extension SingleValueDatasetIterator : IteratorProtocol {
   // Advances to the next element and returns it, or nil if no next element
   // exists.
   @inlinable @inline(__always)
-  public mutating func next() -> Tensor<ScalarOfElement>? {
+  public mutating func next() -> Element? {
     let optional: VariantHandle =
       #tfop("IteratorGetNextAsOptional", handle,
             output_types: [ScalarOfElement.self], output_shapes: [elementShape])
@@ -138,4 +210,212 @@ extension SingleValueDatasetIterator : IteratorProtocol {
                                 output_types: [ScalarOfElement.self],
                                 output_shapes: [elementShape]))
   }
+}
+
+//===----------------------------------------------------------------------===//
+// Double value dataset
+//===----------------------------------------------------------------------===//
+
+/// Represents a potentially large set of elements.
+///
+/// A `DoubleValueDataset` can be used to represent an input pipeline as a
+/// collection of element tensor tuples.
+@_fixed_layout
+public struct DoubleValueDataset<ScalarOfFirstElement, ScalarOfSecondElement>
+  where ScalarOfFirstElement : AccelerableByTensorFlow,
+        ScalarOfSecondElement : AccelerableByTensorFlow {
+  @usableFromInline let _handle: VariantHandle
+  public let elementShapes: (TensorShape, TensorShape)
+
+  @usableFromInline @inline(__always)
+  internal init(_handle: VariantHandle,
+                elementShapes: (TensorShape, TensorShape)) {
+    self._handle = _handle
+    self.elementShapes = elementShapes
+  }
+}
+
+public extension DoubleValueDataset {
+  init(randomSeed: Int64, elementShape: TensorShape) {
+    let (seed1, seed2) = _tensorSeeds(Tensor(randomSeed))
+    enableCPU()
+    self.init(
+      _handle: #tfop("RandomDataset", seed1, seed2,
+                     output_types: [ScalarOfFirstElement.self,
+                                    ScalarOfSecondElement.self],
+                     output_shapes: [elementShapes.0, elementShapes.1]),
+      elementShapes: elementShapes
+    )
+  }
+}
+
+public extension DoubleValueDataset {
+  /// Creates a dataset from a batch of elements as a tensor.
+  ///
+  /// - Parameter
+  ///   - elements: The batch of elements.
+  ///   - elementShape: The shape that the 
+  @inlinable @inline(__always)
+  public init(elements: (Tensor<ScalarOfFirstElement>,
+                         Tensor<ScalarOfSecondElement>),
+              elementShapes: (TensorShape, TensorShape)) {
+    // A dataset creation op only runs on TF CPU.
+    enableCPU()
+    self.init(
+      _handle: #tfop(
+        "TensorSliceDataset", [elements.0, elements.1],
+        Toutput_types: [ScalarOfFirstElement.self, ScalarOfSecondElement.self],
+        output_shapes: [elementShapes.0, elementShapes.1]
+      ),
+      elementShapes: elementShapes
+    )
+  }
+}
+
+extension DoubleValueDataset : Sequence {
+  public typealias Element = (Tensor<ScalarOfFirstElement>,
+                              Tensor<ScalarOfSecondElement>)
+
+  public typealias Iterator =
+    DoubleValueDatasetIterator<ScalarOfFirstElement, ScalarOfSecondElement>
+
+  /// Returns an iterator over the elements of this dataset.
+  @inlinable @inline(__always)
+  public func makeIterator()
+    -> DoubleValueDatasetIterator<ScalarOfFirstElement, ScalarOfSecondElement> {
+    let resource: ResourceHandle =
+      #tfop("AnonymousIterator",
+            output_types: [ScalarOfFirstElement.self,
+                           ScalarOfSecondElement.self],
+            output_shapes: [elementShapes.0, elementShapes.1])
+    #tfop("MakeIterator", _handle, resource) as Void
+    return DoubleValueDatasetIterator(_handle: resource,
+                                      elementShapes: elementShapes)
+  }
+}
+
+public extension DoubleValueDataset {
+  @inlinable @inline(__always)
+  func map<T : AccelerableByTensorFlow, U : AccelerableByTensorFlow>(
+    _ transform:
+      @convention(tensorflow) (Tensor<ScalarOfFirstElement>,
+                               Tensor<ScalarOfSecondElement>) -> Tensor<T>
+  ) -> DoubleValueDataset<T, U> {
+    // FIXME(SR-8570): If we pass an empty Array<TensorHandle<T>> as
+    // other_arguments and an empty Array<Any.Type> as Targuments, partitioning
+    // won't recognize the attribute:
+    //    error: unknown array attribute
+    return DoubleValueDataset<T, U>(
+      _handle: #tfop(
+        "MapDataset", _handle, [Tensor<Int32>(0)], f: transform,
+        Targuments: [Int32.self],
+        output_types: [T.self, U.self],
+        output_shapes: [elementShapes.0, elementShapes.1]
+      ),
+      elementShapes: elementShapes
+    )
+  }
+
+  @inlinable @inline(__always)
+  func filter(
+    _ isIncluded:
+      @convention(tensorflow) (Tensor<ScalarOfFirstElement>,
+                               Tensor<ScalarOfSecondElement>) -> Tensor<Bool>
+  ) -> DoubleValueDataset {
+    // FIXME(SR-8570): If we pass an empty Array<TensorHandle<T>> as
+    // other_arguments and an empty Array<Any.Type> as Targuments, partitioning
+    // won't recognize the attribute:
+    //    error: unknown array attribute
+    return DoubleValueDataset(
+      _handle: #tfop(
+        "FilterDataset", _handle, [Tensor<Int32>(0)],
+        predicate: isIncluded, Targuments: [Int32.self],
+        output_types: [ScalarOfFirstElement.self, ScalarOfSecondElement.self],
+        output_shapes: [elementShapes.0, elementShapes.1]
+      ),
+      elementShapes: elementShapes
+    )
+  }
+
+  // TODO: Make default seeds consistent with TensorFlow Python API.
+  @inlinable @inline(__always)
+  func shuffled(
+    sampleCount: Int64, randomSeed: Int64 = 42
+  ) -> DoubleValueDataset {
+    let (seed1, seed2) = _tensorSeeds(Tensor(randomSeed))
+    return DoubleValueDataset(
+      _handle: #tfop(
+        "ShuffleDataset", _handle, Tensor<Int64>(sampleCount), seed1, seed2,
+        output_types: [ScalarOfFirstElement.self, ScalarOfSecondElement.self],
+        output_shapes: [elementShapes.0, elementShapes.1]
+      )
+    )
+  }
+
+  @inlinable @inline(__always)
+  func batched(_ batchSize: Int64) -> DoubleValueDataset {
+    return DoubleValueDataset(
+      _handle: #tfop(
+        "BatchDataset", _handle, Tensor<Int64>(batchSize),
+        output_types: [ScalarOfFirstElement.self, ScalarOfSecondElement.self],
+        output_shapes: [elementShapes.0, elementShapes.1]
+      )
+    )
+  }
+}
+
+/// Represents the state of iterating through a `DoubleValueDataset`.
+@_fixed_layout
+public struct DoubleValueDatasetIterator<ScalarOfFirstElement,
+                                         ScalarOfSecondElement>
+    where ScalarOfFirstElement : AccelerableByTensorFlow,
+          ScalarOfSecondElement : AccelerableByTensorFlow {
+  @usableFromInline let handle: ResourceHandle
+  public let elementShapes: (TensorShape, TensorShape)
+
+  @usableFromInline @inline(__always)
+  internal init(_handle: ResourceHandle,
+                elementShapes: (TensorShape, TensorShape)) {
+    self.handle = _handle
+    self.elementShapes = elementShapes
+  }
+}
+
+extension DoubleValueDatasetIterator : IteratorProtocol {
+  public typealias Element = (Tensor<ScalarOfFirstElement>,
+                              Tensor<ScalarOfSecondElement>)
+
+  // Advances to the next element and returns it, or nil if no next element
+  // exists.
+  @inlinable @inline(__always)
+  public mutating func next() -> Element? {
+    let optional: VariantHandle =
+      #tfop("IteratorGetNextAsOptional", handle,
+            output_types: [ScalarOfFirstElement.self,
+                           ScalarOfSecondElement.self],
+            output_shapes: [elementShapes.0, elementShapes.1])
+    guard _TFGetScalarOrDie(#tfop("OptionalHasValue", optional)) else {
+      return nil
+    }
+    let (firstHandle, secondHandle): (TensorHandle<ScalarOfFirstElement>,
+                                      TensorHandle<ScalarOfSecondElement>) =
+      #tfop("OptionalGetValue", optional,
+            output_types: [ScalarOfFirstElement.self,
+                           ScalarOfSecondElement.self],
+            output_shapes: [elementShapes.0, elementShapes.1])
+    return (Tensor(handle: firstHandle), Tensor(handle: secondHandle))
+  }
+}
+
+@inlinable @inline(__always)
+public func zip<T, U>(
+  _ first: SingleValueDataset<T>,
+  _ second: SingleValueDataset<U>
+) -> DoubleValueDataset<T, U> {
+  return DoubleValueDataset(
+    _handle: #tfop("ZipDataset", [first, second],
+                   output_types: [T.self, U.self],
+                   output_shapes: [first.elementShape, second.elementShape]),
+    elementShapes: (first.elementShape, second.elementShape)
+  )
 }

--- a/stdlib/public/TensorFlow/Dataset.swift
+++ b/stdlib/public/TensorFlow/Dataset.swift
@@ -237,7 +237,7 @@ public struct DoubleValueDataset<ScalarOfFirstElement, ScalarOfSecondElement>
 }
 
 public extension DoubleValueDataset {
-  init(randomSeed: Int64, elementShape: TensorShape) {
+  init(randomSeed: Int64, elementShapes: (TensorShape, TensorShape)) {
     let (seed1, seed2) = _tensorSeeds(Tensor(randomSeed))
     enableCPU()
     self.init(

--- a/test/TensorFlowRuntime/dataset_api.swift
+++ b/test/TensorFlowRuntime/dataset_api.swift
@@ -17,7 +17,8 @@ var DatasetAPITests = TestSuite("DatasetAPI")
 
 DatasetAPITests.testAllBackends("SingleValueManualIterator") {
   // [[1], [2], [3], [4], [5]]
-  let scalars = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1).reshaped(to: [5, 1])
+  let scalars = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1)
+    .reshaped(to: [5, 1])
   let dataset = SingleValueDataset(elements: scalars, elementShape: [1])
   var iterator = dataset.makeIterator()
   var i: Int32 = 0
@@ -29,7 +30,8 @@ DatasetAPITests.testAllBackends("SingleValueManualIterator") {
 
 DatasetAPITests.testAllBackends("SingleValueDatasetIteration") {
   // [[1], [2], [3], [4], [5]]
-  let scalars = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1).reshaped(to: [5, 1])
+  let scalars = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1)
+    .reshaped(to: [5, 1])
   let dataset = SingleValueDataset(elements: scalars, elementShape: [1])
   var i: Int32 = 0
   for item in dataset {
@@ -38,17 +40,36 @@ DatasetAPITests.testAllBackends("SingleValueDatasetIteration") {
   }
 }
 
+DatasetAPITests.testAllBackends("SingleValueTransformations") {
+  let scalars = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1)
+  let shuffled = scalars.shuffled(seed: 42)
+  expcetEqual(ShapedArray(shape: [5], scalars: [4, 2, 3, 0, 1]), scalars.array)
+}
+
 // FIXME: Only public @TensorFlowGraph functions are being partitioned.
 @TensorFlowGraph
 public func addOne(_ x: Tensor<Float>) -> Tensor<Float> {
   return x + 1
 }
 
-DatasetAPITests.testAllBackends("SingleValueMap") {
+DatasetAPITests.testAllBackends("SingleValueHOFs") {
   let scalars = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1)
   let dataset = SingleValueDataset(elements: scalars, elementShape: [])
   let result: SingleValueDataset = dataset.map(addOne)
   expectEqual(result.flatMap { $0.scalars }, [1, 2, 3, 4, 5])
+}
+
+DatasetAPITests.testAllBackends("DoubleValueDatasetIteration") {
+  let scalars1 = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1)
+  let dataset1 = SingleValueDataset(elements: scalars1, elementShape: [1])
+  let scalars2 = Tensor<Float>(rangeFrom: 5, to: 10, stride: 1)
+  let dataset2 = SingleValueDataset(elements: scalars2, elementShape: [1])
+  var i: Int32 = 0
+  for (item1, item2) in zip(scalars1, scalars2) {
+    expectEqual(scalars1[i].array, item1.array)
+    expectEqual(scalars2[i].array, item2.array)
+    i += 1
+  }
 }
 
 runAllTests()

--- a/test/TensorFlowRuntime/dataset_api.swift
+++ b/test/TensorFlowRuntime/dataset_api.swift
@@ -42,8 +42,9 @@ DatasetAPITests.testAllBackends("SingleValueDatasetIteration") {
 
 DatasetAPITests.testAllBackends("SingleValueTransformations") {
   let scalars = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1)
-  let shuffled = scalars.shuffled(seed: 42)
-  expcetEqual(ShapedArray(shape: [5], scalars: [4, 2, 3, 0, 1]), scalars.array)
+  let dataset = SingleValueDataset(elements: scalars, elementShape: [])
+  let shuffled = dataset.shuffled(sampleCount: 5, randomSeed: 42)
+  expectEqual([0, 4, 1, 3, 2], shuffled.map { $0.scalar! })
 }
 
 // FIXME: Only public @TensorFlowGraph functions are being partitioned.
@@ -61,11 +62,11 @@ DatasetAPITests.testAllBackends("SingleValueHOFs") {
 
 DatasetAPITests.testAllBackends("DoubleValueDatasetIteration") {
   let scalars1 = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1)
-  let dataset1 = SingleValueDataset(elements: scalars1, elementShape: [1])
   let scalars2 = Tensor<Float>(rangeFrom: 5, to: 10, stride: 1)
-  let dataset2 = SingleValueDataset(elements: scalars2, elementShape: [1])
+  let dataset = DoubleValueDataset(elements: (scalars1, scalars2),
+                                   elementShapes: ([], []))
   var i: Int32 = 0
-  for (item1, item2) in zip(scalars1, scalars2) {
+  for (item1, item2) in dataset {
     expectEqual(scalars1[i].array, item1.array)
     expectEqual(scalars2[i].array, item2.array)
     i += 1


### PR DESCRIPTION
- Add a `DoubleValueDataset` to represent a dataset whose elements are tuples of tensors.

- Add random initializer `init(randomSeed:)`.

- Add `shuffled(sampleCount:randomSeed:)` and `batched(_:)`.

**Note**: Arbitrary arity `Dataset` types are not possible until two new features of `#tfop` are implemented. Please refer to [SR-8573](https://bugs.swift.org/browse/SR-8573) and [SR-8574](https://bugs.swift.org/browse/SR-8574) for more details.

Resolves [SR-8597](https://bugs.swift.org/browse/SR-8597).