### PR TITLE
[DA] Support aggregate packing for arbitrary #tfop result type

### DIFF
--- a/include/swift/AST/TensorFlow.h
+++ b/include/swift/AST/TensorFlow.h
@@ -55,9 +55,15 @@ namespace tf {
   /// VariantHandle.
   bool isTensorFlowValue(Type ty);
 
-  /// Returns true if the specified type is a TensorFlow value or an tuple or
+  /// Return true if the specified type is a TensorFlow value or an tuple or
   /// struct of such.
   bool isTensorFlowValueOrAggregate(Type ty);
+
+  /// Flatten an aggregate of TensorFlow value types and push them to the result
+  /// array. If the given type itself is a TensorFlow value type, it will be
+  /// pushed to the array. If any terminal type is not a TensorFlow value type,
+  /// return false and the result will be empty.
+  bool flattenTensorFlowValueAggregate(Type ty, SmallVectorImpl<Type> &result);
 
   /// This class provides an efficient implementation of a predicate that
   /// determines whether a type is or contains a TensorFlow value that will be

--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -2314,33 +2314,47 @@ void TFDeabstraction::formGraphOp(SILTensorOpInfo &opInfo,
   }
   // Okay, if we got this far then we have all valid attributes and inputs.
   // Figure out the result list.
-  SmallVector<SILType, 4> resultTypes;
-  if (auto tuple = inst->getType().getAs<TupleType>()) {
-    for (auto elt : tuple->getElements()) {
-      auto eltTy = elt.getType()->getCanonicalType();
-      resultTypes.push_back(SILType::getPrimitiveObjectType(eltTy));
+  SmallVector<Type, 4> resultTypes;
+  auto userResultTy = inst->getType().getASTType();
+  if (!tf::flattenTensorFlowValueAggregate(userResultTy, resultTypes))
+    return diagnoseInvalid("the specified result type is not a TensorFlow "
+                           "value type or an aggregate of TensorFlow value "
+                           "types");
+  auto resultSILTypes = map<SmallVector<SILType, 8>>(resultTypes, [&](Type ty) {
+      return SILType::getPrimitiveObjectType(ty->getCanonicalType()); });
+
+  auto loc = getUserSourceLocation(inst);
+  auto op = B.createGraphOperation(loc, context.getIdentifier(opName), inputs,
+                                   attributes, resultSILTypes);
+
+  // Recursively pack results to a value with the user-specified aggregate type.
+  auto resultIt = op->getResults().begin();
+  std::function<SILValue(SILType)> packResultsToAggregate;
+  packResultsToAggregate = [&](SILType aggregateTy) -> SILValue {
+    if (isTensorFlowValue(aggregateTy))
+      return *resultIt++;
+    if (auto tupleTy = aggregateTy.getAs<TupleType>()) {
+      SmallVector<SILValue, 8> elts;
+      for (auto i : range(tupleTy->getNumElements()))
+        elts.push_back(
+            packResultsToAggregate(aggregateTy.getTupleElementType(i)));
+      return B.createTuple(loc, aggregateTy, elts);
     }
-  } else {
-    resultTypes.push_back(inst->getType());
-  }
-
-  auto op = B.createGraphOperation(getUserSourceLocation(inst),
-                                   context.getIdentifier(opName), inputs,
-                                   attributes, resultTypes);
-
-  if (auto tuple = inst->getType().getAs<TupleType>()) {
-    SmallVector<SILValue, 4> elts;
-    for (unsigned i = 0, e = tuple->getNumElements(); i != e; ++i)
-      elts.push_back(op->getResult(i));
-    auto tupleResult = B.createTuple(inst->getLoc(), elts);
-    tupleResult->setDebugLocation(inst->getDebugLocation());
-
-    inst->replaceAllUsesWith(tupleResult);
-    inst->eraseFromParent();
-  } else {
-    inst->replaceAllUsesWith(op->getResult(0));
-    inst->eraseFromParent();
-  }
+    if (auto *decl = aggregateTy.getStructOrBoundGenericStruct()) {
+      SmallVector<SILValue, 8> elts;
+      for (auto *field : decl->getStoredProperties())
+        elts.push_back(packResultsToAggregate(
+            aggregateTy.getFieldType(field, B.getModule())));
+      return B.createStruct(loc, aggregateTy, elts);
+    }
+    llvm_unreachable("Non-TF type should have been diagnosed");
+  };
+  auto result = packResultsToAggregate(inst->getType());
+  assert(resultIt == op->getResults().end()
+         && "All result types should've been processed");
+  // Replace any use of the old builtin result with the newly packed aggregate.
+  inst->replaceAllUsesWith(result);
+  inst->eraseFromParent();
 
   // TODO: Analyze the operands to the instruction and remove them if they are
   // now dead.

--- a/test/TensorFlow/diagnostics-da.swift
+++ b/test/TensorFlow/diagnostics-da.swift
@@ -15,3 +15,9 @@ public func shapeError() {
   let _ = Tensor<Float>(shape: [1, 3, 3, 1],
                         scalars: [0, 1, 0, 1, 1, 1, 0, 1])
 }
+
+public func resultPacking() {
+  struct Foo { var x: Tensor<Float>, y: Float }
+  // expected-error @+1 {{the specified result type is not a TensorFlow value type or an aggregate of TensorFlow value types}}
+  let _: Foo = #tfop("SomeOp")
+}

--- a/test/TensorFlow/integration.swift
+++ b/test/TensorFlow/integration.swift
@@ -535,3 +535,19 @@ public func graphFuncReturningOpaqueHandles() -> (ResourceHandle, ResourceHandle
 public func testSR8570() {
   () = #tfop("FooOp", Targuments: [] as [Any.Type]) // expected-error {{op named 'FooOp' is not registered in TensorFlow}}
 }
+
+public func packResultsToAggregate() {
+  struct Foo {
+    let x: Tensor<Float>
+    let y: (Tensor<Float>, (a: Tensor<Int32>, b: Tensor<Bool>))
+  }
+  // expected-error @+1 {{op named 'SomeOp' is not registered in TensorFlow}}
+  let (r0, r1): (Foo, Tensor<Double>) = #tfop("SomeOp")
+  let _ = Tensor(0) + r0.y.1.a
+  _hostOp(r1)
+}
+// CHECK-LABEL --- TFPartition Accelerator Result: {{.*}}packResultsToAggregate{{.*}}
+// CHECK:  ([[R0:%.*]], [[R1:%.*]], [[R2:%.*]], [[R3:%.*]], [[R4:%.*]]) = graph_op "SomeOp"() {__device: "/device:CPU:0"} : $TensorHandle<Float>, $TensorHandle<Float>, $TensorHandle<Int32>, $TensorHandle<Bool>, $TensorHandle<Double>
+// CHECK: graph_op "Add,i,i"({{.*}} : $TensorHandle<Int32>, [[R2]] : $TensorHandle<Int32>) {T: $Int32, __device: "/device:CPU:0"} : $TensorHandle<Int32>
+// CHECK:  [[PACKED:%.*]] = tuple ([[R0]] : $TensorHandle<Float>, [[R1]] : $TensorHandle<Float>, [[R2]] : $TensorHandle<Int32>, [[R3]] : $TensorHandle<Bool>, [[R4]] : $TensorHandle<Double>)
+// CHECK:  return [[PACKED]] : $(TensorHandle<Float>, TensorHandle<Float>, TensorHandle<Int32>, TensorHandle<Bool>, TensorHandle<Double>)


### PR DESCRIPTION
When the user-specified `#tfop` result type is an aggregate of TensorFlow values (`TensorHandle`, `VariantHandle`, etc), pack the all handle results into this aggregate.

This is a big step towards the desired expressivity of `#tfop` for supporting generalized TensorFlow data APIs.

```swift
struct Foo {
  let x: Tensor<Float>
  let y: (Tensor<Float>, (a: Tensor<Int32>, b: Tensor<Bool>))
}
let _: Foo = #tfop("SomeOp")
```

Resolves [SR-8573](https://bugs.swift.org/browse/SR-8573).