### PR TITLE
[SE-0155] Reject empty associated value lists

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -866,6 +866,18 @@ ERROR(initializer_as_typed_pattern,none,
 ERROR(unlabeled_parameter_following_variadic_parameter,none,
       "a parameter following a variadic parameter requires a label", ())
 
+ERROR(enum_element_empty_arglist,none,
+      "enum element with associated values must have at least one "
+      "associated value", ())
+WARNING(enum_element_empty_arglist_swift4,none,
+        "enum element with associated values must have at least one "
+        "associated value; this will be an error in the future "
+        "version of Swift", ())
+NOTE(enum_element_empty_arglist_delete,none,
+     "did you mean to remove the empty associated value list?", ())
+NOTE(enum_element_empty_arglist_add_void,none,
+     "did you mean to explicitly add a 'Void' associated value?", ())
+
 //------------------------------------------------------------------------------
 // Statement parsing diagnostics
 //------------------------------------------------------------------------------

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -169,6 +169,23 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
                                           SyntaxKind::FunctionParameterList);
     }
     rightParenLoc = consumeToken(tok::r_paren);
+
+    // Per SE-0155, enum elements may not have empty parameter lists.
+    if (paramContext == ParameterContextKind::EnumElement) {
+      decltype(diag::enum_element_empty_arglist) diagnostic;
+      if (Context.isSwiftVersionAtLeast(5)) {
+        diagnostic = diag::enum_element_empty_arglist;
+      } else {
+        diagnostic = diag::enum_element_empty_arglist_swift4;
+      }
+
+      diagnose(leftParenLoc, diagnostic)
+        .highlight({leftParenLoc, rightParenLoc});
+      diagnose(leftParenLoc, diag::enum_element_empty_arglist_delete)
+        .fixItRemoveChars(leftParenLoc, rightParenLoc);
+      diagnose(leftParenLoc, diag::enum_element_empty_arglist_add_void)
+        .fixItInsert(leftParenLoc, "Void");
+    }
     return ParserStatus();
   }
 

--- a/test/IRGen/enum_empty_payloads.sil
+++ b/test/IRGen/enum_empty_payloads.sil
@@ -1,19 +1,21 @@
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -verify %s
 sil_stage canonical
 
+typealias Void = ()
+
 struct Empty<T> {}
 
 enum SinglePayload<T> {
   case A(T)
-  case B()
+  case B(Void)
   case C(Empty<T>)
 }
 
 enum MultiPayload<T, U> {
   case A(T)
   case B(U)
-  case C()
-  case D()
+  case C(Void)
+  case D(Void)
   case E(Empty<T>)
   case F(Empty<U>)
 }

--- a/test/Parse/enum.swift
+++ b/test/Parse/enum.swift
@@ -110,7 +110,7 @@ enum Recovery2 {
   case UE1: // expected-error {{'case' label can only appear inside a 'switch' statement}}
 }
 enum Recovery3 {
-  case UE2(): // expected-error {{'case' label can only appear inside a 'switch' statement}}
+  case UE2(Void): // expected-error {{'case' label can only appear inside a 'switch' statement}}
 }
 enum Recovery4 { // expected-note {{in declaration of 'Recovery4'}}
   case Self Self // expected-error {{keyword 'Self' cannot be used as an identifier here}} expected-note {{if this name is unavoidable, use backticks to escape it}} {{8-12=`Self`}} expected-error {{consecutive declarations on a line must be separated by ';'}} {{12-12=;}} expected-error {{expected declaration}}
@@ -542,3 +542,9 @@ enum SE0036_Generic<T> {
 }
 
 enum switch {} // expected-error {{keyword 'switch' cannot be used as an identifier here}} expected-note {{if this name is unavoidable, use backticks to escape it}} {{6-12=`switch`}}
+
+enum SE0155 {
+  case emptyArgs() // expected-warning {{enum element with associated values must have at least one associated value}}
+  // expected-note@-1 {{did you mean to remove the empty associated value list?}} {{17-18=}}
+  // expected-note@-2 {{did you mean to explicitly add a 'Void' associated value?}} {{17-17=Void}}
+}

--- a/test/SIL/Parser/undef.sil
+++ b/test/SIL/Parser/undef.sil
@@ -21,7 +21,7 @@ struct S {
 
 enum E {
   case Case
-  case DataCase(())
+  case DataCase(Void)
 }
 
 sil @general_test : $() -> () {

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -1426,7 +1426,7 @@ func testOptionalWriteGenerics2<T>(p: T) -> T? {
 
 enum TestOptionalEnum {
   case Cons(Int)
-  case Nil()
+  case Nil
 }
 
 func testOptionalWithEnum(p: TestOptionalEnum) -> TestOptionalEnum? {

--- a/test/SILOptimizer/loweraggregateinstrs.sil
+++ b/test/SILOptimizer/loweraggregateinstrs.sil
@@ -37,7 +37,7 @@ struct S {
 }
 
 enum E {
-  case NoElement()
+  case NoElement
   case TrivialElement(Builtin.Int64)
   case ReferenceElement(C1)
   case StructNonTrivialElt(S)

--- a/test/attr/attr_autoclosure.swift
+++ b/test/attr/attr_autoclosure.swift
@@ -125,7 +125,7 @@ class TestFunc12 {
 
 enum AutoclosureFailableOf<T> {
   case Success(@autoclosure () -> T)
-  case Failure()
+  case Failure
 }
 
 let _ : AutoclosureFailableOf<Int> = .Success(42)


### PR DESCRIPTION
SE-0155 makes an empty associated value list in an enum element declaration illegal.