### PR TITLE
[CSRanking] Favour concrete members over protocol requirements

### DIFF
--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -470,7 +470,7 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
       //      x.i // ensure ambiguous.
       //    }
       //
-      if (tc.Context.isSwiftVersionAtLeast(5) && !isDynamicOverloadComparison) {
+      if (true && !isDynamicOverloadComparison) {
         auto *proto1 = dyn_cast<ProtocolDecl>(outerDC1);
         auto *proto2 = dyn_cast<ProtocolDecl>(outerDC2);
         if (proto1 != proto2)
@@ -1018,7 +1018,7 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
     // compatibility under Swift 4 mode by ensuring we don't introduce any new
     // ambiguities. This will become a more general "is more specialised" rule
     // in Swift 5 mode.
-    if (!tc.Context.isSwiftVersionAtLeast(5) && !isDynamicOverloadComparison &&
+    if (false && !isDynamicOverloadComparison &&
         isa<VarDecl>(decl1) && isa<VarDecl>(decl2)) {
       auto *nominal1 = dc1->getSelfNominalTypeDecl();
       auto *nominal2 = dc2->getSelfNominalTypeDecl();
@@ -1187,7 +1187,7 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
   // All other things being equal, apply the Swift 4 compatibility hack for
   // preferring var members in concrete types over a protocol requirement
   // (see the comment above for the rationale of this hack).
-  if (!tc.Context.isSwiftVersionAtLeast(5) && score1 == score2) {
+  if (false && score1 == score2) {
     score1 += isSwift4ConcreteOverProtocolVar1;
     score2 += isSwift4ConcreteOverProtocolVar2;
   }

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -446,6 +446,18 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
         return inProtocolExtension2;
       }
 
+      // A concrete type member is always more specialised than a protocol
+      // member (bearing in mind that we have already handled the case where
+      // exactly one member is in a protocol extension). Only apply this rule in
+      // Swift 5 mode to better maintain source compatibility under Swift 4
+      // mode.
+      if (tc.Context.isSwiftVersionAtLeast(5)) {
+        auto *proto1 = dyn_cast<ProtocolDecl>(outerDC1);
+        auto *proto2 = dyn_cast<ProtocolDecl>(outerDC2);
+        if (proto1 != proto2)
+          return proto2;
+      }
+
       Type type1 = decl1->getInterfaceType();
       Type type2 = decl2->getInterfaceType();
 

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -389,7 +389,8 @@ static bool paramIsIUO(Decl *decl, int paramNum) {
 ///
 /// "Specialized" is essentially a form of subtyping, defined below.
 static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
-                                  ValueDecl *decl1, ValueDecl *decl2) {
+                                  ValueDecl *decl1, ValueDecl *decl2,
+                                  bool isDynamicOverloadComparison = false) {
 
   if (tc.getLangOpts().DebugConstraintSolver) {
     auto &log = tc.Context.TypeCheckerDebug->getStream();
@@ -397,7 +398,9 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
     decl1->print(log); 
     log << "\nand\n";
     decl2->print(log);
-    log << "\n";
+    log << "\n(isDynamicOverloadComparison: ";
+    log << isDynamicOverloadComparison;
+    log << ")\n";
   }
 
   auto *innerDC1 = decl1->getInnermostDeclContext();
@@ -406,7 +409,8 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
   auto *outerDC1 = decl1->getDeclContext();
   auto *outerDC2 = decl2->getDeclContext();
 
-  if (!tc.specializedOverloadComparisonCache.count({decl1, decl2})) {
+  if (!tc.specializedOverloadComparisonCache.count(
+          {decl1, decl2, isDynamicOverloadComparison})) {
 
     auto compareSpecializations = [&] () -> bool {
       // If the kinds are different, there's nothing we can do.
@@ -451,7 +455,21 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
       // exactly one member is in a protocol extension). Only apply this rule in
       // Swift 5 mode to better maintain source compatibility under Swift 4
       // mode.
-      if (tc.Context.isSwiftVersionAtLeast(5)) {
+      //
+      // Don't apply this rule when comparing two overloads found through
+      // dynamic lookup to ensure we keep cases like this ambiguous:
+      //
+      //    @objc protocol P {
+      //      var i: String { get }
+      //    }
+      //    class C {
+      //      @objc var i: Int { return 0 }
+      //    }
+      //    func foo(_ x: AnyObject) {
+      //      x.i // ensure ambiguous.
+      //    }
+      //
+      if (tc.Context.isSwiftVersionAtLeast(5) && !isDynamicOverloadComparison) {
         auto *proto1 = dyn_cast<ProtocolDecl>(outerDC1);
         auto *proto2 = dyn_cast<ProtocolDecl>(outerDC2);
         if (proto1 != proto2)
@@ -709,21 +727,25 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
       return false;
     };
 
-    tc.specializedOverloadComparisonCache[{decl1, decl2}] = 
-        compareSpecializations();
+    tc.specializedOverloadComparisonCache[{
+        decl1, decl2, isDynamicOverloadComparison}] = compareSpecializations();
   } else if (tc.getLangOpts().DebugConstraintSolver) {
     auto &log = tc.Context.TypeCheckerDebug->getStream();
-    log << "Found cached comparison: " 
-        << tc.specializedOverloadComparisonCache[{decl1, decl2}] << "\n";
+    log << "Found cached comparison: "
+        << tc.specializedOverloadComparisonCache[{decl1, decl2,
+                                                  isDynamicOverloadComparison}]
+        << "\n";
   }
 
   if (tc.getLangOpts().DebugConstraintSolver) {
     auto &log = tc.Context.TypeCheckerDebug->getStream();
-    auto result = tc.specializedOverloadComparisonCache[{decl1, decl2}];
+    auto result = tc.specializedOverloadComparisonCache[{
+        decl1, decl2, isDynamicOverloadComparison}];
     log << "comparison result: " << (result ? "better" : "not better") << "\n";
   }
 
-  return tc.specializedOverloadComparisonCache[{decl1, decl2}];
+  return tc.specializedOverloadComparisonCache[{decl1, decl2,
+                                                isDynamicOverloadComparison}];
 }
 
 Comparison TypeChecker::compareDeclarations(DeclContext *dc,
@@ -864,15 +886,23 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
     case OverloadChoiceKind::DynamicMemberLookup:
       break;
     }
-    
+
+    // We don't apply some ranking rules to overloads found through dynamic
+    // lookup in order to keep a few potentially ill-formed cases ambiguous.
+    bool isDynamicOverloadComparison =
+        choice1.getKind() == OverloadChoiceKind::DeclViaDynamic &&
+        choice2.getKind() == OverloadChoiceKind::DeclViaDynamic;
+
     // Determine whether one declaration is more specialized than the other.
     bool firstAsSpecializedAs = false;
     bool secondAsSpecializedAs = false;
-    if (isDeclAsSpecializedAs(tc, cs.DC, decl1, decl2)) {
+    if (isDeclAsSpecializedAs(tc, cs.DC, decl1, decl2,
+                              isDynamicOverloadComparison)) {
       score1 += weight;
       firstAsSpecializedAs = true;
     }
-    if (isDeclAsSpecializedAs(tc, cs.DC, decl2, decl1)) {
+    if (isDeclAsSpecializedAs(tc, cs.DC, decl2, decl1,
+                              isDynamicOverloadComparison)) {
       score2 += weight;
       secondAsSpecializedAs = true;
     }

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -756,6 +756,9 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
   bool isStdlibOptionalMPlusOperator1 = false;
   bool isStdlibOptionalMPlusOperator2 = false;
 
+  bool isSwift4ConcreteOverProtocolVar1 = false;
+  bool isSwift4ConcreteOverProtocolVar2 = false;
+
   auto getWeight = [&](ConstraintLocator *locator) -> unsigned {
     if (auto *anchor = locator->getAnchor()) {
       auto weight = weights.find(anchor);
@@ -962,6 +965,32 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
       }
     }
 
+    // Swift 4.1 compatibility hack: If everything else is considered equal,
+    // favour a property on a concrete type over a protocol property member.
+    //
+    // This hack is required due to changes in shadowing behaviour where a
+    // protocol property member will no longer shadow a property on a concrete
+    // type, which created unintentional ambiguities in 4.2. This hack ensures
+    // we at least keep these cases unambiguous in Swift 5 under Swift 4
+    // compatibility mode. Don't however apply this hack for decls found through
+    // dynamic lookup, as we want the user to have to disambiguate those.
+    //
+    // This is intentionally narrow in order to best preserve source
+    // compatibility under Swift 4 mode by ensuring we don't introduce any new
+    // ambiguities. This will become a more general "is more specialised" rule
+    // in Swift 5 mode.
+    if (!tc.Context.isSwiftVersionAtLeast(5) &&
+        choice1.getKind() != OverloadChoiceKind::DeclViaDynamic &&
+        choice2.getKind() != OverloadChoiceKind::DeclViaDynamic &&
+        isa<VarDecl>(decl1) && isa<VarDecl>(decl2)) {
+      auto *nominal1 = dc1->getSelfNominalTypeDecl();
+      auto *nominal2 = dc2->getSelfNominalTypeDecl();
+      if (nominal1 && nominal2 && nominal1 != nominal2) {
+        isSwift4ConcreteOverProtocolVar1 = isa<ProtocolDecl>(nominal2);
+        isSwift4ConcreteOverProtocolVar2 = isa<ProtocolDecl>(nominal1);
+      }
+    }
+
     // FIXME: Lousy hack for ?? to prefer the catamorphism (flattening)
     // over the mplus (non-flattening) overload if all else is equal.
     if (decl1->getBaseName() == "??") {
@@ -1116,6 +1145,14 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
     // This is correct: we want to /disprefer/ the mplus.
     score2 += isStdlibOptionalMPlusOperator1;
     score1 += isStdlibOptionalMPlusOperator2;
+  }
+
+  // All other things being equal, apply the Swift 4 compatibility hack for
+  // preferring var members in concrete types over a protocol requirement
+  // (see the comment above for the rationale of this hack).
+  if (!tc.Context.isSwiftVersionAtLeast(5) && score1 == score2) {
+    score1 += isSwift4ConcreteOverProtocolVar1;
+    score2 += isSwift4ConcreteOverProtocolVar2;
   }
 
   // FIXME: There are type variables and overloads not common to both solutions

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -555,9 +555,11 @@ public:
   SmallVector<NominalTypeDecl*, 8> DelayedCircularityChecks;
 
   // Caches whether a given declaration is "as specialized" as another.
-  llvm::DenseMap<std::pair<ValueDecl*, ValueDecl*>, bool> 
-    specializedOverloadComparisonCache;
-  
+  llvm::DenseMap<std::tuple<ValueDecl *, ValueDecl *,
+                            /*isDynamicOverloadComparison*/ unsigned>,
+                 bool>
+      specializedOverloadComparisonCache;
+
   /// A list of closures for the most recently type-checked function, which we
   /// will need to compute captures for.
   std::vector<AnyFunctionRef> ClosuresWithUncomputedCaptures;

--- a/test/Constraints/dynamic_lookup.swift
+++ b/test/Constraints/dynamic_lookup.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module %S/Inputs/PrivateObjC.swift -o %t
-// RUN: %target-typecheck-verify-swift -I %t -verify-ignore-unknown
+// RUN: %target-typecheck-verify-swift -swift-version 4 -I %t -verify-ignore-unknown
+// RUN: %target-typecheck-verify-swift -swift-version 5 -I %t -verify-ignore-unknown
 
 // REQUIRES: objc_interop
 import Foundation

--- a/test/Constraints/dynamic_lookup.swift
+++ b/test/Constraints/dynamic_lookup.swift
@@ -341,18 +341,51 @@ func dynamicInitCrash(ao: AnyObject.Type) {
   // expected-error@-1 {{incorrect argument label in call (have 'blahblah:', expected 'toMemory:')}}
 }
 
-// Test that we correctly diagnose ambiguity for different typed properties available
+// Test that we correctly diagnose ambiguity for different typed members available
 // through dynamic lookup.
 @objc protocol P3 {
-  var i: UInt { get } // expected-note {{found this candidate}}
-  var j: Int { get }
+  var ambiguousProperty: String { get } // expected-note {{found this candidate}}
+  var unambiguousProperty: Int { get }
+
+  func ambiguousMethod() -> String // expected-note 2{{found this candidate}}
+  func unambiguousMethod() -> Int
+
+  func ambiguousMethodParam(_ x: String) // expected-note {{found this candidate}}
+  func unambiguousMethodParam(_ x: Int)
+
+  subscript(ambiguousSubscript _: Int) -> String { get } // expected-note {{found this candidate}}
+  subscript(unambiguousSubscript _: String) -> Int { get } // expected-note {{found this candidate}}
 }
 
 class C1 {
-  @objc var i: Int { return 0 } // expected-note {{found this candidate}}
-  @objc var j: Int { return 0 }
+  @objc var ambiguousProperty: Int { return 0 } // expected-note {{found this candidate}}
+  @objc var unambiguousProperty: Int { return 0 }
+
+  @objc func ambiguousMethod() -> Int { return 0 } // expected-note 2{{found this candidate}}
+  @objc func unambiguousMethod() -> Int { return 0 }
+
+  @objc func ambiguousMethodParam(_ x: Int) {} // expected-note {{found this candidate}}
+  @objc func unambiguousMethodParam(_ x: Int) {}
+
+  @objc subscript(ambiguousSubscript _: Int) -> Int { return 0 } // expected-note {{found this candidate}}
+  @objc subscript(unambiguousSubscript _: String) -> Int { return 0 } // expected-note {{found this candidate}}
 }
 
-_ = (C1() as AnyObject).i // expected-error {{ambiguous use of 'i'}}
-_ = (C1() as AnyObject).j // okay
+func testAnyObjectAmbiguity(_ x: AnyObject) {
+  _ = x.ambiguousProperty // expected-error {{ambiguous use of 'ambiguousProperty'}}
+  _ = x.unambiguousProperty
 
+  _ = x.ambiguousMethod() // expected-error {{ambiguous use of 'ambiguousMethod()'}}
+  _ = x.unambiguousMethod()
+
+  _ = x.ambiguousMethod // expected-error {{ambiguous use of 'ambiguousMethod()'}}
+  _ = x.unambiguousMethod
+
+  _ = x.ambiguousMethodParam // expected-error {{ambiguous use of 'ambiguousMethodParam'}}
+  _ = x.unambiguousMethodParam
+
+  _ = x[ambiguousSubscript: 0] // expected-error {{ambiguous use of 'subscript(ambiguousSubscript:)'}}
+
+  // FIX-ME(SR-8611): This is currently ambiguous but shouldn't be.
+  _ = x[unambiguousSubscript: ""] // expected-error {{ambiguous use of 'subscript(unambiguousSubscript:)'}}
+}

--- a/test/Constraints/rdar39401774.swift
+++ b/test/Constraints/rdar39401774.swift
@@ -1,16 +1,16 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -swift-version 5
 
 class A<T> {
-  var foo: Int? { return 42 }      // expected-note {{found this candidate}}
-  func baz() -> T { fatalError() } // expected-note {{found this candidate}}
-  func fiz() -> Int { return 42 }  // expected-note {{found this candidate}}
+  var foo: Int? { return 42 }
+  func baz() -> T { fatalError() }
+  func fiz() -> Int { return 42 }
 }
 
 protocol P1 {
   associatedtype T
-  var foo: Int? { get } // expected-note {{found this candidate}}
-  func baz() -> T       // expected-note {{found this candidate}}
-  func fiz() -> Int     // expected-note {{found this candidate}}
+  var foo: Int? { get }
+  func baz() -> T
+  func fiz() -> Int
 }
 
 protocol P2 : P1 {
@@ -19,8 +19,9 @@ protocol P2 : P1 {
 
 extension P2 where Self: A<Int> {
   var bar: Int? {
-    guard let foo = foo else { return 0 } // expected-error {{ambiguous use of 'foo'}}
-    let _ = baz() // expected-error {{ambiguous use of 'baz()'}}
-    return fiz()  // expected-error {{ambiguous use of 'fiz()'}}
+    guard let foo = foo else { return 0 }
+    _ = foo
+    let _ = baz()
+    return fiz()  
   }
 }

--- a/test/Constraints/sr7425.swift
+++ b/test/Constraints/sr7425.swift
@@ -1,0 +1,79 @@
+// RUN: %target-typecheck-verify-swift -swift-version 4
+
+protocol X {
+  var foo: Int { get }
+  var bar: Int { get }
+}
+
+class Y {
+  var foo: Int = 0
+}
+extension Y {
+  var bar: Int { return foo }
+}
+
+protocol Z : Y {
+  var foo: Int { get }
+  var bar: Int { get }
+}
+
+class GenericClass<T> {
+  var foo: T
+  init(_ foo: T) { self.foo = foo }
+}
+extension GenericClass {
+  var bar: T { return foo }
+}
+
+// Make sure we keep all of the following cases unambiguous to retain source compatibility with Swift 4.1.
+
+func testGenericPropertyProtocolClass<T : X & Y>(_ t: T) {
+  _ = t.foo
+  _ = t.bar
+}
+
+func testExistentialPropertyProtocolClass(_ t: X & Y) {
+  _ = t.foo
+  _ = t.bar
+}
+
+func testGenericPropertySubclassConstrainedProtocol<T : Z>(_ t: T) {
+  _ = t.foo
+  _ = t.bar
+}
+
+func testExistentialPropertySubclassConstrainedProtocol(_ t: Z) {
+  _ = t.foo
+  _ = t.bar
+}
+
+func testExistentialPropertyProtocolGenericClass(_ t: GenericClass<Int> & X) {
+  _ = t.foo
+  _ = t.bar
+}
+
+func testExistentialPropertyProtocolGenericClass(_ t: GenericClass<String> & X) {
+  _ = t.foo
+  _ = t.bar
+}
+
+extension X where Self : Y {
+  func testGenericPropertyProtocolClass(_ x: Self) {
+    _ = self.foo
+    _ = self.bar
+  }
+}
+
+extension X where Self : GenericClass<Int> {
+  func testGenericPropertyProtocolGenericClass(_ x: Self) {
+    _ = self.foo
+    _ = self.bar
+  }
+}
+
+extension X where Self : GenericClass<String> {
+  func testGenericPropertyProtocolGenericClass(_ x: Self) {
+    _ = self.foo
+    _ = self.bar
+  }
+}


### PR DESCRIPTION
This PR comes in two pieces:

#### 1. A narrow Swift 4.1 compatibility hack that favours properties in concrete types over protocol requirements

This was unintentionally regressed by #15412, and is tracked by [SR-7425]. This is added as a ranking tie-breaker in order to ensure we don’t introduce any new ambiguities.

#### 2. A new Swift 5 mode ranking rule that favours arbitrary concrete type members over protocol requirements

We already have a similar rule that prefers concrete members over protocol extension members – IMO this new rule is a natural extension of it.

This allows the following code to become unambiguous in Swift 5 mode:

```swift
protocol X {
  func baz() -> Int
}

class Y {
  func baz() -> Int { return 0 }
}

func foo(_ x: X & Y) {
  // currently ambiguous, will be made unambigous in Swift 5 mode (favouring Y's `baz()`)
  x.baz()
}
```

Note that this new rule isn’t applied to overloads found through dynamic lookup in order to ensure we keep cases such as [SR-7299] ambiguous.

Note also that this new rule is potentially source breaking (hence why it requires Swift 5 mode) – for example, the following contrived case is currently unambiguous, but will be made ambiguous by the change:

```swift
protocol P {
  static func foo() -> Int
}

class C {
  func foo() -> Int { return 0 }
}

extension P where Self : C {
  static func bar() {
    let m = foo // currently unambiguous, will be made ambiguous in Swift 5 mode
  }
}
```

Arguably this change is unifying the behaviour with that of protocol extensions, where a similar example is already ambiguous:

```swift
protocol P {}
extension P {
  static func foo() -> Int { return 0 }
}

class C {
  func foo() -> Int { return 0 }
}

extension P where Self : C {
  static func bar() {
    let m = foo // error: Ambiguous use of 'foo()'
  }
}
```

And currently, adding `static func foo()` as a protocol requirement to the above suddenly resolves the ambiguity – with this Swift 5 mode change, the ambiguity is kept in both cases, which seems more consistent.

I’m happy to split this PR up if the Swift 5 mode change requires more discussion.

Resolves [SR-7425].

  [SR-7425]: https://bugs.swift.org/browse/SR-7425
  [SR-7299]: https://bugs.swift.org/browse/SR-7299
