### PR TITLE
Fix the SIL incoming phi value API, verify critical edges, fix SIL passes that break verification.

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -883,6 +883,11 @@ public:
   /// invariants.
   void verify(bool SingleFunction = true) const;
 
+  /// Verify that all non-cond-br critical edges have been split.
+  ///
+  /// This is a fast subset of the checks performed in the SILVerifier.
+  void verifyCriticalEdges() const;
+
   /// Pretty-print the SILFunction.
   void dump(bool Verbose) const;
   void dump() const;

--- a/include/swift/SILOptimizer/Utils/CFG.h
+++ b/include/swift/SILOptimizer/Utils/CFG.h
@@ -118,12 +118,11 @@ SILBasicBlock *splitBasicBlockAndBranch(SILBuilder &B,
 /// \brief Return true if the function has a critical edge, false otherwise.
 bool hasCriticalEdges(SILFunction &F, bool OnlyNonCondBr);
 
-/// \brief Split all critical edges in the function updating the dominator tree
-/// and loop information (if they are not set to null). If \p OnlyNonCondBr is
-/// true this will not split cond_br edges (Only edges which can't carry
-/// arguments will be split).
-bool splitAllCriticalEdges(SILFunction &F, bool OnlyNonCondBr,
-                           DominanceInfo *DT, SILLoopInfo *LI);
+/// \brief Split all critical edges in the given function, updating the
+/// dominator tree and loop information if they are provided.
+///
+/// FIXME: This should never be called! Fix passes that create critical edges.
+bool splitAllCriticalEdges(SILFunction &F, DominanceInfo *DT, SILLoopInfo *LI);
 
 /// \brief Split all cond_br critical edges with non-trivial arguments in the
 /// function updating the dominator tree and loop information (if they are not

--- a/lib/SIL/InstructionUtils.cpp
+++ b/lib/SIL/InstructionUtils.cpp
@@ -465,7 +465,7 @@ void swift::findClosuresForFunctionValue(
     // This should be done before calling findClosureStoredIntoBlock.
     if (auto *arg = dyn_cast<SILPHIArgument>(V)) {
       SmallVector<std::pair<SILBasicBlock *, SILValue>, 2> blockArgs;
-      arg->getIncomingValues(blockArgs);
+      arg->getIncomingPhiValues(blockArgs);
       for (auto &blockAndArg : blockArgs)
         worklistInsert(blockAndArg.second);
 

--- a/lib/SIL/SILArgument.cpp
+++ b/lib/SIL/SILArgument.cpp
@@ -64,14 +64,96 @@ SILModule &SILArgument::getModule() const {
 //                              SILBlockArgument
 //===----------------------------------------------------------------------===//
 
-static SILValue getIncomingValueForPred(const SILBasicBlock *BB,
-                                        const SILBasicBlock *Pred,
-                                        unsigned Index) {
+// FIXME: SILPHIArgument should only refer to branch arguments. They usually
+// need to be distinguished from projections and casts. Actual phi block
+// arguments are substitutable with their incoming values. It is also needlessly
+// expensive to call this helper instead of simply specifying phis with an
+// opcode. It results in repeated CFG traversals and repeated, unnecessary
+// switching over terminator opcodes.
+bool SILPHIArgument::isPhiArgument() {
+  // No predecessors indicates an unreachable block.
+  if (getParent()->pred_empty())
+    return false;
+
+  // Multiple predecessors require phis.
+  auto *predBB = getParent()->getSinglePredecessorBlock();
+  if (!predBB)
+    return true;
+
+  auto *TI = predBB->getTerminator();
+  return isa<BranchInst>(TI) || isa<CondBranchInst>(TI);
+}
+
+static SILValue getIncomingPhiValueForPred(const SILBasicBlock *BB,
+                                           const SILBasicBlock *Pred,
+                                           unsigned Index) {
+  const TermInst *TI = Pred->getTerminator();
+  if (auto *BI = dyn_cast<BranchInst>(TI))
+    return BI->getArg(Index);
+
+  // FIXME: Disallowing critical edges in SIL would enormously simplify phi and
+  // branch handling and reduce expensive analysis invalidation. If that is
+  // done, then only BranchInst will participate in phi operands, eliminating
+  // the need to search for the appropriate CondBranchInst operand.
+  return cast<CondBranchInst>(TI)->getArgForDestBB(BB, Index);
+}
+
+SILValue SILPHIArgument::getIncomingPhiValue(SILBasicBlock *predBB) {
+  if (!isPhiArgument())
+    return SILValue();
+
+  SILBasicBlock *Parent = getParent();
+  assert(!Parent->pred_empty());
+
+  unsigned Index = getIndex();
+
+  assert(Parent->pred_end()
+         != std::find(Parent->pred_begin(), Parent->pred_end(), predBB));
+
+  return getIncomingPhiValueForPred(Parent, predBB, Index);
+}
+
+bool SILPHIArgument::getIncomingPhiValues(
+    llvm::SmallVectorImpl<SILValue> &ReturnedPhiValues) {
+  if (!isPhiArgument())
+    return false;
+
+  SILBasicBlock *Parent = getParent();
+  assert(!Parent->pred_empty());
+
+  unsigned Index = getIndex();
+  for (SILBasicBlock *Pred : getParent()->getPredecessorBlocks()) {
+    SILValue Value = getIncomingPhiValueForPred(Parent, Pred, Index);
+    assert(Value);
+    ReturnedPhiValues.push_back(Value);
+  }
+  return true;
+}
+
+bool SILPHIArgument::getIncomingPhiValues(
+    llvm::SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>>
+        &ReturnedPredBBAndPhiValuePairs) {
+  if (!isPhiArgument())
+    return false;
+
+  SILBasicBlock *Parent = getParent();
+  assert(!Parent->pred_empty());
+
+  unsigned Index = getIndex();
+  for (SILBasicBlock *Pred : getParent()->getPredecessorBlocks()) {
+    SILValue Value = getIncomingPhiValueForPred(Parent, Pred, Index);
+    assert(Value);
+    ReturnedPredBBAndPhiValuePairs.push_back({Pred, Value});
+  }
+  return true;
+}
+
+static SILValue getSingleTerminatorOperandForPred(const SILBasicBlock *BB,
+                                                  const SILBasicBlock *Pred,
+                                                  unsigned Index) {
   const TermInst *TI = Pred->getTerminator();
 
   switch (TI->getTermKind()) {
-  // TODO: This list is conservative. I think we can probably handle more of
-  // these.
   case TermKind::UnreachableInst:
   case TermKind::ReturnInst:
   case TermKind::ThrowInst:
@@ -98,15 +180,7 @@ static SILValue getIncomingValueForPred(const SILBasicBlock *BB,
   llvm_unreachable("Unhandled TermKind?!");
 }
 
-SILValue SILPHIArgument::getSingleIncomingValue() const {
-  const SILBasicBlock *Parent = getParent();
-  const SILBasicBlock *PredBB = Parent->getSinglePredecessorBlock();
-  if (!PredBB)
-    return SILValue();
-  return getIncomingValueForPred(Parent, PredBB, getIndex());
-}
-
-bool SILPHIArgument::getIncomingValues(
+bool SILPHIArgument::getSingleTerminatorOperands(
     llvm::SmallVectorImpl<SILValue> &OutArray) {
   SILBasicBlock *Parent = getParent();
 
@@ -115,7 +189,7 @@ bool SILPHIArgument::getIncomingValues(
 
   unsigned Index = getIndex();
   for (SILBasicBlock *Pred : getParent()->getPredecessorBlocks()) {
-    SILValue Value = getIncomingValueForPred(Parent, Pred, Index);
+    SILValue Value = getSingleTerminatorOperandForPred(Parent, Pred, Index);
     if (!Value)
       return false;
     OutArray.push_back(Value);
@@ -124,7 +198,7 @@ bool SILPHIArgument::getIncomingValues(
   return true;
 }
 
-bool SILPHIArgument::getIncomingValues(
+bool SILPHIArgument::getSingleTerminatorOperands(
     llvm::SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>> &OutArray) {
   SILBasicBlock *Parent = getParent();
 
@@ -133,7 +207,7 @@ bool SILPHIArgument::getIncomingValues(
 
   unsigned Index = getIndex();
   for (SILBasicBlock *Pred : getParent()->getPredecessorBlocks()) {
-    SILValue Value = getIncomingValueForPred(Parent, Pred, Index);
+    SILValue Value = getSingleTerminatorOperandForPred(Parent, Pred, Index);
     if (!Value)
       return false;
     OutArray.push_back({Pred, Value});
@@ -142,50 +216,12 @@ bool SILPHIArgument::getIncomingValues(
   return true;
 }
 
-SILValue SILPHIArgument::getIncomingValue(unsigned BBIndex) {
-  SILBasicBlock *Parent = getParent();
-
-  if (Parent->pred_empty())
+SILValue SILPHIArgument::getSingleTerminatorOperand() const {
+  const SILBasicBlock *Parent = getParent();
+  const SILBasicBlock *PredBB = Parent->getSinglePredecessorBlock();
+  if (!PredBB)
     return SILValue();
-
-  unsigned Index = getIndex();
-
-  // We could do an early check if the size of the pred list is <= BBIndex, but
-  // that would involve walking the linked list anyways, so we just iterate once
-  // over the loop.
-
-  // We use this funky loop since predecessors are stored in a linked list but
-  // we want array like semantics.
-  unsigned BBCount = 0;
-  for (SILBasicBlock *Pred : Parent->getPredecessorBlocks()) {
-    // If BBCount is not BBIndex, continue.
-    if (BBCount < BBIndex) {
-      BBCount++;
-      continue;
-    }
-
-    // This will return an empty SILValue if we found something we do not
-    // understand.
-    return getIncomingValueForPred(Parent, Pred, Index);
-  }
-
-  return SILValue();
-}
-
-SILValue SILPHIArgument::getIncomingValue(SILBasicBlock *BB) {
-  SILBasicBlock *Parent = getParent();
-
-  assert(!Parent->pred_empty() && "Passed in non-predecessor BB!");
-  unsigned Index = getIndex();
-
-  // We could do an early check if the size of the pred list is <= BBIndex, but
-  // that would involve walking the linked list anyways, so we just iterate once
-  // over the loop.
-
-  auto Target = std::find(Parent->pred_begin(), Parent->pred_end(), BB);
-  if (Target == Parent->pred_end())
-    return SILValue();
-  return getIncomingValueForPred(Parent, BB, Index);
+  return getSingleTerminatorOperandForPred(Parent, PredBB, getIndex());
 }
 
 const SILPHIArgument *BranchInst::getArgForOperand(const Operand *oper) const {

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -378,6 +378,7 @@ class SILVerifier : public SILVerifierBase<SILVerifier> {
   SILOpenedArchetypesTracker OpenedArchetypes;
   SmallVector<StringRef, 16> DebugVars;
   const SILInstruction *CurInstruction = nullptr;
+  const SILArgument *CurArgument = nullptr;
   DominanceInfo *Dominance = nullptr;
 
   // Used for dominance checking within a basic block.
@@ -404,12 +405,12 @@ public:
     if (CurInstruction) {
       llvm::dbgs() << "Verifying instruction:\n";
       CurInstruction->printInContext(llvm::dbgs());
-      llvm::dbgs() << "In function:\n";
-      F.print(llvm::dbgs());
-    } else {
-      llvm::dbgs() << "In function:\n";
-      F.print(llvm::dbgs());
+    } else if (CurArgument) {
+      llvm::dbgs() << "Verifying argument:\n";
+      CurArgument->printInContext(llvm::dbgs());
     }
+    llvm::dbgs() << "In function:\n";
+    F.print(llvm::dbgs());
 
     // We abort by default because we want to always crash in
     // the debugger.
@@ -637,26 +638,46 @@ public:
     return M.getStage() == SILStage::Raw;
   }
 
-  void visitSILArgument(SILArgument *arg) {
-    checkLegalType(arg->getFunction(), arg, nullptr);
-    checkValueBaseOwnership(arg);
-
-    if (isa<SILPHIArgument>(arg) && prohibitAddressBlockArgs()) {
-      // As a structural SIL property, we disallow address-type block
+  void visitSILPHIArgument(SILPHIArgument *arg) {
+    // Verify that the `isPhiArgument` property is sound:
+    // - Phi arguments come from branches.
+    // - Non-phi arguments have a single predecessor.
+    if (arg->isPhiArgument()) {
+      for (SILBasicBlock *predBB : arg->getParent()->getPredecessorBlocks()) {
+        auto *TI = predBB->getTerminator();
+        // FIXME: when critical edges are removed, only allow BranchInst.
+        require(isa <BranchInst>(TI) || isa<CondBranchInst>(TI),
+                "All phi argument inputs must be from branches.");
+      }
+    } else {
+    }
+    if (arg->isPhiArgument() && prohibitAddressBlockArgs()) {
+      // As a property of well-formed SIL, we disallow address-type block
       // arguments. Supporting them would prevent reliably reasoning about the
       // underlying storage of memory access. This reasoning is important for
       // diagnosing violations of memory access rules and supporting future
       // optimizations such as bitfield packing. Address-type block arguments
       // also create unnecessary complexity for SIL optimization passes that
       // need to reason about memory aliasing.
-      //
-      // Note: We could allow non-phi block arguments to be addresses, because
-      // the address source would still be uniquely recoverable. But then
-      // we would need to separately ensure that something like begin_access is
-      // never passed as a block argument before being used by end_access. For
-      // now, it simpler to have a strict prohibition.
       require(!arg->getType().isAddress(),
               "Block arguments cannot be addresses");
+    }
+  }
+
+  void visitSILArgument(SILArgument *arg) {
+    CurArgument = arg;
+    checkLegalType(arg->getFunction(), arg, nullptr);
+    checkValueBaseOwnership(arg);
+    if (auto *phiArg = dyn_cast<SILPHIArgument>(arg)) {
+      if (phiArg->isPhiArgument())
+        visitSILPHIArgument(phiArg);
+      else {
+        // A non-phi BlockArgument must have a single predecessor unless it is
+        // unreachable.
+        require(arg->getParent()->pred_empty()
+                    || arg->getParent()->getSinglePredecessorBlock(),
+                "Non-branch terminator must have a unique successor.");
+      }
     }
   }
 
@@ -4574,7 +4595,7 @@ public:
     }
   }
 
-  void verifyBranches(SILFunction *F) {
+  void verifyBranches(const SILFunction *F) {
     // Verify that there is no non_condbr critical edge.
     auto isCriticalEdgePred = [](const TermInst *T, unsigned EdgeIdx) {
       assert(T->getSuccessors().size() > EdgeIdx && "Not enough successors");
@@ -4595,7 +4616,7 @@ public:
     };
 
     for (auto &BB : *F) {
-      TermInst *TI = BB.getTerminator();
+      const TermInst *TI = BB.getTerminator();
       CurInstruction = TI;
 
       // Check for non-cond_br critical edges.
@@ -4742,6 +4763,7 @@ public:
   }
 
   void visitBasicBlockArguments(SILBasicBlock *BB) {
+    CurInstruction = nullptr;
     for (auto argI = BB->args_begin(), argEnd = BB->args_end(); argI != argEnd;
          ++argI)
       visitSILArgument(*argI);
@@ -4836,6 +4858,10 @@ void SILFunction::verify(bool SingleFunction) const {
   // ensures that the pretty stack trace in the verifier is included with the
   // back trace when the verifier crashes.
   SILVerifier(*this, SingleFunction).verify();
+}
+
+void SILFunction::verifyCriticalEdges() const {
+  SILVerifier(*this, /*SingleFunction=*/true).verifyBranches(this);
 }
 
 /// Verify that a property descriptor follows invariants.

--- a/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
@@ -670,10 +670,9 @@ findMatchingRetains(SILBasicBlock *BB) {
         if (HandledBBs.find(X) != HandledBBs.end())
           continue;
         // Try to use the predecessor edge-value.
-        if (SA && SA->getIncomingValue(X)) {
-          WorkList.push_back(std::make_pair(X, SA->getIncomingValue(X)));
-        }
-        else 
+        if (SA && SA->getIncomingPhiValue(X)) {
+          WorkList.push_back(std::make_pair(X, SA->getIncomingPhiValue(X)));
+        } else
           WorkList.push_back(std::make_pair(X, R.second));
    
         HandledBBs.insert(X);

--- a/lib/SILOptimizer/Analysis/ColdBlockInfo.cpp
+++ b/lib/SILOptimizer/Analysis/ColdBlockInfo.cpp
@@ -44,7 +44,7 @@ ColdBlockInfo::BranchHint ColdBlockInfo::getBranchHint(SILValue Cond,
 
   if (auto *Arg = dyn_cast<SILArgument>(Cond)) {
     llvm::SmallVector<std::pair<SILBasicBlock *, SILValue>, 4> InValues;
-    if (!Arg->getIncomingValues(InValues))
+    if (!Arg->getIncomingPhiValues(InValues))
       return BranchHint::None;
 
     if (recursionDepth > RecursionDepthLimit)

--- a/lib/SILOptimizer/Analysis/EpilogueARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EpilogueARCAnalysis.cpp
@@ -47,7 +47,7 @@ void EpilogueARCContext::initializeDataflow() {
       // Find predecessor and break the SILArgument to predecessors.
       for (auto *X : A->getParent()->getPredecessorBlocks()) {
         // Try to find the predecessor edge-value.
-        SILValue IA = A->getIncomingValue(X);
+        SILValue IA = A->getIncomingPhiValue(X);
         getState(X).LocalArg = IA;
 
         // Maybe the edge value is another SILArgument.

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -1120,7 +1120,7 @@ void EscapeAnalysis::buildConnectionGraph(FunctionInfo *FInfo,
         continue;
 
       llvm::SmallVector<SILValue,4> Incoming;
-      if (!BBArg->getIncomingValues(Incoming)) {
+      if (!BBArg->getSingleTerminatorOperands(Incoming)) {
         // We don't know where the block argument comes from -> treat it
         // conservatively.
         ConGraph->setEscapesGlobal(ArgNode);

--- a/lib/SILOptimizer/Analysis/RCIdentityAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RCIdentityAnalysis.cpp
@@ -117,7 +117,7 @@ static SILValue stripRCIdentityPreservingInsts(SILValue V) {
   // different SILArgument that is actually being used for its phi node like
   // purposes.
   if (auto *A = dyn_cast<SILPHIArgument>(V))
-    if (SILValue Result = A->getSingleIncomingValue())
+    if (SILValue Result = A->getSingleTerminatorOperand())
       return Result;
 
   return SILValue();
@@ -315,7 +315,8 @@ SILValue RCIdentityFunctionInfo::stripRCIdentityPreservingArgs(SILValue V,
   // SILArgument's incoming values. If we don't have an incoming value for each
   // one of our predecessors, just return SILValue().
   llvm::SmallVector<std::pair<SILBasicBlock *, SILValue>, 8> IncomingValues;
-  if (!A->getIncomingValues(IncomingValues) || IncomingValues.empty()) {
+  if (!A->getSingleTerminatorOperands(IncomingValues)
+      || IncomingValues.empty()) {
     return SILValue();
   }
 

--- a/lib/SILOptimizer/Analysis/ValueTracking.cpp
+++ b/lib/SILOptimizer/Analysis/ValueTracking.cpp
@@ -67,7 +67,7 @@ static bool isLocalObject(SILValue Obj) {
       // A BB argument is local if all of its
       // incoming values are local.
       SmallVector<SILValue, 4> IncomingValues;
-      if (Arg->getIncomingValues(IncomingValues)) {
+      if (Arg->getSingleTerminatorOperands(IncomingValues)) {
         for (auto InValue : IncomingValues) {
           WorkList.push_back(InValue);
         }

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -2376,9 +2376,8 @@ class SwiftArrayOptPass : public SILFunctionTransform {
       for (auto &HoistableLoopNest : HoistableLoopNests)
         ArrayPropertiesSpecializer(DT, LA, HoistableLoopNest).run();
 
-      // We might have cloned there might be critical edges that need splitting.
-      splitAllCriticalEdges(*getFunction(), true /* only cond_br terminators*/,
-                            DT, nullptr);
+      // Verify that no illegal critical edges were created.
+      getFunction()->verifyCriticalEdges();
 
       LLVM_DEBUG(getFunction()->viewCFG());
 

--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -150,11 +150,11 @@ static Optional<uint64_t> getMaxLoopTripCount(SILLoop *Loop,
     return None;
 
   auto *Start = dyn_cast_or_null<IntegerLiteralInst>(
-      RecArg->getIncomingValue(Preheader));
+      RecArg->getIncomingPhiValue(Preheader));
   if (!Start)
     return None;
 
-  if (RecNext != RecArg->getIncomingValue(OrigLatch))
+  if (RecNext != RecArg->getIncomingPhiValue(OrigLatch))
     return None;
 
   auto StartVal = Start->getValue();

--- a/lib/SILOptimizer/Transforms/ARCCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/ARCCodeMotion.cpp
@@ -1161,7 +1161,7 @@ public:
     //
     // TODO: maybe we can do this lazily or maybe we should disallow SIL passes
     // to create critical edges.
-    bool EdgeChanged = splitAllCriticalEdges(*F, false, nullptr, nullptr);
+    bool EdgeChanged = splitAllCriticalEdges(*F, nullptr, nullptr);
     if (EdgeChanged)
       POA->invalidateFunction(F);
 

--- a/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
@@ -890,7 +890,7 @@ static bool hoistSILArgumentReleaseInst(SILBasicBlock *BB) {
 
   // Make sure we can get all the incoming values.
   llvm::SmallVector<SILValue, 4> PredValues;
-  if (!SA->getIncomingValues(PredValues))
+  if (!SA->getIncomingPhiValues(PredValues))
     return false;
 
   // Ok, we can get all the incoming values and create releases for them.

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -889,7 +889,7 @@ bool MemoryToRegisters::promoteSingleAllocation(AllocStackInst *alloc,
 bool MemoryToRegisters::run() {
   bool Changed = false;
 
-  Changed = splitAllCriticalEdges(F, true, DT, nullptr);
+  F.verifyCriticalEdges();
 
   // Compute dominator tree node levels for the function.
   DomTreeLevelMap DomTreeLevels;

--- a/lib/SILOptimizer/Utils/CheckedCastBrJumpThreading.cpp
+++ b/lib/SILOptimizer/Utils/CheckedCastBrJumpThreading.cpp
@@ -669,9 +669,7 @@ void CheckedCastBrJumpThreading::optimizeFunction() {
     return;
 
   // Second phase: transformation.
-  // Remove critical edges for the SSA-updater. We do this once and keep the
-  // CFG critical-edge free during our transformations.
-  splitAllCriticalEdges(*Fn, true, nullptr, nullptr);
+  Fn->verifyCriticalEdges();
 
   for (Edit *edit : Edits) {
     Optional<BasicBlockCloner> Cloner;
@@ -687,7 +685,7 @@ void CheckedCastBrJumpThreading::optimizeFunction() {
 
     if (Cloner.hasValue()) {
       updateSSAAfterCloning(*Cloner.getPointer(), Cloner->getDestBB(),
-                            edit->CCBBlock, false);
+                            edit->CCBBlock);
 
       if (!Cloner->getDestBB()->pred_empty())
         BlocksForWorklist.push_back(Cloner->getDestBB());

--- a/lib/SILOptimizer/Utils/CheckedCastBrJumpThreading.cpp
+++ b/lib/SILOptimizer/Utils/CheckedCastBrJumpThreading.cpp
@@ -193,7 +193,8 @@ SILValue CheckedCastBrJumpThreading::isArgValueEquivalentToCondition(
       return SILValue();
 
     SmallVector<SILValue, 4> IncomingValues;
-    if (!V->getIncomingValues(IncomingValues) || IncomingValues.empty())
+    if (!V->getSingleTerminatorOperands(IncomingValues)
+        || IncomingValues.empty())
       return SILValue();
 
     ValueBase *Def = nullptr;
@@ -387,8 +388,9 @@ areEquivalentConditionsAlongSomePaths(CheckedCastBranchInst *DomCCBI,
   // Incoming values for the BBArg.
   SmallVector<SILValue, 4> IncomingValues;
 
-  if (ArgBB->getIterator() != ArgBB->getParent()->begin() &&
-      (!Arg->getIncomingValues(IncomingValues) || IncomingValues.empty()))
+  if (ArgBB->getIterator() != ArgBB->getParent()->begin()
+      && (!Arg->getSingleTerminatorOperands(IncomingValues)
+          || IncomingValues.empty()))
     return false;
 
   // Check for each predecessor, if the incoming value coming from it

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -249,7 +249,7 @@ SILValue swift::getInstanceWithExactDynamicType(SILValue S, SILModule &M,
     // Traverse the chain of predecessors.
     if (isa<BranchInst>(SinglePred->getTerminator()) ||
         isa<CondBranchInst>(SinglePred->getTerminator())) {
-      S = cast<SILPHIArgument>(Arg)->getIncomingValue(SinglePred);
+      S = cast<SILPHIArgument>(Arg)->getIncomingPhiValue(SinglePred);
       continue;
     }
 
@@ -374,8 +374,7 @@ SILType swift::getExactDynamicType(SILValue S, SILModule &M,
     // It is a BB argument, look through incoming values. If they all have the
     // same exact type, then we consider it to be the type of the BB argument.
     SmallVector<SILValue, 4> IncomingValues;
-
-    if (Arg->getIncomingValues(IncomingValues)) {
+    if (Arg->getSingleTerminatorOperands(IncomingValues)) {
       for (auto InValue : IncomingValues) {
         WorkList.push_back(InValue);
       }

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1292,6 +1292,24 @@ void ValueLifetimeAnalysis::dump() const {
   llvm::errs() << '\n';
 }
 
+bool EdgeThreadingCloner::splitCriticalEdges(DominanceInfo *DT,
+                                             SILLoopInfo *LI) {
+  bool changed = false;
+  // Remove any critical edges that the EdgeThreadingCloner may have
+  // accidentally created.
+  for (unsigned succIdx = 0, succEnd = FromBB->getSuccessors().size();
+       succIdx != succEnd; ++succIdx) {
+    if (nullptr != splitCriticalEdge(FromBB->getTerminator(), succIdx, DT, LI))
+      changed |= true;
+  }
+  for (unsigned succIdx = 0, succEnd = DestBB->getSuccessors().size();
+       succIdx != succEnd; ++succIdx) {
+    auto *newBB = splitCriticalEdge(DestBB->getTerminator(), succIdx, DT, LI);
+    changed |= (newBB != nullptr);
+  }
+  return changed;
+}
+
 bool swift::simplifyUsers(SingleValueInstruction *I) {
   bool Changed = false;
 

--- a/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
+++ b/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
@@ -524,7 +524,7 @@ replaceBBArgWithStruct(SILPHIArgument *Arg,
 /// If Arg is replaced, return the cast instruction. Otherwise return nullptr.
 SILValue swift::replaceBBArgWithCast(SILPHIArgument *Arg) {
   SmallVector<SILValue, 4> ArgValues;
-  Arg->getIncomingValues(ArgValues);
+  Arg->getIncomingPhiValues(ArgValues);
   if (isa<StructInst>(ArgValues[0]))
     return replaceBBArgWithStruct(Arg, ArgValues);
   return nullptr;

--- a/test/SILOptimizer/definite_init_failable_initializers.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers.swift
@@ -474,11 +474,13 @@ struct ThrowStruct {
 // CHECK-NEXT:    br bb5([[ERROR]] : $Error)
 // CHECK:       bb5([[ERROR:%.*]] : $Error):
 // CHECK-NEXT:    [[COND:%.*]] = load [[BITMAP_BOX]]
-// CHECK-NEXT:    cond_br [[COND]], bb6, bb7
+// CHECK-NEXT:    cond_br [[COND]], bb7, bb6
 // CHECK:       bb6:
-// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
-// CHECK-NEXT:    br bb7
+// CHECK-NEXT:    br bb8
 // CHECK:       bb7:
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
+// CHECK-NEXT:    br bb8
+// CHECK:       bb8:
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[BITMAP_BOX]]
 // CHECK-NEXT:    throw [[ERROR]]
@@ -515,11 +517,13 @@ struct ThrowStruct {
 // CHECK-NEXT:    br bb5([[ERROR]] : $Error)
 // CHECK:       bb5([[ERROR:%.*]] : $Error):
 // CHECK-NEXT:    [[COND:%.*]] = load [[BITMAP_BOX]]
-// CHECK-NEXT:    cond_br [[COND]], bb6, bb7
+// CHECK-NEXT:    cond_br [[COND]], bb7, bb6
 // CHECK:       bb6:
-// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
-// CHECK-NEXT:    br bb7
+// CHECK-NEXT:    br bb8
 // CHECK:       bb7:
+// CHECK-NEXT:    destroy_addr [[SELF_BOX]]
+// CHECK-NEXT:    br bb8
+// CHECK:       bb8:
 // CHECK-NEXT:    dealloc_stack [[SELF_BOX]]
 // CHECK-NEXT:    dealloc_stack [[BITMAP_BOX]]
 // CHECK-NEXT:    throw [[ERROR]]

--- a/test/SILOptimizer/definite_init_value_types.swift
+++ b/test/SILOptimizer/definite_init_value_types.swift
@@ -33,8 +33,10 @@ enum ValueEnum {
   // CHECK-NEXT:   [[INIT_STATE:%.*]] = integer_literal $Builtin.Int1, 0
   // CHECK-NEXT:   store [[INIT_STATE]] to [[STATE]]
   // CHECK:        [[BOOL:%.*]] = struct_extract %0 : $Bool, #Bool._value
-  // CHECK-NEXT:   cond_br [[BOOL]], bb1, bb2
+  // CHECK-NEXT:   cond_br [[BOOL]], bb2, bb1
   // CHECK:      bb1:
+  // CHECK-NEXT:   br bb3
+  // CHECK:      bb2:
   // CHECK-NEXT:   [[METATYPE:%.*]] = metatype $@thin ValueEnum.Type
   // CHECK-NEXT:   [[NEW_SELF:%.*]] = enum $ValueEnum, #ValueEnum.b!enumelt
   // CHECK-NEXT:   [[SELF_ACCESS:%.*]] = begin_access [modify] [static] [[SELF_BOX]]
@@ -42,17 +44,19 @@ enum ValueEnum {
   // CHECK-NEXT:   store [[NEW_STATE]] to [[STATE]]
   // CHECK-NEXT:   store [[NEW_SELF]] to [[SELF_ACCESS]]
   // CHECK-NEXT:   end_access [[SELF_ACCESS]]
-  // CHECK-NEXT:   br bb2
-  // CHECK:      bb2:
+  // CHECK-NEXT:   br bb3
+  // CHECK:      bb3:
   // CHECK-NEXT:   [[METATYPE:%.*]] = metatype $@thin ValueEnum.Type
   // CHECK-NEXT:   [[NEW_SELF:%.*]] = enum $ValueEnum, #ValueEnum.c!enumelt
   // CHECK-NEXT:   [[SELF_ACCESS:%.*]] = begin_access [modify] [static] [[SELF_BOX]]
   // CHECK-NEXT:   [[STATE_VALUE:%.*]] = load [[STATE]]
-  // CHECK-NEXT:   cond_br [[STATE_VALUE]], bb3, bb4
-  // CHECK:      bb3:
-  // CHECK-NEXT:   destroy_addr [[SELF_BOX]]
-  // CHECK-NEXT:   br bb4
+  // CHECK-NEXT:   cond_br [[STATE_VALUE]], bb5, bb4
   // CHECK:      bb4:
+  // CHECK-NEXT:   br bb6
+  // CHECK:      bb5:
+  // CHECK-NEXT:   destroy_addr [[SELF_BOX]]
+  // CHECK-NEXT:   br bb6
+  // CHECK:      bb6:
   // CHECK-NEXT:   [[NEW_STATE:%.*]] = integer_literal $Builtin.Int1, -1
   // CHECK-NEXT:   store [[NEW_STATE]] to [[STATE]]
   // CHECK-NEXT:   store [[NEW_SELF]] to [[SELF_ACCESS]]

--- a/test/SILOptimizer/diagnose_unreachable.sil
+++ b/test/SILOptimizer/diagnose_unreachable.sil
@@ -288,11 +288,14 @@ bb0(%6 : $Int, %10 : $UnicodeScalar):
   switch_enum %12 : $Singleton, case #Singleton.x!enumelt.1: bb1
 
 bb1(%15 : $(Int, UnicodeScalar)):
-  return %15 : $(Int, UnicodeScalar)
+  br bb2(%15 : $(Int, UnicodeScalar))
 
-b2:
+bb2(%16 : $(Int, UnicodeScalar)):
+  return %16 : $(Int, UnicodeScalar)
+
+b3:
   %111 = tuple (%6 : $Int, %10 : $UnicodeScalar)
-  br bb1(%111 : $(Int, UnicodeScalar))
+  br bb2(%111 : $(Int, UnicodeScalar))
 
 // CHECK-LABEL: sil @constant_fold_switch_enum_with_payload
 // CHECK: bb0(%{{[0-9]+}} : $Int, %{{[0-9]+}} : $Unicode.Scalar):

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -1381,7 +1381,7 @@ bb3:
 }
 
 // CHECK-LABEL: sil @jumpthread_switch_enum3
-// CHECK: switch_enum %0 : $Optional<Int32>, case #Optional.none!enumelt: bb1, case #Optional.some!enumelt.1: bb3
+// CHECK: switch_enum %0 : $Optional<Int32>, case #Optional.none!enumelt: bb1, case #Optional.some!enumelt.1: bb2
 // CHECK: bb1:
 // CHECK-NEXT: switch_enum
 // CHECK: bb2:


### PR DESCRIPTION
Simplify SILPHIArgument::getIncomingValue.

The client of this interface naturally expects to get back the
incoming phi value. Ignoring dominance and SIL ownership, the incoming
phi value and the block argument should be substitutable.

This method was actually returning the incoming operand for
checked_cast and switch_enum terminators, which is deeply misleading
and has been the source of bugs.

If the client wants to peek though casts, and enums, it should do so
explicitly. getSingleTerminatorOperand\[s]() will do just that.