### PR TITLE
[benchmark] Yield when time slice expires

### DIFF
--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -298,22 +298,23 @@ class SampleRunner {
 
   /// Returns maximum resident set size (MAX_RSS) delta in bytes
   func measureMemoryUsage() -> Int {
-      var current = SampleRunner.getResourceUtilization()
-      let maxRSS = current.ru_maxrss - baseline.ru_maxrss
+    let current = SampleRunner.getResourceUtilization()
+    let maxRSS = current.ru_maxrss - baseline.ru_maxrss
 
-      if c.verbose {
-        let pages = maxRSS / sysconf(_SC_PAGESIZE)
-        func deltaEquation(_ stat: KeyPath<rusage, Int>) -> String {
-          let b = baseline[keyPath: stat], c = current[keyPath: stat]
-          return "\(c) - \(b) = \(c - b)"
-        }
-        print("""
-                  MAX_RSS \(deltaEquation(\rusage.ru_maxrss)) (\(pages) pages)
-                  ICS \(deltaEquation(\rusage.ru_nivcsw))
-                  VCS \(deltaEquation(\rusage.ru_nvcsw))
-              """)
+    if c.verbose {
+      let pages = maxRSS / sysconf(_SC_PAGESIZE)
+      func deltaEquation(_ stat: KeyPath<rusage, Int>) -> String {
+        let b = baseline[keyPath: stat], c = current[keyPath: stat]
+        return "\(c) - \(b) = \(c - b)"
       }
-      return maxRSS
+      print("""
+                MAX_RSS \(deltaEquation(\rusage.ru_maxrss)) (\(pages) pages)
+                ICS \(deltaEquation(\rusage.ru_nivcsw))
+                VCS \(deltaEquation(\rusage.ru_nvcsw))
+            """)
+    }
+    return maxRSS
+  }
   }
 
   func run(_ name: String, fn: (Int) -> Void, num_iters: UInt) -> UInt64 {

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -247,7 +247,7 @@ func stopTrackingObjects(_: UnsafePointer<CChar>) -> Int
 #endif
 
 #if os(Linux)
-class Timer {
+final class Timer {
   typealias TimeT = timespec
   func getTime() -> TimeT {
     var ticks = timespec(tv_sec: 0, tv_nsec: 0)
@@ -267,7 +267,7 @@ class Timer {
   }
 }
 #else
-class Timer {
+final class Timer {
   typealias TimeT = UInt64
   var info = mach_timebase_info_data_t(numer: 0, denom: 0)
   init() {
@@ -283,7 +283,7 @@ class Timer {
 }
 #endif
 
-class SampleRunner {
+final class SampleRunner {
   let timer = Timer()
   let baseline = SampleRunner.getResourceUtilization()
   let c: TestConfig


### PR DESCRIPTION
It pays off of to be a nice process and yield the processor at regular intervals, to prevent having measured samples corrupted by preemptive multitasking.

When the scheduled time slice (10ms on Mac OS) is probably about to expire during the next measurement, we voluntarily yield  and resume the measurement within a fresh scheduler quantum.

This cooperative approach to multitasking improves the sample quality and robustness of the measurement process.