### PR TITLE
[Do not merge] Add conditional compilation test for optimization

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -49,6 +49,8 @@ namespace swift {
     CanImport,
     /// Target Environment (currently just 'simulator' or absent)
     TargetEnvironment,
+    /// Compilation configuration (currently 'optimized' and 'assertsWillFire')
+    Configuration, 
   };
 
   /// Describes which Swift 3 Objective-C inference warnings should be
@@ -270,6 +272,14 @@ namespace swift {
     /// \returns A pair - the first element is true if the OS was invalid.
     /// The second element is true if the Arch was invalid.
     std::pair<bool, bool> setTarget(llvm::Triple triple);
+    
+    /// Sets a platform condition indicating whether the compilation
+    /// is optimized with any variation of -O other than -Onone/-Oplayground.
+    void setOptimizationCondition(bool optimized);
+      
+    /// Sets a platform condition indicating whether asserts can
+    /// fire in this build.
+    void setAssertionCondition(bool assertsWillFire);
 
     /// Returns the minimum platform version to which code will be deployed.
     ///
@@ -365,7 +375,7 @@ namespace swift {
     }
 
   private:
-    llvm::SmallVector<std::pair<PlatformConditionKind, std::string>, 5>
+    llvm::SmallVector<std::pair<PlatformConditionKind, std::string>, 7>
         PlatformConditionValues;
     llvm::SmallVector<std::string, 2> CustomConditionalCompilationFlags;
   };

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -61,6 +61,11 @@ static const StringRef SupportedConditionalCompilationRuntimes[] = {
   "_Native",
 };
 
+static const StringRef SupportedConditionalCompilationConfigurations[] = {
+    "optimized",
+    "assertsWillFire"
+};
+
 static const StringRef SupportedConditionalCompilationTargetEnvironments[] = {
   "simulator",
 };
@@ -106,6 +111,9 @@ checkPlatformConditionSupported(PlatformConditionKind Kind, StringRef Value,
                     suggestions);
   case PlatformConditionKind::TargetEnvironment:
     return contains(SupportedConditionalCompilationTargetEnvironments, Value,
+                    suggestions);
+  case PlatformConditionKind::Configuration:
+    return contains(SupportedConditionalCompilationConfigurations, Value,
                     suggestions);
   case PlatformConditionKind::CanImport:
     // All importable names are valid.
@@ -275,3 +283,18 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
 
   return { false, false };
 }
+
+void LangOptions::setOptimizationCondition(bool optimized) {
+    if (optimized) {
+        addPlatformConditionValue(PlatformConditionKind::Configuration,
+                                  "optimized");
+    }
+}
+
+void LangOptions::setAssertionCondition(bool assertsWillFire) {
+    if (assertsWillFire) {
+        addPlatformConditionValue(PlatformConditionKind::Configuration,
+                                  "assertsWillFire");
+    }
+}
+

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -43,6 +43,7 @@ Optional<PlatformConditionKind> getPlatformConditionKind(StringRef Name) {
     .Case("_runtime", PlatformConditionKind::Runtime)
     .Case("canImport", PlatformConditionKind::CanImport)
     .Case("targetEnvironment", PlatformConditionKind::TargetEnvironment)
+    .Case("configuration", PlatformConditionKind::Configuration)
     .Default(None);
 }
 
@@ -333,6 +334,8 @@ public:
         DiagName = "import conditional"; break;
       case PlatformConditionKind::TargetEnvironment:
         DiagName = "target environment"; break;
+      case PlatformConditionKind::Configuration:
+        DiagName = "configuration"; break;
       case PlatformConditionKind::Runtime:
         llvm_unreachable("handled above");
       }


### PR DESCRIPTION
Swift's `fatalError` is a one-size-fits-all hammer.  This proposal provides a namespaced umbrella for common exit scenarios, modernizing a holdover from C-like languages. 

Swift lacks a modern extensible solution that differentiates fatal error scenarios with uniform outcomes. Many developer libraries implement custom exit points to provide that functionality. Namespacing these marker functions to a common type results in groupable, extensible, and discoverable IDE elements.

Discussion thread: [forums](https://forums.swift.org/t/introducing-namespacing-for-common-swift-error-scenarios/10773)