### PR TITLE
switch Dataset.swift to use unknown rank (SR-8632)

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -1112,6 +1112,8 @@ static int decodeShapeAttr(const ASTContext &ctx,
     attr = attr.getEnumPayloadValue();
   }
 
+  attr = attr.lookThroughSingleElementAggregates();
+
   CanType eltType;
   auto arrayValue = attr.getArrayValue(eltType);
   for (auto elt : arrayValue) {

--- a/test/TensorFlow/shape_lowering/implicit_shape_attr.swift
+++ b/test/TensorFlow/shape_lowering/implicit_shape_attr.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s
+// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
+
+// These tests are in separate files because functions appear in the GraphDef
+// in nondeterministic order.
+
+import TensorFlow
+
+public func test() {
+  let _ = Tensor<Float>([1, 2, 3])
+}
+
+// CHECK-LABEL: tensor_shape {
+// CHECK-NEXT: dim {
+// CHECK-NEXT:   size: 3
+// CHECK-NEXT: }

--- a/test/TensorFlow/shape_lowering/shape_rank0.swift
+++ b/test/TensorFlow/shape_lowering/shape_rank0.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s
+// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
+
+// FIXME: Our graph lowering doesn't handle ops with explicit shape attrs.
+// XFAIL: *
+
+// These tests are in separate files because functions appear in the GraphDef
+// in nondeterministic order.
+
+import TensorFlow
+
+public func test() {
+  let _: TensorHandle<Float> = #tfop("Placeholder",
+                                     dtype: Float.self,
+                                     shape: TensorShape([]))
+}
+
+// CHECK-LABEL: key: "shape"
+// CHECK-NEXT: value {
+// CHECK-NEXT:   list {
+// CHECK-NEXT:     shape {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/test/TensorFlow/shape_lowering/shape_unknownrank.swift
+++ b/test/TensorFlow/shape_lowering/shape_unknownrank.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s
+// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
+
+// FIXME: Our graph lowering doesn't handle ops with explicit shape attrs.
+// XFAIL: *
+
+// These tests are in separate files because functions appear in the GraphDef
+// in nondeterministic order.
+
+import TensorFlow
+
+public func test() {
+  let _: TensorHandle<Float> = #tfop("Placeholder",
+                                     dtype: Float.self,
+                                     shape: nil as TensorShape?)
+}
+
+// CHECK-LABEL: key: "shape"
+// CHECK-NEXT: value {
+// CHECK-NEXT:   list {
+// CHECK-NEXT:     shape {
+// CHECK-NEXT:       unknown_rank: true
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/test/TensorFlow/shape_lowering/shapelist_rank0.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank0.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s
+// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
+
+// These tests are in separate files because functions appear in the GraphDef
+// in nondeterministic order.
+
+import TensorFlow
+
+public func test() {
+  let _: ResourceHandle = #tfop("AnonymousIterator",
+                                output_types: [Float.self],
+                                output_shapes: [TensorShape([])])
+}
+
+// CHECK-LABEL: key: "output_shapes"
+// CHECK-NEXT: value {
+// CHECK-NEXT:   list {
+// CHECK-NEXT:     shape {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/test/TensorFlow/shape_lowering/shapelist_rank1.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank1.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s
+// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
+
+// These tests are in separate files because functions appear in the GraphDef
+// in nondeterministic order.
+
+import TensorFlow
+
+public func test() {
+  let _: ResourceHandle = #tfop("AnonymousIterator",
+                                output_types: [Float.self],
+                                output_shapes: [TensorShape([1])])
+
+}
+
+// CHECK-LABEL: key: "output_shapes"
+// CHECK-NEXT: value {
+// CHECK-NEXT:   list {
+// CHECK-NEXT:     shape {
+// CHECK-NEXT:       dim {
+// CHECK-NEXT:         size: 1
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/test/TensorFlow/shape_lowering/shapelist_rank1_rank1.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank1_rank1.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s
+// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
+
+// These tests are in separate files because functions appear in the GraphDef
+// in nondeterministic order.
+
+import TensorFlow
+
+public func test() {
+  let _: ResourceHandle = #tfop("AnonymousIterator",
+                                output_types: [Float.self],
+                                output_shapes: [TensorShape([1]),
+                                                TensorShape([1])])
+
+}
+
+// CHECK-LABEL: key: "output_shapes"
+// CHECK-NEXT: value {
+// CHECK-NEXT:   list {
+// CHECK-NEXT:     shape {
+// CHECK-NEXT:       dim {
+// CHECK-NEXT:         size: 1
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:     shape {
+// CHECK-NEXT:       dim {
+// CHECK-NEXT:         size: 1
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/test/TensorFlow/shape_lowering/shapelist_rank3.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank3.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s
+// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
+
+// These tests are in separate files because functions appear in the GraphDef
+// in nondeterministic order.
+
+import TensorFlow
+
+public func test() {
+  let _: ResourceHandle = #tfop("AnonymousIterator",
+                                output_types: [Float.self],
+                                output_shapes: [TensorShape([1, 2, 3])])
+}
+
+// CHECK-LABEL: key: "output_shapes"
+// CHECK-NEXT: value {
+// CHECK-NEXT:   list {
+// CHECK-NEXT:     shape {
+// CHECK-NEXT:       dim {
+// CHECK-NEXT:         size: 1
+// CHECK-NEXT:       }
+// CHECK-NEXT:       dim {
+// CHECK-NEXT:         size: 2
+// CHECK-NEXT:       }
+// CHECK-NEXT:       dim {
+// CHECK-NEXT:         size: 3
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/test/TensorFlow/shape_lowering/shapelist_rank3_withunknowndim.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_rank3_withunknowndim.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s
+// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
+
+// These tests are in separate files because functions appear in the GraphDef
+// in nondeterministic order.
+
+import TensorFlow
+
+public func test() {
+  let _: ResourceHandle = #tfop("AnonymousIterator",
+                                output_types: [Float.self],
+                                output_shapes: [TensorShape([-1, 2, 3])])
+}
+
+// CHECK-LABEL: key: "output_shapes"
+// CHECK-NEXT: value {
+// CHECK-NEXT:   list {
+// CHECK-NEXT:     shape {
+// CHECK-NEXT:       dim {
+// CHECK-NEXT:         size: -1
+// CHECK-NEXT:       }
+// CHECK-NEXT:       dim {
+// CHECK-NEXT:         size: 2
+// CHECK-NEXT:       }
+// CHECK-NEXT:       dim {
+// CHECK-NEXT:         size: 3
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/test/TensorFlow/shape_lowering/shapelist_unknownrank.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_unknownrank.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s
+// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
+
+// These tests are in separate files because functions appear in the GraphDef
+// in nondeterministic order.
+
+import TensorFlow
+
+public func test() {
+  let _: ResourceHandle = #tfop("AnonymousIterator",
+                                output_types: [Float.self],
+                                output_shapes: [nil as TensorShape?])
+}
+
+// CHECK-LABEL: key: "output_shapes"
+// CHECK-NEXT: value {
+// CHECK-NEXT:   list {
+// CHECK-NEXT:     shape {
+// CHECK-NEXT:       unknown_rank: true
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/test/TensorFlow/shape_lowering/shapelist_unknownrank_rank0.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_unknownrank_rank0.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s
+// RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
+
+// FIXME: Constexpr can't figure out the value of the 2nd TensorShape.
+// XFAIL: *
+
+// These tests are in separate files because functions appear in the GraphDef
+// in nondeterministic order.
+
+import TensorFlow
+
+public func test() {
+  let _: ResourceHandle = #tfop("AnonymousIterator",
+                                output_types: [Float.self],
+                                output_shapes: [nil as TensorShape?,
+                                                TensorShape([1])])
+}
+
+// CHECK-LABEL: key: "output_shapes"
+// CHECK-NEXT: value {
+// CHECK-NEXT:   list {
+// CHECK-NEXT:     shape {
+// CHECK-NEXT:       unknown_rank: true
+// CHECK-NEXT:     }
+// CHECK-NEXT:     shape {
+// CHECK-NEXT:       dim {
+// CHECK-NEXT:         size: 1
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/test/TensorFlowRuntime/dataset_1.swift
+++ b/test/TensorFlowRuntime/dataset_1.swift
@@ -40,7 +40,7 @@ public func createMockDataSet() -> VariantHandle {
   let dataset : VariantHandle = #tfop("TensorSliceDataset",
                                       [values],
                                       Toutput_types: [Float.self],
-                                      output_shapes: [TensorShape()])
+                                      output_shapes: [nil as TensorShape?])
   return dataset
 }
 
