### PR TITLE
Fixed some memory allocation issues in const eval

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
@@ -202,9 +202,12 @@ SymbolicValue ConstExprFunctionState::computeConstantValue(SILValue value) {
 
   // If this a trivial constant instruction that we can handle, then fold it
   // immediately.
-  if (isa<IntegerLiteralInst>(value) || isa<FloatLiteralInst>(value) ||
-      isa<StringLiteralInst>(value))
-    return SymbolicValue::getConstantInst(cast<SingleValueInstruction>(value));
+  if (auto *ili = dyn_cast<IntegerLiteralInst>(value))
+    return SymbolicValue::getInteger(ili->getValue(), evaluator.getAllocator());
+  if (auto *fli = dyn_cast<FloatLiteralInst>(value))
+    return SymbolicValue::getFloat(fli->getValue(), evaluator.getAllocator());
+  if (auto *sli = dyn_cast<StringLiteralInst>(value))
+    return SymbolicValue::getString(sli->getValue(), evaluator.getAllocator());
 
   if (auto *fri = dyn_cast<FunctionRefInst>(value))
     return SymbolicValue::getFunction(fri->getReferencedFunction());

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
@@ -1599,7 +1599,8 @@ static llvm::Optional<SymbolicValue> evaluateAndCacheCall(
 // ConstExprEvaluator implementation.
 //===----------------------------------------------------------------------===//
 
-ConstExprEvaluator::ConstExprEvaluator(SILModule &m) {}
+ConstExprEvaluator::ConstExprEvaluator(SILModule &m)
+    : allocator(m.getASTContext().getAllocator()) {}
 
 ConstExprEvaluator::~ConstExprEvaluator() {}
 

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.h
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.h
@@ -45,7 +45,7 @@ namespace tf {
 class ConstExprEvaluator {
   /// This is a long-lived bump pointer allocator that holds the arguments and
   /// result values for the cached constexpr calls we have already analyzed.
-  llvm::BumpPtrAllocator allocator;
+  llvm::BumpPtrAllocator &allocator;
 
   /// The current call stack, used for providing accurate diagnostics.
   llvm::SmallVector<SourceLoc, 4> callStack;

--- a/test/TensorFlow/shape_lowering/shapelist_unknownrank_rank0.swift
+++ b/test/TensorFlow/shape_lowering/shapelist_unknownrank_rank0.swift
@@ -1,9 +1,6 @@
 // RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s
 // RUN: %target-swift-frontend -emit-sil -Xllvm -tf-dump-graph %s | %FileCheck %s
 
-// FIXME: Constexpr can't figure out the value of the 2nd TensorShape.
-// XFAIL: *
-
 // These tests are in separate files because functions appear in the GraphDef
 // in nondeterministic order.
 


### PR DESCRIPTION
1. Before this PR, the `ConstExprEvaluator` class has its own allocator. When `constantEvaluator` is destroyed in `TFDeabstractionPass::run()`, the allocated
memory is returned, and that causes some symbolic values to be overwritten in
subsequent compiler passes due to new allocation. As a result, TFPartition pass can read invalid symbolic values (which are used as tfop attrs).

One example is this test case:
```swift
public func test() {
  let _: ResourceHandle = #tfop("AnonymousIterator",
                                output_types: [Float.self],
                                output_shapes: [nil as TensorShape?,
                                                TensorShape([1])])
}
```

Right after const eval in deabstraction, the 2 elements in `output_shapes` (of type Optional<TensorShape>) have symbolic values:

```
  enum: case none
  enum: case some(Wrapped), payload:   agg: 1 elt:     array<Int32>: 1 elt:       agg: 1 elt:         inst:   %16 = integer_literal $Builtin.Int32, 1
```

But in TFPartition, those values have been stomped on, causing
`hostFn.print(*outs)` in `TFFunctionPartition::markFunction()` to fail.

The fix is to use the allocator associated with the ASTContext of the SIL
module, whose lifetime covers both the deabstraction and partition passes.

2. For RK_Inst-typed symbolic values, the underlying `inst` might get dead-code-removed before the symbolic value is consumed. In the above example, the second shape element contains a const int backed by inst `%16 = integer_literal $Builtin.Int32, 1`, but that inst is removed (by performance pipeline) by the time TFPartition gets run. 

The fix is to avoid using RK_Inst-typed symbolic values. (Whether to remove the const eval infra code on RK_Inst is deferred out of this PR.)

For reference, the SIL code produced by deabstraction and the SIL code as the input to TFPartition are respectively showed below:
```
--- TFDeabstraction Result: $S27shapelist_unknownrank_rank04testyyF
// test()
sil @$S27shapelist_unknownrank_rank04testyyF : $@convention(thin) () -> () {
bb0:
  %0 = integer_literal $Builtin.Word, 1
  // function_ref _allocateUninitializedArray<A>(_:)
  %1 = function_ref @$Ss27_allocateUninitializedArrayySayxG_BptBwlF : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
  %2 = metatype $@thick Float.Type
  %3 = integer_literal $Builtin.Word, 2
  // function_ref _allocateUninitializedArray<A>(_:)
  %4 = function_ref @$Ss27_allocateUninitializedArrayySayxG_BptBwlF : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
  %5 = enum $Optional<TensorShape>, #Optional.none!enumelt
  %6 = integer_literal $Builtin.Word, 1
  %7 = metatype $@thin TensorShape.Type           // user: %20
  %8 = integer_literal $Builtin.Word, 1           // user: %10
  // function_ref _allocateUninitializedArray<A>(_:)
  %9 = function_ref @$Ss27_allocateUninitializedArrayySayxG_BptBwlF : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer) // user: %10
  %10 = apply %9<Int32>(%8) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer) // users: %14, %11, %13
  %11 = tuple_extract %10 : $(Array<Int32>, Builtin.RawPointer), 0 // users: %20, %12
  retain_value %11 : $Array<Int32>                // id: %12
  %13 = tuple_extract %10 : $(Array<Int32>, Builtin.RawPointer), 1 // user: %15
  release_value %10 : $(Array<Int32>, Builtin.RawPointer) // id: %14
  %15 = pointer_to_address %13 : $Builtin.RawPointer to [strict] $*Int32 // user: %18
  %16 = integer_literal $Builtin.Int32, 1         // user: %17
  %17 = struct $Int32 (%16 : $Builtin.Int32)      // user: %18
  store %17 to %15 : $*Int32                      // id: %18
  // function_ref TensorShape.init(_:)
  %19 = function_ref @$S10TensorFlow0A5ShapeVyACSays5Int32VGcfC : $@convention(method) (@owned Array<Int32>, @thin TensorShape.Type) -> @owned TensorShape // user: %20
  %20 = apply %19(%11, %7) : $@convention(method) (@owned Array<Int32>, @thin TensorShape.Type) -> @owned TensorShape // user: %21
  %21 = enum $Optional<TensorShape>, #Optional.some!enumelt.1, %20 : $TensorShape
  %22 = graph_op "AnonymousIterator"() {output_types: [$Float.Type: $Float], output_shapes: [$Optional<TensorShape>: #Optional.none!enumelt, (#Optional.some!enumelt.1, ([$Int32: (i32 1)]))], __device: "/device:CPU:0"} : $ResourceHandle // user: %23
  strong_release %22 : $ResourceHandle            // id: %23
  %24 = tuple ()                                  // user: %25
  return %24 : $()                                // id: %25
} // end sil function '$S27shapelist_unknownrank_rank04testyyF'

----
---- INPUT FUNCTION $S27shapelist_unknownrank_rank04testyyF ----------
// test()
sil @$S27shapelist_unknownrank_rank04testyyF : $@convention(thin) () -> () {
bb0:
  %0 = graph_op "AnonymousIterator"() {output_types: [$Float.Type: $Float], output_shapes: [$Optional<TensorShape>: #Optional.none!enumelt, (#Optional.some!enumelt.1, ([$Int32: (i32 1)]))], __device: "/device:CPU:0"} : $ResourceHandle // user: %1
  strong_release %0 : $ResourceHandle             // id: %1
  %2 = tuple ()                                   // user: %3
  return %2 : $()                                 // id: %3
} // end sil function '$S27shapelist_unknownrank_rank04testyyF'

---- END OF INPUT FUNCTION ----------
```