### PR TITLE
Fix critical edges

### DIFF
--- a/lib/SILOptimizer/Transforms/ARCCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/ARCCodeMotion.cpp
@@ -96,10 +96,6 @@ STATISTIC(NumReleasesHoisted, "Number of releases hoisted");
 
 llvm::cl::opt<bool> DisableARCCodeMotion("disable-arc-cm", llvm::cl::init(false));
 
-/// Disable optimization if we have to break critical edges in the function.
-llvm::cl::opt<bool>
-DisableIfWithCriticalEdge("disable-with-critical-edge", llvm::cl::init(false));
-
 //===----------------------------------------------------------------------===//
 //                             Block State 
 //===----------------------------------------------------------------------===//
@@ -1154,11 +1150,6 @@ public:
     // Respect function no.optimize.
     SILFunction *F = getFunction();
     if (!F->shouldOptimize())
-      return;
-
-    // Return if there is critical edge and we are disabling critical edge
-    // splitting.
-    if (DisableIfWithCriticalEdge && hasCriticalEdges(*F, false))
       return;
 
     LLVM_DEBUG(llvm::dbgs() << "*** ARCCM on function: " << F->getName()

--- a/test/DebugInfo/return.swift
+++ b/test/DebugInfo/return.swift
@@ -20,10 +20,9 @@ public func ifelseexpr() -> Int64 {
   } else {
     x.x -= 1
   }
-  // CHECK:  [[X:%.*]] = load %T6return1XC*, %T6return1XC** [[ALLOCA]]
-  // CHECK:  @swift_release to void (%T6return1XC*)*)(%T6return1XC* [[X]])
+  // CHECK:  [[L:%.*]] = load %T6return1XC*, %T6return1XC** [[ALLOCA]]
+  // CHECK:  @swift_release to void (%T6return1XC*)*)(%T6return1XC* [[L]])
   // CHECK-SAME:                    , !dbg ![[RELEASE:.*]]
-
   // The ret instruction should be in the same scope as the return expression.
   // CHECK:  ret{{.*}}, !dbg ![[RELEASE]]
   return x.x // CHECK: ![[RELEASE]] = !DILocation(line: [[@LINE]], column: 3

--- a/test/IRGen/dynamic_cast.sil
+++ b/test/IRGen/dynamic_cast.sil
@@ -67,8 +67,10 @@ bb0(%0 : $*P):
   %1 = alloc_stack $S
   checked_cast_addr_br take_always P in %0 : $*P to S in %1 : $*S, bb1, bb2
 bb1:
-  br bb2
+  br bb3
 bb2:
+  br bb3
+bb3:
   destroy_addr %1 : $*S
   dealloc_stack %1 : $*S
   %2 = tuple ()
@@ -88,8 +90,10 @@ bb0(%0 : $*P):
   %1 = alloc_stack $S
   checked_cast_addr_br take_on_success P in %0 : $*P to S in %1 : $*S, bb1, bb2
 bb1:
-  br bb2
+  br bb3
 bb2:
+  br bb3
+bb3:
   destroy_addr %1 : $*S
   dealloc_stack %1 : $*S
   %2 = tuple ()
@@ -109,8 +113,10 @@ bb0(%0 : $*P):
   %1 = alloc_stack $S
   checked_cast_addr_br copy_on_success P in %0 : $*P to S in %1 : $*S, bb1, bb2
 bb1:
-  br bb2
+  br bb3
 bb2:
+  br bb3
+bb3:
   destroy_addr %1 : $*S
   dealloc_stack %1 : $*S
   %2 = tuple ()

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -568,12 +568,10 @@ entry(%u : $SinglePayloadNoXI2):
 // CHECK:   ]
 // CHECK: ; <label>:[[DFLT]]
 // CHECK:   unreachable
-  switch_enum %u : $SinglePayloadNoXI2, case #SinglePayloadNoXI2.x!enumelt.1: x_dest, case #SinglePayloadNoXI2.y!enumelt: y_dest, case #SinglePayloadNoXI2.z!enumelt: z_dest, default end
+  switch_enum %u : $SinglePayloadNoXI2, case #SinglePayloadNoXI2.x!enumelt.1: x_dest, case #SinglePayloadNoXI2.y!enumelt: y_dest, case #SinglePayloadNoXI2.z!enumelt: z_dest, default default_dest
 
 // CHECK: ; <label>:[[X_PREDEST]]
 // CHECK:   br label %[[X_DEST:[0-9]+]]
-// CHECK: ; <label>:[[SPLITEDGE]]
-// CHECK:   br label %[[END:[0-9]+]]
 // CHECK: ; <label>:[[X_DEST]]
 // CHECK:   {{%.*}} = phi [[WORD]] [ %0, %[[X_PREDEST]] ]
 x_dest(%u2 : $Builtin.Word):
@@ -597,6 +595,11 @@ z_dest:
 // CHECK:   br label %[[END]]
   %c = function_ref @c : $@convention(thin) () -> ()
   apply %c() : $@convention(thin) () -> ()
+  br end
+
+// CHECK: ; <label>:[[SPLITEDGE]]
+// CHECK:   br label %[[END:[0-9]+]]
+default_dest:
   br end
 
 // CHECK: ; <label>:[[END]]
@@ -688,7 +691,7 @@ sil @int64_sink : $@convention(thin) (Builtin.Word) -> ()
 // CHECK:         ([[WORD]], [[WORD]], i8) {{.*}} {
 sil @aggregate_single_payload_unpack : $@convention(thin) (AggregateSinglePayload) -> () {
 entry(%u : $AggregateSinglePayload):
-  switch_enum %u : $AggregateSinglePayload, case #AggregateSinglePayload.x!enumelt.1: x_dest, default end
+  switch_enum %u : $AggregateSinglePayload, case #AggregateSinglePayload.x!enumelt.1: x_dest, default default_dest
 
   // CHECK: [[FIRST:%.*]] = phi [[WORD]] [ %0
   // CHECK: [[SECOND:%.*]] = phi [[WORD]] [ %1
@@ -700,6 +703,9 @@ x_dest(%v : $(Builtin.Word, Builtin.Word)):
   %b = tuple_extract %v : $(Builtin.Word, Builtin.Word), 1
   %c = apply %f(%a) : $@convention(thin) (Builtin.Word) -> ()
   %d = apply %f(%b) : $@convention(thin) (Builtin.Word) -> ()
+  br end
+
+default_dest:
   br end
 
 end:
@@ -745,7 +751,7 @@ enum AggregateSinglePayload2 {
 // CHECK-32: define{{( dllexport)?}}{{( protected)?}}  swiftcc void @aggregate_single_payload_unpack_2(%T4enum23AggregateSinglePayload2O* noalias nocapture dereferenceable(16)) {{.*}} {
 sil @aggregate_single_payload_unpack_2 : $@convention(thin) (AggregateSinglePayload2) -> () {
 entry(%u : $AggregateSinglePayload2):
-  switch_enum %u : $AggregateSinglePayload2, case #AggregateSinglePayload2.x!enumelt.1: x_dest, default end
+  switch_enum %u : $AggregateSinglePayload2, case #AggregateSinglePayload2.x!enumelt.1: x_dest, default default_dest
 
 // CHECK-64:   [[TRUNC:%.*]] = trunc [[WORD]] %0 to i21
 // CHECK-64:   phi i21 [ [[TRUNC]]
@@ -753,6 +759,9 @@ entry(%u : $AggregateSinglePayload2):
 // CHECK-64:   phi [[WORD]] [ %2
 // CHECK-64:   phi [[WORD]] [ %3
 x_dest(%v : $(CharLike, IntLike, RangeLike)):
+  br end
+
+default_dest:
   br end
 
 end:
@@ -796,7 +805,7 @@ enum AggregateSinglePayload3 {
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @aggregate_single_payload_unpack_3([[WORD]], [[WORD]]) {{.*}} {
 sil @aggregate_single_payload_unpack_3 : $@convention(thin) (AggregateSinglePayload3) -> () {
 entry(%u : $AggregateSinglePayload3):
-  switch_enum %u : $AggregateSinglePayload3, case #AggregateSinglePayload3.x!enumelt.1: x_dest, default end
+  switch_enum %u : $AggregateSinglePayload3, case #AggregateSinglePayload3.x!enumelt.1: x_dest, default default_dest
 
   // CHECK: [[TRUNC:%.*]] = trunc [[WORD]] %0 to i21
   // CHECK: [[FIRST:%.*]] = phi i21 [ [[TRUNC]]
@@ -811,6 +820,9 @@ x_dest(%v : $(Builtin.Int21, Builtin.Word)):
   %b = tuple_extract %v : $(Builtin.Int21, Builtin.Word), 1
   %c = apply %f(%a) : $@convention(thin) (Builtin.Int21) -> ()
   %d = apply %g(%b) : $@convention(thin) (Builtin.Word) -> ()
+  br end
+
+default_dest:
   br end
 
 end:

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -516,8 +516,11 @@ bb(%0 : $Int):
 
 bb1(%err: $Error):
   %t = tuple ()
-  br bb2(%t: $())
+  br bb3(%t: $())
 
-bb2(%v : $()):
+bb2(%r : $()):
+  br bb3(%r : $())
+
+bb3(%v : $()):
   return %v : $()
 }

--- a/test/SIL/Parser/undef.sil
+++ b/test/SIL/Parser/undef.sil
@@ -313,17 +313,25 @@ bb0:
 
 sil @switch_enum_test : $() -> () {
 bb0:
-  // CHECK: switch_enum undef : $E, case #E.Case!enumelt: bb1, default bb1
-  switch_enum undef : $E, case #E.Case!enumelt: bb1, default bb1
+  // CHECK: switch_enum undef : $E, case #E.Case!enumelt: bb1, default bb2
+  switch_enum undef : $E, case #E.Case!enumelt: bb1, default bb2
 bb1:
+  br bb3
+bb2:
+  br bb3
+bb3:
   return undef : $()
 }
 
 sil @switch_enum_addr_test : $() -> () {
 bb0:
-  // CHECK: switch_enum_addr undef : $*E, case #E.Case!enumelt: bb1, default bb1
-  switch_enum_addr undef : $*E, case #E.Case!enumelt: bb1, default bb1
+  // CHECK: switch_enum_addr undef : $*E, case #E.Case!enumelt: bb1, default bb2
+  switch_enum_addr undef : $*E, case #E.Case!enumelt: bb1, default bb2
 bb1:
+  br bb3
+bb2:
+  br bb3
+bb3:
   return undef : $()
 }
 
@@ -332,8 +340,10 @@ bb0:
   // CHECK: dynamic_method_br undef : $P, #C.fn!1.foreign, bb1, bb2
   dynamic_method_br undef : $P, #C.fn!1.foreign, bb1, bb2
 bb1(%x : $@convention(objc_method) (P) -> ()):
-  br bb2
+  br bb3
 bb2:
+  br bb3
+bb3:
   return undef: $()
 }
 
@@ -342,8 +352,10 @@ bb0:
   // CHECK: checked_cast_br undef : $C to $C, bb1, bb2
   checked_cast_br undef : $C to $C, bb1, bb2
 bb1(%x : $C):
-  br bb2
+  br bb3
 bb2:
+  br bb3
+bb3:
   return undef : $()
 }
 
@@ -352,8 +364,10 @@ bb0:
   // CHECK: checked_cast_addr_br take_always C in undef : $*C to C in undef : $*C, bb1, bb2
   checked_cast_addr_br take_always C in undef : $*C to C in undef : $*C, bb1, bb2
 bb1:
-  br bb2
+  br bb3
 bb2:
+  br bb3
+bb3:
   return undef : $()
 }
 

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -539,6 +539,7 @@ func supportFirstStructure<B: Buildable>(_ b: inout B) throws {
 // CHECK: [[BB_ERROR]]([[ERROR:%.*]] : @owned $Error):
 // CHECK: abort_apply [[TOKEN]]
 // CHECK: throw [[ERROR]]
+
 // CHECK: } // end sil function '$S6errors21supportFirstStructure{{.*}}F'
 
 func supportStructure<B: Buildable>(_ b: inout B, name: String) throws {
@@ -565,6 +566,7 @@ func supportStructure<B: Buildable>(_ b: inout B, name: String) throws {
 // CHECK:   end_borrow [[BORROWED_INDEX_COPY]] from [[INDEX_COPY]]
 // CHECK:   destroy_value [[INDEX_COPY]] : $String
 // CHECK:   throw [[ERROR]]
+
 // CHECK: } // end sil function '$S6errors16supportStructure{{.*}}F'
 
 struct Pylon {

--- a/test/SILOptimizer/cse_objc.sil
+++ b/test/SILOptimizer/cse_objc.sil
@@ -127,28 +127,34 @@ bb0(%0 : $Walkable):
 // CHECK: open_existential_ref %0 : $AnyObject to $[[OPENED:@opened\(.*\) AnyObject]]
 // CHECK: bb1(%{{[0-9]*}} : $@convention(objc_method) ([[OPENED]]) -> @autoreleased Optional<NSString>):
 // CHECK-NOT: open_existential_ref
-// CHECK: bb2(%{{[0-9]*}} : $@convention(objc_method) ([[OPENED]]) -> @autoreleased Optional<NSString>):
+// CHECK: bb3(%{{[0-9]*}} : $@convention(objc_method) ([[OPENED]]) -> @autoreleased Optional<NSString>):
 // CHECK-NOT: open_existential_ref
 // CHECK: return
 sil @cse_open_existential_in_bbarg : $@convention(thin) (@owned AnyObject) -> () {
 bb0(%0 : $AnyObject):
   %1 = open_existential_ref %0 : $AnyObject to $@opened("CCEAC0E2-4BB2-11E6-86F8-B8E856428C60") AnyObject
-  dynamic_method_br %1 : $@opened("CCEAC0E2-4BB2-11E6-86F8-B8E856428C60") AnyObject, #NSProxy.description!getter.1.foreign, bb1, bb3
+  dynamic_method_br %1 : $@opened("CCEAC0E2-4BB2-11E6-86F8-B8E856428C60") AnyObject, #NSProxy.description!getter.1.foreign, bb1, bb2
 
 bb1(%3 : $@convention(objc_method) (@opened("CCEAC0E2-4BB2-11E6-86F8-B8E856428C60") AnyObject) -> @autoreleased Optional<NSString>):
   strong_retain %1 : $@opened("CCEAC0E2-4BB2-11E6-86F8-B8E856428C60") AnyObject
   %5 = partial_apply %3(%1) : $@convention(objc_method) (@opened("CCEAC0E2-4BB2-11E6-86F8-B8E856428C60") AnyObject) -> @autoreleased Optional<NSString>
   %6 = apply %5() : $@callee_owned () -> @owned Optional<NSString>
   %7 = open_existential_ref %0 : $AnyObject to $@opened("CCEDAF1E-4BB2-11E6-86F8-B8E856428C60") AnyObject
-  dynamic_method_br %7 : $@opened("CCEDAF1E-4BB2-11E6-86F8-B8E856428C60") AnyObject, #NSProxy.description!getter.1.foreign, bb2, bb3
+  dynamic_method_br %7 : $@opened("CCEDAF1E-4BB2-11E6-86F8-B8E856428C60") AnyObject, #NSProxy.description!getter.1.foreign, bb3, bb4
 
-bb2(%9 : $@convention(objc_method) (@opened("CCEDAF1E-4BB2-11E6-86F8-B8E856428C60") AnyObject) -> @autoreleased Optional<NSString>):
+bb2:
+  br bb5
+
+bb3(%9 : $@convention(objc_method) (@opened("CCEDAF1E-4BB2-11E6-86F8-B8E856428C60") AnyObject) -> @autoreleased Optional<NSString>):
   strong_retain %7 : $@opened("CCEDAF1E-4BB2-11E6-86F8-B8E856428C60") AnyObject
   %10 = partial_apply %9(%7) : $@convention(objc_method) (@opened("CCEDAF1E-4BB2-11E6-86F8-B8E856428C60") AnyObject) -> @autoreleased Optional<NSString>
   %11 = apply %10() : $@callee_owned () -> @owned Optional<NSString>
-  br bb3
+  br bb5
 
-bb3:
+bb4:
+  br bb5
+
+bb5:
   strong_release %0 : $AnyObject
   %13 = tuple ()
   return %13 : $()

--- a/test/SILOptimizer/diagnose_unreachable.sil
+++ b/test/SILOptimizer/diagnose_unreachable.sil
@@ -395,10 +395,12 @@ sil_scope 1 { loc "f.swift":2:1 parent 0 }
 // CHECK: sil_scope [[S:[0-9]+]] { loc "f.swift":2:1 parent [[F]] }
 // CHECK-LABEL:sil @try_apply_2
 // CHECK:    bb3({{.*}}$Never):
+// CHECK-NEXT: {{ unreachable }}, scope [[F]]
+// CHECK:    bb5({{.*}}$Never):
 // CHECK-NEXT: {{ unreachable }}, scope [[S]]
-// CHECK:    bb4(
+// CHECK:    bb7({{.*}} : $Error):
 // CHECK-NEXT: throw
-
+// CHECK-LABEL: } // end sil function 'try_apply_2'
 sil @try_apply_2 : $@convention(thin) (Builtin.Int1) -> @error Error {
 bb0(%0 : $Builtin.Int1):
   %1 = function_ref @throwing_noreturn : $@convention(thin) () -> (Never, @error Error)
@@ -406,28 +408,40 @@ bb0(%0 : $Builtin.Int1):
 bb1:
   try_apply %1() : $@convention(thin) () -> (Never, @error Error), normal bb3, error bb4, scope 0
 bb2:
-  try_apply %1() : $@convention(thin) () -> (Never, @error Error), normal bb3, error bb4, scope 1
+  try_apply %1() : $@convention(thin) () -> (Never, @error Error), normal bb5, error bb6, scope 1
 bb3(%2 : $Never):
-  %3 = tuple ()
-  return %3 : $()
+  br bb7
 bb4(%4 : $Error):
-  throw %4 : $Error
+  br bb8(%4 : $Error)
+bb5(%5 : $Never):
+  br bb7
+bb6(%7 : $Error):
+  br bb8(%7 : $Error)
+bb7:
+  %8 = tuple ()
+  return %8 : $()
+bb8(%9 : $Error):
+  throw %9 : $Error
 }
 
-// This should arguably be ill-formed.
 // CHECK-LABEL:sil @try_apply_3
 // CHECK:      br bb1
-// CHECK:    bb1(
+// CHECK:    bb1:
 // CHECK-NOT:  {{ unreachable}}
 // CHECK:      try_apply
-// CHECK:    bb2(
+// CHECK:    bb3({{.*}} : $Error):
 // CHECK-NEXT: throw
 sil @try_apply_3 : $@convention(thin) (Never) -> @error Error {
 bb0(%0 : $Never):
   br bb1(%0 : $Never)
+
 bb1(%1 : $Never):
   %2 = function_ref @throwing_noreturn : $@convention(thin) () -> (Never, @error Error)
-  try_apply %2() : $@convention(thin) () -> (Never, @error Error), normal bb1, error bb2
-bb2(%3 : $Error):
-  throw %3 : $Error
+  try_apply %2() : $@convention(thin) () -> (Never, @error Error), normal bb2, error bb3
+
+bb2(%3 : $Never):
+  br bb1(%3 : $Never)
+
+bb3(%4 : $Error):
+  throw %4 : $Error
 }

--- a/test/SILOptimizer/earlycodemotion.sil
+++ b/test/SILOptimizer/earlycodemotion.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -module-name Swift -enable-sil-verify-all %s -early-codemotion -retain-sinking -disable-with-critical-edge=1 | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -module-name Swift -enable-sil-verify-all %s -early-codemotion -retain-sinking | %FileCheck %s
 
 import Builtin
 
@@ -215,86 +215,6 @@ bb3:
   return %4 : $()
 }
 
-// This test makes sure that if any of the switches targets have a predecessor
-// besides the switch enum, we don't do anything.
-//
-// CHECK-LABEL: sil @sink_ref_count_ops_enum_over_switch_enum_2 : $@convention(thin) (Optional<Builtin.NativeObject>) -> () {
-// CHECK: bb0({{.*}}):
-// CHECK-NEXT: function_ref blocker
-// CHECK-NEXT: function_ref @blocker
-// CHECK-NEXT: cond_br
-// CHECK: bb1:
-// CHECK-NEXT: retain_value
-// CHECK-NEXT: switch_enum
-// CHECK: bb2:
-// CHECK-NOT: unchecked_enum_data
-// CHECK-NOT: retain_value
-// CHECK: bb3:
-// CHECK-NOT: unchecked_enum_data
-// CHECK-NOT: retain_value
-// CHECK: bb4:
-// CHECK-NOT: unchecked_enum_data
-// CHECK-NOT: retain_value
-sil @sink_ref_count_ops_enum_over_switch_enum_2 : $@convention(thin) (Optional<Builtin.NativeObject>) -> () {
-bb0(%0 : $Optional<Builtin.NativeObject>):
-  %1 = function_ref @blocker : $@convention(thin) () -> ()
-  cond_br undef, bb1, bb2
-
-bb1:
-  retain_value %0 : $Optional<Builtin.NativeObject>
-  switch_enum %0 : $Optional<Builtin.NativeObject>, case #Optional.some!enumelt.1: bb2, case #Optional.none!enumelt: bb3
-
-bb2:
-  br bb4
-
-bb3:
-  br bb4
-
-bb4:
-  %2 = tuple()
-  return %2 : $()
-}
-
-// This test makes sure that if any of the switches targets have a predecessor
-// besides the switch enum, we don't do anything.
-//
-// CHECK-LABEL: sil @sink_ref_count_ops_enum_over_switch_enum_3 : $@convention(thin) (Optional<Builtin.Int32>) -> () {
-// CHECK: bb0({{.*}}):
-// CHECK-NEXT: function_ref blocker
-// CHECK-NEXT: function_ref @blocker
-// CHECK-NEXT: cond_br
-// CHECK: bb1:
-// CHECK-NEXT: retain_value
-// CHECK-NEXT: switch_enum
-// CHECK: bb2:
-// CHECK-NOT: unchecked_enum_data
-// CHECK-NOT: retain_value
-// CHECK: bb3:
-// CHECK-NOT: unchecked_enum_data
-// CHECK-NOT: retain_value
-// CHECK: bb4:
-// CHECK-NOT: unchecked_enum_data
-// CHECK-NOT: retain_value
-sil @sink_ref_count_ops_enum_over_switch_enum_3 : $@convention(thin) (Optional<Builtin.Int32>) -> () {
-bb0(%0 : $Optional<Builtin.Int32>):
-  %1 = function_ref @blocker : $@convention(thin) () -> ()
-  cond_br undef, bb1, bb3
-
-bb1:
-  retain_value %0 : $Optional<Builtin.Int32>
-  switch_enum %0 : $Optional<Builtin.Int32>, case #Optional.some!enumelt.1: bb2, case #Optional.none!enumelt: bb3
-
-bb2:
-  br bb4
-
-bb3:
-  br bb4
-
-bb4:
-  %2 = tuple()
-  return %2 : $()
-}
-
 // This test makes sure that we do move ref counts over instructions that cannot reference it.
 // CHECK-LABEL: sil @sink_ref_count_ops_enum_over_switch_enum_4 :
 // CHECK: bb0({{%[0-9]+}} : $Optional<Builtin.NativeObject>, [[ARG1:%[0-9]+]] : $Optional<Builtin.NativeObject>):
@@ -425,18 +345,13 @@ bb3:
 // CHECK-NEXT: function_ref @blocker
 // CHECK-NEXT: cond_br
 // CHECK: bb1:
-// CHECK-NEXT: retain_value
+// CHECK: bb2:
 // CHECK-NEXT: select_enum
 // CHECK-NEXT: cond_br
-// CHECK: bb2:
-// CHECK-NOT: unchecked_enum_data
-// CHECK-NOT: retain_value
 // CHECK: bb3:
 // CHECK-NOT: unchecked_enum_data
 // CHECK-NOT: retain_value
-// CHECK: bb4:
-// CHECK-NOT: unchecked_enum_data
-// CHECK-NOT: retain_value
+// CHECK-LABEL: } // end sil function 'sink_ref_count_ops_enum_over_select_enum_2'
 sil @sink_ref_count_ops_enum_over_select_enum_2 : $@convention(thin) (Optional<Builtin.Int32>) -> () {
 bb0(%0 : $Optional<Builtin.Int32>):
   %t = integer_literal $Builtin.Int1, 1
@@ -467,19 +382,13 @@ bb4:
 // CHECK-NEXT: function_ref blocker
 // CHECK-NEXT: function_ref @blocker
 // CHECK-NEXT: cond_br
-// CHECK: bb1:
-// CHECK-NEXT: retain_value
+// CHECK: bb2:
+// CHECK-NOT: retain_value
 // CHECK-NEXT: select_enum
 // CHECK-NEXT: cond_br
-// CHECK: bb2:
 // CHECK-NOT: unchecked_enum_data
 // CHECK-NOT: retain_value
-// CHECK: bb3:
-// CHECK-NOT: unchecked_enum_data
-// CHECK-NOT: retain_value
-// CHECK: bb4:
-// CHECK-NOT: unchecked_enum_data
-// CHECK-NOT: retain_value
+// CHECK-LABEL: } // end sil function 'sink_ref_count_ops_enum_over_select_enum_3'
 sil @sink_ref_count_ops_enum_over_select_enum_3 : $@convention(thin) (Optional<Builtin.Int32>) -> () {
 bb0(%0 : $Optional<Builtin.Int32>):
   %t = integer_literal $Builtin.Int1, 1
@@ -852,11 +761,11 @@ bb3:
 
 // CHECK-LABEL: sil @enum_simplification_test8 : $@convention(thin) (Optional<Builtin.NativeObject>) -> () {
 // CHECK: bb0([[INPUT:%[0-9]+]] : $Optional<Builtin.NativeObject>):
+// CHECK-NOT: retain_value [[INPUT]]
 // CHECK: bb2:
-// CHECK-NEXT: retain_value [[INPUT]]
-// CHECK: bb3:
 // CHECK-NEXT: [[PAYLOAD:%[0-9]+]] = unchecked_enum_data [[INPUT]]
-// CHECK-NEXT: strong_retain [[PAYLOAD]]
+// CHECK-NOT: strong_retain
+// CHECK-NOT: retain_value
 // CHECK: bb4:
 // CHECK: retain_value [[INPUT]]
 sil @enum_simplification_test8 : $@convention(thin) (Optional<Builtin.NativeObject>) -> () {
@@ -953,22 +862,28 @@ bb3:
 // CHECK: retain_value [[INPUT]]
 sil @enum_simplification_test10 : $@convention(thin) (Optional<Builtin.NativeObject>) -> () {
 bb0(%0 : $Optional<Builtin.NativeObject>):
-  switch_enum %0 : $Optional<Builtin.NativeObject>, case #Optional.some!enumelt.1: bb1, case #Optional.none!enumelt: bb2
+  switch_enum %0 : $Optional<Builtin.NativeObject>, case #Optional.some!enumelt.1: bb1, case #Optional.none!enumelt: bb3
+
+bb1:
+  br bb2
 
 // Single BB Loop
-bb1:
+bb2:
   retain_value %0 : $Optional<Builtin.NativeObject>
-  cond_br undef, bb1, bb9999
+  cond_br undef, bb2, bb9999
+
+bb3:
+  br bb4
 
 // Two BB Loop. We can use loop or domination to handle this case. But we don't
 // handle it now.
-bb2:
+bb4:
   retain_value %0 : $Optional<Builtin.NativeObject>
-  br bb3
+  br bb5
 
-bb3:
+bb5:
   retain_value %0 : $Optional<Builtin.NativeObject>
-  cond_br undef, bb2, bb9999
+  cond_br undef, bb4, bb9999
 
 bb9999:
   retain_value %0 : $Optional<Builtin.NativeObject>
@@ -986,10 +901,19 @@ bb0(%0 : $Optional<Builtin.NativeObject>):
   switch_enum %0 : $Optional<Builtin.NativeObject>, case #Optional.some!enumelt.1: bb1, case #Optional.none!enumelt: bb2
 
 bb1:
-  retain_value %0 : $Optional<Builtin.NativeObject>
-  cond_br undef, bb1, bb2
+  br bb3
 
 bb2:
+  br bb5
+
+bb3:
+  retain_value %0 : $Optional<Builtin.NativeObject>
+  cond_br undef, bb3, bb4
+
+bb4:
+  br bb5
+
+bb5:
   retain_value %0 : $Optional<Builtin.NativeObject>
   %9999 = tuple()
   return %9999 : $()
@@ -1449,10 +1373,13 @@ bb1(%1 : $X):
   strong_release %1 : $X
   br bb2(%1 : $X)
 
-bb2(%5 : $X):
-  //CHECK: strong_release %5
-  strong_release %5 : $X
-  br bb2(%5 : $X)
+bb2(%4 : $X):
+  br bb3(%4 : $X)
+
+bb3(%6 : $X):
+  //CHECK: strong_release %6
+  strong_release %6 : $X
+  br bb3(%6 : $X)
 }
 
 

--- a/test/SILOptimizer/latecodemotion.sil
+++ b/test/SILOptimizer/latecodemotion.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -late-codemotion -release-hoisting -retain-sinking -disable-with-critical-edge=1  | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -late-codemotion -release-hoisting -retain-sinking | %FileCheck %s
 
 import Builtin
 import Swift
@@ -360,6 +360,7 @@ bb3(%6 : $Builtin.Int32):
 // CHECK-NEXT: switch_enum
 // CHECK: bb1({{.*}}):
 // CHECK: strong_retain
+// CHECK: apply
 // CHECK: bb2:
 // CHECK-NOT: unchecked_enum_data
 // CHECK-NOT: retain_value
@@ -367,6 +368,7 @@ bb3(%6 : $Builtin.Int32):
 // CHECK: bb3:
 // CHECK-NOT: retain_value
 // CHECK-NOT: strong_retain
+// CHECK-LABEL: } // end sil function 'sink_ref_count_ops_enum_over_switch_enum_1'
 sil @sink_ref_count_ops_enum_over_switch_enum_1 : $@convention(thin) (FakeOptional<Builtin.NativeObject>) -> () {
 bb0(%0 : $FakeOptional<Builtin.NativeObject>):
   %1 = function_ref @blocker : $@convention(thin) () -> ()
@@ -387,86 +389,6 @@ bb2:
 bb3:
   %4 = tuple()
   return %4 : $()
-}
-
-// This test makes sure that if any of the switches targets have a predecessor
-// besides the switch enum, we don't do anything.
-//
-// CHECK-LABEL: sil @sink_ref_count_ops_enum_over_switch_enum_2 : $@convention(thin) (FakeOptional<Builtin.NativeObject>) -> () {
-// CHECK: bb0({{.*}}):
-// CHECK-NEXT: function_ref blocker
-// CHECK-NEXT: function_ref @blocker
-// CHECK-NEXT: cond_br
-// CHECK: bb1:
-// CHECK-NEXT: retain_value
-// CHECK-NEXT: switch_enum
-// CHECK: bb2:
-// CHECK-NOT: unchecked_enum_data
-// CHECK-NOT: retain_value
-// CHECK: bb3:
-// CHECK-NOT: unchecked_enum_data
-// CHECK-NOT: retain_value
-// CHECK: bb4:
-// CHECK-NOT: unchecked_enum_data
-// CHECK-NOT: retain_value
-sil @sink_ref_count_ops_enum_over_switch_enum_2 : $@convention(thin) (FakeOptional<Builtin.NativeObject>) -> () {
-bb0(%0 : $FakeOptional<Builtin.NativeObject>):
-  %1 = function_ref @blocker : $@convention(thin) () -> ()
-  cond_br undef, bb1, bb2
-
-bb1:
-  retain_value %0 : $FakeOptional<Builtin.NativeObject>
-  switch_enum %0 : $FakeOptional<Builtin.NativeObject>, case #FakeOptional.some!enumelt.1: bb2, case #FakeOptional.none!enumelt: bb3
-
-bb2:
-  br bb4
-
-bb3:
-  br bb4
-
-bb4:
-  %2 = tuple()
-  return %2 : $()
-}
-
-// This test makes sure that if any of the switches targets have a predecessor
-// besides the switch enum, we don't do anything.
-//
-// CHECK-LABEL: sil @sink_ref_count_ops_enum_over_switch_enum_3 : $@convention(thin) (FakeOptional<Builtin.Int32>) -> () {
-// CHECK: bb0({{.*}}):
-// CHECK-NEXT: function_ref blocker
-// CHECK-NEXT: function_ref @blocker
-// CHECK-NEXT: cond_br
-// CHECK: bb1:
-// CHECK-NEXT: retain_value
-// CHECK-NEXT: switch_enum
-// CHECK: bb2:
-// CHECK-NOT: unchecked_enum_data
-// CHECK-NOT: retain_value
-// CHECK: bb3:
-// CHECK-NOT: unchecked_enum_data
-// CHECK-NOT: retain_value
-// CHECK: bb4:
-// CHECK-NOT: unchecked_enum_data
-// CHECK-NOT: retain_value
-sil @sink_ref_count_ops_enum_over_switch_enum_3 : $@convention(thin) (FakeOptional<Builtin.Int32>) -> () {
-bb0(%0 : $FakeOptional<Builtin.Int32>):
-  %1 = function_ref @blocker : $@convention(thin) () -> ()
-  cond_br undef, bb1, bb3
-
-bb1:
-  retain_value %0 : $FakeOptional<Builtin.Int32>
-  switch_enum %0 : $FakeOptional<Builtin.Int32>, case #FakeOptional.some!enumelt.1: bb2, case #FakeOptional.none!enumelt: bb3
-
-bb2:
-  br bb4
-
-bb3:
-  br bb4
-
-bb4:
-  %2 = tuple()
-  return %2 : $()
 }
 
 // This test makes sure that we do move ref counts over instructions that cannot reference it.
@@ -598,18 +520,13 @@ bb3:
 // CHECK-NEXT: function_ref @blocker
 // CHECK-NEXT: cond_br
 // CHECK: bb1:
-// CHECK-NEXT: retain_value
+// CHECK-NEXT: br bb4
+// CHECK: bb2:
 // CHECK-NEXT: select_enum
 // CHECK-NEXT: cond_br
-// CHECK: bb2:
 // CHECK-NOT: unchecked_enum_data
 // CHECK-NOT: retain_value
-// CHECK: bb3:
-// CHECK-NOT: unchecked_enum_data
-// CHECK-NOT: retain_value
-// CHECK: bb4:
-// CHECK-NOT: unchecked_enum_data
-// CHECK-NOT: retain_value
+// CHECK-LABEL: } // end sil function 'sink_ref_count_ops_enum_over_select_enum_2'
 sil @sink_ref_count_ops_enum_over_select_enum_2 : $@convention(thin) (FakeOptional<Builtin.Int32>) -> () {
 bb0(%0 : $FakeOptional<Builtin.Int32>):
   %t = integer_literal $Builtin.Int1, 1
@@ -641,18 +558,13 @@ bb4:
 // CHECK-NEXT: function_ref @blocker
 // CHECK-NEXT: cond_br
 // CHECK: bb1:
-// CHECK-NEXT: retain_value
+// CHECK-NEXT: br bb5
+// CHECK: bb2:
 // CHECK-NEXT: select_enum
 // CHECK-NEXT: cond_br
-// CHECK: bb2:
 // CHECK-NOT: unchecked_enum_data
 // CHECK-NOT: retain_value
-// CHECK: bb3:
-// CHECK-NOT: unchecked_enum_data
-// CHECK-NOT: retain_value
-// CHECK: bb4:
-// CHECK-NOT: unchecked_enum_data
-// CHECK-NOT: retain_value
+// CHECK-LABEL: } // end sil function 'sink_ref_count_ops_enum_over_select_enum_3'
 sil @sink_ref_count_ops_enum_over_select_enum_3 : $@convention(thin) (FakeOptional<Builtin.Int32>) -> () {
 bb0(%0 : $FakeOptional<Builtin.Int32>):
   %t = integer_literal $Builtin.Int1, 1
@@ -909,7 +821,13 @@ bb0:
 // CHECK: retain_value [[INPUT]]
 sil @enum_simplification_test10 : $@convention(thin) (FakeOptional<Builtin.NativeObject>) -> () {
 bb0(%0 : $FakeOptional<Builtin.NativeObject>):
-  switch_enum %0 : $FakeOptional<Builtin.NativeObject>, case #FakeOptional.some!enumelt.1: bb1, case #FakeOptional.none!enumelt: bb2
+  switch_enum %0 : $FakeOptional<Builtin.NativeObject>, case #FakeOptional.some!enumelt.1: bbcase1, case #FakeOptional.none!enumelt: bbcase2
+
+bbcase1:
+  br bb1
+
+bbcase2:
+  br bb2
 
 // Single BB Loop
 bb1:
@@ -939,7 +857,13 @@ bb9999:
 // CHECK: retain_value [[INPUT]]
 sil @enum_simplification_test11 : $@convention(thin) (FakeOptional<Builtin.NativeObject>) -> () {
 bb0(%0 : $FakeOptional<Builtin.NativeObject>):
-  switch_enum %0 : $FakeOptional<Builtin.NativeObject>, case #FakeOptional.some!enumelt.1: bb1, case #FakeOptional.none!enumelt: bb2
+  switch_enum %0 : $FakeOptional<Builtin.NativeObject>, case #FakeOptional.some!enumelt.1: bbcase1, case #FakeOptional.none!enumelt: bbcase2
+
+bbcase1:
+  br bb1
+
+bbcase2:
+  br bb2
 
 bb1:
   retain_value %0 : $FakeOptional<Builtin.NativeObject>

--- a/test/SILOptimizer/loop-region-analysis.sil
+++ b/test/SILOptimizer/loop-region-analysis.sil
@@ -389,62 +389,83 @@ bb4:
 // This is an example that can not happen in sil with canonicalized loops.
 //
 // CHECK-LABEL: @inner_natural_loop_with_multiple_backedges@
-// CHECK: (region id:6 kind:func ucfh:false ucft:false
+// CHECK: (region id:8 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:7)
+// CHECK-NEXT:         (region id:9)
 // CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:6
+// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:7 kind:loop ucfh:false ucft:true  parent:6
+// CHECK: (region id:9 kind:loop ucfh:false ucft:false  parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:10)
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:8)))
-// CHECK: (region id:8 kind:loop ucfh:true  ucft:true  parent:7
+// CHECK-NEXT:         (region id:7)))
+// CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:9
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:10 kind:loop ucfh:true  ucft:false  parent:9
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
-// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:2)
 // CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:4)))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:true  parent:8
+// CHECK-NEXT:         (region id:6)))
+// CHECK: (region id:6 kind:bb   ucfh:false ucft:true  parent:10
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:4 kind:bb   ucfh:false ucft:false  parent:10
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
+// CHECK-NEXT:         (parentindex:0)
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:3 kind:bb   ucfh:false ucft:true  parent:8
+// CHECK: (region id:3 kind:bb   ucfh:false  ucft:true parent:10
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (succs
@@ -453,7 +474,7 @@ bb4:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:2 kind:bb   ucfh:true  ucft:false parent:8
+// CHECK: (region id:2 kind:bb   ucfh:true ucft:false parent:10
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:3))
@@ -461,18 +482,18 @@ bb4:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:7
+// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:6
+// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
@@ -491,9 +512,15 @@ bb3:
   cond_br undef, bb2, bb4
 
 bb4:
-  switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bb1, case #ManyCase.Two!enumelt: bb2, case #ManyCase.Three!enumelt: bb5
+  switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bb5, case #ManyCase.Two!enumelt: bb6, case #ManyCase.Three!enumelt: bb7
 
 bb5:
+  br bb1
+
+bb6:
+  br bb2
+
+bb7:
   return undef : $()
 }
 
@@ -626,106 +653,7 @@ bb5:
 //         --------        --------
 //
 // CHECK-LABEL: @two_separate_natural_loops_separated_by_diamond@
-// CHECK: (region id:7 kind:func ucfh:false ucft:false
-// CHECK-NEXT:     (preds)
-// CHECK-NEXT:     (succs)
-// CHECK-NEXT:     (subregs
-// CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:8)
-// CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:9)
-// CHECK-NEXT:         (region id:6))
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:7
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:9))
-// CHECK-NEXT:     (succs)
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:9 kind:loop ucfh:false ucft:false parent:7
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:8))
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:6))
-// CHECK-NEXT:     (subregs
-// CHECK-NEXT:         (region id:4)
-// CHECK-NEXT:         (region id:5))
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:5))
-// CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:5)))
-// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:9
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:4))
-// CHECK-NEXT:     (succs)
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs
-// CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:9
-// CHECK-NEXT:     (preds)
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:5))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:7
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:8))
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:9))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:8 kind:loop ucfh:false ucft:false parent:7
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:0))
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:9))
-// CHECK-NEXT:     (subregs
-// CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:2))
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:2))
-// CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:2)))
-// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:8
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:1))
-// CHECK-NEXT:     (succs)
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs
-// CHECK-NEXT:         (parentindex:0)
-// CHECK-NEXT:         (parentindex:1))
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:8
-// CHECK-NEXT:     (preds)
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:2))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:7
-// CHECK-NEXT:     (preds)
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:8))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
+// CHECK(region id:6 kind:func ucfh:false ucft:false
 sil @two_separate_natural_loops_separated_by_diamond : $@convention(thin) () -> () {
 bb0:
   br bb1
@@ -734,9 +662,15 @@ bb1:
   br bb2
 
 bb2:
-  switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bb1, case #ManyCase.Two!enumelt: bb3, case #ManyCase.Three!enumelt: bb4
+  switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bbcase1, case #ManyCase.Two!enumelt: bbcase2, case #ManyCase.Three!enumelt: bbcase3
 
-bb3:
+bbcase1:
+  br bb1
+
+bbcase2:
+  br bb4
+
+bbcase3:
   br bb4
 
 bb4:
@@ -765,115 +699,156 @@ bb6:
 //         --------           --------
 //
 // CHECK-LABEL: @two_separate_natural_loops_separated_by_diamond_with_loop@
-// CHECK: (region id:8 kind:func ucfh:false ucft:false
+// CHECK: (region id:13 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
+// CHECK-NEXT:         (region id:14)
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:15)
+// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:7)
+// CHECK-NEXT:         (region id:8)
 // CHECK-NEXT:         (region id:9)
