### PR TITLE
[Diagnostics] Make the rvalue-as-lvalue fix symmetric for bind constraints

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2792,7 +2792,7 @@ namespace {
         return TupleType::get(destTupleTypes, CS.getASTContext());
       } else {
         Type destTy = CS.createTypeVariable(CS.getConstraintLocator(expr));
-        CS.addConstraint(ConstraintKind::Bind, CS.getType(expr), LValueType::get(destTy),
+        CS.addConstraint(ConstraintKind::Bind, LValueType::get(destTy), CS.getType(expr),
                          CS.getConstraintLocator(expr));
         return destTy;
       }

--- a/test/Constraints/assignment.swift
+++ b/test/Constraints/assignment.swift
@@ -53,8 +53,7 @@ value(_) // expected-error{{'_' can only appear in a pattern or on the left side
 // <rdar://problem/23798944> = vs. == in Swift if string character count statement causes segmentation fault
 func f23798944() {
   let s = ""
-  // FIXME: better would be: use of '=' in a boolean context, did you mean '=='?
-  if s.count = 0 { // expected-error {{cannot assign to property: 'count' is a get-only property}}
+  if s.count = 0 { // expected-error {{use of '=' in a boolean context, did you mean '=='?}}
   }
 }
 

--- a/test/Constraints/dynamic_lookup.swift
+++ b/test/Constraints/dynamic_lookup.swift
@@ -180,7 +180,7 @@ obj.generic4!(5) // expected-error{{value of type 'Id' (aka 'AnyObject') has no 
 // Find properties via dynamic lookup.
 var prop1Result : Int = obj.prop1!
 var prop2Result : String = obj.prop2!
-obj.prop2 = "hello" // expected-error{{cannot assign to immutable expression of type 'String?'}}
+obj.prop2 = "hello" // expected-error{{cannot assign to property: 'obj' is immutable}}
 var protoPropResult : Int = obj.protoProp!
 
 // Find subscripts via dynamic lookup
@@ -290,9 +290,9 @@ let _: String = o[s]
 let _: String = o[s]!
 let _: String? = o[s]
 // FIXME: These should all produce lvalues that we can write through
-o.s = s // expected-error {{cannot assign to immutable expression of type 'String?'}}
+o.s = s // expected-error {{cannot assign to property: 'o' is immutable}}
 o.s! = s // expected-error {{cannot assign through '!': 'o' is immutable}}
-o[s] = s // expected-error {{cannot assign to immutable expression of type 'String?'}}
+o[s] = s // expected-error {{cannot assign through subscript: 'o' is immutable}}
 o[s]! = s // expected-error {{cannot assign through '!': 'o' is immutable}}
 
 let _: String = o.t
@@ -309,7 +309,7 @@ let _: DynamicIUO = o[dyn_iuo]!
 let _: DynamicIUO = o[dyn_iuo]!!
 let _: DynamicIUO? = o[dyn_iuo]
 // FIXME: These should all produce lvalues that we can write through
-o[dyn_iuo] = dyn_iuo // expected-error {{cannot assign to immutable expression of type 'DynamicIUO??'}}
+o[dyn_iuo] = dyn_iuo // expected-error {{cannot assign through subscript: 'o' is immutable}}
 o[dyn_iuo]! = dyn_iuo // expected-error {{cannot assign through '!': 'o' is immutable}}
 o[dyn_iuo]!! = dyn_iuo // expected-error {{cannot assign through '!': 'o' is immutable}}
 

--- a/test/NameBinding/dynamic-member-lookup.swift
+++ b/test/NameBinding/dynamic-member-lookup.swift
@@ -67,7 +67,7 @@ func test(a: Gettable, b: Settable, c: MutGettable, d: NonMutSettable) {
 
 func test_iuo(a : Gettable!, b : Settable!) {
   global = a.wyverns
-  a.flavor = global  // expected-error {{cannot assign through dynamic lookup property: subscript is get-only}}
+  a.flavor = global  // expected-error {{cannot assign through dynamic lookup property: 'a' is a 'let' constant}}
   
   global = b.flavor
   b.universal = global // expected-error {{cannot assign through dynamic lookup property: 'b' is a 'let' constant}}

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -314,9 +314,9 @@ func testKeyPathSubscript(readonly: ZwithSubscript, writable: inout ZwithSubscri
   sink = writable[keyPath: wkp]
   sink = readonly[keyPath: rkp]
   sink = writable[keyPath: rkp]
-  readonly[keyPath: kp] = sink // expected-error{{cannot assign through subscript: 'kp' is a read-only key path}}
-  writable[keyPath: kp] = sink // expected-error{{cannot assign through subscript: 'kp' is a read-only key path}}
-  readonly[keyPath: wkp] = sink // expected-error{{cannot assign through subscript: 'readonly' is a 'let' constant}}
+  readonly[keyPath: kp] = sink // expected-error{{cannot assign through subscript: subscript is get-only}}
+  writable[keyPath: kp] = sink // expected-error{{cannot assign through subscript: subscript is get-only}}
+  readonly[keyPath: wkp] = sink // expected-error{{cannot assign through subscript: subscript is get-only}}
   // FIXME: silently falls back to keypath application, which seems inconsistent
   writable[keyPath: wkp] = sink
   // FIXME: silently falls back to keypath application, which seems inconsistent
@@ -331,8 +331,8 @@ func testKeyPathSubscript(readonly: ZwithSubscript, writable: inout ZwithSubscri
   var anySink2 = writable[keyPath: pkp]
   expect(&anySink2, toHaveType: Exactly<Any>.self)
 
-  readonly[keyPath: pkp] = anySink1 // expected-error{{cannot assign through subscript: 'readonly' is a 'let' constant}}
-  writable[keyPath: pkp] = anySink2 // expected-error{{cannot assign through subscript: 'writable' is immutable}}
+  readonly[keyPath: pkp] = anySink1 // expected-error{{cannot assign through subscript: subscript is get-only}}
+  writable[keyPath: pkp] = anySink2 // expected-error{{cannot assign through subscript: subscript is get-only}}
 
   let akp: AnyKeyPath = pkp
 


### PR DESCRIPTION
... which causes another set of assignment errors to be discovered in the CS and again slightly cleans up the code in CSDiag.
