### PR TITLE
[Diagnostics] NFC: Refactor assignment diagnostics into `AssignmentFailure`

### DIFF
--- a/lib/Sema/CSDiag.h
+++ b/lib/Sema/CSDiag.h
@@ -26,12 +26,6 @@ namespace swift {
   /// UnresolvedType.
   Type replaceTypeParametersWithUnresolved(Type ty);
   Type replaceTypeVariablesWithUnresolved(Type ty);
-
-  /// Diagnose lvalue expr error.
-  void diagnoseSubElementFailure(Expr *destExpr, SourceLoc loc,
-                                 constraints::ConstraintSystem &CS,
-                                 Diag<StringRef> diagID,
-                                 Diag<Type> unknownDiagID);
 };
 
 #endif /* SWIFT_SEMA_CSDIAG_H */

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -16,11 +16,15 @@
 
 #include "CSDiagnostics.h"
 #include "ConstraintSystem.h"
-#include "CSDiag.h"
 #include "MiscDiagnostics.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/GenericSignature.h"
+#include "swift/AST/Pattern.h"
 #include "swift/AST/Types.h"
+#include "swift/Basic/SourceLoc.h"
+#include "swift/Parse/Lexer.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallString.h"
 
@@ -590,7 +594,368 @@ bool RValueTreatedAsLValueFailure::diagnose() {
     return false;
   }
 
