### PR TITLE
Update SILLoop::canDuplicate to correctly handle begin_apply

### DIFF
--- a/lib/SIL/SILInstruction.cpp
+++ b/lib/SIL/SILInstruction.cpp
@@ -1178,6 +1178,8 @@ bool SILInstruction::isTriviallyDuplicatable() const {
   if (isa<BeginApplyInst>(this))
     return false;
 
+  // If you add more cases here, you should also update SILLoop:canDuplicate.
+
   return true;
 }
 


### PR DESCRIPTION
Leave a warning in isTriviallyDuplicatable so that future updates there will know to also update this code.