### PR TITLE
[Type checker] Introduce resolution stages for "inherited type" requests

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1725,9 +1725,6 @@ public:
 
   void setInherited(MutableArrayRef<TypeLoc> i) { Inherited = i; }
 
-  /// Retrieve one of the types listed in the "inherited" clause.
-  Type getInheritedType(unsigned index) const;
-
   /// Whether we have fully checked the extension signature.
   bool hasValidSignature() const {
     return getValidationState() > ValidationState::CheckingWithValidSignature;
@@ -2607,9 +2604,6 @@ public:
   /// explicitly conforms to).
   MutableArrayRef<TypeLoc> getInherited() { return Inherited; }
   ArrayRef<TypeLoc> getInherited() const { return Inherited; }
-
-  /// Retrieve one of the types listed in the "inherited" clause.
-  Type getInheritedType(unsigned index) const;
 
   void setInherited(MutableArrayRef<TypeLoc> i) { Inherited = i; }
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1486,7 +1486,7 @@ ERROR(extension_nongeneric_trailing_where,none,
       "trailing 'where' clause for extension of non-generic type %0",
       (DeclName))
 ERROR(extension_protocol_inheritance,none,
-      "extension of protocol %0 cannot have an inheritance clause", (Type))
+      "extension of protocol %0 cannot have an inheritance clause", (DeclName))
 ERROR(objc_generic_extension_using_type_parameter,none,
       "extension of a generic Objective-C class cannot access the class's "
       "generic parameters at runtime", ())

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -19,6 +19,7 @@
 #include "swift/AST/Type.h"
 #include "swift/AST/Evaluator.h"
 #include "swift/AST/SimpleRequest.h"
+#include "swift/AST/TypeResolutionStage.h"
 #include "swift/Basic/Statistic.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/TinyPtrVector.h"
@@ -39,7 +40,8 @@ class InheritedTypeRequest :
                          CacheKind::SeparatelyCached,
                          Type,
                          llvm::PointerUnion<TypeDecl *, ExtensionDecl *>,
-                         unsigned>
+                         unsigned,
+                         TypeResolutionStage>
 {
   /// Retrieve the TypeLoc for this inherited type.
   TypeLoc &getTypeLoc(llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
@@ -55,7 +57,8 @@ private:
   llvm::Expected<Type>
   evaluate(Evaluator &evaluator,
            llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
-           unsigned index) const;
+           unsigned index,
+           TypeResolutionStage stage) const;
 
 public:
   // Cycle handling
@@ -63,7 +66,7 @@ public:
   void noteCycleStep(DiagnosticEngine &diags) const;
 
   // Caching
-  bool isCached() const { return true; }
+  bool isCached() const;
   Optional<Type> getCachedResult() const;
   void cacheResult(Type value) const;
 };
@@ -73,7 +76,8 @@ class SuperclassTypeRequest :
     public SimpleRequest<SuperclassTypeRequest,
                          CacheKind::SeparatelyCached,
                          Type,
-                         NominalTypeDecl *> {
+                         NominalTypeDecl *,
+                         TypeResolutionStage> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -82,7 +86,8 @@ private:
 
   // Evaluation.
   llvm::Expected<Type>
-  evaluate(Evaluator &evaluator, NominalTypeDecl *classDecl) const;
+  evaluate(Evaluator &evaluator, NominalTypeDecl *classDecl,
+           TypeResolutionStage stage) const;
 
 public:
   // Cycle handling
@@ -90,7 +95,7 @@ public:
   void noteCycleStep(DiagnosticEngine &diags) const;
 
   // Separate caching.
-  bool isCached() const { return true; }
+  bool isCached() const;
   Optional<Type> getCachedResult() const;
   void cacheResult(Type value) const;
 };
@@ -100,7 +105,8 @@ class EnumRawTypeRequest :
     public SimpleRequest<EnumRawTypeRequest,
                          CacheKind::SeparatelyCached,
                          Type,
