### PR TITLE
[PrintAsObjC] Handle generic typealiases

### DIFF
--- a/test/PrintAsObjC/typealias.swift
+++ b/test/PrintAsObjC/typealias.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module -o %t/typealias.swiftmodule %s -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend -parse-as-library %t/typealias.swiftmodule -typecheck -emit-objc-header-path %t/typealias.h -disable-objc-attr-requires-foundation-module
+// RUN: %FileCheck %s < %t/typealias.h
+// RUN: %check-in-clang %t/typealias.h
+
+// RUN: %target-swift-frontend -typecheck %s -emit-objc-header-path %t/typealias_wmo.h -disable-objc-attr-requires-foundation-module
+// RUN: %FileCheck %s < %t/typealias_wmo.h
+// RUN: %check-in-clang %t/typealias_wmo.h
+
+// REQUIRES: objc_interop
+
+public typealias ActuallyGeneric<T> = T
+
+public struct GenericHelper<T> {
+  public typealias TheType = T
+}
+public typealias PassesThroughGeneric = GenericHelper<Int>.TheType
+
+// CHECK-LABEL: @interface X
+@objc public class X {
+  // CHECK: @property (nonatomic) NSInteger actuallyGeneric;
+  @objc public var actuallyGeneric: ActuallyGeneric<Int> = 0
+  // CHECK: @property (nonatomic) NSInteger passesThroughGeneric;
+  @objc public var passesThroughGeneric: PassesThroughGeneric = 0
+} // CHECK: @end


### PR DESCRIPTION
(either explicitly generic ones, or those embedded in generic contexts)

Previously we tried to look at the typealias decl's underlying type, but that might have generic parameters in it. Oops. Use the NameAliasType's desugared type instead.

Also, drop half-baked support for `@objc typealias`, which isn't supported. (It's not an unreasonable feature, but the bits that were there weren't implemented correctly.)

rdar://problem/43347303