### PR TITLE
[Parse] Consolidate body parsing for Func/Constructor/Destructor decls

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -930,6 +930,7 @@ public:
                                        StaticSpellingKind StaticSpelling,
                                        ParseDeclOptions Flags,
                                        DeclAttributes &Attributes);
+  void parseAbstractFunctionBody(AbstractFunctionDecl *AFD);
   bool parseAbstractFunctionBodyDelayed(AbstractFunctionDecl *AFD);
   ParserResult<ProtocolDecl> parseDeclProtocol(ParseDeclOptions Flags,
                                                DeclAttributes &Attributes);

--- a/include/swift/Parse/Scope.h
+++ b/include/swift/Parse/Scope.h
@@ -67,13 +67,10 @@ enum class ScopeKind {
   StructBody,
   ClassBody,
   ProtocolBody,
-  ConstructorBody,
-  DestructorBody,
   InheritanceClause,
 
   Brace,
   TopLevel,
-  ForVars,
   ForeachVars,
   CaseVars,
   CatchVars,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5354,9 +5354,11 @@ void Parser::parseAbstractFunctionBody(AbstractFunctionDecl *AFD) {
     return;
   }
 
-  // Record the curly braces but nothing inside.
-  SF.recordInterfaceToken("{");
-  SF.recordInterfaceToken("}");
+  if (IsParsingInterfaceTokens) {
+    // Record the curly braces but nothing inside.
+    SF.recordInterfaceToken("{");
+    SF.recordInterfaceToken("}");
+  }
   llvm::SaveAndRestore<bool> T(IsParsingInterfaceTokens, false);
 
   if (isDelayedParsingEnabled()) {

--- a/lib/Parse/Scope.cpp
+++ b/lib/Parse/Scope.cpp
@@ -36,10 +36,7 @@ static bool isResolvableScope(ScopeKind SK) {
     return false;
   case ScopeKind::FunctionBody:
   case ScopeKind::Generics:
-  case ScopeKind::ConstructorBody:
-  case ScopeKind::DestructorBody:
   case ScopeKind::Brace:
-  case ScopeKind::ForVars:
   case ScopeKind::ForeachVars:
   case ScopeKind::ClosureParams:
   case ScopeKind::CaseVars:

--- a/test/InterfaceHash/added_localfunc.swift
+++ b/test/InterfaceHash/added_localfunc.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+// RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
+// RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
+// RUN: cmp %t/a.hash %t/b.hash
+
+// BEGIN a.swift
+func test() -> Int {
+  return 0
+}
+
+// BEGIN b.swift
+func test() -> Int {
+  func inner() -> Int{
+    return 0
+  }
+  return inner()
+}


### PR DESCRIPTION
We can consolidate preparation work for parsing function body of `FuncDecl`/`ConstructorDecl`/`DestructorDecl`.

While I'm around here, fixed a bug where `interface-hash` is accidentally updated even for local functions.