### PR TITLE
[SILOptimizer] Add comment of possibility of public class to isEffectivelyFinalMethod

### DIFF
--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -121,7 +121,7 @@ static bool isEffectivelyFinalMethod(FullApplySite AI,
   if (!CHA)
     return false;
 
-  // This is a private or a module internal class.
+  // This is a private, a module internal or a public class.
   //
   // We can analyze the class hierarchy rooted at it and
   // eventually devirtualize a method call more efficiently.


### PR DESCRIPTION
This can be `public` class which won't be inherited in external module.

https://github.com/apple/swift/blob/f2a23769a909d466c692d08eda064226c5618bbd/lib/SILOptimizer/Utils/Local.cpp#L1475-L1483