### PR TITLE
Basic: update the use of the `ExecuteNoWait` API

### DIFF
--- a/lib/Basic/Program.cpp
+++ b/lib/Basic/Program.cpp
@@ -12,6 +12,7 @@
 
 #include "swift/Basic/Program.h"
 
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/Config/config.h"
 #include "llvm/Support/Program.h"
 
@@ -33,7 +34,9 @@ int swift::ExecuteInPlace(const char *Program, const char **args,
 
   return result;
 #else
-  int result = llvm::sys::ExecuteAndWait(Program, args, env);
+  llvm::ArrayRef<llvm::StringRef> Env = llvm::toStringRefArray(env);
+  int result =
+      llvm::sys::ExecuteAndWait(Program, llvm::toStringRefArray(args), Env);
   if (result >= 0)
     exit(result);
   return result;


### PR DESCRIPTION
This now takes `ArrayRef<StringRef>` and `Optional<ArrayRef<StringRef>>`
parameters.  Explicitly update the interfaces to match.  This is particularly
important to repair the Windows build.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
