### PR TITLE
[ModuleInterface] Don't setAddedImplicitInitializers() in Parse

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5481,8 +5481,6 @@ ParserResult<EnumDecl> Parser::parseDeclEnum(ParseDeclOptions Flags,
                                         { }, nullptr, CurDeclContext);
   setLocalDiscriminator(ED);
   ED->getAttrs() = Attributes;
-  if (SF.Kind == SourceFileKind::Interface)
-    ED->setAddedImplicitInitializers();
 
   ContextChange CC(*this, ED);
 
@@ -5755,8 +5753,6 @@ ParserResult<StructDecl> Parser::parseDeclStruct(ParseDeclOptions Flags,
                                             CurDeclContext);
   setLocalDiscriminator(SD);
   SD->getAttrs() = Attributes;
-  if (SF.Kind == SourceFileKind::Interface)
-    SD->setAddedImplicitInitializers();
 
   ContextChange CC(*this, SD);
 
@@ -5845,8 +5841,6 @@ ParserResult<ClassDecl> Parser::parseDeclClass(ParseDeclOptions Flags,
                                           { }, nullptr, CurDeclContext);
   setLocalDiscriminator(CD);
   CD->getAttrs() = Attributes;
-  if (SF.Kind == SourceFileKind::Interface)
-    CD->setAddedImplicitInitializers();
 
   ContextChange CC(*this, CD);
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5263,6 +5263,14 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
   if (decl->isInvalid())
     return;
 
+  // Don't add implicit constructors in textual interfaces.
+  if (auto *SF = decl->getParentSourceFile()) {
+    if (SF->Kind == SourceFileKind::Interface) {
+      decl->setAddedImplicitInitializers();
+      return;
+    }
+  }
+
   // Bail out if we're validating one of our constructors already; we'll
   // revisit the issue later.
   if (isa<ClassDecl>(decl)) {


### PR DESCRIPTION
...wait until Sema. Parse shouldn't be messing with Sema-level properties in the decls it builds.

No functionality change. Addresses (some of) Doug's feedback on #18778.