### PR TITLE
[DiagnosticEngine] NFC: Remove some code duplication in `diagnose`

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -619,10 +619,7 @@ namespace swift {
     /// be attached.
     InFlightDiagnostic diagnose(SourceLoc Loc, DiagID ID, 
                                 ArrayRef<DiagnosticArgument> Args) {
-      assert(!ActiveDiagnostic && "Already have an active diagnostic");
-      ActiveDiagnostic = Diagnostic(ID, Args);
-      ActiveDiagnostic->setLoc(Loc);
-      return InFlightDiagnostic(*this);
+      return diagnose(Loc, Diagnostic(ID, Args));
     }
 
     /// \brief Emit a diagnostic using a preformatted array of diagnostic
@@ -640,7 +637,7 @@ namespace swift {
     /// be attached.
     InFlightDiagnostic diagnose(DeclNameLoc Loc, DiagID ID, 
                                 ArrayRef<DiagnosticArgument> Args) {
-      return diagnose(Loc.getBaseNameLoc(), ID, Args);
+      return diagnose(Loc.getBaseNameLoc(), Diagnostic(ID, Args));
     }
 
     /// \brief Emit an already-constructed diagnostic at the given location.
@@ -672,10 +669,7 @@ namespace swift {
     InFlightDiagnostic 
     diagnose(SourceLoc Loc, Diag<ArgTypes...> ID,
              typename detail::PassArgument<ArgTypes>::type... Args) {
-      assert(!ActiveDiagnostic && "Already have an active diagnostic");
-      ActiveDiagnostic = Diagnostic(ID, std::move(Args)...);
-      ActiveDiagnostic->setLoc(Loc);
-      return InFlightDiagnostic(*this);
+      return diagnose(Loc, Diagnostic(ID, std::move(Args)...));
     }
 
     /// \brief Emit a diagnostic with the given set of diagnostic arguments.
@@ -691,10 +685,7 @@ namespace swift {
     InFlightDiagnostic 
     diagnose(DeclNameLoc Loc, Diag<ArgTypes...> ID,
              typename detail::PassArgument<ArgTypes>::type... Args) {
-      assert(!ActiveDiagnostic && "Already have an active diagnostic");
-      ActiveDiagnostic = Diagnostic(ID, std::move(Args)...);
-      ActiveDiagnostic->setLoc(Loc.getBaseNameLoc());
-      return InFlightDiagnostic(*this);
+      return diagnose(Loc.getBaseNameLoc(), Diagnostic(ID, std::move(Args)...));
     }
 
     /// \brief Emit a diagnostic using a preformatted array of diagnostic
@@ -712,10 +703,7 @@ namespace swift {
     /// be attached.
     InFlightDiagnostic diagnose(const Decl *decl, DiagID id,
                                 ArrayRef<DiagnosticArgument> args) {
-      assert(!ActiveDiagnostic && "Already have an active diagnostic");
-      ActiveDiagnostic = Diagnostic(id, args);
-      ActiveDiagnostic->setDecl(decl);
-      return InFlightDiagnostic(*this);
+      return diagnose(decl, Diagnostic(id, args));
     }
 
     /// \brief Emit an already-constructed diagnostic referencing the given
@@ -748,9 +736,7 @@ namespace swift {
     InFlightDiagnostic
     diagnose(const Decl *decl, Diag<ArgTypes...> id,
              typename detail::PassArgument<ArgTypes>::type... args) {
-      ActiveDiagnostic = Diagnostic(id, std::move(args)...);
-      ActiveDiagnostic->setDecl(decl);
-      return InFlightDiagnostic(*this);
+      return diagnose(decl, Diagnostic(id, std::move(args)...));
     }
 
     /// \returns true if diagnostic is marked with PointsToFirstBadToken


### PR DESCRIPTION
Make it so there is only one underlying `diagnose` for `SourceLoc`
and `Decl *`, everything else should just be using them.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
