### PR TITLE
[ConstraintSystem] NFC: Move `isExplicitConversion` to `Constraint`

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -2066,7 +2066,7 @@ bool ConstraintSystem::solveForDisjunction(
 
   auto noSolutions = solveForDisjunctionChoices(
       disjunction->getNestedConstraints(), locator, solutions,
-      allowFreeTypeVariables, isExplicitConversionConstraint(disjunction));
+      allowFreeTypeVariables, disjunction->isExplicitConversion());
 
   if (hasDisabledChoices) {
     // Re-enable previously disabled overload choices.

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -536,6 +536,17 @@ static void uniqueTypeVariables(SmallVectorImpl<TypeVariableType *> &typeVars) {
                  typeVars.end());
 }
 
+bool Constraint::isExplicitConversion() const {
+  assert(Kind == ConstraintKind::Disjunction);
+
+  if (auto *locator = getLocator()) {
+    if (auto anchor = locator->getAnchor())
+      return isa<CoerceExpr>(anchor);
+  }
+
+  return false;
+}
+
 Constraint *Constraint::create(ConstraintSystem &cs, ConstraintKind kind, 
                                Type first, Type second,
                                ConstraintLocator *locator) {

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -583,6 +583,10 @@ public:
     return count;
   }
 
+  /// Determine if this constraint represents explicit conversion,
+  /// e.g. coercion constraint "as X" which forms a disjunction.
+  bool isExplicitConversion() const;
+
   /// Retrieve the overload choice for an overload-binding constraint.
   OverloadChoice getOverloadChoice() const {
     assert(Kind == ConstraintKind::BindOverload);

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2108,20 +2108,6 @@ public:
   Type getResultType(const AbstractClosureExpr *E);
 
 private:
-  /// Determine if the given constraint represents explicit conversion,
-  /// e.g. coercion constraint "as X" which forms a disjunction.
-  bool isExplicitConversionConstraint(Constraint *constraint) const {
-    if (constraint->getKind() != ConstraintKind::Disjunction)
-      return false;
-
-    if (auto locator = constraint->getLocator()) {
-      if (auto anchor = locator->getAnchor())
-        return isa<CoerceExpr>(anchor);
-    }
-
-    return false;
-  }
-
   /// Introduce the constraints associated with the given type variable
   /// into the worklist.
   void addTypeVariableConstraintsToWorkList(TypeVariableType *typeVar);


### PR DESCRIPTION
Since this logic is tightly coupled to constraint, it makes sense
to move just there, also it's easier to re-use it elsewhere since
it doesn't have to be `private` anymore.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
