### PR TITLE
[Standard library] Reintroduce operator declarations for pre/postfix ++/--.

### DIFF
--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -390,6 +390,8 @@ precedencegroup BitwiseShiftPrecedence {
 //===----------------------------------------------------------------------===//
 
 // Standard postfix operators.
+postfix operator ++
+postfix operator --
 postfix operator ...
 
 // Optional<T> unwrapping operator is built into the compiler as a part of
@@ -398,6 +400,8 @@ postfix operator ...
 // postfix operator !
 
 // Standard prefix operators.
+prefix operator ++
+prefix operator --
 prefix operator !
 prefix operator ~
 prefix operator +

--- a/test/Compatibility/operators.swift
+++ b/test/Compatibility/operators.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift -swift-version 4
+
+// expect-no-diagnostics
+
+struct X { }
+
+postfix func ++(x: X) -> X { return x }
+prefix func ++(x: X) -> X { return x }
+postfix func --(x: X) -> X { return x }
+prefix func --(x: X) -> X { return x }


### PR DESCRIPTION
The removal of these operator declarations caused a source
compatibility break, because some Swift code is defining prefix or
postfix ++/-- functions without defining the ++ or --
operators. Reinstate the operator declarations in the standard
library... but not any of the functions.

Fixes rdar://problem/43258773.