-                         EnumDecl *> {
+                         EnumDecl *,
+                         TypeResolutionStage> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -109,7 +115,8 @@ private:
 
   // Evaluation.
   llvm::Expected<Type>
-  evaluate(Evaluator &evaluator, EnumDecl *enumDecl) const;
+  evaluate(Evaluator &evaluator, EnumDecl *enumDecl,
+           TypeResolutionStage stage) const;
 
 public:
   // Cycle handling
@@ -117,7 +124,7 @@ public:
   void noteCycleStep(DiagnosticEngine &diags) const;
 
   // Separate caching.
-  bool isCached() const { return true; }
+  bool isCached() const;
   Optional<Type> getCachedResult() const;
   void cacheResult(Type value) const;
 };

--- a/include/swift/AST/TypeResolutionStage.h
+++ b/include/swift/AST/TypeResolutionStage.h
@@ -12,6 +12,10 @@
 #ifndef SWIFT_AST_TYPE_RESOLUTION_STAGE_H
 #define SWIFT_AST_TYPE_RESOLUTION_STAGE_H
 
+namespace llvm {
+class raw_ostream;
+}
+
 namespace swift {
 
 /// Describes the stage at which a particular type should be computed.
@@ -32,6 +36,9 @@ enum class TypeResolutionStage : uint8_t {
   /// the type.
   Contextual,
 };
+
+/// Display a type resolution stage.
+void simple_display(llvm::raw_ostream &out, const TypeResolutionStage &value);
 
 } // end namespace swift
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -988,12 +988,6 @@ NominalTypeDecl *ExtensionDecl::getExtendedNominal() const {
     ExtendedNominalRequest{const_cast<ExtensionDecl *>(this)}, nullptr);
 }
 
-Type ExtensionDecl::getInheritedType(unsigned index) const {
-  ASTContext &ctx = getASTContext();
-  return evaluateOrDefault(ctx.evaluator,
-    InheritedTypeRequest{const_cast<ExtensionDecl *>(this), index}, Type());
-}
-
 bool ExtensionDecl::isConstrainedExtension() const {
   // Non-generic extension.
   if (!getGenericSignature())
@@ -2667,12 +2661,6 @@ void ValueDecl::copyFormalAccessFrom(const ValueDecl *source,
   }
 }
 
