### PR TITLE
[Perf Test][CSSolver] Prefer components with fewer type variables with all else …

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1548,8 +1548,12 @@ bool ConstraintSystem::solveRec(SmallVectorImpl<Solution> &solutions,
   // owning component.
   llvm::DenseMap<TypeVariableType *, unsigned> typeVarComponent;
   llvm::DenseMap<Constraint *, unsigned> constraintComponent;
+  // Sort the constraints into component buckets based on component number.
+  std::unique_ptr<Component[]> buckets(new Component[numComponents]);
+
   for (unsigned i = 0, n = typeVars.size(); i != n; ++i) {
     // Record the component of this type variable.
+    buckets[components[i]].record(typeVars[i]);
     typeVarComponent[typeVars[i]] = components[i];
 
     // Record the component of each of the constraints.
@@ -1565,9 +1569,6 @@ bool ConstraintSystem::solveRec(SmallVectorImpl<Solution> &solutions,
     for (auto constraint : CG.getOrphanedConstraints())
       constraintComponent[constraint] = component++;
   }
-
-  // Sort the constraints into component buckets based on component number.
-  std::unique_ptr<Component[]> buckets(new Component[numComponents]);
 
   while (!InactiveConstraints.empty()) {
     auto *constraint = &InactiveConstraints.front();

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3426,10 +3426,16 @@ class Component {
   ConstraintList Constraints;
   SmallVector<Constraint *, 8> Disjunctions;
 
+  /// Used to break ties in ordering when the number
+  /// of disjunctions is the same in both components.
+  unsigned NumTypeVars = 0;
+
 public:
   void reinstateTo(ConstraintList &workList) {
     workList.splice(workList.end(), Constraints);
   }
+
+  void record(TypeVariableType *typeVar) { ++NumTypeVars; }
 
   void record(Constraint *constraint) {
     Constraints.push_back(constraint);
@@ -3460,7 +3466,16 @@ public:
   }
 
   bool operator<(const Component &other) const {
-    return disjunctionCount() < other.disjunctionCount();
+    auto numDisjunctsA = disjunctionCount();
+    auto numDisjunctsB = other.disjunctionCount();
+
+    // If the number of disjunctions is the same in both
+    // components, let's prioritize the one with fewer
+    // type variables, because it would fail faster.
+    if (numDisjunctsA == numDisjunctsB)
+      return NumTypeVars < other.NumTypeVars;
+
+    return numDisjunctsA < numDisjunctsB;
   }
 
 private:


### PR DESCRIPTION
…equal

If the number of disjunctions is the same in both components, let's
prefer the one which has fewer type variables because it would result
in less work done if something fails.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
