### PR TITLE
Fix SR-8570 by allowing existential metatypes for empty type-list attributes

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -2026,7 +2026,7 @@ TFGraphFunctionLowering::visitGraphOperationInst(GraphOperationInst *inst) {
         for (auto elt : rawElements)
           elements.push_back(elt.lookThroughSingleElementAggregates());
 
-        if (elementType->is<MetatypeType>()) {
+        if (elementType->is<AnyMetatypeType>()) {
           SmallVector<TF_DataType, 4> types;
           for (auto elt : elements) {
             auto dtype = convertSwiftTypeToTF(elt.getMetatypeValue());

--- a/test/TensorFlow/integration.swift
+++ b/test/TensorFlow/integration.swift
@@ -531,3 +531,7 @@ public func graphFuncReturningOpaqueHandles() -> (ResourceHandle, ResourceHandle
 // CHECK:  [[C:%.*]] = tuple ([[A]] : $ResourceHandle, [[B]] : $ResourceHandle)
 // CHECK:  return [[C]] : $(ResourceHandle, ResourceHandle)   
 
+// Allow Any.Type as a type list member for empty type lists.
+public func testSR8570() {
+  () = #tfop("FooOp", Targuments: [] as [Any.Type]) // expected-error {{op named 'FooOp' is not registered in TensorFlow}}
+}


### PR DESCRIPTION
Fix SR-8570 by allowing existential metatypes for empty type-list attributes.