### PR TITLE
Make sure to allow '@objc' on enum elements

### DIFF
--- a/lib/Sema/TypeCheckObjC.h
+++ b/lib/Sema/TypeCheckObjC.h
@@ -65,10 +65,15 @@ public:
     ExplicitlyGKInspectable,
     /// Is it a member of an @objc extension of a class.
     MemberOfObjCExtension,
+
+    // These kinds do not appear in diagnostics.
+
     /// Is it a member of an @objcMembers class.
     MemberOfObjCMembersClass,
     /// A member of an Objective-C-defined class or subclass.
     MemberOfObjCSubclass,
+    /// Is a member of an @objc enum.
+    ElementOfObjCEnum,
     /// An accessor to a property.
     Accessor,
   };

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2186,6 +2186,12 @@ void Serializer::writeDeclAttribute(const DeclAttribute *DA) {
   if (DA->isNotSerialized())
     return;
 
+  // Ignore attributes that have been marked invalid. (This usually means
+  // type-checking removed them, but only provided a warning rather than an
+  // error.)
+  if (DA->isInvalid())
+    return;
+
   switch (DA->getKind()) {
   case DAK_RawDocComment:
   case DAK_ReferenceOwnership: // Serialized as part of the type.

--- a/test/PrintAsObjC/enums.swift
+++ b/test/PrintAsObjC/enums.swift
@@ -1,10 +1,17 @@
 // RUN: %empty-directory(%t)
+
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-source-import -emit-module -emit-module-doc -o %t %s -import-objc-header %S/Inputs/enums.h -disable-objc-attr-requires-foundation-module
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/enums.swiftmodule -typecheck -emit-objc-header-path %t/enums.h -import-objc-header %S/Inputs/enums.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/enums.h
 // RUN: %FileCheck -check-prefix=NEGATIVE %s < %t/enums.h
 // RUN: %check-in-clang %t/enums.h
 // RUN: %check-in-clang -fno-modules -Qunused-arguments %t/enums.h -include ctypes.h -include CoreFoundation.h
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-source-import -emit-module -o /dev/null -emit-module-doc-path /dev/null -module-name enums %s -emit-objc-header-path %t/enums.WMO.h -import-objc-header %S/Inputs/enums.h -disable-objc-attr-requires-foundation-module
+// RUN: %FileCheck %s < %t/enums.WMO.h
+// RUN: %FileCheck -check-prefix=NEGATIVE %s < %t/enums.WMO.h
+// RUN: %check-in-clang %t/enums.WMO.h
+// RUN: %check-in-clang -fno-modules -Qunused-arguments %t/enums.WMO.h -include ctypes.h -include CoreFoundation.h
 
 // REQUIRES: objc_interop
 

--- a/test/Serialization/attr-invalid.swift
+++ b/test/Serialization/attr-invalid.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t/attr.swiftmodule %s -verify
+// RUN: llvm-bcanalyzer -dump %t/attr.swiftmodule | %FileCheck -check-prefix=CHECK-NON-RESILIENT %s
+// RUN: %target-swift-frontend -emit-module -o %t/attr_resilient.swiftmodule -enable-resilience -warnings-as-errors %s
+// RUN: llvm-bcanalyzer -dump %t/attr_resilient.swiftmodule | %FileCheck -check-prefix=CHECK-RESILIENT %s
+
+// These two should be checking for the same thing.
+// CHECK-RESILIENT: Frozen_DECL_ATTR
+// CHECK-NON-RESILIENT-NOT: Frozen_DECL_ATTR
+
+@_frozen // expected-warning {{@_frozen has no effect without -enable-resilience}}
+public enum SomeEnum {
+  case x
+}

--- a/test/api-digester/compare-dump.swift
+++ b/test/api-digester/compare-dump.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t.mod)
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)
-// RUN: %swift -emit-module -o %t.mod/cake1.swiftmodule %S/Inputs/cake1.swift -parse-as-library -I %S/Inputs/APINotesLeft %clang-importer-sdk-nosource
-// RUN: %swift -emit-module -o %t.mod/cake2.swiftmodule %S/Inputs/cake2.swift -parse-as-library -I %S/Inputs/APINotesRight %clang-importer-sdk-nosource
+// RUN: %swift -emit-module -o %t.mod/cake1.swiftmodule %S/Inputs/cake1.swift -parse-as-library -enable-resilience -I %S/Inputs/APINotesLeft %clang-importer-sdk-nosource
+// RUN: %swift -emit-module -o %t.mod/cake2.swiftmodule %S/Inputs/cake2.swift -parse-as-library -enable-resilience -I %S/Inputs/APINotesRight %clang-importer-sdk-nosource
 // RUN: %api-digester -dump-sdk -module cake1 -o %t.dump1.json -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %t.mod -I %S/Inputs/APINotesLeft
 // RUN: %api-digester -dump-sdk -module cake2 -o %t.dump2.json -module-cache-path %t.module-cache %clang-importer-sdk-nosource -I %t.mod -I %S/Inputs/APINotesRight
 // RUN: %api-digester -diagnose-sdk -print-module --input-paths %t.dump1.json -input-paths %t.dump2.json > %t.result

--- a/test/attr/attr_nonobjc.swift
+++ b/test/attr/attr_nonobjc.swift
@@ -111,3 +111,7 @@ protocol SR4226_Protocol : class {}
 extension SR4226_Protocol {
   @nonobjc func function() {} // expected-error {{only class members and extensions of classes can be declared @nonobjc}}
 }
+
+@objc enum SomeEnum: Int {
+  @nonobjc case what // expected-error {{'@nonobjc' attribute cannot be applied to this declaration}}
+}


### PR DESCRIPTION
Previously enum elements were ignored by the checking of `@objc`, but in the refactoring to a request (#17976) the attribute started getting marked as invalid without a diagnostic.

Why didn't we catch this sooner? Because it turns out we were serializing invalid attributes, which is *definitely* a bug because they'd be deserialized as valid. So, stop doing that too.

rdar://problem/43401047
