### PR TITLE
Removed some TF attr modifiers (e.g. $dtype)

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
+++ b/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
@@ -271,7 +271,7 @@ static SILValue createTFIntegerConst(GraphFunctionDeviceInfo &deviceInfo,
   // Literals take attributes specifying the dtype, value, and device.
   std::string opName("Const");
   SmallVector<GraphOperationAttribute, 3>  attributes;
-  attributes.push_back({context.getIdentifier("dtype$dtype"),
+  attributes.push_back({context.getIdentifier("dtype"),
                         SymbolicValue::getMetatype(intType.getASTType())});
   attributes.push_back({context.getIdentifier("value$tensor"),
                         SymbolicValue::getInteger(APInt(bitwidth, value),

--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -2256,7 +2256,7 @@ void TFDeabstraction::formGraphOp(SILTensorOpInfo &opInfo,
       auto elements = constValue.getArrayValue(eltType);
 
       if ((size_t)numEltsFromShapeAttr != elements.size())
-        return diagnoseInvalidAttr("has a mismatch with the shape attribute in "
+        return diagnoseInvalidAttr("does not match the shape attribute in "
                                    "the number of scalar elements");
 
       // Empty tensor value is ok.

--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -2179,74 +2179,15 @@ void TFDeabstraction::formGraphOp(SILTensorOpInfo &opInfo,
       return false;
     };
 
-    // Emits a diagnostic and returns true if the value is invalid for a shape
-    // attr.
-    auto verifyShapeAttr = [&](SymbolicValue constValue) -> bool {
-      // strip away the possible aggregate wrapper.
-      constValue = constValue.lookThroughSingleElementAggregates();
-      if (constValue.getKind() != SymbolicValue::Array) {
-        diagnoseInvalidAttr("requires an array");
-        return true;
-      }
-      CanType eltType;
-      auto elements = constValue.getArrayValue(eltType);
-      if (!StringRef(eltType->getString()).startswith("Int")) {
-        diagnoseInvalidAttr("requires an array of ints");
-        return true;
-      }
-      for (auto elt : elements) {
-        // strip away the possible aggregate wrapper.
-        elt = elt.lookThroughSingleElementAggregates();
-        if (elt.getKind() != SymbolicValue::Integer) {
-          diagnoseInvalidAttr("requires an array of ints");
-          return true;
-        }
-      }
-      return false;
-    };
-
     // Verify that the type of this attribute is ok for the OperandClass we
     // have.
     switch (operandClass.second) {
     case SILTensorOpInfo::OperandClass::Input:
-    case SILTensorOpInfo::OperandClass::InputElt:
-      assert(0 && "Input classes cannot exist for attributes");
     case SILTensorOpInfo::OperandClass::Normal:  // No modifier.
       if (verifyNormalAttr(constValue))
         return; // error already emitted.
       break;
-    case SILTensorOpInfo::OperandClass::DType:
-      // This integer value is a dtype.
-      if (constValue.getKind() != SymbolicValue::Integer)
-        return diagnoseInvalidAttr("requires a constant integer");
-      break;
-    case SILTensorOpInfo::OperandClass::Array:
-      if (constValue.getKind() != SymbolicValue::Array)
-        return diagnoseInvalidAttr("requires an array");
-      break;
-    case SILTensorOpInfo::OperandClass::Shape:
-      if (verifyShapeAttr(constValue))
-        return; // error already emitted.
-      break;
-    case SILTensorOpInfo::OperandClass::ShapeArray: {
-      if (constValue.getKind() != SymbolicValue::Array)
-        return diagnoseInvalidAttr("requires an array");
-      CanType eltType;
-      auto shapes = constValue.getArrayValue(eltType);
-      if (eltType->getString() != "TensorShape")
-        return diagnoseInvalidAttr("requires an array of TensorShape values");
-      for (auto shape : shapes) {
-        if (verifyShapeAttr(shape))
-          return; // error already emitted.
-      }
-      break;
-    }
-    case SILTensorOpInfo::OperandClass::ArrayElement:
-      inst->dump();
-      assert(0 && "FIXME: array elem exprs aren't handled yet");
     case SILTensorOpInfo::OperandClass::Tensor:
-      // FIXME: There needs to be a dtype attribute before this.
-
       if (constValue.getKind() == SymbolicValue::Integer ||
           constValue.getKind() == SymbolicValue::Float   ||
           constValue.getKind() == SymbolicValue::String)
@@ -2256,18 +2197,67 @@ void TFDeabstraction::formGraphOp(SILTensorOpInfo &opInfo,
         return diagnoseInvalidAttr("requires a constant that is an integer,"
                                    " floating point, or array thereof");
 
+      // Emits a diagnostic and returns a negative number if the value is not an
+      // int array.  Otherwise returns the product of the array element
+      // values. e.g. For array [2, 3], return 6.
+      auto getIntArrayProduct = [&](SymbolicValue constValue) -> long long {
+        // strip away the possible aggregate wrapper.
+        constValue = constValue.lookThroughSingleElementAggregates();
+        if (constValue.getKind() != SymbolicValue::Array) {
+          diagnoseInvalidAttr("requires an array");
+          return -1;
+        }
+        CanType eltType;
+        auto elements = constValue.getArrayValue(eltType);
+        if (!StringRef(eltType->getString()).startswith("Int")) {
+          diagnoseInvalidAttr("requires an array of ints");
+          return -1;
+        }
+        long long ret = 1;
+        for (auto elt : elements) {
+          // strip away the possible aggregate wrapper.
+          elt = elt.lookThroughSingleElementAggregates();
+          if (elt.getKind() != SymbolicValue::Integer) {
+            diagnoseInvalidAttr("requires an array of ints");
+            return -1;
+          }
+          // It is possible for this to overflow, but the resulting compilation
+          // will still be correct, so for simplicity we do not guard against
+          // overflow. More specifically, when it overflows, we would either
+          // return a negative value and thus reject the input program, or
+          // return an incorrect positive value. In both cases, the input
+          // program will still be eventually rejected (e.g. in TF graph
+          // compiler), since the specified shape is too large. As such, the
+          // correctness of compilation is preserved.
+          ret *= elt.getIntegerValue().getLimitedValue();
+        }
+        return ret;
+      };
+      // Returns a negative number if the next attr is not a shape.  Otherwise
+      // returns the number of elements as given by the shape attr. e.g. a
+      // tensor with shape [2, 3] has 6 elements.
+      auto getNumEltsFromShapeAttr = [&]() -> long long {
+        if (i + 1 >= opInfo.operandClasses.size())
+          return -1;
+        auto operand = inst->getOperand(i + 1);
+        auto it = constants.find(operand);
+        if (it == constants.end() || !it->second.isConstant())
+          return -1;
+        auto constValue = it->second.lookThroughSingleElementAggregates();
+        return getIntArrayProduct(constValue);
+      };
+      // Shape attr is an int array.
+      auto numEltsFromShapeAttr = getNumEltsFromShapeAttr();
+      if (numEltsFromShapeAttr < 0)
+        return diagnoseInvalidAttr("must be followed by a shape attribute");
+
+      // Validate that the shape matches the # elements we have.
       CanType eltType;
       auto elements = constValue.getArrayValue(eltType);
 
-      /// Tensor array arguments must always be followed by a shape.
-      if (i+1 >= opInfo.operandClasses.size() ||
-          opInfo.operandClasses[i+1].second !=
-                      SILTensorOpInfo::OperandClass::Shape)
-        return diagnoseInvalidAttr("tensor attributes must be followed by "
-                                   "a shape attribute");
-
-      // TODO: Decode the shape and validate that it matches the # elements
-      // we have.
+      if ((size_t)numEltsFromShapeAttr != elements.size())
+        return diagnoseInvalidAttr("has a mismatch with the shape attribute in "
+                                   "the number of scalar elements");
 
       // Empty tensor value is ok.
       if (elements.empty()) break;

--- a/lib/SILOptimizer/Mandatory/TFDeviceSupport.h
+++ b/lib/SILOptimizer/Mandatory/TFDeviceSupport.h
@@ -79,7 +79,7 @@ static DeviceType getOpDeviceType(llvm::StringRef device) {
 }
 
 /// The returned string is compatible with TF device name used in TF graphs.
-static std::string getDeviceString(DeviceType deviceType) {
+static inline std::string getDeviceString(DeviceType deviceType) {
   switch (deviceType) {
   case DeviceType::CPU:
     return DEFAULT_CPU_DEVICE;

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -2155,6 +2155,12 @@ TFGraphFunctionLowering::visitGraphOperationInst(GraphOperationInst *inst) {
         return GLStatus::Error;
       break;
     }
+    case SILTensorOpInfo::OperandClass::Shape: {
+      SmallVector<int64_t, 4> shape;
+      auto rank = decodeShapeAttr(SILFn.getASTContext(), attrValue, shape);
+      TF_SetAttrShape(op, name.c_str(), shape.data(), rank);
+      break;
+    }
     }
   }
 

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -1047,18 +1047,13 @@ static unsigned getTFDataTypeFromTensorGenericType(Type type) {
 
 /// Decode shape elements from the tfop builtin instruction, starting at
 /// operand `operandIdx`, into `shape`.
-static void decodeShapeElements(SILValue attrValue,
-                                const SILTensorOpInfo &tfopInfo,
-                                unsigned &operandIdx, unsigned operandEndIdx,
-                                SmallVectorImpl<int64_t> &shape) {
+static void decodeShapeElementsLegacy(SILValue attrValue,
+                                      const SILTensorOpInfo &tfopInfo,
+                                      unsigned &operandIdx,
+                                      unsigned operandEndIdx,
+                                      SmallVectorImpl<int64_t> &shape) {
   assert(isa<MetatypeInst>(attrValue) && "$shape should start with a metatype");
-  while (operandIdx + 1 < operandEndIdx &&
-         tfopInfo.operandClasses[operandIdx + 1].second ==
-             SILTensorOpInfo::OperandClass::ArrayElement) {
-    auto eltValue = tfopInfo.inst->getOperand(++operandIdx);
-    auto intValue = cast<IntegerLiteralInst>(eltValue);
-    shape.push_back(intValue->getValue().getLimitedValue());
-  }
+  // Only support scalar tensor shapes (with no shape elements).
 }
 
 /// Decode the shape array attribute from the tfop builtin instruction, starting
@@ -1076,11 +1071,9 @@ static void decodeShapeArrayLegacy(const SILTensorOpInfo &tfopInfo,
     auto prevNumDims = dims.size();
     ++operandIdx; // We consumed an operand.
     auto nextOperand = inst->getOperand(operandIdx);
-    assert(tfopInfo.operandClasses[operandIdx].second ==
-               SILTensorOpInfo::OperandClass::Shape &&
-           "expected a shape value");
 
-    decodeShapeElements(nextOperand, tfopInfo, operandIdx, operandEndIdx, dims);
+    decodeShapeElementsLegacy(nextOperand, tfopInfo, operandIdx, operandEndIdx,
+                              dims);
     numDims.push_back(int(dims.size() - prevNumDims));
   }
 
@@ -1160,8 +1153,7 @@ static void decodeShapeArrayAtAttr(const ASTContext &ctx,
   auto *inst = graphOpInfo.inst;
   auto attr = inst->getAttribute(attrIdx);
   auto attrInfo = GraphOperationInfo::decodeAttributeName(attr.name);
-  assert(attrInfo.second == SILTensorOpInfo::OperandClass::Normal ||
-         attrInfo.second == SILTensorOpInfo::OperandClass::ShapeArray);
+  assert(attrInfo.second == SILTensorOpInfo::OperandClass::Normal);
   assert(attrInfo.first == attrName);
   decodeShapeArray(ctx, attr.value, dims, numDims, dimPtrs);
 }
@@ -1942,7 +1934,7 @@ TFGraphFunctionLowering::visitGraphOperationInst(GraphOperationInst *inst) {
 
   // Process all of the attributes.
   // For an inst like:
-  //   graph_op "Const"() {dtype$dtype: $Builtin.Int64, value$tensor: i1 0
+  //   graph_op "Const"() {dtype: $Builtin.Int64, value$tensor: i1 0
   // We will use the `dtype` attr value to lower the `value` attr, so we
   // remember the dtype info here.
   // We use unsigned instead of TF_DataType, to express the invalid initial
@@ -1961,7 +1953,6 @@ TFGraphFunctionLowering::visitGraphOperationInst(GraphOperationInst *inst) {
 
     switch (attrInfo.second) {
     case SILTensorOpInfo::OperandClass::Input:
-    case SILTensorOpInfo::OperandClass::InputElt:
       assert(0 && "Input classes cannot exist for attributes");
 
     case SILTensorOpInfo::OperandClass::Normal: // No modifier.
@@ -2113,12 +2104,6 @@ TFGraphFunctionLowering::visitGraphOperationInst(GraphOperationInst *inst) {
       }
       // Done with normal attributes.
       break;
-    case SILTensorOpInfo::OperandClass::DType: {
-      auto swiftType = attrValue.getMetatypeValue();
-      dtypeAttr = convertSwiftTypeToTF(swiftType);
-      TF_SetAttrType(op, name.data(), (TF_DataType)dtypeAttr);
-      break;
-    }
     case SILTensorOpInfo::OperandClass::Tensor: {
       if (!dtypeAttr) {
         inst->dump();
@@ -2170,27 +2155,6 @@ TFGraphFunctionLowering::visitGraphOperationInst(GraphOperationInst *inst) {
         return GLStatus::Error;
       break;
     }
-    case SILTensorOpInfo::OperandClass::Shape: {
-      SmallVector<int64_t, 4> shape;
-      auto rank = decodeShapeAttr(SILFn.getASTContext(), attrValue, shape);
-      TF_SetAttrShape(op, name.c_str(), shape.data(), rank);
-      break;
-    }
-
-    case SILTensorOpInfo::OperandClass::ShapeArray:
-      // SHAPE_ARRAY_ATTR is a pseudo-attribute used by the compiler's
-      // partitioning and graph lowering passes to propagate shape info for
-      // XLA compilation (e.g. feed shape info to infeed / outfeed ops), and
-      // will not be lowered into this graph op itself.
-      if (isShapeArrayPseudoAttr(name, attrValue))
-        break;
-      internalError(getUserSourceLocation(inst->getDebugLocation()),
-                    "FIXME: Handle shapearray attributes");
-      return GLStatus::Error;
-
-    case SILTensorOpInfo::OperandClass::Array: // Handled as 'normal'
-    case SILTensorOpInfo::OperandClass::ArrayElement:
-      llvm_unreachable("This is a legacy class that shouldn't happen");
     }
   }
 

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -2435,7 +2435,7 @@ static void createConstTensorAttrsOnAccel(
     SmallVectorImpl<GraphOperationAttribute> &attributes) {
   // Literals take attributes specifying the dtype and value.
   attributes.push_back(
-      {ctx.getIdentifier("dtype$dtype"),
+      {ctx.getIdentifier("dtype"),
        SymbolicValue::getMetatype(valTy.getASTType()->getCanonicalType())});
   attributes.push_back({ctx.getIdentifier("value$tensor"), constVal});
 }
@@ -2545,7 +2545,7 @@ void PartitionCloner::visitScalarInst(SingleValueInstruction *inst) {
     // Conversions get an attribute specifying the result dtype, named "DstT".
     opName += GraphOperationInfo::getInputMarker(GraphOperationInfo::IM_Normal);
     attributes.push_back(
-        {ctx.getIdentifier("DstT$dtype"),
+        {ctx.getIdentifier("DstT"),
          SymbolicValue::getMetatype(
              inst->getType().getASTType()->getCanonicalType())});
     break;

--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -380,6 +380,8 @@ const char *SILTensorOpInfo::getOperandClassSuffix(OperandClass opClass) {
     return "";
   case OperandClass::Tensor:
     return "$tensor";
+  case OperandClass::Shape:
+    return "$shape";
   }
 }
 
@@ -390,6 +392,7 @@ SILTensorOpInfo::getOperandClass(StringRef suffix) {
       .Case("in", OperandClass::Input)
       .Case("", OperandClass::Normal)
       .Case("tensor", OperandClass::Tensor)
+      .Case("shape", OperandClass::Shape)
       .Default(None);
 }
 
@@ -580,9 +583,12 @@ tf::createConstTensor(Type elementType, SymbolicValue scalars,
   attributes.push_back(
       {context.getIdentifier(std::string("value") + tensorSuffix), scalars});
 
-  // Add the shape attribute if we have an array value.
+  // Add the shape$shape attribute if we have an array value.
   if (scalars.getKind() == SymbolicValue::Array) {
-    attributes.push_back({context.getIdentifier(std::string("shape")), shape});
+    auto shapeId = SILTensorOpInfo::OperandClass::Shape;
+    auto shapeSuffix = SILTensorOpInfo::getOperandClassSuffix(shapeId);
+    attributes.push_back(
+        {context.getIdentifier(std::string("shape") + shapeSuffix), shape});
   }
 
   // All graph_op's get a device.

--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -376,22 +376,10 @@ const char *SILTensorOpInfo::getOperandClassSuffix(OperandClass opClass) {
   switch (opClass) {
   case OperandClass::Input:
     return "$in";
-  case OperandClass::InputElt:
-    return "$inelt";
   case OperandClass::Normal:
     return "";
-  case OperandClass::DType:
-    return "$dtype";
   case OperandClass::Tensor:
     return "$tensor";
-  case OperandClass::Shape:
-    return "$shape";
-  case OperandClass::Array:
-    return "$array";
-  case OperandClass::ArrayElement:
-    return "$elt";
-  case OperandClass::ShapeArray:
-    return "$shapearray";
   }
 }
 
@@ -400,14 +388,8 @@ llvm::Optional<OperandClass>
 SILTensorOpInfo::getOperandClass(StringRef suffix) {
   return llvm::StringSwitch<llvm::Optional<OperandClass>>(suffix)
       .Case("in", OperandClass::Input)
-      .Case("inelt", OperandClass::InputElt)
       .Case("", OperandClass::Normal)
       .Case("tensor", OperandClass::Tensor)
-      .Case("shape", OperandClass::Shape)
-      .Case("dtype", OperandClass::DType)
-      .Case("array", OperandClass::Array)
-      .Case("elt", OperandClass::ArrayElement)
-      .Case("shapearray", OperandClass::ShapeArray)
       .Default(None);
 }
 
@@ -469,7 +451,7 @@ GraphOperationInfo::decodeName(SmallVectorImpl<InputMarker> &inputInfo) {
   return opName;
 }
 
-/// Given an attribute name like foo$dtype, decode the name and the class.  If
+/// Given an attribute name like foo$tensor, decode the name and the class.  If
 /// there is no modifier specified, this defaults to OperandClass::Normal.
 std::pair<StringRef, SILTensorOpInfo::OperandClass>
 GraphOperationInfo::decodeAttributeName(Identifier name) {
@@ -480,7 +462,12 @@ GraphOperationInfo::decodeAttributeName(Identifier name) {
   auto opClass = OperandClass::Normal;
   if (dollarLoc != StringRef::npos) {
     auto suffix = nameStr.drop_front(dollarLoc + 1);
-    opClass = SILTensorOpInfo::getOperandClass(suffix).getValue();
+    if (auto res = SILTensorOpInfo::getOperandClass(suffix))
+      opClass = res.getValue();
+    else {
+      std::string msg = "invalid attribute modifier '" + name.str().str() + "'";
+      llvm_unreachable(msg.c_str());
+    }
   }
 
   // Slice the suffix off the attribute name and add the decoded version.
@@ -593,12 +580,9 @@ tf::createConstTensor(Type elementType, SymbolicValue scalars,
   attributes.push_back(
       {context.getIdentifier(std::string("value") + tensorSuffix), scalars});
 
-  // Add the value$shape attribute if we have an array value.
+  // Add the shape attribute if we have an array value.
   if (scalars.getKind() == SymbolicValue::Array) {
-    auto shapeId = SILTensorOpInfo::OperandClass::Shape;
-    auto shapeSuffix = SILTensorOpInfo::getOperandClassSuffix(shapeId);
-    attributes.push_back(
-        {context.getIdentifier(std::string("value") + shapeSuffix), shape});
+    attributes.push_back({context.getIdentifier(std::string("shape")), shape});
   }
 
   // All graph_op's get a device.

--- a/lib/SILOptimizer/Mandatory/TFUtilities.h
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.h
@@ -117,24 +117,12 @@ struct SILTensorOpInfo {
   enum class OperandClass {
     /// This marks three sorts of things:
     /// 1) A normal tensor input: the value is a TensorHandle.
-    /// 2) A scalar input suitable for scalar promotion, used by the
-    ///    tf.scalarToTensor pseudo-op, the value is a scalar value.
-    /// 3) A tensor array (TensorFlow "InputList").  The value is a metatype
-    ///    marker value (so we can represent empty arrays) followed by
-    ///    InputElt elements that make up the array.
+    /// 2) An normal attribute (without modifier).
+    /// 3) A tensor attribute.
     Input,
-    InputElt, // Element of an input list.  Always a TensorHandle.
 
     Normal, // No modifier.
-    DType,  // This integer value is a dtype.
     Tensor, // This array or scalar should be turned into a TF_Tensor.
-    Shape,  // This array of integers is a shape specifier.
-
-    Array,        // This marks a normal array value, the value is a metatype.
-    ArrayElement, // This is a continuation element of an attribute array.
-
-    // This is the start of a shape array.  The value is the # elements.
-    ShapeArray,
   };
 
   /// Return the string suffix for the specified attribute modifier.
@@ -148,8 +136,7 @@ struct SILTensorOpInfo {
 
   /// Return true if the specified operand is an input (not an attribute).
   bool isInput(unsigned operandNumber) const {
-    return operandClasses[operandNumber].second == OperandClass::Input ||
-           operandClasses[operandNumber].second == OperandClass::InputElt;
+    return operandClasses[operandNumber].second == OperandClass::Input;
   }
 
   /// Analyze the specified SIL instruction and return a SILTensorOpInfo
@@ -209,7 +196,7 @@ struct GraphOperationInfo {
   /// information about the operands.
   StringRef decodeName(SmallVectorImpl<InputMarker> &inputInfo);
 
-  /// Given an attribute name like foo$dtype, decode the name and the class.
+  /// Given an attribute name like foo$tensor, decode the name and the class.
   /// If there is no modifier specified, this defaults to
   /// OperandClass::Normal.
   static std::pair<StringRef, SILTensorOpInfo::OperandClass>

--- a/lib/SILOptimizer/Mandatory/TFUtilities.h
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.h
@@ -118,11 +118,12 @@ struct SILTensorOpInfo {
     /// This marks three sorts of things:
     /// 1) A normal tensor input: the value is a TensorHandle.
     /// 2) An normal attribute (without modifier).
-    /// 3) A tensor attribute.
+    /// 3) A tensor or shape attribute (need a modifier for proper lowering).
     Input,
 
     Normal, // No modifier.
     Tensor, // This array or scalar should be turned into a TF_Tensor.
+    Shape,  // This array of integers is a shape specifier.
   };
 
   /// Return the string suffix for the specified attribute modifier.

--- a/test/TensorFlow/deabstraction_finished.swift
+++ b/test/TensorFlow/deabstraction_finished.swift
@@ -96,7 +96,7 @@ CHECK-LABEL: --- INPUT FUNCTION {{.*}}stringAttributes
 public func tensorShape() -> Tensor<Float> {
   let shape : TensorShape = [1, 2]
 
-  return Tensor(handle: #tfop("Const", dtype: Float.self, value$tensor: [17.0 as Float, 18.0], value$shape: shape))
+  return Tensor(handle: #tfop("Const", dtype: Float.self, value$tensor: [17.0 as Float, 18.0], shape: shape))
 }
 
 // b/75407624
@@ -110,14 +110,14 @@ public func test75407624() {
   _ = a+b+c+d
 }
 /* CHECK-LABEL: ---- INPUT FUNCTION {{.*}}test75407624
- * CHECK: graph_op "Const"() {dtype: $Float, value$tensor: [$Float: (f32 0x3F800000 /* 1 */)], value$shape: [$Int32: i32 1]
- * CHECK: [[B1X:%.*]] = graph_op "Const"() {dtype: $Int32, value$tensor: [$Int32: (i32 1)], value$shape: [$Int32: i32 1],
+ * CHECK: graph_op "Const"() {dtype: $Float, value$tensor: [$Float: (f32 0x3F800000 /* 1 */)], shape: [$Int32: i32 1]
+ * CHECK: [[B1X:%.*]] = graph_op "Const"() {dtype: $Int32, value$tensor: [$Int32: (i32 1)], shape: [$Int32: i32 1],
  * CHECK: [[BX2:%.*]] = graph_op "Const"() {dtype: $Float, value$tensor: f32 0x3F800000 /* 1 */
  * CHECK:  graph_op "Fill,i,i"([[B1X]] : $TensorHandle<Int32>, [[BX2]] : $TensorHandle<Float>)
- * CHECK: [[C1X:%.*]] = graph_op "Const"() {dtype: $Int32, value$tensor: [$Int32: (i32 1)], value$shape: [$Int32: i32 1],
+ * CHECK: [[C1X:%.*]] = graph_op "Const"() {dtype: $Int32, value$tensor: [$Int32: (i32 1)], shape: [$Int32: i32 1],
  * CHECK: [[CX2:%.*]] = graph_op "Const"() {dtype: $Float, value$tensor: f32 0x3F800000 /* 1 */
  * CHECK:  graph_op "Fill,i,i"([[C1X]] : $TensorHandle<Int32>, [[CX2]] : $TensorHandle<Float>)
- * CHECK: graph_op "Const"() {dtype: $Float, value$tensor: [$Float: (f32 0x3F800000 /* 1 */), (f32 0x40000000 /* 2 */), (f32 0x40400000 /* 3 */), (f32 0x40800000 /* 4 */)], value$shape: [$Int32: (i32 2), (i32 2)],
+ * CHECK: graph_op "Const"() {dtype: $Float, value$tensor: [$Float: (f32 0x3F800000 /* 1 */), (f32 0x40000000 /* 2 */), (f32 0x40400000 /* 3 */), (f32 0x40800000 /* 4 */)], shape: [$Int32: (i32 2), (i32 2)],
  * CHECK-LABEL: ---- END OF
 */
 

--- a/test/TensorFlow/deabstraction_finished.swift
+++ b/test/TensorFlow/deabstraction_finished.swift
@@ -96,7 +96,7 @@ CHECK-LABEL: --- INPUT FUNCTION {{.*}}stringAttributes
 public func tensorShape() -> Tensor<Float> {
   let shape : TensorShape = [1, 2]
 
-  return Tensor(handle: #tfop("Const", dtype: Float.self, value$tensor: [17.0 as Float, 18.0], shape: shape))
+  return Tensor(handle: #tfop("Const", dtype: Float.self, value$tensor: [17.0 as Float, 18.0], shape$shape: shape))
 }
 
 // b/75407624
@@ -110,14 +110,14 @@ public func test75407624() {
   _ = a+b+c+d
 }
 /* CHECK-LABEL: ---- INPUT FUNCTION {{.*}}test75407624
- * CHECK: graph_op "Const"() {dtype: $Float, value$tensor: [$Float: (f32 0x3F800000 /* 1 */)], shape: [$Int32: i32 1]
- * CHECK: [[B1X:%.*]] = graph_op "Const"() {dtype: $Int32, value$tensor: [$Int32: (i32 1)], shape: [$Int32: i32 1],
+ * CHECK: graph_op "Const"() {dtype: $Float, value$tensor: [$Float: (f32 0x3F800000 /* 1 */)], shape$shape: [$Int32: i32 1]
+ * CHECK: [[B1X:%.*]] = graph_op "Const"() {dtype: $Int32, value$tensor: [$Int32: (i32 1)], shape$shape: [$Int32: i32 1],
  * CHECK: [[BX2:%.*]] = graph_op "Const"() {dtype: $Float, value$tensor: f32 0x3F800000 /* 1 */
  * CHECK:  graph_op "Fill,i,i"([[B1X]] : $TensorHandle<Int32>, [[BX2]] : $TensorHandle<Float>)
- * CHECK: [[C1X:%.*]] = graph_op "Const"() {dtype: $Int32, value$tensor: [$Int32: (i32 1)], shape: [$Int32: i32 1],
+ * CHECK: [[C1X:%.*]] = graph_op "Const"() {dtype: $Int32, value$tensor: [$Int32: (i32 1)], shape$shape: [$Int32: i32 1],
  * CHECK: [[CX2:%.*]] = graph_op "Const"() {dtype: $Float, value$tensor: f32 0x3F800000 /* 1 */
  * CHECK:  graph_op "Fill,i,i"([[C1X]] : $TensorHandle<Int32>, [[CX2]] : $TensorHandle<Float>)
- * CHECK: graph_op "Const"() {dtype: $Float, value$tensor: [$Float: (f32 0x3F800000 /* 1 */), (f32 0x40000000 /* 2 */), (f32 0x40400000 /* 3 */), (f32 0x40800000 /* 4 */)], shape: [$Int32: (i32 2), (i32 2)],
+ * CHECK: graph_op "Const"() {dtype: $Float, value$tensor: [$Float: (f32 0x3F800000 /* 1 */), (f32 0x40000000 /* 2 */), (f32 0x40400000 /* 3 */), (f32 0x40800000 /* 4 */)], shape$shape: [$Int32: (i32 2), (i32 2)],
  * CHECK-LABEL: ---- END OF
 */
 

--- a/test/TensorFlow/diagnostics_with_deabstraction_error.swift
+++ b/test/TensorFlow/diagnostics_with_deabstraction_error.swift
@@ -34,4 +34,13 @@ public func invalidAttrTensor(a: Tensor<Float>) {
    () = #tfop("foo", someAttr: a)
 }
 
+public func noTensorShape() -> Tensor<Float> {
+  // expected-error @+1 {{attribute 'value' must be followed by a shape attribute}}
+  return Tensor(handle: #tfop("Const", dtype: Float.self, value$tensor: [17.0 as Float, 18.0]))
+}
 
+public func badTensorShape() -> Tensor<Float> {
+  let badShape : TensorShape = [1]
+  // expected-error @+1 {{attribute 'value' has a mismatch with the shape attribute in the number of scalar elements}}
+  return Tensor(handle: #tfop("Const", dtype: Float.self, value$tensor: [17.0 as Float, 18.0], shape: badShape))
+}

--- a/test/TensorFlow/diagnostics_with_deabstraction_error.swift
+++ b/test/TensorFlow/diagnostics_with_deabstraction_error.swift
@@ -42,5 +42,5 @@ public func noTensorShape() -> Tensor<Float> {
 public func badTensorShape() -> Tensor<Float> {
   let badShape : TensorShape = [1]
   // expected-error @+1 {{attribute 'value' does not match the shape attribute in the number of scalar elements}}
-  return Tensor(handle: #tfop("Const", dtype: Float.self, value$tensor: [17.0 as Float, 18.0], shape: badShape))
+  return Tensor(handle: #tfop("Const", dtype: Float.self, value$tensor: [17.0 as Float, 18.0], shape$shape: badShape))
 }

--- a/test/TensorFlow/diagnostics_with_deabstraction_error.swift
+++ b/test/TensorFlow/diagnostics_with_deabstraction_error.swift
@@ -41,6 +41,6 @@ public func noTensorShape() -> Tensor<Float> {
 
 public func badTensorShape() -> Tensor<Float> {
   let badShape : TensorShape = [1]
-  // expected-error @+1 {{attribute 'value' has a mismatch with the shape attribute in the number of scalar elements}}
+  // expected-error @+1 {{attribute 'value' does not match the shape attribute in the number of scalar elements}}
   return Tensor(handle: #tfop("Const", dtype: Float.self, value$tensor: [17.0 as Float, 18.0], shape: badShape))
 }

--- a/test/TensorFlow/integration.swift
+++ b/test/TensorFlow/integration.swift
@@ -252,7 +252,7 @@ public func test_while1(maxCount: Int, arg1: Tensor<Float>, arg2: Tensor<Float>)
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}test_while1{{.*}}
 // CHECK: sil private @{{.*}}test_while1{{.*}}
 // CHECK: bb0(%0 : @unowned $TensorHandle<Float>, %1 : @unowned $TensorHandle<Float>, %2 : @unowned $TensorHandle<Builtin.Int1>, %3 : @unowned $TensorHandle<Builtin.Int64>):
-// CHECK-NEXT: graph_op "Const"() {dtype$dtype: $Builtin.Int64, value$tensor: i64 0
+// CHECK-NEXT: graph_op "Const"() {dtype: $Builtin.Int64, value$tensor: i64 0
 // CHECK:      graph_op "Add,i,i"(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>
 // CHECK-NEXT: graph_op "tf_tensor_to_i1"(
 // CHECK-NEXT: cond_br {{.*}}, bb2, bb1
@@ -418,7 +418,7 @@ public func testStringHandle() {
     "Const", dtype:
     String.self,
     value$tensor: ["foo", "bar"],
-    value$shape: TensorShape(2)
+    shape: TensorShape(2)
   )
 }
 
@@ -427,7 +427,7 @@ public func testStringHandle() {
 // CHECK: [[POS:%.*]] = graph_op "Const"() {dtype: $Int32, value$tensor: i32 0, __device: "ALL_DEVICES"} : $TensorHandle<Int32>
 // CHECK: [[LEN:%.*]] = graph_op "Const"() {dtype: $Int32, value$tensor: i32 1, __device: "ALL_DEVICES"} : $TensorHandle<Int32>
 // CHECK: graph_op "Substr,i,i,i"([[STR]] : $TensorHandle<String>, [[POS]] : $TensorHandle<Int32>, [[LEN]] : $TensorHandle<Int32>) {__device: "/device:CPU:0"} : $TensorHandle<String>
-// CHECK: graph_op "Const"() {dtype: $String, value$tensor: [$String: "foo", "bar"], value$shape: [$Int32: (i32 2)], __device: "/device:CPU:0"} : $TensorHandle<String>
+// CHECK: graph_op "Const"() {dtype: $String, value$tensor: [$String: "foo", "bar"], shape: [$Int32: (i32 2)], __device: "/device:CPU:0"} : $TensorHandle<String>
 
 
 // b/76117368

--- a/test/TensorFlow/integration.swift
+++ b/test/TensorFlow/integration.swift
@@ -418,7 +418,7 @@ public func testStringHandle() {
     "Const", dtype:
     String.self,
     value$tensor: ["foo", "bar"],
-    shape: TensorShape(2)
+    shape$shape: TensorShape(2)
   )
 }
 
@@ -427,7 +427,7 @@ public func testStringHandle() {
 // CHECK: [[POS:%.*]] = graph_op "Const"() {dtype: $Int32, value$tensor: i32 0, __device: "ALL_DEVICES"} : $TensorHandle<Int32>
 // CHECK: [[LEN:%.*]] = graph_op "Const"() {dtype: $Int32, value$tensor: i32 1, __device: "ALL_DEVICES"} : $TensorHandle<Int32>
 // CHECK: graph_op "Substr,i,i,i"([[STR]] : $TensorHandle<String>, [[POS]] : $TensorHandle<Int32>, [[LEN]] : $TensorHandle<Int32>) {__device: "/device:CPU:0"} : $TensorHandle<String>
-// CHECK: graph_op "Const"() {dtype: $String, value$tensor: [$String: "foo", "bar"], shape: [$Int32: (i32 2)], __device: "/device:CPU:0"} : $TensorHandle<String>
+// CHECK: graph_op "Const"() {dtype: $String, value$tensor: [$String: "foo", "bar"], shape$shape: [$Int32: (i32 2)], __device: "/device:CPU:0"} : $TensorHandle<String>
 
 
 // b/76117368

--- a/test/TensorFlow/no_copy.swift
+++ b/test/TensorFlow/no_copy.swift
@@ -39,7 +39,7 @@ public func testEmptyScalarsArray() {
  CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testEmptyScalarsArray
  CHECK: sil private @{{.*}}testEmptyScalarsArray{{.*}} : $@callee_owned () -> () {
  CHECK: bb0:
- CHECK: graph_op "Const"() {dtype: $Int32, value$tensor: [$Int32: ], value$shape: [$Int32: (i32 0), (i32 20), (i32 30)],
+ CHECK: graph_op "Const"() {dtype: $Int32, value$tensor: [$Int32: ], shape: [$Int32: (i32 0), (i32 20), (i32 30)],
  CHECK: graph_op "Add,i,i"({{.*}} : $TensorHandle<Int32>, {{.*}} : $TensorHandle<Int32>
  */
 
@@ -56,15 +56,15 @@ public func testConvolution(x: Tensor<Float>, filter: Tensor<Float>) -> Tensor<F
 // CHECK-NEXT:  return [[A]] : $TensorHandle<Float>
 // CHECK-NEXT:}
 
-// Testcase for an op that uses the $tensor and $shape modifiers.
+// Testcase for an op that uses the $tensor modifier.
 public func testConstantArray() -> TensorHandle<Float> {
-  return #tfop("Const", dtype: Float.self, value$tensor: [1.0, 2.0], value$shape: [2])
+  return #tfop("Const", dtype: Float.self, value$tensor: [1.0, 2.0], shape: [2])
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testConstantArray
 // CHECK: sil private @{{.*}}testConstantArray{{.*}} : $@callee_owned () -> TensorHandle<Float> {
 // CHECK: bb0:
-// CHECK:  %0 = graph_op "Const"() {dtype: $Float, value$tensor: [$Double: (f64 0x3FF0000000000000 /* 1 */), (f64 0x4000000000000000 /* 2 */)], value$shape: [$Int: (i64 2)], __device: "/device:CPU:0"} : $TensorHandle<Float>
+// CHECK:  %0 = graph_op "Const"() {dtype: $Float, value$tensor: [$Double: (f64 0x3FF0000000000000 /* 1 */), (f64 0x4000000000000000 /* 2 */)], shape: [$Int: (i64 2)], __device: "/device:CPU:0"} : $TensorHandle<Float>
 // CHECK-NEXT:  return %0 : $TensorHandle<Float>
 
 // Sigmoid shouldn't cause copies.  This should compile with no copy warnings/errors.

--- a/test/TensorFlow/no_copy.swift
+++ b/test/TensorFlow/no_copy.swift
@@ -39,7 +39,7 @@ public func testEmptyScalarsArray() {
  CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testEmptyScalarsArray
  CHECK: sil private @{{.*}}testEmptyScalarsArray{{.*}} : $@callee_owned () -> () {
  CHECK: bb0:
- CHECK: graph_op "Const"() {dtype: $Int32, value$tensor: [$Int32: ], shape: [$Int32: (i32 0), (i32 20), (i32 30)],
+ CHECK: graph_op "Const"() {dtype: $Int32, value$tensor: [$Int32: ], shape$shape: [$Int32: (i32 0), (i32 20), (i32 30)],
  CHECK: graph_op "Add,i,i"({{.*}} : $TensorHandle<Int32>, {{.*}} : $TensorHandle<Int32>
  */
 
@@ -56,16 +56,24 @@ public func testConvolution(x: Tensor<Float>, filter: Tensor<Float>) -> Tensor<F
 // CHECK-NEXT:  return [[A]] : $TensorHandle<Float>
 // CHECK-NEXT:}
 
-// Testcase for an op that uses the $tensor modifier.
+// Testcase for an op that uses the $tensor and $shape modifiers.
 public func testConstantArray() -> TensorHandle<Float> {
-  return #tfop("Const", dtype: Float.self, value$tensor: [1.0, 2.0], shape: [2])
+  return #tfop("Const", dtype: Float.self, value$tensor: [1.0, 2.0], shape$shape: [2])
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testConstantArray
 // CHECK: sil private @{{.*}}testConstantArray{{.*}} : $@callee_owned () -> TensorHandle<Float> {
 // CHECK: bb0:
-// CHECK:  %0 = graph_op "Const"() {dtype: $Float, value$tensor: [$Double: (f64 0x3FF0000000000000 /* 1 */), (f64 0x4000000000000000 /* 2 */)], shape: [$Int: (i64 2)], __device: "/device:CPU:0"} : $TensorHandle<Float>
+// CHECK:  %0 = graph_op "Const"() {dtype: $Float, value$tensor: [$Double: (f64 0x3FF0000000000000 /* 1 */), (f64 0x4000000000000000 /* 2 */)], shape$shape: [$Int: (i64 2)], __device: "/device:CPU:0"} : $TensorHandle<Float>
 // CHECK-NEXT:  return %0 : $TensorHandle<Float>
+
+// Testcase for an op that uses the $shape modifier.
+public func tensorShapeModifier() {
+  let _ : TensorHandle<Float> = #tfop("ImmutableConst",
+                                      dtype: Float.self,
+                                      shape$shape: [2, 2],
+                                      memory_region_name: "abc")
+}
 
 // Sigmoid shouldn't cause copies.  This should compile with no copy warnings/errors.
 public func testSigmoid(x: Tensor<Float>, y: Tensor<Float>) -> (Tensor<Float>, Tensor<Float>) {

--- a/test/TensorFlow/sese_loop_canonicalization.sil
+++ b/test/TensorFlow/sese_loop_canonicalization.sil
@@ -38,14 +38,14 @@ public func loopTest(breakCount:Int32) -> Int32 {
 //-- Preheader sets up the undefs, exit index, and stayInLoop flag.
 // CHECK: bb0(%0 : $Builtin.Int32):
 // CHECK: [[CONST_ONE:%.*]] =  integer_literal $Builtin.Int32, 1
-// CHECK: [[PHDR_EXIT:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.Int32, value$tensor: i32 0, __device: "ALL_DEVICES"}
-// CHECK: [[PHDR_FLAG:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.Int1, value$tensor: i1 -1, __device: "ALL_DEVICES"}
+// CHECK: [[PHDR_EXIT:%.*]] = graph_op "Const"() {dtype: $Builtin.Int32, value$tensor: i32 0, __device: "ALL_DEVICES"}
+// CHECK: [[PHDR_FLAG:%.*]] = graph_op "Const"() {dtype: $Builtin.Int1, value$tensor: i1 -1, __device: "ALL_DEVICES"}
 // CHECK: br bb9({{.*}} : $Builtin.Int32, {{.*}} : $Builtin.Int32, undef : $Builtin.Int32, [[PHDR_EXIT]] : $TensorHandle<Builtin.Int32>, [[PHDR_FLAG]] : $TensorHandle<Builtin.Int1>)
 
 //- Sets up index to 0 and flag to false on the exit branch of the original header to latch.
 // CHECK: bb1:
-// CHECK:   [[LOCAL_EXIT_INDEX:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.Int32, value$tensor: i32 0, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int32>
-// CHECK:   [[LOCAL_STAY_FLAG:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.Int1, value$tensor: i1 0, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int1>
+// CHECK:   [[LOCAL_EXIT_INDEX:%.*]] = graph_op "Const"() {dtype: $Builtin.Int32, value$tensor: i32 0, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int32>
+// CHECK:   [[LOCAL_STAY_FLAG:%.*]] = graph_op "Const"() {dtype: $Builtin.Int1, value$tensor: i1 0, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int1>
 //   cond_br {{.*}}, bb4, bb2
 
 // CHECK: bb2:
@@ -59,8 +59,8 @@ public func loopTest(breakCount:Int32) -> Int32 {
 // CHECK: bb4:
 // CHECK:  [[SUM_ESCAPING:%.*]] = builtin "sadd_with_overflow_Int32"([[SUM_AT_HDR]] : $Builtin.Int32, [[COUNT_AT_HDR]] : $Builtin.Int32) : $Builtin.Int32 
 // CHECK:  [[COUNT_ESCAPING:%.*]] = builtin "sadd_with_overflow_Int32"([[COUNT_AT_HDR]] : $Builtin.Int32, [[CONST_ONE]] : $Builtin.Int32) : $Builtin.Int32 
-// CHECK:  [[LOCAL_EXIT_INDEX:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.Int32, value$tensor: i32 1, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int32>
-// CHECK:  [[LOCAL_STAY_FLAG:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.Int1, value$tensor: i1 0, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int1>
+// CHECK:  [[LOCAL_EXIT_INDEX:%.*]] = graph_op "Const"() {dtype: $Builtin.Int32, value$tensor: i32 1, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int32>
+// CHECK:  [[LOCAL_STAY_FLAG:%.*]] = graph_op "Const"() {dtype: $Builtin.Int1, value$tensor: i1 0, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int1>
 // CHECK: cond_br {{.*}}, bb5, bb6
 
 // Original exit block
@@ -70,8 +70,8 @@ public func loopTest(breakCount:Int32) -> Int32 {
 
 //- Sets up index to 0 and flag to true on the false branch of the if with break to latch.
 // CHECK: bb6:
-// CHECK: [[LOCAL_EXIT_INDEX:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.Int32, value$tensor: i32 0, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int32>
-// CHECK: [[LOCAL_STAY_FLAG:%.*]] = graph_op "Const"() {dtype$dtype: $Builtin.Int1, value$tensor: i1 -1, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int1>
+// CHECK: [[LOCAL_EXIT_INDEX:%.*]] = graph_op "Const"() {dtype: $Builtin.Int32, value$tensor: i32 0, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int32>
+// CHECK: [[LOCAL_STAY_FLAG:%.*]] = graph_op "Const"() {dtype: $Builtin.Int1, value$tensor: i1 -1, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int1>
 // CHECK:  br bb10([[SUM_ESCAPING]] : $Builtin.Int32, [[COUNT_ESCAPING]] : $Builtin.Int32, [[SUM_ESCAPING]] : $Builtin.Int32, [[LOCAL_EXIT_INDEX]] : $TensorHandle<Builtin.Int32>, [[LOCAL_STAY_FLAG]] : $TensorHandle<Builtin.Int1>)
 
 //- Exit block from a non-header uses escaping arg.
@@ -86,7 +86,7 @@ public func loopTest(breakCount:Int32) -> Int32 {
 
 //-- Demuxing Block wires the exit blocks correctly.
 // CHECK: bb12:
-// CHECK:  [[ZERO_INDEX:%.*]] = graph_op  "Const"() {dtype$dtype: $Builtin.Int32, value$tensor: i32 0, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int32>
+// CHECK:  [[ZERO_INDEX:%.*]] = graph_op  "Const"() {dtype: $Builtin.Int32, value$tensor: i32 0, __device: "ALL_DEVICES"} : $TensorHandle<Builtin.Int32>
 // CHECK:  [[A:%.*]] = graph_op "Equal,i,i"([[HDR_EXIT_ARG]] : $TensorHandle<Builtin.Int32>, [[ZERO_INDEX]] : $TensorHandle<Builtin.Int32>) {{.*}} : $TensorHandle<Builtin.Int1>
 // CHECK:  [[B:%.*]] = graph_op "tf_tensor_to_i1"([[A]] : $TensorHandle<Builtin.Int1>) {{.*}} : $Builtin.Int1
 // CHECK:  cond_br [[B]], bb3, bb7


### PR DESCRIPTION
Also extended attr sanity check code in TFDeabstraction::formGraphOp() to make
sure for a $tensor attr, its # scalar values match the # of scalars specified in
the subsequent shape attr. e.g. We have 2 scalar elements below.

```swift
  let shape : TensorShape = [1, 2]
  _ = #tfop("Const", dtype: Float.self, value$tensor: [17.0 as Float, 18.0], shape: shape)
```

These special attr modifiers are still needed:
- `$tensor`: for graph lowering to know an int/double array refers to a tensor
- `$shape`: for graph lowering to lower an int array to a shape attr properly
- `$array`: as needed for extracting a dtype list (see https://github.com/apple/swift/pull/18992).