-// CHECK-NEXT:         (region id:10)
-// CHECK-NEXT:         (region id:11)
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:8
+// CHECK: (region id:10 kind:bb   ucfh:true  ucft:true  parent:13
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:10)
-// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:9 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:11 kind:loop ucfh:false ucft:false parent:8
+// CHECK: (region id:8 kind:bb   ucfh:true  ucft:true  parent:13
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:9)
+// CHECK-NEXT:         (region id:7)
 // CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:9)
+// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:15))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:15))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:15 kind:loop ucfh:false ucft:false parent:13
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:6)
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:5)
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:6)))
-// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:11
+// CHECK-NEXT:         (region id:11)))
+// CHECK: (region id:11 kind:bb   ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs
-// CHECK-NEXT:         (parentindex:0))
+// CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:11
+// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:6))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:10 kind:loop ucfh:false ucft:false parent:8
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:9))
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:7)
 // CHECK-NEXT:         (region id:11))
-// CHECK-NEXT:     (subregs
-// CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:4))
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:4))
-// CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:4)))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:10
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:3))
-// CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0)
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:10
-// CHECK-NEXT:     (preds)
+// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:14))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:15))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:9 kind:loop ucfh:false ucft:false parent:8
+// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:14))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:14 kind:loop ucfh:false ucft:false parent:13
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:10)
-// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:         (region id:2)
+// CHECK-NEXT:         (region id:12))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:2)))
-// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:9
+// CHECK-NEXT:         (region id:12)))
+// CHECK: (region id:12 kind:bb   ucfh:false ucft:false parent:14
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:14
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
-// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:12))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0)
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:9
+// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:14
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:2))
@@ -881,10 +856,10 @@ bb6:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:8
+// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:13
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:9))
+// CHECK:         (region id:14))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
@@ -897,13 +872,28 @@ bb1:
   br bb2
 
 bb2:
