### PR TITLE
[test] Update for remote-run-ing tests on a different macOS

### DIFF
--- a/test/Interpreter/SDK/objc_swift3_deprecated_objc_inference.swift
+++ b/test/Interpreter/SDK/objc_swift3_deprecated_objc_inference.swift
@@ -1,28 +1,28 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -swift-version 4 -Xfrontend -enable-swift3-objc-inference %s -o %t/a.out
 // RUN: %target-run %t/a.out 2>&1 | %FileCheck %s -check-prefix=CHECK_WARNINGS
-// RUN: env SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT=0 SIMCTL_CHILD_SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT=0 %target-run %t/a.out 2>&1 | %FileCheck %s -check-prefix=CHECK_NOTHING
+// RUN: env %env-SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT=0 %target-run %t/a.out 2>&1 | %FileCheck %s -check-prefix=CHECK_NOTHING
 
-// RUN: env SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT=1 SIMCTL_CHILD_SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT=2 %target-run %t/a.out > %t/level1.log 2>&1
+// RUN: env %env-SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT=1 %target-run %t/a.out > %t/level1.log 2>&1
 // RUN: %FileCheck %s -check-prefix=CHECK_WARNINGS < %t/level1.log
 
-// RUN: env SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT=2 SIMCTL_CHILD_SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT=2 %target-run %t/a.out > %t/level2.log 2>&1
+// RUN: env %env-SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT=2 %target-run %t/a.out > %t/level2.log 2>&1
 // RUN: %FileCheck %s -check-prefix=CHECK_WARNINGS < %t/level2.log
 
-// RUN: SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT=3 SIMCTL_CHILD_SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT=3 %target-run %t/a.out -expect-crash > %t/level3.log 2>&1
+// RUN: env %env-SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT=3 %target-run %t/a.out -expect-crash > %t/level3.log 2>&1
 // RUN: %FileCheck %s -check-prefix=CHECK_CRASH < %t/level3.log
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
-// REQUIRES: OS=macosx
 
 import StdlibUnittest
 import Foundation
-import Darwin
 
 var DeprecatedObjCInferenceTestSuite = TestSuite("DeprecatedObjCInferenceTestSuite")
 
 class MyClass : NSObject {
+  // The line numbers of the next two methods are mentioned in the CHECK lines
+  // below. Please keep them as 26 and 27.
   func foo() { }
   class func bar() { }
 }

--- a/test/Interpreter/SDK/object_literals.swift
+++ b/test/Interpreter/SDK/object_literals.swift
@@ -2,7 +2,7 @@
 // RUN: %empty-directory(%t/Test.app/Contents/MacOS)
 // RUN: cp -r %S/Inputs/object_literals-Resources %t/Test.app/Contents/Resources
 // RUN: %target-build-swift %s -o %t/Test.app/Contents/MacOS/main
-// RUN: %target-run %t/Test.app/Contents/MacOS/main
+// RUN: %target-run %t/Test.app/Contents/MacOS/main %t/Test.app/Contents/Resources/*
 
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx

--- a/test/Interpreter/conditional_conformances_modules.swift
+++ b/test/Interpreter/conditional_conformances_modules.swift
@@ -3,7 +3,7 @@
 // RUN: %target-build-swift-dylib(%t/libWithAssoc.%target-dylib-extension) %S/../Inputs/conditional_conformance_with_assoc.swift -module-name WithAssoc -emit-module -emit-module-path %t/WithAssoc.swiftmodule
 // RUN: %target-build-swift-dylib(%t/libSubclass.%target-dylib-extension) %S/../Inputs/conditional_conformance_subclass.swift -module-name Subclass -emit-module -emit-module-path %t/Subclass.swiftmodule
 // RUN: %target-build-swift -I%t -L%t -lBasic -lWithAssoc -lSubclass %s -o %t/conditional_conformances_modules -Xlinker -rpath -Xlinker %t
-// RUN: %target-run %t/conditional_conformances_modules %t/libBasic.%target-dylib-extension %t/libWithAssoc.%target-dylib-extension
+// RUN: %target-run %t/conditional_conformances_modules %t/libBasic.%target-dylib-extension %t/libWithAssoc.%target-dylib-extension %t/libSubclass.%target-dylib-extension
 
 // REQUIRES: executable_test
 // FIXME: seems to fail on 32-bit simulator?

