### PR TITLE
Introduce overrides of protocol members and drop them from witness tables

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -1572,6 +1572,13 @@ function(add_swift_library name)
   endif()
 
   if(SWIFTLIB_TARGET_LIBRARY)
+    # In the standard library and overlays, warn about implicit overrides
+    # as a reminder to consider when inherited protocols need different
+    # behavior for their requirements.
+    if (SWIFTLIB_IS_STDLIB)
+      list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS "-warn-implicit-overrides")
+    endif()
+
     if(NOT SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER AND NOT BUILD_STANDALONE)
       list(APPEND SWIFTLIB_DEPENDS clang)
     endif()

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -377,7 +377,7 @@ SIMPLE_DECL_ATTR(_hasInitialValue, HasInitialValue,
   78)
 SIMPLE_DECL_ATTR(_nonoverride, NonOverride,
   OnFunc | OnAccessor | OnVar | OnSubscript | OnConstructor | OnAssociatedType |
-  NotSerialized,
+  UserInaccessible | NotSerialized,
   79)
 
 #undef TYPE_ATTR

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -240,7 +240,7 @@ CONTEXTUAL_SIMPLE_DECL_ATTR(convenience, Convenience,
   DeclModifier |
   NotSerialized, 43)
 CONTEXTUAL_SIMPLE_DECL_ATTR(override, Override,
-  OnFunc | OnAccessor | OnVar | OnSubscript | OnConstructor |
+  OnFunc | OnAccessor | OnVar | OnSubscript | OnConstructor | OnAssociatedType |
   DeclModifier |
   NotSerialized, 44)
 SIMPLE_DECL_ATTR(sil_stored, SILStored,

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -375,6 +375,10 @@ SIMPLE_DECL_ATTR(_hasInitialValue, HasInitialValue,
   OnVar |
   UserInaccessible,
   78)
+SIMPLE_DECL_ATTR(_nonoverride, NonOverride,
+  OnFunc | OnAccessor | OnVar | OnSubscript | OnConstructor | OnAssociatedType |
+  NotSerialized,
+  79)
 
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6579,7 +6579,8 @@ inline bool Decl::isPotentiallyOverridable() const {
       isa<SubscriptDecl>(this) ||
       isa<FuncDecl>(this) ||
       isa<DestructorDecl>(this)) {
-    return getDeclContext()->getSelfClassDecl();
+    return getDeclContext()->getSelfClassDecl() ||
+           isa<ProtocolDecl>(getDeclContext());
   } else {
     return false;
   }

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2094,6 +2094,10 @@ NOTE(override_type_mismatch_with_fixits_init,none,
      (unsigned, Type))
 ERROR(override_nonclass_decl,none,
       "'override' can only be specified on class members", ())
+ERROR(nonoverride_wrong_decl_context,none,
+      "'@_nonoverride' can only be specified on class or protocol members", ())
+ERROR(nonoverride_and_override_attr,none,
+      "'override' cannot be combined with '@_nonoverride'", ())
 ERROR(override_property_type_mismatch,none,
       "property %0 with type %1 cannot override a property with type %2",
       (Identifier, Type, Type))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2031,6 +2031,9 @@ NOTE(overridden_here_can_be_objc,none,
 
 ERROR(missing_override,none,
       "overriding declaration requires an 'override' keyword", ())
+WARNING(missing_override_warn,none,
+        "implicit override should be marked with 'override' or suppressed "
+        "with '@_nonoverride'", ())
 
 ERROR(multiple_override,none,
       "%0 has already been overridden", (DeclName))

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -248,6 +248,9 @@ namespace swift {
     Swift3ObjCInferenceWarnings WarnSwift3ObjCInference =
       Swift3ObjCInferenceWarnings::None;
 
+    /// Diagnose implicit 'override'.
+    bool WarnImplicitOverrides = false;
+
     /// Diagnose uses of NSCoding with classes that have unstable mangled names.
     bool EnableNSKeyedArchiverDiagnostics = true;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -359,6 +359,11 @@ def warn_swift3_objc_inference_minimal :
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Warn about deprecated @objc inference in Swift 3 based on direct uses of the Objective-C entrypoint">;
 
+def warn_implicit_overrides :
+  Flag<["-"], "warn-implicit-overrides">,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Warn about implicit overrides of protocol members">;
+
 def typo_correction_limit : Separate<["-"], "typo-correction-limit">,
   Flags<[FrontendOption, HelpHidden]>,
   MetaVarName<"<n>">,

--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -334,6 +334,10 @@ struct SILDeclRef {
   /// entry.
   bool requiresNewVTableEntry() const;
 
+  /// True if the decl ref references a method which introduces a new witness
+  /// table entry.
+  bool requiresNewWitnessTableEntry() const;
+
   /// Return a SILDeclRef to the declaration overridden by this one, or
   /// a null SILDeclRef if there is no override.
   SILDeclRef getOverridden() const;
@@ -347,6 +351,10 @@ struct SILDeclRef {
   /// If the method does not override anything or no override is vtable
   /// dispatched, will return the least derived method.
   SILDeclRef getOverriddenVTableEntry() const;
+
+  /// Return the original protocol requirement that introduced the witness table
+  /// entry overridden by this method.
+  SILDeclRef getOverriddenWitnessTableEntry() const;
 
   /// True if the referenced entity is some kind of thunk.
   bool isThunk() const;

--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -338,6 +338,9 @@ struct SILDeclRef {
   /// table entry.
   bool requiresNewWitnessTableEntry() const;
 
+  /// True if the decl is a method which introduces a new witness table entry.
+  static bool requiresNewWitnessTableEntry(AbstractFunctionDecl *func);
+
   /// Return a SILDeclRef to the declaration overridden by this one, or
   /// a null SILDeclRef if there is no override.
   SILDeclRef getOverridden() const;

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -754,9 +754,18 @@ namespace {
           << getAccessLevelSpelling(VD->getFormalAccess());
       }
 
-      if (auto Overridden = VD->getOverriddenDecl()) {
-        PrintWithColorRAII(OS, OverrideColor) << " override=";
-        Overridden->dumpRef(PrintWithColorRAII(OS, OverrideColor).getOS());
+      if (VD->overriddenDeclsComputed()) {
+        auto overridden = VD->getOverriddenDecls();
+        if (!overridden.empty()) {
+          PrintWithColorRAII(OS, OverrideColor) << " override=";
+          interleave(overridden,
+                     [&](ValueDecl *overridden) {
+                       overridden->dumpRef(
+                                PrintWithColorRAII(OS, OverrideColor).getOS());
+                     }, [&]() {
+                       OS << ", ";
+                     });
+        }
       }
 
       if (VD->isFinal())

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -865,9 +865,10 @@ public:
           D->getAttrs().hasAttribute<OverrideAttr>()) {
         if (!D->isInvalid() && D->hasInterfaceType() &&
             !isa<ClassDecl>(D->getDeclContext()) &&
+            !isa<ProtocolDecl>(D->getDeclContext()) &&
             !isa<ExtensionDecl>(D->getDeclContext())) {
           PrettyStackTraceDecl debugStack("verifying override", D);
-          Out << "'override' attribute outside of a class\n";
+          Out << "'override' attribute outside of a class or protocol\n";
           D->dump(Out);
           abort();
         }

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4381,9 +4381,11 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
 
       bool shouldWarnAboutRedeclaration =
         source->kind == RequirementSource::RequirementSignatureSelf &&
+        !assocTypeDecl->getAttrs().hasAttribute<NonOverrideAttr>() &&
         assocTypeDecl->getDefaultDefinitionLoc().isNull() &&
         (!assocTypeDecl->getInherited().empty() ||
-         assocTypeDecl->getTrailingWhereClause());
+         assocTypeDecl->getTrailingWhereClause() ||
+         getASTContext().LangOpts.WarnImplicitOverrides);
       for (auto inheritedType : knownInherited->second) {
         // If we have inherited associated type...
         if (auto inheritedAssocTypeDecl =

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4382,6 +4382,7 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
       bool shouldWarnAboutRedeclaration =
         source->kind == RequirementSource::RequirementSignatureSelf &&
         !assocTypeDecl->getAttrs().hasAttribute<NonOverrideAttr>() &&
+        !assocTypeDecl->getAttrs().hasAttribute<OverrideAttr>() &&
         assocTypeDecl->getDefaultDefinitionLoc().isNull() &&
         (!assocTypeDecl->getInherited().empty() ||
          assocTypeDecl->getTrailingWhereClause() ||

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -85,6 +85,15 @@ bool swift::removeOverriddenDecls(SmallVectorImpl<ValueDecl*> &decls) {
 
   llvm::SmallPtrSet<ValueDecl*, 8> overridden;
   for (auto decl : decls) {
+    // Don't look at the overrides of operators in protocols. The global
+    // lookup of operators means that we can find overriding operators that
+    // aren't relevant to the types in hand, and will fail to type check.
+    if (isa<ProtocolDecl>(decl->getDeclContext())) {
+      if (auto func = dyn_cast<FuncDecl>(decl))
+        if (func->isOperator())
+          continue;
+    }
+
     while (auto overrides = decl->getOverriddenDecl()) {
       overridden.insert(overrides);
 

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -541,6 +541,8 @@ SubstitutionMap::getOverrideSubstitutions(const ClassDecl *baseClass,
     if (derivedSubs)
       derivedClassTy = derivedClassTy.subst(*derivedSubs);
     auto baseClassTy = derivedClassTy->getSuperclassForDecl(baseClass);
+    if (baseClassTy->is<ErrorType>())
+      return SubstitutionMap();
 
     baseSubMap = baseClassTy->getContextSubstitutionMap(M, baseClass);
   }

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -505,9 +505,23 @@ SubstitutionMap::getProtocolSubstitutions(ProtocolDecl *protocol,
 }
 
 SubstitutionMap
-SubstitutionMap::getOverrideSubstitutions(const ValueDecl *baseDecl,
-                                          const ValueDecl *derivedDecl,
-                                          Optional<SubstitutionMap> derivedSubs) {
+SubstitutionMap::getOverrideSubstitutions(
+                                      const ValueDecl *baseDecl,
+                                      const ValueDecl *derivedDecl,
+                                      Optional<SubstitutionMap> derivedSubs) {
+  // For overrides within a protocol hierarchy, substitute the Self type.
+  if (auto baseProto = baseDecl->getDeclContext()->getSelfProtocolDecl()) {
+    if (auto derivedProtoSelf =
+          derivedDecl->getDeclContext()->getProtocolSelfType()) {
+      return SubstitutionMap::getProtocolSubstitutions(
+                                             baseProto,
+                                             derivedProtoSelf,
+                                             ProtocolConformanceRef(baseProto));
+    }
+
+    return SubstitutionMap();
+  }
+
   auto *baseClass = baseDecl->getDeclContext()->getSelfClassDecl();
   auto *derivedClass = derivedDecl->getDeclContext()->getSelfClassDecl();
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3349,7 +3349,8 @@ Type TypeBase::adjustSuperclassMemberDeclType(const ValueDecl *baseDecl,
 
   auto type = memberType.subst(subs, SubstFlags::UseErrorType);
 
-  if (isa<AbstractFunctionDecl>(baseDecl)) {
+  if (isa<AbstractFunctionDecl>(baseDecl) &&
+      !baseDecl->getDeclContext()->getSelfProtocolDecl()) {
     type = type->replaceSelfParameterType(this);
     if (auto func = dyn_cast<FuncDecl>(baseDecl)) {
       if (func->hasDynamicSelf()) {

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -182,6 +182,7 @@ static void addCommonFrontendArgs(const ToolChain &TC, const OutputInfo &OI,
   inputArgs.AddLastArg(arguments,
                        options::OPT_warn_swift3_objc_inference_minimal,
                        options::OPT_warn_swift3_objc_inference_complete);
+  inputArgs.AddLastArg(arguments, options::OPT_warn_implicit_overrides);
   inputArgs.AddLastArg(arguments, options::OPT_typo_correction_limit);
   inputArgs.AddLastArg(arguments, options::OPT_enable_app_extension);
   inputArgs.AddLastArg(arguments, options::OPT_enable_testing);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -321,6 +321,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     }
   }
 
+  Opts.WarnImplicitOverrides =
+    Args.hasArg(OPT_warn_implicit_overrides);
+
   Opts.EnableNSKeyedArchiverDiagnostics =
       Args.hasFlag(OPT_enable_nskeyedarchiver_diagnostics,
                    OPT_disable_nskeyedarchiver_diagnostics,

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -969,7 +969,13 @@ bool irgen::isDependentConformance(const NormalProtocolConformance *conformance)
     return true;
 
   // Check whether any of the inherited conformances are dependent.
-  for (auto inherited : conformance->getProtocol()->getInheritedProtocols()) {
+  auto proto = conformance->getProtocol();
+  for (const auto &req : proto->getRequirementSignature()) {
+    if (req.getKind() != RequirementKind::Conformance ||
+        !req.getFirstType()->isEqual(proto->getProtocolSelfType()))
+      continue;
+
+    auto inherited = req.getSecondType()->castTo<ProtocolType>()->getDecl();
     if (inherited->isObjC())
       continue;
 

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -721,7 +721,11 @@ bool SILDeclRef::requiresNewVTableEntry() const {
 }
 
 bool SILDeclRef::requiresNewWitnessTableEntry() const {
-  return cast<AbstractFunctionDecl>(getDecl())->getOverriddenDecls().empty();
+  return requiresNewWitnessTableEntry(cast<AbstractFunctionDecl>(getDecl()));
+}
+
+bool SILDeclRef::requiresNewWitnessTableEntry(AbstractFunctionDecl *func) {
+  return func->getOverriddenDecls().empty();
 }
 
 SILDeclRef SILDeclRef::getOverridden() const {

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -720,6 +720,10 @@ bool SILDeclRef::requiresNewVTableEntry() const {
   return false;
 }
 
+bool SILDeclRef::requiresNewWitnessTableEntry() const {
+  return cast<AbstractFunctionDecl>(getDecl())->getOverriddenDecls().empty();
+}
+
 SILDeclRef SILDeclRef::getOverridden() const {
   if (!hasDecl())
     return SILDeclRef();
@@ -763,6 +767,43 @@ SILDeclRef SILDeclRef::getNextOverriddenVTableEntry() const {
     return overridden;
   }
   return SILDeclRef();
+}
+
+SILDeclRef SILDeclRef::getOverriddenWitnessTableEntry() const {
+  ValueDecl *bestOverridden = nullptr;
+
+  SmallVector<ValueDecl *, 4> stack;
+  SmallPtrSet<ValueDecl *, 4> visited;
+  stack.push_back(getDecl());
+  visited.insert(getDecl());
+
+  while (!stack.empty()) {
+    auto current = stack.back();
+    stack.pop_back();
+
+    auto overriddenDecls = current->getOverriddenDecls();
+    if (overriddenDecls.empty()) {
+      // This entry introduced a witness table entry. Determine whether it is
+      // better than the best entry we've seen thus far.
+      if (!bestOverridden ||
+          ProtocolDecl::compare(
+                        cast<ProtocolDecl>(current->getDeclContext()),
+                        cast<ProtocolDecl>(bestOverridden->getDeclContext()))
+            < 0) {
+        bestOverridden = current;
+      }
+
+      continue;
+    }
+
+    // Add overridden declarations to the stack.
+    for (auto overridden : overriddenDecls) {
+      if (visited.insert(overridden).second)
+        stack.push_back(overridden);
+    }
+  }
+
+  return SILDeclRef(bestOverridden, kind, isCurried);
 }
 
 SILDeclRef SILDeclRef::getOverriddenVTableEntry() const {

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -2522,6 +2522,9 @@ public:
       require(AMI->getModule().lookUpWitnessTable(conformance, false),
               "Could not find witness table for conformance");
     }
+
+    require(AMI->getMember().requiresNewWitnessTableEntry(),
+            "method does not have a witness table entry");
   }
 
   // Get the expected type of a dynamic method reference.

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -332,11 +332,6 @@ protected:
   /// Gets the base implementation of a method.
   /// We always use the most overridden function to describe a method.
   AbstractFunctionDecl *getBase(AbstractFunctionDecl *FD) {
-    // FIXME: We currently don't use the most overridden function in
-    // witness tables.
-    if (isa<ProtocolDecl>(FD->getDeclContext()))
-      return FD;
-
     while (FD->getOverriddenDecl()) {
       FD = FD->getOverriddenDecl();
     }
@@ -352,8 +347,8 @@ protected:
     for (SILBasicBlock &BB : *F) {
       for (SILInstruction &I : BB) {
         if (auto *WMI = dyn_cast<WitnessMethodInst>(&I)) {
-          auto *funcDecl = cast<AbstractFunctionDecl>(WMI->getMember().getDecl());
-          assert(funcDecl == getBase(funcDecl));
+          auto *funcDecl = getBase(
+              cast<AbstractFunctionDecl>(WMI->getMember().getDecl()));
           MethodInfo *mi = getMethodInfo(funcDecl, /*isWitnessTable*/ true);
           ensureAliveProtocolMethod(mi);
         } else if (auto *MI = dyn_cast<MethodInst>(&I)) {

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -332,6 +332,11 @@ protected:
   /// Gets the base implementation of a method.
   /// We always use the most overridden function to describe a method.
   AbstractFunctionDecl *getBase(AbstractFunctionDecl *FD) {
+    // FIXME: We currently don't use the most overridden function in
+    // witness tables.
+    if (isa<ProtocolDecl>(FD->getDeclContext()))
+      return FD;
+
     while (FD->getOverriddenDecl()) {
       FD = FD->getOverriddenDecl();
     }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -569,6 +569,7 @@ visitLLDBDebuggerFunctionAttr(LLDBDebuggerFunctionAttr *attr) {
 
 void AttributeEarlyChecker::visitOverrideAttr(OverrideAttr *attr) {
   if (!isa<ClassDecl>(D->getDeclContext()) &&
+      !isa<ProtocolDecl>(D->getDeclContext()) &&
       !isa<ExtensionDecl>(D->getDeclContext()))
     diagnoseAndRemoveAttr(attr, diag::override_nonclass_decl);
 }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3265,7 +3265,8 @@ public:
           attr->setInvalid();
         } else if (attr->isImplicit()) {
           // Don't diagnose implicit attributes.
-        } else if (!overrideRequiresKeyword(CD->getOverriddenDecl())) {
+        } else if (overrideRequiresKeyword(CD->getOverriddenDecl())
+                     == OverrideRequiresKeyword::Never) {
           // Special case: we are overriding a 'required' initializer, so we
           // need (only) the 'required' keyword.
           if (cast<ConstructorDecl>(CD->getOverriddenDecl())->isRequired()) {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1528,7 +1528,8 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
   // it, complain.
   if (!override->getAttrs().hasAttribute<OverrideAttr>() &&
       overrideRequiresKeyword(base) != OverrideRequiresKeyword::Never &&
-      !override->isImplicit()) {
+      !override->isImplicit() &&
+      override->getDeclContext()->getParentSourceFile()) {
     // FIXME: rdar://16320042 - For properties, we don't have a useful
     // location for the 'var' token.  Instead of emitting a bogus fixit, only
     // emit the fixit for 'func's.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -2197,8 +2197,18 @@ bool isAcceptableDynamicMemberLookupSubscript(SubscriptDecl *decl,
 /// \endcode
 bool isPassThroughTypealias(TypeAliasDecl *typealias);
 
+/// Whether an overriding declaration requires the 'override' keyword.
+enum class OverrideRequiresKeyword {
+  /// The keyword is never required.
+  Never,
+  /// The keyword is always required.
+  Always,
+  /// The keyword can be implicit; it is not required.
+  Implicit,
+};
+
 /// Determine whether overriding the given declaration requires a keyword.
-bool overrideRequiresKeyword(ValueDecl *overridden);
+OverrideRequiresKeyword overrideRequiresKeyword(ValueDecl *overridden);
 
 /// Compute the type of a member that will be used for comparison when
 /// performing override checking.

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2842,8 +2842,7 @@ ModuleFile::getDeclCheckedImpl(DeclID DID) {
       ctor->setStubImplementation(true);
     if (initKind.hasValue())
       ctor->setInitKind(initKind.getValue());
-    if (auto overriddenCtor = cast_or_null<ConstructorDecl>(overridden.get()))
-      ctor->setOverriddenDecl(overriddenCtor);
+    ctor->setOverriddenDecl(cast_or_null<ConstructorDecl>(overridden.get()));
     ctor->setNeedsNewVTableEntry(needsNewVTableEntry);
 
     if (auto defaultArgumentResilienceExpansion = getActualResilienceExpansion(
@@ -2967,10 +2966,9 @@ ModuleFile::getDeclCheckedImpl(DeclID DID) {
       var->setImplicit();
     var->setIsObjC(isObjC);
 
-    if (auto overriddenVar = cast_or_null<VarDecl>(overridden.get())) {
-      var->setOverriddenDecl(overriddenVar);
+    var->setOverriddenDecl(cast_or_null<VarDecl>(overridden.get()));
+    if (var->getOverriddenDecl())
       AddAttribute(new (ctx) OverrideAttr(SourceLoc()));
-    }
 
     break;
   }
@@ -3229,10 +3227,9 @@ ModuleFile::getDeclCheckedImpl(DeclID DID) {
     if (auto errorConvention = maybeReadForeignErrorConvention())
       fn->setForeignErrorConvention(*errorConvention);
 
-    if (auto overriddenFunc = cast_or_null<FuncDecl>(overridden.get())) {
-      fn->setOverriddenDecl(overriddenFunc);
+    fn->setOverriddenDecl(cast_or_null<FuncDecl>(overridden.get()));
+    if (fn->getOverriddenDecl())
       AddAttribute(new (ctx) OverrideAttr(SourceLoc()));
-    }
 
     if (isImplicit)
       fn->setImplicit();
@@ -3812,10 +3809,9 @@ ModuleFile::getDeclCheckedImpl(DeclID DID) {
     if (isImplicit)
       subscript->setImplicit();
     subscript->setIsObjC(isObjC);
-    if (auto overriddenSub = cast_or_null<SubscriptDecl>(overridden.get())) {
-      subscript->setOverriddenDecl(overriddenSub);
+    subscript->setOverriddenDecl(cast_or_null<SubscriptDecl>(overridden.get()));
+    if (subscript->getOverriddenDecl())
       AddAttribute(new (ctx) OverrideAttr(SourceLoc()));
-    }
     break;
   }
 

--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -96,7 +96,7 @@ internal protocol _ArrayBufferProtocol
   ) rethrows -> R
 
   /// The number of elements the buffer stores.
-  var count: Int { get set }
+  override var count: Int { get set }
 
   /// The number of elements the buffer can store without reallocation.
   var capacity: Int { get }

--- a/stdlib/public/core/ArrayType.swift
+++ b/stdlib/public/core/ArrayType.swift
@@ -17,13 +17,13 @@ internal protocol ArrayProtocol
 {
   //===--- public interface -----------------------------------------------===//
   /// The number of elements the Array stores.
-  var count: Int { get }
+  override var count: Int { get }
 
   /// The number of elements the Array can store without reallocation.
   var capacity: Int { get }
 
   /// `true` if and only if the Array is empty.
-  var isEmpty: Bool { get }
+  override var isEmpty: Bool { get }
 
   /// An object that guarantees the lifetime of this array's elements.
   var _owner: AnyObject? { get }
@@ -42,7 +42,7 @@ internal protocol ArrayProtocol
   ///   mutable contiguous storage.
   ///
   /// - Complexity: O(`self.count`).
-  mutating func reserveCapacity(_ minimumCapacity: Int)
+  override mutating func reserveCapacity(_ minimumCapacity: Int)
 
   /// Insert `newElement` at index `i`.
   ///

--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -38,16 +38,16 @@
 public protocol BidirectionalCollection: Collection
 where SubSequence: BidirectionalCollection, Indices: BidirectionalCollection {
   // FIXME(ABI): Associated type inference requires this.
-  associatedtype Element
+  override associatedtype Element
 
   // FIXME(ABI): Associated type inference requires this.
-  associatedtype Index
+  override associatedtype Index
 
   // FIXME(ABI): Associated type inference requires this.
-  associatedtype SubSequence
+  override associatedtype SubSequence
 
   // FIXME(ABI): Associated type inference requires this.
-  associatedtype Indices
+  override associatedtype Indices
 
   /// Returns the position immediately before the given index.
   ///
@@ -71,13 +71,13 @@ where SubSequence: BidirectionalCollection, Indices: BidirectionalCollection {
   /// - Parameter i: A valid index of the collection. `i` must be less than
   ///   `endIndex`.
   /// - Returns: The index value immediately after `i`.
-  func index(after i: Index) -> Index
+  override func index(after i: Index) -> Index
 
   /// Replaces the given index with its successor.
   ///
   /// - Parameter i: A valid index of the collection. `i` must be less than
   ///   `endIndex`.
-  func formIndex(after i: inout Index)
+  override func formIndex(after i: inout Index)
 
   /// Returns an index that is the specified distance from the given index.
   ///
@@ -106,7 +106,7 @@ where SubSequence: BidirectionalCollection, Indices: BidirectionalCollection {
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is the absolute
   ///   value of `distance`.
-  func index(_ i: Index, offsetBy distance: Int) -> Index
+  @_nonoverride func index(_ i: Index, offsetBy distance: Int) -> Index
 
   /// Returns an index that is the specified distance from the given index,
   /// unless that distance is beyond a given limiting index.
@@ -150,7 +150,7 @@ where SubSequence: BidirectionalCollection, Indices: BidirectionalCollection {
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is the absolute
   ///   value of `distance`.
-  func index(
+  @_nonoverride func index(
     _ i: Index, offsetBy distance: Int, limitedBy limit: Index
   ) -> Index?
 
@@ -170,7 +170,7 @@ where SubSequence: BidirectionalCollection, Indices: BidirectionalCollection {
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is the
   ///   resulting distance.
-  func distance(from start: Index, to end: Index) -> Int
+  @_nonoverride func distance(from start: Index, to end: Index) -> Int
 
   /// The indices that are valid for subscripting the collection, in ascending
   /// order.
@@ -189,7 +189,7 @@ where SubSequence: BidirectionalCollection, Indices: BidirectionalCollection {
   ///         i = c.index(after: i)
   ///     }
   ///     // c == MyFancyCollection([2, 4, 6, 8, 10])
-  var indices: Indices { get }
+  override var indices: Indices { get }
   
   // TODO: swift-3-indexing-model: tests.
   /// The last element of the collection.
@@ -228,16 +228,16 @@ where SubSequence: BidirectionalCollection, Indices: BidirectionalCollection {
   ///   the range must be valid indices of the collection.
   ///
   /// - Complexity: O(1)
-  subscript(bounds: Range<Index>) -> SubSequence { get }
+  override subscript(bounds: Range<Index>) -> SubSequence { get }
 
   // FIXME(ABI): Associated type inference requires this.
-  subscript(position: Index) -> Element { get }
+  override subscript(position: Index) -> Element { get }
 
   // FIXME(ABI): Associated type inference requires this.
-  var startIndex: Index { get }
+  override var startIndex: Index { get }
 
   // FIXME(ABI): Associated type inference requires this.
-  var endIndex: Index { get }
+  override var endIndex: Index { get }
 }
 
 /// Default implementation for bidirectional collections.

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -339,7 +339,7 @@ public protocol Collection: Sequence where SubSequence: Collection {
   typealias IndexDistance = Int  
 
   // FIXME(ABI): Associated type inference requires this.
-  associatedtype Element
+  override associatedtype Element
 
   /// A type that represents a position in the collection.
   ///
@@ -382,7 +382,7 @@ public protocol Collection: Sequence where SubSequence: Collection {
   // a custom `makeIterator()` function.  Otherwise we get an
   // `IndexingIterator`. <rdar://problem/21539115>
   /// Returns an iterator over the elements of the collection.
-  func makeIterator() -> Iterator
+  override func makeIterator() -> Iterator
 
   /// A sequence that represents a contiguous subrange of the collection's
   /// elements.

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -500,7 +500,7 @@ public protocol FloatingPoint : SignedNumeric, Strideable, Hashable
   /// - Parameters:
   ///   - lhs: The first value to add.
   ///   - rhs: The second value to add.
-  static func +(lhs: Self, rhs: Self) -> Self
+  override static func +(lhs: Self, rhs: Self) -> Self
 
   /// Adds two values and stores the result in the left-hand-side variable,
   /// rounded to a representable value.
@@ -508,7 +508,7 @@ public protocol FloatingPoint : SignedNumeric, Strideable, Hashable
   /// - Parameters:
   ///   - lhs: The first value to add.
   ///   - rhs: The second value to add.
-  static func +=(lhs: inout Self, rhs: Self)
+  override static func +=(lhs: inout Self, rhs: Self)
 
   /// Calculates the additive inverse of a value.
   ///
@@ -520,7 +520,7 @@ public protocol FloatingPoint : SignedNumeric, Strideable, Hashable
   ///     // y == -21.5
   ///
   /// - Parameter operand: The value to negate.
-  static prefix func - (_ operand: Self) -> Self
+  override static prefix func - (_ operand: Self) -> Self
 
   /// Replaces this value with its additive inverse.
   ///
@@ -530,7 +530,7 @@ public protocol FloatingPoint : SignedNumeric, Strideable, Hashable
   ///     var x = 21.5
   ///     x.negate()
   ///     // x == -21.5
-  mutating func negate()
+  override mutating func negate()
 
   /// Subtracts one value from another and produces their difference, rounded
   /// to a representable value.
@@ -550,7 +550,7 @@ public protocol FloatingPoint : SignedNumeric, Strideable, Hashable
   /// - Parameters:
   ///   - lhs: A numeric value.
   ///   - rhs: The value to subtract from `lhs`.
-  static func -(lhs: Self, rhs: Self) -> Self
+  override static func -(lhs: Self, rhs: Self) -> Self
 
   /// Subtracts the second value from the first and stores the difference in
   /// the left-hand-side variable, rounding to a representable value.
@@ -558,7 +558,7 @@ public protocol FloatingPoint : SignedNumeric, Strideable, Hashable
   /// - Parameters:
   ///   - lhs: A numeric value.
   ///   - rhs: The value to subtract from `lhs`.
-  static func -=(lhs: inout Self, rhs: Self)
+  override static func -=(lhs: inout Self, rhs: Self)
 
   /// Multiplies two values and produces their product, rounding to a
   /// representable value.
@@ -578,7 +578,7 @@ public protocol FloatingPoint : SignedNumeric, Strideable, Hashable
   /// - Parameters:
   ///   - lhs: The first value to multiply.
   ///   - rhs: The second value to multiply.
-  static func *(lhs: Self, rhs: Self) -> Self
+  override static func *(lhs: Self, rhs: Self) -> Self
 
   /// Multiplies two values and stores the result in the left-hand-side
   /// variable, rounding to a representable value.
@@ -586,7 +586,7 @@ public protocol FloatingPoint : SignedNumeric, Strideable, Hashable
   /// - Parameters:
   ///   - lhs: The first value to multiply.
   ///   - rhs: The second value to multiply.
-  static func *=(lhs: inout Self, rhs: Self)
+  override static func *=(lhs: inout Self, rhs: Self)
 
   /// Returns the quotient of dividing the first value by the second, rounded
   /// to a representable value.

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -758,14 +758,14 @@ public protocol BinaryInteger :
   /// - Parameters:
   ///   - lhs: The first value to add.
   ///   - rhs: The second value to add.
-  static func +(lhs: Self, rhs: Self) -> Self
+  override static func +(lhs: Self, rhs: Self) -> Self
 
   /// Adds two values and stores the result in the left-hand-side variable.
   ///
   /// - Parameters:
   ///   - lhs: The first value to add.
   ///   - rhs: The second value to add.
-  static func +=(lhs: inout Self, rhs: Self)
+  override static func +=(lhs: inout Self, rhs: Self)
 
   /// Subtracts one value from another and produces their difference.
   ///
@@ -787,7 +787,7 @@ public protocol BinaryInteger :
   /// - Parameters:
   ///   - lhs: A numeric value.
   ///   - rhs: The value to subtract from `lhs`.
-  static func -(lhs: Self, rhs: Self) -> Self
+  override static func -(lhs: Self, rhs: Self) -> Self
 
   /// Subtracts the second value from the first and stores the difference in the
   /// left-hand-side variable.
@@ -795,7 +795,7 @@ public protocol BinaryInteger :
   /// - Parameters:
   ///   - lhs: A numeric value.
   ///   - rhs: The value to subtract from `lhs`.
-  static func -=(lhs: inout Self, rhs: Self)
+  override static func -=(lhs: inout Self, rhs: Self)
 
   /// Multiplies two values and produces their product.
   ///
@@ -817,7 +817,7 @@ public protocol BinaryInteger :
   /// - Parameters:
   ///   - lhs: The first value to multiply.
   ///   - rhs: The second value to multiply.
-  static func *(lhs: Self, rhs: Self) -> Self
+  override static func *(lhs: Self, rhs: Self) -> Self
 
   /// Multiplies two values and stores the result in the left-hand-side
   /// variable.
@@ -825,7 +825,7 @@ public protocol BinaryInteger :
   /// - Parameters:
   ///   - lhs: The first value to multiply.
   ///   - rhs: The second value to multiply.
-  static func *=(lhs: inout Self, rhs: Self)
+  override static func *=(lhs: inout Self, rhs: Self)
 
   /// Returns the inverse of the bits set in the argument.
   ///

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -61,13 +61,13 @@ public protocol MutableCollection: Collection
 where SubSequence: MutableCollection
 {
   // FIXME(ABI): Associated type inference requires this.
-  associatedtype Element
+  override associatedtype Element
 
   // FIXME(ABI): Associated type inference requires this.
-  associatedtype Index
+  override associatedtype Index
 
   // FIXME(ABI): Associated type inference requires this.
-  associatedtype SubSequence
+  override associatedtype SubSequence
 
   /// Accesses the element at the specified position.
   ///
@@ -89,7 +89,7 @@ where SubSequence: MutableCollection
   ///   `endIndex` property.
   ///
   /// - Complexity: O(1)
-  subscript(position: Index) -> Element { get set }
+  override subscript(position: Index) -> Element { get set }
 
   /// Accesses a contiguous subrange of the collection's elements.
   ///
@@ -115,7 +115,7 @@ where SubSequence: MutableCollection
   ///   the range must be valid indices of the collection.
   ///
   /// - Complexity: O(1)
-  subscript(bounds: Range<Index>) -> SubSequence { get set }
+  override subscript(bounds: Range<Index>) -> SubSequence { get set }
 
   /// Reorders the elements of the collection such that all the elements
   /// that match the given predicate are after all the elements that don't

--- a/stdlib/public/core/RandomAccessCollection.swift
+++ b/stdlib/public/core/RandomAccessCollection.swift
@@ -34,16 +34,16 @@ public protocol RandomAccessCollection: BidirectionalCollection
 where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection
 {
   // FIXME(ABI): Associated type inference requires this.
-  associatedtype Element
+  override associatedtype Element
 
   // FIXME(ABI): Associated type inference requires this.
-  associatedtype Index
+  override associatedtype Index
 
   // FIXME(ABI): Associated type inference requires this.
-  associatedtype SubSequence
+  override associatedtype SubSequence
 
   // FIXME(ABI): Associated type inference requires this.
-  associatedtype Indices
+  override associatedtype Indices
 
   /// The indices that are valid for subscripting the collection, in ascending
   /// order.
@@ -62,7 +62,7 @@ where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection
   ///         i = c.index(after: i)
   ///     }
   ///     // c == MyFancyCollection([2, 4, 6, 8, 10])
-  var indices: Indices { get }
+  override var indices: Indices { get }
 
   /// Accesses a contiguous subrange of the collection's elements.
   ///
@@ -87,29 +87,29 @@ where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection
   ///   the range must be valid indices of the collection.
   ///
   /// - Complexity: O(1)
-  subscript(bounds: Range<Index>) -> SubSequence { get }
+  override subscript(bounds: Range<Index>) -> SubSequence { get }
 
   // FIXME(ABI): Associated type inference requires this.
-  subscript(position: Index) -> Element { get }
+  override subscript(position: Index) -> Element { get }
 
   // FIXME(ABI): Associated type inference requires this.
-  var startIndex: Index { get }
+  override var startIndex: Index { get }
 
   // FIXME(ABI): Associated type inference requires this.
-  var endIndex: Index { get }
+  override var endIndex: Index { get }
 
   /// Returns the position immediately before the given index.
   ///
   /// - Parameter i: A valid index of the collection. `i` must be greater than
   ///   `startIndex`.
   /// - Returns: The index value immediately before `i`.
-  func index(before i: Index) -> Index
+  override func index(before i: Index) -> Index
 
   /// Replaces the given index with its predecessor.
   ///
   /// - Parameter i: A valid index of the collection. `i` must be greater than
   ///   `startIndex`.
-  func formIndex(before i: inout Index)
+  override func formIndex(before i: inout Index)
 
   /// Returns the position immediately after the given index.
   ///
@@ -120,13 +120,13 @@ where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection
   /// - Parameter i: A valid index of the collection. `i` must be less than
   ///   `endIndex`.
   /// - Returns: The index value immediately after `i`.
-  func index(after i: Index) -> Index
+  override func index(after i: Index) -> Index
 
   /// Replaces the given index with its successor.
   ///
   /// - Parameter i: A valid index of the collection. `i` must be less than
   ///   `endIndex`.
-  func formIndex(after i: inout Index)
+  override func formIndex(after i: inout Index)
 
   /// Returns an index that is the specified distance from the given index.
   ///
@@ -153,7 +153,7 @@ where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection
   ///   `index(before:)`.
   ///
   /// - Complexity: O(1)
-  func index(_ i: Index, offsetBy distance: Int) -> Index
+  @_nonoverride func index(_ i: Index, offsetBy distance: Int) -> Index
 
   /// Returns an index that is the specified distance from the given index,
   /// unless that distance is beyond a given limiting index.
@@ -195,7 +195,7 @@ where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection
   ///   case, the method returns `nil`.
   ///
   /// - Complexity: O(1)
-  func index(
+  @_nonoverride func index(
     _ i: Index, offsetBy distance: Int, limitedBy limit: Index
   ) -> Index?
 
@@ -213,7 +213,7 @@ where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection
   ///   `BidirectionalCollection` protocol.
   ///
   /// - Complexity: O(1)
-  func distance(from start: Index, to end: Index) -> Int
+  @_nonoverride func distance(from start: Index, to end: Index) -> Int
 }
 
 // TODO: swift-3-indexing-model - (By creating an ambiguity?), try to

--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -64,7 +64,7 @@
 public protocol RangeReplaceableCollection : Collection
   where SubSequence : RangeReplaceableCollection {
   // FIXME(ABI): Associated type inference requires this.
-  associatedtype SubSequence
+  override associatedtype SubSequence
 
   //===--- Fundamental Requirements ---------------------------------------===//
 
@@ -363,10 +363,10 @@ public protocol RangeReplaceableCollection : Collection
     where shouldBeRemoved: (Element) throws -> Bool) rethrows
 
   // FIXME(ABI): Associated type inference requires this.
-  subscript(bounds: Index) -> Element { get }
+  override subscript(bounds: Index) -> Element { get }
 
   // FIXME(ABI): Associated type inference requires this.
-  subscript(bounds: Range<Index>) -> SubSequence { get }
+  override subscript(bounds: Range<Index>) -> SubSequence { get }
 }
 
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/core/ShadowProtocols.swift
+++ b/stdlib/public/core/ShadowProtocols.swift
@@ -67,7 +67,7 @@ public protocol _NSArrayCore :
   func getObjects(_: UnsafeMutablePointer<AnyObject>, range: _SwiftNSRange)
 
   @objc(countByEnumeratingWithState:objects:count:)
-  func countByEnumerating(
+  override func countByEnumerating(
     with state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
     objects: UnsafeMutablePointer<AnyObject>?, count: Int
   ) -> Int
@@ -101,7 +101,7 @@ public protocol _NSDictionaryCore :
   // We also override the following methods for efficiency.
 
   @objc(copyWithZone:)
-  func copy(with zone: _SwiftNSZone?) -> AnyObject
+  override func copy(with zone: _SwiftNSZone?) -> AnyObject
 
   @objc(getObjects:andKeys:count:)
   func getObjects(
@@ -111,7 +111,7 @@ public protocol _NSDictionaryCore :
   )
 
   @objc(countByEnumeratingWithState:objects:count:)
-  func countByEnumerating(
+  override func countByEnumerating(
     with state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
     objects: UnsafeMutablePointer<AnyObject>?, count: Int
   ) -> Int
@@ -129,7 +129,7 @@ public protocol _NSDictionaryCore :
 public protocol _NSDictionary : _NSDictionaryCore {
   // Note! This API's type is different from what is imported by the clang
   // importer.
-  func getObjects(
+  override func getObjects(
     _ objects: UnsafeMutablePointer<AnyObject>?,
     andKeys keys: UnsafeMutablePointer<AnyObject>?,
     count: Int)
@@ -156,10 +156,10 @@ public protocol _NSSetCore :
   // We also override the following methods for efficiency.
 
   @objc(copyWithZone:)
-  func copy(with zone: _SwiftNSZone?) -> AnyObject
+  override func copy(with zone: _SwiftNSZone?) -> AnyObject
 
   @objc(countByEnumeratingWithState:objects:count:)
-  func countByEnumerating(
+  override func countByEnumerating(
     with state: UnsafeMutablePointer<_SwiftNSFastEnumerationState>,
     objects: UnsafeMutablePointer<AnyObject>?, count: Int
   ) -> Int

--- a/test/Compatibility/attr_override.swift
+++ b/test/Compatibility/attr_override.swift
@@ -155,7 +155,7 @@ enum E {
 }
 
 protocol P {
-  override func f() // expected-error{{'override' can only be specified on class members}} {{3-12=}}
+  override func f() // FIXME wording: expected-error{{method does not override any method from its superclass}}
 }
 
 override func f() { } // expected-error{{'override' can only be specified on class members}} {{1-10=}}

--- a/test/IDE/complete_associated_types.swift
+++ b/test/IDE/complete_associated_types.swift
@@ -267,7 +267,7 @@ struct StructWithBrokenConformance : FooProtocolWithAssociatedTypes {
 func testBrokenConformances1() {
   StructWithBrokenConformance.#^BROKEN_CONFORMANCE_1^#
 }
-// BROKEN_CONFORMANCE_1: Begin completions, 35 items
+// BROKEN_CONFORMANCE_1: Begin completions, 33 items
 // BROKEN_CONFORMANCE_1-DAG: Decl[TypeAlias]/CurrNominal:        DefaultedTypeCommonA[#StructWithBrokenConformance.DefaultedTypeCommonA#]; name=DefaultedTypeCommonA
 // BROKEN_CONFORMANCE_1-DAG: Decl[TypeAlias]/CurrNominal:        DefaultedTypeCommonB[#StructWithBrokenConformance.DefaultedTypeCommonB#]; name=DefaultedTypeCommonB
 // BROKEN_CONFORMANCE_1-DAG: Decl[TypeAlias]/CurrNominal:        FooBaseDefaultedTypeB[#StructWithBrokenConformance.FooBaseDefaultedTypeB#]; name=FooBaseDefaultedTypeB
@@ -289,8 +289,6 @@ func testBrokenConformances1() {
 // BROKEN_CONFORMANCE_1-DAG: Decl[TypeAlias]/CurrNominal:        FooBaseDefaultedTypeC[#StructWithBrokenConformance.FooBaseDefaultedTypeC#]; name=FooBaseDefaultedTypeC
 // BROKEN_CONFORMANCE_1-DAG: Decl[TypeAlias]/CurrNominal:        DeducedTypeCommonC[#StructWithBrokenConformance.DeducedTypeCommonC#]; name=DeducedTypeCommonC
 // BROKEN_CONFORMANCE_1-DAG: Decl[TypeAlias]/CurrNominal:        DeducedTypeCommonD[#StructWithBrokenConformance.DeducedTypeCommonD#]; name=DeducedTypeCommonD
-// BROKEN_CONFORMANCE_1-DAG: Decl[InstanceMethod]/Super:         deduceCommonA({#self: StructWithBrokenConformance#})[#() -> StructWithBrokenConformance.DeducedTypeCommonA#]{{; name=.+$}}
-// BROKEN_CONFORMANCE_1-DAG: Decl[InstanceMethod]/Super:         deduceCommonB({#self: StructWithBrokenConformance#})[#() -> StructWithBrokenConformance.DeducedTypeCommonB#]{{; name=.+$}}
 // BROKEN_CONFORMANCE_1-DAG: Decl[InstanceMethod]/Super:         deduceCommonC({#self: StructWithBrokenConformance#})[#() -> StructWithBrokenConformance.DeducedTypeCommonC#]{{; name=.+$}}
 // BROKEN_CONFORMANCE_1-DAG: Decl[InstanceMethod]/Super:         deduceCommonD({#self: StructWithBrokenConformance#})[#() -> StructWithBrokenConformance.DeducedTypeCommonD#]{{; name=.+$}}
 // BROKEN_CONFORMANCE_1-DAG: Decl[TypeAlias]/CurrNominal:        FooBaseDeducedTypeA[#StructWithBrokenConformance.FooBaseDeducedTypeA#]; name=FooBaseDeducedTypeA

--- a/test/Index/conformances.swift
+++ b/test/Index/conformances.swift
@@ -80,8 +80,8 @@ class SubMultiConf: BaseMultiConf,P2,P1,P3 { // CHECK: [[@LINE]]:7 | class/Swift
 }
 
 protocol InheritingP: P1 { // CHECK: [[@LINE]]:10 | protocol/Swift | InheritingP | [[InheritingP_USR:.*]] | Def
-  // FIXME: Should have override relation with P1.foo()
-  func foo() // CHECK: [[@LINE]]:8 | instance-method/Swift | foo() | [[InheritingP_foo_USR:.*]] | Def,Dyn,RelChild | rel: 1
+  func foo() // CHECK: [[@LINE]]:8 | instance-method/Swift | foo() | [[InheritingP_foo_USR:.*]] | Def,Dyn,RelChild,RelOver | rel: 2
+    // CHECK-NEXT: RelOver | instance-method/Swift | foo() | s:14swift_ide_test2P1P3fooyyF
     // CHECK-NEXT: RelChild | protocol/Swift | InheritingP | [[InheritingP_USR]]
 }
 
@@ -94,9 +94,7 @@ struct DirectConf2: InheritingP { // CHECK: [[@LINE]]:8 | struct/Swift | DirectC
 }
 
 extension InheritingP { // CHECK: [[@LINE]]:11 | extension/ext-protocol/Swift | InheritingP | [[InheritingP_USR:.*]] | Def
-  // FIXME: Should only override InheritingP.foo()
-  func foo() {} // CHECK: [[@LINE]]:8 | instance-method/Swift | foo() | [[InheritingP_ext_foo_USR:.*]] | Def,Dyn,RelChild,RelOver | rel: 3
+  func foo() {} // CHECK: [[@LINE]]:8 | instance-method/Swift | foo() | [[InheritingP_ext_foo_USR:.*]] | Def,Dyn,RelChild,RelOver | rel: 2
     // CHECK-NEXT: RelOver | instance-method/Swift | foo() | [[InheritingP_foo_USR]]
-    // CHECK-NEXT: RelOver | instance-method/Swift | foo() | [[P1_foo_USR]]
     // CHECK-NEXT: RelChild | extension/ext-protocol/Swift | InheritingP | [[InheritingP_USR]]
 }

--- a/test/Index/roles.swift
+++ b/test/Index/roles.swift
@@ -427,6 +427,8 @@ protocol ProtRoot {
 
 protocol ProtDerived : ProtRoot {
   func fooCommon()
+  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | fooCommon() | s:14swift_ide_test11ProtDerivedP9fooCommonyyF | Def,Dyn,RelChild,RelOver | rel: 2
+  
   func bar1()
   func bar2()
   func bar3(_ : Int)
@@ -435,9 +437,8 @@ protocol ProtDerived : ProtRoot {
 
 extension ProtDerived {
   func fooCommon() {}
-  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | fooCommon() | s:14swift_ide_test11ProtDerivedPAAE9fooCommonyyF | Def,Dyn,RelChild,RelOver | rel: 3
+  // CHECK: [[@LINE-1]]:8 | instance-method/Swift | fooCommon() | s:14swift_ide_test11ProtDerivedPAAE9fooCommonyyF | Def,Dyn,RelChild,RelOver | rel: 2
   // CHECK-NEXT: RelOver | instance-method/Swift | fooCommon() | s:14swift_ide_test11ProtDerivedP9fooCommonyyF
-  // CHECK-NEXT: RelOver | instance-method/Swift | fooCommon() | s:14swift_ide_test8ProtRootP9fooCommonyyF
 
   func foo1() {}
   // CHECK: [[@LINE-1]]:8 | instance-method/Swift | foo1() | s:14swift_ide_test11ProtDerivedPAAE4foo1yyF | Def,Dyn,RelChild,RelOver | rel: 2

--- a/test/SILGen/witness_table_overrides.swift
+++ b/test/SILGen/witness_table_overrides.swift
@@ -23,3 +23,20 @@ func callFoo<T: P3>(t: T) {
   // CHECK: witness_method $T, #P0.foo!1 : <Self where Self : P0> (Self) -> () -> ()
   t.foo()
 }
+
+// CHECK-LABEL: sil_witness_table hidden X3: P3 module witness_table_overrides {
+// CHECK-NEXT:    base_protocol P0: X3: P0 module witness_table_overrides
+// CHECK-NEXT:    base_protocol P2: X3: P2 module witness_table_overrides
+// CHECK-NEXT:  }
+
+// CHECK-LABEL: sil_witness_table hidden X3: P0 module witness_table_overrides {
+// CHECK-NEXT:    method #P0.foo!1: <Self where Self : P0> (Self) -> () -> () : @$S23witness_table_overrides2X3VAA2P0A2aDP3fooyyFTW
+// CHECK-NEXT:  }
+
+// CHECK-LABEL: sil_witness_table hidden X3: P2 module witness_table_overrides {
+// CHECK-NEXT:    base_protocol P1: X3: P1 module witness_table_overrides
+// CHECK-NEXT:  }
+struct X3: P3 {
+  func foo() { }
+}
+

--- a/test/SILGen/witness_table_overrides.swift
+++ b/test/SILGen/witness_table_overrides.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-emit-silgen -enable-sil-ownership %s | %FileCheck %s
+
+// Test the use of "override" on protocol requirements.
+
+protocol P0 {
+  func foo()
+}
+
+protocol P1 {
+  func foo()
+}
+
+protocol P2: P1 {
+  override func foo()
+}
+
+protocol P3: P0, P2 {
+  override func foo()
+}
+
+// CHECK-LABEL: sil hidden @$S23witness_table_overrides7callFoo1tyx_tAA2P3RzlF
+func callFoo<T: P3>(t: T) {
+  // CHECK: witness_method $T, #P0.foo!1 : <Self where Self : P0> (Self) -> () -> ()
+  t.foo()
+}

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -3463,7 +3463,7 @@ protocol Prot0 : class {
 
 
 protocol Prot1 : Prot0 {
-  static func newWithConfig() throws -> Builtin.Int32
+  @_nonoverride static func newWithConfig() throws -> Builtin.Int32
 }
 
 protocol Prot2 : Prot1 {

--- a/test/attr/attr_override.swift
+++ b/test/attr/attr_override.swift
@@ -155,7 +155,7 @@ enum E {
 }
 
 protocol P {
-  override func f() // expected-error{{'override' can only be specified on class members}} {{3-12=}}
+  override func f() // FIXME wording: expected-error{{method does not override any method from its superclass}}
 }
 
 override func f() { } // expected-error{{'override' can only be specified on class members}} {{1-10=}}

--- a/test/decl/class/nonoverride.swift
+++ b/test/decl/class/nonoverride.swift
@@ -1,0 +1,17 @@
+// RUN: %target-typecheck-verify-swift
+
+class A {
+  func foo() -> A { return self }
+}
+
+class B: A {
+  @_nonoverride
+  func foo() -> B { return self }
+
+  @_nonoverride override // expected-error{{'override' cannot be combined with '@_nonoverride'}}
+  func foo() -> Int { return 0 }
+}
+
+struct X {
+  @_nonoverride func foo() { } // expected-error{{'@_nonoverride' can only be specified on class or protocol members}}
+}

--- a/test/decl/protocol/override.swift
+++ b/test/decl/protocol/override.swift
@@ -103,3 +103,26 @@ protocol P7: P0 {
   // expected-error@+1{{property 'prop' with type 'Int' cannot override a property with type 'Self.A'}}
   override var prop: Int { get }
 }
+
+// Suppress overrides.
+protocol P8: P0 {
+  // CHECK: associated_type_decl
+  // CHECK-SAME: "A"
+  // CHECK-NOT: override
+  // CHECK-SAME: )
+  @_nonoverride
+  associatedtype A
+
+  // CHECK: func_decl{{.*}}foo(){{.*}}Self : P8
+  // CHECK-NOT: override=
+  // CHECK-SAME: )
+  @_nonoverride
+  func foo()
+
+  // CHECK: var_decl
+  // CHECK-SAME: "prop"
+  // CHECK-NOT: override=
+  // CHECK-SAME: immutable
+  @_nonoverride
+  var prop: A { get }
+}

--- a/test/decl/protocol/override.swift
+++ b/test/decl/protocol/override.swift
@@ -105,6 +105,7 @@ protocol P7: P0 {
 }
 
 // Suppress overrides.
+// CHECK: protocol{{.*}}"P8"
 protocol P8: P0 {
   // CHECK: associated_type_decl
   // CHECK-SAME: "A"
@@ -125,4 +126,34 @@ protocol P8: P0 {
   // CHECK-SAME: immutable
   @_nonoverride
   var prop: A { get }
+}
+
+class Base { }
+class Derived : Base { }
+
+// Protocol overrides require exact type matches.
+protocol SubtypingP0 {
+  init?()
+  func foo() -> Base
+}
+
+// CHECK: protocol{{.*}}"SubtypingP1"
+protocol SubtypingP1: SubtypingP0 {
+  // CHECK: constructor_decl{{.*}}Self : SubtypingP1
+  // CHECK-NOT: override=
+  // CHECK-SAME: designated
+  init()
+
+  // CHECK: func_decl{{.*}}foo(){{.*}}Self : SubtypingP1
+  // CHECK-NOT: override=
+  // CHECK-SAME: )
+  func foo() -> Derived
+}
+
+// CHECK: protocol{{.*}}"SubtypingP2"
+protocol SubtypingP2: SubtypingP0 {
+  // CHECK: constructor_decl{{.*}}Self : SubtypingP2
+  // CHECK: override={{.*}}SubtypingP0.init
+  // CHECK-SAME: designated
+  init?()
 }

--- a/test/decl/protocol/override.swift
+++ b/test/decl/protocol/override.swift
@@ -1,0 +1,29 @@
+// RUN: %target-typecheck-verify-swift -dump-ast > %t.ast 2>&1
+// RUN: %FileCheck %s < %t.ast
+
+// Test overriding of protocol members.
+
+protocol P0 {
+  func foo()
+}
+
+protocol P1: P0 {
+  // CHECK: func_decl{{.*}}foo(){{.*}}Self : P1{{.*}}override={{.*}}P0.foo
+  func foo()
+}
+
+protocol P2 {
+  func foo()
+}
+
+protocol P3: P1, P2 {
+  // CHECK: func_decl{{.*}}foo(){{.*}}Self : P3{{.*}}override={{.*}}P2.foo{{.*,.*}}P1.foo
+  func foo()
+}
+
+protocol P4: P0 {
+  // CHECK: func_decl{{.*}}foo(){{.*}}Self : P4
+  // CHECK-NOT: override=
+  // CHECK-SAME: )
+  func foo() -> Int
+}

--- a/test/decl/protocol/override.swift
+++ b/test/decl/protocol/override.swift
@@ -7,8 +7,10 @@
 protocol P0 {
   associatedtype A
 
+  // expected-note@+1{{potential overridden instance method 'foo()' here}}
   func foo()
 
+  // expected-note@+1{{attempt to override property here}}
   var prop: A { get }
 }
 
@@ -79,4 +81,25 @@ protocol P5: P0 where Self.A == Int {
   // CHECK-SAME: "prop"
   // CHECK-SAME: override=override.(file).P0.prop
   var prop: Int { get }
+}
+
+// Allow the 'override' keyword on protocol members (it is not required).
+// CHECK: protocol{{.*}}"P6"
+protocol P6: P0 {
+  // CHECK: func_decl{{.*}}foo(){{.*}}Self : P6{{.*}}override={{.*}}P0.foo
+  override func foo()
+
+  // CHECK: var_decl
+  // CHECK-SAME: "prop"
+  // CHECK-SAME: override=override.(file).P0.prop
+  override var prop: A { get }
+}
+
+// Complain if 'override' is present but there is no overridden declaration.
+protocol P7: P0 {
+  // expected-error@+1{{method does not override any method from its superclass}}
+  override func foo() -> Int
+
+  // expected-error@+1{{property 'prop' with type 'Int' cannot override a property with type 'Self.A'}}
+  override var prop: Int { get }
 }

--- a/test/decl/protocol/override.swift
+++ b/test/decl/protocol/override.swift
@@ -3,27 +3,80 @@
 
 // Test overriding of protocol members.
 
+// CHECK: protocol{{.*}}"P0"
 protocol P0 {
+  associatedtype A
+
   func foo()
+
+  var prop: A { get }
 }
 
+// CHECK: protocol{{.*}}"P1"
 protocol P1: P0 {
+  // CHECK: associated_type_decl
+  // CHECK-SAME: overridden=P0
+  associatedtype A
+
   // CHECK: func_decl{{.*}}foo(){{.*}}Self : P1{{.*}}override={{.*}}P0.foo
   func foo()
+
+  // CHECK: var_decl
+  // CHECK-SAME: "prop"
+  // CHECK-SAME: override=override.(file).P0.prop
+  var prop: A { get }
 }
 
+// CHECK: protocol{{.*}}"P2"
 protocol P2 {
+  associatedtype A
+
   func foo()
+
+  var prop: A { get }
 }
 
+// CHECK: protocol{{.*}}"P3"
 protocol P3: P1, P2 {
+  // CHECK: associated_type_decl
+  // CHECK-SAME: "A"
+  // CHECK-SAME: override=override.(file).P1.A
+  // CHECK-SAME: override.(file).P2.A
+  associatedtype A
+
   // CHECK: func_decl{{.*}}foo(){{.*}}Self : P3{{.*}}override={{.*}}P2.foo{{.*,.*}}P1.foo
   func foo()
+
+  // CHECK: var_decl
+  // CHECK-SAME: "prop"
+  // CHECK-SAME: override=override.(file).P2.prop
+  // CHECK-SAME: override.(file).P1.prop
+  var prop: A { get }
 }
 
+// CHECK: protocol{{.*}}"P4"
 protocol P4: P0 {
   // CHECK: func_decl{{.*}}foo(){{.*}}Self : P4
   // CHECK-NOT: override=
   // CHECK-SAME: )
   func foo() -> Int
+
+  // CHECK: var_decl
+  // CHECK-SAME: "prop"
+  // CHECK-NOT: override=
+  // CHECK-SAME: immutable
+  var prop: Int { get }
+}
+
+// CHECK: protocol{{.*}}"P5"
+protocol P5: P0 where Self.A == Int {
+  // CHECK: func_decl{{.*}}foo(){{.*}}Self : P5
+  // CHECK-NOT: override=
+  // CHECK-SAME: )
+  func foo() -> Int
+
+  // CHECK: var_decl
+  // CHECK-SAME: "prop"
+  // CHECK-SAME: override=override.(file).P0.prop
+  var prop: Int { get }
 }

--- a/test/decl/protocol/warn_override.swift
+++ b/test/decl/protocol/warn_override.swift
@@ -1,0 +1,32 @@
+// RUN: %target-typecheck-verify-swift -warn-implicit-overrides
+
+// Test the warnings about implicit 'override' of protocol members.
+
+
+protocol P0 {
+  associatedtype A // expected-note{{'A' declared here}}
+
+  func foo() // expected-note{{overridden declaration is here}}
+
+  var prop: A { get } // expected-note{{overridden declaration is here}}
+}
+
+protocol P1: P0 {
+  associatedtype A // expected-warning{{redeclaration of associated type 'A' from protocol 'P0' is better expressed as a 'where' clause on the protocol}}
+
+  func foo() // expected-warning{{implicit override should be marked with 'override' or suppressed with '@_nonoverride'}}
+
+  var prop: A { get } // expected-warning{{implicit override should be marked with 'override' or suppressed with '@_nonoverride'}}
+}
+
+// Silence warnings with @_nonoveride.
+protocol P2: P0 {
+  @_nonoverride
+  associatedtype A
+
+  @_nonoverride
+  func foo()
+
+  @_nonoverride
+  var prop: A { get }
+}


### PR DESCRIPTION
When a protocol restates a requirement from its inherited protocol, track that as an override the same way we do with overrides in classes. Such overrides are recorded in the AST but are omitted from the witness table itself. This makes restating protocol requirements in inheriting protocols ABI-neutral, so we can restate protocol requirements to influence associated type inference without baking those decisions into the ABI.

As part of this, introduce tools that allow us to audit all of the restated protocol requirements within the standard library, via a warning new warning flag (`-warn-implicit-overrides`) to warn about such requirements, as well as an appropriate suppression mechanism (`override` to treat it as an override, `@_nonoverride` to give it a new witness table entry). Only those restated requirements that are meant to have a semantic effect, like `BidirectionalCollection.index(_:offsetBy:)`, should use `@_nonoverride`, because it commits us to having that entry in the witness table forever.

Rolling this out in the standard library shrinks the size of the standard library binary by 196k.

Implements rdar://problem/43870489.