### PR TITLE
[Conformance lookup] Don’t form an inherited conformance to an error type.

### DIFF
--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -818,6 +818,8 @@ ConformanceLookupTable::getConformance(NominalTypeDecl *nominal,
     // declared.
     auto *conformingClass = cast<ClassDecl>(conformingNominal);
     Type superclassTy = type->getSuperclassForDecl(conformingClass);
+    if (superclassTy->is<ErrorType>())
+      return nullptr;
 
     // Look up the inherited conformance.
     ModuleDecl *module = entry->getDeclContext()->getParentModule();

--- a/validation-test/compiler_crashers_2_fixed/0171-sr-8642.swift
+++ b/validation-test/compiler_crashers_2_fixed/0171-sr-8642.swift
@@ -1,0 +1,10 @@
+// RUN: not %target-swift-frontend -typecheck %s
+
+protocol P {}
+protocol Q {}
+class A : P {}
+class B : A {}
+
+struct A<T:B> {
+  var x: T { fatalError("death") }
+}


### PR DESCRIPTION
Fixes SR-8642, a crash-on-invalid.
