### PR TITLE
[ModuleInterface] Allow conformances to be missing value witnesses

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2699,6 +2699,7 @@ ModuleFile::getDeclCheckedImpl(DeclID DID) {
       return nullptr;
     }
 
+    theStruct->setAddedImplicitInitializers();
     if (isImplicit)
       theStruct->setImplicit();
     theStruct->setIsObjC(isObjC);
@@ -3606,6 +3607,7 @@ ModuleFile::getDeclCheckedImpl(DeclID DID) {
       return nullptr;
     }
 
+    theEnum->setAddedImplicitInitializers();
     if (isImplicit)
       theEnum->setImplicit();
     theEnum->setIsObjC(isObjC);

--- a/test/ModuleInterface/Conformances.swiftinterface
+++ b/test/ModuleInterface/Conformances.swiftinterface
@@ -1,0 +1,34 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -enable-resilience -o %t/Conformances.swiftmodule %s
+// RUN: %target-swift-frontend -emit-sil -I %t %S/Inputs/ConformancesUser.swift -O | %FileCheck %s
+
+public protocol MyProto {
+  init()
+  func method()
+  var prop: Int { get set }
+  subscript(index: Int) -> Int { get set }
+}
+
+@_fixed_layout // allow conformance devirtualization
+public struct FullStructImpl: MyProto {
+  public init()
+  public func method()
+  public var prop: Int { get set }
+  public subscript(index: Int) -> Int { get set }
+}
+// CHECK-LABEL: sil @$S16ConformancesUser8testFullSiyF
+// CHECK: function_ref @$S12Conformances14FullStructImplVACycfC
+// CHECK: function_ref @$S12Conformances14FullStructImplV6methodyyF
+// CHECK: function_ref @$S12Conformances14FullStructImplV4propSivs
+// CHECK: function_ref @$S12Conformances14FullStructImplVyS2icig
+// CHECK: end sil function '$S16ConformancesUser8testFullSiyF'
+
+@_fixed_layout // allow conformance devirtualization
+public struct OpaqueStructImpl: MyProto {}
+
+// CHECK-LABEL: sil @$S16ConformancesUser10testOpaqueSiyF
+// CHECK: function_ref @$S12Conformances7MyProtoPxycfC
+// CHECK: function_ref @$S12Conformances7MyProtoP6methodyyF
+// CHECK: function_ref @$S12Conformances7MyProtoP4propSivs
+// CHECK: function_ref @$S12Conformances7MyProtoPyS2icig
+// CHECK: end sil function '$S16ConformancesUser10testOpaqueSiyF'

--- a/test/ModuleInterface/Inputs/ConformancesUser.swift
+++ b/test/ModuleInterface/Inputs/ConformancesUser.swift
@@ -1,0 +1,16 @@
+import Conformances
+
+func testGeneric<T: MyProto>(_: T.Type) -> Int {
+  var impl = T.init()
+  impl.method()
+  impl.prop = 0
+  return impl[0]
+}
+
+public func testFull() -> Int {
+  return testGeneric(FullStructImpl.self)
+}
+
+public func testOpaque() -> Int {
+  return testGeneric(OpaqueStructImpl.self)
+}


### PR DESCRIPTION
It's not clear whether we'll actually need this feature in the long run, but we certainly need it now because non-`@usableFromInline` members can (currently) satisfy public requirements when a `@usableFromInline` internal type conforms to a public protocol. In these cases, we'll treat the witnesses as present but opaque, and clients will perform dynamic dispatch when using them even when a generic function gets specialized.

With this, we're able to generate a textual interface for the standard library, compile it back to a swiftmodule, and use it to build a Hello World program!