### PR TITLE
[AutoDiff] Fix bugs in nested differentiation and allow differentiation to be invoked by reverse_differentiable attribute

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -360,6 +360,9 @@ ERROR(pound_assert_failure,none,
 // Automatic differentiation diagnostics
 ERROR(autodiff_internal_swift_not_imported,none,
       "AD internal error: the Swift module is not imported", ())
+ERROR(autodiff_incomplete_differentiable_attr,none,
+      "incomplete `reverse_differentiable` attribute; it should specify either "
+      "both primal and adjoint or nothing", ())
 ERROR(autodiff_opaque_function_unsupported,none,
       "differentiating an opaque function is not supported yet", ())
 ERROR(autodiff_cannot_synthesize_primal_yet,none,

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -1077,7 +1077,8 @@ static bool parseSymbolicValue(SymbolicValue &value, SILParser &SP,
 };
 
 /// SWIFT_ENABLE_TENSORFLOW
-/// Parse an adjoint attribute, e.g. `[differentiable wrt 0, 1 adjoint @other]`.
+/// Parse a `reverse_differentiable` attribute, e.g.
+/// `[reverse_differentiable wrt 0, 1 adjoint @other]`.
 /// Returns true on error.
 static bool parseReverseDifferentiableAttr(
   SmallVectorImpl<SILReverseDifferentiableAttr *> &DAs, SILParser &SP) {
@@ -1126,12 +1127,12 @@ static bool parseReverseDifferentiableAttr(
     P.consumeToken();
     if (parseFnName(PrimName)) return true;
   }
-  // Parse 'adjoint'.
+  // Parse optional 'adjoint'.
   Identifier AdjName;
-  if (P.parseSpecificIdentifier("adjoint", LastLoc,
-        diag::sil_attr_differentiable_expected_adjoint_identifier) ||
-      parseFnName(AdjName))
-    return true;
+  if (P.Tok.is(tok::identifier) && P.Tok.getText() == "adjoint") {
+    P.consumeToken();
+    if (parseFnName(AdjName)) return true;
+  }
   // Parse ']'.
   if (P.parseToken(tok::r_square,
                    diag::sil_attr_differentiable_expected_rsquare))

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -128,7 +128,7 @@ SILFunctionType::getGradientType(
     case ResultConvention::UnownedInnerPointer:
       seedConv = ParameterConvention::Indirect_In_Guaranteed; break;
     }
-    gradParams.push_back({ originalSourceResultTy, seedConv });
+    gradParams.push_back({originalSourceResultTy, seedConv});
   }
   // If no differentiation parameters are specified, differentiation is with
   // respect to all of original's parameters. For simplicity, we add all

--- a/test/AutoDiff/builtin_math.sil
+++ b/test/AutoDiff/builtin_math.sil
@@ -51,8 +51,6 @@ bb0(%0 : @trivial $Builtin.FPIEEE32):
   %simple_mul = function_ref @simple_mul : $@convention(thin) (Builtin.FPIEEE32, Builtin.FPIEEE32) -> Builtin.FPIEEE32
   %simple_mul_grad = gradient [source 0] [wrt 0, 1] %simple_mul : $@convention(thin) (Builtin.FPIEEE32, Builtin.FPIEEE32) -> Builtin.FPIEEE32
 
-  // FIXME(SR-8584): Uncomment this test when the crasher gets fixed.
-  //
   %simple_div = function_ref @simple_div : $@convention(thin) (Builtin.FPIEEE32, Builtin.FPIEEE32) -> Builtin.FPIEEE32
   %simple_div_grad = gradient [source 0] [wrt 0, 1] %simple_div : $@convention(thin) (Builtin.FPIEEE32, Builtin.FPIEEE32) -> Builtin.FPIEEE32
 

--- a/test/AutoDiff/nested_calls.sil
+++ b/test/AutoDiff/nested_calls.sil
@@ -5,24 +5,24 @@ import Swift
 
 sil_stage raw
 
-sil hidden @foo_prim : $@convention(thin) (Float) -> (Float, Float) {
+sil @foo_prim : $@convention(thin) (Float) -> (Float, Float) {
 bb0(%0 : @trivial $Float):
   %1 = tuple (%0 : $Float, %0 : $Float)
   return %1 : $(Float, Float)
 }
 
-sil hidden @foo_adj : $@convention(thin) (Float, Float, Float, Float) -> Float {
+sil @foo_adj : $@convention(thin) (Float, Float, Float, Float) -> Float {
 bb0(%0 : @trivial $Float, %1 : @trivial $Float, %2 : @trivial $Float, %3 : @trivial $Float):
   return %3 : $Float
 }
 
-sil hidden [reverse_differentiable source 0 wrt 0 primal @foo_prim adjoint @foo_adj] @foo : $@convention(thin) (Float) -> Float {
+sil [reverse_differentiable source 0 wrt 0 primal @foo_prim adjoint @foo_adj] @foo : $@convention(thin) (Float) -> Float {
 bb0(%0 : @trivial $Float):
   return %0 : $Float
 }
 
 // Nested function being called by `@func_to_diff`.
-sil hidden @nested_func_without_diffattr : $@convention(thin) (Float) -> Float {
+sil @nested_func_without_diffattr : $@convention(thin) (Float) -> Float {
 bb0(%0 : @trivial $Float):
   %1 = function_ref @foo : $@convention(thin) (Float) -> Float
   %2 = apply %1(%0) : $@convention(thin) (Float) -> Float
@@ -30,7 +30,7 @@ bb0(%0 : @trivial $Float):
 }
 
 // Main function to differentiate.
-sil hidden [reverse_differentiable source 0 wrt 0] @func_to_diff : $@convention(thin) (Float) -> Float {
+sil [reverse_differentiable source 0 wrt 0] @func_to_diff : $@convention(thin) (Float) -> Float {
 bb0(%0 : @trivial $Float):
   %1 = function_ref @nested_func_without_diffattr : $@convention(thin) (Float) -> Float
   %2 = apply %1(%0) : $@convention(thin) (Float) -> Float
@@ -42,13 +42,29 @@ bb0(%0 : @trivial $Float):
 }
 
 // CHECK-LABEL: struct func_to_diff__Type {
-// CHECK:   @sil_stored var pv_0: nested_func_without_diffattr__Type
-// CHECK:   @sil_stored var v_0: Float
-// CHECK: }
+// CHECK-NEXT:   @sil_stored var pv_0: nested_func_without_diffattr__Type
+// CHECK-NEXT:   @sil_stored var v_0: Float
+// CHECK-NEXT: }
 
 // CHECK-LABEL: struct nested_func_without_diffattr__Type {
-// CHECK:   @sil_stored var pv_0: Float
-// CHECK:   @sil_stored var v_0: Float
+// CHECK-NEXT:   @sil_stored var pv_0: Float
+// CHECK-NEXT:   @sil_stored var v_0: Float
+// CHECK-NEXT: }
+
+// CHECK-LABEL: @foo_prim : $@convention(thin) (Float) -> (Float, Float) {
+// CHECK: bb0(%0 : $Float):
+// CHECK:   %1 = tuple (%0 : $Float, %0 : $Float)
+// CHECK:   return %1 : $(Float, Float)
+// CHECK: }
+
+// CHECK-LABEL: @foo_adj : $@convention(thin) (Float, Float, Float, Float) -> Float {
+// CHECK: bb0(%0 : $Float, %1 : $Float, %2 : $Float, %3 : $Float):
+// CHECK:   return %3 : $Float
+// CHECK: }
+
+// CHECK-LABEL: [reverse_differentiable source 0 wrt 0 primal @foo_prim adjoint @foo_adj] @foo : $@convention(thin) (Float) -> Float {
+// CHECK: bb0(%0 : $Float):
+// CHECK:   return %0 : $Float
 // CHECK: }
 
 // CHECK-LABEL: [reverse_differentiable source 0 wrt 0 primal @nested_func_without_diffattr__primal_src_0_wrt_0 adjoint @nested_func_without_diffattr__adjoint_src_0_wrt_0] @nested_func_without_diffattr : $@convention(thin) (Float) -> Float {

--- a/test/AutoDiff/nested_calls.sil
+++ b/test/AutoDiff/nested_calls.sil
@@ -1,0 +1,87 @@
+// RUN: %target-swift-frontend -emit-sil -O %s | %FileCheck %s
+
+import Builtin
+import Swift
+
+sil_stage raw
+
+sil hidden @foo_prim : $@convention(thin) (Float) -> (Float, Float) {
+bb0(%0 : @trivial $Float):
+  %1 = tuple (%0 : $Float, %0 : $Float)
+  return %1 : $(Float, Float)
+}
+
+sil hidden @foo_adj : $@convention(thin) (Float, Float, Float, Float) -> Float {
+bb0(%0 : @trivial $Float, %1 : @trivial $Float, %2 : @trivial $Float, %3 : @trivial $Float):
+  return %3 : $Float
+}
+
+sil hidden [reverse_differentiable source 0 wrt 0 primal @foo_prim adjoint @foo_adj] @foo : $@convention(thin) (Float) -> Float {
+bb0(%0 : @trivial $Float):
+  return %0 : $Float
+}
+
+// Nested function being called by `@func_to_diff`.
+sil hidden @nested_func_without_diffattr : $@convention(thin) (Float) -> Float {
+bb0(%0 : @trivial $Float):
+  %1 = function_ref @foo : $@convention(thin) (Float) -> Float
+  %2 = apply %1(%0) : $@convention(thin) (Float) -> Float
+  return %2 : $Float
+}
+
+// Main function to differentiate.
+sil hidden [reverse_differentiable source 0 wrt 0] @func_to_diff : $@convention(thin) (Float) -> Float {
+bb0(%0 : @trivial $Float):
+  %1 = function_ref @nested_func_without_diffattr : $@convention(thin) (Float) -> Float
+  %2 = apply %1(%0) : $@convention(thin) (Float) -> Float
+  %3 = function_ref @nested_func_without_diffattr : $@convention(thin) (Float) -> Float
+  %4 = apply %3(%2) : $@convention(thin) (Float) -> Float
+  %5 = tuple (%2 : $Float, %2 : $Float)
+  %6 = tuple_extract %5 : $(Float, Float), 0
+  return %6 : $Float
+}
+
+// CHECK-LABEL: struct func_to_diff__Type {
+// CHECK:   @sil_stored var pv_0: nested_func_without_diffattr__Type
+// CHECK:   @sil_stored var v_0: Float
+// CHECK: }
+
+// CHECK-LABEL: struct nested_func_without_diffattr__Type {
+// CHECK:   @sil_stored var pv_0: Float
+// CHECK:   @sil_stored var v_0: Float
+// CHECK: }
+
+// CHECK-LABEL: [reverse_differentiable source 0 wrt 0 primal @nested_func_without_diffattr__primal_src_0_wrt_0 adjoint @nested_func_without_diffattr__adjoint_src_0_wrt_0] @nested_func_without_diffattr : $@convention(thin) (Float) -> Float {
+// CHECK: bb0(%0 : $Float):
+// CHECK:   return %0 : $Float
+// CHECK: }
+
+// CHECK-LABEL: [reverse_differentiable source 0 wrt 0 primal @func_to_diff__primal_src_0_wrt_0 adjoint @func_to_diff__adjoint_src_0_wrt_0] @func_to_diff : $@convention(thin) (Float) -> Float {
+// CHECK: bb0(%0 : $Float):
+// CHECK:   return %0 : $Float
+// CHECK: }
+
+// CHECK-LABEL: @func_to_diff__primal_src_0_wrt_0 : $@convention(thin) (Float) -> (@owned func_to_diff__Type, Float) {
+// CHECK: bb0(%0 : $Float):
+// CHECK:   %1 = struct $nested_func_without_diffattr__Type (%0 : $Float, %0 : $Float)
+// CHECK:   %2 = struct $func_to_diff__Type (%1 : $nested_func_without_diffattr__Type, %0 : $Float)
+// CHECK:   %3 = tuple (%2 : $func_to_diff__Type, %0 : $Float)
+// CHECK:   return %3 : $(func_to_diff__Type, Float)
+// CHECK: }
+
+// CHECK-LABEL: @nested_func_without_diffattr__primal_src_0_wrt_0 : $@convention(thin) (Float) -> (@owned nested_func_without_diffattr__Type, Float) {
+// CHECK: bb0(%0 : $Float):
+// CHECK:   %1 = struct $nested_func_without_diffattr__Type (%0 : $Float, %0 : $Float)
+// CHECK:   %2 = tuple (%1 : $nested_func_without_diffattr__Type, %0 : $Float)
+// CHECK:   return %2 : $(nested_func_without_diffattr__Type, Float)
+// CHECK: }
+
+// CHECK-LABEL: @func_to_diff__adjoint_src_0_wrt_0 : $@convention(thin) (Float, func_to_diff__Type, Float, Float) -> Float {
+// CHECK: bb0(%0 : $Float, %1 : $func_to_diff__Type, %2 : $Float, %3 : $Float):
+// CHECK:   return %3 : $Float
+// CHECK: }
+
+// CHECK-LABEL: @nested_func_without_diffattr__adjoint_src_0_wrt_0 : $@convention(thin) (Float, nested_func_without_diffattr__Type, Float, Float) -> Float {
+// CHECK: bb0(%0 : $Float, %1 : $nested_func_without_diffattr__Type, %2 : $Float, %3 : $Float):
+// CHECK:   return %3 : $Float
+// CHECK: }

--- a/test/AutoDiff/simple_math.swift
+++ b/test/AutoDiff/simple_math.swift
@@ -10,20 +10,6 @@ import Glibc
 
 var SimpleMathTests = TestSuite("SimpleMath")
 
-struct Vector : Equatable {
-  var x: Float
-  var y: Float
-
-  init(_ x: Float, _ y: Float) { self.x = x; self.y = y }
-  @differentiable(reverse, adjoint: dAdd)
-  static func + (lhs: Vector, rhs: Vector) -> Vector {
-    return Vector(lhs.x + rhs.x, lhs.y + rhs.y)
-  }
-  static func dAdd(lhs: Vector, rhs: Vector, _: Vector, seed: Vector) -> (Vector, Vector) {
-    return (seed, seed)
-  }
-}
-
 SimpleMathTests.test("Arithmetics") {
   let dfoo1 = #gradient({ (x: Float, y: Float) -> Float in
     return x * y
@@ -52,20 +38,6 @@ SimpleMathTests.test("Fanout") {
     x + x + x * y * sin(1.0)
   })
   expectEqual((3.682942, 2.5244129), dfoo3(3, 2))
-}
-
-SimpleMathTests.test("Aggregates") {
-  let grad0 = #gradient({ (x: Vector, y: Vector) -> Vector in
-    return x
-  })
-  expectEqual((Vector(1, 1), Vector(0, 0)),
-              grad0(Vector(1, 2), Vector(10, 20)))
-
-  let grad1 = #gradient({ (x: Vector, y: Vector) -> Vector in
-    return x + y
-  })
-  expectEqual((Vector(1, 1), Vector(0, 0)),
-              grad1(Vector(1, 2), Vector(10, 20)))
 }
 
 SimpleMathTests.test("FunctionCall") {

--- a/test/AutoDiff/simple_math.swift
+++ b/test/AutoDiff/simple_math.swift
@@ -10,6 +10,20 @@ import Glibc
 
 var SimpleMathTests = TestSuite("SimpleMath")
 
+struct Vector : Equatable {
+  var x: Float
+  var y: Float
+
+  init(_ x: Float, _ y: Float) { self.x = x; self.y = y }
+  @differentiable(reverse, adjoint: dAdd)
+  static func + (lhs: Vector, rhs: Vector) -> Vector {
+    return Vector(lhs.x + rhs.x, lhs.y + rhs.y)
+  }
+  static func dAdd(lhs: Vector, rhs: Vector, _: Vector, seed: Vector) -> (Vector, Vector) {
+    return (seed, seed)
+  }
+}
+
 SimpleMathTests.test("Arithmetics") {
   let dfoo1 = #gradient({ (x: Float, y: Float) -> Float in
     return x * y
@@ -38,6 +52,20 @@ SimpleMathTests.test("Fanout") {
     x + x + x * y * sin(1.0)
   })
   expectEqual((3.682942, 2.5244129), dfoo3(3, 2))
+}
+
+SimpleMathTests.test("Aggregates") {
+  let grad0 = #gradient({ (x: Vector, y: Vector) -> Vector in
+    return x
+  })
+  expectEqual((Vector(1, 1), Vector(0, 0)),
+              grad0(Vector(1, 2), Vector(10, 20)))
+
+  let grad1 = #gradient({ (x: Vector, y: Vector) -> Vector in
+    return x + y
+  })
+  expectEqual((Vector(1, 1), Vector(0, 0)),
+              grad1(Vector(1, 2), Vector(10, 20)))
 }
 
 SimpleMathTests.test("FunctionCall") {


### PR DESCRIPTION
1. Fix various bugs in nested differentiation. Add a nested call test.
2. Allow differentiation of a function to be triggered by a `[reverse_differentiable source ... wrt ...]` attribute in SIL without any differential operators. This is useful for testing only primal synthesis and adjoint synthesis.
3.  Clean up and add more debug messages.
4. Address some code review comments from #18977.