-  diagnoseSubElementFailure(diagExpr, loc, getConstraintSystem(),
+  AssignmentFailure failure(diagExpr, getConstraintSystem(), loc,
                             subElementDiagID, rvalueDiagID);
+  return failure.diagnose();
+}
+
+AssignmentFailure::AssignmentFailure(Expr *destExpr, ConstraintSystem &cs,
+                                     SourceLoc diagnosticLoc)
+    : FailureDiagnostic(destExpr, cs, cs.getConstraintLocator(destExpr)),
+      Loc(diagnosticLoc),
+      DeclDiagnostic(findDeclDiagonstic(cs.getASTContext(), destExpr)),
+      TypeDiagnostic(diag::assignment_lhs_not_lvalue) {}
+
+bool AssignmentFailure::diagnose() {
+  auto &cs = getConstraintSystem();
+  auto *DC = getDC();
+  auto *destExpr = getParentExpr();
+
+  // Diagnose obvious assignments to literals.
+  if (isa<LiteralExpr>(destExpr->getValueProvidingExpr())) {
+    emitDiagnostic(Loc, diag::cannot_assign_to_literal);
+    return true;
+  }
+
+  // Diagnose assignments to let-properties in delegating initializers.
+  if (auto *member = dyn_cast<UnresolvedDotExpr>(destExpr)) {
+    if (auto *ctor = dyn_cast<ConstructorDecl>(DC)) {
+      if (auto *baseRef = dyn_cast<DeclRefExpr>(member->getBase())) {
+        if (baseRef->getDecl() == ctor->getImplicitSelfDecl() &&
+            ctor->getDelegatingOrChainedInitKind(nullptr) ==
+                ConstructorDecl::BodyInitKind::Delegating) {
+          auto resolved = resolveImmutableBase(member);
+          assert(resolved.first == member);
+          emitDiagnostic(Loc, diag::assignment_let_property_delegating_init,
+                         member->getName());
+
+          if (resolved.second)
+            emitDiagnostic(resolved.second, diag::decl_declared_here,
+                           member->getName());
+          return true;
+        }
+      }
+    }
+  }
+
+  // Walk through the destination expression, resolving what the problem is.  If
+  // we find a node in the lvalue path that is problematic, this returns it.
+  auto immInfo = resolveImmutableBase(destExpr);
+
+  // Otherwise, we cannot resolve this because the available setter candidates
+  // are all mutating and the base must be mutating.  If we dug out a
+  // problematic decl, we can produce a nice tailored diagnostic.
+  if (auto *VD = dyn_cast_or_null<VarDecl>(immInfo.second)) {
+    std::string message = "'";
+    message += VD->getName().str().str();
+    message += "'";
+
+    if (VD->isCaptureList())
+      message += " is an immutable capture";
+    else if (VD->isImplicit())
+      message += " is immutable";
+    else if (VD->isLet())
+      message += " is a 'let' constant";
+    else if (!VD->isSettable(DC))
+      message += " is a get-only property";
+    else if (!VD->isSetterAccessibleFrom(DC))
+      message += " setter is inaccessible";
+    else {
+      message += " is immutable";
+    }
+
+    emitDiagnostic(Loc, DeclDiagnostic, message)
+        .highlight(immInfo.first->getSourceRange());
+
+    // If this is a simple variable marked with a 'let', emit a note to fixit
+    // hint it to 'var'.
+    VD->emitLetToVarNoteIfSimple(DC);
+    return true;
+  }
+
+  // If the underlying expression was a read-only subscript, diagnose that.
+  if (auto *SD = dyn_cast_or_null<SubscriptDecl>(immInfo.second)) {
+    StringRef message;
+    if (!SD->isSettable())
+      message = "subscript is get-only";
+    else if (!SD->isSetterAccessibleFrom(DC))
+      message = "subscript setter is inaccessible";
+    else
+      message = "subscript is immutable";
+
+    emitDiagnostic(Loc, DeclDiagnostic, message)
+        .highlight(immInfo.first->getSourceRange());
+    return true;
+  }
+
+  // If we're trying to set an unapplied method, say that.
+  if (auto *VD = immInfo.second) {
+    std::string message = "'";
+    message += VD->getBaseName().getIdentifier().str();
+    message += "'";
+
+    auto diagID = DeclDiagnostic;
+    if (auto *AFD = dyn_cast<AbstractFunctionDecl>(VD)) {
+      if (AFD->hasImplicitSelfDecl()) {
+        message += " is a method";
+        diagID = diag::assignment_lhs_is_immutable_variable;
+      } else {
+        message += " is a function";
+      }
+    } else
+      message += " is not settable";
+
+    emitDiagnostic(Loc, diagID, message)
+        .highlight(immInfo.first->getSourceRange());
+    return true;
+  }
+
+  // If the expression is the result of a call, it is an rvalue, not a mutable
+  // lvalue.
+  if (auto *AE = dyn_cast<ApplyExpr>(immInfo.first)) {
+    // Handle literals, which are a call to the conversion function.
+    auto argsTuple =
+        dyn_cast<TupleExpr>(AE->getArg()->getSemanticsProvidingExpr());
+    if (isa<CallExpr>(AE) && AE->isImplicit() && argsTuple &&
+        argsTuple->getNumElements() == 1) {
+      if (auto LE = dyn_cast<LiteralExpr>(
+              argsTuple->getElement(0)->getSemanticsProvidingExpr())) {
+        emitDiagnostic(Loc, DeclDiagnostic, "literals are not mutable")
+            .highlight(LE->getSourceRange());
+        return true;
+      }
+    }
+
+    std::string name = "call";
+    if (isa<PrefixUnaryExpr>(AE) || isa<PostfixUnaryExpr>(AE))
+      name = "unary operator";
+    else if (isa<BinaryExpr>(AE))
+      name = "binary operator";
+    else if (isa<CallExpr>(AE))
+      name = "function call";
+    else if (isa<DotSyntaxCallExpr>(AE) || isa<DotSyntaxBaseIgnoredExpr>(AE))
+      name = "method call";
+
+    if (auto *DRE = dyn_cast<DeclRefExpr>(AE->getFn()->getValueProvidingExpr()))
+      name = std::string("'") +
+             DRE->getDecl()->getBaseName().getIdentifier().str().str() + "'";
+
+    emitDiagnostic(Loc, DeclDiagnostic, name + " returns immutable value")
+        .highlight(AE->getSourceRange());
+    return true;
+  }
+
+  if (auto contextualType = cs.getContextualType(immInfo.first)) {
+    Type neededType = contextualType->getInOutObjectType();
+    Type actualType = getType(immInfo.first)->getInOutObjectType();
+    if (!neededType->isEqual(actualType)) {
+      if (DeclDiagnostic.ID == diag::cannot_pass_rvalue_inout_subelement.ID) {
+        // We have a special diagnostic with tailored wording for this
+        // common case.
+        emitDiagnostic(Loc, diag::cannot_pass_rvalue_inout_converted,
+                       actualType, neededType)
+            .highlight(immInfo.first->getSourceRange());
+
+        if (auto inoutExpr = dyn_cast<InOutExpr>(immInfo.first))
+          fixItChangeInoutArgType(inoutExpr->getSubExpr(), actualType,
+                                  neededType);
+      } else {
+        emitDiagnostic(Loc, DeclDiagnostic,
+                       "implicit conversion from '" + actualType->getString() +
+                           "' to '" + neededType->getString() +
+                           "' requires a temporary")
+            .highlight(immInfo.first->getSourceRange());
+      }
+      return true;
+    }
+  }
+
+  if (auto IE = dyn_cast<IfExpr>(immInfo.first)) {
+    if (isLoadedLValue(IE)) {
+      emitDiagnostic(Loc, DeclDiagnostic,
+                     "result of conditional operator '? :' is never mutable")
+          .highlight(IE->getQuestionLoc())
+          .highlight(IE->getColonLoc());
+      return true;
+    }
+  }
+
+  emitDiagnostic(Loc, TypeDiagnostic, getType(destExpr))
+      .highlight(immInfo.first->getSourceRange());
   return true;
+}
+
+void AssignmentFailure::fixItChangeInoutArgType(const Expr *arg,
+                                                Type actualType,
+                                                Type neededType) const {
+  auto *DC = getDC();
+  auto *DRE = dyn_cast<DeclRefExpr>(arg);
+  if (!DRE)
+    return;
+
+  auto *VD = dyn_cast_or_null<VarDecl>(DRE->getDecl());
+  if (!VD)
+    return;
+
+  // Don't emit for non-local variables.
+  // (But in script-mode files, we consider module-scoped
+  // variables in the same file to be local variables.)
+  auto VDC = VD->getDeclContext();
+  bool isLocalVar = VDC->isLocalContext();
+  if (!isLocalVar && VDC->isModuleScopeContext()) {
+    auto argFile = DC->getParentSourceFile();
+    auto varFile = VDC->getParentSourceFile();
+    isLocalVar = (argFile == varFile && argFile->isScriptMode());
+  }
+  if (!isLocalVar)
+    return;
+
+  SmallString<32> scratch;
+  SourceLoc endLoc;   // Filled in if we decide to diagnose this
+  SourceLoc startLoc; // Left invalid if we're inserting
+
+  auto isSimpleTypelessPattern = [](Pattern *P) -> bool {
+    if (auto VP = dyn_cast_or_null<VarPattern>(P))
+      P = VP->getSubPattern();
+    return P && isa<NamedPattern>(P);
+  };
+
+  auto typeRange = VD->getTypeSourceRangeForDiagnostics();
+  if (typeRange.isValid()) {
+    startLoc = typeRange.Start;
+    endLoc = typeRange.End;
+  } else if (isSimpleTypelessPattern(VD->getParentPattern())) {
+    endLoc = VD->getNameLoc();
+    scratch += ": ";
+  }
+
+  if (endLoc.isInvalid())
+    return;
+
+  scratch += neededType.getString();
+
+  // Adjust into the location where we actually want to insert
+  endLoc = Lexer::getLocForEndOfToken(getASTContext().SourceMgr, endLoc);
+
+  // Since we already adjusted endLoc, this will turn an insertion
+  // into a zero-character replacement.
+  if (!startLoc.isValid())
+    startLoc = endLoc;
+
+  emitDiagnostic(VD->getLoc(), diag::inout_change_var_type_if_possible,
+                 actualType, neededType)
+      .fixItReplaceChars(startLoc, endLoc, scratch);
+}
+
+std::pair<Expr *, ValueDecl *>
+AssignmentFailure::resolveImmutableBase(Expr *expr) const {
+  auto &cs = getConstraintSystem();
+  auto *DC = getDC();
+  expr = expr->getValueProvidingExpr();
+
+  // Provide specific diagnostics for assignment to subscripts whose base expr
+  // is known to be an rvalue.
+  if (auto *SE = dyn_cast<SubscriptExpr>(expr)) {
+    // If we found a decl for the subscript, check to see if it is a set-only
+    // subscript decl.
+    SubscriptDecl *member = nullptr;
+    if (SE->hasDecl())
+      member = dyn_cast_or_null<SubscriptDecl>(SE->getDecl().getDecl());
+
+    if (!member) {
+      auto loc =
+          cs.getConstraintLocator(SE, ConstraintLocator::SubscriptMember);
+      member = dyn_cast_or_null<SubscriptDecl>(cs.findResolvedMemberRef(loc));
+    }
+
+    // If it isn't settable, return it.
+    if (member) {
+      if (!member->isSettable() || !member->isSetterAccessibleFrom(DC))
+        return {expr, member};
+    }
+
+    // If it is settable, then the base must be the problem, recurse.
+    return resolveImmutableBase(SE->getBase());
+  }
+
+  // Look through property references.
+  if (auto *UDE = dyn_cast<UnresolvedDotExpr>(expr)) {
+    // If we found a decl for the UDE, check it.
+    auto loc = cs.getConstraintLocator(UDE, ConstraintLocator::Member);
+
+    // If we can resolve a member, we can determine whether it is settable in
+    // this context.
+    if (auto *member = cs.findResolvedMemberRef(loc)) {
+      auto *memberVD = dyn_cast<VarDecl>(member);
+
+      // If the member isn't a vardecl (e.g. its a funcdecl), or it isn't
+      // settable, then it is the problem: return it.
+      if (!memberVD || !member->isSettable(nullptr) ||
+          !memberVD->isSetterAccessibleFrom(DC))
+        return {expr, member};
+    }
+
+    // If we weren't able to resolve a member or if it is mutable, then the
+    // problem must be with the base, recurse.
+    return resolveImmutableBase(UDE->getBase());
+  }
+
+  if (auto *MRE = dyn_cast<MemberRefExpr>(expr)) {
+    // If the member isn't settable, then it is the problem: return it.
+    if (auto member = dyn_cast<AbstractStorageDecl>(MRE->getMember().getDecl()))
+      if (!member->isSettable(nullptr) || !member->isSetterAccessibleFrom(DC))
+        return {expr, member};
+
+    // If we weren't able to resolve a member or if it is mutable, then the
+    // problem must be with the base, recurse.
+    return resolveImmutableBase(MRE->getBase());
+  }
+
+  if (auto *DRE = dyn_cast<DeclRefExpr>(expr))
+    return {expr, DRE->getDecl()};
+
+  // Look through x!
+  if (auto *FVE = dyn_cast<ForceValueExpr>(expr))
+    return resolveImmutableBase(FVE->getSubExpr());
+
+  // Look through x?
+  if (auto *BOE = dyn_cast<BindOptionalExpr>(expr))
+    return resolveImmutableBase(BOE->getSubExpr());
+
+  // Look through implicit conversions
+  if (auto *ICE = dyn_cast<ImplicitConversionExpr>(expr))
+    if (!isa<LoadExpr>(ICE->getSubExpr()))
+      return resolveImmutableBase(ICE->getSubExpr());
+
+  return {expr, nullptr};
+}
+
+Diag<StringRef> AssignmentFailure::findDeclDiagonstic(ASTContext &ctx,
+                                                      Expr *destExpr) {
+  if (isa<ApplyExpr>(destExpr))
+    return diag::assignment_lhs_is_apply_expression;
+
+  if (isa<DeclRefExpr>(destExpr))
+    return diag::assignment_lhs_is_immutable_variable;
+
+  if (isa<ForceValueExpr>(destExpr))
+    return diag::assignment_bang_has_immutable_subcomponent;
+
+  if (isa<UnresolvedDotExpr>(destExpr) || isa<MemberRefExpr>(destExpr))
+    return diag::assignment_lhs_is_immutable_property;
+
+  if (auto *subscript = dyn_cast<SubscriptExpr>(destExpr)) {
+    auto diagID = diag::assignment_subscript_has_immutable_base;
+    // If the destination is a subscript with a 'dynamicLookup:' label and if
+    // the tuple is implicit, then this was actually a @dynamicMemberLookup
+    // access. Emit a more specific diagnostic.
+    if (subscript->getIndex()->isImplicit() &&
+        subscript->getArgumentLabels().size() == 1 &&
+        subscript->getArgumentLabels().front() == ctx.Id_dynamicMember)
+      diagID = diag::assignment_dynamic_property_has_immutable_base;
+
+    return diagID;
+  }
+
+  return diag::assignment_lhs_is_immutable_variable;
 }

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -19,9 +19,12 @@
 #include "Constraint.h"
 #include "ConstraintSystem.h"
 #include "OverloadChoice.h"
