### PR TITLE
Fix an issue found with UBSAN where we call walk() with a nullptr for…

### DIFF
--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -705,6 +705,9 @@ void TypeChecker::maybeDiagnoseCaptures(Expr *E, AnyFunctionRef AFR) {
 
 void TypeChecker::computeCaptures(AnyFunctionRef AFR) {
   if (AFR.getCaptureInfo().hasBeenComputed())
+    return;
+
+  if (!AFR.getBody())
     return;
 
   SmallVector<CapturedValue, 4> Captures;


### PR DESCRIPTION
… 'this'.

Fixes: rdar://problem/43657456
