### PR TITLE
MemAccessUtils: change the interface of getProjectionPath to Optional value

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -54,10 +54,9 @@ public:
 
   const Projection &getProjection() const { return proj; }
 
-  const ProjectionPath getProjectionPath() const {
+  const Optional<ProjectionPath> getProjectionPath() const {
     return ProjectionPath::getProjectionPath(stripBorrow(REA->getOperand()),
-                                             REA)
-        .getValue();
+                                             REA);
   }
 
   bool operator==(const ObjectProjection &other) const {
@@ -284,7 +283,11 @@ public:
     }
     auto projPath = getObjectProjection().getProjectionPath();
     auto otherProjPath = other.getObjectProjection().getProjectionPath();
-    return projPath.hasNonEmptySymmetricDifference(otherProjPath);
+    if (!projPath.hasValue() || !otherProjPath.hasValue()) {
+      return false;
+    }
+    return projPath.getValue().hasNonEmptySymmetricDifference(
+        otherProjPath.getValue());
   }
 
   /// Returns the ValueDecl for the underlying storage, if it can be


### PR DESCRIPTION
Sometions we don't have a projection path for each ref_elem_addr - fixes a compiler crash in Deferred in the Source Compatibility Suite

When checking if two storage locations are distinct from one another, play it safe in such a case.

radar rdar://problem/43403553