### PR TITLE
[CMake] Make GNU-style response files for long argument lists

### DIFF
--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -455,13 +455,14 @@ function(_compile_swift_files
   # Then we can compile both the object files and the swiftmodule files
   # in parallel in this target for the object file, and ...
 
-  # Windows doesn't support long command line paths, of 8191 chars or over.
-  # We need to work around this by avoiding long command line arguments. This can be
-  # achieved by writing the list of file paths to a file, then reading that list
-  # in the Python script.
+  # Windows doesn't support long command line paths, of 8191 chars or over. We
+  # need to work around this by avoiding long command line arguments. This can
+  # be achieved by writing the list of file paths to a file, then reading that
+  # list in the Python script.
   string(RANDOM file_name)
   set(file_path "${CMAKE_CURRENT_BINARY_DIR}/${file_name}.txt")
-  file(WRITE "${file_path}" "${source_files}")
+  string(REPLACE ";" "'\n'" source_files_quoted "${source_files}")
+  file(WRITE "${file_path}" "'${source_files_quoted}'")
   
   add_custom_command_target(
       dependency_target

--- a/utils/line-directive
+++ b/utils/line-directive
@@ -21,6 +21,7 @@ from __future__ import print_function
 import bisect
 import os
 import re
+import shlex
 import subprocess
 import sys
 
@@ -178,7 +179,11 @@ def map_line_from_source_file(source_filename, source_line_num,
 
 def read_response_file(file_path):
     with open(file_path, 'r') as files:
-        return filter(None, files.read().split(';'))
+        # "Make an iterator out of shlex.shlex.get_token, then consume items
+        # until it returns None." (Then eagerly convert the result to a list so
+        # that we can close the file.)
+        return list(iter(shlex.shlex(files, file_path, posix=True).get_token,
+                         None))
 
 
 def expand_response_files(files):


### PR DESCRIPTION
...i.e. an actual shell-like argument list, rather than a semicolon-separated list (CMake's internal stringification mechanism for lists). Apart from being a little easier to read, this also works directly with the response file support in swiftc itself now (not depending on utils/line-directive).

(It's still not *quite* enough to expand on a command-line, though, since that will escape the quotes. The 'sed' command can get around that: `$(sed "s/'//g" foo.txt)`.)