-  switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bb1, case #ManyCase.Two!enumelt: bb3, case #ManyCase.Three!enumelt: bb5
+  switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bbcase1, case #ManyCase.Two!enumelt: bbcase2, case #ManyCase.Three!enumelt: bbcase3
 
-bb3:
+bbcase1:
+  br bb1
+
+bbcase2:
   br bb4
 
+bbcase3:
+  br bb5
+
 bb4:
-  switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bb3, case #ManyCase.Two!enumelt: bb5, case #ManyCase.Three!enumelt: bb7
+  switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bbcase41, case #ManyCase.Two!enumelt: bbcase42, case #ManyCase.Three!enumelt: bbcase43
+
+bbcase41:
+  br bb4
+
+bbcase42:
+  br bb6
+
+bbcase43:
+  br bb7
 
 bb5:
   br bb6
@@ -917,112 +907,142 @@ bb7:
 }
 
 // CHECK-LABEL: @three_separate_natural_loops@
-// CHECK: (region id:8 kind:func ucfh:false ucft:false
+// CHECK: (region id:11 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:9)
+// CHECK-NEXT:         (region id:12)
 // CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:10)
-// CHECK-NEXT:         (region id:11)
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:13)
+// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:14)
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:8
+// CHECK: (region id:9 kind:bb   ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:10)
-// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:         (region id:13)
+// CHECK-NEXT:         (region id:14))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:11 kind:loop ucfh:false ucft:false parent:8
+// CHECK: (region id:14 kind:loop ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:9))
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:7))
-// CHECK-NEXT:     (subregs
-// CHECK-NEXT:         (region id:5)
 // CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:     (subregs
