### PR TITLE
[Stats] Clear all timers on print, since they stopped self-clearing recently.

### DIFF
--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -444,6 +444,7 @@ UnifiedStatsReporter::printAlwaysOnStatsAndTimers(raw_ostream &OS) {
   }
   // Print timers.
   TimerGroup::printAllJSONValues(OS, delim);
+  TimerGroup::clearAll();
   OS << "\n}\n";
   OS.flush();
 }
@@ -664,6 +665,7 @@ UnifiedStatsReporter::~UnifiedStatsReporter()
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_STATS)
   publishAlwaysOnStatsToLLVM();
   PrintStatisticsJSON(ostream);
+  TimerGroup::clearAll();
 #else
   printAlwaysOnStatsAndTimers(ostream);
 #endif

--- a/test/Misc/stats_dir.swift
+++ b/test/Misc/stats_dir.swift
@@ -24,12 +24,15 @@
 // RUN: %{python} %utils/process-stats-dir.py --compare-to-csv-baseline %t/driver.csv %t
 
 // RUN: %target-swiftc_driver -c -o %t/out.o -stats-output-dir %t/this/is/not/a/directory %s 2>&1 | %FileCheck -check-prefix=CHECK-NODIR %s
+// RUN: %target-swiftc_driver -c -o %t/out.o -stats-output-dir %t %s 2>&1 | %FileCheck -allow-empty -check-prefix=CHECK-SILENT %s
 
 // CHECK: {{"AST.NumSourceLines"	[1-9][0-9]*$}}
 // CHECK: {{"IRModule.NumIRFunctions"	[1-9][0-9]*$}}
 // CHECK: {{"LLVM.NumLLVMBytesOutput"	[1-9][0-9]*$}}
 
 // CHECK-NODIR: {{Error opening -stats-output-dir file}}
+
+// CHECK-SILENT-NOT: {{---}}
 
 public func foo() {
     print("hello")


### PR DESCRIPTION
You may have seen giant swathes of timers being printed to stderr in recent logs that gather stats from swiftc. That is because LLVM changed their TimerGroup semantics. This fixes our use thereof.

(see https://reviews.llvm.org/rL339980 for details; relevant LLVM change was cherry-picked over in apple/swift-llvm@3b20ef35078c815907afd9a2881f21ef925fde3a)