### PR TITLE
Disable ASan in coroutine functions; it interferes with splitting.

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1243,8 +1243,12 @@ IRGenSILFunction::IRGenSILFunction(IRGenModule &IGM,
   // Apply sanitizer attributes to the function.
   // TODO: Check if the function is supposed to be excluded from ASan either by
   // being in the external file or via annotations.
-  if (IGM.IRGen.Opts.Sanitizers & SanitizerKind::Address)
-    CurFn->addFnAttr(llvm::Attribute::SanitizeAddress);
+  if (IGM.IRGen.Opts.Sanitizers & SanitizerKind::Address) {
+    // Disable ASan in coroutines; stack poisoning is not going to do
+    // reasonable things to the structural invariants.
+    if (!f->getLoweredFunctionType()->isCoroutine())
+      CurFn->addFnAttr(llvm::Attribute::SanitizeAddress);
+  }
   if (IGM.IRGen.Opts.Sanitizers & SanitizerKind::Thread) {
     auto declContext = f->getDeclContext();
     if (declContext && isa<DestructorDecl>(declContext))

--- a/test/IRGen/asan-attributes.swift
+++ b/test/IRGen/asan-attributes.swift
@@ -1,8 +1,22 @@
 // This test verifies that we add the function attributes used by ASan.
 
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -sanitize=address %s | %FileCheck %s -check-prefix=ASAN
+// RUN: %target-swift-frontend -emit-ir -disable-llvm-optzns -sanitize=address %s | %FileCheck %s -check-prefix=ASAN
 
-func test() {
+// ASAN: define {{.*}} @"$S4main4testyyF"() [[DEFAULT_ATTRS:#[0-9]+]]
+public func test() {
 }
 
-// ASAN: Function Attrs: sanitize_address
+// ASAN: define {{.*}} @"$S4main1xSivr"({{.*}}) [[COROUTINE_ATTRS:#[0-9]+]]
+public var x: Int {
+  _read {
+    yield 0
+  }
+}
+
+// ASAN: attributes [[DEFAULT_ATTRS]] =
+// ASAN-SAME: sanitize_address
+// ASAN-SAME: }
+
+// ASAN: attributes [[COROUTINE_ATTRS]] =
+// ASAN-NOT: sanitize_address
+// ASAN-SAME: }


### PR DESCRIPTION
I filed rdar://43673059 to track re-enabling it.