### PR TITLE
Remove unnecessary semicolon in Swift file

### DIFF
--- a/stdlib/public/SDK/UIKit/UIKit.swift
+++ b/stdlib/public/SDK/UIKit/UIKit.swift
@@ -424,7 +424,7 @@ extension UIDragDropSession {
   public func canLoadObjects<
     T : _ObjectiveCBridgeable
   >(ofClass: T.Type) -> Bool where T._ObjectiveCType : NSItemProviderReading {
-    return self.canLoadObjects(ofClass: T._ObjectiveCType.self);
+    return self.canLoadObjects(ofClass: T._ObjectiveCType.self)
   }
 }
 


### PR DESCRIPTION
The semicolon was not used to join two Swift statements on one line and can therefore be removed.