### PR TITLE
[TF] Fix dataset deabstraction and higher-order function bugs

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -1902,10 +1902,13 @@ static Type conformsToTensorProtocol(Type ty, ModuleDecl *module) {
 
 /// Given something that conforms to the TensorProtocol protocol, extract the
 /// 'handle' out of it.
+// TODO: This should not be specific to TensorProtocol because TensorProtocol
+// requires a TensorHandle whereas members can be other opaque handles. This
+// will go away when TensorHandle unifies all handle types in the future.
 static SILValue getTensorProtocolHandleMember(SILValue v, SILLocation loc,
                                               SILBuilder &B) {
-  // If we already have a TensorHandle, just use it.
-  if (isTensorHandle(v->getType()))
+  // If we already have a TensorFlow value, just use it.
+  if (classifyTensorFlowValue(v->getType()) != TFValueKind::Nope)
     return v;
 
   auto module = B.getFunction().getModule().getSwiftModule();

--- a/stdlib/public/TensorFlow/Dataset.swift
+++ b/stdlib/public/TensorFlow/Dataset.swift
@@ -68,7 +68,6 @@ public extension SingleValueDataset {
   @inlinable @inline(__always)
   init(randomSeed: Int64, elementShape: TensorShape) {
     let (seed1, seed2) = _tensorSeeds(Tensor(randomSeed))
-    enableCPU()
     self.init(
       _handle: #tfop("RandomDataset", seed1, seed2,
                      output_types: [ScalarOfElement.self],
@@ -83,7 +82,6 @@ public extension SingleValueDataset {
   @inlinable @inline(__always)
   public init(elements: Tensor<ScalarOfElement>, elementShape: TensorShape) {
     // A dataset creation op only runs on TF CPU.
-    enableCPU()
     self.init(
       _handle: #tfop(
         "TensorSliceDataset", [elements],
@@ -237,7 +235,6 @@ public extension DoubleValueDataset {
   @inlinable @inline(__always)
   init(randomSeed: Int64, elementShapes: (TensorShape, TensorShape)) {
     let (seed1, seed2) = _tensorSeeds(Tensor(randomSeed))
-    enableCPU()
     self.init(
       _handle: #tfop("RandomDataset", seed1, seed2,
                      output_types: [ScalarOfFirstElement.self,
@@ -255,7 +252,6 @@ public extension DoubleValueDataset {
                          Tensor<ScalarOfSecondElement>),
               elementShapes: (TensorShape, TensorShape)) {
     // A dataset creation op only runs on TF CPU.
-    enableCPU()
     self.init(
       _handle: #tfop(
         "TensorSliceDataset", [elements.0.handle, elements.1.handle],

--- a/test/TensorFlowRuntime/dataset_api.swift
+++ b/test/TensorFlowRuntime/dataset_api.swift
@@ -50,17 +50,21 @@ DatasetAPITests.testAllBackends("SingleValueTransformations") {
 DatasetAPITests.testAllBackends("SingleValueHOFs") {
   let scalars = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1)
   let dataset = SingleValueDataset(elements: scalars, elementShape: [])
-  let result: SingleValueDataset = dataset.map { $0 + 1 }
-  expectEqual(result.flatMap { $0.scalars }, [1, 2, 3, 4, 5])
+  let addedOne: SingleValueDataset = dataset.map { $0 + 1 }
+  expectEqual([1, 2, 3, 4, 5], addedOne.flatMap { $0.scalars })
+  let evens: SingleValueDataset = dataset.filter { Tensor($0 % 2 == Tensor(0)) }
+  expectEqual([0, 2, 4], evens.flatMap { $0.scalars })
 }
 
 DatasetAPITests.testAllBackends("DoubleValueDatasetIteration") {
   let scalars1 = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1)
   let scalars2 = Tensor<Float>(rangeFrom: 5, to: 10, stride: 1)
-  let dataset = DoubleValueDataset(elements: (scalars1, scalars2),
-                                   elementShapes: ([], []))
+  let datasetLeft = SingleValueDataset(elements: scalars1,
+                                   elementShape: [])
+  let datasetRight = SingleValueDataset(elements: scalars2,
+                                   elementShape: [])
   var i: Int32 = 0
-  for (item1, item2) in dataset {
+  for (item1, item2) in zip(datasetLeft, datasetRight) {
     expectEqual(scalars1[i].array, item1.array)
     expectEqual(scalars2[i].array, item2.array)
     i += 1

--- a/test/TensorFlowRuntime/dataset_api.swift
+++ b/test/TensorFlowRuntime/dataset_api.swift
@@ -59,10 +59,8 @@ DatasetAPITests.testAllBackends("SingleValueHOFs") {
 DatasetAPITests.testAllBackends("DoubleValueDatasetIteration") {
   let scalars1 = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1)
   let scalars2 = Tensor<Float>(rangeFrom: 5, to: 10, stride: 1)
-  let datasetLeft = SingleValueDataset(elements: scalars1,
-                                   elementShape: [])
-  let datasetRight = SingleValueDataset(elements: scalars2,
-                                   elementShape: [])
+  let datasetLeft = SingleValueDataset(elements: scalars1, elementShape: [])
+  let datasetRight = SingleValueDataset(elements: scalars2, elementShape: [])
   var i: Int32 = 0
   for (item1, item2) in zip(datasetLeft, datasetRight) {
     expectEqual(scalars1[i].array, item1.array)

--- a/test/TensorFlowRuntime/dataset_api.swift
+++ b/test/TensorFlowRuntime/dataset_api.swift
@@ -47,16 +47,10 @@ DatasetAPITests.testAllBackends("SingleValueTransformations") {
   expectEqual([0, 4, 1, 3, 2], shuffled.map { $0.scalar! })
 }
 
-// FIXME: Only public @TensorFlowGraph functions are being partitioned.
-@TensorFlowGraph
-public func addOne(_ x: Tensor<Float>) -> Tensor<Float> {
-  return x + 1
-}
-
 DatasetAPITests.testAllBackends("SingleValueHOFs") {
   let scalars = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1)
   let dataset = SingleValueDataset(elements: scalars, elementShape: [])
-  let result: SingleValueDataset = dataset.map(addOne)
+  let result: SingleValueDataset = dataset.map { $0 + 1 }
   expectEqual(result.flatMap { $0.scalars }, [1, 2, 3, 4, 5])
 }
 


### PR DESCRIPTION
* Remove `enableCPU()` from library functions to work around [SR-8547](https://bugs.swift.org/browse/SR-8547). Fix `TensorFlow.zip(_:_:)`.
* Allow input lists to have any TensorFlow handle value as element. Fix [SR-8609](https://bugs.swift.org/browse/SR-8609).
* Enable dataset API trailing closure test. Add filter test and zip test.