--- a/test/Profiler/coverage_smoke.swift
+++ b/test/Profiler/coverage_smoke.swift
@@ -1,6 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -profile-generate -profile-coverage-mapping -Xfrontend -disable-incremental-llvm-codegen -o %t/main
-// RUN: env LLVM_PROFILE_FILE=%t/default.profraw %target-run %t/main
+
+// This unusual use of 'sh' allows the path of the profraw file to be
+// substituted by %target-run.
+// RUN: %target-run sh -c 'env LLVM_PROFILE_FILE=$1 $2' -- %t/default.profraw %t/main
+
 // RUN: %llvm-profdata merge %t/default.profraw -o %t/default.profdata
 // RUN: %llvm-profdata show %t/default.profdata -function=f_internal | %FileCheck %s --check-prefix=CHECK-INTERNAL
 // RUN: %llvm-profdata show %t/default.profdata -function=f_private | %FileCheck %s --check-prefix=CHECK-PRIVATE
@@ -11,6 +15,7 @@
 // RUN: rm -rf %t
 
 // REQUIRES: profile_runtime
+// REQUIRES: executable_test
 // REQUIRES: OS=macosx
 
 // CHECK-INTERNAL: Functions shown: 1

--- a/test/Profiler/pgo_checked_cast.swift
+++ b/test/Profiler/pgo_checked_cast.swift
@@ -1,7 +1,11 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -profile-generate -Xfrontend -disable-incremental-llvm-codegen -module-name pgo_checked_cast -o %t/main
-// RUN: env LLVM_PROFILE_FILE=%t/default.profraw %target-run %t/main
+
+// This unusual use of 'sh' allows the path of the profraw file to be
+// substituted by %target-run.
+// RUN: %target-run sh -c 'env LLVM_PROFILE_FILE=$1 $2' -- %t/default.profraw %t/main
+
 // RUN: %llvm-profdata merge %t/default.profraw -o %t/default.profdata
 // RUN: %target-swift-frontend %s -Xllvm -sil-full-demangle -profile-use=%t/default.profdata -emit-sorted-sil -emit-sil -module-name pgo_checked_cast -o - | %FileCheck %s --check-prefix=SIL
 // need to lower checked_cast_addr_br(addr) into IR for this
@@ -11,6 +15,7 @@
 // %target-swift-frontend %s -Xllvm -sil-full-demangle -profile-use=%t/default.profdata -O -emit-ir -module-name pgo_checked_cast -o - | %FileCheck %s --check-prefix=IR-OPT
 
 // REQUIRES: profile_runtime
+// REQUIRES: executable_test
 // REQUIRES: OS=macosx
 
 // SIL-LABEL: // pgo_checked_cast.check1<A>(Any, A) -> A

--- a/test/Profiler/pgo_foreach.swift
+++ b/test/Profiler/pgo_foreach.swift
@@ -1,6 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -profile-generate -Xfrontend -disable-incremental-llvm-codegen -module-name pgo_foreach -o %t/main
-// RUN: env LLVM_PROFILE_FILE=%t/default.profraw %target-run %t/main
+
+// This unusual use of 'sh' allows the path of the profraw file to be
+// substituted by %target-run.
+// RUN: %target-run sh -c 'env LLVM_PROFILE_FILE=$1 $2' -- %t/default.profraw %t/main
+
 // RUN: %llvm-profdata merge %t/default.profraw -o %t/default.profdata
 // need to move counts attached to expr for this
 // RUN: %target-swift-frontend %s -Xllvm -sil-full-demangle -profile-use=%t/default.profdata -emit-sorted-sil -emit-sil -module-name pgo_foreach -o - | %FileCheck %s --check-prefix=SIL
@@ -12,6 +16,7 @@
 // %target-swift-frontend %s -Xllvm -sil-full-demangle -profile-use=%t/default.profdata -O -emit-ir -module-name pgo_foreach -o - | %FileCheck %s --check-prefix=IR-OPT
 
 // REQUIRES: profile_runtime
+// REQUIRES: executable_test
 // REQUIRES: OS=macosx
 
 // SIL-LABEL: // pgo_foreach.guessForEach1

--- a/test/Profiler/pgo_guard.swift
+++ b/test/Profiler/pgo_guard.swift
@@ -1,6 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -profile-generate -Xfrontend -disable-incremental-llvm-codegen -module-name pgo_guard -o %t/main
-// RUN: env LLVM_PROFILE_FILE=%t/default.profraw %target-run %t/main
+
+// This unusual use of 'sh' allows the path of the profraw file to be
+// substituted by %target-run.
+// RUN: %target-run sh -c 'env LLVM_PROFILE_FILE=$1 $2' -- %t/default.profraw %t/main
+
 // RUN: %llvm-profdata merge %t/default.profraw -o %t/default.profdata
 // RUN: %target-swift-frontend %s -Xllvm -sil-full-demangle -profile-use=%t/default.profdata -emit-sorted-sil -emit-sil -module-name pgo_guard -o - | %FileCheck %s --check-prefix=SIL
 // RUN: %target-swift-frontend %s -Xllvm -sil-full-demangle -profile-use=%t/default.profdata -emit-ir -module-name pgo_guard -o - | %FileCheck %s --check-prefix=IR
