### PR TITLE
Correct most UBSan errors in the compiler

### DIFF
--- a/include/swift/Basic/ExponentialGrowthAppendingBinaryByteStream.h
+++ b/include/swift/Basic/ExponentialGrowthAppendingBinaryByteStream.h
@@ -59,10 +59,10 @@ public:
 
   /// This is an optimized version of \c writeBytes that assumes we know the
   /// size of \p Value at compile time (which in particular holds for integers).
-  /// It does so by avoiding the memcopy that \c writeBytes requires to copy
-  /// the arbitrarily sized Buffer to the output buffer and using a direct
-  /// memory assignment instead.
-  /// This assumes that the enianess of this steam is the same as the native
+  /// It does so by exposing the memcpy to the optimizer along with the size 
+  /// of the value being assigned; the compiler can then optimize the memcpy
+  /// into a fixed set of instructions.
+  /// This assumes that the endianess of this steam is the same as the native
   /// endianess on the executing machine. No endianess transformations are
   /// performed.
   template<typename T>
@@ -77,7 +77,7 @@ public:
       Data.resize(RequiredSize);
     }
 
-    *(T *)(Data.data() + Offset) = Value;
+    ::memcpy(Data.data() + Offset, &Value, sizeof Value);
 
     return llvm::Error::success();
   }

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -2202,7 +2202,9 @@ public:
   SavedInsertionPointRAII &operator=(SavedInsertionPointRAII &&) = delete;
 
   ~SavedInsertionPointRAII() {
-    if (SavedIP.is<SILInstruction *>()) {
+    if (SavedIP.isNull()) {
+      Builder.clearInsertionPoint();
+    } else if (SavedIP.is<SILInstruction *>()) {
       Builder.setInsertionPoint(SavedIP.get<SILInstruction *>());
     } else {
       Builder.setInsertionPoint(SavedIP.get<SILBasicBlock *>());

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -264,6 +264,7 @@ public:
   /// setInsertionPoint - Set the insertion point to insert before the specified
   /// instruction.
   void setInsertionPoint(SILInstruction *I) {
+    assert(I && "can't set insertion point to a null instruction");
     setInsertionPoint(I->getParent(), I->getIterator());
   }
 
@@ -276,6 +277,7 @@ public:
   /// setInsertionPoint - Set the insertion point to insert at the end of the
   /// specified block.
   void setInsertionPoint(SILBasicBlock *BB) {
+    assert(BB && "can't set insertion point to a null basic block");
     setInsertionPoint(BB, BB->end());
   }
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1598,7 +1598,7 @@ class CompletionLookup final : public swift::VisibleDeclConsumer {
   Type ExprType;
 
   /// Whether the expr is of statically inferred metatype.
-  bool IsStaticMetatype;
+  bool IsStaticMetatype = false;
 
   /// User-provided base type for LookupKind::Type completions.
   Type BaseType;

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -395,7 +395,7 @@ private:
 
   Expr *getContainingExpr(size_t index) const {
     if (ExprStack.size() > index)
-      return ExprStack.end()[-(index + 1)];
+      return ExprStack.end()[-std::ptrdiff_t(index + 1)];
     return nullptr;
   }
 

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -730,8 +730,13 @@ ReabstractionInfo::createSubstitutedType(SILFunction *OrigF,
     // FIXME: Some of the added new requirements may not have been taken into
     // account by the substGenericArgs. So, canonicalize in the context of the
     // specialized signature.
-    FnTy = cast<SILFunctionType>(
-        CanSpecializedGenericSig->getCanonicalTypeInContext(FnTy));
+    if (CanSpecializedGenericSig)
+      FnTy = cast<SILFunctionType>(
+          CanSpecializedGenericSig->getCanonicalTypeInContext(FnTy));
+    else {
+      FnTy = cast<SILFunctionType>(FnTy->getCanonicalType());
+      assert(!FnTy->hasTypeParameter() && "Type parameters outside generic context?");
+    }
   }
   assert(FnTy);
 

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -719,7 +719,8 @@ void TypeChecker::computeCaptures(AnyFunctionRef AFR) {
                           DynamicSelfCaptureLoc,
                           DynamicSelf,
                           AFR);
-  AFR.getBody()->walk(finder);
+  if (AFR.getBody())
+    AFR.getBody()->walk(finder);
 
   unsigned inoutCount = 0;
   for (auto C : Captures) {

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -873,7 +873,8 @@ static bool passCursorInfoForDecl(SourceFile* SF,
   auto ClangNode = VD->getClangNode();
   if (ClangNode) {
     auto ClangMod = Importer->getClangOwningModule(ClangNode);
-    ModuleName = ClangMod->getFullModuleName();
+    if (ClangMod)
+      ModuleName = ClangMod->getFullModuleName();
   } else if (VD->getLoc().isInvalid() && VD->getModuleContext() != MainModule) {
     ModuleName = VD->getModuleContext()->getName().str();
   }

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/CompactArray.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/CompactArray.h
@@ -102,7 +102,9 @@ protected:
   CompactArrayReaderImpl(void *Buf) : Buf(Buf) {}
 
   uint64_t getEntriesBufSize() const {
-    return *(uint64_t*)Buf;
+    uint64_t result;
+    std::memcpy(&result, Buf, sizeof result);
+    return result;
   }
   const uint8_t *getEntriesBufStart() const {
     return (const uint8_t *)(((uint64_t*)Buf)+1);


### PR DESCRIPTION
This PR corrects most cases of undefined behavior caught by UndefinedBehaviorSanitizer in the Swift compiler by running `utils/build-script -enable-ubsan -t`. Most of these are caused by calling methods on null objects; a few of them are unaligned memory accesses or other issues. One of them—an integer overflow in an inlining estimation which happens when compiling our dictionary benchmarks—has a fix which might impact the performance of generated code.

This doesn't fix the biggest cause of undefined behavior: `BumpPtrAllocator::Allocate()` can sometimes return `nullptr` for zero-size allocations even though it's annotated with `returns_nonnull`. This issue causes about fifteen or twenty UBSan errors, including in many libIDE tests. [I'm working on a fix upstream](https://reviews.llvm.org/D51317), but [this patch](https://gist.github.com/brentdax/ad6c85db21c9d70a41a68548e43c0f9d) works around the cases we encounter in our tests.

This touches a lot of different areas of the compiler, so it might make sense to split it up. Some of the fixes might be patching over deeper issues—for example, some of the calls on null objects may be in places where they should never be null. If you see anything that looks like it's a symptom of a deeper issue, flag it and I'll take another look.