### PR TITLE
[CodeCompletion] Implement completion for # directives

### DIFF
--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -503,7 +503,7 @@ enum class CompletionKind {
   ReturnStmtExpr,
   YieldStmtExpr,
   ForEachSequence,
-  AfterPound,
+  AfterPoundExpr,
   AfterIfStmtElse,
   GenericParams,
   SwiftKeyPath,

--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -505,6 +505,7 @@ enum class CompletionKind {
   ForEachSequence,
   AfterPoundExpr,
   AfterPoundDirective,
+  PlatformConditon,
   AfterIfStmtElse,
   GenericParams,
   SwiftKeyPath,

--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -504,6 +504,7 @@ enum class CompletionKind {
   YieldStmtExpr,
   ForEachSequence,
   AfterPoundExpr,
+  AfterPoundDirective,
   AfterIfStmtElse,
   GenericParams,
   SwiftKeyPath,

--- a/include/swift/Parse/CodeCompletionCallbacks.h
+++ b/include/swift/Parse/CodeCompletionCallbacks.h
@@ -208,7 +208,7 @@ public:
   virtual void completeYieldStmt(CodeCompletionExpr *E,
                                  Optional<unsigned> yieldIndex) = 0;
 
-  virtual void completeAfterPound(CodeCompletionExpr *E, StmtKind ParentKind) = 0;
+  virtual void completeAfterPound(CodeCompletionExpr *E, Optional<StmtKind> ParentKind) = 0;
 
   virtual void completeAfterIfStmt(bool hasElse) = 0;
 

--- a/include/swift/Parse/CodeCompletionCallbacks.h
+++ b/include/swift/Parse/CodeCompletionCallbacks.h
@@ -208,7 +208,8 @@ public:
   virtual void completeYieldStmt(CodeCompletionExpr *E,
                                  Optional<unsigned> yieldIndex) = 0;
 
-  virtual void completeAfterPound(CodeCompletionExpr *E, Optional<StmtKind> ParentKind) = 0;
+  virtual void completeAfterPoundExpr(CodeCompletionExpr *E,
+                                      Optional<StmtKind> ParentKind) = 0;
 
   virtual void completeAfterIfStmt(bool hasElse) = 0;
 

--- a/include/swift/Parse/CodeCompletionCallbacks.h
+++ b/include/swift/Parse/CodeCompletionCallbacks.h
@@ -213,6 +213,8 @@ public:
 
   virtual void completeAfterPoundDirective() = 0;
 
+  virtual void completePlatformCondition() = 0;
+
   virtual void completeAfterIfStmt(bool hasElse) = 0;
 
   virtual void completeGenericParams(TypeLoc TL) = 0;

--- a/include/swift/Parse/CodeCompletionCallbacks.h
+++ b/include/swift/Parse/CodeCompletionCallbacks.h
@@ -211,6 +211,8 @@ public:
   virtual void completeAfterPoundExpr(CodeCompletionExpr *E,
                                       Optional<StmtKind> ParentKind) = 0;
 
+  virtual void completeAfterPoundDirective() = 0;
+
   virtual void completeAfterIfStmt(bool hasElse) = 0;
 
   virtual void completeGenericParams(TypeLoc TL) = 0;

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1332,6 +1332,8 @@ public:
   ParserResult<Expr> parseExprArray(SourceLoc LSquareLoc);
   ParserResult<Expr> parseExprDictionary(SourceLoc LSquareLoc);
   ParserResult<Expr> parseExprPoundUnknown(SourceLoc LSquareLoc);
+  ParserResult<Expr>
+  parseExprPoundCodeCompletion(Optional<StmtKind> ParentKind);
 
   UnresolvedDeclRefExpr *parseExprOperator();
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1466,7 +1466,8 @@ public:
   void completeReturnStmt(CodeCompletionExpr *E) override;
   void completeYieldStmt(CodeCompletionExpr *E,
                          Optional<unsigned> yieldIndex) override;
-  void completeAfterPound(CodeCompletionExpr *E, Optional<StmtKind> ParentKind) override;
+  void completeAfterPoundExpr(CodeCompletionExpr *E,
+                              Optional<StmtKind> ParentKind) override;
   void completeGenericParams(TypeLoc TL) override;
   void completeAfterIfStmt(bool hasElse) override;
   void addKeywords(CodeCompletionResultSink &Sink, bool MaybeFuncBody);
@@ -4608,11 +4609,11 @@ void CodeCompletionCallbacksImpl::completeYieldStmt(CodeCompletionExpr *E,
   Kind = CompletionKind::YieldStmtExpr;
 }
 
-void CodeCompletionCallbacksImpl::completeAfterPound(CodeCompletionExpr *E,
-                                                     Optional<StmtKind> ParentKind) {
+void CodeCompletionCallbacksImpl::completeAfterPoundExpr(
+    CodeCompletionExpr *E, Optional<StmtKind> ParentKind) {
   CurDeclContext = P.CurDeclContext;
   CodeCompleteTokenExpr = E;
-  Kind = CompletionKind::AfterPound;
+  Kind = CompletionKind::AfterPoundExpr;
   ParentStmtKind = ParentKind;
 }
 
@@ -4739,7 +4740,7 @@ void CodeCompletionCallbacksImpl::addKeywords(CodeCompletionResultSink &Sink,
   case CompletionKind::Import:
   case CompletionKind::UnresolvedMember:
   case CompletionKind::CallArg:
-  case CompletionKind::AfterPound:
+  case CompletionKind::AfterPoundExpr:
   case CompletionKind::GenericParams:
   case CompletionKind::KeyPathExpr:
   case CompletionKind::KeyPathExprDot:
@@ -5403,7 +5404,7 @@ void CodeCompletionCallbacksImpl::doneParsing() {
     break;
   }
 
-  case CompletionKind::AfterPound: {
+  case CompletionKind::AfterPoundExpr: {
     Lookup.addPoundAvailable(ParentStmtKind);
     Lookup.addPoundSelector(/*needPound=*/false);
     Lookup.addPoundKeyPath(/*needPound=*/false);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2636,6 +2636,18 @@ Parser::parseDecl(ParseDeclOptions Flags,
     DeclResult = makeParserError();
     // Handled below.
     break;
+  case tok::pound:
+    if (Tok.isAtStartOfLine() &&
+        peekToken().is(tok::code_complete) &&
+        Tok.getLoc().getAdvancedLoc(1) == peekToken().getLoc()) {
+      consumeToken();
+      if (CodeCompletion)
+        CodeCompletion->completeAfterPoundDirective();
+      consumeToken(tok::code_complete);
+      DeclResult = makeParserCodeCompletionResult<Decl>();
+      break;
+    }
+    LLVM_FALLTHROUGH;
 
   case tok::pound_if:
   case tok::pound_sourceLocation:

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3123,7 +3123,7 @@ Parser::parseExprPoundCodeCompletion(Optional<StmtKind> ParentKind) {
   auto CodeCompletionPos = consumeToken();
   auto Expr = new (Context) CodeCompletionExpr(CodeCompletionPos);
   if (CodeCompletion)
-    CodeCompletion->completeAfterPound(Expr, ParentKind);
+    CodeCompletion->completeAfterPoundExpr(Expr, ParentKind);
   return makeParserCodeCompletionResult(Expr);
 }
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1712,9 +1712,14 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
     Result.setHasCodeCompletion();
     if (CodeCompletion &&
         // We cannot code complete anything after var/let.
-        (!InVarOrLetPattern || InVarOrLetPattern == IVOLP_InMatchingPattern))
-      CodeCompletion->completePostfixExprBeginning(
-          dyn_cast<CodeCompletionExpr>(Result.get()));
+        (!InVarOrLetPattern || InVarOrLetPattern == IVOLP_InMatchingPattern)) {
+      if (InPoundIfEnvironment) {
+        CodeCompletion->completePlatformCondition();
+      } else {
+        CodeCompletion->completePostfixExprBeginning(
+            cast<CodeCompletionExpr>(Result.get()));
+      }
+    }
     consumeToken(tok::code_complete);
     return Result;
   }

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -585,6 +585,8 @@ ParserResult<IfConfigDecl> Parser::parseIfConfig(
       ParserResult<Expr> Result = parseExprSequence(diag::expected_expr,
                                                       /*isBasic*/true,
                                                       /*isForDirective*/true);
+      if (Result.hasCodeCompletion())
+        return makeParserCodeCompletionStatus();
       if (Result.isNull())
         return makeParserError();
       Condition = Result.get();

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -102,7 +102,16 @@ ParserStatus Parser::parseExprOrStmt(ASTNode &Result) {
     consumeToken();
     return makeParserError();
   }
-  
+
+  if (Tok.is(tok::pound) && Tok.isAtStartOfLine() &&
+      peekToken().is(tok::code_complete)) {
+    consumeToken();
+    if (CodeCompletion)
+      CodeCompletion->completeAfterPoundDirective();
+    consumeToken(tok::code_complete);
+    return makeParserCodeCompletionStatus();
+  }
+
   if (isStartOfStmt()) {
     ParserResult<Stmt> Res = parseStmt();
     if (Res.isNonNull())

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -361,6 +361,11 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
                             ? BraceItemListKind::ActiveConditionalBlock
                             : BraceItemListKind::InactiveConditionalBlock);
         });
+      if (IfConfigResult.hasCodeCompletion() && isCodeCompletionFirstPass()) {
+        consumeDecl(BeginParserPosition, None, IsTopLevel);
+        return IfConfigResult;
+      }
+      BraceItemsStatus |= IfConfigResult;
       if (auto ICD = IfConfigResult.getPtrOrNull()) {
         Result = ICD;
         // Add the #if block itself

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1353,15 +1353,11 @@ Parser::parseStmtConditionElement(SmallVectorImpl<StmtConditionElement> &result,
   }
 
   // Handle code completion after the #.
-  if (Tok.is(tok::pound) && peekToken().is(tok::code_complete)) {
-    consumeToken(); // '#' token.
-    auto CodeCompletionPos = consumeToken();
-    auto Expr = new (Context) CodeCompletionExpr(CodeCompletionPos);
-    if (CodeCompletion)
-      CodeCompletion->completeAfterPound(Expr, ParentKind);
-    result.push_back(Expr);
-    Status.setHasCodeCompletion();
-    return Status;
+  if (Tok.is(tok::pound) && peekToken().is(tok::code_complete) &&
+      Tok.getLoc().getAdvancedLoc(1) == peekToken().getLoc()) {
+    auto Expr = parseExprPoundCodeCompletion(ParentKind);
+    Status |= Expr;
+    result.push_back(Expr.get());
   }
 
   // Parse the basic expression case.  If we have a leading let/var/case

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -679,6 +679,7 @@ SourceLoc Parser::skipUntilGreaterInTypeList(bool protocolComposition) {
 
 void Parser::skipUntilDeclRBrace() {
   while (Tok.isNot(tok::eof, tok::r_brace, tok::pound_endif,
+                   tok::pound_else, tok::pound_elseif,
                    tok::code_complete) &&
          !isStartOfDecl())
     skipSingle();
@@ -686,6 +687,7 @@ void Parser::skipUntilDeclRBrace() {
 
 void Parser::skipUntilDeclStmtRBrace(tok T1) {
   while (Tok.isNot(T1, tok::eof, tok::r_brace, tok::pound_endif,
+                   tok::pound_else, tok::pound_elseif,
                    tok::code_complete) &&
          !isStartOfStmt() && !isStartOfDecl()) {
     skipSingle();
@@ -694,6 +696,7 @@ void Parser::skipUntilDeclStmtRBrace(tok T1) {
 
 void Parser::skipUntilDeclStmtRBrace(tok T1, tok T2) {
   while (Tok.isNot(T1, T2, tok::eof, tok::r_brace, tok::pound_endif,
+                   tok::pound_else, tok::pound_elseif,
                    tok::code_complete) &&
          !isStartOfStmt() && !isStartOfDecl()) {
     skipSingle();
@@ -701,7 +704,8 @@ void Parser::skipUntilDeclStmtRBrace(tok T1, tok T2) {
 }
 
 void Parser::skipUntilDeclRBrace(tok T1, tok T2) {
-  while (Tok.isNot(T1, T2, tok::eof, tok::r_brace, tok::pound_endif) &&
+  while (Tok.isNot(T1, T2, tok::eof, tok::r_brace, tok::pound_endif,
+                   tok::pound_else, tok::pound_elseif) &&
          !isStartOfDecl()) {
     skipSingle();
   }

--- a/test/IDE/complete_pound_directive.swift
+++ b/test/IDE/complete_pound_directive.swift
@@ -1,0 +1,40 @@
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_NOMINAL_TOP | %FileCheck %s -check-prefix=POUND_DIRECTIVE
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_NOMINAL_IN_IF | %FileCheck %s -check-prefix=POUND_DIRECTIVE
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_NOMINAL_IN_ELSEIF | %FileCheck %s -check-prefix=POUND_DIRECTIVE
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_NOMINAL_IN_ELSE | %FileCheck %s -check-prefix=POUND_DIRECTIVE
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_GLOBAL_TOP | %FileCheck %s -check-prefix=POUND_DIRECTIVE
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_GLOBAL_IN_IF | %FileCheck %s -check-prefix=POUND_DIRECTIVE
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_GLOBAL_IN_ELSEIF | %FileCheck %s -check-prefix=POUND_DIRECTIVE
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_GLOBAL_IN_ELSE | %FileCheck %s -check-prefix=POUND_DIRECTIVE
+
+// POUND_DIRECTIVE: Begin completions, 7 items
+// POUND_DIRECTIVE-DAG: Keyword[#sourceLocation]/None:      sourceLocation(file: {#String#}, line: {#Int#}); name=sourceLocation(file: String, line: Int)
+// POUND_DIRECTIVE-DAG: Keyword[#warning]/None:             warning("{#(message)#}"); name=warning("message")
+// POUND_DIRECTIVE-DAG: Keyword[#error]/None:               error("{#(message)#}"); name=error("message")
+// POUND_DIRECTIVE-DAG: Keyword[#if]/None:                  if {#(condition)#}; name=if condition
+// POUND_DIRECTIVE-DAG: Keyword[#elseif]/None:              elseif {#(condition)#}; name=elseif condition
+// POUND_DIRECTIVE-DAG: Keyword[#else]/None:                else; name=else
+// POUND_DIRECTIVE-DAG: Keyword[#endif]/None:               endif; name=endif
+
+class C {
+##^POUND_NOMINAL_TOP^#
+
+#if true
+  ##^POUND_NOMINAL_IN_IF^#
+#elseif true
+  ##^POUND_NOMINAL_IN_ELSEIF^#
+#else
+  ##^POUND_NOMINAL_IN_ELSE^#
+#endif
+}
+
+##^POUND_GLOBAL_TOP^#
+
+#if false
+  ##^POUND_GLOBAL_IN_IF^#
+#elseif false
+  ##^POUND_GLOBAL_IN_ELSEIF^#
+#else
+  ##^POUND_GLOBAL_IN_ELSE^#
+#endif
+

--- a/test/IDE/complete_pound_directive.swift
+++ b/test/IDE/complete_pound_directive.swift
@@ -7,6 +7,13 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_GLOBAL_IN_ELSEIF | %FileCheck %s -check-prefix=POUND_DIRECTIVE
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_GLOBAL_IN_ELSE | %FileCheck %s -check-prefix=POUND_DIRECTIVE
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONDITION_NOMINAL_1 | %FileCheck %s -check-prefix=CONDITION -check-prefix=NOFLAG
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONDITION_NOMINAL_1 -D FOO -D BAR | %FileCheck %s -check-prefix=CONDITION -check-prefix=WITHFLAG
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONDITION_NOMINAL_2 | %FileCheck %s -check-prefix=CONDITION -check-prefix=NOFLAGlll
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONDITION_GLOBAL_1 | %FileCheck %s -check-prefix=CONDITION -check-prefix=NOFLAG
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONDITION_GLOBAL_2 | %FileCheck %s -check-prefix=CONDITION -check-prefix=NOFLAG
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONDITION_GLOBAL_2 -D FOO -D BAR | %FileCheck %s -check-prefix=CONDITION -check-prefix=WITHFLAG
+
 // POUND_DIRECTIVE: Begin completions, 7 items
 // POUND_DIRECTIVE-DAG: Keyword[#sourceLocation]/None:      sourceLocation(file: {#String#}, line: {#Int#}); name=sourceLocation(file: String, line: Int)
 // POUND_DIRECTIVE-DAG: Keyword[#warning]/None:             warning("{#(message)#}"); name=warning("message")
@@ -38,3 +45,39 @@ class C {
   ##^POUND_GLOBAL_IN_ELSE^#
 #endif
 
+// CONDITION: Begin completions
+// CONDITION-NOT: globalVar
+// CONDITION-DAG: Pattern/ExprSpecific:               os({#(name)#}); name=os(name)
+// CONDITION-DAG: Pattern/ExprSpecific:               arch({#(name)#}); name=arch(name)
+// CONDITION-DAG: Pattern/ExprSpecific:               canImport({#(module)#}); name=canImport(module)
+// CONDITION-DAG: Pattern/ExprSpecific:               targetEnvironment(simulator); name=targetEnvironment(simulator)
+// CONDITION-DAG: Pattern/ExprSpecific:               swift(>={#(version)#}); name=swift(>=version)
+// CONDITION-DAG: Pattern/ExprSpecific:               swift(<{#(version)#}); name=swift(<version)
+// CONDITION-DAG: Pattern/ExprSpecific:               compiler(>={#(version)#}); name=compiler(>=version)
+// CONDITION-DAG: Pattern/ExprSpecific:               compiler(<{#(version)#}); name=compiler(<version)
+// CONDITION-DAG: Keyword[true]/None:                 true[#Bool#]; name=true
+// CONDITION-DAG: Keyword[false]/None:                false[#Bool#]; name=false
+// CONDITION-NOT: globalVar
+
+// WITHFLAG: Keyword/ExprSpecific:               FOO; name=FOO
+// WITHFLAG: Keyword/ExprSpecific:               BAR; name=BAR
+
+// NOFLAG-NOT: FOO 
+// NOFLAG-NOT: BAR
+
+var globalVar = 1
+extension C {
+#if #^CONDITION_NOMINAL_1^#
+#endif
+
+#if true
+#elseif false || (#^CONDITION_NOMINAL_2^#)
+#endif
+}
+
+#if swift(>=1000) && #^CONDITION_GLOBAL_1^#
+#endif
+
+#if false
+#elseif #^CONDITION_GLOBAL_2^#
+// This '#if' is intentionally not closed with '#endif'

--- a/test/IDE/complete_pound_expr.swift
+++ b/test/IDE/complete_pound_expr.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=POUND_EXPR_1 | %FileCheck %s -check-prefix=POUND_EXPR_STRINGCONTEXT
+// REQUIRES: objc_interop
+
+func use(_ str: String) -> Bool {}
+
+func test1() {
+  _ = use(##^POUND_EXPR_1^#)
+}
+
+// POUND_EXPR_STRINGCONTEXT: Begin completions, 2 items
+// POUND_EXPR_STRINGCONTEXT-NOT: available
+// POUND_EXPR_STRINGCONTEXT-DAG: Keyword/ExprSpecific: selector({#@objc method#}); name=selector(@objc method)
+// POUND_EXPR_STRINGCONTEXT-DAG: Keyword/ExprSpecific: keyPath({#@objc property sequence#}); name=keyPath(@objc property sequence)
+// POUND_EXPR_STRINGCONTEXT: End completions

--- a/test/IDE/complete_pound_selector.swift
+++ b/test/IDE/complete_pound_selector.swift
@@ -1,10 +1,12 @@
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -code-completion -source-filename %s -code-completion-token=AFTER_POUND | %FileCheck -check-prefix=CHECK-AFTER_POUND %s
 
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -code-completion -source-filename %s -code-completion-token=CONTEXT_SELECTOR | %FileCheck -check-prefix=CHECK-CONTEXT_SELECTOR %s
+
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -code-completion -source-filename %s -code-completion-token=SELECTOR_ARG1 | %FileCheck -check-prefix=CHECK-CONTEXT_SELECTOR %s
+
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -code-completion -source-filename %s -code-completion-token=SELECTOR_ARG2 | %FileCheck -check-prefix=CHECK-CONTEXT_SELECTOR %s
+
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -code-completion -source-filename %s -code-completion-token=SELECTOR_BASIC | %FileCheck -check-prefix=CHECK-SELECTOR_BASIC %s
-
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -code-completion -source-filename %s -code-completion-token=SELECTOR_ARG1 | %FileCheck -check-prefix=CHECK-SELECTOR_ARG %s
-
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -code-completion -source-filename %s -code-completion-token=SELECTOR_ARG2 | %FileCheck -check-prefix=CHECK-SELECTOR_ARG %s
 
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -code-completion -source-filename %s -code-completion-token=IN_SELECTOR1 | %FileCheck -check-prefix=CHECK-IN_SELECTOR %s
 
@@ -22,8 +24,12 @@
 
 import Foundation
 
-{
+do {
   if ##^AFTER_POUND^#
+}
+
+do {
+  let _: Selector = #^CONTEXT_SELECTOR^#
 }
 
 func selectorArg1(obj: NSObject) {
@@ -68,7 +74,7 @@ class Subclass : NSObject {
 // CHECK-AFTER_POUND: Keyword/ExprSpecific:               available({#Platform...#}, *); name=available(Platform..., *)
 // CHECK-AFTER_POUND: Keyword/ExprSpecific:               selector({#@objc method#}); name=selector(@objc method)
 
-// CHECK-SELECTOR_ARG: Keyword/ExprSpecific:               #selector({#@objc method#}); name=#selector(@objc method)
+// CHECK-CONTEXT_SELECTOR: Keyword/None:                  #selector({#@objc method#}); name=#selector(@objc method)
 
 // CHECK-SELECTOR_BASIC: Keyword/None:                       getter: {#@objc property#}; name=getter: @objc property
 // CHECK-SELECTOR_BASIC: Keyword/None:                       setter: {#@objc property#}; name=setter: @objc property


### PR DESCRIPTION
* Enable `#` completion at arbitrary expr position.
  * `#selector(<@objc method>)`
  * `#keyPath(<@objc property>)`
  * `#available(<platform ...>, *)` - only in statement condition
* Implement completion for `#` at directive position. 
  * `#sourceLocation(file: <name>, line: <number>)`
  * `#warning("<message>")`/`#error("<message>")`
  * `#if <condition>`, `#elseif <condition>`, `#else`, `#endif`
* Implement completion for condition part of conditional compilation directive.
  * `os(<name>)`, `arch(<name>)`, `canImport(<module>)`, `targetEnvironment(simulator)`
  * `true`/`false`
  * Custom conditional compilation flags specified by `-D`

rdar://problem/19572779
rdar://problem/29976235