### PR TITLE
[benchmark] Fix benchmarks for Set operations

### DIFF
--- a/benchmark/single-source/SetTests.swift
+++ b/benchmark/single-source/SetTests.swift
@@ -52,33 +52,6 @@ let setQ: Set<Int> = {
 }()
 
 public let SetTests = [
-  // Legacy benchmarks, kept for continuity with previous releases.
-  BenchmarkInfo(
-    name: "SetExclusiveOr", // ~"SetSymmetricDifferenceInt0"
-    runFunction: { n in run_SetSymmetricDifferenceInt(setAB, setCD, countABCD, 100 * n) },
-    tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setAB, setCD]) }),
-  BenchmarkInfo(
-    name: "SetExclusiveOr_OfObjects", // ~"SetSymmetricDifferenceBox0"
-    runFunction: { n in run_SetSymmetricDifferenceBox(setOAB, setOCD, countABCD, 100 * n) },
-    tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setOAB, setOCD]) }),
-  BenchmarkInfo(
-    name: "SetIntersect", // ~"SetIntersectionInt0"
-    runFunction: { n in run_SetIntersectionInt(setAB, setCD, 0, 100 * n) },
-    tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setAB, setCD]) }),
-  BenchmarkInfo(
-    name: "SetUnion", // ~"SetUnionInt0"
-    runFunction: { n in run_SetUnionInt(setAB, setCD, countABCD, 100 * n) },
-    tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setAB, setCD]) }),
-  BenchmarkInfo(
-    name: "SetUnion_OfObjects", // ~"SetUnionBox0"
-    runFunction: { n in run_SetUnionBox(setOAB, setOCD, countABCD, 100 * n) },
-    tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setOAB, setOCD]) }),
-
   // Mnemonic: number after name is percentage of common elements in input sets.
   BenchmarkInfo(
     name: "SetIsSubsetInt0",
@@ -234,6 +207,33 @@ public let SetTests = [
     runFunction: { n in run_SetSubtractingInt(setP, setQ, 0, 10 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setP, setQ]) }),
+
+  // Legacy benchmarks, kept for continuity with previous releases.
+  BenchmarkInfo(
+    name: "SetExclusiveOr", // ~"SetSymmetricDifferenceInt0"
+    runFunction: { n in run_SetSymmetricDifferenceInt(setAB, setCD, countABCD, 100 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, setCD]) }),
+  BenchmarkInfo(
+    name: "SetExclusiveOr_OfObjects", // ~"SetSymmetricDifferenceBox0"
+    runFunction: { n in run_SetSymmetricDifferenceBox(setOAB, setOCD, countABCD, 100 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, setOCD]) }),
+  BenchmarkInfo(
+    name: "SetIntersect", // ~"SetIntersectionInt0"
+    runFunction: { n in run_SetIntersectionInt(setAB, setCD, 0, 100 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, setCD]) }),
+  BenchmarkInfo(
+    name: "SetUnion", // ~"SetUnionInt0"
+    runFunction: { n in run_SetUnionInt(setAB, setCD, countABCD, 100 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, setCD]) }),
+  BenchmarkInfo(
+    name: "SetUnion_OfObjects", // ~"SetUnionBox0"
+    runFunction: { n in run_SetUnionBox(setOAB, setOCD, countABCD, 100 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, setOCD]) }),
 ]
 
 @inline(never)

--- a/benchmark/single-source/SetTests.swift
+++ b/benchmark/single-source/SetTests.swift
@@ -32,10 +32,20 @@ let countB = overlap
 
 public let SetTests = [
   BenchmarkInfo(
+    name: "SetExclusiveOr",
+    runFunction: { n in run_SetExclusiveOr(setAB, setCD, countABCD, 100 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, setCD]) }),
+  BenchmarkInfo(
     name: "SetExclusiveOr2",
     runFunction: { n in run_SetExclusiveOr(setAB, setBC, countAC, 10 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setAB, setBC]) }),
+  BenchmarkInfo(
+    name: "SetExclusiveOr_OfObjects",
+    runFunction: { n in run_SetExclusiveOr_OfObjects(setOAB, setOCD, countABCD, 100 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, setOCD]) }),
   BenchmarkInfo(
     name: "SetExclusiveOr2_OfObjects",
     runFunction: { n in run_SetExclusiveOr_OfObjects(setOAB, setOBC, countAC, 10 * n) },
@@ -43,10 +53,20 @@ public let SetTests = [
     setUpFunction: { blackHole([setOAB, setOBC]) }),
 
   BenchmarkInfo(
+    name: "SetIntersect",
+    runFunction: { n in run_SetIntersect(setAB, setCD, 0, 100 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, setCD]) }),
+  BenchmarkInfo(
     name: "SetIntersect2",
     runFunction: { n in run_SetIntersect(setAB, setBC, countB, 10 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setAB, setBC]) }),
+  BenchmarkInfo(
+    name: "SetIntersect_OfObjects",
+    runFunction: { n in run_SetIntersect_OfObjects(setOAB, setOCD, 0, 100 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, setOCD]) }),
   BenchmarkInfo(
     name: "SetIntersect2_OfObjects",
     runFunction: { n in run_SetIntersect_OfObjects(setOAB, setOBC, countB, 10 * n) },
@@ -54,10 +74,20 @@ public let SetTests = [
     setUpFunction: { blackHole([setOAB, setOBC]) }),
 
   BenchmarkInfo(
+    name: "SetIsSubsetOf",
+    runFunction: { n in run_SetIsSubsetOf(setAB, setCD, false, 5000 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, setCD]) }),
+  BenchmarkInfo(
     name: "SetIsSubsetOf2",
     runFunction: { n in run_SetIsSubsetOf(setB, setAB, true, 50 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setB, setAB]) }),
