### PR TITLE
[test] Add --param remote_run_extra_args

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -126,6 +126,9 @@ out with ``lit.py -h``. We document some of the more useful ones below:
 * ``--param remote_run_identity=<FILE>`` provides an SSH private key to be used
   when testing with `remote_run_host`. (`remote-run` does not support
   passwords.)
+* ``--param remote_run_extra_args="ARG1 ARG2 ..."`` provides a list of extra
+  arguments to pass to `remote-run`. (This can be used with `remote-run`'s `-o`
+  option to pass extra options to SSH.)
 * ``--param remote_run_skip_upload_stdlib`` assumes that the standard library
   binaries have already been uploaded to `remote_run_tmpdir` and are up to date.
   This is meant for repeat runs and probably shouldn't be used in automation.

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -21,6 +21,7 @@
 import os
 import platform
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -950,10 +951,12 @@ if (not getattr(config, 'target_run', None) and
     remote_run_host = lit_config.params['remote_run_host']
     remote_tmp_dir = lit_config.params['remote_run_tmpdir']
     remote_lib_dir = os.path.join(remote_tmp_dir, 'stdlib')
+
+    remote_run_extra_args_param = lit_config.params.get('remote_run_extra_args')
+    remote_run_extra_args = shlex.split(remote_run_extra_args_param or '')
     if 'remote_run_identity' in lit_config.params:
-        identity_args = ['-i', lit_config.params['remote_run_identity']]
-    else:
-        identity_args = []
+        remote_run_identity = lit_config.params['remote_run_identity']
+        remote_run_extra_args += ['-i', remote_run_identity]
 
     if 'remote_run_skip_upload_stdlib' not in lit_config.params:
         lit_config.note(
@@ -969,7 +972,7 @@ if (not getattr(config, 'target_run', None) and
                 '--remote-dir', remote_tmp_dir,
                 '--input-prefix', sdk_lib_dir,
                 '--remote-input-prefix', 'stdlib/'
-            ] + identity_args + [
+            ] + remote_run_extra_args + [
                 remote_run_host,
                 '--',
                 'true' # A dummy command that ignores its arguments.
@@ -977,11 +980,11 @@ if (not getattr(config, 'target_run', None) and
 
     config.target_run = (
         "/usr/bin/env "
-        "REMOTE_RUN_CHILD_DYLD_FALLBACK_LIBRARY_PATH='{0}' " # Apple option
+        "REMOTE_RUN_CHILD_DYLD_LIBRARY_PATH='{0}' " # Apple option
         "REMOTE_RUN_CHILD_LD_LIBRARY_PATH='{0}' " # Linux option
         "%utils/remote-run --input-prefix %S --output-prefix %t "
         "--remote-dir '{1}'%t {2} {3}".format(remote_lib_dir, remote_tmp_dir,
-                                              ' '.join(identity_args),
+                                              ' '.join(remote_run_extra_args),
                                               remote_run_host))
     TARGET_ENV_PREFIX = 'REMOTE_RUN_CHILD_'
 


### PR DESCRIPTION
This goes with #18814: if we want to pass extra arguments to SSH when using remote-run, there has to be a way to get them to remote-run when using lit.