### PR TITLE
[Diagnostics] Switch to using `ConstraintSystem` directly in new diagnostics infra

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7776,7 +7776,7 @@ bool ConstraintSystem::applySolutionFixes(Expr *E, const Solution &solution) {
 
     bool diagnosed = false;
     for (const auto *fix : fixes->second)
-      diagnosed |= fix->diagnose(E, solution);
+      diagnosed |= fix->diagnose(E);
     return diagnosed;
   };
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -55,8 +55,7 @@ std::pair<Expr *, bool> FailureDiagnostic::computeAnchor() const {
 }
 
 Type FailureDiagnostic::getType(Expr *expr) const {
-  auto &cs = getConstraintSystem();
-  return solution.simplifyType(cs.getType(expr));
+  return resolveType(CS.getType(expr));
 }
 
 template <typename... ArgTypes>

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -23,6 +23,7 @@
 #include "swift/AST/Expr.h"
 #include "swift/AST/Types.h"
 #include "llvm/ADT/ArrayRef.h"
+#include <tuple>
 
 namespace swift {
 namespace constraints {
@@ -32,7 +33,7 @@ namespace constraints {
 /// the problem, parent expression and some utility methods.
 class FailureDiagnostic {
   Expr *E;
-  const Solution &solution;
+  ConstraintSystem &CS;
   ConstraintLocator *Locator;
 
   Expr *Anchor;
@@ -41,9 +42,9 @@ class FailureDiagnostic {
   bool HasComplexLocator;
 
 public:
-  FailureDiagnostic(Expr *expr, const Solution &solution,
+  FailureDiagnostic(Expr *expr, ConstraintSystem &cs,
                     ConstraintLocator *locator)
-      : E(expr), solution(solution), Locator(locator) {
+      : E(expr), CS(cs), Locator(locator) {
     std::tie(Anchor, HasComplexLocator) = computeAnchor();
   }
 
@@ -58,7 +59,7 @@ public:
   virtual bool diagnose() = 0;
 
   ConstraintSystem &getConstraintSystem() const {
-    return solution.getConstraintSystem();
+    return CS;
   }
 
   Expr *getParentExpr() const { return E; }
@@ -71,38 +72,40 @@ public:
 
   /// Resolve type variables present in the raw type, if any.
   Type resolveType(Type rawType) const {
-    return solution.simplifyType(rawType);
+    return CS.simplifyType(rawType);
   }
 
   template <typename... ArgTypes>
   InFlightDiagnostic emitDiagnostic(ArgTypes &&... Args) const;
 
 protected:
-  TypeChecker &getTypeChecker() const { return getConstraintSystem().TC; }
+  TypeChecker &getTypeChecker() const { return CS.TC; }
 
-  DeclContext *getDC() const { return getConstraintSystem().DC; }
-
-  const Solution &getSolution() const { return solution; }
+  DeclContext *getDC() const { return CS.DC; }
 
   Optional<std::pair<Type, ConversionRestrictionKind>>
   restrictionForType(Type type) const {
-    for (auto &restriction : solution.ConstraintRestrictions) {
-      if (restriction.first.first->isEqual(type))
+    for (auto &restriction : CS.ConstraintRestrictions) {
+      if (std::get<0>(restriction)->isEqual(type))
         return std::pair<Type, ConversionRestrictionKind>(
-            restriction.first.second, restriction.second);
+            std::get<1>(restriction), std::get<2>(restriction));
     }
     return None;
   }
 
   Optional<SelectedOverload>
   getOverloadChoiceIfAvailable(ConstraintLocator *locator) const {
-    return solution.getOverloadChoiceIfAvailable(locator);
+    if (auto *overload = getResolvedOverload(locator))
+      return Optional<SelectedOverload>(
+           {overload->Choice, overload->OpenedFullType, overload->ImpliedType});
+    return None;
   }
 
   /// Retrieve overload choice resolved for given locator
   /// by the constraint solver.
-  ResolvedOverloadSetListItem *getResolvedOverload(ConstraintLocator *locator) {
-    auto resolvedOverload = getConstraintSystem().getResolvedOverloadSets();
+  ResolvedOverloadSetListItem *
+  getResolvedOverload(ConstraintLocator *locator) const {
+    auto resolvedOverload = CS.getResolvedOverloadSets();
     while (resolvedOverload) {
       if (resolvedOverload->Locator == locator)
         return resolvedOverload;
@@ -135,9 +138,9 @@ protected:
   const ApplyExpr *Apply = nullptr;
 
 public:
-  RequirementFailure(Expr *expr, const Solution &solution,
+  RequirementFailure(Expr *expr, ConstraintSystem &cs,
                      ConstraintLocator *locator)
-      : FailureDiagnostic(expr, solution, locator), AffectedDecl(getDeclRef()) {
+      : FailureDiagnostic(expr, cs, locator), AffectedDecl(getDeclRef()) {
     auto *anchor = getAnchor();
     expr->forEachChildExpr([&](Expr *subExpr) -> Expr * {
       auto *AE = dyn_cast<ApplyExpr>(subExpr);
@@ -212,10 +215,10 @@ class MissingConformanceFailure final : public RequirementFailure {
   ProtocolDecl *Protocol;
 
 public:
-  MissingConformanceFailure(Expr *expr, const Solution &solution,
+  MissingConformanceFailure(Expr *expr, ConstraintSystem &cs,
                             ConstraintLocator *locator,
                             std::pair<Type, ProtocolDecl *> conformance)
-      : RequirementFailure(expr, solution, locator),
+      : RequirementFailure(expr, cs, locator),
         NonConformingType(conformance.first), Protocol(conformance.second) {}
 
   bool diagnose() override;
@@ -257,9 +260,9 @@ class SameTypeRequirementFailure final : public RequirementFailure {
   Type LHS, RHS;
 
 public:
-  SameTypeRequirementFailure(Expr *expr, const Solution &solution, Type lhs,
+  SameTypeRequirementFailure(Expr *expr, ConstraintSystem &cs, Type lhs,
                              Type rhs, ConstraintLocator *locator)
-      : RequirementFailure(expr, solution, locator), LHS(lhs), RHS(rhs) {}
+      : RequirementFailure(expr, cs, locator), LHS(lhs), RHS(rhs) {}
 
   Type getLHS() const override { return LHS; }
   Type getRHS() const override { return RHS; }
@@ -291,9 +294,9 @@ class SuperclassRequirementFailure final : public RequirementFailure {
   Type LHS, RHS;
 
 public:
-  SuperclassRequirementFailure(Expr *expr, const Solution &solution, Type lhs,
+  SuperclassRequirementFailure(Expr *expr, ConstraintSystem &cs, Type lhs,
                                Type rhs, ConstraintLocator *locator)
-      : RequirementFailure(expr, solution, locator), LHS(lhs), RHS(rhs) {}
+      : RequirementFailure(expr, cs, locator), LHS(lhs), RHS(rhs) {}
 
   Type getLHS() const override { return LHS; }
   Type getRHS() const override { return RHS; }
@@ -320,9 +323,9 @@ class LabelingFailure final : public FailureDiagnostic {
   ArrayRef<Identifier> CorrectLabels;
 
 public:
-  LabelingFailure(const Solution &solution, ConstraintLocator *locator,
+  LabelingFailure(ConstraintSystem &cs, ConstraintLocator *locator,
                   ArrayRef<Identifier> labels)
-      : FailureDiagnostic(nullptr, solution, locator), CorrectLabels(labels) {}
+      : FailureDiagnostic(nullptr, cs, locator), CorrectLabels(labels) {}
 
   bool diagnose() override;
 };
@@ -333,19 +336,19 @@ class NoEscapeFuncToTypeConversionFailure final : public FailureDiagnostic {
   Type ConvertTo;
 
 public:
-  NoEscapeFuncToTypeConversionFailure(Expr *expr, const Solution &solution,
+  NoEscapeFuncToTypeConversionFailure(Expr *expr, ConstraintSystem &cs,
                                       ConstraintLocator *locator,
                                       Type toType = Type())
-      : FailureDiagnostic(expr, solution, locator), ConvertTo(toType) {}
+      : FailureDiagnostic(expr, cs, locator), ConvertTo(toType) {}
 
   bool diagnose() override;
 };
 
 class MissingForcedDowncastFailure final : public FailureDiagnostic {
 public:
-  MissingForcedDowncastFailure(Expr *expr, const Solution &solution,
+  MissingForcedDowncastFailure(Expr *expr, ConstraintSystem &cs,
                                ConstraintLocator *locator)
-      : FailureDiagnostic(expr, solution, locator) {}
+      : FailureDiagnostic(expr, cs, locator) {}
 
   bool diagnose() override;
 };
@@ -354,9 +357,9 @@ public:
 /// to `inout` parameter, without explicitly specifying `&`.
 class MissingAddressOfFailure final : public FailureDiagnostic {
 public:
-  MissingAddressOfFailure(Expr *expr, const Solution &solution,
+  MissingAddressOfFailure(Expr *expr, ConstraintSystem &cs,
                           ConstraintLocator *locator)
-      : FailureDiagnostic(expr, solution, locator) {}
+      : FailureDiagnostic(expr, cs, locator) {}
 
   bool diagnose() override;
 };
@@ -368,9 +371,9 @@ class MissingExplicitConversionFailure final : public FailureDiagnostic {
   Type ConvertingTo;
 
 public:
-  MissingExplicitConversionFailure(Expr *expr, const Solution &solution,
+  MissingExplicitConversionFailure(Expr *expr, ConstraintSystem &cs,
                                    ConstraintLocator *locator, Type toType)
-      : FailureDiagnostic(expr, solution, locator), ConvertingTo(toType) {}
+      : FailureDiagnostic(expr, cs, locator), ConvertingTo(toType) {}
 
   bool diagnose() override;
 
@@ -407,10 +410,10 @@ class MemberAccessOnOptionalBaseFailure final : public FailureDiagnostic {
   bool ResultTypeIsOptional;
 
 public:
-  MemberAccessOnOptionalBaseFailure(Expr *expr, const Solution &solution,
+  MemberAccessOnOptionalBaseFailure(Expr *expr, ConstraintSystem &cs,
                                     ConstraintLocator *locator,
                                     DeclName memberName, bool resultOptional)
-      : FailureDiagnostic(expr, solution, locator), Member(memberName),
+      : FailureDiagnostic(expr, cs, locator), Member(memberName),
         ResultTypeIsOptional(resultOptional) {}
 
   bool diagnose() override;
@@ -420,9 +423,9 @@ public:
 /// which require some type of force-unwrap e.g. "!" or "try!".
 class MissingOptionalUnwrapFailure final : public FailureDiagnostic {
 public:
-  MissingOptionalUnwrapFailure(Expr *expr, const Solution &solution,
+  MissingOptionalUnwrapFailure(Expr *expr, ConstraintSystem &cs,
                                ConstraintLocator *locator)
-      : FailureDiagnostic(expr, solution, locator) {}
+      : FailureDiagnostic(expr, cs, locator) {}
 
   bool diagnose() override;
 };
@@ -432,8 +435,8 @@ public:
 class RValueTreatedAsLValueFailure final : public FailureDiagnostic {
 
 public:
-  RValueTreatedAsLValueFailure(const Solution &solution, ConstraintLocator *locator)
-    : FailureDiagnostic(nullptr, solution, locator) {}
+  RValueTreatedAsLValueFailure(ConstraintSystem &cs, ConstraintLocator *locator)
+      : FailureDiagnostic(nullptr, cs, locator) {}
 
   bool diagnose() override;
 };

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -34,15 +34,15 @@ ConstraintFix::~ConstraintFix() {}
 
 Expr *ConstraintFix::getAnchor() const { return getLocator()->getAnchor(); }
 
-void ConstraintFix::print(llvm::raw_ostream &Out, SourceManager *sm) const {
+void ConstraintFix::print(llvm::raw_ostream &Out) const {
   Out << "[fix: ";
   Out << getName();
   Out << ']';
   Out << " @ ";
-  getLocator()->dump(sm, Out);
+  getLocator()->dump(&CS.getASTContext().SourceMgr, Out);
 }
 
-void ConstraintFix::dump(SourceManager *sm) const { print(llvm::errs(), sm); }
+void ConstraintFix::dump() const {print(llvm::errs()); }
 
 std::string ForceDowncast::getName() const {
   llvm::SmallString<16> name;

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -53,8 +53,8 @@ std::string ForceDowncast::getName() const {
 }
 
 bool ForceDowncast::diagnose(Expr *expr, const Solution &solution) const {
-  MissingExplicitConversionFailure failure(expr, solution, getLocator(),
-                                           DowncastTo);
+  MissingExplicitConversionFailure failure(expr, solution.getConstraintSystem(),
+                                           getLocator(), DowncastTo);
   return failure.diagnose();
 }
 
@@ -64,7 +64,8 @@ ForceDowncast *ForceDowncast::create(ConstraintSystem &cs, Type toType,
 }
 
 bool ForceOptional::diagnose(Expr *root, const Solution &solution) const {
-  MissingOptionalUnwrapFailure failure(root, solution, getLocator());
+  MissingOptionalUnwrapFailure failure(root, solution.getConstraintSystem(),
+                                       getLocator());
   return failure.diagnose();
 }
 
@@ -76,8 +77,9 @@ ForceOptional *ForceOptional::create(ConstraintSystem &cs,
 bool UnwrapOptionalBase::diagnose(Expr *root, const Solution &solution) const {
   bool resultIsOptional =
       getKind() == FixKind::UnwrapOptionalBaseWithOptionalResult;
-  MemberAccessOnOptionalBaseFailure failure(root, solution, getLocator(),
-                                            MemberName, resultIsOptional);
+  MemberAccessOnOptionalBaseFailure failure(
+      root, solution.getConstraintSystem(), getLocator(), MemberName,
+      resultIsOptional);
   return failure.diagnose();
 }
 
@@ -95,7 +97,8 @@ UnwrapOptionalBase *UnwrapOptionalBase::createWithOptionalResult(
 }
 
 bool AddAddressOf::diagnose(Expr *root, const Solution &solution) const {
-  MissingAddressOfFailure failure(root, solution, getLocator());
+  MissingAddressOfFailure failure(root, solution.getConstraintSystem(),
+                                  getLocator());
   return failure.diagnose();
 }
 
@@ -105,7 +108,8 @@ AddAddressOf *AddAddressOf::create(ConstraintSystem &cs,
 }
 
 bool TreatRValueAsLValue::diagnose(Expr *root, const Solution &solution) const {
-  RValueTreatedAsLValueFailure failure(solution, getLocator());
+  RValueTreatedAsLValueFailure failure(solution.getConstraintSystem(),
+                                       getLocator());
   return failure.diagnose();
 }
 
@@ -116,7 +120,8 @@ TreatRValueAsLValue *TreatRValueAsLValue::create(ConstraintSystem &cs,
 
 
 bool CoerceToCheckedCast::diagnose(Expr *root, const Solution &solution) const {
-  MissingForcedDowncastFailure failure(root, solution, getLocator());
+  MissingForcedDowncastFailure failure(root, solution.getConstraintSystem(),
+                                       getLocator());
   return failure.diagnose();
 }
 
@@ -127,8 +132,8 @@ CoerceToCheckedCast *CoerceToCheckedCast::create(ConstraintSystem &cs,
 
 bool MarkExplicitlyEscaping::diagnose(Expr *root,
                                       const Solution &solution) const {
-  NoEscapeFuncToTypeConversionFailure failure(root, solution, getLocator(),
-                                              ConvertTo);
+  NoEscapeFuncToTypeConversionFailure failure(
+      root, solution.getConstraintSystem(), getLocator(), ConvertTo);
   return failure.diagnose();
 }
 
@@ -139,7 +144,8 @@ MarkExplicitlyEscaping::create(ConstraintSystem &cs, ConstraintLocator *locator,
 }
 
 bool RelabelArguments::diagnose(Expr *root, const Solution &solution) const {
-  LabelingFailure failure(solution, getLocator(), getLabels());
+  LabelingFailure failure(solution.getConstraintSystem(), getLocator(),
+                          getLabels());
   return failure.diagnose();
 }
 
@@ -153,7 +159,8 @@ RelabelArguments::create(ConstraintSystem &cs,
 }
 
 bool MissingConformance::diagnose(Expr *root, const Solution &solution) const {
-  MissingConformanceFailure failure(root, solution, getLocator(),
+  MissingConformanceFailure failure(root, solution.getConstraintSystem(),
+                                    getLocator(),
                                     {NonConformingType, Protocol});
   return failure.diagnose();
 }
@@ -166,7 +173,8 @@ MissingConformance *MissingConformance::create(ConstraintSystem &cs, Type type,
 
 bool SkipSameTypeRequirement::diagnose(Expr *root,
                                        const Solution &solution) const {
-  SameTypeRequirementFailure failure(root, solution, LHS, RHS, getLocator());
+  SameTypeRequirementFailure failure(root, solution.getConstraintSystem(), LHS,
+                                     RHS, getLocator());
   return failure.diagnose();
 }
 
@@ -178,7 +186,8 @@ SkipSameTypeRequirement::create(ConstraintSystem &cs, Type lhs, Type rhs,
 
 bool SkipSuperclassRequirement::diagnose(Expr *root,
                                          const Solution &solution) const {
-  SuperclassRequirementFailure failure(root, solution, LHS, RHS, getLocator());
+  SuperclassRequirementFailure failure(root, solution.getConstraintSystem(),
+                                       LHS, RHS, getLocator());
   return failure.diagnose();
 }
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -52,34 +52,33 @@ std::string ForceDowncast::getName() const {
   return name.c_str();
 }
 
-bool ForceDowncast::diagnose(Expr *expr, const Solution &solution) const {
-  MissingExplicitConversionFailure failure(expr, solution.getConstraintSystem(),
+bool ForceDowncast::diagnose(Expr *expr) const {
+  MissingExplicitConversionFailure failure(expr, getConstraintSystem(),
                                            getLocator(), DowncastTo);
   return failure.diagnose();
 }
 
 ForceDowncast *ForceDowncast::create(ConstraintSystem &cs, Type toType,
                                      ConstraintLocator *locator) {
-  return new (cs.getAllocator()) ForceDowncast(toType, locator);
+  return new (cs.getAllocator()) ForceDowncast(cs, toType, locator);
 }
 
-bool ForceOptional::diagnose(Expr *root, const Solution &solution) const {
-  MissingOptionalUnwrapFailure failure(root, solution.getConstraintSystem(),
+bool ForceOptional::diagnose(Expr *root) const {
+  MissingOptionalUnwrapFailure failure(root, getConstraintSystem(),
                                        getLocator());
   return failure.diagnose();
 }
 
 ForceOptional *ForceOptional::create(ConstraintSystem &cs,
                                      ConstraintLocator *locator) {
-  return new (cs.getAllocator()) ForceOptional(locator);
+  return new (cs.getAllocator()) ForceOptional(cs, locator);
 }
 
-bool UnwrapOptionalBase::diagnose(Expr *root, const Solution &solution) const {
+bool UnwrapOptionalBase::diagnose(Expr *root) const {
   bool resultIsOptional =
       getKind() == FixKind::UnwrapOptionalBaseWithOptionalResult;
   MemberAccessOnOptionalBaseFailure failure(
-      root, solution.getConstraintSystem(), getLocator(), MemberName,
-      resultIsOptional);
+      root, getConstraintSystem(), getLocator(), MemberName, resultIsOptional);
   return failure.diagnose();
 }
 
@@ -87,65 +86,61 @@ UnwrapOptionalBase *UnwrapOptionalBase::create(ConstraintSystem &cs,
                                                DeclName member,
                                                ConstraintLocator *locator) {
   return new (cs.getAllocator())
-      UnwrapOptionalBase(FixKind::UnwrapOptionalBase, member, locator);
+      UnwrapOptionalBase(cs, FixKind::UnwrapOptionalBase, member, locator);
 }
 
 UnwrapOptionalBase *UnwrapOptionalBase::createWithOptionalResult(
     ConstraintSystem &cs, DeclName member, ConstraintLocator *locator) {
   return new (cs.getAllocator()) UnwrapOptionalBase(
-      FixKind::UnwrapOptionalBaseWithOptionalResult, member, locator);
+      cs, FixKind::UnwrapOptionalBaseWithOptionalResult, member, locator);
 }
 
-bool AddAddressOf::diagnose(Expr *root, const Solution &solution) const {
-  MissingAddressOfFailure failure(root, solution.getConstraintSystem(),
-                                  getLocator());
+bool AddAddressOf::diagnose(Expr *root) const {
+  MissingAddressOfFailure failure(root, getConstraintSystem(), getLocator());
   return failure.diagnose();
 }
 
 AddAddressOf *AddAddressOf::create(ConstraintSystem &cs,
                                    ConstraintLocator *locator) {
-  return new (cs.getAllocator()) AddAddressOf(locator);
+  return new (cs.getAllocator()) AddAddressOf(cs, locator);
 }
 
-bool TreatRValueAsLValue::diagnose(Expr *root, const Solution &solution) const {
-  RValueTreatedAsLValueFailure failure(solution.getConstraintSystem(),
-                                       getLocator());
+bool TreatRValueAsLValue::diagnose(Expr *root) const {
+  RValueTreatedAsLValueFailure failure(getConstraintSystem(), getLocator());
   return failure.diagnose();
 }
 
 TreatRValueAsLValue *TreatRValueAsLValue::create(ConstraintSystem &cs,
                                    ConstraintLocator *locator) {
-  return new (cs.getAllocator()) TreatRValueAsLValue(locator);
+  return new (cs.getAllocator()) TreatRValueAsLValue(cs, locator);
 }
 
-
-bool CoerceToCheckedCast::diagnose(Expr *root, const Solution &solution) const {
-  MissingForcedDowncastFailure failure(root, solution.getConstraintSystem(),
+bool CoerceToCheckedCast::diagnose(Expr *root) const {
+  MissingForcedDowncastFailure failure(root, getConstraintSystem(),
                                        getLocator());
   return failure.diagnose();
 }
 
 CoerceToCheckedCast *CoerceToCheckedCast::create(ConstraintSystem &cs,
                                                  ConstraintLocator *locator) {
-  return new (cs.getAllocator()) CoerceToCheckedCast(locator);
+  return new (cs.getAllocator()) CoerceToCheckedCast(cs, locator);
 }
 
-bool MarkExplicitlyEscaping::diagnose(Expr *root,
-                                      const Solution &solution) const {
-  NoEscapeFuncToTypeConversionFailure failure(
-      root, solution.getConstraintSystem(), getLocator(), ConvertTo);
+bool MarkExplicitlyEscaping::diagnose(Expr *root) const {
+  NoEscapeFuncToTypeConversionFailure failure(root, getConstraintSystem(),
+                                              getLocator(), ConvertTo);
   return failure.diagnose();
 }
 
 MarkExplicitlyEscaping *
 MarkExplicitlyEscaping::create(ConstraintSystem &cs, ConstraintLocator *locator,
                                Type convertingTo) {
-  return new (cs.getAllocator()) MarkExplicitlyEscaping(locator, convertingTo);
+  return new (cs.getAllocator())
+      MarkExplicitlyEscaping(cs, locator, convertingTo);
 }
 
-bool RelabelArguments::diagnose(Expr *root, const Solution &solution) const {
-  LabelingFailure failure(solution.getConstraintSystem(), getLocator(),
-                          getLabels());
+bool RelabelArguments::diagnose(Expr *root) const {
+  LabelingFailure failure(getConstraintSystem(), getLocator(), getLabels());
   return failure.diagnose();
 }
 
@@ -155,12 +150,11 @@ RelabelArguments::create(ConstraintSystem &cs,
                          ConstraintLocator *locator) {
   unsigned size = totalSizeToAlloc<Identifier>(correctLabels.size());
   void *mem = cs.getAllocator().Allocate(size, alignof(RelabelArguments));
-  return new (mem) RelabelArguments(correctLabels, locator);
+  return new (mem) RelabelArguments(cs, correctLabels, locator);
 }
 
-bool MissingConformance::diagnose(Expr *root, const Solution &solution) const {
-  MissingConformanceFailure failure(root, solution.getConstraintSystem(),
-                                    getLocator(),
+bool MissingConformance::diagnose(Expr *root) const {
+  MissingConformanceFailure failure(root, getConstraintSystem(), getLocator(),
                                     {NonConformingType, Protocol});
   return failure.diagnose();
 }
@@ -168,31 +162,31 @@ bool MissingConformance::diagnose(Expr *root, const Solution &solution) const {
 MissingConformance *MissingConformance::create(ConstraintSystem &cs, Type type,
                                                ProtocolDecl *protocol,
                                                ConstraintLocator *locator) {
-  return new (cs.getAllocator()) MissingConformance(type, protocol, locator);
+  return new (cs.getAllocator())
+      MissingConformance(cs, type, protocol, locator);
 }
 
-bool SkipSameTypeRequirement::diagnose(Expr *root,
-                                       const Solution &solution) const {
-  SameTypeRequirementFailure failure(root, solution.getConstraintSystem(), LHS,
-                                     RHS, getLocator());
+bool SkipSameTypeRequirement::diagnose(Expr *root) const {
+  SameTypeRequirementFailure failure(root, getConstraintSystem(), LHS, RHS,
+                                     getLocator());
   return failure.diagnose();
 }
 
 SkipSameTypeRequirement *
 SkipSameTypeRequirement::create(ConstraintSystem &cs, Type lhs, Type rhs,
                                 ConstraintLocator *locator) {
-  return new (cs.getAllocator()) SkipSameTypeRequirement(lhs, rhs, locator);
+  return new (cs.getAllocator()) SkipSameTypeRequirement(cs, lhs, rhs, locator);
 }
 
-bool SkipSuperclassRequirement::diagnose(Expr *root,
-                                         const Solution &solution) const {
-  SuperclassRequirementFailure failure(root, solution.getConstraintSystem(),
-                                       LHS, RHS, getLocator());
+bool SkipSuperclassRequirement::diagnose(Expr *root) const {
+  SuperclassRequirementFailure failure(root, getConstraintSystem(), LHS, RHS,
+                                       getLocator());
   return failure.diagnose();
 }
 
 SkipSuperclassRequirement *
 SkipSuperclassRequirement::create(ConstraintSystem &cs, Type lhs, Type rhs,
                                   ConstraintLocator *locator) {
-  return new (cs.getAllocator()) SkipSuperclassRequirement(lhs, rhs, locator);
+  return new (cs.getAllocator())
+      SkipSuperclassRequirement(cs, lhs, rhs, locator);
 }

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -78,12 +78,13 @@ enum class FixKind : uint8_t {
 };
 
 class ConstraintFix {
+  ConstraintSystem &CS;
   FixKind Kind;
   ConstraintLocator *Locator;
 
 public:
-  ConstraintFix(FixKind kind, ConstraintLocator *locator)
-      : Kind(kind), Locator(locator) {}
+  ConstraintFix(ConstraintSystem &cs, FixKind kind, ConstraintLocator *locator)
+      : CS(cs), Kind(kind), Locator(locator) {}
 
   virtual ~ConstraintFix();
 
@@ -92,8 +93,8 @@ public:
   virtual std::string getName() const = 0;
 
   /// Diagnose a failure associated with this fix given
-  /// root expression and information from well-formed solution.
-  virtual bool diagnose(Expr *root, const Solution &solution) const = 0;
+  /// root expression and information from constraint system.
+  virtual bool diagnose(Expr *root) const = 0;
 
   void print(llvm::raw_ostream &Out, SourceManager *sm) const;
 
@@ -106,18 +107,22 @@ public:
   /// any simplication attempts.
   Expr *getAnchor() const;
   ConstraintLocator *getLocator() const { return Locator; }
+
+protected:
+  ConstraintSystem &getConstraintSystem() const { return CS; }
 };
 
 /// Append 'as! T' to force a downcast to the specified type.
 class ForceDowncast final : public ConstraintFix {
   Type DowncastTo;
 
-  ForceDowncast(Type toType, ConstraintLocator *locator)
-      : ConstraintFix(FixKind::ForceDowncast, locator), DowncastTo(toType) {}
+  ForceDowncast(ConstraintSystem &cs, Type toType, ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::ForceDowncast, locator), DowncastTo(toType) {
+  }
 
 public:
   std::string getName() const override;
-  bool diagnose(Expr *root, const Solution &solution) const override;
+  bool diagnose(Expr *root) const override;
 
   static ForceDowncast *create(ConstraintSystem &cs, Type toType,
                                ConstraintLocator *locator);
@@ -125,13 +130,13 @@ public:
 
 /// Introduce a '!' to force an optional unwrap.
 class ForceOptional final : public ConstraintFix {
-  ForceOptional(ConstraintLocator *locator)
-      : ConstraintFix(FixKind::ForceOptional, locator) {}
+  ForceOptional(ConstraintSystem &cs, ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::ForceOptional, locator) {}
 
 public:
   std::string getName() const override { return "force optional"; }
 
-  bool diagnose(Expr *root, const Solution &solution) const override;
+  bool diagnose(Expr *root) const override;
 
   static ForceOptional *create(ConstraintSystem &cs,
                                ConstraintLocator *locator);
@@ -141,8 +146,9 @@ public:
 class UnwrapOptionalBase final : public ConstraintFix {
   DeclName MemberName;
 
-  UnwrapOptionalBase(FixKind kind, DeclName member, ConstraintLocator *locator)
-      : ConstraintFix(kind, locator), MemberName(member) {
+  UnwrapOptionalBase(ConstraintSystem &cs, FixKind kind, DeclName member,
+                     ConstraintLocator *locator)
+      : ConstraintFix(cs, kind, locator), MemberName(member) {
     assert(kind == FixKind::UnwrapOptionalBase ||
            kind == FixKind::UnwrapOptionalBaseWithOptionalResult);
   }
@@ -152,7 +158,7 @@ public:
     return "unwrap optional base of member lookup";
   }
 
-  bool diagnose(Expr *root, const Solution &solution) const override;
+  bool diagnose(Expr *root) const override;
 
   static UnwrapOptionalBase *create(ConstraintSystem &cs, DeclName member,
                                     ConstraintLocator *locator);
@@ -164,40 +170,41 @@ public:
 
 /// Introduce a '&' to take the address of an lvalue.
 class AddAddressOf final : public ConstraintFix {
-  AddAddressOf(ConstraintLocator *locator)
-      : ConstraintFix(FixKind::AddressOf, locator) {}
+  AddAddressOf(ConstraintSystem &cs, ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::AddressOf, locator) {}
 
 public:
   std::string getName() const override { return "add address-of"; }
 
-  bool diagnose(Expr *root, const Solution &solution) const override;
+  bool diagnose(Expr *root) const override;
 
   static AddAddressOf *create(ConstraintSystem &cs, ConstraintLocator *locator);
 };
 
 // Treat rvalue as if it was an lvalue
 class TreatRValueAsLValue final : public ConstraintFix {
-  TreatRValueAsLValue(ConstraintLocator *locator)
-    : ConstraintFix(FixKind::TreatRValueAsLValue, locator) {}
+  TreatRValueAsLValue(ConstraintSystem &cs, ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::TreatRValueAsLValue, locator) {}
 
 public:
   std::string getName() const override { return "treat rvalue as lvalue"; }
 
-  bool diagnose(Expr *root, const Solution &solution) const override;
+  bool diagnose(Expr *root) const override;
 
-  static TreatRValueAsLValue *create(ConstraintSystem &cs, ConstraintLocator *locator);
+  static TreatRValueAsLValue *create(ConstraintSystem &cs,
+                                     ConstraintLocator *locator);
 };
 
 
 /// Replace a coercion ('as') with a forced checked cast ('as!').
 class CoerceToCheckedCast final : public ConstraintFix {
-  CoerceToCheckedCast(ConstraintLocator *locator)
-      : ConstraintFix(FixKind::CoerceToCheckedCast, locator) {}
+  CoerceToCheckedCast(ConstraintSystem &cs, ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::CoerceToCheckedCast, locator) {}
 
 public:
   std::string getName() const override { return "as to as!"; }
 
-  bool diagnose(Expr *root, const Solution &solution) const override;
+  bool diagnose(Expr *root) const override;
 
   static CoerceToCheckedCast *create(ConstraintSystem &cs,
                                      ConstraintLocator *locator);
@@ -209,14 +216,15 @@ class MarkExplicitlyEscaping final : public ConstraintFix {
   /// to be converted to some other generic type.
   Type ConvertTo;
 
-  MarkExplicitlyEscaping(ConstraintLocator *locator, Type convertingTo = Type())
-      : ConstraintFix(FixKind::ExplicitlyEscaping, locator),
+  MarkExplicitlyEscaping(ConstraintSystem &cs, ConstraintLocator *locator,
+                         Type convertingTo = Type())
+      : ConstraintFix(cs, FixKind::ExplicitlyEscaping, locator),
         ConvertTo(convertingTo) {}
 
 public:
   std::string getName() const override { return "add @escaping"; }
 
-  bool diagnose(Expr *root, const Solution &solution) const override;
+  bool diagnose(Expr *root) const override;
 
   static MarkExplicitlyEscaping *create(ConstraintSystem &cs,
                                         ConstraintLocator *locator,
@@ -232,9 +240,10 @@ class RelabelArguments final
 
   unsigned NumLabels;
 
-  RelabelArguments(llvm::ArrayRef<Identifier> correctLabels,
+  RelabelArguments(ConstraintSystem &cs,
+                   llvm::ArrayRef<Identifier> correctLabels,
                    ConstraintLocator *locator)
-      : ConstraintFix(FixKind::RelabelArguments, locator),
+      : ConstraintFix(cs, FixKind::RelabelArguments, locator),
         NumLabels(correctLabels.size()) {
     std::uninitialized_copy(correctLabels.begin(), correctLabels.end(),
                             getLabelsBuffer().begin());
@@ -247,7 +256,7 @@ public:
     return {getTrailingObjects<Identifier>(), NumLabels};
   }
 
-  bool diagnose(Expr *root, const Solution &solution) const override;
+  bool diagnose(Expr *root) const override;
 
   static RelabelArguments *create(ConstraintSystem &cs,
                                   llvm::ArrayRef<Identifier> correctLabels,
@@ -264,9 +273,9 @@ class MissingConformance final : public ConstraintFix {
   Type NonConformingType;
   ProtocolDecl *Protocol;
 
-  MissingConformance(Type type, ProtocolDecl *protocol,
+  MissingConformance(ConstraintSystem &cs, Type type, ProtocolDecl *protocol,
                      ConstraintLocator *locator)
-      : ConstraintFix(FixKind::AddConformance, locator),
+      : ConstraintFix(cs, FixKind::AddConformance, locator),
         NonConformingType(type), Protocol(protocol) {}
 
 public:
@@ -274,7 +283,7 @@ public:
     return "add missing protocol conformance";
   }
 
-  bool diagnose(Expr *root, const Solution &solution) const override;
+  bool diagnose(Expr *root) const override;
 
   static MissingConformance *create(ConstraintSystem &cs, Type type,
                                     ProtocolDecl *protocol,
@@ -286,8 +295,9 @@ public:
 class SkipSameTypeRequirement final : public ConstraintFix {
   Type LHS, RHS;
 
-  SkipSameTypeRequirement(Type lhs, Type rhs, ConstraintLocator *locator)
-      : ConstraintFix(FixKind::SkipSameTypeRequirement, locator), LHS(lhs),
+  SkipSameTypeRequirement(ConstraintSystem &cs, Type lhs, Type rhs,
+                          ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::SkipSameTypeRequirement, locator), LHS(lhs),
         RHS(rhs) {}
 
 public:
@@ -295,7 +305,7 @@ public:
     return "skip same-type generic requirement";
   }
 
-  bool diagnose(Expr *root, const Solution &solution) const override;
+  bool diagnose(Expr *root) const override;
 
   static SkipSameTypeRequirement *create(ConstraintSystem &cs, Type lhs,
                                          Type rhs, ConstraintLocator *locator);
@@ -306,8 +316,9 @@ public:
 class SkipSuperclassRequirement final : public ConstraintFix {
   Type LHS, RHS;
 
-  SkipSuperclassRequirement(Type lhs, Type rhs, ConstraintLocator *locator)
-      : ConstraintFix(FixKind::SkipSameTypeRequirement, locator), LHS(lhs),
+  SkipSuperclassRequirement(ConstraintSystem &cs, Type lhs, Type rhs,
+                            ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::SkipSameTypeRequirement, locator), LHS(lhs),
         RHS(rhs) {}
 
 public:
@@ -315,7 +326,7 @@ public:
     return "skip superclass generic requirement";
   }
 
-  bool diagnose(Expr *root, const Solution &solution) const override;
+  bool diagnose(Expr *root) const override;
 
   static SkipSuperclassRequirement *
   create(ConstraintSystem &cs, Type lhs, Type rhs, ConstraintLocator *locator);

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -96,10 +96,10 @@ public:
   /// root expression and information from constraint system.
   virtual bool diagnose(Expr *root) const = 0;
 
-  void print(llvm::raw_ostream &Out, SourceManager *sm) const;
+  void print(llvm::raw_ostream &Out) const;
 
-  LLVM_ATTRIBUTE_DEPRECATED(void dump(SourceManager *sm)
-                                const LLVM_ATTRIBUTE_USED,
+  LLVM_ATTRIBUTE_DEPRECATED(void dump() const
+                              LLVM_ATTRIBUTE_USED,
                             "only for use within the debugger");
 
   /// Retrieve anchor expression associated with this fix.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4988,7 +4988,7 @@ bool ConstraintSystem::recordFix(ConstraintFix *fix) {
     auto &log = ctx.TypeCheckerDebug->getStream();
     log.indent(solverState ? solverState->depth * 2 + 2 : 0)
       << "(attempting fix ";
-    fix->print(log, &ctx.SourceMgr);
+    fix->print(log);
     log << ")\n";
   }
 

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -390,7 +390,7 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm) const {
 
   if (auto *fix = getFix()) {
     Out << ' ';
-    fix->print(Out, sm);
+    fix->print(Out);
   }
 
   if (Locator) {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -907,12 +907,12 @@ public:
   ConstraintSystemOptions Options;
   Optional<ExpressionTimer> Timer;
   
-  friend class Fix;
   friend class ConstraintFix;
   friend class OverloadChoice;
   friend class ConstraintGraph;
   friend class DisjunctionChoice;
   friend class Component;
+  friend class FailureDiagnostic;
 
   class SolverScope;
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3349,7 +3349,7 @@ void Solution::dump(raw_ostream &out) const {
     out << "\nFixes:\n";
     for (auto *fix : Fixes) {
       out.indent(2);
-      fix->print(out, &ctx.SourceMgr);
+      fix->print(out);
       out << "\n";
     }
   }
@@ -3544,7 +3544,7 @@ void ConstraintSystem::print(raw_ostream &out) {
     out << "\nFixes:\n";
     for (auto *fix : Fixes) {
       out.indent(2);
-      fix->print(out, &getTypeChecker().Context.SourceMgr);
+      fix->print(out);
       out << "\n";
     }
   }


### PR DESCRIPTION
Since solution is now applied before fixes are diagnosed it means that all of the requirement
information would be in constraint system, so there is no reason to use information from solution.

These changes switch both `ConstraintFix` and `FailureDiagnostic` to use `ConstraintSystem`
which certain things like printing and diagnose API simpler.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