@@ -8,6 +12,7 @@
 // RUN: %target-swift-frontend %s -Xllvm -sil-full-demangle -profile-use=%t/default.profdata -O -emit-ir -module-name pgo_guard -o - | %FileCheck %s --check-prefix=IR-OPT
 
 // REQUIRES: profile_runtime
+// REQUIRES: executable_test
 // REQUIRES: OS=macosx
 
 // SIL-LABEL: // pgo_guard.guess1

--- a/test/Profiler/pgo_if.swift
+++ b/test/Profiler/pgo_if.swift
@@ -1,6 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -profile-generate -Xfrontend -disable-incremental-llvm-codegen -module-name pgo_if -o %t/main
-// RUN: env LLVM_PROFILE_FILE=%t/default.profraw %target-run %t/main
+
+// This unusual use of 'sh' allows the path of the profraw file to be
+// substituted by %target-run.
+// RUN: %target-run sh -c 'env LLVM_PROFILE_FILE=$1 $2' -- %t/default.profraw %t/main
+
 // RUN: %llvm-profdata merge %t/default.profraw -o %t/default.profdata
 // RUN: %target-swift-frontend %s -Xllvm -sil-full-demangle -profile-use=%t/default.profdata -emit-sorted-sil -emit-sil -module-name pgo_if -o - | %FileCheck %s --check-prefix=SIL
 // RUN: %target-swift-frontend %s -Xllvm -sil-full-demangle -profile-use=%t/default.profdata -emit-ir -module-name pgo_if -o - | %FileCheck %s --check-prefix=IR
@@ -9,6 +13,7 @@
 
 // REQUIRES: profile_runtime
 // REQUIRES: OS=macosx
+// REQUIRES: executable_test
 
 // SIL-LABEL: // pgo_if.guess1
 // SIL-LABEL: sil @$S6pgo_if6guess11xs5Int32VAE_tF : $@convention(thin) (Int32) -> Int32 !function_entry_count(5001) {

--- a/test/Profiler/pgo_repeatwhile.swift
+++ b/test/Profiler/pgo_repeatwhile.swift
@@ -1,6 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -profile-generate -Xfrontend -disable-incremental-llvm-codegen -module-name pgo_repeatwhile -o %t/main
-// RUN: env LLVM_PROFILE_FILE=%t/default.profraw %target-run %t/main
+
+// This unusual use of 'sh' allows the path of the profraw file to be
+// substituted by %target-run.
+// RUN: %target-run sh -c 'env LLVM_PROFILE_FILE=$1 $2' -- %t/default.profraw %t/main
+
 // RUN: %llvm-profdata merge %t/default.profraw -o %t/default.profdata
 // RUN: %target-swift-frontend %s -Xllvm -sil-full-demangle -profile-use=%t/default.profdata -emit-sorted-sil -emit-sil -module-name pgo_repeatwhile -o - | %FileCheck %s --check-prefix=SIL
 // RUN: %target-swift-frontend %s -Xllvm -sil-full-demangle -profile-use=%t/default.profdata -emit-ir -module-name pgo_repeatwhile -o - | %FileCheck %s --check-prefix=IR
@@ -9,6 +13,7 @@
 // %target-swift-frontend %s -Xllvm -sil-full-demangle -profile-use=%t/default.profdata -O -emit-ir -module-name pgo_repeatwhile -o - | %FileCheck %s --check-prefix=IR-OPT
 
 // REQUIRES: profile_runtime
+// REQUIRES: executable_test
 // REQUIRES: OS=macosx
 
 // SIL-LABEL: // pgo_repeatwhile.guessWhile

--- a/test/Profiler/pgo_switchenum.swift
+++ b/test/Profiler/pgo_switchenum.swift
@@ -1,7 +1,11 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -Xfrontend -enable-sil-ownership -profile-generate -Xfrontend -disable-incremental-llvm-codegen -module-name pgo_switchenum -o %t/main
-// RUN: env LLVM_PROFILE_FILE=%t/default.profraw %target-run %t/main
+
+// This unusual use of 'sh' allows the path of the profraw file to be
+// substituted by %target-run.
+// RUN: %target-run sh -c 'env LLVM_PROFILE_FILE=$1 $2' -- %t/default.profraw %t/main
+
 // RUN: %llvm-profdata merge %t/default.profraw -o %t/default.profdata
 // need to move counts attached to expr for this
 // RUN: %target-swift-frontend %s -Xllvm -sil-full-demangle -profile-use=%t/default.profdata -enable-sil-ownership -emit-sorted-sil -emit-sil -module-name pgo_switchenum -o - | %FileCheck %s --check-prefix=SIL
