### PR TITLE
Build libdispatch with the stdlib build type on linux when building

### DIFF
--- a/tools/SourceKit/CMakeLists.txt
+++ b/tools/SourceKit/CMakeLists.txt
@@ -106,6 +106,7 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
                           -DCMAKE_SWIFT_COMPILER=$<TARGET_FILE:swift>c
                           -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                           -DENABLE_SWIFT=YES
+                          -DCMAKE_BUILD_TYPE=${SWIFT_STDLIB_BUILD_TYPE}
                         BUILD_BYPRODUCTS
                           ${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/src/${CMAKE_SHARED_LIBRARY_PREFIX}dispatch${CMAKE_SHARED_LIBRARY_SUFFIX}
                           ${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/${CMAKE_STATIC_LIBRARY_PREFIX}BlocksRuntime${CMAKE_STATIC_LIBRARY_SUFFIX}


### PR DESCRIPTION
sourcekit

We were using the tools build type before.

rdar://43516251