+// CHECK-NEXT:         (region id:7)
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:6)))
-// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:11
+// CHECK-NEXT:         (region id:8)))
+// CHECK: (region id:8 kind:bb   ucfh:false ucft:false parent:14
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:11
+// CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:14
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:10 kind:loop ucfh:false ucft:false parent:8
+// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:11
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:14))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:13 kind:loop ucfh:false ucft:false parent:11
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:     (subregs
+// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:5)))
+// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT:     (preds)
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs
+// CHECK-NEXT:         (parentindex:0))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:7))
-// CHECK-NEXT:     (subregs
-// CHECK-NEXT:         (region id:4))
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:4))
-// CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:4)))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:10
-// CHECK-NEXT:     (preds)
-// CHECK-NEXT:     (succs)
+// CHECK-NEXT:         (region id:13))
 // CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs
-// CHECK-NEXT:         (parentindex:0))
+// CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:8
+// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:         (region id:12))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:9 kind:loop ucfh:false ucft:false parent:8
+// CHECK: (region id:12 kind:loop ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:         (region id:2)
+// CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:2)))
-// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:9
+// CHECK-NEXT:         (region id:10)))
+// CHECK: (region id:10 kind:bb   ucfh:false ucft:false parent:12
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:12
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
-// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0)
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:9
+// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:12
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:2))
@@ -1030,10 +1050,10 @@ bb7:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:8
+// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:         (region id:12))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
@@ -1046,7 +1066,16 @@ bb1:
   br bb2
 
 bb2:
