### PR TITLE
[NFC] [Parse/SILGen] Switch statement silgen cleanup

### DIFF
--- a/lib/AST/NameLookupImpl.h
+++ b/lib/AST/NameLookupImpl.h
@@ -214,21 +214,20 @@ private:
       return;
     // Pattern names aren't visible in the patterns themselves,
     // just in the body or in where guards.
-    auto body = S->getBody();
     bool inPatterns = isReferencePointInRange(S->getLabelItemsRange());
     auto items = S->getCaseLabelItems();
     if (inPatterns) {
       for (const auto &CLI : items) {
         auto guard = CLI.getGuardExpr();
         if (guard && isReferencePointInRange(guard->getSourceRange())) {
-          inPatterns = false;
+          checkPattern(CLI.getPattern(), DeclVisibilityKind::LocalVariable);
           break;
         }
       }
     }
     if (!inPatterns && !items.empty())
       checkPattern(items[0].getPattern(), DeclVisibilityKind::LocalVariable);
-    visit(body);
+    visit(S->getBody());
   }
 
   void visitDoCatchStmt(DoCatchStmt *S) {

--- a/test/refactoring/rename/Outputs/local/casebind_2.swift.expected
+++ b/test/refactoring/rename/Outputs/local/casebind_2.swift.expected
@@ -21,7 +21,7 @@ func test3(arg: Int?) {
   case let .some(x) where x == 0:
     print(x)
   case let .some(xRenamed) where xRenamed == 1,
-       let .some(x) where xRenamed == 2: // FIXME: This 'x' in '.some(x)' isn't properly renamed in 'casebind_2' case.
+       let .some(x) where x == 2: // FIXME: This 'x' in '.some(x)' isn't properly renamed in 'casebind_2' case.
     print(xRenamed)
   default:
     break


### PR DESCRIPTION
General cleanup, mostly via combining functions with single callees into their callers and simplifying where that can result in cleaner code.

And then fix name lookup of parsing where guards in switch cases so that the where expression references the correct bound pattern variables instead of always those from the first pattern. Which gets rid of the managed value juggling in SILGen for those expressions.