### PR TITLE
SIL Optimizer: fix a crash in constant folding.

### DIFF
--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -1632,6 +1632,12 @@ ConstantFolder::processWorkList() {
       // instructions.
       auto UserV = cast<SingleValueInstruction>(User);
 
+      // Handle a corner case: if this instruction is an unreachable CFG loop
+      // there is no defined dominance order and we can end up with loops in the
+      // use-def chain. Just bail in this case.
+      if (C == UserV)
+        continue;
+
       // Ok, we have succeeded. Add user to the FoldedUsers list and perform the
       // necessary cleanups, RAUWs, etc.
       FoldedUsers.insert(User);

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -3047,3 +3047,51 @@ bb3(%res : $Builtin.Int32):
   release_value %pa : $@callee_guaranteed (Builtin.Int32) -> (Builtin.Int32)
   return  %res : $Builtin.Int32
 }
+
+struct TestStr {
+  let a: Int32
+  let c: Int32
+}
+
+enum TestEnm {
+  case X
+  case Y(TestStr)
+}
+
+// CHECK-LABEL: sil @dont_crash
+// CHECK:      bb0(%0 : $TestEnm, %1 : $Int32):
+// CHECK-NEXT:   %2 = tuple ()
+// CHECK-NEXT:   return %2 : $()
+sil @dont_crash : $@convention(method) (TestEnm, Int32) -> () {
+bb0(%2 : $TestEnm, %3 : $Int32):
+  %98 = integer_literal $Builtin.Int1, -1
+  cond_br %98, bb2, bb3
+
+bb2:
+  %18 = tuple()
+  return %18 : $()
+
+bb3:
+  br bb8(%2 : $TestEnm)
+
+bb8(%47 : $TestEnm):
+  %49 = unchecked_enum_data %47 : $TestEnm, #TestEnm.Y!enumelt.1
+  %57 = struct_extract %49 : $TestStr, #TestStr.c
+  cond_br undef, bb9, bb11
+
+bb9:
+  br bb10
+
+bb10:
+  %64 = struct $TestStr (%3 : $Int32, %57 : $Int32)
+  %65 = enum $TestEnm, #TestEnm.Y!enumelt.1, %64 : $TestStr
+  cond_br undef, bb2, bb16
+
+bb11:
+  br bb10
+
+
+bb16:
+  br bb8(%65 : $TestEnm)
+}
+


### PR DESCRIPTION
When the folded instructions are in an unreachable CFG loop, there may be loops in the use-def chain (there is no defined dominance order).
We have to handle this special case.

rdar://problem/43530134