+  BenchmarkInfo(
+    name: "SetIsSubsetOf_OfObjects",
+    runFunction: { n in run_SetIsSubsetOf_OfObjects(setOAB, setOCD, false, 5000 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, setOCD]) }),
   BenchmarkInfo(
     name: "SetIsSubsetOf2_OfObjects",
     runFunction: { n in run_SetIsSubsetOf_OfObjects(setOB, setOAB, true, 50 * n) },
@@ -65,10 +95,20 @@ public let SetTests = [
     setUpFunction: { blackHole([setOB, setOAB]) }),
 
   BenchmarkInfo(
+    name: "SetUnion",
+    runFunction: { n in run_SetUnion(setAB, setCD, countABCD, 100 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, setCD]) }),
+  BenchmarkInfo(
     name: "SetUnion2",
     runFunction: { n in run_SetUnion(setAB, setBC, countABC, 10 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setAB, setBC]) }),
+  BenchmarkInfo(
+    name: "SetUnion_OfObjects",
+    runFunction: { n in run_SetUnion_OfObjects(setOAB, setOCD, countABCD, 100 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, setOCD]) }),
   BenchmarkInfo(
     name: "SetUnion2_OfObjects",
     runFunction: { n in run_SetUnion_OfObjects(setOAB, setOBC, countABC, 10 * n) },

--- a/benchmark/single-source/SetTests.swift
+++ b/benchmark/single-source/SetTests.swift
@@ -13,111 +13,231 @@
 import TestsUtils
 
 let size = 400
-let overlap = 100
+let half = size / 2
+let quarter = size / 4
 
+// Construction kit for sets with 25% overlap
 let setAB = Set(0 ..< size)                              //   0 ..< 400
 let setCD = Set(size ..< 2 * size)                       // 400 ..< 800
-let setBC = Set(size - overlap ..< 2 * size - overlap)   // 300 ..< 700
-let setB = Set(size - overlap ..< size)                  // 300 ..< 400
+let setBC = Set(size - quarter ..< 2 * size - quarter)   // 300 ..< 700
+let setB = Set(size - quarter ..< size)                  // 300 ..< 400
 
 let setOAB = Set(setAB.map(Box.init))
 let setOCD = Set(setCD.map(Box.init))
 let setOBC = Set(setBC.map(Box.init))
 let setOB = Set(setB.map(Box.init))
 
-let countAC = 2 * (size - overlap) // 600
-let countABC = 2 * size - overlap  // 700
-let countABCD = 2 * size           // 800
-let countB = overlap               // 100
+let countA = size - quarter        // 300
+let countB = quarter               // 100
+let countC = countA                // 300
+let countD = countB                // 100
+
+let countAB = size                 // 400
+let countAC = countA + countC      // 600
+let countABC = countA + countB + countC           // 700
+let countABCD = countA + countB + countC + countD // 800
+
+// Construction kit for sets with 50% overlap
+let setXY = Set(0 ..< size)           //   0 ..< 400
+let setYZ = Set(half ..< size + half) // 200 ..< 600
+let setY = Set(half ..< size)         // 200 ..< 400
+
+// Two sets with 100% overlap, but different bucket counts (let's not make it
+// too easy...)
+let setP = Set(0 ..< size)
+let setQ: Set<Int> = {
+  var set = Set(0 ..< size)
+  set.reserveCapacity(2 * size)
+  return set
+}()
 
 public let SetTests = [
+  // Legacy benchmarks, kept for continuity with previous releases.
   BenchmarkInfo(
-    name: "SetExclusiveOr",
-    runFunction: { n in run_SetExclusiveOr(setAB, setCD, countABCD, 100 * n) },
+    name: "SetExclusiveOr", // ~"SetSymmetricDifferenceInt0"
+    runFunction: { n in run_SetSymmetricDifferenceInt(setAB, setCD, countABCD, 100 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setAB, setCD]) }),
   BenchmarkInfo(
-    name: "SetExclusiveOr2",
-    runFunction: { n in run_SetExclusiveOr(setAB, setBC, countAC, 10 * n) },
-    tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setAB, setBC]) }),
-  BenchmarkInfo(
-    name: "SetExclusiveOr_OfObjects",
-    runFunction: { n in run_SetExclusiveOr_OfObjects(setOAB, setOCD, countABCD, 100 * n) },
+    name: "SetExclusiveOr_OfObjects", // ~"SetSymmetricDifferenceBox0"
+    runFunction: { n in run_SetSymmetricDifferenceBox(setOAB, setOCD, countABCD, 100 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setOAB, setOCD]) }),
   BenchmarkInfo(
-    name: "SetExclusiveOr2_OfObjects",
-    runFunction: { n in run_SetExclusiveOr_OfObjects(setOAB, setOBC, countAC, 10 * n) },
-    tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setOAB, setOBC]) }),
-
-  BenchmarkInfo(
-    name: "SetIntersect",
-    runFunction: { n in run_SetIntersect(setAB, setCD, 0, 100 * n) },
+    name: "SetIntersect", // ~"SetIntersectionInt0"
+    runFunction: { n in run_SetIntersectionInt(setAB, setCD, 0, 100 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setAB, setCD]) }),
   BenchmarkInfo(
-    name: "SetIntersect2",
-    runFunction: { n in run_SetIntersect(setAB, setBC, countB, 10 * n) },
+    name: "SetUnion", // ~"SetUnionInt0"
+    runFunction: { n in run_SetUnionInt(setAB, setCD, countABCD, 100 * n) },
     tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setAB, setBC]) }),
