### PR TITLE
[TF CI] Temporarily disable non-TF tests for macOS builds

### DIFF
--- a/test/ClangImporter/pch-bridging-header-deps.swift
+++ b/test/ClangImporter/pch-bridging-header-deps.swift
@@ -1,3 +1,5 @@
+// SWIFT_ENABLE_TENSORFLOW
+// UNSUPPORTED: macos
 // RUN: rm -f %t.*
 //
 // Generate a bridging PCH, use it in a swift file, and check that the swift file's .swiftdeps

--- a/test/Driver/working-directory.swift
+++ b/test/Driver/working-directory.swift
@@ -1,3 +1,5 @@
+// SWIFT_ENABLE_TENSORFLOW
+// UNSUPPORTED: macos
 // RUN: %empty-directory(%t)
 
 // RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %S/Inputs -c main.swift | %FileCheck %s -check-prefix=INPUT

--- a/test/Frontend/parse-sil-inputs.swift
+++ b/test/Frontend/parse-sil-inputs.swift
@@ -1,3 +1,5 @@
+// SWIFT_ENABLE_TENSORFLOW
+// UNSUPPORTED: macos
 // RUN: not %target-swift-frontend -parse-sil -emit-sil 2>&1 | %FileCheck -check-prefix=SIL_FILES %s
 // SIL_FILES: this mode requires a single input file
 

--- a/test/SourceKit/CompileNotifications/code-completion.swift
+++ b/test/SourceKit/CompileNotifications/code-completion.swift
@@ -1,3 +1,5 @@
+// SWIFT_ENABLE_TENSORFLOW
+// UNSUPPORTED: macos
 // RUN: %sourcekitd-test -req=track-compiles == -req=complete %s -offset=0 -- %s | %FileCheck %s -check-prefix=COMPILE_1
 // COMPILE_1: {
 // COMPILE_1:  key.notification: source.notification.compile-will-start,

--- a/test/SourceKit/CompileNotifications/cursor-info.swift
+++ b/test/SourceKit/CompileNotifications/cursor-info.swift
@@ -1,3 +1,5 @@
+// SWIFT_ENABLE_TENSORFLOW
+// UNSUPPORTED: macos
 // RUN: %sourcekitd-test -req=track-compiles == -req=cursor %s -offset=0 -- %s | %FileCheck %s -check-prefix=COMPILE_1
 // COMPILE_1: {
 // COMPILE_1:  key.notification: source.notification.compile-will-start,

--- a/test/SourceKit/CompileNotifications/enable-disable.swift
+++ b/test/SourceKit/CompileNotifications/enable-disable.swift
@@ -1,3 +1,5 @@
+// SWIFT_ENABLE_TENSORFLOW
+// UNSUPPORTED: macos
 // RUN: %sourcekitd-test -req=sema %s -- %s | %FileCheck %s -check-prefix=NONE
 // RUN: %sourcekitd-test -req=track-compiles == -req=version | %FileCheck %s -check-prefix=NONE
 // RUN: %sourcekitd-test -req=track-compiles -req-opts=value=0 \


### PR DESCRIPTION
macOS builds were failing because the CI machine has a non-standard build path, causing file checks to fail. These non-TF tests should be disabled until the build machine issue is fixed.

```console
Command Output (stderr):
--
/Volumes/BuildData/Users/swiftci/jenkins/workspace/swift-PR-TensorFlow-macOS/swift/test/ClangImporter/pch-bridging-header-deps.swift:22:21: error: expected string not found in input
// CHECK-SWIFTDEPS: - "SOURCE_DIR/test/ClangImporter/Inputs/app-bridging-header-to-pch.h"
                    ^
<stdin>:15:1: note: scanning from here
- "/Volumes/BuildDataBUILD_DIR/lib/swift/macosx/x86_64/Swift.swiftmodule"
^
<stdin>:17:19: note: possible intended match here
- "/Volumes/BuildDataSOURCE_DIR/test/ClangImporter/Inputs/app-bridging-header-to-pch.h"
                  ^
```