### PR TITLE
[test] Temporarily disable Reflection tests on non-macOS

### DIFF
--- a/validation-test/Reflection/existentials.swift
+++ b/validation-test/Reflection/existentials.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 /*
    This file pokes at the swift_reflection_projectExistential API
    of the SwiftRemoteMirror library.

--- a/validation-test/Reflection/functions.swift
+++ b/validation-test/Reflection/functions.swift
@@ -13,6 +13,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 /*
    This file pokes at the swift_reflection_infoForInstance() API
    of the SwiftRemoteMirror library.

--- a/validation-test/Reflection/functions_objc.swift
+++ b/validation-test/Reflection/functions_objc.swift
@@ -11,6 +11,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import SwiftReflectionTest
 import Foundation
 import CoreGraphics

--- a/validation-test/Reflection/inherits_NSObject.swift
+++ b/validation-test/Reflection/inherits_NSObject.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import Foundation
 import simd
 

--- a/validation-test/Reflection/inherits_ObjCClasses.swift
+++ b/validation-test/Reflection/inherits_ObjCClasses.swift
@@ -13,6 +13,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import simd
 import ObjCClasses
 import SwiftReflectionTest

--- a/validation-test/Reflection/inherits_Swift.swift
+++ b/validation-test/Reflection/inherits_Swift.swift
@@ -11,6 +11,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import SwiftReflectionTest
 
 class BaseClass {

--- a/validation-test/Reflection/reflect_Array.swift
+++ b/validation-test/Reflection/reflect_Array.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import SwiftReflectionTest
 
 class TestClass {

--- a/validation-test/Reflection/reflect_Bool.swift
+++ b/validation-test/Reflection/reflect_Bool.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import SwiftReflectionTest
 
 class TestClass {

--- a/validation-test/Reflection/reflect_Character.swift
+++ b/validation-test/Reflection/reflect_Character.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import SwiftReflectionTest
 
 class TestClass {

--- a/validation-test/Reflection/reflect_Dictionary.swift
+++ b/validation-test/Reflection/reflect_Dictionary.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import SwiftReflectionTest
 
 class TestClass {

--- a/validation-test/Reflection/reflect_Double.swift
+++ b/validation-test/Reflection/reflect_Double.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import SwiftReflectionTest
 
 class TestClass {

--- a/validation-test/Reflection/reflect_Float.swift
+++ b/validation-test/Reflection/reflect_Float.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import SwiftReflectionTest
 
 class TestClass {

--- a/validation-test/Reflection/reflect_Int.swift
+++ b/validation-test/Reflection/reflect_Int.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import SwiftReflectionTest
 
 class TestClass {

--- a/validation-test/Reflection/reflect_Int16.swift
+++ b/validation-test/Reflection/reflect_Int16.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import SwiftReflectionTest
 
 class TestClass {

--- a/validation-test/Reflection/reflect_Int32.swift
+++ b/validation-test/Reflection/reflect_Int32.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import SwiftReflectionTest
 
 class TestClass {

--- a/validation-test/Reflection/reflect_Int64.swift
+++ b/validation-test/Reflection/reflect_Int64.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import SwiftReflectionTest
 
 class TestClass {

--- a/validation-test/Reflection/reflect_Int8.swift
+++ b/validation-test/Reflection/reflect_Int8.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import SwiftReflectionTest
 
 class TestClass {

--- a/validation-test/Reflection/reflect_NSArray.swift
+++ b/validation-test/Reflection/reflect_NSArray.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import SwiftReflectionTest
 import Foundation
 

--- a/validation-test/Reflection/reflect_NSNumber.swift
+++ b/validation-test/Reflection/reflect_NSNumber.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import SwiftReflectionTest
 import Foundation
 

--- a/validation-test/Reflection/reflect_NSSet.swift
+++ b/validation-test/Reflection/reflect_NSSet.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import SwiftReflectionTest
 import Foundation
 

--- a/validation-test/Reflection/reflect_NSString.swift
+++ b/validation-test/Reflection/reflect_NSString.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import SwiftReflectionTest
 import Foundation
 

--- a/validation-test/Reflection/reflect_Set.swift
+++ b/validation-test/Reflection/reflect_Set.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import SwiftReflectionTest
 
 class TestClass {

--- a/validation-test/Reflection/reflect_String.swift
+++ b/validation-test/Reflection/reflect_String.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import SwiftReflectionTest
 
 class TestClass {

--- a/validation-test/Reflection/reflect_UInt.swift
+++ b/validation-test/Reflection/reflect_UInt.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import SwiftReflectionTest
 
 class TestClass {

--- a/validation-test/Reflection/reflect_UInt16.swift
+++ b/validation-test/Reflection/reflect_UInt16.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import SwiftReflectionTest
 
 class TestClass {

--- a/validation-test/Reflection/reflect_UInt32.swift
+++ b/validation-test/Reflection/reflect_UInt32.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import SwiftReflectionTest
 
 class TestClass {

--- a/validation-test/Reflection/reflect_UInt64.swift
+++ b/validation-test/Reflection/reflect_UInt64.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import SwiftReflectionTest
 
 class TestClass {

--- a/validation-test/Reflection/reflect_UInt8.swift
+++ b/validation-test/Reflection/reflect_UInt8.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import SwiftReflectionTest
 
 class TestClass {

--- a/validation-test/Reflection/reflect_empty_class.swift
+++ b/validation-test/Reflection/reflect_empty_class.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import SwiftReflectionTest
 
 class EmptyClass { }

--- a/validation-test/Reflection/reflect_existential.swift
+++ b/validation-test/Reflection/reflect_existential.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import SwiftReflectionTest
 
 class TestGeneric<T> {

--- a/validation-test/Reflection/reflect_multiple_types.swift
+++ b/validation-test/Reflection/reflect_multiple_types.swift
@@ -10,6 +10,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
 
+// FIXME: Handle different forms of %target-run more robustly
+// REQUIRES: OS=macosx
+
 import SwiftReflectionTest
 import Foundation
 


### PR DESCRIPTION
Fix-up for #18966. The change made there was in support of utils/remote-run, which won't run things that are outside of `%t`, but it broke an internal testing tool at Apple, which doesn't follow symlinks. ~Use a hard link instead, which everything supports.~ Disable the tests on non-macOS for now while I think about this more.