+    setUpFunction: { blackHole([setAB, setCD]) }),
   BenchmarkInfo(
-    name: "SetIntersect_OfObjects",
-    runFunction: { n in run_SetIntersect_OfObjects(setOAB, setOCD, 0, 100 * n) },
+    name: "SetUnion_OfObjects", // ~"SetUnionBox0"
+    runFunction: { n in run_SetUnionBox(setOAB, setOCD, countABCD, 100 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, setOCD]) }),
+
+  // Mnemonic: number after name is percentage of common elements in input sets.
+  BenchmarkInfo(
+    name: "SetIsSubsetInt0",
+    runFunction: { n in run_SetIsSubsetInt(setAB, setCD, false, 5000 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, setCD]) }),
+  BenchmarkInfo(
+    name: "SetIsSubsetBox0",
+    runFunction: { n in run_SetIsSubsetBox(setOAB, setOCD, false, 5000 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setOAB, setOCD]) }),
   BenchmarkInfo(
-    name: "SetIntersect2_OfObjects",
-    runFunction: { n in run_SetIntersect_OfObjects(setOAB, setOBC, countB, 10 * n) },
-    tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setOAB, setOBC]) }),
-
-  BenchmarkInfo(
-    name: "SetIsSubsetOf",
-    runFunction: { n in run_SetIsSubsetOf(setAB, setCD, false, 5000 * n) },
-    tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setAB, setCD]) }),
-  BenchmarkInfo(
-    name: "SetIsSubsetOf2",
-    runFunction: { n in run_SetIsSubsetOf(setB, setAB, true, 50 * n) },
+    name: "SetIsSubsetInt25",
+    runFunction: { n in run_SetIsSubsetInt(setB, setAB, true, 50 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setB, setAB]) }),
   BenchmarkInfo(
-    name: "SetIsSubsetOf_OfObjects",
-    runFunction: { n in run_SetIsSubsetOf_OfObjects(setOAB, setOCD, false, 5000 * n) },
-    tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setOAB, setOCD]) }),
-  BenchmarkInfo(
-    name: "SetIsSubsetOf2_OfObjects",
-    runFunction: { n in run_SetIsSubsetOf_OfObjects(setOB, setOAB, true, 50 * n) },
+    name: "SetIsSubsetBox25",
+    runFunction: { n in run_SetIsSubsetBox(setOB, setOAB, true, 50 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setOB, setOAB]) }),
+  BenchmarkInfo(
+    name: "SetIsSubsetInt50",
+    runFunction: { n in run_SetIsSubsetInt(setY, setXY, true, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setY, setXY]) }),
+  BenchmarkInfo(
+    name: "SetIsSubsetInt100",
+    runFunction: { n in run_SetIsSubsetInt(setP, setQ, true, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setP, setQ]) }),
 
   BenchmarkInfo(
-    name: "SetUnion",
-    runFunction: { n in run_SetUnion(setAB, setCD, countABCD, 100 * n) },
+    name: "SetSymmetricDifferenceInt0",
+    runFunction: { n in run_SetSymmetricDifferenceInt(setAB, setCD, countABCD, 10 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setAB, setCD]) }),
   BenchmarkInfo(
-    name: "SetUnion2",
-    runFunction: { n in run_SetUnion(setAB, setBC, countABC, 10 * n) },
-    tags: [.validation, .api, .Set],
-    setUpFunction: { blackHole([setAB, setBC]) }),
-  BenchmarkInfo(
-    name: "SetUnion_OfObjects",
-    runFunction: { n in run_SetUnion_OfObjects(setOAB, setOCD, countABCD, 100 * n) },
+    name: "SetSymmetricDifferenceBox0",
+    runFunction: { n in run_SetSymmetricDifferenceBox(setOAB, setOCD, countABCD, 10 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setOAB, setOCD]) }),
   BenchmarkInfo(
-    name: "SetUnion2_OfObjects",
-    runFunction: { n in run_SetUnion_OfObjects(setOAB, setOBC, countABC, 10 * n) },
+    name: "SetSymmetricDifferenceInt25",
+    runFunction: { n in run_SetSymmetricDifferenceInt(setAB, setBC, countAC, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, setBC]) }),
+  BenchmarkInfo(
+    name: "SetSymmetricDifferenceBox25",
+    runFunction: { n in run_SetSymmetricDifferenceBox(setOAB, setOBC, countAC, 10 * n) },
     tags: [.validation, .api, .Set],
     setUpFunction: { blackHole([setOAB, setOBC]) }),
