### PR TITLE
 [Integer protocols] Make BinaryInteger.Words conform to RandomAccessCollection

### DIFF
--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1399,10 +1399,9 @@ ${assignmentOperatorComment(x.operator, True)}
       )._lowWord._value)
   }
 
-  // FIXME should be RandomAccessCollection
   /// A type that represents the words of this integer.
   @_fixed_layout // FIXME(sil-serialize-all)
-  public struct Words : BidirectionalCollection {
+  public struct Words : RandomAccessCollection {
     public typealias Indices = Range<Int>
     public typealias SubSequence = Slice<${Self}.Words>
 

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -630,13 +630,12 @@ public protocol BinaryInteger :
   /// - Parameter source: An integer to convert to this type.
   init<T : BinaryInteger>(clamping source: T)
 
-  // FIXME: Should be `Words : Collection where Words.Element == UInt`
-  // See <rdar://problem/31798916> for why it isn't.
   /// A type that represents the words of a binary integer.
   ///
-  /// The `Words` type must conform to the `Collection` protocol with an
-  /// `Element` type of `UInt`.
-  associatedtype Words : Sequence where Words.Element == UInt
+  /// The `Words` type must conform to the `RandomAccessCollection` protocol
+  /// with an `Element` type of `UInt` and `Index` type of `Int.
+  associatedtype Words : RandomAccessCollection
+      where Words.Element == UInt, Words.Index == Int
 
   /// A collection containing the words of this value's binary
   /// representation, in order from the least significant to most significant.

--- a/test/Prototypes/DoubleWidth.swift.gyb
+++ b/test/Prototypes/DoubleWidth.swift.gyb
@@ -38,9 +38,7 @@ import StdlibUnittest
 /// The `DoubleWidth` type is not intended as a replacement for a variable-width
 /// integer type. Nesting `DoubleWidth` instances, in particular, may result in
 /// undesirable performance.
-public struct DoubleWidth<Base : FixedWidthInteger>
-  where Base.Words : Collection, Base.Magnitude.Words : Collection {
-
+public struct DoubleWidth<Base : FixedWidthInteger> {
   public typealias High = Base
   public typealias Low = Base.Magnitude
 
@@ -239,72 +237,33 @@ extension DoubleWidth {
   }
 }
 
-extension DoubleWidth.Words {  
-  public struct Index {
-    internal enum _WordsIndexValue: Equatable {
-      case low(DoubleWidth.Low.Words.Index)
-      case high(DoubleWidth.High.Words.Index)
-    }
-
-    internal var _value: _WordsIndexValue
-
-    internal init(_ _value: _WordsIndexValue) { self._value = _value }
-  }
-}
-
-extension DoubleWidth.Words.Index: Equatable { }
-
-extension DoubleWidth.Words.Index: Comparable {
-  public static func <(lhs: DoubleWidth.Words.Index, rhs: DoubleWidth.Words.Index) -> Bool {
-    switch (lhs._value, rhs._value) {
-    case let (.low(l), .low(r)): return l < r
-    case (.low, .high): return true
-    case (.high, .low): return false
-    case let (.high(l), .high(r)): return l < r
-    }
-  }
-}
-
-extension DoubleWidth.Words: Collection {
+extension DoubleWidth.Words: RandomAccessCollection {
+  public typealias Index = Int
+  
   public var startIndex: Index {
-    return Index(.low(_low.startIndex))
+    return 0
   }
 
   public var endIndex: Index {
-    return Index(.high(_high.endIndex))
+    return count
   }
   
   public var count: Int {
     if Base.bitWidth < UInt.bitWidth { return 1 }
-    return Int(_low.count) + Int(_high.count)
-  }
-
-  public func index(after i: Index) -> Index {
-    switch i._value {
-    case .low where Base.bitWidth < UInt.bitWidth:
-      return Index(.high(_high.endIndex)) 
-    case let .low(li):
-      let next = _low.index(after: li)
-      if next == _low.endIndex { 
-        return Index(.high(_high.startIndex)) 
-      } else {
-        return Index(.low(next))        
-      }
-    case let .high(hi):
-      return Index(.high(_high.index(after: hi)))
-    }
+    return _low.count + _high.count
   }
 
   public subscript(_ i: Index) -> UInt {
     if Base.bitWidth < UInt.bitWidth {
-      precondition(i == Index(.low(_low.startIndex)), "Invalid index")
+      precondition(i == 0, "Invalid index")
       assert(2 * Base.bitWidth <= UInt.bitWidth)
       return _low.first! | (_high.first! &<< Base.bitWidth._lowWord) 
     }
-    switch i._value {
-    case let .low(li): return _low[li]
-    case let .high(hi): return _high[hi]
+    if i < _low.count {
+      return _low[i + _low.startIndex]
     }
+    
+    return _high[i - _low.count + _high.startIndex]
   }
 }
 

--- a/test/api-digester/source-stability.swift.expected
+++ b/test/api-digester/source-stability.swift.expected
@@ -1,6 +1,6 @@
 
 /* Generic Signature Changes */
-
+Protocol BinaryInteger has generic signature change from <Self : CustomStringConvertible, Self : Hashable, Self : Numeric, Self : Strideable, Self.Magnitude : BinaryInteger, Self.Magnitude == Self.Magnitude.Magnitude, Self.Words : Sequence, Self.Words.Element == UInt> to <Self : CustomStringConvertible, Self : Hashable, Self : Numeric, Self : Strideable, Self.Magnitude : BinaryInteger, Self.Magnitude == Self.Magnitude.Magnitude, Self.Words : RandomAccessCollection, Self.Words.Element == UInt, Self.Words.Index == Int>
 /* RawRepresentable Changes */
 
 /* Removed Decls */

--- a/test/stdlib/Integers.swift.gyb
+++ b/test/stdlib/Integers.swift.gyb
@@ -29,7 +29,7 @@ public func _log(_ message: @autoclosure () -> String) {
   // print(message())
 }
 
-extension FixedWidthInteger where Words : Collection {
+extension FixedWidthInteger {
   /// a hex representation of every bit in the number
   func hexBits(_ bitWidth: Int) -> String {
     let hexDigits: [Unicode.Scalar] = [
@@ -236,7 +236,7 @@ func expectEqual<T : FixedWidthInteger>(
   stackTrace: SourceLocStack = SourceLocStack(),
   showFrame: Bool = true,
   file: String = #file, line: UInt = #line
-) where T.Words : Collection {
+) {
   if expected != actual {
     expectationFailure(
       "expected: \(String(reflecting: expected))"
@@ -727,6 +727,9 @@ tests.test("words") {
 
   expectEqualSequence([1], 1.words)
   expectEqualSequence([0], 0.words)
+
+  // Random access to words with Int indexing
+  expectEqual(1, 1.words[0])
 }
 
 tests.test("multipliedFullWidth/UInt8") {


### PR DESCRIPTION
Require that BinaryInteger.Words conform to RandomAccessCollection with
an Index type of Int, simplifying clients.

Fixes rdar://problem/36410936.