### PR TITLE
[NFC] Switch subscript index emission to use SILGenApply

### DIFF
--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -266,7 +266,7 @@ public:
   struct AccessedStorage {
     AbstractStorageDecl *Storage;
     bool IsSuper;
-    const RValue *Indices;
+    const PreparedArguments *Indices;
     Expr *IndexExprForDiagnostics;
   };
 
@@ -444,7 +444,7 @@ public:
                           bool isSuper,
                           AccessStrategy accessStrategy,
                           CanType formalRValueType,
-                          RValue &&indices,
+                          PreparedArguments &&indices,
                           Expr *indexExprForDiagnostics);
 
   void addMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
@@ -462,8 +462,8 @@ public:
                                    bool isSuper,
                                    AccessStrategy accessStrategy,
                                    CanType formalRValueType,
-                                   RValue &&indices,
-                                   Expr *indexExprForDiagnostics = nullptr);
+                                   PreparedArguments &&indices,
+                                   Expr *indexExprForDiagnostics);
 
   /// Add a subst-to-orig reabstraction component.  That is, given
   /// that this l-value trafficks in values following the substituted

--- a/lib/SILGen/RValue.cpp
+++ b/lib/SILGen/RValue.cpp
@@ -39,7 +39,7 @@ static unsigned getTupleSize(CanType t) {
   return 1;
 }
 