+  BenchmarkInfo(
+    name: "SetSymmetricDifferenceInt50",
+    runFunction: { n in run_SetSymmetricDifferenceInt(setXY, setYZ, size, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setXY, setYZ]) }),
+  BenchmarkInfo(
+    name: "SetSymmetricDifferenceInt100",
+    runFunction: { n in run_SetSymmetricDifferenceInt(setP, setQ, 0, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setP, setQ]) }),
+
+  BenchmarkInfo(
+    name: "SetIntersectionInt0",
+    runFunction: { n in run_SetIntersectionInt(setAB, setCD, 0, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, setCD]) }),
+  BenchmarkInfo(
+    name: "SetIntersectionBox0",
+    runFunction: { n in run_SetIntersectionBox(setOAB, setOCD, 0, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, setOCD]) }),
+  BenchmarkInfo(
+    name: "SetIntersectionInt25",
+    runFunction: { n in run_SetIntersectionInt(setAB, setBC, countB, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, setBC]) }),
+  BenchmarkInfo(
+    name: "SetIntersectionBox25",
+    runFunction: { n in run_SetIntersectionBox(setOAB, setOBC, countB, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, setOBC]) }),
+  BenchmarkInfo(
+    name: "SetIntersectionInt50",
+    runFunction: { n in run_SetIntersectionInt(setXY, setYZ, half, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setXY, setYZ]) }),
+  BenchmarkInfo(
+    name: "SetIntersectionInt100",
+    runFunction: { n in run_SetIntersectionInt(setP, setQ, size, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setP, setQ]) }),
+
+  BenchmarkInfo(
+    name: "SetUnionInt0",
+    runFunction: { n in run_SetUnionInt(setAB, setCD, countABCD, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, setCD]) }),
+  BenchmarkInfo(
+    name: "SetUnionBox0",
+    runFunction: { n in run_SetUnionBox(setOAB, setOCD, countABCD, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, setOCD]) }),
+  BenchmarkInfo(
+    name: "SetUnionInt25",
+    runFunction: { n in run_SetUnionInt(setAB, setBC, countABC, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, setBC]) }),
+  BenchmarkInfo(
+    name: "SetUnionBox25",
+    runFunction: { n in run_SetUnionBox(setOAB, setOBC, countABC, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, setOBC]) }),
+  BenchmarkInfo(
+    name: "SetUnionInt50",
+    runFunction: { n in run_SetUnionInt(setXY, setYZ, size + half, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setXY, setYZ]) }),
+  BenchmarkInfo(
+    name: "SetUnionInt100",
+    runFunction: { n in run_SetUnionInt(setP, setQ, size, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setP, setQ]) }),
+
+  BenchmarkInfo(
+    name: "SetSubtractingInt0",
+    runFunction: { n in run_SetSubtractingInt(setAB, setCD, countAB, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, setCD]) }),
+  BenchmarkInfo(
+    name: "SetSubtractingBox0",
+    runFunction: { n in run_SetSubtractingBox(setOAB, setOCD, countAB, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, setOCD]) }),
+  BenchmarkInfo(
+    name: "SetSubtractingInt25",
+    runFunction: { n in run_SetSubtractingInt(setAB, setBC, countA, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, setBC]) }),
+  BenchmarkInfo(
+    name: "SetSubtractingBox25",
+    runFunction: { n in run_SetSubtractingBox(setOAB, setOBC, countA, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, setOBC]) }),
+  BenchmarkInfo(
+    name: "SetSubtractingInt50",
+    runFunction: { n in run_SetSubtractingInt(setXY, setYZ, half, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setXY, setYZ]) }),
+  BenchmarkInfo(
+    name: "SetSubtractingInt100",
+    runFunction: { n in run_SetSubtractingInt(setP, setQ, 0, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setP, setQ]) }),
 ]
 
 @inline(never)
