### PR TITLE
[TBDGen] Fix check for global accessors

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4528,6 +4528,9 @@ public:
     ParentPattern = S;
   }
 
+  /// True if the global stored property requires lazy initialization.
+  bool isLazilyInitializedGlobal() const;
+
   /// Return the initializer involved in this VarDecl.  Recall that the
   /// initializer may be involved in initializing more than just this one
   /// vardecl though.  For example, if this is a VarDecl for "x", the pattern

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4481,6 +4481,27 @@ bool VarDecl::isSettable(const DeclContext *UseDC,
   return false;
 }
 
+bool VarDecl::isLazilyInitializedGlobal() const {
+  assert(!getDeclContext()->isLocalContext() &&
+         "not a global variable!");
+  assert(hasStorage() && "not a stored global variable!");
+
+  // Imports from C are never lazily initialized.
+  if (hasClangNode())
+    return false;
+
+  if (isDebuggerVar())
+    return false;
+
+  // Top-level global variables in the main source file and in the REPL are not
+  // lazily initialized.
+  auto sourceFileContext = dyn_cast<SourceFile>(getDeclContext());
+  if (!sourceFileContext)
+    return true;
+
+  return !sourceFileContext->isScriptMode();
+}
+
 bool SubscriptDecl::isSettable() const {
   return supportsMutation();
 }

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -208,9 +208,7 @@ void TBDGenVisitor::visitVarDecl(VarDecl *VD) {
       addSymbol(mangler.mangleEntity(VD, false));
     }
 
-    // Top-level variables (*not* statics) in the main file don't get accessors,
-    // despite otherwise looking like globals.
-    if (!FileHasEntryPoint || VD->isStatic())
+    if (VD->isLazilyInitializedGlobal())
       addSymbol(SILDeclRef(VD, SILDeclRef::Kind::GlobalAccessor));
   }
 
@@ -459,7 +457,7 @@ static void enumeratePublicSymbolsAndWrite(ModuleDecl *M, FileUnit *singleFile,
     SmallVector<Decl *, 16> decls;
     file->getTopLevelDecls(decls);
 
-    visitor.setFileHasEntryPoint(file->hasEntryPoint());
+    visitor.addMainIfNecessary(file);
 
     for (auto d : decls)
       visitor.visit(d);

--- a/lib/TBDGen/TBDGenVisitor.h
+++ b/lib/TBDGen/TBDGenVisitor.h
@@ -51,8 +51,6 @@ public:
   const TBDGenOptions &Opts;
 
 private:
-  bool FileHasEntryPoint = false;
-
   void addSymbol(StringRef name, tapi::internal::SymbolKind kind =
                                      tapi::internal::SymbolKind::GlobalSymbol);
 
@@ -73,10 +71,11 @@ public:
         UniversalLinkInfo(universalLinkInfo), SwiftModule(swiftModule),
         Opts(opts) {}
 
-  void setFileHasEntryPoint(bool hasEntryPoint) {
-    FileHasEntryPoint = hasEntryPoint;
-
-    if (hasEntryPoint)
+  void addMainIfNecessary(FileUnit *file) {
+    // HACK: 'main' is a special symbol that's always emitted in SILGen if
+    //       the file has an entry point. Since it doesn't show up in the
+    //       module until SILGen, we need to explicitly add it here.
+    if (file->hasEntryPoint())
       addSymbol("main");
   }
 

--- a/test/TBD/objc-entry-point.swift
+++ b/test/TBD/objc-entry-point.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir -o /dev/null -validate-tbd-against-ir=all -parse-as-library -verify -enable-testing %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir -o /dev/null -validate-tbd-against-ir=all -parse-as-library -verify %s
+
+// REQUIRES: objc_interop
+import AppKit
+
+// Globals in non-script mode files that still have entry points
+// (via NSApplicationMain) _do_ have lazy initializers. Ensure the symbols are
+// present in the TBD.
+let globalConstantWithLazyInitializer: String = "hello, world"
+
+@NSApplicationMain
+class MyDelegate: NSObject, NSApplicationDelegate {
+}


### PR DESCRIPTION
Previously, TBDGen skipped emitting lazy initializers for globals that
appeared in any file with an entry point. This breaks, however on files
that have an `NSApplicationMain`/`UIApplicationMain` class in them, where
the entry point is synthesized but top-level globals are not locally
scoped. This change re-uses SILGen's check and only skips variable
declarations that appear at top level in a script mode file.

Resolves rdar://43549749