### PR TITLE
fix NumpyConversion for strided numpy arrays

### DIFF
--- a/stdlib/public/Python/NumpyConversion.swift
+++ b/stdlib/public/Python/NumpyConversion.swift
@@ -171,8 +171,13 @@ extension Array : ConvertibleFromNumpyArray
     guard shape.count == 1 else {
       return nil
     }
+
+    // Make sure that the array is contiguous in memory. This does a copy if
+    // the array is not already contiguous in memory.
+    let contiguousNumpyArray = np.ascontiguousarray(numpyArray)
+
     guard let ptrVal =
-      UInt(numpyArray.__array_interface__["data"].tuple2.0) else {
+      UInt(contiguousNumpyArray.__array_interface__["data"].tuple2.0) else {
       return nil
     }
     guard let ptr = UnsafePointer<Element>(bitPattern: ptrVal) else {

--- a/stdlib/public/TensorFlow/NumpyConversion.swift
+++ b/stdlib/public/TensorFlow/NumpyConversion.swift
@@ -40,8 +40,13 @@ extension ShapedArray : ConvertibleFromNumpyArray
     guard let shape = Array<Int>(pyShape) else {
       return nil
     }
+
+    // Make sure that the array is contiguous in memory. This does a copy if
+    // the array is not already contiguous in memory.
+    let contiguousNumpyArray = np.ascontiguousarray(numpyArray)
+
     guard let ptrVal =
-      UInt(numpyArray.__array_interface__["data"].tuple2.0) else {
+      UInt(contiguousNumpyArray.__array_interface__["data"].tuple2.0) else {
       return nil
     }
     // Note: `ptr` is not nil even if the `ndarray` is empty (i.e. has a shape
@@ -84,8 +89,13 @@ extension Tensor : ConvertibleFromNumpyArray
       return nil
     }
     let shape = TensorShape(dimensions)
+
+    // Make sure that the array is contiguous in memory. This does a copy if
+    // the array is not already contiguous in memory.
+    let contiguousNumpyArray = np.ascontiguousarray(numpyArray)
+
     guard let ptrVal =
-      UInt(numpyArray.__array_interface__["data"].tuple2.0) else {
+      UInt(contiguousNumpyArray.__array_interface__["data"].tuple2.0) else {
       return nil
     }
     // Note: `ptr` is not nil even if the `ndarray` is empty (i.e. has a shape

--- a/test/Python/numpy_conversion.swift
+++ b/test/Python/numpy_conversion.swift
@@ -52,6 +52,15 @@ NumpyConversionTests.test("array-conversion") {
 
   let numpyArray2D = np.ones([2, 3])
   expectNil(Array<Float>(numpyArray: numpyArray2D))
+
+  let numpyArrayStrided = np.array([[1, 2], [1, 2]], dtype: np.int32)[
+      Python.slice(Python.None), 1]
+  // Assert that the array has a stride, so that we're certainly testing a
+  // strided array.
+  expectNotEqual(numpyArrayStrided.__array_interface__["strides"], Python.None)
+  if let array = expectNotNil(Array<Int32>(numpyArray: numpyArrayStrided)) {
+    expectEqual([2, 2], array)
+  }
 }
 
 runAllTests()

--- a/test/TensorFlowRuntime/numpy_conversion.swift
+++ b/test/TensorFlowRuntime/numpy_conversion.swift
@@ -49,6 +49,16 @@ NumpyConversionTests.test("shaped-array-conversion") {
     expectEqual(ShapedArray(shape: [1, 2, 3], scalars: [1, 2, 3, 4, 5, 6]),
                 array)
   }
+
+  let numpyArrayStrided = np.array([[1, 2], [1, 2]], dtype: np.int32)[
+      Python.slice(Python.None), 1]
+  // Assert that the array has a stride, so that we're certainly testing a
+  // strided array.
+  expectNotEqual(numpyArrayStrided.__array_interface__["strides"], Python.None)
+  if let array = expectNotNil(
+      ShapedArray<Int32>(numpyArray: numpyArrayStrided)) {
+    expectEqual(ShapedArray(shape: [2], scalars: [2, 2]), array)
+  }
 }
 
 NumpyConversionTests.test("tensor-conversion") {
@@ -81,6 +91,15 @@ NumpyConversionTests.test("tensor-conversion") {
   if let tensor = expectNotNil(Tensor<Int32>(numpyArray: numpyArrayInt32)) {
     expectEqual(ShapedArray(shape: [1, 2, 3], scalars: [1, 2, 3, 4, 5, 6]),
                 tensor.array)
+  }
+
+  let numpyArrayStrided = np.array([[1, 2], [1, 2]], dtype: np.int32)[
+      Python.slice(Python.None), 1]
+  // Assert that the array has a stride, so that we're certainly testing a
+  // strided array.
+  expectNotEqual(numpyArrayStrided.__array_interface__["strides"], Python.None)
+  if let tensor = expectNotNil(Tensor<Int32>(numpyArray: numpyArrayStrided)) {
+    expectEqual(ShapedArray(shape: [2], scalars: [2, 2]), tensor.array)
   }
 }
 #endif


### PR DESCRIPTION
This PR is like https://github.com/apple/swift/pull/18936, but without the deduplication changes.