-static unsigned getRValueSize(AbstractionPattern pattern, CanType formalType) {
+unsigned RValue::getRValueSize(AbstractionPattern pattern, CanType formalType) {
   if (pattern.isTuple()) {
     unsigned count = 0;
     auto formalTupleType = cast<TupleType>(formalType);
@@ -54,7 +54,7 @@ static unsigned getRValueSize(AbstractionPattern pattern, CanType formalType) {
 }
 
 /// Return the number of rvalue elements in the given canonical type.
-static unsigned getRValueSize(CanType type) {
+unsigned RValue::getRValueSize(CanType type) {
   if (auto tupleType = dyn_cast<TupleType>(type)) {
     unsigned count = 0;
     for (auto eltType : tupleType.getElementTypes())
@@ -367,7 +367,7 @@ static void copyOrInitValuesInto(Initialization *init,
   ManagedValue scalar = implodeTupleValues<KIND>(values, SGF, type, loc);
 
   // This will have just used up the first values in the list, pop them off.
-  values = values.slice(getRValueSize(type));
+  values = values.slice(RValue::getRValueSize(type));
 
   init->copyOrInitValueInto(SGF, loc, scalar, isInit);
   init->finishInitialization(SGF);
@@ -635,9 +635,10 @@ getElementRange(CanTupleType tupleType, unsigned eltIndex) {
   assert(eltIndex < tupleType->getNumElements());
   unsigned begin = 0;
   for (unsigned i = 0; i < eltIndex; ++i) {
-    begin += getRValueSize(tupleType.getElementType(i));
+    begin += RValue::getRValueSize(tupleType.getElementType(i));
   }
-  unsigned end = begin + getRValueSize(tupleType.getElementType(eltIndex));
+  unsigned end =
+    begin + RValue::getRValueSize(tupleType.getElementType(eltIndex));
   return { begin, end };
 }
 

--- a/lib/SILGen/RValue.h
+++ b/lib/SILGen/RValue.h
@@ -172,6 +172,9 @@ public:
   static RValue forInContext() {
     return RValue(InContext);
   }
+
+  static unsigned getRValueSize(CanType substType);
+  static unsigned getRValueSize(AbstractionPattern origType, CanType substType);
   
   /// Create an RValue to which values will be subsequently added using
   /// addElement(), with the level of tuple expansion in the input specified

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1285,7 +1285,9 @@ void SILGenModule::tryEmitPropertyDescriptor(AbstractStorageDecl *decl) {
   
   if (!decl->exportsPropertyDescriptor())
     return;
-  
+
+  PrettyStackTraceDecl stackTrace("emitting property descriptor for", decl);
+
   Type baseTy;
   if (decl->getDeclContext()->isTypeContext()) {
     // TODO: Static properties should eventually be referenceable as

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -26,6 +26,7 @@
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/ForeignErrorConvention.h"
 #include "swift/AST/GenericSignature.h"
+#include "swift/AST/ParameterList.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/Basic/ExternalUnion.h"
@@ -2433,6 +2434,22 @@ public:
     maybeEmitForeignErrorArgument();
   }
 
+  void emitTopLevel(PreparedArguments &&args,
+                    AbstractionPattern origParamType) {
+    assert(args.isValid());
+    auto argSources = std::move(args).getSources();
+    if (args.isScalar()) {
+      assert(argSources.size() == 1);
+      emitTopLevel(std::move(argSources[0]), origParamType);
+    } else {
+      for (auto i : indices(argSources)) {
+        emitTopLevel(std::move(argSources[i]),
+                     origParamType.getTupleElementType(i));
+      }
+      maybeEmitForeignErrorArgument();
+    }
+  }
+
 private:
   void emit(ArgumentSource &&arg, AbstractionPattern origParamType) {
     // If it was a tuple in the original type, or the argument
@@ -3582,24 +3599,40 @@ public:
   CanType SubstResultType;
 
 private:
-  ArgumentSource ArgValue;
+  PreparedArguments Args;
   bool Throws;
 
 public:
   CallSite(ApplyExpr *apply)
       : Loc(apply), SubstResultType(apply->getType()->getCanonicalType()),
-        ArgValue(apply->getArg()), Throws(apply->throws()) {}
+        Throws(apply->throws()) {
+    Expr *arg = apply->getArg();
+    Args.emplace(arg->getType()->getCanonicalType(), /*scalar*/true);
+    Args.addArbitrary(arg);
+  }
+
+  CallSite(SILLocation loc, PreparedArguments &&args, CanType resultType,
+           bool throws)
+      : Loc(loc), SubstResultType(resultType), Args(std::move(args)),
+        Throws(throws) {
+    assert(Args.isValid());
+  }
 
   CallSite(SILLocation loc, ArgumentSource &&value, CanType resultType,
            bool throws)
-      : Loc(loc), SubstResultType(resultType), ArgValue(std::move(value)),
-        Throws(throws) {}
+      : Loc(loc), SubstResultType(resultType),
+        Args(value.getSubstType(), /*scalar*/ true), Throws(throws) {
+    Args.addArbitrary(std::move(value));
+  }
 
   CallSite(SILLocation loc, ArgumentSource &&value, CanAnyFunctionType fnType)
       : CallSite(loc, std::move(value), fnType.getResult(), fnType->throws()) {}
 
+  CallSite(SILLocation loc, PreparedArguments &&args, CanAnyFunctionType fnType)
+      : CallSite(loc, std::move(args), fnType.getResult(), fnType->throws()) {}
+
   /// Return the substituted, unlowered AST type of the argument.
-  CanType getSubstArgType() const { return ArgValue.getSubstType(); }
+  CanType getSubstArgType() const { return Args.getFormalType(); }
 
   /// Return the substituted, unlowered AST type of the result of
   /// this application.
@@ -3618,11 +3651,14 @@ public:
 
     ArgEmitter emitter(SGF, lowering.Rep, params, args, delayedArgs,
                        foreignError, foreignSelf);
-    emitter.emitTopLevel(std::move(ArgValue), origParamType);
+    emitter.emitTopLevel(std::move(Args), origParamType);
   }
 
   /// Take the arguments for special processing, in place of the above.
-  ArgumentSource &&forward() && { return std::move(ArgValue); }
+  ArgumentSource &&forward() && {
+    assert(Args.isScalar());
+    return std::move(std::move(Args).getSources()[0]);
+  }
 };
 
 } // end anonymous namespace
@@ -5347,6 +5383,81 @@ ArgumentSource SILGenFunction::prepareAccessorBaseArg(SILLocation loc,
   return Preparer.prepare();
 }
 
+static void collectFakeIndexParameters(SILGenModule &SGM,
+                                       CanType substType,
+                                    SmallVectorImpl<SILParameterInfo> &params) {
+  if (auto tuple = dyn_cast<TupleType>(substType)) {
+    for (auto substEltType : tuple.getElementTypes())
+      collectFakeIndexParameters(SGM, substEltType, params);
+    return;
+  }
+
+  // Use conventions that will produce a +1 value.
+  auto &tl = SGM.Types.getTypeLowering(substType);
+  ParameterConvention convention;
+  if (tl.isFormallyPassedIndirectly()) {
+    convention = ParameterConvention::Indirect_In;
+  } else if (tl.isTrivial()) {
+    convention = ParameterConvention::Direct_Unowned;
+  } else {
+    convention = ParameterConvention::Direct_Owned;
+  }
+
+  params.push_back(SILParameterInfo{tl.getLoweredType().getASTType(),
+                                    convention});
+}
+
+PreparedArguments
+SILGenFunction::prepareSubscriptIndices(SubscriptDecl *subscript,
+                                        SubstitutionMap subs,
+                                        AccessStrategy strategy,
+                                        Expr *indexExpr) {
+  // FIXME: we should expect an array of index expressions.
+
+  // TODO: use the real abstraction pattern from the accessor(s) in the
+  // strategy.
+  // Currently we use the substituted type so that we can reconstitute these
+  // as RValues.
+
+  auto substArgType = indexExpr->getType()->getCanonicalType();
+  SmallVector<SILParameterInfo, 4> substParamTys;
+  collectFakeIndexParameters(SGM, substArgType, substParamTys);
+
+  SmallVector<ManagedValue, 4> argValues;
+  SmallVector<DelayedArgument, 2> delayedArgs;
+
+  ArgEmitter emitter(*this, SILFunctionTypeRepresentation::Thin,
+                     ClaimedParamsRef(substParamTys),
+                     argValues, delayedArgs,
+                     /*foreign error*/None,
+                     ImportAsMemberStatus());
+
+  emitter.emitTopLevel(indexExpr, AbstractionPattern(substArgType));
+
+  // TODO: do something to preserve LValues in the delayed arguments?
+  if (!delayedArgs.empty())
+    emitDelayedArguments(*this, delayedArgs, argValues);
+
+  bool isScalar = subscript->getIndices()->size() == 1;
+  PreparedArguments result(substArgType, isScalar);
+  if (isScalar) {
+    result.add(indexExpr, RValue(*this, argValues, substArgType));
+  } else {
+    ArrayRef<ManagedValue> remainingArgs = argValues;
+    auto substArgTupleType = cast<TupleType>(substArgType);
+    for (auto substArgEltType : substArgTupleType.getElementTypes()) {
+      auto count = RValue::getRValueSize(substArgEltType);
+      RValue elt(*this, remainingArgs.slice(0, count), substArgEltType);
+      result.add(indexExpr, std::move(elt));
+      remainingArgs = remainingArgs.slice(count);
+    }
+    assert(remainingArgs.empty());
+  }
+
+  assert(result.isValid());
+  return result;
+}
+
 SILDeclRef SILGenModule::getGetterDeclRef(AbstractStorageDecl *storage) {
   auto *getter = storage->getGetter();
   return SILDeclRef(getter, SILDeclRef::Kind::Func)
@@ -5359,7 +5470,7 @@ emitGetAccessor(SILLocation loc, SILDeclRef get,
                 SubstitutionMap substitutions,
                 ArgumentSource &&selfValue,
                 bool isSuper, bool isDirectUse,
-                RValue &&subscripts, SGFContext c) {
+                PreparedArguments &&subscriptIndices, SGFContext c) {
   // Scope any further writeback just within this operation.
   FormalEvaluationScope writebackScope(*this);
 
@@ -5376,11 +5487,10 @@ emitGetAccessor(SILLocation loc, SILDeclRef get,
     accessType = cast<AnyFunctionType>(accessType.getResult());
   }
   // Index or () if none.
-  if (subscripts.isNull())
-    subscripts = emitEmptyTupleRValue(loc, SGFContext());
+  if (subscriptIndices.isNull())
+    subscriptIndices.emplaceEmptyArgumentList(*this);
 
-  emission.addCallSite(loc, ArgumentSource(loc, std::move(subscripts)),
-                       accessType);
+  emission.addCallSite(loc, std::move(subscriptIndices), accessType);
 
   // T
   return emission.apply(c);
@@ -5396,7 +5506,7 @@ void SILGenFunction::emitSetAccessor(SILLocation loc, SILDeclRef set,
                                      SubstitutionMap substitutions,
                                      ArgumentSource &&selfValue,
                                      bool isSuper, bool isDirectUse,
-                                     RValue &&subscripts,
+                                     PreparedArguments &&subscriptIndices,
                                      ArgumentSource &&setValue) {
   // Scope any further writeback just within this operation.
   FormalEvaluationScope writebackScope(*this);
@@ -5414,47 +5524,27 @@ void SILGenFunction::emitSetAccessor(SILLocation loc, SILDeclRef set,
     accessType = cast<AnyFunctionType>(accessType.getResult());
   }
 
-  // (value)  or (value, indices)
-  if (!subscripts.isNull()) {
-    // If we have a value and index list, create a new rvalue to represent the
-    // both of them together.
-    auto inputTupleType = dyn_cast<TupleType>(accessType.getInput());
+  // (value)  or (value, indices...)
+  bool isScalar = subscriptIndices.isNull() ||
+                  std::move(subscriptIndices).getSources().empty();
+  PreparedArguments values(accessType.getInput(), isScalar);
+  values.addArbitrary(std::move(setValue));
+  if (!isScalar) {
+    unsigned paramIndex = 1;
+    for (auto &component : std::move(subscriptIndices).getSources()) {
+      auto param = accessType.getParams()[paramIndex++];
+      auto paramType = param.getType();
+      if (param.isVariadic())
+        paramType = ArraySliceType::get(paramType)->getCanonicalType();
 
-    SmallVector<ArgumentSource, 4> eltSources;
-
-    // The value comes first.
-    eltSources.push_back(std::move(setValue));
-
-    // The indices come after.  Whether they are expanded or not depends on
-    // whether they were written as separate parameters, which should be
-    // reflected in the params list.
-    // TODO: we should really take an array of RValues.
-    if (accessType->getNumParams() != 2) {
-      auto subscriptsTupleType = cast<TupleType>(subscripts.getType());
-      assert(accessType.getParams().size()
-              == 1 + subscriptsTupleType->getNumElements());
-      (void)subscriptsTupleType;
-      SmallVector<RValue, 8> eltRVs;
-      std::move(subscripts).extractElements(eltRVs);
-      for (auto &elt : eltRVs)
-        eltSources.emplace_back(loc, std::move(elt));
-    } else {
-      assert(inputTupleType && "Must have an input tuple here");
-      subscripts.rewriteType(inputTupleType.getElementType(1));
-      eltSources.emplace_back(loc, std::move(subscripts));
+      auto argLoc = component.getKnownRValueLocation();
+      RValue &&arg = std::move(component).asKnownRValue(*this);
+      arg.rewriteType(paramType);
+      values.add(argLoc, std::move(arg));
     }
-
-    if (eltSources.size() == 1) {
-      setValue = std::move(eltSources.front());
-    } else {
-      assert(inputTupleType);
-      setValue = ArgumentSource(loc, inputTupleType, eltSources);
-    }
-
-  } else {
-    setValue.rewriteType(accessType.getInput());
   }
-  emission.addCallSite(loc, std::move(setValue), accessType);
+  assert(values.isValid());
+  emission.addCallSite(loc, std::move(values), accessType);
   // ()
   emission.apply();
 }
@@ -5562,7 +5652,8 @@ emitAddressorAccessor(SILLocation loc, SILDeclRef addressor,
                       SubstitutionMap substitutions,
                       ArgumentSource &&selfValue,
                       bool isSuper, bool isDirectUse,
-                      RValue &&subscripts, SILType addressType) {
+                      PreparedArguments &&subscriptIndices,
+                      SILType addressType) {
   // Scope any further writeback just within this operation.
   FormalEvaluationScope writebackScope(*this);
 
@@ -5580,11 +5671,10 @@ emitAddressorAccessor(SILLocation loc, SILDeclRef addressor,
     accessType = cast<AnyFunctionType>(accessType.getResult());
   }
   // Index or () if none.
-  if (subscripts.isNull())
-    subscripts = emitEmptyTupleRValue(loc, SGFContext());
+  if (subscriptIndices.isNull())
+    subscriptIndices.emplaceEmptyArgumentList(*this);
 
-  emission.addCallSite(loc, ArgumentSource(loc, std::move(subscripts)),
-                       accessType);
+  emission.addCallSite(loc, std::move(subscriptIndices), accessType);
 
   // Unsafe{Mutable}Pointer<T> or
   // (Unsafe{Mutable}Pointer<T>, Builtin.UnknownPointer) or
@@ -5661,7 +5751,7 @@ SILGenFunction::emitCoroutineAccessor(SILLocation loc, SILDeclRef accessor,
                                       SubstitutionMap substitutions,
                                       ArgumentSource &&selfValue,
                                       bool isSuper, bool isDirectUse,
-                                      RValue &&subscripts,
+                                      PreparedArguments &&subscriptIndices,
                                       SmallVectorImpl<ManagedValue> &yields) {
   Callee callee =
     emitSpecializedAccessorFunctionRef(*this, loc, accessor,
@@ -5683,11 +5773,10 @@ SILGenFunction::emitCoroutineAccessor(SILLocation loc, SILDeclRef accessor,
     accessType = cast<AnyFunctionType>(accessType.getResult());
   }
   // Index or () if none.
-  if (subscripts.isNull())
-    subscripts = emitEmptyTupleRValue(loc, SGFContext());
+  if (subscriptIndices.isNull())
+    subscriptIndices.emplaceEmptyArgumentList(*this);
 
-  emission.addCallSite(loc, ArgumentSource(loc, std::move(subscripts)),
-                       accessType);
+  emission.addCallSite(loc, std::move(subscriptIndices), accessType);
 
   auto endApplyHandle = emission.applyCoroutine(yields);
 

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -601,7 +601,7 @@ ManagedValue SILGenFunction::emitExistentialErasure(
       ManagedValue nsError =
           emitRValueForStorageLoad(
               loc, nativeError, concreteFormalType,
-              /*super*/ false, nsErrorVar, RValue(),
+              /*super*/ false, nsErrorVar, PreparedArguments(),
               nsErrorVarSubstitutions,
               AccessSemantics::Ordinary, nsErrorType, SGFContext())
               .getAsSingleValue(*this, loc);

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -38,6 +38,7 @@ class ConsumableManagedValue;
 class LogicalPathComponent;
 class LValue;
 class ManagedValue;
+class PreparedArguments;
 class RValue;
 class CalleeTypeInfo;
 class ResultPlan;
@@ -1103,7 +1104,7 @@ public:
                                   ManagedValue base,
                                   CanType baseFormalType,
                                   bool isSuper, AbstractStorageDecl *storage,
-                                  RValue indexes,
+                                  PreparedArguments &&indices,
                                   SubstitutionMap substitutions,
                                   AccessSemantics semantics, Type propTy,
                                   SGFContext C,
@@ -1121,7 +1122,12 @@ public:
                                 SILDeclRef function,
                                 CanType expectedType,
                                 SubstitutionMap subs);
-  
+
+  PreparedArguments prepareSubscriptIndices(SubscriptDecl *subscript,
+                                            SubstitutionMap subs,
+                                            AccessStrategy strategy,
+                                            Expr *indices);
+
   ArgumentSource prepareAccessorBaseArg(SILLocation loc, ManagedValue base,
                                         CanType baseFormalType,
                                         SILDeclRef accessor);
@@ -1130,13 +1136,13 @@ public:
                          SubstitutionMap substitutions,
                          ArgumentSource &&optionalSelfValue,
                          bool isSuper, bool isDirectAccessorUse,
-                         RValue &&optionalSubscripts, SGFContext C);
+                         PreparedArguments &&optionalSubscripts, SGFContext C);
 
   void emitSetAccessor(SILLocation loc, SILDeclRef setter,
                        SubstitutionMap substitutions,
                        ArgumentSource &&optionalSelfValue,
                        bool isSuper, bool isDirectAccessorUse,
-                       RValue &&optionalSubscripts,
+                       PreparedArguments &&optionalSubscripts,
                        ArgumentSource &&value);
 
   MaterializedLValue
@@ -1160,7 +1166,7 @@ public:
                         SubstitutionMap substitutions,
                         ArgumentSource &&optionalSelfValue,
                         bool isSuper, bool isDirectAccessorUse,
-                        RValue &&optionalSubscripts,
+                        PreparedArguments &&optionalSubscripts,
                         SILType addressType);
 
   CleanupHandle
@@ -1168,7 +1174,7 @@ public:
                         SubstitutionMap substitutions,
                         ArgumentSource &&optionalSelfValue,
                         bool isSuper, bool isDirectAccessorUse,
-                        RValue &&optionalSubscripts,
+                        PreparedArguments &&optionalSubscripts,
                         SmallVectorImpl<ManagedValue> &yields);
 
   RValue emitApplyConversionFunction(SILLocation loc,


### PR DESCRIPTION
As always, most of the work here went into working around the AST representations of parameter and argument lists.