-Type TypeDecl::getInheritedType(unsigned index) const {
-  ASTContext &ctx = getASTContext();
-  return evaluateOrDefault(ctx.evaluator,
-    InheritedTypeRequest{const_cast<TypeDecl *>(this), index}, Type());
-}
-
 Type TypeDecl::getDeclaredInterfaceType() const {
   if (auto *NTD = dyn_cast<NominalTypeDecl>(this))
     return NTD->getDeclaredInterfaceType();
@@ -3174,7 +3162,8 @@ EnumDecl::EnumDecl(SourceLoc EnumLoc,
 Type EnumDecl::getRawType() const {
   ASTContext &ctx = getASTContext();
   return evaluateOrDefault(ctx.evaluator,
-    EnumRawTypeRequest{const_cast<EnumDecl *>(this)}, Type());
+    EnumRawTypeRequest{const_cast<EnumDecl *>(this),
+                       TypeResolutionStage::Interface}, Type());
 }
 
 StructDecl::StructDecl(SourceLoc StructLoc, Identifier Name, SourceLoc NameLoc,
@@ -3611,7 +3600,9 @@ ProtocolDecl::getAssociatedTypeMembers() const {
 Type ProtocolDecl::getSuperclass() const {
   ASTContext &ctx = getASTContext();
   return evaluateOrDefault(ctx.evaluator,
-    SuperclassTypeRequest{const_cast<ProtocolDecl *>(this)}, Type());
+    SuperclassTypeRequest{const_cast<ProtocolDecl *>(this),
+                          TypeResolutionStage::Interface},
+    Type());
 }
 
 ClassDecl *ProtocolDecl::getSuperclassDecl() const {
@@ -6066,7 +6057,9 @@ Type TypeBase::getSwiftNewtypeUnderlyingType() {
 Type ClassDecl::getSuperclass() const {
   ASTContext &ctx = getASTContext();
   return evaluateOrDefault(ctx.evaluator,
-    SuperclassTypeRequest{const_cast<ClassDecl *>(this)}, Type());
+    SuperclassTypeRequest{const_cast<ClassDecl *>(this),
+                          TypeResolutionStage::Interface},
+    Type());
 }
 
 ClassDecl *ClassDecl::getSuperclassDecl() const {

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -43,6 +43,23 @@ void swift::simple_display(
     ext->getSelfNominalTypeDecl()->dumpRef(out);
 }
 
+void swift::simple_display(llvm::raw_ostream &out,
+                           const TypeResolutionStage &value) {
+  switch (value) {
+  case TypeResolutionStage::Structural:
+    out << "structural";
+    break;
+
+  case TypeResolutionStage::Interface:
+    out << "interface";
+    break;
+
+  case TypeResolutionStage::Contextual:
+    out << "contextual";
+    break;
+  }
+}
+
 //----------------------------------------------------------------------------//
 // Inherited type computation.
 //----------------------------------------------------------------------------//
@@ -66,6 +83,10 @@ void InheritedTypeRequest::noteCycleStep(DiagnosticEngine &diags) const {
   const auto &storage = getStorage();
   auto &typeLoc = getTypeLoc(std::get<0>(storage), std::get<1>(storage));
   diags.diagnose(typeLoc.getLoc(), diag::circular_reference_through);
+}
+
+bool InheritedTypeRequest::isCached() const {
+  return std::get<2>(getStorage()) == TypeResolutionStage::Interface;
 }
 
 Optional<Type> InheritedTypeRequest::getCachedResult() const {
@@ -97,6 +118,10 @@ void SuperclassTypeRequest::noteCycleStep(DiagnosticEngine &diags) const {
   auto nominalDecl = std::get<0>(getStorage());
   // FIXME: Customize this further.
   diags.diagnose(nominalDecl, diag::circular_reference_through);
+}
+
+bool SuperclassTypeRequest::isCached() const {
+  return std::get<1>(getStorage()) == TypeResolutionStage::Interface;
 }
 
 Optional<Type> SuperclassTypeRequest::getCachedResult() const {
@@ -136,6 +161,10 @@ void EnumRawTypeRequest::noteCycleStep(DiagnosticEngine &diags) const {
   auto enumDecl = std::get<0>(getStorage());
   // FIXME: Customize this further.
   diags.diagnose(enumDecl, diag::circular_reference_through);
+}
+
+bool EnumRawTypeRequest::isCached() const {
+  return std::get<1>(getStorage()) == TypeResolutionStage::Interface;
 }
 
 Optional<Type> EnumRawTypeRequest::getCachedResult() const {

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -21,6 +21,7 @@
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/Pattern.h"
 #include "swift/AST/ParameterList.h"
+#include "swift/AST/TypeCheckRequests.h"
 
 using namespace swift;
 
@@ -680,6 +681,15 @@ void AccessControlChecker::check(Decl *D) {
     auto minAccessScope = AccessScope::getPublic();
     const TypeRepr *complainRepr = nullptr;
     auto downgradeToWarning = DowngradeToWarning::No;
+
+    // FIXME: Hack to ensure that we've computed the types involved here.
+    ASTContext &ctx = proto->getASTContext();
+    for (unsigned i : indices(proto->getInherited())) {
+      (void)evaluateOrDefault(ctx.evaluator,
+                              InheritedTypeRequest{
+                                proto, i, TypeResolutionStage::Interface},
+                              Type());
+    }
 
     std::for_each(proto->getInherited().begin(),
                   proto->getInherited().end(),

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -234,7 +234,7 @@ void TypeChecker::validateWhereClauses(ProtocolDecl *protocol,
 
 void TypeChecker::checkInheritanceClause(Decl *decl) {
   auto dc = decl->getInnermostDeclContext();
-  checkInheritanceClause(decl, TypeResolution::forContextual(dc));
+  checkInheritanceClause(decl, TypeResolution::forInterface(dc));
 }
 
 /// check the inheritance clause of a type declaration or extension thereof.
@@ -244,6 +244,8 @@ void TypeChecker::checkInheritanceClause(Decl *decl) {
 /// to which this type declaration conforms.
 void TypeChecker::checkInheritanceClause(Decl *decl,
                                          TypeResolution resolution) {
+  assert(resolution.getStage() != TypeResolutionStage::Contextual);
+
   TypeResolutionOptions options = None;
   DeclContext *DC;
   if (auto nominal = dyn_cast<NominalTypeDecl>(decl)) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -535,6 +535,11 @@ void TypeChecker::checkInheritanceClause(Decl *decl,
       continue;
     }
 
+    // The GenericSignatureBuilder diagnoses problems with generic type
+    // parameters.
+    if (isa<GenericTypeParamDecl>(decl))
+      continue;
+
     // We can't inherit from a non-class, non-protocol type.
     diagnose(decl->getLoc(),
              (isa<StructDecl>(decl) || isa<ExtensionDecl>(decl))
@@ -542,7 +547,6 @@ void TypeChecker::checkInheritanceClause(Decl *decl,
                : diag::inheritance_from_non_protocol_or_class,
              inheritedTy);
     // FIXME: Note pointing to the declaration 'inheritedTy' references?
-    inherited.setInvalidType(Context);
   }
 }
 

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -62,13 +62,13 @@ void checkGenericParamList(TypeChecker &tc,
       builder->addGenericParameter(param);
   }
 
+  // Add the requirements for each of the generic parameters to the builder.
   // Now, check the inheritance clauses of each parameter.
-  for (auto param : *genericParams) {
-    tc.checkInheritanceClause(param, resolution);
-
-    if (builder)
+  if (builder) {
+    for (auto param : *genericParams)
       builder->addGenericParameterRequirements(param);
   }
+
 
   // Add the requirements clause to the builder, validating the types in
   // the requirements clause along the way.

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -263,12 +263,6 @@ static void revertDependentTypeLoc(TypeLoc &tl) {
 /// Revert the dependent types within the given generic parameter list.
 static void revertGenericParamList(TypeChecker &tc,
                                    GenericParamList *genericParams) {
-  // Revert the inherited clause of the generic parameter list.
-  for (auto param : *genericParams) {
-    for (auto &inherited : param->getInherited())
-      revertDependentTypeLoc(inherited);
-  }
-
   // Revert the requirements of the generic parameter list.
   tc.revertGenericRequirements(genericParams->getRequirements());
 }

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -43,14 +43,12 @@ InheritedTypeRequest::evaluate(
   // FIXME: This should be part of the request!
   TypeResolution resolution =
     isa<ProtocolDecl>(dc) ? TypeResolution::forStructural(dc)
-                          : TypeResolution::forContextual(dc);
+                          : TypeResolution::forInterface(dc);
 
   TypeLoc &typeLoc = getTypeLoc(decl, index);
 
   Type inheritedType =
     resolution.resolveType(typeLoc.getTypeRepr(), options);
-  if (inheritedType && !isa<ProtocolDecl>(dc))
-    inheritedType = inheritedType->mapTypeOutOfContext();
   return inheritedType ? inheritedType : ErrorType::get(dc->getASTContext());
 }
 
@@ -76,9 +74,6 @@ SuperclassTypeRequest::evaluate(Evaluator &evaluator,
 
     // If we found a class, return it.
     if (inheritedType->getClassOrBoundGenericClass()) {
-      if (inheritedType->hasArchetype())
-        return inheritedType->mapTypeOutOfContext();
-
       return inheritedType;
     }
 
@@ -87,9 +82,6 @@ SuperclassTypeRequest::evaluate(Evaluator &evaluator,
       if (auto superclassType =
             inheritedType->getExistentialLayout().explicitSuperclass) {
         if (superclassType->getClassOrBoundGenericClass()) {
-          if (superclassType->hasArchetype())
-            return superclassType->mapTypeOutOfContext();
-
           return superclassType;
         }
       }
@@ -120,9 +112,6 @@ EnumRawTypeRequest::evaluate(Evaluator &evaluator, EnumDecl *enumDecl) const {
     if (inheritedType->isExistentialType()) continue;
 
     // We found a raw type; return it.
-    if (inheritedType->hasArchetype())
-      return inheritedType->mapTypeOutOfContext();
-
     return inheritedType;
   }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -55,6 +55,10 @@ TypeResolution TypeResolution::forStructural(DeclContext *dc) {
   return TypeResolution(dc, TypeResolutionStage::Structural);
 }
 
+TypeResolution TypeResolution::forInterface(DeclContext *dc) {
+  return forInterface(dc, dc->getGenericSignatureOfContext());
+}
+
 TypeResolution TypeResolution::forInterface(DeclContext *dc,
                                             GenericSignature *genericSig) {
   TypeResolution result(dc, TypeResolutionStage::Interface);

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -16,6 +16,9 @@
 #ifndef SWIFT_SEMA_TYPE_CHECK_TYPE_H
 #define SWIFT_SEMA_TYPE_CHECK_TYPE_H
 
+#include "swift/AST/TypeResolutionStage.h"
+#include "llvm/ADT/None.h"
+
 namespace swift {
 
 /// Flags that describe the context of type checking a pattern or
@@ -290,6 +293,10 @@ public:
 
   /// Form a type resolution for an interface type, which is a complete
   /// description of the type using generic parameters.
+  static TypeResolution forInterface(DeclContext *dc);
+
+  /// Form a type resolution for an interface type, which is a complete
+  /// description of the type using generic parameters.
   static TypeResolution forInterface(DeclContext *dc,
                                      GenericSignature *genericSig);
 
@@ -310,6 +317,9 @@ public:
   /// Retrieve the declaration context in which type resolution will be
   /// performed.
   DeclContext *getDeclContext() const { return dc; }
+
+  /// Retrieve the type resolution stage.
+  TypeResolutionStage getStage() const { return stage; }
 
   /// Retrieves the generic signature for the context, or NULL if there is
   /// no generic signature to resolve types.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1263,12 +1263,6 @@ public:
 
   void resolveTrailingWhereClause(ProtocolDecl *proto) override;
 
-  /// Check the inheritance clause of the given declaration.
-  void checkInheritanceClause(Decl *decl, TypeResolution resolution);
-
-  /// Check the inheritance clause of the given declaration.
-  void checkInheritanceClause(Decl *decl);
-
   /// Diagnose if the class has no designated initializers.
   void maybeDiagnoseClassWithoutInitializers(ClassDecl *classDecl);
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2715,8 +2715,10 @@ void Serializer::writeDecl(const Decl *D) {
                           nullptr, /*sorted=*/true);
 
     SmallVector<TypeID, 8> inheritedAndDependencyTypes;
-    for (auto inherited : extension->getInherited())
+    for (auto inherited : extension->getInherited()) {
+      assert(!inherited.getType()->hasArchetype());
       inheritedAndDependencyTypes.push_back(addTypeRef(inherited.getType()));
+    }
     size_t numInherited = inheritedAndDependencyTypes.size();
 
     llvm::SmallSetVector<Type, 4> dependencies;
@@ -2959,8 +2961,10 @@ void Serializer::writeDecl(const Decl *D) {
                           nullptr, /*sorted=*/true);
 
     SmallVector<TypeID, 4> inheritedTypes;
-    for (auto inherited : theStruct->getInherited())
+    for (auto inherited : theStruct->getInherited()) {
+      assert(!inherited.getType()->hasArchetype());
       inheritedTypes.push_back(addTypeRef(inherited.getType()));
+    }
 
     uint8_t rawAccessLevel =
       getRawStableAccessLevel(theStruct->getFormalAccess());
@@ -2995,8 +2999,10 @@ void Serializer::writeDecl(const Decl *D) {
                           nullptr, /*sorted=*/true);
 
     SmallVector<TypeID, 4> inheritedAndDependencyTypes;
-    for (auto inherited : theEnum->getInherited())
+    for (auto inherited : theEnum->getInherited()) {
+      assert(!inherited.getType()->hasArchetype());
       inheritedAndDependencyTypes.push_back(addTypeRef(inherited.getType()));
+    }
 
     llvm::SmallSetVector<Type, 4> dependencyTypes;
     for (const EnumElementDecl *nextElt : theEnum->getAllElements()) {
@@ -3048,8 +3054,10 @@ void Serializer::writeDecl(const Decl *D) {
                           nullptr, /*sorted=*/true);
 
     SmallVector<TypeID, 4> inheritedTypes;
-    for (auto inherited : theClass->getInherited())
+    for (auto inherited : theClass->getInherited()) {
+      assert(!inherited.getType()->hasArchetype());
       inheritedTypes.push_back(addTypeRef(inherited.getType()));
+    }
 
     uint8_t rawAccessLevel =
       getRawStableAccessLevel(theClass->getFormalAccess());
@@ -3087,8 +3095,10 @@ void Serializer::writeDecl(const Decl *D) {
     auto contextID = addDeclContextRef(proto->getDeclContext());
 
     SmallVector<DeclID, 8> inherited;
-    for (auto element : proto->getInherited())
+    for (auto element : proto->getInherited()) {
+      assert(!element.getType()->hasArchetype());
       inherited.push_back(addTypeRef(element.getType()));
+    }
 
     uint8_t rawAccessLevel = getRawStableAccessLevel(proto->getFormalAccess());
 

--- a/test/Generics/function_decls.swift
+++ b/test/Generics/function_decls.swift
@@ -13,8 +13,7 @@ func f4<T>(x: T, y: T) { }
 // Non-protocol type constraints.
 func f6<T : Wonka>(x: T) {} // expected-error{{use of undeclared type 'Wonka'}}
 
-// FIXME: The term 'inherit' is unfortunate here.
-func f7<T : Int>(x: T) {} // expected-error{{inheritance from non-protocol, non-class type 'Int'}}
+func f7<T : Int>(x: T) {} // expected-error{{type 'T' constrained to non-protocol, non-class type 'Int'}}
 
 func f8<T> (x: Int) {} //expected-error{{generic parameter 'T' is not used in function signature}}
 

--- a/test/Generics/generic_types.swift
+++ b/test/Generics/generic_types.swift
@@ -234,11 +234,11 @@ class Bottom<T : Bottom<Top>> {}
 // Invalid inheritance clause
 
 struct UnsolvableInheritance1<T : T.A> {}
-// expected-error@-1 {{inheritance from non-protocol, non-class type 'T.A'}}
+// expected-error@-1 {{'A' is not a member type of 'T'}}
 
 struct UnsolvableInheritance2<T : U.A, U : T.A> {}
-// expected-error@-1 {{inheritance from non-protocol, non-class type 'U.A'}}
-// expected-error@-2 {{inheritance from non-protocol, non-class type 'T.A'}}
+// expected-error@-1 {{'A' is not a member type of 'U'}}
+// expected-error@-2 {{'A' is not a member type of 'T'}}
 
 enum X7<T> where X7.X : G { case X } // expected-error{{enum case 'X' is not a member type of 'X7<T>'}}
 // expected-error@-1{{use of undeclared type 'G'}}

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -45,7 +45,7 @@ func f10<T : GB<A>>(_: T) where T : GA<A> {}
 
 func f11<T : GA<T>>(_: T) { } // expected-error{{superclass constraint 'T' : 'GA<T>' is recursive}}
 func f12<T : GA<U>, U : GB<T>>(_: T, _: U) { } // expected-error{{superclass constraint 'U' : 'GB<T>' is recursive}} // expected-error{{superclass constraint 'T' : 'GA<U>' is recursive}}
-func f13<T : U, U : GA<T>>(_: T, _: U) { } // expected-error{{inheritance from non-protocol, non-class type 'U'}}
+func f13<T : U, U : GA<T>>(_: T, _: U) { } // expected-error{{type 'T' constrained to non-protocol, non-class type 'U'}}
 
 // rdar://problem/24730536
 // Superclass constraints can be used to resolve nested types to concrete types.

--- a/test/Sema/circular_decl_checking.swift
+++ b/test/Sema/circular_decl_checking.swift
@@ -15,10 +15,10 @@ class HasFunc {
 }
 
 class HasGenericFunc {
-  func HasGenericFunc<HasGenericFunc : HasGenericFunc>(x: HasGenericFunc) -> HasGenericFunc { // expected-error {{inheritance from non-protocol, non-class type 'HasGenericFunc'}}
+  func HasGenericFunc<HasGenericFunc : HasGenericFunc>(x: HasGenericFunc) -> HasGenericFunc { // expected-error {{type 'HasGenericFunc' constrained to non-protocol, non-class type 'HasGenericFunc'}}
     return x
   }
-  func SomethingElse<SomethingElse : SomethingElse>(_: SomethingElse) -> SomethingElse? { // expected-error {{inheritance from non-protocol, non-class type 'SomethingElse'}}
+  func SomethingElse<SomethingElse : SomethingElse>(_: SomethingElse) -> SomethingElse? { // expected-error {{type 'SomethingElse' constrained to non-protocol, non-class type 'SomethingElse'}}
     return nil
   }
 }
@@ -38,7 +38,7 @@ protocol ReferenceSomeProtocol {
 }
 
 func TopLevelFunc(x: TopLevelFunc) -> TopLevelFunc { return x } // expected-error 2 {{use of undeclared type 'TopLevelFunc'}}'
-func TopLevelGenericFunc<TopLevelGenericFunc : TopLevelGenericFunc>(x: TopLevelGenericFunc) -> TopLevelGenericFunc { return x } // expected-error {{inheritance from non-protocol, non-class type 'TopLevelGenericFunc'}}
+func TopLevelGenericFunc<TopLevelGenericFunc : TopLevelGenericFunc>(x: TopLevelGenericFunc) -> TopLevelGenericFunc { return x } // expected-error {{type 'TopLevelGenericFunc' constrained to non-protocol, non-class type 'TopLevelGenericFunc'}}
 func TopLevelGenericFunc2<T : TopLevelGenericFunc2>(x: T) -> T { return x} // expected-error {{use of undeclared type 'TopLevelGenericFunc2'}}
 var TopLevelVar: TopLevelVar? { return nil } // expected-error {{use of undeclared type 'TopLevelVar'}}
 

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -28,7 +28,7 @@ let _: Container.YourType<Int>
 
 typealias DS<T> = MyType<String, T>
 
-typealias BadA<T : Int> = MyType<String, T>  // expected-error {{inheritance from non-protocol, non-class type 'Int'}}
+typealias BadA<T : Int> = MyType<String, T>  // expected-error {{type 'T' constrained to non-protocol, non-class type 'Int'}}
 
 typealias BadB<T where T == Int> = MyType<String, T>  // expected-error {{associated types must not have a generic parameter list}}
 // expected-error@-1 {{same-type requirement makes generic parameter 'T' non-generic}}


### PR DESCRIPTION
Extend the inputs to `InheritedTypeRequest`, `SuperclassTypeRequest`, and
`EnumRawTypeRequest` to also take a `TypeResolutionStage`, describing what
level of type checking is required. The `GenericSignatureBuilder` relies
only on structural information, while other clients care about the
full interface type.

Only the full interface type will be cached, and the contextual type
(if requested) will depend on that.

While here, switch inherited types over to interface types (always) and simplify the
checking of the inheritance clauses of generic parameters.