### PR TITLE
[libSyntax] Make the ByteTree protocol version consist of a major and minor component

### DIFF
--- a/docs/ByteTree.md
+++ b/docs/ByteTree.md
@@ -21,7 +21,7 @@ Arrays are modelled as objects whose fields are all of the same type and whose l
 
 ## Versioning
 
-The ByteTree format is prepended by a 4-byte protocol version number that describes the version of the object tree that was serialized. Its exact semantics are up to each specific application, but it is encouraged to interpret it as a two-comentent number where the first component, consisting of the first three bytes, is incremented for breaking changes and the last byte is incremented for backwards-compatible changes.
+The ByteTree format is prepended by a 4-byte protocol version number that describes the version of the object tree that was serialized. Its exact semantics are up to each specific application, but it is encouraged to interpret it as a two-comentent number where the first component, consisting of the three most significant bytes, is incremented for breaking changes and the last byte is incremented for backwards-compatible changes.
 
 ## Forward compatilibity
 

--- a/include/swift/Syntax/Serialization/SyntaxSerialization.h
+++ b/include/swift/Syntax/Serialization/SyntaxSerialization.h
@@ -203,6 +203,20 @@ struct NullableTraits<RC<syntax::RawSyntax>> {
 
 namespace byteTree {
 
+/// Increase the major version for every change that is not just adding a new
+/// field at the end of an object. Older swiftSyntax clients will no longer be
+/// able to deserialize the format.
+const uint16_t SYNTAX_TREE_VERSION_MAJOR = 1; // Last change: initial version
+/// Increase the minor version if only new field has been added at the end of
+/// an object. Older swiftSyntax clients will still be able to deserialize the
+/// format.
+const uint8_t SYNTAX_TREE_VERSION_MINOR = 0; // Last change: initial version
+
+// Combine the major and minor version into one. The first three bytes
+// represent the major version, the last byte the minor version.
+const uint32_t SYNTAX_TREE_VERSION =
+    SYNTAX_TREE_VERSION_MAJOR << 8 | SYNTAX_TREE_VERSION_MINOR;
+
 /// The key for a ByteTree serializion user info of type
 /// `std::unordered_set<unsigned> *`. Specifies the IDs of syntax nodes that
 /// shall be omitted when the syntax tree gets serialized.

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -2448,7 +2448,8 @@ void serializeSyntaxTreeAsByteTree(
   Stream.reserve(32 * 1024);
   std::map<void *, void *> UserInfo;
   UserInfo[swift::byteTree::UserInfoKeyReusedNodeIds] = &ReusedNodeIds;
-  swift::byteTree::ByteTreeWriter::write(Stream, /*ProtocolVersion=*/1,
+  swift::byteTree::ByteTreeWriter::write(Stream,
+                                         swift::byteTree::SYNTAX_TREE_VERSION,
                                          *SyntaxTree.getRaw(), UserInfo);
 
   std::unique_ptr<llvm::WritableMemoryBuffer> Buf =

--- a/tools/SwiftSyntax/SwiftSyntax.swift
+++ b/tools/SwiftSyntax/SwiftSyntax.swift
@@ -80,8 +80,8 @@ public final class SyntaxTreeDeserializer {
     userInfo[.omittedNodeLookupFunction] = self.lookupNode
     return try ByteTreeReader.read(RawSyntax.self, from: data,
                                             userInfo: &userInfo) {
-      (version: ByteTreeReader.ProtocolVersion) in
-      return version == 1
+      (version: ByteTreeProtocolVersion) in
+      return version.major == 1
     }
   }
 

--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -737,7 +737,8 @@ int doSerializeRawTree(const char *MainExecutablePath,
       if (options::AddByteTreeFields) {
         UserInfo[swift::byteTree::UserInfoKeyAddInvalidFields] = (void *)true;
       }
-      swift::byteTree::ByteTreeWriter::write(Stream, /*ProtocolVersion=*/1,
+      swift::byteTree::ByteTreeWriter::write(Stream,
+                                             byteTree::SYNTAX_TREE_VERSION,
                                              *Root, UserInfo);
       auto OutputBufferOrError = llvm::FileOutputBuffer::create(
           options::OutputFilename, Stream.data().size());


### PR DESCRIPTION
The idea is that we can increment the minor version if we do forward-compatible changes as described in https://github.com/apple/swift/pull/18889 and only need to increment the major version if we do changes that will disallow older version of swiftSyntax to read the syntax tree.