### PR TITLE
[swiftSyntax] Default to unknown node if SyntaxKind/TokenKind raw value is unexpected

### DIFF
--- a/tools/SwiftSyntax/SyntaxKind.swift.gyb
+++ b/tools/SwiftSyntax/SyntaxKind.swift.gyb
@@ -99,11 +99,11 @@ extension SyntaxKind: ByteTreeScalarDecodable {
 % for name, nodes in grouped_nodes.items():
 %   for node in nodes:
     case ${SYNTAX_NODE_SERIALIZATION_CODES[node.syntax_kind]}: 
-      return .${node.swift_syntax_kind};
+      return .${node.swift_syntax_kind}
 %   end
 % end
     default:
-      fatalError("Unknown SyntaxKind \(rawValue)")
+      return .unknown
     }
   }
 }

--- a/tools/SwiftSyntax/TokenKind.swift.gyb
+++ b/tools/SwiftSyntax/TokenKind.swift.gyb
@@ -129,7 +129,16 @@ extension TokenKind: ByteTreeObjectDecodable {
 %   end
 % end
     default:
-      fatalError("Unknown TokenKind \(kind)")
+      if numFields > 1 {
+        // Default to an unknown token with the passed text if we don't know 
+        // its kind.
+        let text = reader.readField(String.self, index: 1)
+        return .unknown(text)
+      } else {
+        // If we were not passed the token's text, we cannot recover since we 
+        // would lose roundtripness.
+        fatalError("Unknown TokenKind \(kind)")
+      }
     }
   }
 }


### PR DESCRIPTION
This will allow us to add new `SyntaxKind`s and `TokenKind`s (unless they are keyword) while older `swiftSyntax` clients are still able to parse the syntax tree.