### PR TITLE
[master-next] Add HermitCore OS type for LLVM triples

### DIFF
--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -137,6 +137,7 @@ StringRef swift::getPlatformNameForTriple(const llvm::Triple &triple) {
   case llvm::Triple::Mesa3D:
   case llvm::Triple::Contiki:
   case llvm::Triple::AMDPAL:
+  case llvm::Triple::HermitCore:
     return "";
   case llvm::Triple::Darwin:
   case llvm::Triple::MacOSX:


### PR DESCRIPTION
LLVM r340675 added a new HermitCore OS type to triples, which broke the
Swift build because it is using -Werror,-Wswitch and the new value was not
handled in swift::getPlatformNameForTriple