-  switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bb1, case #ManyCase.Two!enumelt: bb3, case #ManyCase.Three!enumelt: bb5
+  switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bbcase1, case #ManyCase.Two!enumelt: bbcase2, case #ManyCase.Three!enumelt: bbcase3
+
+bbcase1:
+  br bb1
+
+bbcase2:
+  br bb3
+
+bbcase3:
+  br bb5
 
 bb3:
   br bb4
@@ -1177,92 +1206,124 @@ bb4:
 //         ---------------
 //
 // CHECK-LABEL: @two_level_natural_loop_with_diamond_and_multiple_loop_exits@
-// CHECK: (region id:6 kind:func ucfh:false ucft:false
+// CHECK: (region id:9 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:7)
-// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:         (region id:10)
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:6
+// CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:7 kind:loop ucfh:false ucft:false parent:6
+// CHECK: (region id:10 kind:loop ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:8)
+// CHECK-NEXT:         (region id:11)
 // CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:5)
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:4))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT:         (region id:6)))
+// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:7
+// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:8))
-// CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:8 kind:loop ucfh:false ucft:false parent:7
+// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:10
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:10
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:11 kind:loop ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:3)
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (subregs
-// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:         (region id:2)
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:8)))
+// CHECK: (region id:8 kind:bb   ucfh:false ucft:false parent:11
+// CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:2))
-// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:8
-// CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:11
+// CHECK-NEXT:     (preds)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0)
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:5)
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:6
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:9
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
@@ -1275,7 +1336,16 @@ bb1:
   cond_br undef, bb2, bb3
 
 bb2:
-  switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bb2, case #ManyCase.Two!enumelt: bb3, case #ManyCase.Three!enumelt: bb4
+  switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bbcase1, case #ManyCase.Two!enumelt: bbcase2, case #ManyCase.Three!enumelt: bbcase3
+
+bbcase1:
+  br bb2
+
+bbcase2:
+  br bb3
+
+bbcase3:
+  br bb4
 
 bb3:
   br bb4
@@ -1404,7 +1474,7 @@ bb5:
 // Make sure that we properly identify irreducible loop boundaries.
 //
 // CHECK-LABEL: @one_level_irreducible_loop@
-// CHECK: (region id:5 kind:func ucfh:false ucft:false
+// CHECK: (region id:8 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
@@ -1412,55 +1482,85 @@ bb5:
 // CHECK-NEXT:         (region id:1)
 // CHECK-NEXT:         (region id:2)
 // CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:5)
+// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:5
+// CHECK: (region id:7 kind:bb   ucfh:true  ucft:true  parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:1))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:8
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:3 kind:bb   ucfh:true  ucft:true  parent:5
+// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:8
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:4 kind:bb   ucfh:true  ucft:true  parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:2 kind:bb   ucfh:true  ucft:true  parent:5
+// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:3)
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:true  ucft:true  parent:5
+// CHECK: (region id:2 kind:bb   ucfh:true  ucft:true  parent:8
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:1)
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:5)
+// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:1 kind:bb   ucfh:true  ucft:true  parent:8
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:2))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:5
+// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:8
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
@@ -1473,7 +1573,16 @@ bb1:
   br bb2
 
 bb2:
-  switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bb1, case #ManyCase.Two!enumelt: bb5, case #ManyCase.Three!enumelt: bb3
+  switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bbcase1, case #ManyCase.Two!enumelt: bbcase2, case #ManyCase.Three!enumelt: bbcase3
+
+bbcase1:
+  br bb1
+
+bbcase2:
+  br bb5
+
+bbcase3:
+  br bb3
 
 bb3:
   br bb2
@@ -1486,94 +1595,124 @@ bb5:
 // One natural loop with one internal irreducible loop
 //
 // CHECK-LABEL: @natural_loop_containing_irreducible_loop@
-// CHECK: (region id:7 kind:func ucfh:false ucft:false
+// CHECK: (region id:10 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:8)
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:11)
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:7
+// CHECK: (region id:8 kind:bb   ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:8 kind:loop ucfh:false ucft:false parent:7
+// CHECK: (region id:11 kind:loop ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:1)
 // CHECK-NEXT:         (region id:2)
 // CHECK-NEXT:         (region id:3)
 // CHECK-NEXT:         (region id:4)
-// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:         (region id:5)
+// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:7)
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:5)))
-// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:8
+// CHECK-NEXT:         (region id:7)))
+// CHECK: (region id:9 kind:bb   ucfh:true  ucft:true  parent:11
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:11
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:4 kind:bb   ucfh:true  ucft:true  parent:8
+// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:11
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:5 kind:bb   ucfh:true  ucft:true  parent:11
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:3 kind:bb   ucfh:true  ucft:true  parent:8
+// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:4)
 // CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:2 kind:bb   ucfh:true  ucft:true  parent:8
+// CHECK: (region id:3 kind:bb   ucfh:true  ucft:true  parent:11
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:2)
+// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:2 kind:bb   ucfh:true  ucft:true  parent:11
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:8
+// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:11
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:7
+// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:10
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
@@ -1589,7 +1728,16 @@ bb1:
   br bb2
 
 bb2:
