### PR TITLE
[stdlib] More inalienable auditing

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -353,7 +353,7 @@ extension Array: RandomAccessCollection, MutableCollection {
   ///     // Prints "[30, 40, 50]"
   ///
   /// If the array is empty, `endIndex` is equal to `startIndex`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   public var endIndex: Int {
     @inlinable
     get {

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -179,7 +179,7 @@ extension ArraySlice: RandomAccessCollection, MutableCollection {
   ///     // Prints "[30, 40, 50]"
   ///
   /// If the array is empty, `endIndex` is equal to `startIndex`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   public var endIndex: Int {
     return _buffer.endIndex
   }

--- a/stdlib/public/core/Assert.swift
+++ b/stdlib/public/core/Assert.swift
@@ -122,7 +122,7 @@ public func precondition(
 ///     where `assertionFailure(_:file:line:)` is called.
 ///   - line: The line number to print along with `message`. The default is the
 ///     line number where `assertionFailure(_:file:line:)` is called.
-@inlinable // FIXME(sil-serialize-all)
+@inlinable
 @inline(__always)
 public func assertionFailure(
   _ message: @autoclosure () -> String = String(),

--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -75,7 +75,7 @@ func _fatalErrorFlags() -> UInt32 {
 ///
 /// This function should not be inlined because it is cold and inlining just
 /// bloats code.
-@usableFromInline // FIXME(sil-serialize-all)
+@usableFromInline
 @inline(never)
 internal func _assertionFailure(
   _ prefix: StaticString, _ message: StaticString,
@@ -105,7 +105,7 @@ internal func _assertionFailure(
 ///
 /// This function should not be inlined because it is cold and inlining just
 /// bloats code.
-@usableFromInline // FIXME(sil-serialize-all)
+@usableFromInline
 @inline(never)
 internal func _assertionFailure(
   _ prefix: StaticString, _ message: String,
@@ -135,7 +135,7 @@ internal func _assertionFailure(
 ///
 /// This function should not be inlined because it is cold and inlining just
 /// bloats code.
-@usableFromInline // FIXME(sil-serialize-all)
+@usableFromInline
 @inline(never)
 internal func _assertionFailure(
   _ prefix: StaticString, _ message: String,
@@ -160,7 +160,7 @@ internal func _assertionFailure(
 ///
 /// This function should not be inlined because it is cold and it inlining just
 /// bloats code.
-@usableFromInline // FIXME(sil-serialize-all)
+@usableFromInline
 @inline(never)
 @_semantics("arc.programtermination_point")
 internal func _fatalErrorMessage(
@@ -246,7 +246,6 @@ func _unimplementedInitializer(className: StaticString,
   Builtin.int_trap()
 }
 
-// FIXME(ABI)#21 (Type Checker): rename to something descriptive.
 @inlinable // FIXME(sil-serialize-all)
 public // COMPILER_INTRINSIC
 func _undefined<T>(

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -18,7 +18,7 @@ import SwiftShims
 // This function is the implementation of the `_roundUp` overload set.  It is
 // marked `@inline(__always)` to make primary `_roundUp` entry points seem
 // cheap enough for the inliner.
-@inlinable // FIXME(sil-serialize-all)
+@inlinable
 @inline(__always)
 internal func _roundUpImpl(_ offset: UInt, toAlignment alignment: Int) -> UInt {
   _sanityCheck(alignment > 0)
@@ -31,12 +31,12 @@ internal func _roundUpImpl(_ offset: UInt, toAlignment alignment: Int) -> UInt {
   return x & ~(UInt(bitPattern: alignment) &- 1)
 }
 
-@inlinable // FIXME(sil-serialize-all)
+@inlinable
 internal func _roundUp(_ offset: UInt, toAlignment alignment: Int) -> UInt {
   return _roundUpImpl(offset, toAlignment: alignment)
 }
 
-@inlinable // FIXME(sil-serialize-all)
+@inlinable
 internal func _roundUp(_ offset: Int, toAlignment alignment: Int) -> Int {
   _sanityCheck(offset >= 0)
   return Int(_roundUpImpl(UInt(bitPattern: offset), toAlignment: alignment))

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -160,7 +160,7 @@ public struct OpaquePointer {
 }
 
 extension OpaquePointer: Equatable {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // unsafe-performance
   public static func == (lhs: OpaquePointer, rhs: OpaquePointer) -> Bool {
     return Bool(Builtin.cmp_eq_RawPointer(lhs._rawValue, rhs._rawValue))
   }
@@ -193,7 +193,7 @@ extension Int {
   ///
   /// - Parameter pointer: The pointer to use as the source for the new
   ///   integer.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // unsafe-performance
   public init(bitPattern pointer: OpaquePointer?) {
     self.init(bitPattern: UnsafeRawPointer(pointer))
   }
@@ -207,7 +207,7 @@ extension UInt {
   ///
   /// - Parameter pointer: The pointer to use as the source for the new
   ///   integer.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // unsafe-performance
   public init(bitPattern pointer: OpaquePointer?) {
     self.init(bitPattern: UnsafeRawPointer(pointer))
   }
@@ -216,10 +216,10 @@ extension UInt {
 /// A wrapper around a C `va_list` pointer.
 @_fixed_layout
 public struct CVaListPointer {
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // unsafe-performance
   internal var value: UnsafeMutableRawPointer
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // unsafe-performance
   public // @testable
   init(_fromUnsafeMutablePointer from: UnsafeMutableRawPointer) {
     value = from

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -79,7 +79,7 @@ extension CollectionOfOne: RandomAccessCollection, MutableCollection {
   /// The position of the first element.
   ///
   /// In a `CollectionOfOne` instance, `startIndex` is always `0`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public var startIndex: Index {
     return 0
   }

--- a/stdlib/public/core/CommandLine.swift
+++ b/stdlib/public/core/CommandLine.swift
@@ -13,7 +13,7 @@
 import SwiftShims
 
 /// Command-line arguments for the current process.
-@_frozen // FIXME(sil-serialize-all)
+@_frozen // namespace
 public enum CommandLine {
   /// The backing static variable for argument count may come either from the
   /// entry point or it may need to be computed e.g. if we're in the REPL.
@@ -31,7 +31,6 @@ public enum CommandLine {
       =  _swift_stdlib_getUnsafeArgvArgc(&_argc)
 
   /// Access to the raw argc value from C.
-  @inlinable // FIXME(sil-serialize-all)
   public static var argc: Int32 {
     _ = CommandLine.unsafeArgv // Force evaluation of argv.
     return _argc
@@ -39,7 +38,6 @@ public enum CommandLine {
 
   /// Access to the raw argv value from C. Accessing the argument vector
   /// through this pointer is unsafe.
-  @inlinable // FIXME(sil-serialize-all)
   public static var unsafeArgv:
     UnsafeMutablePointer<UnsafeMutablePointer<Int8>?> {
     return _unsafeArgv

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -85,7 +85,6 @@ extension ContiguousArray: RandomAccessCollection, MutableCollection {
   ///     // Prints "[30, 40, 50]"
   ///
   /// If the array is empty, `endIndex` is equal to `startIndex`.
-  @inlinable // FIXME(sil-serialize-all)
   public var endIndex: Int {
     @inlinable
     get {

--- a/stdlib/public/core/Dump.swift
+++ b/stdlib/public/core/Dump.swift
@@ -25,7 +25,6 @@
 ///   - maxItems: The maximum number of elements for which to write the full
 ///     contents. The default is `Int.max`.
 /// - Returns: The instance passed as `value`.
-@inlinable // FIXME(sil-serialize-all)
 @discardableResult
 @_semantics("optimize.sil.specialize.generic.never")
 public func dump<T, TargetStream : TextOutputStream>(
@@ -64,7 +63,6 @@ public func dump<T, TargetStream : TextOutputStream>(
 ///   - maxItems: The maximum number of elements for which to write the full
 ///     contents. The default is `Int.max`.
 /// - Returns: The instance passed as `value`.
-@inlinable // FIXME(sil-serialize-all)
 @discardableResult
 @_semantics("optimize.sil.specialize.generic.never")
 public func dump<T>(
@@ -85,7 +83,6 @@ public func dump<T>(
 }
 
 /// Dump an object's contents. User code should use dump().
-@inlinable // FIXME(sil-serialize-all)
 @_semantics("optimize.sil.specialize.generic.never")
 internal func _dump_unlocked<TargetStream : TextOutputStream>(
   _ value: Any,
@@ -185,7 +182,6 @@ internal func _dump_unlocked<TargetStream : TextOutputStream>(
 
 /// Dump information about an object's superclass, given a mirror reflecting
 /// that superclass.
-@inlinable // FIXME(sil-serialize-all)
 @_semantics("optimize.sil.specialize.generic.never")
 internal func _dumpSuperclass_unlocked<TargetStream : TextOutputStream>(
   mirror: Mirror,

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -18,30 +18,30 @@
 //===----------------------------------------------------------------------===//
 
 /// A collection whose element type is `Element` but that is always empty.
-@_fixed_layout // FIXME(sil-serialize-all)
+@_fixed_layout // trivial-implementation
 public struct EmptyCollection<Element> {
   // no properties
 
   /// Creates an instance.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public init() {}
 }
 
 extension EmptyCollection {
   /// An iterator that never produces an element.
-  @_fixed_layout // FIXME(sil-serialize-all)
+  @_fixed_layout // trivial-implementation
   public struct Iterator {
     // no properties
   
     /// Creates an instance.
-    @inlinable // FIXME(sil-serialize-all)
+    @inlinable // trivial-implementation
     public init() {}
   }  
 }
 
 extension EmptyCollection.Iterator: IteratorProtocol, Sequence {
   /// Returns `nil`, indicating that there are no more elements.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public mutating func next() -> Element? {
     return nil
   }
@@ -49,7 +49,7 @@ extension EmptyCollection.Iterator: IteratorProtocol, Sequence {
 
 extension EmptyCollection: Sequence {
   /// Returns an empty iterator.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public func makeIterator() -> Iterator {
     return Iterator()
   }
@@ -65,13 +65,13 @@ extension EmptyCollection: RandomAccessCollection, MutableCollection {
   public typealias SubSequence = EmptyCollection<Element>
 
   /// Always zero, just like `endIndex`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public var startIndex: Index {
     return 0
   }
 
   /// Always zero, just like `startIndex`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public var endIndex: Index {
     return 0
   }
@@ -80,7 +80,7 @@ extension EmptyCollection: RandomAccessCollection, MutableCollection {
   ///
   /// `EmptyCollection` does not have any element indices, so it is not
   /// possible to advance indices.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public func index(after i: Index) -> Index {
     _preconditionFailure("EmptyCollection can't advance indices")
   }
@@ -89,7 +89,7 @@ extension EmptyCollection: RandomAccessCollection, MutableCollection {
   ///
   /// `EmptyCollection` does not have any element indices, so it is not
   /// possible to advance indices.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public func index(before i: Index) -> Index {
     _preconditionFailure("EmptyCollection can't advance indices")
   }
@@ -97,7 +97,7 @@ extension EmptyCollection: RandomAccessCollection, MutableCollection {
   /// Accesses the element at the given position.
   ///
   /// Must never be called, since this collection is always empty.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public subscript(position: Index) -> Element {
     get {
       _preconditionFailure("Index out of range")
@@ -107,7 +107,7 @@ extension EmptyCollection: RandomAccessCollection, MutableCollection {
     }
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public subscript(bounds: Range<Index>) -> SubSequence {
     get {
       _debugPrecondition(bounds.lowerBound == 0 && bounds.upperBound == 0,
@@ -121,18 +121,18 @@ extension EmptyCollection: RandomAccessCollection, MutableCollection {
   }
 
   /// The number of elements (always zero).
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public var count: Int {
     return 0
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public func index(_ i: Index, offsetBy n: Int) -> Index {
     _debugPrecondition(i == startIndex && n == 0, "Index out of range")
     return i
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public func index(
     _ i: Index, offsetBy n: Int, limitedBy limit: Index
   ) -> Index? {
@@ -142,20 +142,20 @@ extension EmptyCollection: RandomAccessCollection, MutableCollection {
   }
 
   /// The distance between two indexes (always zero).
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public func distance(from start: Index, to end: Index) -> Int {
     _debugPrecondition(start == 0, "From must be startIndex (or endIndex)")
     _debugPrecondition(end == 0, "To must be endIndex (or startIndex)")
     return 0
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public func _failEarlyRangeCheck(_ index: Index, bounds: Range<Index>) {
     _debugPrecondition(index == 0, "out of bounds")
     _debugPrecondition(bounds == indices, "invalid bounds for an empty collection")
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public func _failEarlyRangeCheck(
     _ range: Range<Index>, bounds: Range<Index>
   ) {
@@ -165,7 +165,7 @@ extension EmptyCollection: RandomAccessCollection, MutableCollection {
 }
 
 extension EmptyCollection : Equatable {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public static func == (
     lhs: EmptyCollection<Element>, rhs: EmptyCollection<Element>
   ) -> Bool {

--- a/stdlib/public/core/Equatable.swift
+++ b/stdlib/public/core/Equatable.swift
@@ -244,7 +244,7 @@ extension Equatable {
 /// - Parameters:
 ///   - lhs: A reference to compare.
 ///   - rhs: Another reference to compare.
-@inlinable // FIXME(sil-serialize-all)
+@inlinable // trivial-implementation
 public func === (lhs: AnyObject?, rhs: AnyObject?) -> Bool {
   switch (lhs, rhs) {
   case let (l?, r?):
@@ -266,7 +266,7 @@ public func === (lhs: AnyObject?, rhs: AnyObject?) -> Bool {
 /// - Parameters:
 ///   - lhs: A reference to compare.
 ///   - rhs: Another reference to compare.
-@inlinable // FIXME(sil-serialize-all)
+@inlinable // trivial-implementation
 public func !== (lhs: AnyObject?, rhs: AnyObject?) -> Bool {
   return !(lhs === rhs)
 }

--- a/stdlib/public/core/ErrorType.swift
+++ b/stdlib/public/core/ErrorType.swift
@@ -127,7 +127,6 @@ public protocol Error {
 #if _runtime(_ObjC)
 extension Error {
   /// Default implementation: there is no embedded NSError.
-  @inlinable // FIXME(sil-serialize-all)
   public func _getEmbeddedNSError() -> AnyObject? { return nil }
 }
 #endif
@@ -160,7 +159,6 @@ internal func _getErrorEmbeddedNSErrorIndirect<T : Error>(
 }
 
 /// Called by compiler-generated code to extract an NSError from an Error value.
-@inlinable // FIXME(sil-serialize-all)
 public // COMPILER_INTRINSIC
 func _getErrorEmbeddedNSError<T : Error>(_ x: T)
 -> AnyObject? {
@@ -179,14 +177,12 @@ public func _bridgeErrorToNSError(_ error: __owned Error) -> AnyObject
 
 /// Invoked by the compiler when the subexpression of a `try!` expression
 /// throws an error.
-@inlinable // FIXME(sil-serialize-all)
 @_silgen_name("swift_unexpectedError")
 public func _unexpectedError(_ error: Error) {
   preconditionFailure("'try!' expression unexpectedly raised an error: \(String(reflecting: error))")
 }
 
 /// Invoked by the compiler when code at top level throws an uncaught error.
-@inlinable // FIXME(sil-serialize-all)
 @_silgen_name("swift_errorInMain")
 public func _errorInMain(_ error: Error) {
   fatalError("Error raised at top level: \(String(reflecting: error))")
@@ -198,12 +194,10 @@ public func _errorInMain(_ error: Error) {
 public func _getDefaultErrorCode<T : Error>(_ error: T) -> Int
 
 extension Error {
-  @inlinable // FIXME(sil-serialize-all)
   public var _code: Int {
     return _getDefaultErrorCode(self)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public var _domain: String {
     return String(reflecting: type(of: self))
   }
@@ -219,7 +213,6 @@ extension Error {
 
 extension Error where Self: RawRepresentable, Self.RawValue: SignedInteger {
   // The error code of Error with integral raw values is the raw value.
-  @inlinable // FIXME(sil-serialize-all)
   public var _code: Int {
     return numericCast(self.rawValue)
   }
@@ -227,7 +220,6 @@ extension Error where Self: RawRepresentable, Self.RawValue: SignedInteger {
 
 extension Error where Self: RawRepresentable, Self.RawValue: UnsignedInteger {
   // The error code of Error with integral raw values is the raw value.
-  @inlinable // FIXME(sil-serialize-all)
   public var _code: Int {
     return numericCast(self.rawValue)
   }

--- a/stdlib/public/core/Filter.swift
+++ b/stdlib/public/core/Filter.swift
@@ -16,7 +16,7 @@
 ///
 /// - Note: `s.lazy.filter { ... }`, for an arbitrary sequence `s`,
 ///   is a `LazyFilterSequence`.
-@_fixed_layout // FIXME(sil-serialize-all)
+@_fixed_layout // lazy-performance
 public struct LazyFilterSequence<Base: Sequence> {
   @usableFromInline // FIXME(sil-serialize-all)
   internal var _base: Base
@@ -42,19 +42,19 @@ extension LazyFilterSequence {
   ///
   /// - Note: This is the associated `Iterator` of `LazyFilterSequence`
   /// and `LazyFilterCollection`.
-  @_fixed_layout // FIXME(sil-serialize-all)
+  @_fixed_layout // lazy-performance
   public struct Iterator {
     /// The underlying iterator whose elements are being filtered.
     public var base: Base.Iterator { return _base }
 
-    @usableFromInline // FIXME(sil-serialize-all)
+    @usableFromInline // lazy-performance
     internal var _base: Base.Iterator
-    @usableFromInline // FIXME(sil-serialize-all)
+    @usableFromInline // lazy-performance
     internal let _predicate: (Base.Element) -> Bool
 
     /// Creates an instance that produces the elements `x` of `base`
     /// for which `isIncluded(x) == true`.
-    @inlinable // FIXME(sil-serialize-all)
+    @inlinable // lazy-performance
     internal init(_base: Base.Iterator, _ isIncluded: @escaping (Base.Element) -> Bool) {
       self._base = _base
       self._predicate = isIncluded
@@ -72,7 +72,7 @@ extension LazyFilterSequence.Iterator: IteratorProtocol, Sequence {
   ///
   /// - Precondition: `next()` has not been applied to a copy of `self`
   ///   since the copy was made.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public mutating func next() -> Element? {
     while let n = _base.next() {
       if _predicate(n) {
@@ -88,7 +88,7 @@ extension LazyFilterSequence: LazySequenceProtocol {
   /// Returns an iterator over the elements of this sequence.
   ///
   /// - Complexity: O(1).
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func makeIterator() -> Iterator {
     return Iterator(_base: _base.makeIterator(), _predicate)
   }
@@ -110,16 +110,16 @@ extension LazyFilterSequence: LazySequenceProtocol {
 ///   the usual performance given by `Collection`. Be aware, therefore, that
 ///   general operations on `LazyFilterCollection` instances may not have the
 ///   documented complexity.
-@_fixed_layout // FIXME(sil-serialize-all)
+@_fixed_layout // lazy-performance
 public struct LazyFilterCollection<Base : Collection> {
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // lazy-performance
   internal var _base: Base
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // lazy-performance
   internal let _predicate: (Base.Element) -> Bool
 
   /// Creates an instance containing the elements of `base` that
   /// satisfy `isIncluded`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public // @testable
   init(_base: Base, _ isIncluded: @escaping (Base.Element) -> Bool) {
     self._base = _base
@@ -136,10 +136,10 @@ extension LazyFilterCollection : LazySequenceProtocol {
   // iterating the collection and evaluating each element, which can be costly,
   // is unexpected, and usually doesn't pay for itself in saving time through
   // preventing intermediate reallocations. (SR-4164)
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public var underestimatedCount: Int { return 0 }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func _copyToContiguousArray() -> ContiguousArray<Base.Element> {
 
     // The default implementation of `_copyToContiguousArray` queries the
@@ -152,7 +152,7 @@ extension LazyFilterCollection : LazySequenceProtocol {
   /// Returns an iterator over the elements of this sequence.
   ///
   /// - Complexity: O(1).
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func makeIterator() -> Iterator {
     return Iterator(_base: _base.makeIterator(), _predicate)
   }
@@ -177,7 +177,7 @@ extension LazyFilterCollection : LazyCollectionProtocol {
   ///
   /// - Complexity: O(*n*), where *n* is the ratio between unfiltered and
   ///   filtered collection counts.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public var startIndex: Index {
     var index = _base.startIndex
     while index != _base.endIndex && !_predicate(_base[index]) {
@@ -191,20 +191,20 @@ extension LazyFilterCollection : LazyCollectionProtocol {
   ///
   /// `endIndex` is always reachable from `startIndex` by zero or more
   /// applications of `index(after:)`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public var endIndex: Index {
     return _base.endIndex
   }
 
   // TODO: swift-3-indexing-model - add docs
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func index(after i: Index) -> Index {
     var i = i
     formIndex(after: &i)
     return i
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func formIndex(after i: inout Index) {
     // TODO: swift-3-indexing-model: _failEarlyRangeCheck i?
     var index = i
@@ -216,7 +216,7 @@ extension LazyFilterCollection : LazyCollectionProtocol {
   }
 
   @inline(__always)
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   internal func _advanceIndex(_ i: inout Index, step: Int) {
     repeat {
       _base.formIndex(&i, offsetBy: step)
@@ -224,7 +224,7 @@ extension LazyFilterCollection : LazyCollectionProtocol {
   }
 
   @inline(__always)
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   internal func _ensureBidirectional(step: Int) {
     // FIXME: This seems to be the best way of checking whether _base is
     // forward only without adding an extra protocol requirement.
@@ -237,7 +237,7 @@ extension LazyFilterCollection : LazyCollectionProtocol {
     }
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func distance(from start: Index, to end: Index) -> Int {
     // The following line makes sure that distance(from:to:) is invoked on the
     // _base at least once, to trigger a _precondition in forward only
@@ -264,7 +264,7 @@ extension LazyFilterCollection : LazyCollectionProtocol {
     return count
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func index(_ i: Index, offsetBy n: Int) -> Index {
     var i = i
     let step = n.signum()
@@ -278,12 +278,12 @@ extension LazyFilterCollection : LazyCollectionProtocol {
     return i
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func formIndex(_ i: inout Index, offsetBy n: Int) {
     i = index(i, offsetBy: n)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func index(
     _ i: Index, offsetBy n: Int, limitedBy limit: Index
   ) -> Index? {
@@ -302,7 +302,7 @@ extension LazyFilterCollection : LazyCollectionProtocol {
     return i
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func formIndex(
     _ i: inout Index, offsetBy n: Int, limitedBy limit: Index
   ) -> Bool {
@@ -318,12 +318,12 @@ extension LazyFilterCollection : LazyCollectionProtocol {
   ///
   /// - Precondition: `position` is a valid position in `self` and
   /// `position != endIndex`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public subscript(position: Index) -> Element {
     return _base[position]
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public subscript(bounds: Range<Index>) -> SubSequence {
     return SubSequence(_base: _base[bounds], _predicate)
   }
@@ -338,14 +338,14 @@ extension LazyFilterCollection : LazyCollectionProtocol {
 extension LazyFilterCollection : BidirectionalCollection
   where Base : BidirectionalCollection {
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func index(before i: Index) -> Index {
     var i = i
     formIndex(before: &i)
     return i
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func formIndex(before i: inout Index) {
     // TODO: swift-3-indexing-model: _failEarlyRangeCheck i?
     var index = i
@@ -364,7 +364,7 @@ extension LazySequenceProtocol {
   ///   the result is used. No buffering storage is allocated and each
   ///   traversal step invokes `predicate` on one or more underlying
   ///   elements.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func filter(
     _ isIncluded: @escaping (Elements.Element) -> Bool
   ) -> LazyFilterSequence<Self.Elements> {
@@ -379,7 +379,7 @@ extension LazyCollectionProtocol {
   ///   the result is used. No buffering storage is allocated and each
   ///   traversal step invokes `predicate` on one or more underlying
   ///   elements.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func filter(
     _ isIncluded: @escaping (Elements.Element) -> Bool
   ) -> LazyFilterCollection<Self.Elements> {

--- a/stdlib/public/core/FlatMap.swift
+++ b/stdlib/public/core/FlatMap.swift
@@ -20,7 +20,7 @@ extension LazySequenceProtocol {
   /// `s.map(transform).joined()`.
   ///
   /// - Complexity: O(1)
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func flatMap<SegmentOfResult>(
     _ transform: @escaping (Elements.Element) -> SegmentOfResult
   ) -> LazySequence<
@@ -38,7 +38,7 @@ extension LazySequenceProtocol {
   ///   as its argument and returns an optional value.
   ///
   /// - Complexity: O(1)
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func compactMap<ElementOfResult>(
     _ transform: @escaping (Elements.Element) -> ElementOfResult?
   ) -> LazyMapSequence<
@@ -60,7 +60,7 @@ extension LazyCollectionProtocol {
   /// `c.map(transform).joined()`.
   ///
   /// - Complexity: O(1)
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func flatMap<SegmentOfResult>(
     _ transform: @escaping (Elements.Element) -> SegmentOfResult
   ) -> LazyCollection<
@@ -80,7 +80,7 @@ extension LazyCollectionProtocol {
   ///   collection as its argument and returns an optional value.
   ///
   /// - Complexity: O(1)
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func compactMap<ElementOfResult>(
     _ transform: @escaping (Elements.Element) -> ElementOfResult?
   ) -> LazyMapCollection<

--- a/stdlib/public/core/Flatten.swift
+++ b/stdlib/public/core/Flatten.swift
@@ -25,31 +25,31 @@
 /// * `s.lazy.joined().map(f)` maps lazily and returns a `LazyMapSequence`
 ///
 /// - See also: `FlattenCollection`
-@_fixed_layout // FIXME(sil-serialize-all)
+@_fixed_layout // lazy-performance
 public struct FlattenSequence<Base: Sequence> where Base.Element: Sequence {
 
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // lazy-performance
   internal var _base: Base
 
   /// Creates a concatenation of the elements of the elements of `base`.
   ///
   /// - Complexity: O(1)
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   internal init(_base: Base) {
     self._base = _base
   }
 }
 
 extension FlattenSequence {
-  @_fixed_layout // FIXME(sil-serialize-all)
+  @_fixed_layout // lazy-performance
   public struct Iterator {
-    @usableFromInline // FIXME(sil-serialize-all)
+    @usableFromInline // lazy-performance
     internal var _base: Base.Iterator
-    @usableFromInline // FIXME(sil-serialize-all)
+    @usableFromInline // lazy-performance
     internal var _inner: Base.Element.Iterator?
 
     /// Construct around a `base` iterator.
-    @inlinable // FIXME(sil-serialize-all)
+    @inlinable // lazy-performance
     internal init(_base: Base.Iterator) {
       self._base = _base
     }
@@ -66,7 +66,7 @@ extension FlattenSequence.Iterator: IteratorProtocol {
   ///
   /// - Precondition: `next()` has not been applied to a copy of `self`
   ///   since the copy was made.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public mutating func next() -> Element? {
     repeat {
       if _fastPath(_inner != nil) {
@@ -91,7 +91,7 @@ extension FlattenSequence: Sequence {
   /// Returns an iterator over the elements of this sequence.
   ///
   /// - Complexity: O(1).
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func makeIterator() -> Iterator {
     return Iterator(_base: _base.makeIterator())
   }
@@ -121,7 +121,7 @@ extension Sequence where Element : Sequence {
   ///
   /// - Returns: A flattened view of the elements of this
   ///   sequence of sequences.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func joined() -> FlattenSequence<Self> {
     return FlattenSequence(_base: self)
   }
@@ -130,7 +130,7 @@ extension Sequence where Element : Sequence {
 extension LazySequenceProtocol where Element : Sequence {
   /// Returns a lazy sequence that concatenates the elements of this sequence of
   /// sequences.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func joined() -> LazySequence<FlattenSequence<Elements>> {
     return FlattenSequence(_base: elements).lazy
   }
@@ -157,14 +157,14 @@ extension LazySequenceProtocol where Element : Sequence {
 ///   `FlattenCollection` instances may not have the documented complexity.
 ///
 /// - See also: `FlattenSequence`
-@_fixed_layout // FIXME(sil-serialize-all)
+@_fixed_layout // lazy-performance
 public struct FlattenCollection<Base>
   where Base : Collection, Base.Element : Collection {
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // lazy-performance
   internal var _base: Base
 
   /// Creates a flattened view of `base`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public init(_ base: Base) {
     self._base = base
   }
@@ -172,10 +172,10 @@ public struct FlattenCollection<Base>
 
 extension FlattenCollection {
   /// A position in a FlattenCollection
-  @_fixed_layout // FIXME(sil-serialize-all)
+  @_fixed_layout // lazy-performance
   public struct Index {
     /// The position in the outer collection of collections.
-    @usableFromInline // FIXME(sil-serialize-all)
+    @usableFromInline // lazy-performance
     internal let _outer: Base.Index
 
     /// The position in the inner collection at `base[_outer]`, or `nil` if
@@ -184,10 +184,10 @@ extension FlattenCollection {
     /// When `_inner != nil`, `_inner!` is a valid subscript of `base[_outer]`;
     /// when `_inner == nil`, `_outer == base.endIndex` and this index is
     /// `endIndex` of the `FlattenCollection`.
-    @usableFromInline // FIXME(sil-serialize-all)
+    @usableFromInline // lazy-performance
     internal let _inner: Base.Element.Index?
 
-    @inlinable // FIXME(sil-serialize-all)
+    @inlinable // lazy-performance
     internal init(_ _outer: Base.Index, _ inner: Base.Element.Index?) {
       self._outer = _outer
       self._inner = inner
@@ -196,7 +196,7 @@ extension FlattenCollection {
 }
 
 extension FlattenCollection.Index : Equatable {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public static func == (
     lhs: FlattenCollection<Base>.Index,
     rhs: FlattenCollection<Base>.Index
@@ -206,7 +206,7 @@ extension FlattenCollection.Index : Equatable {
 }
 
 extension FlattenCollection.Index : Comparable {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public static func < (
     lhs: FlattenCollection<Base>.Index,
     rhs: FlattenCollection<Base>.Index
@@ -250,7 +250,7 @@ extension FlattenCollection : Sequence {
   /// Returns an iterator over the elements of this sequence.
   ///
   /// - Complexity: O(1).
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func makeIterator() -> Iterator {
     return Iterator(_base: _base.makeIterator())
   }
@@ -260,7 +260,7 @@ extension FlattenCollection : Sequence {
   // just return zero.
   public var underestimatedCount: Int { return 0 }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func _copyToContiguousArray() -> ContiguousArray<Base.Element.Element> {
     // The default implementation of `_copyToContiguousArray` queries the
     // `count` property, which materializes every inner collection.  This is a
@@ -270,7 +270,7 @@ extension FlattenCollection : Sequence {
   }
 
   // TODO: swift-3-indexing-model - add docs
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func forEach(
     _ body: (Base.Element.Element) throws -> Void
   ) rethrows {
@@ -285,7 +285,7 @@ extension FlattenCollection : Collection {
   /// The position of the first element in a non-empty collection.
   ///
   /// In an empty collection, `startIndex == endIndex`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public var startIndex: Index {
     let end = _base.endIndex
     var outer = _base.startIndex
@@ -305,12 +305,12 @@ extension FlattenCollection : Collection {
   /// `endIndex` is not a valid argument to `subscript`, and is always
   /// reachable from `startIndex` by zero or more applications of
   /// `index(after:)`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public var endIndex: Index {
     return Index(_base.endIndex, nil)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   internal func _index(after i: Index) -> Index {
     let innerCollection = _base[i._outer]
     let nextInner = innerCollection.index(after: i._inner!)
@@ -330,7 +330,7 @@ extension FlattenCollection : Collection {
     return endIndex
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   internal func _index(before i: Index) -> Index {
     var prevOuter = i._outer
     if prevOuter == _base.endIndex {
@@ -349,17 +349,17 @@ extension FlattenCollection : Collection {
   }
 
   // TODO: swift-3-indexing-model - add docs
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func index(after i: Index) -> Index {
     return _index(after: i)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func formIndex(after i: inout Index) {
     i = index(after: i)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func distance(from start: Index, to end: Index) -> Int {
     // The following check makes sure that distance(from:to:) is invoked on the
     // _base at least once, to trigger a _precondition in forward only
@@ -389,14 +389,14 @@ extension FlattenCollection : Collection {
   }
 
   @inline(__always)
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   internal func _advanceIndex(_ i: inout Index, step: Int) {
     _sanityCheck(-1...1 ~= step, "step should be within the -1...1 range")
     i = step < 0 ? _index(before: i) : _index(after: i)
   }
 
   @inline(__always)
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   internal func _ensureBidirectional(step: Int) {
     // FIXME: This seems to be the best way of checking whether _base is
     // forward only without adding an extra protocol requirement.
@@ -409,7 +409,7 @@ extension FlattenCollection : Collection {
     }
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func index(_ i: Index, offsetBy n: Int) -> Index {
     var i = i
     let step = n.signum()
@@ -420,12 +420,12 @@ extension FlattenCollection : Collection {
     return i
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func formIndex(_ i: inout Index, offsetBy n: Int) {
     i = index(i, offsetBy: n)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func index(
     _ i: Index, offsetBy n: Int, limitedBy limit: Index
   ) -> Index? {
@@ -444,7 +444,7 @@ extension FlattenCollection : Collection {
     return i
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func formIndex(
     _ i: inout Index, offsetBy n: Int, limitedBy limit: Index
   ) -> Bool {
@@ -460,12 +460,12 @@ extension FlattenCollection : Collection {
   ///
   /// - Precondition: `position` is a valid position in `self` and
   ///   `position != endIndex`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public subscript(position: Index) -> Base.Element.Element {
     return _base[position._outer][position._inner!]
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public subscript(bounds: Range<Index>) -> SubSequence {
     return Slice(base: self, bounds: bounds)
   }
@@ -478,12 +478,12 @@ extension FlattenCollection : BidirectionalCollection
   // methods that skip over inner collections when random-access
 
   // TODO: swift-3-indexing-model - add docs
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func index(before i: Index) -> Index {
     return _index(before: i)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func formIndex(before i: inout Index) {
     i = index(before: i)
   }
@@ -513,7 +513,7 @@ extension Collection where Element : Collection {
   ///
   /// - Returns: A flattened view of the elements of this
   ///   collection of collections.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func joined() -> FlattenCollection<Self> {
     return FlattenCollection(self)
   }
@@ -522,7 +522,7 @@ extension Collection where Element : Collection {
 extension LazyCollectionProtocol
   where Self : Collection, Element : Collection {
   /// A concatenation of the elements of `self`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func joined() -> LazyCollection<FlattenCollection<Elements>> {
     return FlattenCollection(elements).lazy
   }

--- a/stdlib/public/core/IntegerParsing.swift
+++ b/stdlib/public/core/IntegerParsing.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@inlinable // FIXME(sil-serialize-all)
+@inlinable
 @inline(__always)
 internal func _asciiDigit<CodeUnit : UnsignedInteger, Result : BinaryInteger>(
   codeUnit u_: CodeUnit, radix: Result
@@ -29,7 +29,7 @@ internal func _asciiDigit<CodeUnit : UnsignedInteger, Result : BinaryInteger>(
   return Result(truncatingIfNeeded: d)
 }
 
-@inlinable // FIXME(sil-serialize-all)
+@inlinable
 @inline(__always)
 internal func _parseUnsignedASCII<
   Rest : IteratorProtocol, Result: FixedWidthInteger
@@ -65,7 +65,7 @@ where Rest.Element : UnsignedInteger {
 // always-inline code, most of which are MOV instructions.
 //
 
-@inlinable // FIXME(sil-serialize-all)
+@inlinable
 @inline(__always)
 internal func _parseASCII<
   CodeUnits : IteratorProtocol, Result: FixedWidthInteger

--- a/stdlib/public/core/LazySequence.swift
+++ b/stdlib/public/core/LazySequence.swift
@@ -176,14 +176,14 @@ extension LazySequenceProtocol where Elements: LazySequenceProtocol {
 /// implemented lazily.
 ///
 /// - See also: `LazySequenceProtocol`
-@_fixed_layout // FIXME(sil-serialize-all)
+@_fixed_layout // lazy-performance
 public struct LazySequence<Base : Sequence>: _SequenceWrapper {
   public var _base: Base
 
   /// Creates a sequence that has the same elements as `base`, but on
   /// which some operations such as `map` and `filter` are implemented
   /// lazily.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   internal init(_base: Base) {
     self._base = _base
   }
@@ -193,7 +193,7 @@ extension LazySequence: LazySequenceProtocol {
   public typealias Elements = Base
 
   /// The `Base` (presumably non-lazy) sequence from which `self` was created.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public var elements: Elements { return _base }
 }
 

--- a/stdlib/public/core/MemoryLayout.swift
+++ b/stdlib/public/core/MemoryLayout.swift
@@ -39,7 +39,7 @@
 ///     let pointPointer = UnsafeMutableRawPointer.allocate(
 ///             bytes: count * MemoryLayout<Point>.stride,
 ///             alignedTo: MemoryLayout<Point>.alignment)
-@_frozen // FIXME(sil-serialize-all)
+@_frozen // namespace
 public enum MemoryLayout<T> {
   /// The contiguous memory footprint of `T`, in bytes.
   ///

--- a/stdlib/public/core/Mirrors.swift.gyb
+++ b/stdlib/public/core/Mirrors.swift.gyb
@@ -46,7 +46,6 @@ extension ${Type[0]} : CustomReflectable {
 
 extension ${Type[0]} : _CustomPlaygroundQuickLookable {
   /// A custom playground Quick Look for the `${Type[0]}` instance.
-  @inlinable // FIXME(sil-serialize-all)
   @available(*, deprecated, message: "${Type[0]}.customPlaygroundQuickLook will be removed in a future Swift version")
   public var customPlaygroundQuickLook: _PlaygroundQuickLook {
     return ${Type[1]}(${Type[2]})

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -686,7 +686,6 @@ extension Unsafe${Mutable}RawBufferPointer : CustomDebugStringConvertible {
 }
 
 extension ${Self} {
-  @inlinable // FIXME(sil-serialize-all)
   @available(*, unavailable, 
     message: "use 'Unsafe${Mutable}RawBufferPointer(rebasing:)' to convert a slice into a zero-based raw buffer.")
   public subscript(bounds: Range<Int>) -> ${Self} {


### PR DESCRIPTION
- Remove comment from things already marked always/never inline
- Deprecated/obsoleted things don't need to be inlined
- Some trivial implementations (like `CollectionOfOne`/`None`)
- Enums for namespaces can be frozen
- Unsafe performance
- Dump and Error paths shouldn’t need inlining
- Some `Array` properties were inconsistent with the rest of the implementation
- Lazy types must be specialized and inlined to achieve their goals
