### PR TITLE
[ConstraintSystem] Diagnose ambiguities related to solutions with fixes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1539,6 +1539,10 @@ NOTE(where_requirement_failure_both_subst,none,
      "where %0 = %1, %2 = %3", (Type, Type, Type, Type))
 NOTE(requirement_implied_by_conditional_conformance,none,
      "requirement from conditional conformance of %0 to %1", (Type, Type))
+NOTE(candidate_types_conformance_requirement,none,
+     "candidate requires that %0 conform to %1 "
+     "(requirement specified as %2 == %3%4)",
+     (Type, Type, Type, Type, StringRef))
 NOTE(candidate_types_equal_requirement,none,
      "candidate requires that the types %0 and %1 be equivalent "
      "(requirement specified as %2 == %3%4)",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -58,6 +58,8 @@ NOTE(extended_type_declared_here,none,
 
 ERROR(ambiguous_member_overload_set,none,
       "ambiguous reference to member %0", (DeclName))
+ERROR(ambiguous_reference_to_decl,none,
+      "ambiguous reference to %0 %1", (DescriptiveDeclKind, DeclName))
 
 ERROR(ambiguous_subscript,none,
       "ambiguous subscript with base type %0 and index type %1",

--- a/lib/Sema/CSDiag.h
+++ b/lib/Sema/CSDiag.h
@@ -18,8 +18,16 @@
 #ifndef SWIFT_SEMA_CSDIAG_H
 #define SWIFT_SEMA_CSDIAG_H
 
+#include "ConstraintSystem.h"
+#include "swift/AST/DiagnosticEngine.h"
+#include "llvm/ADT/StringRef.h"
+#include <string>
+
 namespace swift {
-  
+  class Expr;
+  class Type;
+  class SourceLoc;
+
   std::string getTypeListString(Type type);
   
   /// Rewrite any type variables & archetypes in the specified type with

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -234,6 +234,9 @@ bool MissingConformanceFailure::diagnose(bool asNote) {
 }
 
 bool LabelingFailure::diagnose(bool asNote) {
+  if (asNote)
+    return false;
+
   auto &cs = getConstraintSystem();
   auto *call = cast<CallExpr>(getAnchor());
   return diagnoseArgumentLabelError(cs.getASTContext(), call->getArg(),

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -116,8 +116,8 @@ const DeclContext *RequirementFailure::getRequirementDC() const {
   return AffectedDecl->getAsGenericContext();
 }
 
-bool RequirementFailure::diagnose() {
-  if (!canDiagnoseFailure())
+bool RequirementFailure::diagnose(bool asNote) {
+  if (!canDiagnoseFailure() || asNote)
     return false;
 
   auto *anchor = getAnchor();
@@ -159,8 +159,8 @@ void RequirementFailure::emitRequirementNote(const Decl *anchor) const {
                  req.getFirstType(), getLHS(), req.getSecondType(), getRHS());
 }
 
-bool MissingConformanceFailure::diagnose() {
-  if (!canDiagnoseFailure())
+bool MissingConformanceFailure::diagnose(bool asNote) {
+  if (!canDiagnoseFailure() || asNote)
     return false;
 
   auto *anchor = getAnchor();
@@ -223,7 +223,7 @@ bool MissingConformanceFailure::diagnose() {
   return RequirementFailure::diagnose();
 }
 
-bool LabelingFailure::diagnose() {
+bool LabelingFailure::diagnose(bool asNote) {
   auto &cs = getConstraintSystem();
   auto *call = cast<CallExpr>(getAnchor());
   return diagnoseArgumentLabelError(cs.getASTContext(), call->getArg(),
@@ -231,7 +231,11 @@ bool LabelingFailure::diagnose() {
                                     isa<SubscriptExpr>(call->getFn()));
 }
 
-bool NoEscapeFuncToTypeConversionFailure::diagnose() {
+bool NoEscapeFuncToTypeConversionFailure::diagnose(bool asNote) {
+  // Can't diagnose this problem as a note at the moment.
+  if (asNote)
+    return false;
+
   auto *anchor = getAnchor();
 
   if (ConvertTo) {
@@ -254,8 +258,9 @@ bool NoEscapeFuncToTypeConversionFailure::diagnose() {
   return true;
 }
 
-bool MissingForcedDowncastFailure::diagnose() {
-  if (hasComplexLocator())
+bool MissingForcedDowncastFailure::diagnose(bool asNote) {
+  // Can't diagnose this problem as a note at the moment.
+  if (hasComplexLocator() || asNote)
     return false;
 
   auto &TC = getTypeChecker();
@@ -295,8 +300,9 @@ bool MissingForcedDowncastFailure::diagnose() {
   }
 }
 
-bool MissingAddressOfFailure::diagnose() {
-  if (hasComplexLocator())
+bool MissingAddressOfFailure::diagnose(bool asNote) {
+  // Can't diagnose this problem as a note at the moment.
+  if (hasComplexLocator() || asNote)
     return false;
 
   auto *anchor = getAnchor();
@@ -306,8 +312,9 @@ bool MissingAddressOfFailure::diagnose() {
   return true;
 }
 
-bool MissingExplicitConversionFailure::diagnose() {
-  if (hasComplexLocator())
+bool MissingExplicitConversionFailure::diagnose(bool asNote) {
+  // Can't diagnose this problem as a note at the moment.
+  if (hasComplexLocator() || asNote)
     return false;
 
   auto *DC = getDC();
@@ -363,8 +370,9 @@ bool MissingExplicitConversionFailure::diagnose() {
   return true;
 }
 
-bool MemberAccessOnOptionalBaseFailure::diagnose() {
-  if (hasComplexLocator())
+bool MemberAccessOnOptionalBaseFailure::diagnose(bool asNote) {
+  // Can't diagnose this problem as a note at the moment.
+  if (hasComplexLocator() || asNote)
     return false;
 
   auto *anchor = getAnchor();
@@ -516,8 +524,9 @@ static bool diagnoseUnwrap(ConstraintSystem &CS, Expr *expr, Type type) {
   return true;
 }
 
-bool MissingOptionalUnwrapFailure::diagnose() {
-  if (hasComplexLocator())
+bool MissingOptionalUnwrapFailure::diagnose(bool asNote) {
+  // Can't diagnose this problem as a note at the moment.
+  if (hasComplexLocator() || asNote)
     return false;
 
   auto *anchor = getAnchor();
@@ -533,7 +542,11 @@ bool MissingOptionalUnwrapFailure::diagnose() {
   return true;
 }
 
-bool RValueTreatedAsLValueFailure::diagnose() {
+bool RValueTreatedAsLValueFailure::diagnose(bool asNote) {
+  // Can't diagnose this problem as a note at the moment.
+  if (asNote)
+    return false;
+
   Diag<StringRef> subElementDiagID;
   Diag<Type> rvalueDiagID;
   Expr *diagExpr = getLocator()->getAnchor();

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -133,6 +133,7 @@ protected:
   using PathEltKind = ConstraintLocator::PathElementKind;
   using DiagOnDecl = Diag<DescriptiveDeclKind, DeclName, Type, Type>;
   using DiagInReference = Diag<DescriptiveDeclKind, DeclName, Type, Type, Type>;
+  using DiagAsNote = Diag<Type, Type, Type, Type, StringRef>;
 
   const ValueDecl *AffectedDecl;
   /// If possible, find application expression associated
@@ -182,6 +183,7 @@ protected:
 
   virtual DiagOnDecl getDiagnosticOnDecl() const = 0;
   virtual DiagInReference getDiagnosticInRereference() const = 0;
+  virtual DiagAsNote getDiagnosticAsNote() const = 0;
 
   /// Determine whether it would be possible to diagnose
   /// current requirement failure.
@@ -242,6 +244,10 @@ protected:
   DiagInReference getDiagnosticInRereference() const override {
     return diag::type_does_not_conform_in_decl_ref;
   }
+
+  DiagAsNote getDiagnosticAsNote() const override {
+    return diag::candidate_types_conformance_requirement;
+  }
 };
 
 /// Diagnose failures related to same-type generic requirements, e.g.
@@ -278,6 +284,10 @@ protected:
   DiagInReference getDiagnosticInRereference() const override {
     return diag::types_not_equal_in_decl_ref;
   }
+
+  DiagAsNote getDiagnosticAsNote() const override {
+    return diag::candidate_types_equal_requirement;
+  }
 };
 
 /// Diagnose failures related to superclass generic requirements, e.g.
@@ -311,6 +321,10 @@ protected:
 
   DiagInReference getDiagnosticInRereference() const override {
     return diag::types_not_inherited_in_decl_ref;
+  }
+
+  DiagAsNote getDiagnosticAsNote() const override {
+    return diag::candidate_types_inheritance_requirement;
   }
 };
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -54,9 +54,12 @@ public:
   /// failure location, types and declarations deduced by
   /// constraint system, and other auxiliary information.
   ///
+  /// \param asNote In ambiguity cases it's beneficial to
+  /// produce diagnostic as a note instead of an error if possible.
+  ///
   /// \returns true If the problem has been successfully diagnosed
   /// and diagnostic message emitted, false otherwise.
-  virtual bool diagnose() = 0;
+  virtual bool diagnose(bool asNote = false) = 0;
 
   ConstraintSystem &getConstraintSystem() const {
     return CS;
@@ -170,7 +173,7 @@ public:
   virtual Type getLHS() const = 0;
   virtual Type getRHS() const = 0;
 
-  bool diagnose() override;
+  bool diagnose(bool asNote = false) override;
 
 protected:
   /// Retrieve declaration contextual where current
@@ -221,7 +224,7 @@ public:
       : RequirementFailure(expr, cs, locator),
         NonConformingType(conformance.first), Protocol(conformance.second) {}
 
-  bool diagnose() override;
+  bool diagnose(bool asNote = false) override;
 
 private:
   /// The type which was expected, by one of the generic requirements,
@@ -327,7 +330,7 @@ public:
                   ArrayRef<Identifier> labels)
       : FailureDiagnostic(nullptr, cs, locator), CorrectLabels(labels) {}
 
-  bool diagnose() override;
+  bool diagnose(bool asNote = false) override;
 };
 
 /// Diagnose errors related to converting function type which
@@ -341,7 +344,7 @@ public:
                                       Type toType = Type())
       : FailureDiagnostic(expr, cs, locator), ConvertTo(toType) {}
 
-  bool diagnose() override;
+  bool diagnose(bool asNote = false) override;
 };
 
 class MissingForcedDowncastFailure final : public FailureDiagnostic {
@@ -350,7 +353,7 @@ public:
                                ConstraintLocator *locator)
       : FailureDiagnostic(expr, cs, locator) {}
 
-  bool diagnose() override;
+  bool diagnose(bool asNote = false) override;
 };
 
 /// Diagnose failures related to passing value of some type
@@ -361,7 +364,7 @@ public:
                           ConstraintLocator *locator)
       : FailureDiagnostic(expr, cs, locator) {}
 
-  bool diagnose() override;
+  bool diagnose(bool asNote = false) override;
 };
 
 /// Diagnose failures related attempt to implicitly convert types which
@@ -375,7 +378,7 @@ public:
                                    ConstraintLocator *locator, Type toType)
       : FailureDiagnostic(expr, cs, locator), ConvertingTo(toType) {}
 
-  bool diagnose() override;
+  bool diagnose(bool asNote = false) override;
 
 private:
   bool exprNeedsParensBeforeAddingAs(Expr *expr) {
@@ -416,7 +419,7 @@ public:
       : FailureDiagnostic(expr, cs, locator), Member(memberName),
         ResultTypeIsOptional(resultOptional) {}
 
-  bool diagnose() override;
+  bool diagnose(bool asNote = false) override;
 };
 
 /// Diagnose failures related to use of the unwrapped optional types,
@@ -427,7 +430,7 @@ public:
                                ConstraintLocator *locator)
       : FailureDiagnostic(expr, cs, locator) {}
 
-  bool diagnose() override;
+  bool diagnose(bool asNote = false) override;
 };
 
 /// Diagnose errors associated with rvalues in positions
@@ -438,7 +441,7 @@ public:
   RValueTreatedAsLValueFailure(ConstraintSystem &cs, ConstraintLocator *locator)
       : FailureDiagnostic(nullptr, cs, locator) {}
 
-  bool diagnose() override;
+  bool diagnose(bool asNote = false) override;
 };
 
 } // end namespace constraints

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -59,7 +59,15 @@ public:
   ///
   /// \returns true If the problem has been successfully diagnosed
   /// and diagnostic message emitted, false otherwise.
-  virtual bool diagnose(bool asNote = false) = 0;
+  bool diagnose(bool asNote = false);
+
+  /// Try to produce an error diagnostic for the problem at hand.
+  virtual bool diagnoseAsError() = 0;
+
+  /// Instead of producing an error diagnostic, attempt to
+  /// produce a "note" to complement some other diagnostic
+  /// e.g. ambiguity error.
+  virtual bool diagnoseAsNote();
 
   ConstraintSystem &getConstraintSystem() const {
     return CS;
@@ -174,7 +182,8 @@ public:
   virtual Type getLHS() const = 0;
   virtual Type getRHS() const = 0;
 
-  bool diagnose(bool asNote = false) override;
+  bool diagnoseAsError() override;
+  bool diagnoseAsNote() override;
 
 protected:
   /// Retrieve declaration contextual where current
@@ -226,7 +235,7 @@ public:
       : RequirementFailure(expr, cs, locator),
         NonConformingType(conformance.first), Protocol(conformance.second) {}
 
-  bool diagnose(bool asNote = false) override;
+  bool diagnoseAsError() override;
 
 private:
   /// The type which was expected, by one of the generic requirements,
@@ -344,7 +353,7 @@ public:
                   ArrayRef<Identifier> labels)
       : FailureDiagnostic(nullptr, cs, locator), CorrectLabels(labels) {}
 
-  bool diagnose(bool asNote = false) override;
+  bool diagnoseAsError() override;
 };
 
 /// Diagnose errors related to converting function type which
@@ -358,7 +367,7 @@ public:
                                       Type toType = Type())
       : FailureDiagnostic(expr, cs, locator), ConvertTo(toType) {}
 
-  bool diagnose(bool asNote = false) override;
+  bool diagnoseAsError() override;
 };
 
 class MissingForcedDowncastFailure final : public FailureDiagnostic {
@@ -367,7 +376,7 @@ public:
                                ConstraintLocator *locator)
       : FailureDiagnostic(expr, cs, locator) {}
 
-  bool diagnose(bool asNote = false) override;
+  bool diagnoseAsError() override;
 };
 
 /// Diagnose failures related to passing value of some type
@@ -378,7 +387,7 @@ public:
                           ConstraintLocator *locator)
       : FailureDiagnostic(expr, cs, locator) {}
 
-  bool diagnose(bool asNote = false) override;
+  bool diagnoseAsError() override;
 };
 
 /// Diagnose failures related attempt to implicitly convert types which
@@ -392,7 +401,7 @@ public:
                                    ConstraintLocator *locator, Type toType)
       : FailureDiagnostic(expr, cs, locator), ConvertingTo(toType) {}
 
-  bool diagnose(bool asNote = false) override;
+  bool diagnoseAsError() override;
 
 private:
   bool exprNeedsParensBeforeAddingAs(Expr *expr) {
@@ -433,7 +442,7 @@ public:
       : FailureDiagnostic(expr, cs, locator), Member(memberName),
         ResultTypeIsOptional(resultOptional) {}
 
-  bool diagnose(bool asNote = false) override;
+  bool diagnoseAsError() override;
 };
 
 /// Diagnose failures related to use of the unwrapped optional types,
@@ -444,7 +453,7 @@ public:
                                ConstraintLocator *locator)
       : FailureDiagnostic(expr, cs, locator) {}
 
-  bool diagnose(bool asNote = false) override;
+  bool diagnoseAsError() override;
 };
 
 /// Diagnose errors associated with rvalues in positions
@@ -455,7 +464,7 @@ public:
   RValueTreatedAsLValueFailure(ConstraintSystem &cs, ConstraintLocator *locator)
       : FailureDiagnostic(nullptr, cs, locator) {}
 
-  bool diagnose(bool asNote = false) override;
+  bool diagnoseAsError() override;
 };
 
 } // end namespace constraints

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -52,10 +52,10 @@ std::string ForceDowncast::getName() const {
   return name.c_str();
 }
 