-  switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bb1, case #ManyCase.Two!enumelt: bb5, case #ManyCase.Three!enumelt: bb3
+  switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bbcase1, case #ManyCase.Two!enumelt: bbcase2, case #ManyCase.Three!enumelt: bbcase3
+
+bbcase1:
+  br bb1
+
+bbcase2:
+  br bb5
+
+bbcase3:
+  br bb3
 
 bb3:
   br bb2
@@ -1608,39 +1756,84 @@ bb7:
 // into siblings.
 //
 // CHECK-LABEL: @two_natural_loop_one_with_irreducible_loop@
-// CHECK: (region id:9 kind:func ucfh:false ucft:false
+// CHECK: (region id:12 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:10)
-// CHECK-NEXT:         (region id:11)
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:13)
+// CHECK-NEXT:         (region id:14)
+// CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:8 kind:bb   ucfh:false ucft:false parent:9
+// CHECK: (region id:10 kind:bb   ucfh:false ucft:false parent:12
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:         (region id:14))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:11 kind:loop ucfh:false ucft:false parent:9
+// CHECK: (region id:14 kind:loop ucfh:false ucft:false parent:12
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:         (region id:13))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (subregs
+// CHECK-NEXT:         (region id:8)
+// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:9)))
+// CHECK: (region id:9 kind:bb   ucfh:false ucft:false parent:14
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs
+// CHECK-NEXT:         (parentindex:0))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:8 kind:bb   ucfh:false ucft:false parent:14
+// CHECK-NEXT:     (preds)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:13 kind:loop ucfh:false ucft:false parent:12
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:0))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:14))
+// CHECK-NEXT:     (subregs
+// CHECK-NEXT:         (region id:1)
+// CHECK-NEXT:         (region id:2)
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:5)
 // CHECK-NEXT:         (region id:6)
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:7)
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:7)))
-// CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:11
+// CHECK: (region id:11 kind:bb   ucfh:true  ucft:true  parent:13
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:13
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (succs)
@@ -1649,84 +1842,69 @@ bb7:
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:11
-// CHECK-NEXT:     (preds)
+// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:10 kind:loop ucfh:false ucft:false parent:9
+// CHECK: (region id:5 kind:bb   ucfh:true  ucft:true  parent:13
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:0))
+// CHECK-NEXT:         (region id:1)
+// CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:3 kind:bb   ucfh:true  ucft:true  parent:13
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:2)
+// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:6)
 // CHECK-NEXT:         (region id:11))
-// CHECK-NEXT:     (subregs
-// CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:4)
-// CHECK-NEXT:         (region id:5))
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:5))
-// CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:5)))
-// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:10
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:3))
-// CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs
-// CHECK-NEXT:         (parentindex:0))
+// CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:4 kind:bb   ucfh:true  ucft:true  parent:10
+// CHECK: (region id:2 kind:bb   ucfh:true  ucft:true  parent:13
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:3 kind:bb   ucfh:true  ucft:true  parent:10
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:4))
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:4)
-// CHECK-NEXT:         (region id:5))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:2 kind:bb   ucfh:true  ucft:true  parent:10
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:3))
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:3))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:10
+// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:13
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:9
+// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:12
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:         (region id:13))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
@@ -1742,7 +1920,16 @@ bb1:
   br bb2
 
 bb2:
-  switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bb1, case #ManyCase.Two!enumelt: bb5, case #ManyCase.Three!enumelt: bb3
+  switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bbcase1, case #ManyCase.Two!enumelt: bbcase2, case #ManyCase.Three!enumelt: bbcase3
+
+bbcase1:
+  br bb1
+
+bbcase2:
+  br bb5
+
+bbcase3:
+  br bb3
 
 bb3:
   br bb2
@@ -1762,38 +1949,83 @@ bb9:
 }
 
 // CHECK-LABEL: @multiple_level_natural_loop_with_irreducible_loop_sandwich@
-// CHECK: (region id:12 kind:func ucfh:false ucft:false
+// CHECK: (region id:15 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:13)
 // CHECK-NEXT:         (region id:16)
-// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:         (region id:19)
+// CHECK-NEXT:         (region id:13))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:11 kind:bb   ucfh:false ucft:false parent:12
+// CHECK: (region id:13 kind:bb   ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:16))
+// CHECK-NEXT:         (region id:19))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:16 kind:loop ucfh:false ucft:false parent:12
+// CHECK: (region id:19 kind:loop ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:13))
+// CHECK-NEXT:         (region id:16))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:         (region id:13))
 // CHECK-NEXT:     (subregs
+// CHECK-NEXT:         (region id:11)
+// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:12)))
+// CHECK: (region id:12 kind:bb   ucfh:false ucft:false parent:19
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:11))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs
+// CHECK-NEXT:         (parentindex:0))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:11 kind:bb   ucfh:false ucft:false parent:19
+// CHECK-NEXT:     (preds)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:16 kind:loop ucfh:false ucft:false parent:15
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:0))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:19))
+// CHECK-NEXT:     (subregs
+// CHECK-NEXT:         (region id:1)
+// CHECK-NEXT:         (region id:2)
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:17)
 // CHECK-NEXT:         (region id:9)
-// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:         (region id:10)
+// CHECK-NEXT:         (region id:14))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (backedge-regs
 // CHECK-NEXT:         (region id:10)))
+// CHECK: (region id:14 kind:bb   ucfh:true  ucft:true  parent:16
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:10 kind:bb   ucfh:false ucft:false parent:16
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:9))
@@ -1804,135 +2036,120 @@ bb9:
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
 // CHECK: (region id:9 kind:bb   ucfh:false ucft:false parent:16
-// CHECK-NEXT:     (preds)
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:13 kind:loop ucfh:false ucft:false parent:12
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:0))
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:16))
-// CHECK-NEXT:     (subregs
-// CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:3)
-// CHECK-NEXT:         (region id:14)
-// CHECK-NEXT:         (region id:8))
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:8))
-// CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:8)))
-// CHECK: (region id:8 kind:bb   ucfh:false ucft:false parent:13
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:3))
-// CHECK-NEXT:     (succs)
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs
-// CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:14 kind:loop ucfh:true  ucft:true  parent:13
+// CHECK: (region id:17 kind:loop ucfh:true  ucft:true  parent:16
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:3))
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:3))
-// CHECK-NEXT:     (subregs
-// CHECK-NEXT:         (region id:4)
-// CHECK-NEXT:         (region id:15)
-// CHECK-NEXT:         (region id:7))
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:4))
-// CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:7)))
-// CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:14
-// CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:15))
-// CHECK-NEXT:     (succs)
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs)
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:15 kind:loop ucfh:false ucft:false parent:14
-// CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:5)
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:18)
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:6)))
-// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:15
+// CHECK-NEXT:         (region id:8)))
+// CHECK: (region id:8 kind:bb   ucfh:false ucft:false parent:17
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:18))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:18 kind:loop ucfh:false ucft:false parent:17
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:     (subregs
+// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs
+// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:     (backedge-regs
+// CHECK-NEXT:         (region id:7)))
+// CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:18
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:15
+// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:18
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:4 kind:bb   ucfh:true  ucft:true  parent:14
+// CHECK: (region id:5 kind:bb   ucfh:true  ucft:true  parent:17
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:15))
+// CHECK-NEXT:         (region id:18))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:3 kind:bb   ucfh:true  ucft:true  parent:13
+// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:16
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:17))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:3 kind:bb   ucfh:true  ucft:true  parent:16
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:14))
+// CHECK-NEXT:         (region id:17))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:8)
+// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:9)
 // CHECK-NEXT:         (region id:14))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:2 kind:bb   ucfh:true  ucft:true  parent:13
+// CHECK: (region id:2 kind:bb   ucfh:true  ucft:true  parent:16
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:         (region id:14))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:13
+// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:16
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:14))
+// CHECK-NEXT:         (region id:17))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:12
+// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:13))
+// CHECK-NEXT:         (region id:16))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
@@ -1948,7 +2165,16 @@ bb1:
   br bb2
 
 bb2:
-  switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bb1, case #ManyCase.Two!enumelt: bb5, case #ManyCase.Three!enumelt: bb3
+  switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bbcase1, case #ManyCase.Two!enumelt: bbcase2, case #ManyCase.Three!enumelt: bbcase3
+
+bbcase1:
+  br bb1
+
+bbcase2:
+  br bb5
+
+bbcase3:
+  br bb3
 
 bb3:
   cond_br undef, bb2, bb10
@@ -2174,100 +2400,175 @@ bb6:
 }
 
 // CHECK-LABEL: @unreachable_bb_in_inner_loop_with_multiple_edges@
-// CHECK: (region id:7 kind:func ucfh:false ucft:false
+// CHECK: (region id:13 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:8)
-// CHECK-NEXT:         (region id:5)
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:14)
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:9)
+// CHECK-NEXT:         (region id:11)
+// CHECK-NEXT:         (region id:12))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:12 kind:bb   ucfh:false ucft:false parent:13
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:11 kind:bb   ucfh:false ucft:false parent:13
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:14))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:9 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:14))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:8 kind:loop ucfh:false ucft:false parent:7
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:14))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:13
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:14))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:14 kind:loop ucfh:false ucft:false parent:13
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:5)
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:6)
+// CHECK-NEXT:         (region id:9)
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:9)
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:15)
+// CHECK-NEXT:         (region id:7)
+// CHECK-NEXT:         (region id:8))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:4)
-// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:         (region id:8)
+// CHECK-NEXT:         (region id:15))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:4)))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:8
+// CHECK-NEXT:         (region id:8)))
+// CHECK: (region id:8 kind:bb   ucfh:false ucft:false parent:14
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:9 kind:loop ucfh:false ucft:false parent:8
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:14
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:15))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:15 kind:loop ucfh:false ucft:false parent:14
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:         (region id:4)
+// CHECK-NEXT:         (region id:5)
+// CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (non-local-succs
-// CHECK-NEXT:         (parentindex:1))
+// CHECK-NEXT:         (parentindex:1)
+// CHECK-NEXT:         (parentindex:2)
+// CHECK-NEXT:         (parentindex:3))
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:         (region id:5))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:3)))
-// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:9
+// CHECK-NEXT:         (region id:10)))
+// CHECK: (region id:10 kind:bb   ucfh:false ucft:false parent:15
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:15
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs
+// CHECK-NEXT:         (parentindex:2)
+// CHECK-NEXT:         (parentindex:3))
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:2))
-// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:15
+// CHECK-NEXT:     (preds)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:4))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0)
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:9
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:14
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:3))
-// CHECK-NEXT:     (subregs)
-// CHECK-NEXT:     (non-local-succs
-// CHECK-NEXT:         (parentindex:0))
-// CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:1 kind:bb   ucfh:false ucft:false parent:8
-// CHECK-NEXT:     (preds)
-// CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:9))
+// CHECK-NEXT:         (region id:15))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:7
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:13
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:14))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
 sil @unreachable_bb_in_inner_loop_with_multiple_edges : $@convention(thin) () -> () {
 bb0:
   br bb1
@@ -2276,13 +2577,31 @@ bb1:
   br bb2
 
 bb2:
-  switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bb3, case #ManyCase.Two!enumelt: bb4, case #ManyCase.Three!enumelt: bb3
+  switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bbcase1, case #ManyCase.Two!enumelt: bbcase2, case #ManyCase.Three!enumelt: bbcase3
+
+bbcase1:
+  br bb3
+
+bbcase2:
+  br bb4
+
+bbcase3:
+  br bb3
 
 bb3:
   unreachable
 
 bb4:
-  switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bb2, case #ManyCase.Two!enumelt: bb5, case #ManyCase.Three!enumelt: bb3
+  switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bbcase41, case #ManyCase.Two!enumelt: bbcase42, case #ManyCase.Three!enumelt: bbcase43
+
+bbcase41:
+  br bb2
+
+bbcase42:
+  br bb5
+
+bbcase43:
+  br bb3
 
 bb5:
   cond_br undef, bb1, bb6
@@ -2672,115 +2991,177 @@ bb4:
 // This is the double backedge loop case.
 //
 // CHECK-LABEL: @multiple_exit_blocks_that_are_loops@
-// CHECK: (region id:9 kind:func ucfh:false ucft:false
+// CHECK: (region id:15 kind:func ucfh:false ucft:false
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:0)
-// CHECK-NEXT:         (region id:10)
+// CHECK-NEXT:         (region id:16)
 // CHECK-NEXT:         (region id:4)