@@ -13,6 +17,7 @@
 // %target-swift-frontend -enable-sil-ownership %s -Xllvm -sil-full-demangle -profile-use=%t/default.profdata -O -emit-ir -module-name pgo_switchenum -o - | %FileCheck %s --check-prefix=IR-OPT
 
 // REQUIRES: profile_runtime
+// REQUIRES: executable_test
 // REQUIRES: OS=macosx
 
 public enum MaybePair {

--- a/test/Profiler/pgo_while.swift
+++ b/test/Profiler/pgo_while.swift
@@ -1,6 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -profile-generate -Xfrontend -disable-incremental-llvm-codegen -module-name pgo_while -o %t/main
-// RUN: env LLVM_PROFILE_FILE=%t/default.profraw %target-run %t/main
+
+// This unusual use of 'sh' allows the path of the profraw file to be
+// substituted by %target-run.
+// RUN: %target-run sh -c 'env LLVM_PROFILE_FILE=$1 $2' -- %t/default.profraw %t/main
+
 // RUN: %llvm-profdata merge %t/default.profraw -o %t/default.profdata
 // RUN: %target-swift-frontend %s -Xllvm -sil-full-demangle -profile-use=%t/default.profdata -emit-sorted-sil -emit-sil -module-name pgo_while -o - | %FileCheck %s --check-prefix=SIL
 // RUN: %target-swift-frontend %s -Xllvm -sil-full-demangle -profile-use=%t/default.profdata -emit-ir -module-name pgo_while -o - | %FileCheck %s --check-prefix=IR
@@ -9,6 +13,7 @@
 // %target-swift-frontend %s -Xllvm -sil-full-demangle -profile-use=%t/default.profdata -O -emit-ir -module-name pgo_while -o - | %FileCheck %s --check-prefix=IR-OPT
 
 // REQUIRES: profile_runtime
+// REQUIRES: executable_test
 // REQUIRES: OS=macosx
 
 // SIL-LABEL: // pgo_while.guessWhile

--- a/test/SILOptimizer/pgo_si_inlinelarge.swift
+++ b/test/SILOptimizer/pgo_si_inlinelarge.swift
@@ -1,11 +1,16 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -profile-generate -Xfrontend -disable-incremental-llvm-codegen -module-name pgo_si_inlinelarge -o %t/main
-// RUN: env LLVM_PROFILE_FILE=%t/default.profraw %target-run %t/main
+
+// This unusual use of 'sh' allows the path of the profraw file to be
+// substituted by %target-run.
+// RUN: %target-run sh -c 'env LLVM_PROFILE_FILE=$1 $2' -- %t/default.profraw %t/main
+
 // RUN: %llvm-profdata merge %t/default.profraw -o %t/default.profdata
 // RUN: %target-swift-frontend %s -profile-use=%t/default.profdata -emit-sorted-sil -emit-sil -module-name pgo_si_inlinelarge -o - | %FileCheck %s --check-prefix=SIL
 // RUN: %target-swift-frontend %s -profile-use=%t/default.profdata -O -emit-sorted-sil -emit-sil -module-name pgo_si_inlinelarge -o - | %FileCheck %s --check-prefix=SIL-OPT
 
 // REQUIRES: profile_runtime
+// REQUIRES: executable_test
 // REQUIRES: OS=macosx
 
 public func bar(_ x: Int64) -> Int64 {

--- a/test/SILOptimizer/pgo_si_reduce.swift
+++ b/test/SILOptimizer/pgo_si_reduce.swift
@@ -1,11 +1,16 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -profile-generate -Xfrontend -disable-incremental-llvm-codegen -module-name pgo_si_reduce -o %t/main
-// RUN: env LLVM_PROFILE_FILE=%t/default.profraw %target-run %t/main
+
+// This unusual use of 'sh' allows the path of the profraw file to be
+// substituted by %target-run.
+// RUN: %target-run sh -c 'env LLVM_PROFILE_FILE=$1 $2' -- %t/default.profraw %t/main
+
 // RUN: %llvm-profdata merge %t/default.profraw -o %t/default.profdata
 // RUN: %target-swift-frontend %s -profile-use=%t/default.profdata -emit-sorted-sil -emit-sil -module-name pgo_si_reduce -o - | %FileCheck %s --check-prefix=SIL
 // RUN: %target-swift-frontend %s -profile-use=%t/default.profdata -O -emit-sorted-sil -emit-sil -module-name pgo_si_reduce -o - | %FileCheck %s --check-prefix=SIL-OPT
 
 // REQUIRES: profile_runtime
+// REQUIRES: executable_test
 // REQUIRES: OS=macosx
 
 public func bar(_ x: Int32) -> Int32 {

--- a/test/Sanitizers/sanitizer_coverage.swift
+++ b/test/Sanitizers/sanitizer_coverage.swift
@@ -8,6 +8,7 @@
 // REQUIRES: asan_runtime
 // For now restrict this test to platforms where we know this test will pass
 // REQUIRES: CPU=x86_64
+// UNSUPPORTED: remote_run
 
 // XFAIL: linux
 

--- a/test/SwiftSyntax/DiagnosticTest.swift
+++ b/test/SwiftSyntax/DiagnosticTest.swift
@@ -2,6 +2,7 @@
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx
 // REQUIRES: objc_interop
+// UNSUPPORTED: remote_run
 
 import Foundation
 import StdlibUnittest

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -962,31 +962,39 @@ if (not getattr(config, 'target_run', None) and
         lit_config.note(
             "Uploading dylibs to {0} on {1}".format(remote_lib_dir,
                                                     remote_run_host))
-        sdk_lib_dir = os.path.join(test_resource_dir, config.target_sdk_name)
-        glob_pattern = os.path.join(sdk_lib_dir,
-                                    '*.' + config.target_dylib_extension)
-        libs = glob.glob(glob_pattern)
-        subprocess.check_call(
-            [
-                os.path.join(config.swift_utils, 'remote-run'),
-                '--remote-dir', remote_tmp_dir,
-                '--input-prefix', sdk_lib_dir,
-                '--remote-input-prefix', 'stdlib/'
-            ] + remote_run_extra_args + [
-                remote_run_host,
-                '--',
-                'true' # A dummy command that ignores its arguments.
-            ] + libs)
+        def upload_dylibs(dylib_dir):
+            glob_pattern = os.path.join(dylib_dir,
+                                        '*.' + config.target_dylib_extension)
+            libs = glob.glob(glob_pattern)
+            subprocess.check_call(
+                [
+                    os.path.join(config.swift_utils, 'remote-run'),
+                    '--remote-dir', remote_tmp_dir,
+                    '--input-prefix', dylib_dir,
+                    '--remote-input-prefix', 'stdlib/'
+                ] + remote_run_extra_args + [
+                    remote_run_host,
+                    '--',
+                    'true' # A dummy command that ignores its arguments.
+                ] + libs)
+        upload_dylibs(os.path.join(test_resource_dir, config.target_sdk_name))
+        # FIXME: This could be more principled.
+        upload_dylibs(os.path.join(test_resource_dir, "clang", "lib", "darwin"))
+        upload_dylibs(os.path.join(test_resource_dir, "clang", "lib", "linux"))
 
     config.target_run = (
         "/usr/bin/env "
         "REMOTE_RUN_CHILD_DYLD_LIBRARY_PATH='{0}' " # Apple option
         "REMOTE_RUN_CHILD_LD_LIBRARY_PATH='{0}' " # Linux option
-        "%utils/remote-run --input-prefix %S --output-prefix %t "
-        "--remote-dir '{1}'%t {2} {3}".format(remote_lib_dir, remote_tmp_dir,
+        "'{1}'/remote-run --input-prefix '{2}' --output-prefix %t "
+        "--remote-dir '{3}'%t {4} {5}".format(remote_lib_dir,
+                                              config.swift_utils,
+                                              config.swift_src_root,
+                                              remote_tmp_dir,
                                               ' '.join(remote_run_extra_args),
                                               remote_run_host))
     TARGET_ENV_PREFIX = 'REMOTE_RUN_CHILD_'
+    config.available_features.add('remote_run')
 
 config.substitutions.append(('%env-', TARGET_ENV_PREFIX))
 config.substitutions.append(("%target-sdk-name", config.target_sdk_name))

--- a/test/stdlib/StringBridge.swift
+++ b/test/stdlib/StringBridge.swift
@@ -40,7 +40,7 @@ func expectCocoa(_ str: String,
 }
 
 StringBridgeTests.test("Tagged NSString") {
-  guard #available(iOS 11.0, *) else { return }
+  guard #available(macOS 10.13, iOS 11.0, tvOS 11.0, *) else { return }
 #if arch(i386) || arch(arm)
 #else
   // Bridge tagged strings as small

--- a/utils/rth
+++ b/utils/rth
@@ -12,6 +12,7 @@
 from __future__ import print_function
 
 import argparse
+import glob
 import os
 import pipes
 import shlex
@@ -164,7 +165,8 @@ class ResilienceTest(object):
             config2_lower = config2.lower()
             output_obj = os.path.join(self.tmp_dir,
                                       config1_lower + '_' + config2_lower)
-            command = self.target_run + [output_obj, self.tmp_dir]
+            tmp_dir_contents = glob.glob(os.path.join(self.tmp_dir, '*', '*'))
+            command = self.target_run + [output_obj] + tmp_dir_contents
             verbose_print_command(command)
             returncode = subprocess.call(command)
             assert returncode == 0, str(command)

--- a/validation-test/Reflection/existentials.swift
+++ b/validation-test/Reflection/existentials.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/existentials
 // RUN: %target-codesign %t/existentials
-// RUN: %target-run %target-swift-reflection-test %t/existentials | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/existentials | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 

--- a/validation-test/Reflection/functions.swift
+++ b/validation-test/Reflection/functions.swift
@@ -1,7 +1,11 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/functions
 // RUN: %target-codesign %t/functions
-// RUN: %target-run %target-swift-reflection-test %t/functions | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/functions | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 // FIXME: Should not require objc_interop -- please put Objective-C-specific
 // testcases in functions_objc.swift

--- a/validation-test/Reflection/functions_objc.swift
+++ b/validation-test/Reflection/functions_objc.swift
@@ -1,7 +1,13 @@
 // RUN: %empty-directory(%t)
+
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/functions
 // RUN: %target-codesign %t/functions
-// RUN: %target-run %target-swift-reflection-test %t/functions | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/functions | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 

--- a/validation-test/Reflection/inherits_NSObject.swift
+++ b/validation-test/Reflection/inherits_NSObject.swift
@@ -1,7 +1,11 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/inherits_NSObject
 // RUN: %target-codesign %t/inherits_NSObject
-// RUN: %target-run %target-swift-reflection-test %t/inherits_NSObject | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/inherits_NSObject | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test

--- a/validation-test/Reflection/inherits_ObjCClasses.swift
+++ b/validation-test/Reflection/inherits_ObjCClasses.swift
@@ -3,7 +3,12 @@
 // RUN: %clang %target-cc-options -isysroot %sdk -fobjc-arc %S/Inputs/ObjCClasses/ObjCClasses.m -c -o %t/ObjCClasses.o
 // RUN: %target-build-swift -I %S/Inputs/ObjCClasses/ -lswiftSwiftReflectionTest %t/ObjCClasses.o %s -o %t/inherits_ObjCClasses
 // RUN: %target-codesign %t/inherits_ObjCClasses
-// RUN: %target-run %target-swift-reflection-test %t/inherits_ObjCClasses | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/inherits_ObjCClasses | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test

--- a/validation-test/Reflection/inherits_Swift.swift
+++ b/validation-test/Reflection/inherits_Swift.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/inherits_Swift
 // RUN: %target-codesign %t/inherits_Swift
-// RUN: %target-run %target-swift-reflection-test %t/inherits_Swift | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/inherits_Swift | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test

--- a/validation-test/Reflection/reflect_Array.swift
+++ b/validation-test/Reflection/reflect_Array.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Array
 // RUN: %target-codesign %t/reflect_Array
-// RUN: %target-run %target-swift-reflection-test %t/reflect_Array 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/reflect_Array | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 

--- a/validation-test/Reflection/reflect_Bool.swift
+++ b/validation-test/Reflection/reflect_Bool.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Bool
 // RUN: %target-codesign %t/reflect_Bool
-// RUN: %target-run %target-swift-reflection-test %t/reflect_Bool 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/reflect_Bool | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 

--- a/validation-test/Reflection/reflect_Character.swift
+++ b/validation-test/Reflection/reflect_Character.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Character
 // RUN: %target-codesign %t/reflect_Character
-// RUN: %target-run %target-swift-reflection-test %t/reflect_Character 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/reflect_Character | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 

--- a/validation-test/Reflection/reflect_Dictionary.swift
+++ b/validation-test/Reflection/reflect_Dictionary.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Dictionary
 // RUN: %target-codesign %t/reflect_Dictionary
-// RUN: %target-run %target-swift-reflection-test %t/reflect_Dictionary 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/reflect_Dictionary | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 

--- a/validation-test/Reflection/reflect_Double.swift
+++ b/validation-test/Reflection/reflect_Double.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Double
 // RUN: %target-codesign %t/reflect_Double
-// RUN: %target-run %target-swift-reflection-test %t/reflect_Double 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/reflect_Double | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 

--- a/validation-test/Reflection/reflect_Float.swift
+++ b/validation-test/Reflection/reflect_Float.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Float
 // RUN: %target-codesign %t/reflect_Float
-// RUN: %target-run %target-swift-reflection-test %t/reflect_Float 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/reflect_Float | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 

--- a/validation-test/Reflection/reflect_Int.swift
+++ b/validation-test/Reflection/reflect_Int.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Int
 // RUN: %target-codesign %t/reflect_Int
-// RUN: %target-run %target-swift-reflection-test %t/reflect_Int 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/reflect_Int | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 

--- a/validation-test/Reflection/reflect_Int16.swift
+++ b/validation-test/Reflection/reflect_Int16.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Int16
 // RUN: %target-codesign %t/reflect_Int16
-// RUN: %target-run %target-swift-reflection-test %t/reflect_Int16 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/reflect_Int16 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 

--- a/validation-test/Reflection/reflect_Int32.swift
+++ b/validation-test/Reflection/reflect_Int32.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Int32
 // RUN: %target-codesign %t/reflect_Int32
-// RUN: %target-run %target-swift-reflection-test %t/reflect_Int32 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/reflect_Int32 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 

--- a/validation-test/Reflection/reflect_Int64.swift
+++ b/validation-test/Reflection/reflect_Int64.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Int64
 // RUN: %target-codesign %t/reflect_Int64
-// RUN: %target-run %target-swift-reflection-test %t/reflect_Int64 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/reflect_Int64 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 

--- a/validation-test/Reflection/reflect_Int8.swift
+++ b/validation-test/Reflection/reflect_Int8.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Int8
 // RUN: %target-codesign %t/reflect_Int8
-// RUN: %target-run %target-swift-reflection-test %t/reflect_Int8 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/reflect_Int8 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 

--- a/validation-test/Reflection/reflect_NSArray.swift
+++ b/validation-test/Reflection/reflect_NSArray.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_NSArray
 // RUN: %target-codesign %t/reflect_NSArray
-// RUN: %target-run %target-swift-reflection-test %t/reflect_NSArray 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/reflect_NSArray | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 

--- a/validation-test/Reflection/reflect_NSNumber.swift
+++ b/validation-test/Reflection/reflect_NSNumber.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_NSNumber
 // RUN: %target-codesign %t/reflect_NSNumber
-// RUN: %target-run %target-swift-reflection-test %t/reflect_NSNumber 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/reflect_NSNumber | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 

--- a/validation-test/Reflection/reflect_NSSet.swift
+++ b/validation-test/Reflection/reflect_NSSet.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_NSSet
 // RUN: %target-codesign %t/reflect_NSSet
-// RUN: %target-run %target-swift-reflection-test %t/reflect_NSSet 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/reflect_NSSet | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 

--- a/validation-test/Reflection/reflect_NSString.swift
+++ b/validation-test/Reflection/reflect_NSString.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_NSString
 // RUN: %target-codesign %t/reflect_NSString
-// RUN: %target-run %target-swift-reflection-test %t/reflect_NSString 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/reflect_NSString | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 

--- a/validation-test/Reflection/reflect_Set.swift
+++ b/validation-test/Reflection/reflect_Set.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Set
 // RUN: %target-codesign %t/reflect_Set
-// RUN: %target-run %target-swift-reflection-test %t/reflect_Set 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/reflect_Set | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 

--- a/validation-test/Reflection/reflect_String.swift
+++ b/validation-test/Reflection/reflect_String.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_String
 // RUN: %target-codesign %t/reflect_String
-// RUN: %target-run %target-swift-reflection-test %t/reflect_String 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/reflect_String | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 

--- a/validation-test/Reflection/reflect_UInt.swift
+++ b/validation-test/Reflection/reflect_UInt.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_UInt
 // RUN: %target-codesign %t/reflect_UInt
-// RUN: %target-run %target-swift-reflection-test %t/reflect_UInt 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/reflect_UInt | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 

--- a/validation-test/Reflection/reflect_UInt16.swift
+++ b/validation-test/Reflection/reflect_UInt16.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_UInt16
 // RUN: %target-codesign %t/reflect_UInt16
-// RUN: %target-run %target-swift-reflection-test %t/reflect_UInt16 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/reflect_UInt16 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 

--- a/validation-test/Reflection/reflect_UInt32.swift
+++ b/validation-test/Reflection/reflect_UInt32.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_UInt32
 // RUN: %target-codesign %t/reflect_UInt32
-// RUN: %target-run %target-swift-reflection-test %t/reflect_UInt32 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/reflect_UInt32 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 

--- a/validation-test/Reflection/reflect_UInt64.swift
+++ b/validation-test/Reflection/reflect_UInt64.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_UInt64
 // RUN: %target-codesign %t/reflect_UInt64
-// RUN: %target-run %target-swift-reflection-test %t/reflect_UInt64 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/reflect_UInt64 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 

--- a/validation-test/Reflection/reflect_UInt8.swift
+++ b/validation-test/Reflection/reflect_UInt8.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_UInt8
 // RUN: %target-codesign %t/reflect_UInt8
-// RUN: %target-run %target-swift-reflection-test %t/reflect_UInt8 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/reflect_UInt8 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 

--- a/validation-test/Reflection/reflect_empty_class.swift
+++ b/validation-test/Reflection/reflect_empty_class.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_empty_class
 // RUN: %target-codesign %t/reflect_empty_class
-// RUN: %target-run %target-swift-reflection-test %t/reflect_empty_class 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/reflect_empty_class | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 

--- a/validation-test/Reflection/reflect_existential.swift
+++ b/validation-test/Reflection/reflect_existential.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_existential
 // RUN: %target-codesign %t/reflect_existential
-// RUN: %target-run %target-swift-reflection-test %t/reflect_existential 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/reflect_existential | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 

--- a/validation-test/Reflection/reflect_multiple_types.swift
+++ b/validation-test/Reflection/reflect_multiple_types.swift
@@ -1,7 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_multiple_types
 // RUN: %target-codesign %t/reflect_multiple_types
-// RUN: %target-run %target-swift-reflection-test %t/reflect_multiple_types 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// Link %target-swift-reflection-test into %t to convince %target-run to copy
+// it.
+// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
+// RUN: %target-run %t/swift-reflection-test %t/reflect_multiple_types | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 

--- a/validation-test/execution/dsohandle-multi-module.swift
+++ b/validation-test/execution/dsohandle-multi-module.swift
@@ -1,13 +1,14 @@
 // RUN: %empty-directory(%t)
 
-// RUN: (cd %t && %target-build-swift %S/Inputs/dsohandle-first.swift -emit-library -emit-module -module-name first)
-// RUN: (cd %t && %target-build-swift %S/Inputs/dsohandle-second.swift -emit-library -emit-module -module-name second)
+// RUN: (cd %t && %target-build-swift %S/Inputs/dsohandle-first.swift -emit-library -emit-module -module-name first -Xlinker -install_name -Xlinker '@executable_path/libfirst.dylib')
+// RUN: (cd %t && %target-build-swift %S/Inputs/dsohandle-second.swift -emit-library -emit-module -module-name second -Xlinker -install_name -Xlinker '@executable_path/libsecond.dylib')
 // RUN: %target-build-swift -I %t -L %t -lfirst -lsecond %s -o %t/main
-// RUN: env LD_LIBRARY_PATH=%t DYLD_LIBRARY_PATH=%t %target-run %t/main
+// RUN: %target-codesign %t/main %t/libfirst.%target-dylib-extension %t/libsecond.%target-dylib-extension
+// RUN: %target-run %t/main %t/libfirst.%target-dylib-extension %t/libsecond.%target-dylib-extension
+
 // REQUIRES: executable_test
 
-// rdar://problem/27620565
-// REQUIRES: OS=macosx
+// UNSUPPORTED: linux
 
 import first
 import second

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -908,7 +908,7 @@ StringTests.test("stringGutsReserve")
   .skip(.nativeRuntime("Foundation dependency"))
   .code {
 #if _runtime(_ObjC)
-  guard #available(iOS 11.0, *) else { return }
+  guard #available(macOS 10.13, iOS 11.0, tvOS 11.0, *) else { return }
   for k in 0...7 {
     var base: String
     var startedNative: Bool

--- a/validation-test/stdlib/XCTest.swift
+++ b/validation-test/stdlib/XCTest.swift
@@ -6,6 +6,7 @@
 
 // FIXME: Add a feature for "platforms that support XCTest".
 // REQUIRES: OS=macosx
+// UNSUPPORTED: remote_run
 
 import StdlibUnittest
 


### PR DESCRIPTION
Most of this is just "remember to specify the inputs and outputs on the command line, so remote-run can see them". A bit is "prefix environment variables with '%env-'". And the last few are "yeah, this was never going to work in a remote environment".

In the few cases where I couldn't think of anything reasonable, I just marked the test as "UNSUPPORTED: remote_run", a new "feature".