### PR TITLE
AST: Allocate FunctionTypes containing type variables in the solver arena [4.2]

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3720,7 +3720,7 @@ FunctionType *FunctionType::get(Type input, Type result,
   AnyFunctionType::decomposeInput(input, params);
   void *mem = C.Allocate(sizeof(FunctionType) +
                            sizeof(AnyFunctionType::Param) * params.size(),
-                         alignof(FunctionType));
+                         alignof(FunctionType), arena);
   return Entry = new (mem) FunctionType(params, input, result,
                                         properties, info);
 }


### PR DESCRIPTION
- Description: We were allocating FunctionTypes in the permanent arena even if they contained type variables. This wastes memory since type variables have limited dynamic extent. All other types containing type variables were being allocated in the solver scope.

- Origination: Introduced in 4.2 by 0b5f44245320dfcc54e9a2632d9df7d2281fab35 as part of the new function type representation.

- Scope of the issue: Internal testing shows a significant reduction in type checker memory usage as a result of this change on the master branch.

- Risk: Very low. This shortens the lifetime of such FunctionTypes, but if someone was holding on to them longer than is allowed, they would find that the input and result types were just dangling pointers, because all other types are allocated in the correct arena already, so its unlikely that this change has any effect on useful behavior even if existing code was wrong.

- Tested: Existing tests pass.

- Reviewed by: @DougGregor 

- Radar: rdar://43817071