-// CHECK-NEXT:         (region id:7)
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:5)
+// CHECK-NEXT:         (region id:10)
+// CHECK-NEXT:         (region id:11)
+// CHECK-NEXT:         (region id:12))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:8 kind:bb   ucfh:false ucft:false parent:9
+// CHECK: (region id:12 kind:bb   ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:4)
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:5)
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:7 kind:bb   ucfh:false ucft:false parent:9
+// CHECK: (region id:11 kind:bb   ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:12))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:9
+// CHECK: (region id:10 kind:bb   ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:         (region id:16))
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:         (region id:11))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:10 kind:loop ucfh:true  ucft:true  parent:9
+// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:15
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:4))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:4 kind:bb   ucfh:false ucft:false parent:15
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:16))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:16 kind:loop ucfh:true  ucft:false parent:15
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:0))
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:4)
-// CHECK-NEXT:         (region id:7))
+// CHECK-NEXT:         (region id:10))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:1)
-// CHECK-NEXT:         (region id:11)
-// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:         (region id:17)
+// CHECK-NEXT:         (region id:7)
+// CHECK-NEXT:         (region id:18)
+// CHECK-NEXT:         (region id:14))
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:11)
-// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:         (region id:17)
+// CHECK-NEXT:         (region id:18))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:11)
-// CHECK-NEXT:         (region id:12))
-// CHECK: (region id:12 kind:loop ucfh:false ucft:true  parent:10
+// CHECK-NEXT:         (region id:7)
+// CHECK-NEXT:         (region id:14)))
+// CHECK: (region id:14 kind:bb   ucfh:false ucft:true  parent:16
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:18))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:18 kind:loop ucfh:false ucft:false parent:16
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
-// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:14))
 // CHECK-NEXT:     (subregs
-// CHECK-NEXT:         (region id:5)
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:8)
+// CHECK-NEXT:         (region id:9)
+// CHECK-NEXT:         (region id:13))
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:6)))
-// CHECK: (region id:6 kind:bb   ucfh:false ucft:true  parent:12
+// CHECK-NEXT:         (region id:13)))
+// CHECK: (region id:13 kind:bb   ucfh:false ucft:false parent:18
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:5))
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:9 kind:bb   ucfh:false ucft:false parent:18
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:8))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:13))
+// CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
+// CHECK-NEXT:         (parentindex:0)
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:5 kind:bb   ucfh:false ucft:false parent:12
+// CHECK: (region id:8 kind:bb   ucfh:false ucft:false parent:18
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:         (region id:9))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:11 kind:loop ucfh:false ucft:true  parent:10
+// CHECK: (region id:7 kind:bb   ucfh:false ucft:true  parent:16
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:17))
+// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:17 kind:loop ucfh:false ucft:false parent:16
 // CHECK-NEXT:     (preds
 // CHECK-NEXT:         (region id:1))
-// CHECK-NEXT:     (succs)
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:7))
 // CHECK-NEXT:     (subregs
 // CHECK-NEXT:         (region id:2)
-// CHECK-NEXT:         (region id:3))
+// CHECK-NEXT:         (region id:3)
+// CHECK-NEXT:         (region id:6))
 // CHECK-NEXT:     (non-local-succs
 // CHECK-NEXT:         (parentindex:0))
 // CHECK-NEXT:     (exiting-subregs
 // CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (backedge-regs
-// CHECK-NEXT:         (region id:3)))
-// CHECK: (region id:3 kind:bb   ucfh:false ucft:true  parent:11
+// CHECK-NEXT:         (region id:6)))
+// CHECK: (region id:6 kind:bb   ucfh:false ucft:false parent:17
 // CHECK-NEXT:     (preds
-// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:         (region id:3))
 // CHECK-NEXT:     (succs)
 // CHECK-NEXT:     (subregs)
+// CHECK-NEXT:     (non-local-succs)
+// CHECK-NEXT:     (exiting-subregs)
+// CHECK-NEXT:     (backedge-regs))
+// CHECK: (region id:3 kind:bb   ucfh:false ucft:false parent:17
+// CHECK-NEXT:     (preds
+// CHECK-NEXT:         (region id:2))
+// CHECK-NEXT:     (succs
+// CHECK-NEXT:         (region id:6))
+// CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs
+// CHECK-NEXT:         (parentindex:0)
 // CHECK-NEXT:         (parentindex:1))
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:11
+// CHECK: (region id:2 kind:bb   ucfh:false ucft:false parent:17
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
 // CHECK-NEXT:         (region id:3))
@@ -2788,19 +3169,19 @@ bb4:
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:1 kind:bb   ucfh:true  ucft:false parent:10
+// CHECK: (region id:1 kind:bb   ucfh:true  ucft:false parent:16
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:11)
-// CHECK-NEXT:         (region id:12))
+// CHECK-NEXT:         (region id:17)
+// CHECK-NEXT:         (region id:18))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
 // CHECK-NEXT:     (backedge-regs))
-// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:9
+// CHECK: (region id:0 kind:bb   ucfh:false ucft:false parent:15
 // CHECK-NEXT:     (preds)
 // CHECK-NEXT:     (succs
-// CHECK-NEXT:         (region id:10))
+// CHECK-NEXT:         (region id:16))
 // CHECK-NEXT:     (subregs)
 // CHECK-NEXT:     (non-local-succs)
 // CHECK-NEXT:     (exiting-subregs)
@@ -2816,13 +3197,31 @@ bb2:
   br bb3
 
 bb3:
-  switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bb1, case #ManyCase.Two!enumelt: bb2, case #ManyCase.Three!enumelt: bb6
+  switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bbcase1, case #ManyCase.Two!enumelt: bbcase2, case #ManyCase.Three!enumelt: bbcase3
+
+bbcase1:
+  br bb1
+
+bbcase2:
+  br bb2
+
+bbcase3:
+  br bb6
 
 bb4:
   br bb5
 
 bb5:
-  switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bb1, case #ManyCase.Two!enumelt: bb4, case #ManyCase.Three!enumelt: bb7
+  switch_enum undef : $ManyCase, case #ManyCase.One!enumelt: bbcase51, case #ManyCase.Two!enumelt: bbcase52, case #ManyCase.Three!enumelt: bbcase53
+
+bbcase51:
+  br bb1
+
+bbcase52:
+  br bb4
+
+bbcase53:
+  br bb7
 
 bb6:
   br bb8

--- a/test/SILOptimizer/simplify_cfg_args.sil
+++ b/test/SILOptimizer/simplify_cfg_args.sil
@@ -167,17 +167,20 @@ bb1:                                              // Preds: bb0
 bb2:                                              // Preds: bb1
   %6 = integer_literal $Builtin.Int32, 0          // user: %7
   %7 = struct $Int32 (%6 : $Builtin.Int32)        // user: %8
-  br bb5
+  br bb6
 
 bb3(%9 : $(Int32, Int32)):                        // Preds: bb0
   %10 = tuple_extract %9 : $(Int32, Int32), 0     // user: %12
   br bb4                                          // id: %11
 
 bb4:                                              // Preds: bb3
-  br bb5                                          // id: %12
+  br bb6                                          // id: %12
 
-bb5:                                              // Preds: bb0
-  return %0 : $Int32                              // id: %17
+bb5:
+  br bb6
+
+bb6:
+  return %0 : $Int32
 }
 
 // CHECK-LABEL: simplify_switch_dont_include_args_nested
@@ -195,7 +198,7 @@ bb1(%12: $(Int32, Int32)):
 bb2:
   %6 = integer_literal $Builtin.Int32, 0
   %7 = struct $Int32 (%6 : $Builtin.Int32)
-  br bb5(%7 : $Int32)
+  br bb9(%7 : $Int32)
 
 bb3:
   %9 = integer_literal $Builtin.Int32, 1
@@ -203,23 +206,27 @@ bb3:
   br bb4(%10 : $Int32)
 
 bb4(%16 : $Int32):
-  br bb5(%16 : $Int32)
+  br bb9(%16 : $Int32)
 
-bb5(%19 : $Int32):
-  return %19 : $Int32
+bb5(%18 : $Int32):
+  br bb9(%18 : $Int32)
 
 bb6:
-  %14 = integer_literal $Builtin.Int32, 2
-  %15 = struct $Int32 (%14 : $Builtin.Int32)
-  br bb5(%15 : $Int32)
+  %20 = integer_literal $Builtin.Int32, 2
+  %21 = struct $Int32 (%20 : $Builtin.Int32)
+  br bb9(%21 : $Int32)
 
 bb7:
-  %17 = integer_literal $Builtin.Int32, 3
-  %18 = struct $Int32 (%17 : $Builtin.Int32)
-  br bb5(%18 : $Int32)
+  %22 = integer_literal $Builtin.Int32, 3
+  %23 = struct $Int32 (%22 : $Builtin.Int32)
+  br bb9(%23 : $Int32)
 
