### PR TITLE
[AutoDiff] No longer check whether a type supports differentiation in Sema

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -757,8 +757,6 @@ ERROR(gradient_expr_parameter_index_out_of_bounds,none,
 ERROR(gradient_expr_parameter_not_value_type,none,
       "gradient parameter has non-value type %0 and thus cannot be a "
       "differentiation parameter", (Type))
-ERROR(gradient_expr_parameter_not_differentiable,none,
-      "gradient parameter has non-differentiable type %0", (Type))
 ERROR(gradient_expr_incompatible_contextual_type,none,
       "cannot convert gradient expression to incompatible contextual type %0",
       (Type))

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2399,7 +2399,6 @@ namespace {
     // SWIFT_ENABLE_TENSORFLOW
     Expr *handleReverseAutoDiffExpr(ReverseAutoDiffExpr *expr,
                                     bool preservingOriginalResult) {
-      auto &TC = cs.getTypeChecker();
       auto gradType = simplifyType(cs.getType(expr));
       auto gradFnType = gradType->getAs<AnyFunctionType>();
       assert(gradFnType &&
@@ -2421,15 +2420,6 @@ namespace {
       } else {
         for (auto &param : expr->getParameters())
           diffParamTypes.push_back(gradParams[param.index].getType());
-      }
-      for (auto &paramTy : diffParamTypes) {
-        if (!(TC.isCompatibleWithScalarAutoDiff(paramTy, dc) ||
-              TC.isCompatibleWithVectorAutoDiff(paramTy, dc))) {
-          TC.diagnose(expr->getLoc(),
-                      diag::gradient_expr_parameter_not_differentiable,
-                      paramTy);
-          return nullptr;
-        }
       }
       return expr;
     }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1358,28 +1358,6 @@ namespace {
         }
       }
 
-      // Differentiation parameter types must conform to VectorNumeric or
-      // FloatingPoint.
-      // TODO: consider generalizing to aggregate types of VectorNumeric or
-      // FloatingPoint.
-      for (auto &param : diffParamTypes) {
-        auto paramTy = param.getType();
-        // If diff parameter type does not have type variables, it must conform
-        // to VectorNumeric.
-        // NOTE: It is intentional that diff parameter types with type variables
-        // are not constrained to VectorNumeric or FloatingPoint. Instead,
-        // conformance to VectorNumeric or FloatingPoint is checked in CSApply
-        // to produce better diagnostics about specific types that are
-        // incompatible with differentiation.
-        if (!paramTy->hasTypeVariable() &&
-            !(TC.isCompatibleWithScalarAutoDiff(paramTy, CurDC) ||
-              TC.isCompatibleWithVectorAutoDiff(paramTy, CurDC))) {
-          TC.diagnose(GE->getLoc(),
-                      diag::gradient_expr_parameter_not_differentiable, paramTy);
-          return nullptr;
-        }
-      }
-
       // Create a type for the gradient. The gradient has the same generic
       // signature as the original function. The gradient's result types are
       // what we collected in `diffParamTypes`.

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -683,36 +683,6 @@ Expr *TypeChecker::foldSequence(SequenceExpr *expr, DeclContext *dc) {
   return Result;
 }
 
-/// SWIFT_ENABLE_TENSORFLOW
-/// Determines whether the specified type supports scalar differentiation.
-/// We say that a type supports scalar AD when it conforms to
-/// `FloatingPoint`.
-bool TypeChecker::isCompatibleWithScalarAutoDiff(Type type, DeclContext *DC) {
-  auto *floatingPointProto =
-    DC->getASTContext().getProtocol(KnownProtocolKind::FloatingPoint);
-  auto conf = conformsToProtocol(type, floatingPointProto, DC,
-                                 ConformanceCheckFlags::InExpression);
-  return conf.hasValue();
-}
-
-/// Determines whether the specified type supports vector differentiation.
-/// We say that a type supports vector AD when it conforms to
-/// `VectorNumeric` while its `ScalarElement` supports scalar AD.
-bool TypeChecker::isCompatibleWithVectorAutoDiff(Type type, DeclContext *DC) {
-  auto &ctx = DC->getASTContext();
-  auto *vectorNumericProto = ctx.getProtocol(KnownProtocolKind::VectorNumeric);
-  if (auto conf = conformsToProtocol(type, vectorNumericProto, DC,
-                                     ConformanceCheckFlags::InExpression)) {
-    auto scalarElementName = ctx.getIdentifier("ScalarElement");
-    auto assocTyDecl = cast<AssociatedTypeDecl>(
-      conf->getRequirement()->lookupDirect(scalarElementName).front());
-    auto assocTy = assocTyDecl->getDeclaredInterfaceType();
-    auto scalarTy = conf->getAssociatedType(type, assocTy);
-    return isCompatibleWithScalarAutoDiff(scalarTy, DC);
-  }
-  return false;
-}
-
 // SWIFT_ENABLE_TENSORFLOW
 // Returns the function declaration corresponding to the given function name and
 // lookup context. If the base type of the function is specified, member lookup

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -2359,21 +2359,10 @@ public:
   /// Check if the given decl has a @_semantics attribute that gives it
   /// special case type-checking behavior.
   DeclTypeCheckingSemantics getDeclTypeCheckingSemantics(ValueDecl *decl);
-  
-  /// SWIFT_ENABLE_TENSORFLOW
-  /// Determines whether the specified type supports scalar differentiation.
-  /// We say that a type supports scalar AD when it conforms to
-  /// `FloatingPoint`.
-  bool isCompatibleWithScalarAutoDiff(Type type, DeclContext *DC);
-
-  /// Determines whether the specified type supports vector differentiation.
-  /// We say that a type supports vector AD when it conforms to
-  /// `VectorNumeric` while its `ScalarElement` supports scalar AD.
-  bool isCompatibleWithVectorAutoDiff(Type type, DeclContext *DC);
 
   /// SWIFT_ENABLE_TENSORFLOW
-  // Returns the function declaration corresponding to the given function name and
-  // lookup context. If the function declaration cannot be resolved, emits a
+  // Returns the function declaration corresponding to the given function name
+  // and lookup context. If the function declaration cannot be resolved, emits a
   // diagnostic and returns nullptr.
   FuncDecl *lookupFuncDecl(
       DeclName funcName, SourceLoc funcNameLoc, Type baseType,

--- a/test/AutoDiff/gradient_expr_type_checking.swift
+++ b/test/AutoDiff/gradient_expr_type_checking.swift
@@ -74,7 +74,7 @@ func addNumeric<T : Numeric>(_ x: T, _ y: T) -> T {
   return x + y
 }
 func daddNumeric<T : Numeric>(_ x: T, _ y: T) -> (T, T) {
-  return #gradient(addNumeric)(x, y) // expected-error {{gradient parameter has non-differentiable type 'T'}}
+  return #gradient(addNumeric)(x, y)
 }
 // Ok because the constraint on daddNumeric is FloatingPoint, not Numeric.
 func daddFloatingPoint<T : FloatingPoint>(_ x: T, _ y: T) -> (T, T) {

--- a/test/AutoDiff/gradient_expr_type_checking.swift
+++ b/test/AutoDiff/gradient_expr_type_checking.swift
@@ -53,8 +53,8 @@ let _: (Float) -> (Float, Float) = #valueAndGradient(e)
 let _: (Double) -> (Double, Double) = #valueAndGradient(e)
 
 let _: (Float) -> (Float, Float, Float) = #gradient(e) // expected-error {{cannot convert gradient expression to incompatible contextual type}}
-let _: ((Float, Float)) -> (Float, Float) = #gradient(e) // expected-error {{gradient parameter has non-differentiable type '(Float, Float)'}}
-let _: (Int) -> (Int) = #gradient(e) // expected-error {{gradient parameter has non-differentiable type 'Int'}}
+let _: ((Float, Float)) -> (Float, Float) = #gradient(e)
+let _: (Int) -> (Int) = #gradient(e)
 let _: (Float) -> Double = #gradient(e) // expected-error {{cannot convert gradient expression to incompatible contextual type}}
 
 // Complex type inference.


### PR DESCRIPTION
Differentiability checking is temporarily going full-SIL. This should land after https://github.com/apple/swift/pull/18977.