+#include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/Types.h"
+#include "swift/Basic/SourceLoc.h"
 #include "llvm/ADT/ArrayRef.h"
 #include <tuple>
 
@@ -82,6 +85,8 @@ protected:
   TypeChecker &getTypeChecker() const { return CS.TC; }
 
   DeclContext *getDC() const { return CS.DC; }
+
+  ASTContext &getASTContext() const { return CS.getASTContext(); }
 
   Optional<std::pair<Type, ConversionRestrictionKind>>
   restrictionForType(Type type) const {
@@ -439,6 +444,53 @@ public:
       : FailureDiagnostic(nullptr, cs, locator) {}
 
   bool diagnose() override;
+};
+
+/// Diagnose errors related to assignment expressions e.g.
+/// trying to assign something to immutable value, or trying
+/// to access mutating member on immutable base.
+class AssignmentFailure final : public FailureDiagnostic {
+  SourceLoc Loc;
+  Diag<StringRef> DeclDiagnostic;
+  Diag<Type> TypeDiagnostic;
+
+public:
+  AssignmentFailure(Expr *destExpr, ConstraintSystem &cs,
+                    SourceLoc diagnosticLoc);
+
+  AssignmentFailure(Expr *destExpr, ConstraintSystem &cs,
+                    SourceLoc diagnosticLoc, Diag<StringRef> declDiag,
+                    Diag<Type> typeDiag)
+      : FailureDiagnostic(destExpr, cs, cs.getConstraintLocator(destExpr)),
+        Loc(diagnosticLoc), DeclDiagnostic(declDiag), TypeDiagnostic(typeDiag) {
+  }
+
+  bool diagnose() override;
+
+private:
+  void fixItChangeInoutArgType(const Expr *arg, Type actualType,
+                               Type neededType) const;
+
+  /// Given an expression that has a non-lvalue type, dig into it until
+  /// we find the part of the expression that prevents the entire subexpression
+  /// from being mutable.  For example, in a sequence like "x.v.v = 42" we want
+  /// to complain about "x" being a let property if "v.v" are both mutable.
+  ///
+  /// \returns The base subexpression that looks immutable (or that can't be
+  /// analyzed any further) along with a decl extracted from it if we could.
+  std::pair<Expr *, ValueDecl *> resolveImmutableBase(Expr *expr) const;
+
+  static Diag<StringRef> findDeclDiagonstic(ASTContext &ctx, Expr *destExpr);
+
+  static bool isLoadedLValue(Expr *expr) {
+    expr = expr->getSemanticsProvidingExpr();
+    if (isa<LoadExpr>(expr))
+      return true;
+    if (auto ifExpr = dyn_cast<IfExpr>(expr))
+      return isLoadedLValue(ifExpr->getThenExpr()) &&
+             isLoadedLValue(ifExpr->getElseExpr());
+    return false;
+  }
 };
 
 } // end namespace constraints

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1761,11 +1761,6 @@ public:
   /// \c viable[0] contains the resulting solution. Otherwise, emits a
   /// diagnostic and returns true.
   bool salvage(SmallVectorImpl<Solution> &viable, Expr *expr);
-
-  /// When an assignment to an expression is detected and the destination is
-  /// invalid, emit a detailed error about the condition.
-  void diagnoseAssignmentFailure(Expr *dest, Type destTy, SourceLoc equalLoc);
-
   
   /// \brief Mine the active and inactive constraints in the constraint
   /// system to generate a plausible diagnosis of why the system could not be

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -17,6 +17,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "ConstraintSystem.h"
+#include "CSDiagnostics.h"
 #include "MiscDiagnostics.h"
 #include "TypeChecker.h"
 #include "TypeCheckType.h"
@@ -2717,7 +2718,8 @@ Type ConstraintSystem::computeAssignDestType(Expr *dest, SourceLoc equalLoc) {
   }
 
   // Otherwise, it is a structural problem, diagnose that.
-  diagnoseAssignmentFailure(dest, destTy, equalLoc);
+  AssignmentFailure failure(dest, *this, equalLoc);
+  (void)failure.diagnose();
   return Type();
 }
 


### PR DESCRIPTION
Merge logic from `diagnoseAssignmentFailure` and `diagnoseSubElementFailure`
into new `AssignmentFailure`, together with their support functions, which
decouples `CSDiagnostics` from `CSDiag` and scrubs latter from some functionality.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
