### PR TITLE
[ABI] Don't emit overriding associated type declarations into witness tables.

### DIFF
--- a/include/swift/SIL/SILWitnessVisitor.h
+++ b/include/swift/SIL/SILWitnessVisitor.h
@@ -61,7 +61,10 @@ public:
       SmallVector<AssociatedTypeDecl *, 2> associatedTypes;
       for (Decl *member : protocol->getMembers()) {
         if (auto associatedType = dyn_cast<AssociatedTypeDecl>(member)) {
-          associatedTypes.push_back(associatedType);
+          // If this is a new associated type (which does not override an
+          // existing associated type), add it.
+          if (associatedType->getOverriddenDecls().empty())
+            associatedTypes.push_back(associatedType);
         }
       }
 
@@ -70,7 +73,6 @@ public:
                            TypeDecl::compare);
 
       for (auto *associatedType : associatedTypes) {
-        // TODO: only add associated types when they're new?
         asDerived().addAssociatedType(AssociatedType(associatedType));
       }
     };

--- a/test/IRGen/generic_structs.sil
+++ b/test/IRGen/generic_structs.sil
@@ -262,7 +262,7 @@ struct GenericLayoutWithAssocType<T: ParentHasAssociatedType> {
 // CHECK: [[T4:%.*]] = call swiftcc %swift.metadata_response [[T3]](i64 0, %swift.type* %T, i8** [[T1]])
 // CHECK: %T.Assoc = extractvalue %swift.metadata_response [[T4]], 0
 
-// CHECK:   [[T0:%.*]] = getelementptr inbounds i8*, i8** %T.ParentHasAssociatedType, i32 3
+// CHECK:   [[T0:%.*]] = getelementptr inbounds i8*, i8** %T.ParentHasAssociatedType, i32 2
 // CHECK:   [[T1:%.*]] = load i8*, i8** [[T0]],
 // CHECK:   [[T2:%.*]] = bitcast i8* [[T1]] to i8** (%swift.type*, %swift.type*, i8**)*
 // CHECK:   %T.Assoc.HasAssociatedType = call swiftcc i8** [[T2]](%swift.type* %T.Assoc, %swift.type* %T, i8** %T.ParentHasAssociatedType)

--- a/test/SILGen/witnesses_refinement.swift
+++ b/test/SILGen/witnesses_refinement.swift
@@ -13,3 +13,44 @@ extension Int: Saturable {
 // CHECK-NOT: sil_witness_table Int: Equatable module witnesses_refinement { 
 // CHECK-NOT: sil_witness_table Int: Comparable module witnesses_refinement { 
 // CHECK: sil_witness_table hidden Int: Saturable module witnesses_refinement { 
+
+protocol P { }
+
+protocol P0 {
+  associatedtype A
+}
+
+protocol P1 {
+  associatedtype A
+}
+
+protocol P2: P0 {
+  associatedtype A
+}
+
+protocol P3: P2, P1 {
+  associatedtype A: P
+}
+
+struct ConformsToP: P { }
+
+// CHECK-LABEL: sil_witness_table hidden ConformsToP3: P3
+// CHECK:         base_protocol P1
+// CHECK-NEXT:    base_protocol P2
+// CHECK-NEXT:    associated_type_protocol (A: P)
+// CHECK-NEXT:   }
+struct ConformsToP3: P3 {
+  typealias A = ConformsToP
+}
+
+// CHECK-LABEL: sil_witness_table hidden ConformsToP3: P2
+// CHECK:         base_protocol P0
+// CHECK-NEXT:   }
+
+// CHECK-LABEL: sil_witness_table hidden ConformsToP3: P1
+// CHECK:         associated_type A: ConformsToP
+// CHECK-NEXT:   }
+
+// CHECK-LABEL: sil_witness_table hidden ConformsToP3: P0
+// CHECK:         associated_type A: ConformsToP
+// CHECK-NEXT:   }


### PR DESCRIPTION
When an associated type defined in a given protocol has the same name as
an associated type in an inherited protocol, it is always equivalent to
the "overridden" associated type. Don't emit a new entry in the
witness table for the overriding associated type.

Saves ~68k of binary size in the standard library.
