### PR TITLE
Generate swiftinterface files next to the stdlib swiftmodules

### DIFF
--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -317,6 +317,7 @@ function(_compile_swift_files
     set(sibopt_file "${module_base}.O.sib")
     set(sibgen_file "${module_base}.sibgen")
     set(module_doc_file "${module_base}.swiftdoc")
+    set(interface_file "${module_base}.swiftinterface")
 
     list(APPEND command_create_dirs
         COMMAND "${CMAKE_COMMAND}" -E make_directory "${module_dir}")
@@ -395,7 +396,7 @@ function(_compile_swift_files
 
   set(standard_outputs ${SWIFTFILE_OUTPUT})
   set(apinotes_outputs ${apinote_files})
-  set(module_outputs "${module_file}" "${module_doc_file}")
+  set(module_outputs "${module_file}" "${module_doc_file}" "${interface_file}")
   set(sib_outputs "${sib_file}")
   set(sibopt_outputs "${sibopt_file}")
   set(sibgen_outputs "${sibgen_file}")
@@ -483,13 +484,14 @@ function(_compile_swift_files
   #
   # 1. *.swiftmodule
   # 2. *.swiftdoc
-  # 3. *.Onone.sib
-  # 4. *.O.sib
-  # 5. *.sibgen
+  # 3. *.swiftinterface
+  # 4. *.Onone.sib
+  # 5. *.O.sib
+  # 6. *.sibgen
   #
-  # Only 1,2 are built by default. 3,4,5 are utility targets for use by engineers
-  # and thus even though the targets are generated, the targets are not built by
-  # default.
+  # Only 1,2,3 are built by default. 4,5,6 are utility targets for use by
+  # engineers and thus even though the targets are generated, the targets are
+  # not built by default.
   #
   # We only build these when we are not producing a main file. We could do this
   # with sib/sibgen, but it is useful for looking at the stdlib.
@@ -501,9 +503,11 @@ function(_compile_swift_files
         COMMAND
           "${CMAKE_COMMAND}" "-E" "remove" "-f" "${module_doc_file}"
         COMMAND
+          "${CMAKE_COMMAND}" "-E" "remove" "-f" "${interface_file}"
+        COMMAND
           "${PYTHON_EXECUTABLE}" "${line_directive_tool}" "@${file_path}" --
-          "${swift_compiler_tool}" "-emit-module" "-o" "${module_file}" ${swift_flags}
-          "@${file_path}"
+          "${swift_compiler_tool}" "-emit-module" "-o" "${module_file}"
+          "-experimental-emit-interface" ${swift_flags} "@${file_path}"
         ${command_touch_module_outputs}
         OUTPUT ${module_outputs}
         DEPENDS

--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -341,6 +341,11 @@ private:
                                       StringRef workingDirectory,
                                       CommandOutput *Output) const;
 
+  void chooseTextualInterfacePath(Compilation &C, const JobAction *JA,
+                                  StringRef workingDirectory,
+                                  llvm::SmallString<128> &buffer,
+                                  CommandOutput *output) const;
+
   void chooseRemappingOutputPath(Compilation &C, const TypeToPathMap *OutputMap,
                                  CommandOutput *Output) const;
 

--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -308,22 +308,19 @@ public:
   ///
   /// \param C The Compilation which this Job will eventually be part of
   /// \param JA The Action for which a Job should be created
-  /// \param OI The OutputInfo for which a Job should be created
   /// \param OFM The OutputFileMap for which a Job should be created
-  /// \param TC The tool chain which should be used to create the Job
   /// \param AtTopLevel indicates whether or not this is a top-level Job
   /// \param JobCache maps existing Action/ToolChain pairs to Jobs
   ///
   /// \returns a Job for the given Action/ToolChain pair
   Job *buildJobsForAction(Compilation &C, const JobAction *JA,
-                          const OutputInfo &OI, const OutputFileMap *OFM,
-                          StringRef workingDirectory, const ToolChain &TC,
+                          const OutputFileMap *OFM,
+                          StringRef workingDirectory,
                           bool AtTopLevel, JobCacheMap &JobCache) const;
 
 private:
   void computeMainOutput(Compilation &C, const JobAction *JA,
-                         const OutputInfo &OI, const OutputFileMap *OFM,
-                         const ToolChain &TC, bool AtTopLevel,
+                         const OutputFileMap *OFM, bool AtTopLevel,
                          SmallVectorImpl<const Action *> &InputActions,
                          SmallVectorImpl<const Job *> &InputJobs,
                          const TypeToPathMap *OutputMap,
@@ -333,7 +330,7 @@ private:
                          llvm::SmallString<128> &Buf,
                          CommandOutput *Output) const;
 
-  void chooseSwiftModuleOutputPath(Compilation &C, const OutputInfo &OI,
+  void chooseSwiftModuleOutputPath(Compilation &C,
                                    const OutputFileMap *OFM,
                                    const TypeToPathMap *OutputMap,
                                    StringRef workingDirectory,
@@ -343,39 +340,39 @@ private:
                                       const TypeToPathMap *OutputMap,
                                       StringRef workingDirectory,
                                       CommandOutput *Output) const;
+
   void chooseRemappingOutputPath(Compilation &C, const TypeToPathMap *OutputMap,
                                  CommandOutput *Output) const;
 
   void chooseSerializedDiagnosticsPath(Compilation &C, const JobAction *JA,
-                                       const OutputInfo &OI,
                                        const TypeToPathMap *OutputMap,
                                        StringRef workingDirectory,
                                        CommandOutput *Output) const;
 
-  void chooseDependenciesOutputPaths(Compilation &C, const OutputInfo &OI,
+  void chooseDependenciesOutputPaths(Compilation &C,
                                      const TypeToPathMap *OutputMap,
                                      StringRef workingDirectory,
                                      llvm::SmallString<128> &Buf,
                                      CommandOutput *Output) const;
 
-  void chooseOptimizationRecordPath(Compilation &C, const OutputInfo &OI,
+  void chooseOptimizationRecordPath(Compilation &C,
                                     StringRef workingDirectory,
                                     llvm::SmallString<128> &Buf,
                                     CommandOutput *Output) const;
 
-  void chooseObjectiveCHeaderOutputPath(Compilation &C, const OutputInfo &OI,
+  void chooseObjectiveCHeaderOutputPath(Compilation &C,
                                         const TypeToPathMap *OutputMap,
                                         StringRef workingDirectory,
                                         CommandOutput *Output) const;
 
-  void chooseLoadedModuleTracePath(Compilation &C, const OutputInfo &OI,
+  void chooseLoadedModuleTracePath(Compilation &C,
                                    StringRef workingDirectory,
                                    llvm::SmallString<128> &Buf,
                                    CommandOutput *Output) const;
 
-  void chooseTBDPath(Compilation &C, const OutputInfo &OI,
-                     const TypeToPathMap *OutputMap, StringRef workingDirectory,
-                     llvm::SmallString<128> &Buf, CommandOutput *Output) const;
+  void chooseTBDPath(Compilation &C, const TypeToPathMap *OutputMap,
+                     StringRef workingDirectory, llvm::SmallString<128> &Buf,
+                     CommandOutput *Output) const;
 
 public:
   /// Handle any arguments which should be treated before building actions or

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -296,6 +296,10 @@ def emit_module_path_EQ : Joined<["-"], "emit-module-path=">,
          ArgumentIsPath]>,
   Alias<emit_module_path>;
 
+def experimental_emit_interface : Flag<["-"], "experimental-emit-interface">,
+  Flags<[NoInteractiveOption, HelpHidden]>,
+  HelpText<"Test out the textual interfaces feature">;
+
 def emit_objc_header : Flag<["-"], "emit-objc-header">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Emit an Objective-C header file">;

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2018,8 +2018,8 @@ void Driver::buildJobs(ArrayRef<const Action *> TopLevelActions,
 
   for (const Action *A : TopLevelActions) {
     if (auto *JA = dyn_cast<JobAction>(A)) {
-      (void)buildJobsForAction(C, JA, OI, OFM, workingDirectory, TC,
-                               /*TopLevel=*/true, JobCache);
+      (void)buildJobsForAction(C, JA, OFM, workingDirectory, /*TopLevel=*/true,
+                               JobCache);
     }
   }
 }
@@ -2077,7 +2077,6 @@ static Optional<StringRef> getOutputFilenameFromPathArgOrAsTopLevel(
 }
 
 static StringRef assignOutputName(Compilation &C, const JobAction *JA,
-                                  DiagnosticEngine &Diags,
                                   llvm::SmallString<128> &Buffer,
                                   StringRef BaseName,
                                   PreserveOnSignal ShouldPreserveOnSignal) {
@@ -2087,8 +2086,9 @@ static StringRef assignOutputName(Compilation &C, const JobAction *JA,
   StringRef Suffix = file_types::getExtension(JA->getType());
   std::error_code EC = llvm::sys::fs::createTemporaryFile(Stem, Suffix, Buffer);
   if (EC) {
-    Diags.diagnose(SourceLoc(), diag::error_unable_to_make_temporary_file,
-                   EC.message());
+    C.getDiags().diagnose(SourceLoc(),
+                          diag::error_unable_to_make_temporary_file,
+                          EC.message());
     return {};
   }
   C.addTemporaryFile(Buffer.str(), ShouldPreserveOnSignal);
@@ -2122,15 +2122,11 @@ static StringRef baseNameForImage(const JobAction *JA, const OutputInfo &OI,
 
 static StringRef getOutputFilename(Compilation &C,
                                    const JobAction *JA,
-                                   const OutputInfo &OI,
                                    const TypeToPathMap *OutputMap,
                                    StringRef workingDirectory,
-                                   const llvm::Triple &Triple,
-                                   const llvm::opt::DerivedArgList &Args,
                                    bool AtTopLevel,
                                    StringRef BaseInput,
                                    StringRef PrimaryInput,
-                                   DiagnosticEngine &Diags,
                                    llvm::SmallString<128> &Buffer) {
   if (JA->getType() == file_types::TY_Nothing)
     return {};
@@ -2144,6 +2140,8 @@ static StringRef getOutputFilename(Compilation &C,
 
   // Process Action-specific output-specifying options next,
   // since we didn't find anything applicable in the OutputMap.
+  const OutputInfo &OI = C.getOutputInfo();
+  const llvm::opt::DerivedArgList &Args = C.getArgs();
 
   if (isa<MergeModuleJobAction>(JA)) {
     auto optFilename = getOutputFilenameFromPathArgOrAsTopLevel(
@@ -2190,10 +2188,10 @@ static StringRef getOutputFilename(Compilation &C,
 
   // We don't yet have a name, assign one.
   if (!AtTopLevel)
-    return assignOutputName(C, JA, Diags, Buffer, BaseName,
-                            ShouldPreserveOnSignal);
+    return assignOutputName(C, JA, Buffer, BaseName, ShouldPreserveOnSignal);
 
   if (JA->getType() == file_types::TY_Image) {
+    const llvm::Triple &Triple = C.getToolChain().getTriple();
     SmallString<16> Base =
         baseNameForImage(JA, OI, Triple, Buffer, BaseInput, BaseName);
     formFilenameFromBaseAndExt(Base, /*newExt=*/"", workingDirectory, Buffer);
@@ -2223,8 +2221,8 @@ static bool hasExistingAdditionalOutput(CommandOutput &output,
 
 static void addAuxiliaryOutput(
     Compilation &C, CommandOutput &output, file_types::ID outputType,
-    const OutputInfo &OI, const TypeToPathMap *outputMap,
-    StringRef workingDirectory, StringRef outputPath = StringRef(),
+    const TypeToPathMap *outputMap, StringRef workingDirectory,
+    StringRef outputPath = StringRef(),
     llvm::opt::OptSpecifier requireArg = llvm::opt::OptSpecifier()) {
 
   if (hasExistingAdditionalOutput(output, outputType, outputPath))
@@ -2261,10 +2259,10 @@ static void addAuxiliaryOutput(
     if (output.getPrimaryOutputType() != file_types::TY_Nothing)
       path = output.getPrimaryOutputFilenames()[0];
     else if (!output.getBaseInput(0).empty())
-      path = llvm::sys::path::stem(output.getBaseInput(0));
+      path = llvm::sys::path::filename(output.getBaseInput(0));
     else {
-      formFilenameFromBaseAndExt(OI.ModuleName, /*newExt=*/"", workingDirectory,
-                                 path);
+      formFilenameFromBaseAndExt(C.getOutputInfo().ModuleName, /*newExt=*/"",
+                                 workingDirectory, path);
     }
     assert(!path.empty());
 
@@ -2279,8 +2277,7 @@ static void addAuxiliaryOutput(
 
 static void addDiagFileOutputForPersistentPCHAction(
     Compilation &C, const GeneratePCHJobAction *JA, CommandOutput &output,
-    const OutputInfo &OI, const TypeToPathMap *outputMap,
-    StringRef workingDirectory, DiagnosticEngine &diags) {
+    const TypeToPathMap *outputMap, StringRef workingDirectory) {
   assert(JA->isPersistentPCH());
 
   // For a persistent PCH we don't use an output, the frontend determines
@@ -2314,16 +2311,16 @@ static void addDiagFileOutputForPersistentPCHAction(
     std::error_code EC =
     llvm::sys::fs::createTemporaryFile(stem, suffix, outPathBuf);
     if (EC) {
-      diags.diagnose(SourceLoc(),
-                     diag::error_unable_to_make_temporary_file,
-                     EC.message());
+      C.getDiags().diagnose(SourceLoc(),
+                            diag::error_unable_to_make_temporary_file,
+                            EC.message());
       return;
     }
     C.addTemporaryFile(outPathBuf.str());
   }
 
   if (!outPathBuf.empty()) {
-    addAuxiliaryOutput(C, output, file_types::TY_SerializedDiagnostics, OI,
+    addAuxiliaryOutput(C, output, file_types::TY_SerializedDiagnostics,
                        outputMap, workingDirectory, outPathBuf.str());
   }
 }
@@ -2376,13 +2373,14 @@ handleCompileJobCondition(Job *J, CompileJobAction::InputInfo inputInfo,
 }
 
 Job *Driver::buildJobsForAction(Compilation &C, const JobAction *JA,
-                                const OutputInfo &OI, const OutputFileMap *OFM,
-                                StringRef workingDirectory, const ToolChain &TC,
+                                const OutputFileMap *OFM,
+                                StringRef workingDirectory,
                                 bool AtTopLevel, JobCacheMap &JobCache) const {
 
   PrettyStackTraceDriverAction CrashInfo("building jobs", JA);
 
   // 1. See if we've already got this cached.
+  const ToolChain &TC = C.getToolChain();
   std::pair<const Action *, const ToolChain *> Key(JA, &TC);
   {
     auto CacheIter = JobCache.find(Key);
@@ -2397,7 +2395,7 @@ Job *Driver::buildJobsForAction(Compilation &C, const JobAction *JA,
   for (const Action *Input : *JA) {
     if (auto *InputJobAction = dyn_cast<JobAction>(Input)) {
       InputJobs.push_back(buildJobsForAction(
-          C, InputJobAction, OI, OFM, workingDirectory, TC, false, JobCache));
+          C, InputJobAction, OFM, workingDirectory, false, JobCache));
     } else {
       InputActions.push_back(Input);
     }
@@ -2430,6 +2428,7 @@ Job *Driver::buildJobsForAction(Compilation &C, const JobAction *JA,
     }
   }
 
+  const OutputInfo &OI = C.getOutputInfo();
   const TypeToPathMap *OutputMap = nullptr;
   if (OFM) {
     if (isa<CompileJobAction>(JA)) {
@@ -2449,12 +2448,12 @@ Job *Driver::buildJobsForAction(Compilation &C, const JobAction *JA,
   PrettyStackTraceDriverCommandOutput CrashInfo2("determining output",
                                                  Output.get());
   llvm::SmallString<128> Buf;
-  computeMainOutput(C, JA, OI, OFM, TC, AtTopLevel, InputActions, InputJobs,
-                    OutputMap, workingDirectory, BaseInput, PrimaryInput, Buf,
+  computeMainOutput(C, JA, OFM, AtTopLevel, InputActions, InputJobs, OutputMap,
+                    workingDirectory, BaseInput, PrimaryInput, Buf,
                     Output.get());
 
   if (OI.ShouldGenerateModule && isa<CompileJobAction>(JA))
-    chooseSwiftModuleOutputPath(C, OI, OFM, OutputMap, workingDirectory,
+    chooseSwiftModuleOutputPath(C, OFM, OutputMap, workingDirectory,
                                 Output.get());
 
   if (OI.ShouldGenerateModule &&
@@ -2468,7 +2467,7 @@ Job *Driver::buildJobsForAction(Compilation &C, const JobAction *JA,
   if (isa<CompileJobAction>(JA) || isa<GeneratePCHJobAction>(JA)) {
     // Choose the serialized diagnostics output path.
     if (C.getArgs().hasArg(options::OPT_serialize_diagnostics))
-      chooseSerializedDiagnosticsPath(C, JA, OI, OutputMap, workingDirectory,
+      chooseSerializedDiagnosticsPath(C, JA, OutputMap, workingDirectory,
                                       Output.get());
   }
 
@@ -2477,23 +2476,23 @@ Job *Driver::buildJobsForAction(Compilation &C, const JobAction *JA,
        OI.CompilerMode == OutputInfo::Mode::SingleCompile)) {
     // An emit-tbd argument gets passed down to a job that sees the whole
     // module, either the -merge-modules job or a -wmo compiler invocation.
-    chooseTBDPath(C, OI, OutputMap, workingDirectory, Buf, Output.get());
+    chooseTBDPath(C, OutputMap, workingDirectory, Buf, Output.get());
   }
 
   if (isa<CompileJobAction>(JA))
-    chooseDependenciesOutputPaths(C, OI, OutputMap, workingDirectory, Buf,
+    chooseDependenciesOutputPaths(C, OutputMap, workingDirectory, Buf,
                                   Output.get());
 
   if (C.getArgs().hasArg(options::OPT_save_optimization_record,
                          options::OPT_save_optimization_record_path))
-    chooseOptimizationRecordPath(C, OI, workingDirectory, Buf, Output.get());
+    chooseOptimizationRecordPath(C, workingDirectory, Buf, Output.get());
 
   if ((isa<MergeModuleJobAction>(JA) ||
        (isa<CompileJobAction>(JA) &&
         OI.CompilerMode == OutputInfo::Mode::SingleCompile)) &&
       C.getArgs().hasArg(options::OPT_emit_objc_header,
                          options::OPT_emit_objc_header_path))
-    chooseObjectiveCHeaderOutputPath(C, OI, OutputMap, workingDirectory,
+    chooseObjectiveCHeaderOutputPath(C, OutputMap, workingDirectory,
                                      Output.get());
 
   // 4. Construct a Job which produces the right CommandOutput.
@@ -2584,14 +2583,13 @@ Job *Driver::buildJobsForAction(Compilation &C, const JobAction *JA,
 }
 
 void Driver::computeMainOutput(
-    Compilation &C, const JobAction *JA, const OutputInfo &OI,
-    const OutputFileMap *OFM, const ToolChain &TC, bool AtTopLevel,
-    SmallVectorImpl<const Action *> &InputActions,
+    Compilation &C, const JobAction *JA, const OutputFileMap *OFM,
+    bool AtTopLevel, SmallVectorImpl<const Action *> &InputActions,
     SmallVectorImpl<const Job *> &InputJobs, const TypeToPathMap *OutputMap,
     StringRef workingDirectory, StringRef BaseInput, StringRef PrimaryInput,
     llvm::SmallString<128> &Buf, CommandOutput *Output) const {
   StringRef OutputFile;
-  if (OI.isMultiThreading() && isa<CompileJobAction>(JA) &&
+  if (C.getOutputInfo().isMultiThreading() && isa<CompileJobAction>(JA) &&
       file_types::isAfterLLVM(JA->getType())) {
     // Multi-threaded compilation: A single frontend command produces multiple
     // output file: one for each input files.
@@ -2609,9 +2607,8 @@ void Driver::computeMainOutput(
       if (OFM)
         OMForInput = OFM->getOutputMapForInput(Base);
 
-      OutputFile = getOutputFilename(C, JA, OI, OMForInput, workingDirectory,
-                                     TC.getTriple(), C.getArgs(), AtTopLevel,
-                                     Base, Primary, Diags, Buf);
+      OutputFile = getOutputFilename(C, JA, OMForInput, workingDirectory,
+                                     AtTopLevel, Base, Primary, Buf);
       Output->addPrimaryOutput(CommandInputPair(Base, Primary),
                                OutputFile);
     };
@@ -2631,15 +2628,14 @@ void Driver::computeMainOutput(
     }
   } else {
     // The common case: there is a single output file.
-    OutputFile = getOutputFilename(C, JA, OI, OutputMap, workingDirectory,
-                                   TC.getTriple(), C.getArgs(), AtTopLevel,
-                                   BaseInput, PrimaryInput, Diags, Buf);
+    OutputFile = getOutputFilename(C, JA, OutputMap, workingDirectory,
+                                   AtTopLevel, BaseInput, PrimaryInput, Buf);
     Output->addPrimaryOutput(CommandInputPair(BaseInput, PrimaryInput),
                              OutputFile);
   }
 }
 
-void Driver::chooseSwiftModuleOutputPath(Compilation &C, const OutputInfo &OI,
+void Driver::chooseSwiftModuleOutputPath(Compilation &C,
                                          const OutputFileMap *OFM,
                                          const TypeToPathMap *OutputMap,
                                          StringRef workingDirectory,
@@ -2655,6 +2651,7 @@ void Driver::chooseSwiftModuleOutputPath(Compilation &C, const OutputInfo &OI,
       OFMModuleOutputPath = iter->second;
   }
 
+  const OutputInfo &OI = C.getOutputInfo();
   const Arg *A = C.getArgs().getLastArg(options::OPT_emit_module_path);
   using file_types::TY_SwiftModuleFile;
 
@@ -2762,17 +2759,16 @@ void Driver::chooseRemappingOutputPath(Compilation &C,
 
 void Driver::chooseSerializedDiagnosticsPath(Compilation &C,
                                              const JobAction *JA,
-                                             const OutputInfo &OI,
                                              const TypeToPathMap *OutputMap,
                                              StringRef workingDirectory,
                                              CommandOutput *Output) const {
   if (C.getArgs().hasArg(options::OPT_serialize_diagnostics)) {
     auto pchJA = dyn_cast<GeneratePCHJobAction>(JA);
     if (pchJA && pchJA->isPersistentPCH()) {
-      addDiagFileOutputForPersistentPCHAction(C, pchJA, *Output, OI, OutputMap,
-                                              workingDirectory, Diags);
+      addDiagFileOutputForPersistentPCHAction(C, pchJA, *Output, OutputMap,
+                                              workingDirectory);
     } else {
-      addAuxiliaryOutput(C, *Output, file_types::TY_SerializedDiagnostics, OI,
+      addAuxiliaryOutput(C, *Output, file_types::TY_SerializedDiagnostics,
                          OutputMap, workingDirectory);
     }
 
@@ -2785,23 +2781,23 @@ void Driver::chooseSerializedDiagnosticsPath(Compilation &C,
   }
 }
 
-void Driver::chooseDependenciesOutputPaths(Compilation &C, const OutputInfo &OI,
+void Driver::chooseDependenciesOutputPaths(Compilation &C,
                                            const TypeToPathMap *OutputMap,
                                            StringRef workingDirectory,
                                            llvm::SmallString<128> &Buf,
                                            CommandOutput *Output) const {
   if (C.getArgs().hasArg(options::OPT_emit_dependencies)) {
-    addAuxiliaryOutput(C, *Output, file_types::TY_Dependencies, OI, OutputMap,
+    addAuxiliaryOutput(C, *Output, file_types::TY_Dependencies, OutputMap,
                        workingDirectory);
   }
   if (C.getIncrementalBuildEnabled()) {
-    addAuxiliaryOutput(C, *Output, file_types::TY_SwiftDeps, OI, OutputMap,
+    addAuxiliaryOutput(C, *Output, file_types::TY_SwiftDeps, OutputMap,
                        workingDirectory);
   }
-  chooseLoadedModuleTracePath(C, OI, workingDirectory, Buf, Output);
+  chooseLoadedModuleTracePath(C, workingDirectory, Buf, Output);
 }
 
-void Driver::chooseLoadedModuleTracePath(Compilation &C, const OutputInfo &OI,
+void Driver::chooseLoadedModuleTracePath(Compilation &C,
                                          StringRef workingDirectory,
                                          llvm::SmallString<128> &Buf,
                                          CommandOutput *Output) const {
@@ -2825,7 +2821,8 @@ void Driver::chooseLoadedModuleTracePath(Compilation &C, const OutputInfo &OI,
       // By treating this as a top-level output, the return value always
       // exists.
       filename = *getOutputFilenameFromPathArgOrAsTopLevel(
-          OI, C.getArgs(), options::OPT_emit_loaded_module_trace_path,
+          C.getOutputInfo(), C.getArgs(),
+          options::OPT_emit_loaded_module_trace_path,
           file_types::TY_ModuleTrace,
           /*TreatAsTopLevelOutput=*/true, workingDirectory, Buf);
     }
@@ -2834,8 +2831,7 @@ void Driver::chooseLoadedModuleTracePath(Compilation &C, const OutputInfo &OI,
   }
 }
 
-void Driver::chooseTBDPath(Compilation &C, const OutputInfo &OI,
-                           const TypeToPathMap *OutputMap,
+void Driver::chooseTBDPath(Compilation &C, const TypeToPathMap *OutputMap,
                            StringRef workingDirectory,
                            llvm::SmallString<128> &Buf,
                            CommandOutput *Output) const {
@@ -2844,15 +2840,16 @@ void Driver::chooseTBDPath(Compilation &C, const OutputInfo &OI,
     pathFromArgs = A->getValue();
   }
 
-  addAuxiliaryOutput(C, *Output, file_types::TY_TBD, OI, OutputMap,
+  addAuxiliaryOutput(C, *Output, file_types::TY_TBD, OutputMap,
                      workingDirectory, pathFromArgs,
                      /*requireArg=*/options::OPT_emit_tbd);
 }
 
-void Driver::chooseOptimizationRecordPath(Compilation &C, const OutputInfo &OI,
+void Driver::chooseOptimizationRecordPath(Compilation &C,
                                           StringRef workingDirectory,
                                           llvm::SmallString<128> &Buf,
                                           CommandOutput *Output) const {
+  const OutputInfo &OI = C.getOutputInfo();
   if (OI.CompilerMode == OutputInfo::Mode::SingleCompile) {
     auto filename = *getOutputFilenameFromPathArgOrAsTopLevel(
         OI, C.getArgs(), options::OPT_save_optimization_record_path,
@@ -2866,7 +2863,6 @@ void Driver::chooseOptimizationRecordPath(Compilation &C, const OutputInfo &OI,
 }
 
 void Driver::chooseObjectiveCHeaderOutputPath(Compilation &C,
-                                              const OutputInfo &OI,
                                               const TypeToPathMap *OutputMap,
                                               StringRef workingDirectory,
                                               CommandOutput *Output) const {
@@ -2892,7 +2888,7 @@ void Driver::chooseObjectiveCHeaderOutputPath(Compilation &C,
     // Put the header next to the primary output file.
     // FIXME: That's not correct if the user /just/ passed -emit-header
     // and not -emit-module.
-    addAuxiliaryOutput(C, *Output, file_types::TY_ObjCHeader, OI,
+    addAuxiliaryOutput(C, *Output, file_types::TY_ObjCHeader,
                        /*output file map*/ nullptr, workingDirectory);
   }
 }

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -544,6 +544,10 @@ void ToolChain::JobContext::addFrontendSupplementaryOutputArguments(
                    "-emit-module-doc-path");
 
   addOutputsOfType(arguments, Output, Args,
+                   file_types::ID::TY_SwiftModuleInterfaceFile,
+                   "-emit-interface-path");
+
+  addOutputsOfType(arguments, Output, Args,
                    file_types::TY_SerializedDiagnostics,
                    "-serialize-diagnostics-path");
 
@@ -792,6 +796,9 @@ ToolChain::constructInvocation(const MergeModuleJobAction &job,
                         Arguments);
   addOutputsOfType(Arguments, context.Output, context.Args,
                    file_types::TY_SwiftModuleDocFile, "-emit-module-doc-path");
+  addOutputsOfType(Arguments, context.Output, context.Args,
+                   file_types::ID::TY_SwiftModuleInterfaceFile,
+                   "-emit-interface-path");
   addOutputsOfType(Arguments, context.Output, context.Args,
                    file_types::TY_SerializedDiagnostics,
                    "-serialize-diagnostics-path");

--- a/test/Driver/emit-interface.swift
+++ b/test/Driver/emit-interface.swift
@@ -1,0 +1,15 @@
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s -experimental-emit-interface -o %t/foo 2>&1 | %FileCheck %s
+
+// CHECK: swift -frontend
+// CHECK-SAME: emit-interface.swift
+// CHECK: swift -frontend -merge-modules
+// CHECK-SAME: -emit-interface-path {{.+}}/foo.swiftinterface
+// CHECK: bin/ld
+
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s -experimental-emit-interface -o %t/foo -force-single-frontend-invocation 2>&1 | %FileCheck -check-prefix=CHECK-WHOLE-MODULE %s
+
+// CHECK-WHOLE-MODULE: swift -frontend
+// CHECK-WHOLE-MODULE-SAME: emit-interface.swift
+// CHECK-WHOLE-MODULE-SAME: -emit-interface-path {{.+}}/foo.swiftinterface
+// CHECK-WHOLE-MODULE-NOT: -merge-modules
+// CHECK-WHOLE-MODULE: bin/ld

--- a/test/Driver/emit-objc-header-single-vs-multi-file.swift
+++ b/test/Driver/emit-objc-header-single-vs-multi-file.swift
@@ -1,0 +1,20 @@
+// FIXME: BEGIN -enable-source-import hackaround
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
+// FIXME: END -enable-source-import hackaround
+
+// RUN: %target-swiftc_driver %clang-importer-sdk-nosource -emit-module -o %t.1.swiftmodule -emit-objc-header -emit-objc-header-path %t.1.h -module-name ThisModule %s %S/Inputs/main.swift %S/Inputs/lib.swift -I %t
+// RUN: %target-swiftc_driver %clang-importer-sdk-nosource -emit-module -o %t.2.swiftmodule -emit-objc-header -emit-objc-header-path %t.2.h -module-name ThisModule %s %S/Inputs/main.swift %S/Inputs/lib.swift -force-single-frontend-invocation -I %t
+// RUN: diff %t.1.h %t.2.h
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+public class A: NSObject {
+  func foo() {}
+  @objc func bar(x: Int, baz y: Int) -> Int { return 1 }
+}
+public class B: A {
+  func doSomething() {}
+}

--- a/test/Driver/emit-objc-header.swift
+++ b/test/Driver/emit-objc-header.swift
@@ -1,20 +1,15 @@
-// FIXME: BEGIN -enable-source-import hackaround
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
-// FIXME: END -enable-source-import hackaround
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s -emit-objc-header-path %t/foo.h 2>&1 | %FileCheck %s
 
-// RUN: %target-swiftc_driver %clang-importer-sdk-nosource -emit-module -o %t.1.swiftmodule -emit-objc-header -emit-objc-header-path %t.1.h -module-name ThisModule %s %S/Inputs/main.swift %S/Inputs/lib.swift -I %t
-// RUN: %target-swiftc_driver %clang-importer-sdk-nosource -emit-module -o %t.2.swiftmodule -emit-objc-header -emit-objc-header-path %t.2.h -module-name ThisModule %s %S/Inputs/main.swift %S/Inputs/lib.swift -force-single-frontend-invocation -I %t
-// RUN: diff %t.1.h %t.2.h
+// CHECK: swift -frontend
+// CHECK-SAME: emit-objc-header.swift
+// CHECK: swift -frontend -merge-modules
+// CHECK-SAME: -emit-objc-header-path {{.+}}/foo.h
+// CHECK: bin/ld
 
-// REQUIRES: objc_interop
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s -emit-objc-header-path %t/foo.h -force-single-frontend-invocation 2>&1 | %FileCheck -check-prefix=CHECK-WHOLE-MODULE %s
 
-import Foundation
-
-public class A: NSObject {
-  func foo() {}
-  @objc func bar(x: Int, baz y: Int) -> Int { return 1 }
-}
-public class B: A {
-  func doSomething() {}
-}
+// CHECK-WHOLE-MODULE: swift -frontend
+// CHECK-WHOLE-MODULE-SAME: emit-objc-header.swift
+// CHECK-WHOLE-MODULE-SAME: -emit-objc-header-path {{.+}}/foo.h
+// CHECK-WHOLE-MODULE-NOT: -merge-modules
+// CHECK-WHOLE-MODULE: bin/ld


### PR DESCRIPTION
Add a driver option -experimental-emit-interface for textual interfaces, then hook it up in CMake. We're not using this for anything yet, but this will exercise -emit-interface while we're working on it and make sure that it doesn't crash when processing complex code like the standard library.

Looking for review from David or Graydon on the Driver changes and Ross or Michael for the CMake.