### PR TITLE
Disable inlining coroutines until the coroutine-splitting pass runs

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1259,6 +1259,11 @@ IRGenSILFunction::IRGenSILFunction(IRGenModule &IGM,
     else
       CurFn->addFnAttr(llvm::Attribute::SanitizeThread);
   }
+
+  // Disable inlining of coroutine functions until we split.
+  if (f->getLoweredFunctionType()->isCoroutine()) {
+    CurFn->addFnAttr(llvm::Attribute::NoInline);
+  }
 }
 
 IRGenSILFunction::~IRGenSILFunction() {

--- a/test/IRGen/yield_once.sil
+++ b/test/IRGen/yield_once.sil
@@ -7,6 +7,7 @@ sil @marker : $(Builtin.Int32) -> ()
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i8* @test_simple
 // CHECK-32-SAME:  i8* noalias dereferenceable([[BUFFER_SIZE:16]]))
 // CHECK-64-SAME:  (i8* noalias dereferenceable([[BUFFER_SIZE:32]]))
+// CHECK-SAME:  [[CORO_ATTRIBUTES:#[0-9]+]]
 sil @test_simple : $@yield_once () -> () {
 entry:
   // CHECK-32:      [[ID:%.*]] = call token @llvm.coro.id.retcon.once(i32 [[BUFFER_SIZE]], i32 [[BUFFER_ALIGN:4]], i8* %0, i8* bitcast (void (i8*, i1)* @"$SIet_TC" to i8*), i8* bitcast (i8* (i32)* @malloc to i8*), i8* bitcast (void (i8*)* @free to i8*))
@@ -88,3 +89,6 @@ cont:
   %ret = tuple ()
   return %ret : $()
 }
+
+// CHECK:       attributes [[CORO_ATTRIBUTES]] =
+// CHECK-SAME:    noinline


### PR DESCRIPTION
Cloning the coroutine intrinsics generally yields invalid IR.