### PR TITLE
build: honour the libdispatch build type

### DIFF
--- a/tools/SourceKit/CMakeLists.txt
+++ b/tools/SourceKit/CMakeLists.txt
@@ -100,6 +100,7 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
                         BINARY_DIR
                           "${SWIFT_PATH_TO_LIBDISPATCH_BUILD}"
                         CMAKE_ARGS
+                          -DCMAKE_BUILD_TYPE=${LIBDISPATCH_CMAKE_BUILD_TYPE}
                           -DCMAKE_C_COMPILER=${PATH_TO_CLANG_BUILD}/bin/clang
                           -DCMAKE_CXX_COMPILER=${PATH_TO_CLANG_BUILD}/bin/clang++
                           -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -961,6 +961,7 @@ release-debuginfo
 assertions
 enable-lsan
 debug-swift-stdlib
+debug-libdispatch
 
 dash-dash
 

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2132,6 +2132,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DSWIFT_EMBED_BITCODE_SECTION:BOOL=$(true_false "${EMBED_BITCODE_SECTION}")
                     -DSWIFT_TOOLS_ENABLE_LTO:STRING="${SWIFT_TOOLS_ENABLE_LTO}"
                     -DSWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER:BOOL=$(true_false "${BUILD_RUNTIME_WITH_HOST_COMPILER}")
+                    -DLIBDISPATCH_CMAKE_BUILD_TYPE:STRING="${LIBDISPATCH_BUILD_TYPE}"
                     "${swift_cmake_options[@]}"
                 )
 


### PR DESCRIPTION
When configuring libdispatch as part of the swift build on Linux with SourceKit
enabled, we would default to a release build.  However, that results in known
leaks being reported with LSAN when building with a debug standard library.
Pass along the `LIBDISPATCH_BUILD_TYPE` into the CMake build and map that to the
CMAKE_BUILD_TYPE for the project.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