-bool ForceDowncast::diagnose(Expr *expr) const {
+bool ForceDowncast::diagnose(Expr *expr, bool asNote) const {
   MissingExplicitConversionFailure failure(expr, getConstraintSystem(),
                                            getLocator(), DowncastTo);
-  return failure.diagnose();
+  return failure.diagnose(asNote);
 }
 
 ForceDowncast *ForceDowncast::create(ConstraintSystem &cs, Type toType,
@@ -63,10 +63,10 @@ ForceDowncast *ForceDowncast::create(ConstraintSystem &cs, Type toType,
   return new (cs.getAllocator()) ForceDowncast(cs, toType, locator);
 }
 
-bool ForceOptional::diagnose(Expr *root) const {
+bool ForceOptional::diagnose(Expr *root, bool asNote) const {
   MissingOptionalUnwrapFailure failure(root, getConstraintSystem(),
                                        getLocator());
-  return failure.diagnose();
+  return failure.diagnose(asNote);
 }
 
 ForceOptional *ForceOptional::create(ConstraintSystem &cs,
@@ -74,12 +74,12 @@ ForceOptional *ForceOptional::create(ConstraintSystem &cs,
   return new (cs.getAllocator()) ForceOptional(cs, locator);
 }
 
-bool UnwrapOptionalBase::diagnose(Expr *root) const {
+bool UnwrapOptionalBase::diagnose(Expr *root, bool asNote) const {
   bool resultIsOptional =
       getKind() == FixKind::UnwrapOptionalBaseWithOptionalResult;
   MemberAccessOnOptionalBaseFailure failure(
       root, getConstraintSystem(), getLocator(), MemberName, resultIsOptional);
-  return failure.diagnose();
+  return failure.diagnose(asNote);
 }
 
 UnwrapOptionalBase *UnwrapOptionalBase::create(ConstraintSystem &cs,
@@ -95,9 +95,9 @@ UnwrapOptionalBase *UnwrapOptionalBase::createWithOptionalResult(
       cs, FixKind::UnwrapOptionalBaseWithOptionalResult, member, locator);
 }
 
-bool AddAddressOf::diagnose(Expr *root) const {
+bool AddAddressOf::diagnose(Expr *root, bool asNote) const {
   MissingAddressOfFailure failure(root, getConstraintSystem(), getLocator());
-  return failure.diagnose();
+  return failure.diagnose(asNote);
 }
 
 AddAddressOf *AddAddressOf::create(ConstraintSystem &cs,
@@ -105,9 +105,9 @@ AddAddressOf *AddAddressOf::create(ConstraintSystem &cs,
   return new (cs.getAllocator()) AddAddressOf(cs, locator);
 }
 
-bool TreatRValueAsLValue::diagnose(Expr *root) const {
+bool TreatRValueAsLValue::diagnose(Expr *root, bool asNote) const {
   RValueTreatedAsLValueFailure failure(getConstraintSystem(), getLocator());
-  return failure.diagnose();
+  return failure.diagnose(asNote);
 }
 
 TreatRValueAsLValue *TreatRValueAsLValue::create(ConstraintSystem &cs,
@@ -115,10 +115,10 @@ TreatRValueAsLValue *TreatRValueAsLValue::create(ConstraintSystem &cs,
   return new (cs.getAllocator()) TreatRValueAsLValue(cs, locator);
 }
 
-bool CoerceToCheckedCast::diagnose(Expr *root) const {
+bool CoerceToCheckedCast::diagnose(Expr *root, bool asNote) const {
   MissingForcedDowncastFailure failure(root, getConstraintSystem(),
                                        getLocator());
-  return failure.diagnose();
+  return failure.diagnose(asNote);
 }
 
 CoerceToCheckedCast *CoerceToCheckedCast::create(ConstraintSystem &cs,
@@ -126,10 +126,10 @@ CoerceToCheckedCast *CoerceToCheckedCast::create(ConstraintSystem &cs,
   return new (cs.getAllocator()) CoerceToCheckedCast(cs, locator);
 }
 
-bool MarkExplicitlyEscaping::diagnose(Expr *root) const {
+bool MarkExplicitlyEscaping::diagnose(Expr *root, bool asNote) const {
   NoEscapeFuncToTypeConversionFailure failure(root, getConstraintSystem(),
                                               getLocator(), ConvertTo);
-  return failure.diagnose();
+  return failure.diagnose(asNote);
 }
 
 MarkExplicitlyEscaping *
@@ -139,9 +139,9 @@ MarkExplicitlyEscaping::create(ConstraintSystem &cs, ConstraintLocator *locator,
       MarkExplicitlyEscaping(cs, locator, convertingTo);
 }
 
-bool RelabelArguments::diagnose(Expr *root) const {
+bool RelabelArguments::diagnose(Expr *root, bool asNote) const {
   LabelingFailure failure(getConstraintSystem(), getLocator(), getLabels());
-  return failure.diagnose();
+  return failure.diagnose(asNote);
 }
 
 RelabelArguments *
@@ -153,10 +153,10 @@ RelabelArguments::create(ConstraintSystem &cs,
   return new (mem) RelabelArguments(cs, correctLabels, locator);
 }
 
-bool MissingConformance::diagnose(Expr *root) const {
+bool MissingConformance::diagnose(Expr *root, bool asNote) const {
   MissingConformanceFailure failure(root, getConstraintSystem(), getLocator(),
                                     {NonConformingType, Protocol});
-  return failure.diagnose();
+  return failure.diagnose(asNote);
 }
 
 MissingConformance *MissingConformance::create(ConstraintSystem &cs, Type type,
@@ -166,10 +166,10 @@ MissingConformance *MissingConformance::create(ConstraintSystem &cs, Type type,
       MissingConformance(cs, type, protocol, locator);
 }
 
-bool SkipSameTypeRequirement::diagnose(Expr *root) const {
+bool SkipSameTypeRequirement::diagnose(Expr *root, bool asNote) const {
   SameTypeRequirementFailure failure(root, getConstraintSystem(), LHS, RHS,
                                      getLocator());
-  return failure.diagnose();
+  return failure.diagnose(asNote);
 }
 
 SkipSameTypeRequirement *
@@ -178,10 +178,10 @@ SkipSameTypeRequirement::create(ConstraintSystem &cs, Type lhs, Type rhs,
   return new (cs.getAllocator()) SkipSameTypeRequirement(cs, lhs, rhs, locator);
 }
 
-bool SkipSuperclassRequirement::diagnose(Expr *root) const {
+bool SkipSuperclassRequirement::diagnose(Expr *root, bool asNote) const {
   SuperclassRequirementFailure failure(root, getConstraintSystem(), LHS, RHS,
                                        getLocator());
-  return failure.diagnose();
+  return failure.diagnose(asNote);
 }
 
 SkipSuperclassRequirement *

--- a/lib/Sema/CSFix.h
+++ b/lib/Sema/CSFix.h
@@ -94,7 +94,7 @@ public:
 
   /// Diagnose a failure associated with this fix given
   /// root expression and information from constraint system.
-  virtual bool diagnose(Expr *root) const = 0;
+  virtual bool diagnose(Expr *root, bool asNote = false) const = 0;
 
   void print(llvm::raw_ostream &Out) const;
 
@@ -122,7 +122,7 @@ class ForceDowncast final : public ConstraintFix {
 
 public:
   std::string getName() const override;
-  bool diagnose(Expr *root) const override;
+  bool diagnose(Expr *root, bool asNote = false) const override;
 
   static ForceDowncast *create(ConstraintSystem &cs, Type toType,
                                ConstraintLocator *locator);
@@ -136,7 +136,7 @@ class ForceOptional final : public ConstraintFix {
 public:
   std::string getName() const override { return "force optional"; }
 
-  bool diagnose(Expr *root) const override;
+  bool diagnose(Expr *root, bool asNote = false) const override;
 
   static ForceOptional *create(ConstraintSystem &cs,
                                ConstraintLocator *locator);
@@ -158,7 +158,7 @@ public:
     return "unwrap optional base of member lookup";
   }
 
-  bool diagnose(Expr *root) const override;
+  bool diagnose(Expr *root, bool asNote = false) const override;
 
   static UnwrapOptionalBase *create(ConstraintSystem &cs, DeclName member,
                                     ConstraintLocator *locator);
@@ -176,7 +176,7 @@ class AddAddressOf final : public ConstraintFix {
 public:
   std::string getName() const override { return "add address-of"; }
 
-  bool diagnose(Expr *root) const override;
+  bool diagnose(Expr *root, bool asNote = false) const override;
 
   static AddAddressOf *create(ConstraintSystem &cs, ConstraintLocator *locator);
 };
@@ -189,7 +189,7 @@ class TreatRValueAsLValue final : public ConstraintFix {
 public:
   std::string getName() const override { return "treat rvalue as lvalue"; }
 
-  bool diagnose(Expr *root) const override;
+  bool diagnose(Expr *root, bool asNote = false) const override;
 
   static TreatRValueAsLValue *create(ConstraintSystem &cs,
                                      ConstraintLocator *locator);
@@ -204,7 +204,7 @@ class CoerceToCheckedCast final : public ConstraintFix {
 public:
   std::string getName() const override { return "as to as!"; }
 
-  bool diagnose(Expr *root) const override;
+  bool diagnose(Expr *root, bool asNote = false) const override;
 
   static CoerceToCheckedCast *create(ConstraintSystem &cs,
                                      ConstraintLocator *locator);
@@ -224,7 +224,7 @@ class MarkExplicitlyEscaping final : public ConstraintFix {
 public:
   std::string getName() const override { return "add @escaping"; }
 
-  bool diagnose(Expr *root) const override;
+  bool diagnose(Expr *root, bool asNote = false) const override;
 
   static MarkExplicitlyEscaping *create(ConstraintSystem &cs,
                                         ConstraintLocator *locator,
@@ -256,7 +256,7 @@ public:
     return {getTrailingObjects<Identifier>(), NumLabels};
   }
 
-  bool diagnose(Expr *root) const override;
+  bool diagnose(Expr *root, bool asNote = false) const override;
 
   static RelabelArguments *create(ConstraintSystem &cs,
                                   llvm::ArrayRef<Identifier> correctLabels,
@@ -283,7 +283,7 @@ public:
     return "add missing protocol conformance";
   }
 
-  bool diagnose(Expr *root) const override;
+  bool diagnose(Expr *root, bool asNote = false) const override;
 
   static MissingConformance *create(ConstraintSystem &cs, Type type,
                                     ProtocolDecl *protocol,
@@ -305,7 +305,7 @@ public:
     return "skip same-type generic requirement";
   }
 
-  bool diagnose(Expr *root) const override;
+  bool diagnose(Expr *root, bool asNote = false) const override;
 
   static SkipSameTypeRequirement *create(ConstraintSystem &cs, Type lhs,
                                          Type rhs, ConstraintLocator *locator);
@@ -326,7 +326,7 @@ public:
     return "skip superclass generic requirement";
   }
 
-  bool diagnose(Expr *root) const override;
+  bool diagnose(Expr *root, bool asNote = false) const override;
 
   static SkipSuperclassRequirement *
   create(ConstraintSystem &cs, Type lhs, Type rhs, ConstraintLocator *locator);

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -707,6 +707,16 @@ public:
     return None;
   }
 
+  /// Retrieve overload choices associated with given expression.
+  void getOverloadChoices(Expr *anchor,
+                          SmallVectorImpl<SelectedOverload> &overloads) const {
+    for (auto &e : overloadChoices) {
+      auto *locator = e.first;
+      if (locator->getAnchor() == anchor)
+        overloads.push_back(e.second);
+    }
+  }
+
   LLVM_ATTRIBUTE_DEPRECATED(
       void dump() const LLVM_ATTRIBUTE_USED,
       "only for use within the debugger");
@@ -1777,6 +1787,9 @@ public:
   /// Assuming that this constraint system is actually erroneous, this *always*
   /// emits an error message.
   void diagnoseFailureForExpr(Expr *expr);
+
+  bool diagnoseAmbiguity(Expr *expr, ArrayRef<Solution> solutions);
+  bool diagnoseAmbiguityWithFixes(Expr *expr, ArrayRef<Solution> solutions);
 
   /// \brief Give the deprecation warning for referring to a global function
   /// when there's a method from a conditional conformance in a smaller/closer

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -180,7 +180,9 @@ extension S1 {
 // Protocol extensions with additional requirements
 // ----------------------------------------------------------------------------
 extension P4 where Self.AssocP4 : P1 {
-  func extP4a() { // expected-note 2 {{found this candidate}}
+// expected-note@-1 {{candidate requires that 'Int' conform to 'P1' (requirement specified as 'Self.AssocP4' == 'P1')}}
+// expected-note@-2 {{candidate requires that 'S4aHelper' conform to 'P1' (requirement specified as 'Self.AssocP4' == 'P1')}}
+  func extP4a() {
     acceptsP1(reqP4a())
   }
 }
@@ -211,7 +213,9 @@ extension P4 where Self.AssocP4 == Int {
 }
 
 extension P4 where Self.AssocP4 == Bool {
-  func extP4a() -> Bool { return reqP4a() } // expected-note 2 {{found this candidate}}
+// expected-note@-1 {{candidate requires that the types 'Int' and 'Bool' be equivalent (requirement specified as 'Self.AssocP4' == 'Bool')}}
+// expected-note@-2 {{candidate requires that the types 'S4aHelper' and 'Bool' be equivalent (requirement specified as 'Self.AssocP4' == 'Bool')}}
+  func extP4a() -> Bool { return reqP4a() }
 }
 
 func testP4(_ s4a: S4a, s4b: S4b, s4c: S4c, s4d: S4d) {
@@ -219,9 +223,9 @@ func testP4(_ s4a: S4a, s4b: S4b, s4c: S4c, s4d: S4d) {
   //        because they don't match on conformance and same-type
   //        requirement of different overloads, but diagnostic
   //        could be improved to point out exactly what is missing in each case.
-  s4a.extP4a() // expected-error{{ambiguous reference to member 'extP4a()'}}
+  s4a.extP4a() // expected-error{{ambiguous reference to instance method 'extP4a()'}}
   s4b.extP4a() // ok
-  s4c.extP4a() // expected-error{{ambiguous reference to member 'extP4a()'}}
+  s4c.extP4a() // expected-error{{ambiguous reference to instance method 'extP4a()'}}
   s4c.extP4Int() // okay
   var b1 = s4d.extP4a() // okay, "Bool" version
   b1 = true // checks type above


### PR DESCRIPTION
If all of the solutions in the set have a single fix, which points
to the common anchor, attempt to diagnose the failure as an
ambiguity with a list of candidates and their related problems as notes.

Having richer message like that helps to understand why something is
ambiguous e.g. if there are two overloads, one requires conformance
to some protocol and another has a same-type requirement on some type,
but neither matched exactly, having both candidates in the diagnostic
message with associated errors, instead of simplify pointing to related
declarations, helps tremendously.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
