### PR TITLE
[libSyntax] Make the ByteTree format forwards-compatible

### DIFF
--- a/docs/ByteTree.md
+++ b/docs/ByteTree.md
@@ -7,7 +7,7 @@ The ByteTree format consists of two different constructs: *objects* and *scalars
 
 ## Serialization of scalars
 
-A scalar is encoded as its size followed by the data. Size is a `uint_32` that represents the size of the data in bytes in little endian order.
+A scalar is encoded as its size followed by the data. Size is a `uint_32` that represents the size of the data in bytes in little endian order. It always has its most significant bit set to 0 (to distinguish objects from scalars, see *Forwards compatibility*).
 
 For example, the string "Hello World" would be encoded as `(uint32_t)11` `"Hello World"`, or in hex `0B 00 00 00   48 65 6C 6C 6F 20 57 6F 72 6C 64`.
 
@@ -15,11 +15,17 @@ For example, the string "Hello World" would be encoded as `(uint32_t)11` `"Hello
 
 An object consists of its size, measured in the number of fields and represented as a `uint_32t` in little endian order, followed by the direct concatenation of its fields. Because each field is again prefixed with its size, no delimites are necessary in between the fields.
 
+To distinguish scalars and objects, the size of objects has its most-siginificant bit set to 1. It must be ignored to retrieve the number of fields in the object.
+
 Arrays are modelled as objects whose fields are all of the same type and whose length is variadic (and is indicated by the object's size).
 
 ## Versioning
 
 The ByteTree format is prepended by a 4-byte protocol version number that describes the version of the object tree that was serialized. Its exact semantics are up to each specific application, but it is encouraged to interpret it as a two-comentent number where the first component, consisting of the first three bytes, is incremented for breaking changes and the last byte is incremented for backwards-compatible changes.
+
+## Forward compatilibity
+
+Fields may be added to the end of objects in a backwards compatible manner (older deserialisers will still be able to deserialise the format). It does so by skipping over all fields that are not read during deserialisation. Newer versions of the deserialiser can detect if recently added fields are not present in the serialised data by inspecting the `numFields` property passed during deserialisation.
 
 ## Serialization safety
 

--- a/test/Syntax/round_trip_function.swift
+++ b/test/Syntax/round_trip_function.swift
@@ -1,4 +1,16 @@
+// We need to require macOS because swiftSyntax currently doesn't build on Linux
+// REQUIRES: OS=macosx
+
+// RUN: %empty-directory(%t)
 // RUN: %round-trip-syntax-test --swift-syntax-test %swift-syntax-test --file %s
+
+// RUN: %swift-syntax-test --serialize-raw-tree --serialize-byte-tree --input-source-filename %s --output-filename %t/tree.bin
+// RUN: %swift-swiftsyntax-test -deserialize -serialization-format byteTree -pre-edit-tree %t/tree.bin -out %t/afterRoundtrip.swift
+// RUN: diff -u %t/afterRoundtrip.swift %s
+
+// RUN: %swift-syntax-test --serialize-raw-tree --serialize-byte-tree --input-source-filename %s --output-filename %t/tree_with_additional_fields.bin --add-bytetree-fields
+// RUN: %swift-swiftsyntax-test -deserialize -serialization-format byteTree -pre-edit-tree %t/tree_with_additional_fields.bin -out %t/afterRoundtripWithAdditionalFields.swift
+// RUN: diff -u %t/afterRoundtripWithAdditionalFields.swift %s
 
 func noArgs() {}
 func oneArg(x: Int) {}

--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -157,6 +157,15 @@ SerializeAsByteTree("serialize-byte-tree",
                                    "of JSON."));
 
 static llvm::cl::opt<bool>
+AddByteTreeFields("add-bytetree-fields",
+                  llvm::cl::desc("If specified, further fields will be added "
+                                 "to the syntax tree if it is serialized as a "
+                                 "ByteTree. This is to test forward "
+                                 "compatibility with future versions of "
+                                 "SwiftSyntax that might add more fields to "
+                                 "syntax nodes."));
+
+static llvm::cl::opt<bool>
 IncrementalSerialization("incremental-serialization",
                          llvm::cl::desc("If specified, the serialized syntax "
                                         "tree will omit nodes that have not "
@@ -724,6 +733,9 @@ int doSerializeRawTree(const char *MainExecutablePath,
       llvm::BinaryStreamWriter Writer(Stream);
       std::map<void *, void *> UserInfo;
       UserInfo[swift::byteTree::UserInfoKeyReusedNodeIds] = &ReusedNodeIds;
+      if (options::AddByteTreeFields) {
+        UserInfo[swift::byteTree::UserInfoKeyAddInvalidFields] = (void *)true;
+      }
       swift::byteTree::ByteTreeWriter::write(/*ProtocolVersion=*/1, Writer,
                                              *Root, UserInfo);
       auto OutputBufferOrError = llvm::FileOutputBuffer::create(


### PR DESCRIPTION
Adjust the ByteTree format so that the server can add new versions to the tree it serialises while the client is still able to deserialise it.

To test the forwards compatibility, I added a flag that can be passed to the serialisation of the syntax tree as a ByteTree that will add additional garbage fields that the client should ignore. While this is not exactly beautiful, it is *way* easier to maintain than generating an entire class structure, constructing an object tree and adding the same class layout on the Swift side just to diff the output.