-bb8(%20 : $Int32):
-  br bb5(%20 : $Int32)
+bb8(%25 : $Int32):
+  br bb9(%25 : $Int32)
+
+bb9(%27 : $Int32):
+  return %27 : $Int32
+
 }
 
 // CHECK-LABEL: simplify_switch_wrong_args
@@ -227,7 +234,7 @@ sil @simplify_switch_wrong_args : $@convention(thin) (Int32, Int32, X, Builtin.I
 // CHECK: bb0
 // CHECK: switch_enum %2
 bb0(%0 : $Int32, %1 : $Int32, %2 : $X, %24 : $Builtin.Int1):
-  switch_enum %2 : $X, case #X.A!enumelt: bb3, case #X.B!enumelt.1: bb9, case #X.C!enumelt.1: bb5
+  switch_enum %2 : $X, case #X.A!enumelt: bb3, case #X.B!enumelt.1: bb9, case #X.C!enumelt.1: bb10
 
 bb9(%21 : $(Int32, Int32)):
   %22 = tuple_extract %21 : $(Int32, Int32), 1
@@ -250,6 +257,9 @@ bb3:
 
 bb4(%16 : $Int32):
   br bb5(%16 : $Int32)
+
+bb10(%18 : $Int32):
+  br bb5(%18 : $Int32)
 
 bb5(%19 : $Int32):
   return %19 : $Int32
@@ -414,7 +424,7 @@ bb0(%0 : $E):
 
 bb1:
   %1 = integer_literal $Builtin.Int1, -1
-  br bb4(%1 : $Builtin.Int1)
+  br bb5(%1 : $Builtin.Int1)
 
 bb2:
 // CHECK: unchecked_enum_data %0 : $E, #E.Yup!enumelt.1
@@ -424,10 +434,13 @@ bb2:
 
 bb3:
   %2 = integer_literal $Builtin.Int1, 0
-  br bb4(%2 : $Builtin.Int1)
+  br bb5(%2 : $Builtin.Int1)
 
 bb4(%3 : $Builtin.Int1):
-  return %3 : $Builtin.Int1
+  br bb5(%3 : $Builtin.Int1)
+
+bb5(%4 : $Builtin.Int1):
+  return %4 : $Builtin.Int1
 }
 
 // CHECK-LABEL: sil @same_destination_unused_arg

--- a/test/SILOptimizer/split_critical_edges.sil
+++ b/test/SILOptimizer/split_critical_edges.sil
@@ -10,47 +10,6 @@ enum OnePayload {
   case y
 }
 
-// CHECK-LABEL: sil @check_switch_enum
-// CHECK: bb0(
-// CHECK:  cond_br %1, bb1, bb2
-// CHECK: bb1:
-// CHECK:   integer_literal $Builtin.Int64, 1
-// CHECK:   br bb4(
-// CHECK: bb2:
-// CHECK:   switch_enum {{.*}} : $OnePayload, case #OnePayload.x!enumelt.1: bb3, case #OnePayload.y!enumelt: bb5
-// CHECK: bb3([[PAYLOAD:%.]] : $Builtin.Int64):
-// CHECK:   br bb4([[PAYLOAD]] : $Builtin.Int64)
-// CHECK: bb4([[VAL:%.*]] : $Builtin.Int64):
-// CHECK:   struct $Int64 ([[VAL]] : $Builtin.Int64)
-// CHECK:   br bb6
-// CHECK: bb5:
-// CHECK:   br bb6
-// CHECK: bb6:
-// CHECK:   return
-
-sil @check_switch_enum : $(OnePayload, Builtin.Int1) -> () {
-entry(%0 : $OnePayload, %1: $Builtin.Int1):
-  cond_br %1, bb1, bb2
-
-bb1:
-  %2 = integer_literal $Builtin.Int64, 1
-  br x_dest(%2 : $Builtin.Int64)
-
-bb2:
-  switch_enum %0 : $OnePayload, case #OnePayload.x!enumelt.1: x_dest, case #OnePayload.y!enumelt: y_dest
-
-x_dest(%4: $Builtin.Int64):
-  %5 = struct $Int64 (%4 : $Builtin.Int64)
-  br end
-
-y_dest:
-  br end
-
-end:
-  %v = tuple ()
-  return %v : $()
-}
-
 // CHECK-LABEL: sil @check_switch_value
 // CHECK: bb0
 // CHECK:   cond_br %1, bb1, bb2
@@ -75,12 +34,16 @@ entry(%0 : $Builtin.Int32, %1: $Builtin.Int1):
 
 bb1:
   %2 = integer_literal $Builtin.Int64, 1
-  br x_dest
+  br x_cont
+
 bb2:
   %3 = integer_literal $Builtin.Int32, 1
   switch_value %0 : $Builtin.Int32, case %3: x_dest, default y_dest
 
 x_dest:
+  br x_cont
+
+x_cont:
   br end
 
 y_dest:
@@ -100,26 +63,22 @@ class X {
 
 // CHECK: sil @dynamic_lookup_br : $@convention(thin) (AnyObject, Builtin.Int1) -> () {
 // CHECK: bb0(
-// CHECK:   cond_br %1, bb1, bb4
+// CHECK:   cond_br %1, bb1, bb2
 // CHECK: bb1:
-// CHECK:   dynamic_method_br {{.*}} : $Builtin.UnknownObject, #X.f!1.foreign, bb3, bb2
+// CHECK:   dynamic_method_br {{.*}} : $Builtin.UnknownObject, #X.f!1.foreign, bb3, bb4
 // CHECK: bb2:
-// CHECK:   br bb8
+// CHECK:   dynamic_method_br {{.*}} : $Builtin.UnknownObject, #X.f!1.foreign, bb5, bb6
 // CHECK: bb3({{.*}} : $@convention(objc_method) (Builtin.UnknownObject) -> ())
-// CHECK:   br bb7({{.*}} : $@convention(objc_method) (Builtin.UnknownObject) -> ())
+// CHECK:   br bb7
 // CHECK: bb4:
-// CHECK:   dynamic_method_br {{.*}} : $Builtin.UnknownObject, #X.f!1.foreign, bb6, bb5
-// CHECK: bb5:
-// CHECK:   br bb8
-// CHECK: bb6({{.*}} : $@convention(objc_method) (Builtin.UnknownObject) -> ()):
-// CHECK:   br bb7({{.*}} : $@convention(objc_method) (Builtin.UnknownObject) -> ())
-// CHECK: bb7({{.*}} : $@convention(objc_method) (Builtin.UnknownObject) -> ()):
-// CHECK:   br bb9
-// CHECK: bb8:
-// CHECK:   br bb9
-// CHECK: bb9:
+// CHECK:   br bb7
+// CHECK: bb5({{.*}} : $@convention(objc_method) (Builtin.UnknownObject) -> ()):
+// CHECK:   br bb7
+// CHECK: bb6:
+// CHECK:   br bb7
+// CHECK: bb7:
 // CHECK:   return
-
+// CHECK-LABEL: } // end sil function 'dynamic_lookup_br'
 sil @dynamic_lookup_br : $@convention(thin) (AnyObject, Builtin.Int1) -> () {
 bb0(%0 : $AnyObject, %10: $Builtin.Int1):
   cond_br %10, lookup1, lookup2
@@ -144,15 +103,21 @@ lookup2:
   strong_retain %24 : $AnyObject
   %26 = open_existential_ref %24 : $AnyObject to $@opened("12345678-89ab-cdef-0123-000000000000") AnyObject
   %27 = unchecked_ref_cast %26 : $@opened("12345678-89ab-cdef-0123-000000000000") AnyObject to $Builtin.UnknownObject
-  dynamic_method_br %27 : $Builtin.UnknownObject, #X.f!1.foreign, bb1, bb2
+  dynamic_method_br %27 : $Builtin.UnknownObject, #X.f!1.foreign, bb3, bb4
 
 bb1(%8 : $@convention(objc_method) (Builtin.UnknownObject) -> ()):
-  br bb3
+  br bb5
 
 bb2:
-  br bb3
+  br bb5
 
-bb3:
+bb3(%9 : $@convention(objc_method) (Builtin.UnknownObject) -> ()):
+  br bb5
+
+bb4:
+  br bb5
+
+bb5:
   %43 = tuple ()
   return %43 : $()
 }
@@ -165,24 +130,20 @@ class ParentNode : Node {
 
 // CHECK-LABEL: sil @test_checked_cast_br
 // CHECK: bb0(
-// CHECK:   cond_br %1, bb1, bb4
+// CHECK:   cond_br %1, bb1, bb2
 // CHECK: bb1:
-// CHECK:   checked_cast_br [exact] {{.*}} : $Node to $ParentNode, bb3, bb2
+// CHECK:   checked_cast_br [exact] {{.*}} : $Node to $ParentNode, bb3, bb4
 // CHECK: bb2:
-// CHECK:   br bb8
+// CHECK:   checked_cast_br [exact] {{.*}} : $Node to $ParentNode, bb5, bb6
 // CHECK: bb3({{.*}} : $ParentNode):
-// CHECK:   br bb7({{.*}} : $ParentNode)
+// CHECK:   br bb7
 // CHECK: bb4:
-// CHECK:   checked_cast_br [exact] {{.*}} : $Node to $ParentNode, bb6, bb5
-// CHECK: bb5:
-// CHECK:   br bb8
-// CHECK: bb6({{.*}} : $ParentNode):
-// CHECK:   br bb7({{.*}} : $ParentNode)
-// CHECK: bb7({{.*}} : $ParentNode):
-// CHECK:   br bb9
-// CHECK: bb8:
-// CHECK:   br bb9
-// CHECK: bb9:
+// CHECK:   br bb7
+// CHECK: bb5({{.*}} : $ParentNode):
+// CHECK:   br bb7
+// CHECK: bb6:
+// CHECK:   br bb7
+// CHECK: bb7:
 // CHECK:   return
 
 sil @test_checked_cast_br : $@convention(method) (@owned Node, Builtin.Int1) -> () {
@@ -193,12 +154,18 @@ ccb1:
   checked_cast_br [exact] %0 : $Node to $ParentNode, bb2, bb3
 
 ccb2:
-  checked_cast_br [exact] %0 : $Node to $ParentNode, bb2, bb3
+  checked_cast_br [exact] %0 : $Node to $ParentNode, bb4, bb5
 
 bb2(%5 : $ParentNode):
   br bb1
 
 bb3:
+  br bb1
+
+bb4(%6 : $ParentNode):
+  br bb1
+
+bb5:
   br bb1
 
 bb1:


### PR DESCRIPTION
Handle critical edges consistently in all SIL stages.
    
This will allow passes that optimize phis to be run in the mandatory
pipeline. It also simplifies SIL invariants and will unblock
much needed simplification of BlockArgument handling.

