### PR TITLE
Generic pattern emission refactoring

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3275,13 +3275,11 @@ IRGenModule::getAddrOfTypeMetadataInPlaceInitializationCache(
 /// existing external declaration to the address point as an alias into the
 /// full metadata object.
 llvm::GlobalValue *IRGenModule::defineTypeMetadata(CanType concreteType,
-                                 bool isIndirect,
-                                 bool isPattern,
-                                 bool isConstant,
-                                 ConstantInitFuture init,
-                                 llvm::StringRef section) {
+                                                   bool isPattern,
+                                                   bool isConstant,
+                                                   ConstantInitFuture init,
+                                                   llvm::StringRef section) {
   assert(init);
-  assert(!isIndirect && "indirect type metadata not used yet");
 
   if (isPattern) {
     auto addr = getAddrOfTypeMetadataPattern(concreteType->getAnyNominal(),

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2880,24 +2880,19 @@ void irgen::emitClassMetadata(IRGenModule &IGM, ClassDecl *classDecl,
 
   CanType declaredType = classDecl->getDeclaredType()->getCanonicalType();
 
-  // For now, all type metadata is directly stored.
-  bool isIndirect = false;
-
   StringRef section{};
   if (classDecl->isObjC() &&
       IGM.TargetInfo.OutputObjectFormat == llvm::Triple::MachO)
     section = "__DATA,__objc_data, regular";
 
-  auto var = IGM.defineTypeMetadata(declaredType, isIndirect, isGeneric,
-                                    canBeConstant,
-                                    init.finishAndCreateFuture(),
-                                    section);
+  auto var = IGM.defineTypeMetadata(declaredType, isGeneric, canBeConstant,
+                                    init.finishAndCreateFuture(), section);
 
   // Add classes that don't require dynamic initialization to the
   // ObjC class list.
   //
   // FIXME: This is where we check the completely fragile layout.
-  if (IGM.ObjCInterop && !isGeneric && !isIndirect &&
+  if (IGM.ObjCInterop && !isGeneric &&
       !doesClassMetadataRequireInitialization(IGM, classDecl)) {
     // Emit the ObjC class symbol to make the class visible to ObjC.
     if (classDecl->isObjC()) {
@@ -3289,11 +3284,8 @@ void irgen::emitStructMetadata(IRGenModule &IGM, StructDecl *structDecl) {
 
   CanType declaredType = structDecl->getDeclaredType()->getCanonicalType();
 
-  // For now, all type metadata is directly stored.
-  bool isIndirect = false;
-
-  IGM.defineTypeMetadata(declaredType, isIndirect, isPattern,
-                         canBeConstant, init.finishAndCreateFuture());
+  IGM.defineTypeMetadata(declaredType, isPattern, canBeConstant,
+                         init.finishAndCreateFuture());
 
   IGM.IRGen.noteUseOfAnyParentTypeMetadata(structDecl);
 }
@@ -3487,11 +3479,8 @@ void irgen::emitEnumMetadata(IRGenModule &IGM, EnumDecl *theEnum) {
 
   CanType declaredType = theEnum->getDeclaredType()->getCanonicalType();
 
-  // For now, all type metadata is directly stored.
-  bool isIndirect = false;
-  
-  IGM.defineTypeMetadata(declaredType, isIndirect, isPattern,
-                         canBeConstant, init.finishAndCreateFuture());
+  IGM.defineTypeMetadata(declaredType, isPattern, canBeConstant,
+                         init.finishAndCreateFuture());
 
   IGM.IRGen.noteUseOfAnyParentTypeMetadata(theEnum);
 }

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -3129,11 +3129,11 @@ namespace {
     }
 
     void addGenericArgument() {
-      B.addNullPointer(IGM.TypeMetadataPtrTy);
+      llvm_unreachable("Concrete type metadata cannot have generic parameters");
     }
 
     void addGenericWitnessTable() {
-      B.addNullPointer(IGM.WitnessTablePtrTy);
+      llvm_unreachable("Concrete type metadata cannot have generic requirements");
     }
 
     void emitInitializeMetadata(IRGenFunction &IGF,
@@ -3380,11 +3380,11 @@ namespace {
     }
 
     void addGenericArgument() {
-      B.addNullPointer(IGM.TypeMetadataPtrTy);
+      llvm_unreachable("Concrete type metadata cannot have generic parameters");
     }
 
     void addGenericWitnessTable() {
-      B.addNullPointer(IGM.WitnessTablePtrTy);
+      llvm_unreachable("Concrete type metadata cannot have generic requirements");
     }
 
     Optional<Size> getConstantPayloadSize() {

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1156,11 +1156,10 @@ public:
                                                      bool isForeign,
                                                      ForDefinition_t forDefinition);
   llvm::GlobalValue *defineTypeMetadata(CanType concreteType,
-                                  bool isIndirect,
-                                  bool isPattern,
-                                  bool isConstant,
-                                  ConstantInitFuture init,
-                                  llvm::StringRef section = {});
+                                        bool isPattern,
+                                        bool isConstant,
+                                        ConstantInitFuture init,
+                                        llvm::StringRef section = {});
 
   TypeEntityReference getTypeEntityReference(NominalTypeDecl *D);
 


### PR DESCRIPTION
Concrete and generic metadata builders shared a base class, but ever since generic metadata patterns became true-const with a layout distinct from instantiated metadata, the generic case no longer uses most of the functionality of the base class.

This is a refactoring in preparation for giving concrete resilient classes a proper true-const pattern.