### PR TITLE
[Type checker] Never “revert” a generic parameter list or where clause.

### DIFF
--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1129,9 +1129,6 @@ public:
   void prepareGenericParamList(GenericParamList *genericParams,
                                DeclContext *dc);
 
-  /// Revert the dependent types within a set of requirements.
-  void revertGenericRequirements(MutableArrayRef<RequirementRepr> requirements);
-
   /// Compute the generic signature, generic environment and interface type
   /// of a generic function.
   void validateGenericFuncSignature(AbstractFunctionDecl *func);


### PR DESCRIPTION
We no longer splat structural types anywhere into a generic parameter
list or a where clause, so this “revert” code is a no-op. Remove it.