@@ -53,7 +53,7 @@ func getNextScalarFloatTensor(_ iterator: ResourceHandle) -> Tensor<Float> {
   let ret: TensorHandle<Float> = #tfop("IteratorGetNext",
                                        iterator,
                                        output_types: [Float.self],
-                                       output_shapes: [TensorShape()])
+                                       output_shapes: [nil as TensorShape?])
   return Tensor(handle: ret)
 }
 
@@ -69,7 +69,7 @@ public func model() {
     "OneShotIterator",
     dataset_factory : createMockDataSet,
     output_types: [Float.self],
-    output_shapes: [TensorShape()]
+    output_shapes: [nil as TensorShape?]
   )
 
   let one = getNextScalarFloatTensor(iterator)
@@ -91,7 +91,7 @@ public func model() {
   // let _: TensorHandle<Float> = #tfop("IteratorGetNext",
   //                                    iterator,
   //                                    output_types: [Float.self],
-  //                                    output_shapes: [TensorShape()])
+  //                                    output_shapes: [nil as TensorShape?])
 }
 
 DatasetTests.testAllBackends("Basic") {
@@ -103,7 +103,7 @@ DatasetTests.testAllBackends("MultiValue") {
   let elements1: Tensor<Int32> = [0, 1, 2]
   let elements2: Tensor<Int32> = [10, 11, 12]
   let outputTypes = [Int32.self, Int32.self]
-  let outputShapes: [TensorShape] = [[], []]
+  let outputShapes: [TensorShape?] = [nil, nil]
   let dataset: VariantHandle = #tfop(
     "TensorSliceDataset", [elements1, elements2],
     Toutput_types: outputTypes,

--- a/test/TensorFlowRuntime/dataset_api.swift
+++ b/test/TensorFlowRuntime/dataset_api.swift
@@ -19,7 +19,7 @@ DatasetAPITests.testAllBackends("SingleValueManualIterator") {
   // [[1], [2], [3], [4], [5]]
   let scalars = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1)
     .reshaped(to: [5, 1])
-  let dataset = SingleValueDataset(elements: scalars, elementShape: [1])
+  let dataset = SingleValueDataset(elements: scalars)
   var iterator = dataset.makeIterator()
   var i: Int32 = 0
   while let item = iterator.next() {
@@ -32,7 +32,7 @@ DatasetAPITests.testAllBackends("SingleValueDatasetIteration") {
   // [[1], [2], [3], [4], [5]]
   let scalars = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1)
     .reshaped(to: [5, 1])
-  let dataset = SingleValueDataset(elements: scalars, elementShape: [1])
+  let dataset = SingleValueDataset(elements: scalars)
   var i: Int32 = 0
   for item in dataset {
     expectEqual(scalars[i].array, item.array)
@@ -42,25 +42,36 @@ DatasetAPITests.testAllBackends("SingleValueDatasetIteration") {
 
 DatasetAPITests.testAllBackends("SingleValueTransformations") {
   let scalars = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1)
-  let dataset = SingleValueDataset(elements: scalars, elementShape: [])
+  let dataset = SingleValueDataset(elements: scalars)
   let shuffled = dataset.shuffled(sampleCount: 5, randomSeed: 42)
   expectEqual([0, 4, 1, 3, 2], shuffled.map { $0.scalar! })
 }
 
 DatasetAPITests.testAllBackends("SingleValueHOFs") {
   let scalars = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1)
-  let dataset = SingleValueDataset(elements: scalars, elementShape: [])
+  let dataset = SingleValueDataset(elements: scalars)
   let addedOne: SingleValueDataset = dataset.map { $0 + 1 }
   expectEqual([1, 2, 3, 4, 5], addedOne.flatMap { $0.scalars })
   let evens: SingleValueDataset = dataset.filter { Tensor($0 % 2 == Tensor(0)) }
   expectEqual([0, 2, 4], evens.flatMap { $0.scalars })
 }
 
+DatasetAPITests.testAllBackends("SingleValueBatched") {
+  let scalars = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1)
+  let dataset = SingleValueDataset(elements: scalars)
+  let batched = dataset.batched(2)
+
+  var iterator = batched.makeIterator()
+  expectEqual([0, 1], iterator.next()!.scalars)
+  expectEqual([2, 3], iterator.next()!.scalars)
+  expectEqual([4], iterator.next()!.scalars)
+}
+
 DatasetAPITests.testAllBackends("DoubleValueDatasetIteration") {
   let scalars1 = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1)
   let scalars2 = Tensor<Float>(rangeFrom: 5, to: 10, stride: 1)
-  let datasetLeft = SingleValueDataset(elements: scalars1, elementShape: [])
-  let datasetRight = SingleValueDataset(elements: scalars2, elementShape: [])
+  let datasetLeft = SingleValueDataset(elements: scalars1)
+  let datasetRight = SingleValueDataset(elements: scalars2)
   var i: Int32 = 0
   for (item1, item2) in zip(datasetLeft, datasetRight) {
     expectEqual(scalars1[i].array, item1.array)


### PR DESCRIPTION
It seems to work quite well. Dataset API no longer relies on constexpr!

I discovered a bug in lowering and a bug in constexpr while writing test cases. I included those testcases, with XFAIL, so that someone can fix them later.