### PR TITLE
[SILGen] force immeidate LValue assignment cleanups.

### DIFF
--- a/test/SILGen/tuples.swift
+++ b/test/SILGen/tuples.swift
@@ -156,3 +156,26 @@ extension P {
     return tuple.value.foo()
   }
 }
+
+// CHECK-LABEL: sil @$S6tuples15testTupleAssign1xySaySiGz_tF : $@convention(thin) (@inout Array<Int>) -> () {
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] %0 : $*Array<Int>
+// function_ref Array.subscript.nativeOwningMutableAddressor
+// CHECK: [[ADDRESSOR:%.*]] = function_ref @$SSayxSiciao : $@convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> (UnsafeMutablePointer<τ_0_0>, @owned Builtin.NativeObject)
+// CHECK: [[TUPLE:%.*]] = apply [[ADDRESSOR]]<Int>(%{{.*}}, [[ACCESS]]) : $@convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> (UnsafeMutablePointer<τ_0_0>, @owned Builtin.NativeObject)
+// CHECK: ([[PTR:%.*]], [[OBJ:%.*]]) = destructure_tuple [[TUPLE]] : $(UnsafeMutablePointer<Int>, Builtin.NativeObject)
+// CHECK: assign %{{.*}} to %{{.*}} : $*Int
+// CHECK: end_access [[ACCESS]] : $*Array<Int>
+// CHECK: destroy_value [[OBJ]] : $Builtin.NativeObject
+//
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] %0 : $*Array<Int>
+// function_ref Array.subscript.nativeOwningMutableAddressor
+// CHECK: [[ADDRESSOR:%.*]] = function_ref @$SSayxSiciao : $@convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> (UnsafeMutablePointer<τ_0_0>, @owned Builtin.NativeObject)
+// CHECK: [[TUPLE:%.*]] = apply [[ADDRESSOR]]<Int>(%{{.*}}, [[ACCESS]]) : $@convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> (UnsafeMutablePointer<τ_0_0>, @owned Builtin.NativeObject)
+// CHECK: ([[PTR:%.*]], [[OBJ:%.*]]) = destructure_tuple [[TUPLE]] : $(UnsafeMutablePointer<Int>, Builtin.NativeObject)
+// CHECK: assign %{{.*}} to %{{.*}} : $*Int
+// CHECK: end_access [[ACCESS]] : $*Array<Int>
+// CHECK: destroy_value [[OBJ]] : $Builtin.NativeObject
+// CHECK-LABEL: } // end sil function '$S6tuples15testTupleAssign1xySaySiGz_tF'
+public func testTupleAssign(x: inout [Int]) {
+  (x[0], x[1]) = (0, 1)
+}


### PR DESCRIPTION
In SILGenFunction::emitAssignToLValue, use an ArgumentScope instead of
a FormalEvaluationScope. This ensures that the lifetime of objects
needed to materialize each LValue component do not overlap.

For example in this tuple assignment:

public func testTupleAssign(x: inout [Int]) {
  (x[0], x[1]) = (0, 1)
}

Array.subscript.nativeOwningMutableAddressor keeps a reference to the
array across the assignment, unnecessarily forcing a copy of the
array.

Fixes SR-8621: SILGen creates destroys for tuple assignment at the
wrong places.
