### PR TITLE
fix NumpyConversion for strided numpy arrays

### DIFF
--- a/stdlib/public/Python/NumpyConversion.swift
+++ b/stdlib/public/Python/NumpyConversion.swift
@@ -152,41 +152,79 @@ extension Double : NumpyScalarCompatible {
   }
 }
 
-extension Array : ConvertibleFromNumpyArray
-  where Element : NumpyScalarCompatible {
+/// A helper struct with all the data that ConvertibleFromNumpyArray
+/// implementations need to copy memory from a NumpyArray.
+public struct ContiguousNumpyArray<Scalar, ShapeSize> {
+  /// The shape of the array.
+  public let shape: [ShapeSize]
+
+  /// A pointer to the memory, which is guaranteed to hold the array data in
+  /// C_CONTIGUOUS format.
+  public let ptr: UnsafePointer<Scalar>
+
+  /// The array itself. We hold it in this struct so that `ptr` points to valid
+  /// memory as long as this struct is around.
+  private let contiguousNumpyArray: PythonObject
+}
+
+extension ContiguousNumpyArray : ConvertibleFromNumpyArray
+  where Scalar : NumpyScalarCompatible, ShapeSize : PythonConvertible {
   public init?(numpyArray: PythonObject) {
     // Check if input is a `numpy.ndarray` instance.
     guard Python.isinstance(numpyArray, np.ndarray) == true else {
       return nil
     }
-    // Check if the dtype of the `ndarray` is compatible with the `Element`
+    // Check if the dtype of the `ndarray` is compatible with the `Scalar`
     // type.
-    guard Element.isCompatible(withNumpyScalarType: numpyArray.dtype) else {
+    guard Scalar.isCompatible(withNumpyScalarType: numpyArray.dtype) else {
       return nil
     }
 
-    // Only 1-D `ndarray` instances can be converted to `Array`.
     let pyShape = numpyArray.__array_interface__["shape"]
-    guard let shape = Array<Int>(pyShape) else { return nil }
-    guard shape.count == 1 else {
+    guard let shape = Array<ShapeSize>(pyShape) else {
       return nil
     }
+
+    // Make sure that the array is contiguous in memory. This does a copy if
+    // the array is not already contiguous in memory.
+    let contiguousNumpyArray = np.ascontiguousarray(numpyArray)
+
     guard let ptrVal =
-      UInt(numpyArray.__array_interface__["data"].tuple2.0) else {
+      UInt(contiguousNumpyArray.__array_interface__["data"].tuple2.0) else {
       return nil
     }
-    guard let ptr = UnsafePointer<Element>(bitPattern: ptrVal) else {
+    // Note: `ptr` is not nil even if the `ndarray` is empty (i.e. has a shape
+    // of `(0,)`).
+    guard let ptr = UnsafePointer<Scalar>(bitPattern: ptrVal) else {
       fatalError("numpy.ndarray data pointer was nil")
     }
+
+    self.shape = shape
+    self.ptr = ptr
+    self.contiguousNumpyArray = contiguousNumpyArray
+  }
+}
+
+extension Array : ConvertibleFromNumpyArray
+  where Element : NumpyScalarCompatible {
+  public init?(numpyArray: PythonObject) {
+    guard let array = ContiguousNumpyArray<Element, Int>(numpyArray: numpyArray)
+      else { return nil }
+
+    // Only 1-D `ndarray` instances can be converted to `Array`.
+    guard array.shape.count == 1 else {
+      return nil
+    }
+
     // This code avoids constructing and initialize from `UnsafeBufferPointer`
     // because that uses the `init<S : Sequence>(_ elements: S)` initializer,
     // which performs unnecessary copying.
     let dummyPointer = UnsafeMutablePointer<Element>.allocate(capacity: 1)
-    let scalarCount = shape.reduce(1, *)
+    let scalarCount = array.shape.reduce(1, *)
     self.init(repeating: dummyPointer.move(), count: scalarCount)
     dummyPointer.deallocate()
     withUnsafeMutableBufferPointer { buffPtr in
-      buffPtr.baseAddress!.assign(from: ptr, count: scalarCount)
+      buffPtr.baseAddress!.assign(from: array.ptr, count: scalarCount)
     }
   }
 }

--- a/stdlib/public/TensorFlow/NumpyConversion.swift
+++ b/stdlib/public/TensorFlow/NumpyConversion.swift
@@ -26,76 +26,38 @@ private let np = Python.import("numpy")
 extension ShapedArray : ConvertibleFromNumpyArray
   where Scalar : NumpyScalarCompatible {
   public init?(numpyArray: PythonObject) {
-    // Check if input is a `numpy.ndarray` instance.
-    guard Python.isinstance(numpyArray, np.ndarray) == true else {
-      return nil
-    }
-    // Check if the dtype of the `ndarray` is compatible with the `Scalar`
-    // type.
-    guard Scalar.isCompatible(withNumpyScalarType: numpyArray.dtype) else {
-      return nil
-    }
+    guard let array = ContiguousNumpyArray<Scalar, Int>(numpyArray: numpyArray)
+      else { return nil }
 
-    let pyShape = numpyArray.__array_interface__["shape"]
-    guard let shape = Array<Int>(pyShape) else {
-      return nil
-    }
-    guard let ptrVal =
-      UInt(numpyArray.__array_interface__["data"].tuple2.0) else {
-      return nil
-    }
-    // Note: `ptr` is not nil even if the `ndarray` is empty (i.e. has a shape
-    // of `(0,)`).
-    guard let ptr = UnsafePointer<Scalar>(bitPattern: ptrVal) else {
-      fatalError("numpy.ndarray data pointer was nil")
-    }
     // This code avoids calling `init<S : Sequence>(shape: [Int], scalars: S)`,
     // which inefficiently copies scalars one by one. Instead,
     // `init(shape: [Int], scalars: [Scalar])` is called, which efficiently
     // does a `memcpy` of the entire `scalars` array.
     // Unecessary copying is minimized.
     let dummyPointer = UnsafeMutablePointer<Scalar>.allocate(capacity: 1)
-    let scalarCount = shape.reduce(1, *)
+    let scalarCount = array.shape.reduce(1, *)
     var scalars: [Scalar] = Array(repeating: dummyPointer.move(),
                                   count: scalarCount)
     dummyPointer.deallocate()
     scalars.withUnsafeMutableBufferPointer { buffPtr in
-      buffPtr.baseAddress!.assign(from: ptr, count: scalarCount)
+      buffPtr.baseAddress!.assign(from: array.ptr, count: scalarCount)
     }
-    self.init(shape: shape, scalars: scalars)
+    self.init(shape: array.shape, scalars: scalars)
   }
 }
 
 extension Tensor : ConvertibleFromNumpyArray
   where Scalar : NumpyScalarCompatible {
   public init?(numpyArray: PythonObject) {
-    // Check if input is a `numpy.ndarray` instance.
-    guard Python.isinstance(numpyArray, np.ndarray) == true else {
-      return nil
-    }
-    // Check if the dtype of the `ndarray` is compatible with the `Scalar`
-    // type.
-    guard Scalar.isCompatible(withNumpyScalarType: numpyArray.dtype) else {
+    guard let array = ContiguousNumpyArray<Scalar, Int32>(
+        numpyArray: numpyArray) else {
       return nil
     }
 
-    let pyShape = numpyArray.__array_interface__["shape"]
-    guard let dimensions = Array<Int32>(pyShape) else {
-      return nil
-    }
-    let shape = TensorShape(dimensions)
-    guard let ptrVal =
-      UInt(numpyArray.__array_interface__["data"].tuple2.0) else {
-      return nil
-    }
-    // Note: `ptr` is not nil even if the `ndarray` is empty (i.e. has a shape
-    // of `(0,)`).
-    guard let ptr = UnsafePointer<Scalar>(bitPattern: ptrVal) else {
-      fatalError("numpy.ndarray data pointer was nil")
-    }
-    let buffPtr = UnsafeBufferPointer(start: ptr,
-                                      count: Int(shape.contiguousSize))
-    self.init(shape: shape, scalars: buffPtr)
+    let tensorShape = TensorShape(array.shape)
+    let buffPtr = UnsafeBufferPointer(start: array.ptr,
+                                      count: Int(tensorShape.contiguousSize))
+    self.init(shape: tensorShape, scalars: buffPtr)
   }
 }
 #endif

--- a/test/Python/numpy_conversion.swift
+++ b/test/Python/numpy_conversion.swift
@@ -52,6 +52,15 @@ NumpyConversionTests.test("array-conversion") {
 
   let numpyArray2D = np.ones([2, 3])
   expectNil(Array<Float>(numpyArray: numpyArray2D))
+
+  let numpyArrayStrided = np.array([[1, 2], [1, 2]], dtype: np.int32)[
+      Python.slice(Python.None), 1]
+  // Assert that the array has a stride, so that we're certainly testing a
+  // strided array.
+  expectNotEqual(numpyArrayStrided.__array_interface__["strides"], Python.None)
+  if let array = expectNotNil(Array<Int32>(numpyArray: numpyArrayStrided)) {
+    expectEqual([2, 2], array)
+  }
 }
 
 runAllTests()

--- a/test/TensorFlowRuntime/numpy_conversion.swift
+++ b/test/TensorFlowRuntime/numpy_conversion.swift
@@ -49,6 +49,16 @@ NumpyConversionTests.test("shaped-array-conversion") {
     expectEqual(ShapedArray(shape: [1, 2, 3], scalars: [1, 2, 3, 4, 5, 6]),
                 array)
   }
+
+  let numpyArrayStrided = np.array([[1, 2], [1, 2]], dtype: np.int32)[
+      Python.slice(Python.None), 1]
+  // Assert that the array has a stride, so that we're certainly testing a
+  // strided array.
+  expectNotEqual(numpyArrayStrided.__array_interface__["strides"], Python.None)
+  if let array = expectNotNil(
+      ShapedArray<Int32>(numpyArray: numpyArrayStrided)) {
+    expectEqual(ShapedArray(shape: [2], scalars: [2, 2]), array)
+  }
 }
 
 NumpyConversionTests.test("tensor-conversion") {
@@ -81,6 +91,15 @@ NumpyConversionTests.test("tensor-conversion") {
   if let tensor = expectNotNil(Tensor<Int32>(numpyArray: numpyArrayInt32)) {
     expectEqual(ShapedArray(shape: [1, 2, 3], scalars: [1, 2, 3, 4, 5, 6]),
                 tensor.array)
+  }
+
+  let numpyArrayStrided = np.array([[1, 2], [1, 2]], dtype: np.int32)[
+      Python.slice(Python.None), 1]
+  // Assert that the array has a stride, so that we're certainly testing a
+  // strided array.
+  expectNotEqual(numpyArrayStrided.__array_interface__["strides"], Python.None)
+  if let tensor = expectNotNil(Tensor<Int32>(numpyArray: numpyArrayStrided)) {
+    expectEqual(ShapedArray(shape: [2], scalars: [2, 2]), tensor.array)
   }
 }
 #endif


### PR DESCRIPTION
The main point of this PR is `let contiguousNumpyArray = np.ascontiguousarray(numpyArray)`, which makes NumpyConversion correct for strided numpy arrays. The rest of the PR is just factoring common code out into a helper, so that it's less likely that future implementations contain the same bug.