-public func run_SetIsSubsetOf(
+public func run_SetIsSubsetInt(
   _ a: Set<Int>,
   _ b: Set<Int>,
   _ r: Bool,
@@ -129,7 +249,7 @@ public func run_SetIsSubsetOf(
 }
 
 @inline(never)
-public func run_SetExclusiveOr(
+public func run_SetSymmetricDifferenceInt(
   _ a: Set<Int>,
   _ b: Set<Int>,
   _ r: Int,
@@ -141,7 +261,7 @@ public func run_SetExclusiveOr(
 }
 
 @inline(never)
-public func run_SetUnion(
+public func run_SetUnionInt(
   _ a: Set<Int>,
   _ b: Set<Int>,
   _ r: Int,
@@ -153,13 +273,25 @@ public func run_SetUnion(
 }
 
 @inline(never)
-public func run_SetIntersect(
+public func run_SetIntersectionInt(
   _ a: Set<Int>,
   _ b: Set<Int>,
   _ r: Int,
   _ n: Int) {
   for _ in 0 ..< n {
     let and = a.intersection(identity(b))
+    CheckResults(and.count == r)
+  }
+}
+
+@inline(never)
+public func run_SetSubtractingInt(
+  _ a: Set<Int>,
+  _ b: Set<Int>,
+  _ r: Int,
+  _ n: Int) {
+  for _ in 0 ..< n {
+    let and = a.subtracting(identity(b))
     CheckResults(and.count == r)
   }
 }
@@ -181,7 +313,7 @@ class Box<T : Hashable> : Hashable {
 }
 
 @inline(never)
-func run_SetIsSubsetOf_OfObjects(
+func run_SetIsSubsetBox(
   _ a: Set<Box<Int>>,
   _ b: Set<Box<Int>>,
   _ r: Bool,
@@ -193,7 +325,7 @@ func run_SetIsSubsetOf_OfObjects(
 }
 
 @inline(never)
-func run_SetExclusiveOr_OfObjects(
+func run_SetSymmetricDifferenceBox(
   _ a: Set<Box<Int>>,
   _ b: Set<Box<Int>>,
   _ r: Int,
@@ -205,7 +337,7 @@ func run_SetExclusiveOr_OfObjects(
 }
 
 @inline(never)
-func run_SetUnion_OfObjects(
+func run_SetUnionBox(
   _ a: Set<Box<Int>>,
   _ b: Set<Box<Int>>,
   _ r: Int,
@@ -217,13 +349,25 @@ func run_SetUnion_OfObjects(
 }
 
 @inline(never)
-func run_SetIntersect_OfObjects(
+func run_SetIntersectionBox(
   _ a: Set<Box<Int>>,
   _ b: Set<Box<Int>>,
   _ r: Int,
   _ n: Int) {
   for _ in 0 ..< n {
     let and = a.intersection(b)
+    CheckResults(and.count == r)
+  }
+}
+
+@inline(never)
+func run_SetSubtractingBox(
+  _ a: Set<Box<Int>>,
+  _ b: Set<Box<Int>>,
+  _ r: Int,
+  _ n: Int) {
+  for _ in 0 ..< n {
+    let and = a.subtracting(b)
     CheckResults(and.count == r)
   }
 }

--- a/benchmark/single-source/SetTests.swift
+++ b/benchmark/single-source/SetTests.swift
@@ -13,106 +13,69 @@
 import TestsUtils
 
 public let SetTests = [
-  BenchmarkInfo(name: "SetExclusiveOr", runFunction: run_SetExclusiveOr, tags: [.validation, .api, .Set]),
-  BenchmarkInfo(name: "SetExclusiveOr_OfObjects", runFunction: run_SetExclusiveOr_OfObjects, tags: [.validation, .api, .Set]),
-  BenchmarkInfo(name: "SetIntersect", runFunction: run_SetIntersect, tags: [.validation, .api, .Set]),
-  BenchmarkInfo(name: "SetIntersect_OfObjects", runFunction: run_SetIntersect_OfObjects, tags: [.validation, .api, .Set]),
-  BenchmarkInfo(name: "SetIsSubsetOf", runFunction: run_SetIsSubsetOf, tags: [.validation, .api, .Set]),
-  BenchmarkInfo(name: "SetIsSubsetOf_OfObjects", runFunction: run_SetIsSubsetOf_OfObjects, tags: [.validation, .api, .Set]),
-  BenchmarkInfo(name: "SetUnion", runFunction: run_SetUnion, tags: [.validation, .api, .Set]),
-  BenchmarkInfo(name: "SetUnion_OfObjects", runFunction: run_SetUnion_OfObjects, tags: [.validation, .api, .Set]),
+  BenchmarkInfo(name: "SetExclusiveOr2", runFunction: run_SetExclusiveOr2, tags: [.validation, .api, .Set]),
+  BenchmarkInfo(name: "SetExclusiveOr2_OfObjects", runFunction: run_SetExclusiveOr2_OfObjects, tags: [.validation, .api, .Set]),
+  BenchmarkInfo(name: "SetIntersect2", runFunction: run_SetIntersect2, tags: [.validation, .api, .Set]),
+  BenchmarkInfo(name: "SetIntersect2_OfObjects", runFunction: run_SetIntersect2_OfObjects, tags: [.validation, .api, .Set]),
+  BenchmarkInfo(name: "SetIsSubsetOf2", runFunction: run_SetIsSubsetOf2, tags: [.validation, .api, .Set]),
+  BenchmarkInfo(name: "SetIsSubsetOf2_OfObjects", runFunction: run_SetIsSubsetOf2_OfObjects, tags: [.validation, .api, .Set]),
+  BenchmarkInfo(name: "SetUnion2", runFunction: run_SetUnion2, tags: [.validation, .api, .Set]),
+  BenchmarkInfo(name: "SetUnion2_OfObjects", runFunction: run_SetUnion2_OfObjects, tags: [.validation, .api, .Set]),
 ]
 
 @inline(never)
-public func run_SetIsSubsetOf(_ N: Int) {
-  let size = 200
+public func run_SetIsSubsetOf2(_ N: Int) {
+  let size = 400
 
-  SRand()
+  let set = Set<Int>(size / 2 ..< size)
+  let otherSet = Set<Int>(0 ..< size)
 
-  var set = Set<Int>(minimumCapacity: size)
-  var otherSet = Set<Int>(minimumCapacity: size)
-
-  for _ in 0 ..< size {
-    set.insert(Int(truncatingIfNeeded: Random()))
-    otherSet.insert(Int(truncatingIfNeeded: Random()))
-  }
-
-  var isSubset = false
   for _ in 0 ..< N * 5000 {
-    isSubset = set.isSubset(of: otherSet)
-    if isSubset {
-      break
-    }
+    let isSubset = set.isSubset(of: identity(otherSet))
+    CheckResults(isSubset)
   }
-
-  CheckResults(!isSubset)
 }
 
 @inline(never)
-func sink(_ s: inout Set<Int>) {
-}
-
-@inline(never)
-public func run_SetExclusiveOr(_ N: Int) {
+public func run_SetExclusiveOr2(_ N: Int) {
   let size = 400
+  let overlap = 100
 
-  SRand()
+  let set = Set<Int>(0 ..< size)
+  let otherSet = Set<Int>(size - overlap ..< 2 * size - overlap)
 
-  var set = Set<Int>(minimumCapacity: size)
-  var otherSet = Set<Int>(minimumCapacity: size)
-
-  for _ in 0 ..< size {
-    set.insert(Int(truncatingIfNeeded: Random()))
-    otherSet.insert(Int(truncatingIfNeeded: Random()))
-  }
-
-  var xor = Set<Int>()
   for _ in 0 ..< N * 100 {
-    xor = set.symmetricDifference(otherSet)
+    let diff = set.symmetricDifference(identity(otherSet))
+    CheckResults(diff.count == 2 * (size - overlap))
   }
-  sink(&xor)
 }
 
 @inline(never)
-public func run_SetUnion(_ N: Int) {
+public func run_SetUnion2(_ N: Int) {
   let size = 400
+  let overlap = 100
 
-  SRand()
+  let set = Set<Int>(0 ..< size)
+  let otherSet = Set<Int>(size - overlap ..< 2 * size - overlap)
 
-  var set = Set<Int>(minimumCapacity: size)
-  var otherSet = Set<Int>(minimumCapacity: size)
-
-  for _ in 0 ..< size {
-    set.insert(Int(truncatingIfNeeded: Random()))
-    otherSet.insert(Int(truncatingIfNeeded: Random()))
-  }
-
-  var or = Set<Int>()
   for _ in 0 ..< N * 100 {
-    or = set.union(otherSet)
+    let or = set.union(identity(otherSet))
+    CheckResults(or.count == 2 * size)
   }
-  sink(&or)
 }
 
 @inline(never)
-public func run_SetIntersect(_ N: Int) {
+public func run_SetIntersect2(_ N: Int) {
   let size = 400
+  let overlap = 100
 
-  SRand()
+  let set = Set<Int>(0 ..< size)
+  let otherSet = Set<Int>(size - overlap ..< 2 * size - overlap)
 
-  var set = Set<Int>(minimumCapacity: size)
-  var otherSet = Set<Int>(minimumCapacity: size)
-
-  for _ in 0 ..< size {
-    set.insert(Int(truncatingIfNeeded: Random()))
-    otherSet.insert(Int(truncatingIfNeeded: Random()))
-  }
-
-  var and = Set<Int>()
   for _ in 0 ..< N * 100 {
-    and = set.intersection(otherSet)
+    let and = set.intersection(identity(otherSet))
+    CheckResults(and.count == overlap)
   }
-  sink(&and)
 }
 
 class Box<T : Hashable> : Hashable {
@@ -133,92 +96,58 @@ class Box<T : Hashable> : Hashable {
 
 @inline(never)
 public func run_SetIsSubsetOf_OfObjects(_ N: Int) {
-  let size = 200
+  let size = 400
 
-  SRand()
+  let set = Set<Box<Int>>((size / 2 ..< size).map(Box.init))
+  let otherSet = Set<Box<Int>>((0 ..< size).map(Box.init))
 
-  var set = Set<Box<Int>>(minimumCapacity: size)
-  var otherSet = Set<Box<Int>>(minimumCapacity: size)
-
-  for _ in 0 ..< size {
-    set.insert(Box(Int(truncatingIfNeeded: Random())))
-    otherSet.insert(Box(Int(truncatingIfNeeded: Random())))
-  }
-
-  var isSubset = false
   for _ in 0 ..< N * 5000 {
-    isSubset = set.isSubset(of: otherSet)
-    if isSubset {
-      break
-    }
+    let isSubset = set.isSubset(of: identity(otherSet))
+    CheckResults(isSubset)
   }
-
-  CheckResults(!isSubset)
-}
-
-@inline(never)
-func sink(_ s: inout Set<Box<Int>>) {
 }
 
 @inline(never)
 public func run_SetExclusiveOr_OfObjects(_ N: Int) {
   let size = 400
+  let overlap = 100
 
-  SRand()
+  let set = Set<Box<Int>>((0 ..< size).map(Box.init))
+  let otherSet = Set<Box<Int>>(
+    (size - overlap ..< 2 * size - overlap).map(Box.init))
 
-  var set = Set<Box<Int>>(minimumCapacity: size)
-  var otherSet = Set<Box<Int>>(minimumCapacity: size)
-
-  for _ in 0 ..< size {
-    set.insert(Box(Int(truncatingIfNeeded: Random())))
-    otherSet.insert(Box(Int(truncatingIfNeeded: Random())))
-  }
-
-  var xor = Set<Box<Int>>()
   for _ in 0 ..< N * 100 {
-    xor = set.symmetricDifference(otherSet)
+    let diff = set.symmetricDifference(identity(otherSet))
+    CheckResults(diff.count == 2 * (size - overlap))
   }
-  sink(&xor)
 }
 
 @inline(never)
 public func run_SetUnion_OfObjects(_ N: Int) {
   let size = 400
+  let overlap = 100
 
-  SRand()
+  let set = Set<Box<Int>>((0 ..< size).map(Box.init))
+  let otherSet = Set<Box<Int>>(
+    (size - overlap ..< 2 * size - overlap).map(Box.init))
 
-  var set = Set<Box<Int>>(minimumCapacity: size)
-  var otherSet = Set<Box<Int>>(minimumCapacity: size)
-
-  for _ in 0 ..< size {
-    set.insert(Box(Int(truncatingIfNeeded: Random())))
-    otherSet.insert(Box(Int(truncatingIfNeeded: Random())))
-  }
-
-  var or = Set<Box<Int>>()
   for _ in 0 ..< N * 100 {
-    or = set.union(otherSet)
+    let or = set.union(identity(otherSet))
+    CheckResults(or.count == 2 * size)
   }
-  sink(&or)
 }
 
 @inline(never)
-public func run_SetIntersect_OfObjects(_ N: Int) {
+public func run_SetIntersect2_OfObjects(_ N: Int) {
   let size = 400
+  let overlap = 100
 
-  SRand()
+  let set = Set<Box<Int>>((0 ..< size).map(Box.init))
+  let otherSet = Set<Box<Int>>(
+    (size - overlap ..< 2 * size - overlap).map(Box.init))
 
-  var set = Set<Box<Int>>(minimumCapacity: size)
-  var otherSet = Set<Box<Int>>(minimumCapacity: size)
-
-  for _ in 0 ..< size {
-    set.insert(Box(Int(truncatingIfNeeded: Random())))
-    otherSet.insert(Box(Int(truncatingIfNeeded: Random())))
-  }
-
-  var and = Set<Box<Int>>()
   for _ in 0 ..< N * 100 {
-    and = set.intersection(otherSet)
+    let and = set.intersection(otherSet)
+    CheckResults(and.count == overlap)
   }
-  sink(&and)
 }

--- a/benchmark/single-source/SetTests.swift
+++ b/benchmark/single-source/SetTests.swift
@@ -12,69 +12,115 @@
 
 import TestsUtils
 
+let size = 400
+let overlap = 100
+
+let setAB = Set(0 ..< size)
+let setCD = Set(size ..< 2 * size)
+let setBC = Set(size - overlap ..< 2 * size - overlap)
+let setB = Set(size - overlap ..< size)
+
+let setOAB = Set(setAB.map(Box.init))
+let setOCD = Set(setCD.map(Box.init))
+let setOBC = Set(setBC.map(Box.init))
+let setOB = Set(setB.map(Box.init))
+
+let countAC = 2 * (size - overlap)
+let countABC = 2 * size - overlap
+let countABCD = 2 * size
+let countB = overlap
+
 public let SetTests = [
-  BenchmarkInfo(name: "SetExclusiveOr2", runFunction: run_SetExclusiveOr2, tags: [.validation, .api, .Set]),
-  BenchmarkInfo(name: "SetExclusiveOr2_OfObjects", runFunction: run_SetExclusiveOr2_OfObjects, tags: [.validation, .api, .Set]),
-  BenchmarkInfo(name: "SetIntersect2", runFunction: run_SetIntersect2, tags: [.validation, .api, .Set]),
-  BenchmarkInfo(name: "SetIntersect2_OfObjects", runFunction: run_SetIntersect2_OfObjects, tags: [.validation, .api, .Set]),
-  BenchmarkInfo(name: "SetIsSubsetOf2", runFunction: run_SetIsSubsetOf2, tags: [.validation, .api, .Set]),
-  BenchmarkInfo(name: "SetIsSubsetOf2_OfObjects", runFunction: run_SetIsSubsetOf2_OfObjects, tags: [.validation, .api, .Set]),
-  BenchmarkInfo(name: "SetUnion2", runFunction: run_SetUnion2, tags: [.validation, .api, .Set]),
-  BenchmarkInfo(name: "SetUnion2_OfObjects", runFunction: run_SetUnion2_OfObjects, tags: [.validation, .api, .Set]),
+  BenchmarkInfo(
+    name: "SetExclusiveOr2",
+    runFunction: { n in run_SetExclusiveOr(setAB, setBC, countAC, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, setBC]) }),
+  BenchmarkInfo(
+    name: "SetExclusiveOr2_OfObjects",
+    runFunction: { n in run_SetExclusiveOr_OfObjects(setOAB, setOBC, countAC, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, setOBC]) }),
+
+  BenchmarkInfo(
+    name: "SetIntersect2",
+    runFunction: { n in run_SetIntersect(setAB, setBC, countB, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, setBC]) }),
+  BenchmarkInfo(
+    name: "SetIntersect2_OfObjects",
+    runFunction: { n in run_SetIntersect_OfObjects(setOAB, setOBC, countB, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, setOBC]) }),
+
+  BenchmarkInfo(
+    name: "SetIsSubsetOf2",
+    runFunction: { n in run_SetIsSubsetOf(setB, setAB, true, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setB, setAB]) }),
+  BenchmarkInfo(
+    name: "SetIsSubsetOf2_OfObjects",
+    runFunction: { n in run_SetIsSubsetOf_OfObjects(setOB, setOAB, true, 50 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOB, setOAB]) }),
+
+  BenchmarkInfo(
+    name: "SetUnion2",
+    runFunction: { n in run_SetUnion(setAB, setBC, countABC, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setAB, setBC]) }),
+  BenchmarkInfo(
+    name: "SetUnion2_OfObjects",
+    runFunction: { n in run_SetUnion_OfObjects(setOAB, setOBC, countABC, 10 * n) },
+    tags: [.validation, .api, .Set],
+    setUpFunction: { blackHole([setOAB, setOBC]) }),
 ]
 
 @inline(never)
-public func run_SetIsSubsetOf2(_ N: Int) {
-  let size = 400
-
-  let set = Set<Int>(size / 2 ..< size)
-  let otherSet = Set<Int>(0 ..< size)
-
-  for _ in 0 ..< N * 5000 {
-    let isSubset = set.isSubset(of: identity(otherSet))
-    CheckResults(isSubset)
+public func run_SetIsSubsetOf(
+  _ a: Set<Int>,
+  _ b: Set<Int>,
+  _ r: Bool,
+  _ n: Int) {
+  for _ in 0 ..< n {
+    let isSubset = a.isSubset(of: identity(b))
+    CheckResults(isSubset == r)
   }
 }
 
 @inline(never)
-public func run_SetExclusiveOr2(_ N: Int) {
-  let size = 400
-  let overlap = 100
-
-  let set = Set<Int>(0 ..< size)
-  let otherSet = Set<Int>(size - overlap ..< 2 * size - overlap)
-
-  for _ in 0 ..< N * 100 {
-    let diff = set.symmetricDifference(identity(otherSet))
-    CheckResults(diff.count == 2 * (size - overlap))
+public func run_SetExclusiveOr(
+  _ a: Set<Int>,
+  _ b: Set<Int>,
+  _ r: Int,
+  _ n: Int) {
+  for _ in 0 ..< n {
+    let diff = a.symmetricDifference(identity(b))
+    CheckResults(diff.count == r)
   }
 }
 
 @inline(never)
-public func run_SetUnion2(_ N: Int) {
-  let size = 400
-  let overlap = 100
-
-  let set = Set<Int>(0 ..< size)
-  let otherSet = Set<Int>(size - overlap ..< 2 * size - overlap)
-
-  for _ in 0 ..< N * 100 {
-    let or = set.union(identity(otherSet))
-    CheckResults(or.count == 2 * size)
+public func run_SetUnion(
+  _ a: Set<Int>,
+  _ b: Set<Int>,
+  _ r: Int,
+  _ n: Int) {
+  for _ in 0 ..< n {
+    let or = a.union(identity(b))
+    CheckResults(or.count == r)
   }
 }
 
 @inline(never)
-public func run_SetIntersect2(_ N: Int) {
-  let size = 400
-  let overlap = 100
-
-  let set = Set<Int>(0 ..< size)
-  let otherSet = Set<Int>(size - overlap ..< 2 * size - overlap)
-
-  for _ in 0 ..< N * 100 {
-    let and = set.intersection(identity(otherSet))
-    CheckResults(and.count == overlap)
+public func run_SetIntersect(
+  _ a: Set<Int>,
+  _ b: Set<Int>,
+  _ r: Int,
+  _ n: Int) {
+  for _ in 0 ..< n {
+    let and = a.intersection(identity(b))
+    CheckResults(and.count == r)
   }
 }
 
@@ -95,59 +141,49 @@ class Box<T : Hashable> : Hashable {
 }
 
 @inline(never)
-public func run_SetIsSubsetOf_OfObjects(_ N: Int) {
-  let size = 400
-
-  let set = Set<Box<Int>>((size / 2 ..< size).map(Box.init))
-  let otherSet = Set<Box<Int>>((0 ..< size).map(Box.init))
-
-  for _ in 0 ..< N * 5000 {
-    let isSubset = set.isSubset(of: identity(otherSet))
-    CheckResults(isSubset)
+func run_SetIsSubsetOf_OfObjects(
+  _ a: Set<Box<Int>>,
+  _ b: Set<Box<Int>>,
+  _ r: Bool,
+  _ n: Int) {
+  for _ in 0 ..< n {
+    let isSubset = a.isSubset(of: identity(b))
+    CheckResults(isSubset == r)
   }
 }
 
 @inline(never)
-public func run_SetExclusiveOr_OfObjects(_ N: Int) {
-  let size = 400
-  let overlap = 100
-
-  let set = Set<Box<Int>>((0 ..< size).map(Box.init))
-  let otherSet = Set<Box<Int>>(
-    (size - overlap ..< 2 * size - overlap).map(Box.init))
-
-  for _ in 0 ..< N * 100 {
-    let diff = set.symmetricDifference(identity(otherSet))
-    CheckResults(diff.count == 2 * (size - overlap))
+func run_SetExclusiveOr_OfObjects(
+  _ a: Set<Box<Int>>,
+  _ b: Set<Box<Int>>,
+  _ r: Int,
+  _ n: Int) {
+  for _ in 0 ..< n {
+    let diff = a.symmetricDifference(identity(b))
+    CheckResults(diff.count == r)
   }
 }
 
 @inline(never)
-public func run_SetUnion_OfObjects(_ N: Int) {
-  let size = 400
-  let overlap = 100
-
-  let set = Set<Box<Int>>((0 ..< size).map(Box.init))
-  let otherSet = Set<Box<Int>>(
-    (size - overlap ..< 2 * size - overlap).map(Box.init))
-
-  for _ in 0 ..< N * 100 {
-    let or = set.union(identity(otherSet))
-    CheckResults(or.count == 2 * size)
+func run_SetUnion_OfObjects(
+  _ a: Set<Box<Int>>,
+  _ b: Set<Box<Int>>,
+  _ r: Int,
+  _ n: Int) {
+  for _ in 0 ..< n {
+    let or = a.union(identity(b))
+    CheckResults(or.count == r)
   }
 }
 
 @inline(never)
-public func run_SetIntersect2_OfObjects(_ N: Int) {
-  let size = 400
-  let overlap = 100
-
-  let set = Set<Box<Int>>((0 ..< size).map(Box.init))
-  let otherSet = Set<Box<Int>>(
-    (size - overlap ..< 2 * size - overlap).map(Box.init))
-
-  for _ in 0 ..< N * 100 {
-    let and = set.intersection(otherSet)
-    CheckResults(and.count == overlap)
+func run_SetIntersect_OfObjects(
+  _ a: Set<Box<Int>>,
+  _ b: Set<Box<Int>>,
+  _ r: Int,
+  _ n: Int) {
+  for _ in 0 ..< n {
+    let and = a.intersection(b)
+    CheckResults(and.count == r)
   }
 }

--- a/benchmark/single-source/SetTests.swift
+++ b/benchmark/single-source/SetTests.swift
@@ -15,20 +15,20 @@ import TestsUtils
 let size = 400
 let overlap = 100
 
-let setAB = Set(0 ..< size)
-let setCD = Set(size ..< 2 * size)
-let setBC = Set(size - overlap ..< 2 * size - overlap)
-let setB = Set(size - overlap ..< size)
+let setAB = Set(0 ..< size)                              //   0 ..< 400
+let setCD = Set(size ..< 2 * size)                       // 400 ..< 800
+let setBC = Set(size - overlap ..< 2 * size - overlap)   // 300 ..< 700
+let setB = Set(size - overlap ..< size)                  // 300 ..< 400
 
 let setOAB = Set(setAB.map(Box.init))
 let setOCD = Set(setCD.map(Box.init))
 let setOBC = Set(setBC.map(Box.init))
 let setOB = Set(setB.map(Box.init))
 
-let countAC = 2 * (size - overlap)
-let countABC = 2 * size - overlap
-let countABCD = 2 * size
-let countB = overlap
+let countAC = 2 * (size - overlap) // 600
+let countABC = 2 * size - overlap  // 700
+let countABCD = 2 * size           // 800
+let countB = overlap               // 100
 
 public let SetTests = [
   BenchmarkInfo(


### PR DESCRIPTION
- Don’t use a random number generator. (Hashing already scrambles elements.)
- Add benchmarks for `Set.subtracting`.
- Add new benchmarks for 0%, 25%, 50% and 100% overlap between sets. (The latter two only for `Set<Int>`.)
- Also keep original benchmarks where feasible. (These only tested disjunct sets, so they were relatively useless.)
