### PR TITLE
[swiftSyntax] Performance improvements for deserialising ByteTrees

### DIFF
--- a/tools/SwiftSyntax/ByteTreeDeserialization.swift
+++ b/tools/SwiftSyntax/ByteTreeDeserialization.swift
@@ -149,10 +149,10 @@ struct ByteTreeReader {
   /// A pointer pointing to the next byte of serialized data to be read
   private var pointer: UnsafeRawPointer
 
-  private var userInfo: [ByteTreeUserInfoKey: Any]
+  private var userInfo: UnsafePointer<[ByteTreeUserInfoKey: Any]>
 
   private init(pointer: UnsafeRawPointer,
-               userInfo: [ByteTreeUserInfoKey: Any]) {
+               userInfo: UnsafePointer<[ByteTreeUserInfoKey: Any]>) {
     self.pointer = pointer
     self.userInfo = userInfo
   }
@@ -172,7 +172,7 @@ struct ByteTreeReader {
   ///            failed
   static func read<T: ByteTreeObjectDecodable>(
     _ rootObjectType: T.Type, from pointer: UnsafeRawPointer,
-    userInfo: [ByteTreeUserInfoKey: Any],
+    userInfo: UnsafePointer<[ByteTreeUserInfoKey: Any]>,
     protocolVersionValidation: (ProtocolVersion) -> Bool
   ) throws -> T {
     var reader = ByteTreeReader(pointer: pointer, userInfo: userInfo)
@@ -192,7 +192,7 @@ struct ByteTreeReader {
   /// - Returns: The deserialized tree
   static func read<T: ByteTreeObjectDecodable>(
     _ rootObjectType: T.Type, from data: Data,
-    userInfo: [ByteTreeUserInfoKey: Any],
+    userInfo: UnsafePointer<[ByteTreeUserInfoKey: Any]>,
     protocolVersionValidation versionValidate: (ProtocolVersion) -> Bool
   ) throws -> T {
     return try data.withUnsafeBytes { (pointer: UnsafePointer<UInt8>) in
@@ -273,7 +273,7 @@ struct ByteTreeReader {
       objectReader.finalize()
     }
     return T.read(from: &objectReader, numFields: numFields,
-                  userInfo: &userInfo)
+                  userInfo: userInfo)
   }
 
   /// Read the next field in the tree as a scalar of the specified type.
@@ -287,7 +287,7 @@ struct ByteTreeReader {
     defer {
       pointer = pointer.advanced(by: fieldSize)
     }
-    return T.read(from: pointer, size: fieldSize, userInfo: &userInfo)
+    return T.read(from: pointer, size: fieldSize, userInfo: userInfo)
   }
 
   /// Discard the next scalar field, advancing the pointer to the next field

--- a/tools/SwiftSyntax/RawSyntax.swift
+++ b/tools/SwiftSyntax/RawSyntax.swift
@@ -406,25 +406,25 @@ extension RawSyntax: ByteTreeObjectDecodable {
     }
   }
 
-  static func read(from reader: ByteTreeObjectReader, numFields: Int,
-                   userInfo: [ByteTreeUserInfoKey: Any]
+  static func read(from reader: UnsafeMutablePointer<ByteTreeObjectReader>,
+                   numFields: Int, userInfo: [ByteTreeUserInfoKey: Any]
   ) -> RawSyntax {
     let syntaxNode: RawSyntax
-    let type = reader.readField(SyntaxType.self, index: 0)
-    let id = reader.readField(SyntaxNodeId.self, index: 1)
+    let type = reader.pointee.readField(SyntaxType.self, index: 0)
+    let id = reader.pointee.readField(SyntaxNodeId.self, index: 1)
     switch type {
     case .token:
-      let presence = reader.readField(SourcePresence.self, index: 2)
-      let kind = reader.readField(TokenKind.self, index: 3)
-      let leadingTrivia = reader.readField(Trivia.self, index: 4)
-      let trailingTrivia = reader.readField(Trivia.self, index: 5)
+      let presence = reader.pointee.readField(SourcePresence.self, index: 2)
+      let kind = reader.pointee.readField(TokenKind.self, index: 3)
+      let leadingTrivia = reader.pointee.readField(Trivia.self, index: 4)
+      let trailingTrivia = reader.pointee.readField(Trivia.self, index: 5)
       syntaxNode = RawSyntax(kind: kind, leadingTrivia: leadingTrivia,
                              trailingTrivia: trailingTrivia,
                              presence: presence, id: id)
     case .layout:
-      let presence = reader.readField(SourcePresence.self, index: 2)
-      let kind = reader.readField(SyntaxKind.self, index: 3)
-      let layout = reader.readField([RawSyntax?].self, index: 4)
+      let presence = reader.pointee.readField(SourcePresence.self, index: 2)
+      let kind = reader.pointee.readField(SyntaxKind.self, index: 3)
+      let layout = reader.pointee.readField([RawSyntax?].self, index: 4)
       syntaxNode = RawSyntax(kind: kind, layout: layout, presence: presence,
                              id: id)
     case .omitted:

--- a/tools/SwiftSyntax/RawSyntax.swift
+++ b/tools/SwiftSyntax/RawSyntax.swift
@@ -75,7 +75,7 @@ public struct SyntaxNodeId: Hashable, Codable {
 }
 
 /// The data that is specific to a tree or token node
-fileprivate indirect enum RawSyntaxData {
+fileprivate enum RawSyntaxData {
   /// A tree node with a kind and an array of children
   case node(kind: SyntaxKind, layout: [RawSyntax?])
   /// A token with a token kind, leading trivia, and trailing trivia

--- a/tools/SwiftSyntax/RawSyntax.swift
+++ b/tools/SwiftSyntax/RawSyntax.swift
@@ -396,7 +396,7 @@ extension RawSyntax: ByteTreeObjectDecodable {
     case omitted = 2
 
     static func read(from pointer: UnsafeRawPointer, size: Int,
-                     userInfo: [ByteTreeUserInfoKey: Any]
+                     userInfo: UnsafePointer<[ByteTreeUserInfoKey: Any]>
     ) -> SyntaxType {
       let rawValue = UInt8.read(from: pointer, size: size, userInfo: userInfo)
       guard let type = SyntaxType(rawValue: rawValue) else {
@@ -407,7 +407,8 @@ extension RawSyntax: ByteTreeObjectDecodable {
   }
 
   static func read(from reader: UnsafeMutablePointer<ByteTreeObjectReader>,
-                   numFields: Int, userInfo: [ByteTreeUserInfoKey: Any]
+                   numFields: Int,
+                   userInfo: UnsafePointer<[ByteTreeUserInfoKey: Any]>
   ) -> RawSyntax {
     let syntaxNode: RawSyntax
     let type = reader.pointee.readField(SyntaxType.self, index: 0)
@@ -428,7 +429,7 @@ extension RawSyntax: ByteTreeObjectDecodable {
       syntaxNode = RawSyntax(kind: kind, layout: layout, presence: presence,
                              id: id)
     case .omitted:
-      guard let lookupFunc = userInfo[.omittedNodeLookupFunction] as?
+      guard let lookupFunc = userInfo.pointee[.omittedNodeLookupFunction] as?
         (SyntaxNodeId) -> RawSyntax? else {
           fatalError("omittedNodeLookupFunction is required when decoding an " +
                      "incrementally transferred syntax tree")
@@ -438,7 +439,7 @@ extension RawSyntax: ByteTreeObjectDecodable {
       }
       syntaxNode = lookupNode
     }
-    if let callback = userInfo[.rawSyntaxDecodedCallback] as?
+    if let callback = userInfo.pointee[.rawSyntaxDecodedCallback] as?
       (RawSyntax) -> Void {
       callback(syntaxNode)
     }
@@ -448,7 +449,7 @@ extension RawSyntax: ByteTreeObjectDecodable {
 
 extension SyntaxNodeId: ByteTreeScalarDecodable {
   static func read(from pointer: UnsafeRawPointer, size: Int,
-                   userInfo: [ByteTreeUserInfoKey: Any]
+                   userInfo: UnsafePointer<[ByteTreeUserInfoKey: Any]>
   ) -> SyntaxNodeId {
     let rawValue = UInt32.read(from: pointer, size: size, userInfo: userInfo)
     return SyntaxNodeId(rawValue: UInt(rawValue))

--- a/tools/SwiftSyntax/SourceLength.swift
+++ b/tools/SwiftSyntax/SourceLength.swift
@@ -13,7 +13,7 @@
 /// The length a syntax node spans in the source code. From any AbsolutePosition
 /// you reach a node's end location by either adding its UTF-8 length or by
 /// inserting `lines` newlines and then moving `columns` columns to the right.
-public final class SourceLength {
+public struct SourceLength {
   public let newlines: Int
   public let columnsAtLastLine: Int
   public let utf8Length: Int

--- a/tools/SwiftSyntax/SourcePresence.swift
+++ b/tools/SwiftSyntax/SourcePresence.swift
@@ -26,7 +26,7 @@ public enum SourcePresence: String, Codable {
 
 extension SourcePresence: ByteTreeScalarDecodable {
   static func read(from pointer: UnsafeRawPointer, size: Int,
-                   userInfo: [ByteTreeUserInfoKey: Any]
+                   userInfo: UnsafePointer<[ByteTreeUserInfoKey: Any]>
   ) -> SourcePresence {
     let rawValue = pointer.bindMemory(to: UInt8.self, capacity: 1).pointee
     switch rawValue {

--- a/tools/SwiftSyntax/SwiftSyntax.swift
+++ b/tools/SwiftSyntax/SwiftSyntax.swift
@@ -79,7 +79,7 @@ public final class SyntaxTreeDeserializer {
     userInfo[.rawSyntaxDecodedCallback] = self.addToLookupTable
     userInfo[.omittedNodeLookupFunction] = self.lookupNode
     return try ByteTreeReader.read(RawSyntax.self, from: data,
-                                            userInfo: userInfo) {
+                                            userInfo: &userInfo) {
       (version: ByteTreeReader.ProtocolVersion) in
       return version == 1
     }

--- a/tools/SwiftSyntax/SyntaxData.swift
+++ b/tools/SwiftSyntax/SyntaxData.swift
@@ -18,14 +18,6 @@ import Foundation
 /// exposed to clients.
 typealias NodeIdentifier = [Int]
 
-/// Box a value type into a reference type
-fileprivate class Box<T> {
-  let value: T
-
-  init(_ value: T) {
-    self.value = value
-  }
-}
 
 /// SyntaxData is the underlying storage for each Syntax node.
 /// It's modelled as an array that stores and caches a SyntaxData for each raw

--- a/tools/SwiftSyntax/SyntaxKind.swift.gyb
+++ b/tools/SwiftSyntax/SyntaxKind.swift.gyb
@@ -86,7 +86,7 @@ internal func makeSyntax(root: SyntaxData?, data: SyntaxData) -> Syntax {
 
 extension SyntaxKind: ByteTreeScalarDecodable {
   static func read(from pointer: UnsafeRawPointer, size: Int,
-                   userInfo: [ByteTreeUserInfoKey: Any]
+                   userInfo: UnsafePointer<[ByteTreeUserInfoKey: Any]>
   ) -> SyntaxKind {
     // Explicitly spell out all SyntaxKinds to keep the serialized value stable
     // even if its members get reordered or members get removed

--- a/tools/SwiftSyntax/TokenKind.swift.gyb
+++ b/tools/SwiftSyntax/TokenKind.swift.gyb
@@ -111,12 +111,12 @@ extension TokenKind: Equatable {
 }
 
 extension TokenKind: ByteTreeObjectDecodable {
-  static func read(from reader: ByteTreeObjectReader, numFields: Int,
-                   userInfo: [ByteTreeUserInfoKey: Any]
+  static func read(from reader: UnsafeMutablePointer<ByteTreeObjectReader>,
+                   numFields: Int, userInfo: [ByteTreeUserInfoKey: Any]
   ) -> TokenKind {
     // Explicitly spell out all TokenKinds to keep the serialized value stable
     // even if its members get reordered or members get removed
-    let kind = reader.readField(UInt8.self, index: 0)
+    let kind = reader.pointee.readField(UInt8.self, index: 0)
     switch kind {
     case 0: return .eof
 % for token in SYNTAX_TOKENS:
@@ -124,7 +124,7 @@ extension TokenKind: ByteTreeObjectDecodable {
 %   if token.text: # The token does not have text associated with it
       return .${token.swift_kind()}
 %   else:
-      let text = reader.readField(String.self, index: 1)
+      let text = reader.pointee.readField(String.self, index: 1)
       return .${token.swift_kind()}(text)
 %   end
 % end

--- a/tools/SwiftSyntax/TokenKind.swift.gyb
+++ b/tools/SwiftSyntax/TokenKind.swift.gyb
@@ -112,7 +112,8 @@ extension TokenKind: Equatable {
 
 extension TokenKind: ByteTreeObjectDecodable {
   static func read(from reader: UnsafeMutablePointer<ByteTreeObjectReader>,
-                   numFields: Int, userInfo: [ByteTreeUserInfoKey: Any]
+                   numFields: Int,
+                   userInfo: UnsafePointer<[ByteTreeUserInfoKey: Any]>
   ) -> TokenKind {
     // Explicitly spell out all TokenKinds to keep the serialized value stable
     // even if its members get reordered or members get removed

--- a/tools/SwiftSyntax/Trivia.swift.gyb
+++ b/tools/SwiftSyntax/Trivia.swift.gyb
@@ -222,7 +222,8 @@ extension TriviaPiece {
 
 extension Trivia: ByteTreeObjectDecodable {
   static func read(from reader: UnsafeMutablePointer<ByteTreeObjectReader>,
-                   numFields: Int, userInfo: [ByteTreeUserInfoKey: Any]
+                   numFields: Int,
+                   userInfo: UnsafePointer<[ByteTreeUserInfoKey: Any]>
   ) -> Trivia {
     let pieces = [TriviaPiece].read(from: reader, numFields: numFields,
                                     userInfo: userInfo)
@@ -232,7 +233,8 @@ extension Trivia: ByteTreeObjectDecodable {
 
 extension TriviaPiece: ByteTreeObjectDecodable {
   static func read(from reader: UnsafeMutablePointer<ByteTreeObjectReader>,
-                   numFields: Int, userInfo: [ByteTreeUserInfoKey: Any]
+                   numFields: Int,
+                   userInfo: UnsafePointer<[ByteTreeUserInfoKey: Any]>
   ) -> TriviaPiece {
     let kind = reader.pointee.readField(UInt8.self, index: 0)
     switch kind {

--- a/tools/SwiftSyntax/Trivia.swift.gyb
+++ b/tools/SwiftSyntax/Trivia.swift.gyb
@@ -221,8 +221,8 @@ extension TriviaPiece {
 }
 
 extension Trivia: ByteTreeObjectDecodable {
-  static func read(from reader: ByteTreeObjectReader, numFields: Int,
-                   userInfo: [ByteTreeUserInfoKey: Any]
+  static func read(from reader: UnsafeMutablePointer<ByteTreeObjectReader>,
+                   numFields: Int, userInfo: [ByteTreeUserInfoKey: Any]
   ) -> Trivia {
     let pieces = [TriviaPiece].read(from: reader, numFields: numFields,
                                     userInfo: userInfo)
@@ -231,18 +231,18 @@ extension Trivia: ByteTreeObjectDecodable {
 }
 
 extension TriviaPiece: ByteTreeObjectDecodable {
-  static func read(from reader: ByteTreeObjectReader, numFields: Int,
-                   userInfo: [ByteTreeUserInfoKey: Any]
+  static func read(from reader: UnsafeMutablePointer<ByteTreeObjectReader>,
+                   numFields: Int, userInfo: [ByteTreeUserInfoKey: Any]
   ) -> TriviaPiece {
-    let kind = reader.readField(UInt8.self, index: 0)
+    let kind = reader.pointee.readField(UInt8.self, index: 0)
     switch kind {
 % for trivia in TRIVIAS:
     case ${trivia.serialization_code}:
 %   if trivia.is_collection():
-      let count = Int(reader.readField(UInt32.self, index: 1))
+      let count = Int(reader.pointee.readField(UInt32.self, index: 1))
       return .${trivia.lower_name}s(count)      
 %   else:
-      let text = reader.readField(String.self, index: 1)
+      let text = reader.pointee.readField(String.self, index: 1)
       return .${trivia.lower_name}(text)      
 %   end
 % end


### PR DESCRIPTION
This PR contains several performance for deserialising syntax trees in binary encoding (see the separate commits):

- Make `SourceLength` a struct 
  - It should have been one all the while
- Make `RawSyntaxData` a direct enum
  - I do not see any reason why it shouldn't be
- Make `ByteTree(Object)Reader` a struct and pass a reference to it around using an `UnsafeMutabelPointer`
  - This improves the deserialisation performance by 13% because we are able to eliminate unnecessary retain and release calls
- Only reference `userInfo` through an `UnsafePointer` and don't pass it around
  - This improves deserialisation performance by another 11% because we are again able to eliminate unnecessary retain/release calls
- Use the more efficient array initialiser that was introduced in https://github.com/apple/swift/pull/17774