### PR TITLE
[Parse] refactor get/set block parsing

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -379,25 +379,14 @@ public:
 
   void restoreParserPosition(ParserPosition PP, bool enableDiagnostics = false) {
     L->restoreState(PP.LS, enableDiagnostics);
-
-    // We might be at tok::eof now, so ensure that consumeToken() does not
-    // assert about lexing past eof.
-    Tok.setKind(tok::unknown);
-    consumeTokenWithoutFeedingReceiver();
-
+    L->lex(Tok, LeadingTrivia, TrailingTrivia);
     PreviousLoc = PP.PreviousLoc;
   }
 
   void backtrackToPosition(ParserPosition PP) {
     assert(PP.isValid());
-
     L->backtrackToState(PP.LS);
-
-    // We might be at tok::eof now, so ensure that consumeToken() does not
-    // assert about lexing past eof.
-    Tok.setKind(tok::unknown);
-    consumeTokenWithoutFeedingReceiver();
-
+    L->lex(Tok, LeadingTrivia, TrailingTrivia);
     PreviousLoc = PP.PreviousLoc;
   }
 
@@ -895,8 +884,6 @@ public:
                SourceLoc TryLoc);
 
   void consumeGetSetBody(AbstractFunctionDecl *AFD, SourceLoc LBLoc);
-
-  void parseAccessorAttributes(DeclAttributes &Attributes);
 
   struct ParsedAccessors;
   bool parseGetSetImpl(ParseDeclOptions Flags,

--- a/include/swift/Parse/PersistentParserState.h
+++ b/include/swift/Parse/PersistentParserState.h
@@ -52,23 +52,6 @@ public:
     {}
   };
 
-  class AccessorBodyState {
-    ParserPos BodyPos;
-    SavedScope Scope;
-    SourceLoc LBLoc;
-    friend class Parser;
-
-    SavedScope takeScope() {
-      return std::move(Scope);
-    }
-
-  public:
-    AccessorBodyState(SourceRange BodyRange, SourceLoc PreviousLoc,
-                      SavedScope &&Scope, SourceLoc LBLoc)
-        : BodyPos{BodyRange.Start, PreviousLoc}, Scope(std::move(Scope)),
-          LBLoc(LBLoc) {}
-  };
-
   enum class DelayedDeclKind {
     TopLevelCodeDecl,
     Decl,
@@ -109,11 +92,6 @@ private:
                      std::unique_ptr<FunctionBodyState>>;
   DelayedFunctionBodiesTy DelayedFunctionBodies;
 
-  using DelayedAccessorBodiesTy =
-      llvm::DenseMap<AbstractFunctionDecl *,
-                     std::unique_ptr<AccessorBodyState>>;
-  DelayedAccessorBodiesTy DelayedAccessorBodies;
-
   /// \brief Parser sets this if it stopped parsing before the buffer ended.
   ParserPosition MarkedPos;
 
@@ -132,13 +110,6 @@ public:
   takeFunctionBodyState(AbstractFunctionDecl *AFD);
 
   bool hasFunctionBodyState(AbstractFunctionDecl *AFD);
-
-  void delayAccessorBodyParsing(AbstractFunctionDecl *AFD,
-                                SourceRange BodyRange,
-                                SourceLoc PreviousLoc,
-                                SourceLoc LBLoc);
-  std::unique_ptr<AccessorBodyState>
-  takeAccessorBodyState(AbstractFunctionDecl *AFD);
 
   void delayDecl(DelayedDeclKind Kind, unsigned Flags,
                  DeclContext *ParentContext,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3989,23 +3989,6 @@ static void diagnoseRedundantAccessors(Parser &P, SourceLoc loc,
              /*already*/ true);
 }
 
-void Parser::parseAccessorAttributes(DeclAttributes &Attributes) {
-  bool FoundCCToken;
-  parseDeclAttributeList(Attributes, FoundCCToken);
-  SyntaxParsingContext ModifierCtx(SyntaxContext, SyntaxKind::DeclModifier);
-  // Parse the contextual keywords for 'mutating' and 'nonmutating' before
-  // get and set.
-  if (Tok.isContextualKeyword("mutating")) {
-    parseNewDeclAttribute(Attributes, /*AtLoc*/ {}, DAK_Mutating);
-  } else if (Tok.isContextualKeyword("nonmutating")) {
-    parseNewDeclAttribute(Attributes, /*AtLoc*/ {}, DAK_NonMutating);
-  } else if (Tok.isContextualKeyword("__consuming")) {
-    parseNewDeclAttribute(Attributes, /*AtLoc*/ {}, DAK_Consuming);
-  } else {
-    ModifierCtx.setTransparent();
-  }
-}
-
 static bool isAllowedInLimitedSyntax(AccessorKind kind) {
   switch (kind) {
   case AccessorKind::Get:
@@ -4065,16 +4048,59 @@ struct Parser::ParsedAccessors {
   }
 };
 
-/// \brief Parse a get-set clause, optionally containing a getter, setter,
-/// willSet, and/or didSet clauses.  'Indices' is a paren or tuple pattern,
-/// specifying the index list for a subscript.
-bool Parser::parseGetSetImpl(ParseDeclOptions Flags,
-                             GenericParamList *GenericParams,
-                             ParameterList *Indices,
-                             TypeLoc ElementTy, ParsedAccessors &accessors,
-                             AbstractStorageDecl *storage,
-                             SourceLoc &LastValidLoc, SourceLoc StaticLoc,
-                             SourceLoc VarLBLoc) {
+static bool parseAccessorIntroducer(Parser &P, bool parsingLimitedSyntax,
+                                    DeclAttributes &Attributes, AccessorKind &Kind,
+                                    AddressorKind &addressorKind, SourceLoc &Loc) {
+  bool FoundCCToken;
+  P.parseDeclAttributeList(Attributes, FoundCCToken);
+
+  // Parse the contextual keywords for 'mutating' and 'nonmutating' before
+  // get and set.
+  {
+    SyntaxParsingContext ModifierCtx(P.SyntaxContext, SyntaxKind::DeclModifier);
+
+    if (P.Tok.isContextualKeyword("mutating")) {
+      P.parseNewDeclAttribute(Attributes, /*AtLoc*/ {}, DAK_Mutating);
+    } else if (P.Tok.isContextualKeyword("nonmutating")) {
+      P.parseNewDeclAttribute(Attributes, /*AtLoc*/ {}, DAK_NonMutating);
+    } else if (P.Tok.isContextualKeyword("__consuming")) {
+      P.parseNewDeclAttribute(Attributes, /*AtLoc*/ {}, DAK_Consuming);
+    } else {
+      ModifierCtx.setTransparent();
+    }
+  }
+
+  if (!P.Tok.is(tok::identifier) || P.Tok.isEscapedIdentifier()) {
+    return true;
+  }
+#define SUPPRESS_ARTIFICIAL_ACCESSORS 1
+#define ACCESSOR_KEYWORD(KEYWORD)
+#define SINGLETON_ACCESSOR(ID, KEYWORD)                                        \
+  else if (P.Tok.getRawText() == #KEYWORD) {                                   \
+    Kind = AccessorKind::ID;                                                   \
+  }
+#define ANY_ADDRESSOR(ID, ADDRESSOR_ID, KEYWORD)                               \
+  else if (P.Tok.getRawText() == #KEYWORD) {                                   \
+    Kind = AccessorKind::ID;                                                   \
+    addressorKind = AddressorKind::ADDRESSOR_ID;                               \
+  }
+#include "swift/AST/AccessorKinds.def"
+  else {
+    return true;
+  }
+  P.Tok.setKind(tok::contextual_keyword);
+  Loc = P.consumeToken();
+  return false;
+}
+
+bool Parser::parseGetSet(ParseDeclOptions Flags,
+                         GenericParamList *GenericParams,
+                         ParameterList *Indices,
+                         TypeLoc ElementTy, ParsedAccessors &accessors,
+                         AbstractStorageDecl *storage,
+                         SourceLoc StaticLoc) {
+  assert(Tok.is(tok::l_brace));
+
   // Properties in protocols use a very limited syntax.
   // SIL mode and textual interfaces use the same syntax.
   // Otherwise, we have a normal var or subscript declaration and we need
@@ -4094,97 +4120,86 @@ bool Parser::parseGetSetImpl(ParseDeclOptions Flags,
     }
   }
 
-  // If the body is completely empty, preserve it.  This is at best a getter with
+  SyntaxParsingContext AccessorListCtx(SyntaxContext,
+                                       SyntaxKind::AccessorBlock);
+
+  // If the body is completely empty, preserve it. This is at best a getter with
   // an implicit fallthrough off the end.
-  if (Tok.is(tok::r_brace)) {
-    // Give syntax node an empty statement list.
-    SyntaxParsingContext StmtListContext(SyntaxContext,
-                                         SyntaxKind::CodeBlockItemList);
+  if (peekToken().is(tok::r_brace)) {
+    accessors.LBLoc = consumeToken(tok::l_brace);
+    // Give syntax node an empty accessor list.
+    if (SyntaxContext->isEnabled())
+      SyntaxContext->addSyntax(
+          SyntaxFactory::makeBlankAccessorList(SyntaxContext->getArena()));
+    accessors.RBLoc = consumeToken(tok::r_brace);
 
     // In the limited syntax, fall out and let the caller handle it.
     if (parsingLimitedSyntax)
       return false;
 
-    diagnose(Tok, diag::computed_property_no_accessors, /*subscript*/Indices != nullptr);
+    diagnose(accessors.RBLoc, diag::computed_property_no_accessors,
+             /*subscript*/ Indices != nullptr);
     return true;
   }
 
+  auto parseImplicitGetter = [&]() -> bool {
+    assert(Tok.is(tok::l_brace));
+    accessors.LBLoc = Tok.getLoc();
+    auto getter =
+        createAccessorFunc(Tok.getLoc(), /*ValueNamePattern*/ nullptr,
+                           GenericParams, Indices, ElementTy, StaticLoc, Flags,
+                           AccessorKind::Get, AddressorKind::NotAddressor,
+                           storage, this, /*AccessorKeywordLoc*/ SourceLoc());
+    accessors.add(getter);
+    parseAbstractFunctionBody(getter);
+    accessors.RBLoc = getter->getEndLoc();
+    return false;
+  };
+
+  // Prepare backtracking for implicit getter.
+  Optional<BacktrackingScope> backtrack;
+  backtrack.emplace(*this);
+
+  bool Invalid = false;
   bool IsFirstAccessor = true;
-  while (Tok.isNot(tok::r_brace)) {
-    if (Tok.is(tok::eof))
-      return true;
-    SyntaxParsingContext AccessorCtx(SyntaxContext, SyntaxKind::AccessorDecl);
-    // If there are any attributes, we are going to parse them.  Because these
-    // attributes might not be appertaining to the accessor, but to the first
-    // declaration inside the implicit getter, we need to save the parser
-    // position and restore it later.
-    llvm::Optional<SyntaxParsingContext> BacktrackCtxt;
-    ParserPosition BeginParserPosition;
-    if (!parsingLimitedSyntax && Tok.is(tok::at_sign)) {
-      BeginParserPosition = getParserPosition();
-      BacktrackCtxt.emplace(SyntaxContext);
-      BacktrackCtxt->setTransparent();
-    }
+  accessors.LBLoc = consumeToken(tok::l_brace);
+  while (!Tok.isAny(tok::r_brace, tok::eof)) {
+    Optional<SyntaxParsingContext> AccessorCtx;
+    AccessorCtx.emplace(SyntaxContext, SyntaxKind::AccessorDecl);
 
-    // Parse any leading attributes.
+    // Parse introducer if possible.
     DeclAttributes Attributes;
-    parseAccessorAttributes(Attributes);
-
-    bool isImplicitGet = false;
-    AccessorKind Kind;
+    AccessorKind Kind = AccessorKind::Get;
     AddressorKind addressorKind = AddressorKind::NotAddressor;
-    SourceLoc AccessorKeywordLoc = Tok.getLoc();
-    if (false) {}
-#define SUPPRESS_ARTIFICIAL_ACCESSORS 1
-#define ACCESSOR_KEYWORD(KEYWORD)
-#define SINGLETON_ACCESSOR(ID, KEYWORD)               \
-    else if (Tok.isContextualKeyword(#KEYWORD)) {     \
-      Kind = AccessorKind::ID;                        \
-    }
-#define ANY_ADDRESSOR(ID, ADDRESSOR_ID, KEYWORD)      \
-    else if (Tok.isContextualKeyword(#KEYWORD)) {     \
-      Kind = AccessorKind::ID;                        \
-      addressorKind = AddressorKind::ADDRESSOR_ID;    \
-    }
-#include "swift/AST/AccessorKinds.def"
-    else if (parsingLimitedSyntax) {
-      AccessorCtx.setTransparent();
-      AccessorKeywordLoc = SourceLoc();
-      diagnose(Tok, diag::expected_getset_in_protocol);
-      return true;
-    } else {
-      AccessorKeywordLoc = SourceLoc();
-      // This is an implicit getter.  Might be not valid in this position,
-      // though.  Anyway, go back to the beginning of the getter code to ensure
-      // that the diagnostics point to correct tokens.
-      if (BeginParserPosition.isValid()) {
-        backtrackToPosition(BeginParserPosition);
-        BacktrackCtxt->setBackTracking();
-        BacktrackCtxt.reset();
-        Attributes = DeclAttributes();
+    SourceLoc Loc;
+    bool NotAccessor = parseAccessorIntroducer(
+        *this, parsingLimitedSyntax, Attributes, Kind, addressorKind, Loc);
+    if (NotAccessor) {
+      AccessorCtx->setTransparent();
+      AccessorCtx.reset();
+
+      // parsingLimitedSyntax mode cannot have a body.
+      if (parsingLimitedSyntax) {
+        diagnose(Tok, diag::expected_getset_in_protocol);
+        Invalid = true;
+        break;
       }
+
+      // Cannot have an implicit getter after other accessor.
       if (!IsFirstAccessor) {
-        // Cannot have an implicit getter after other accessor.
         diagnose(Tok, diag::expected_accessor_kw);
         skipUntil(tok::r_brace);
         // Don't signal an error since we recovered.
-        return false;
+        break;
       }
-      Kind = AccessorKind::Get;
-      isImplicitGet = true;
-    }
-    if (BacktrackCtxt)
-      BacktrackCtxt.reset();
 
-    // Set the contextual keyword kind properly.
-    if (AccessorKeywordLoc.isValid()) {
-      Tok.setKind(tok::contextual_keyword);
+      // This is an implicit getter. Cancel accessor contexts, backtrack to '{'
+      // position.
+      backtrack.reset();
+      AccessorListCtx.setTransparent();
+      return parseImplicitGetter();
     }
-
     IsFirstAccessor = false;
-
-    // Consume the contextual keyword, if present.
-    SourceLoc Loc = isImplicitGet ? VarLBLoc : consumeToken();
 
     // For now, immediately reject illegal accessors in protocols just to
     // avoid having to deal with them everywhere.
@@ -4204,10 +4219,9 @@ bool Parser::parseGetSetImpl(ParseDeclOptions Flags,
         parseOptionalAccessorArgument(Loc, *this, Kind, ElementTy);
 
     // Set up a function declaration.
-    auto accessor = createAccessorFunc(Loc, ValueNamePattern,
-                                       GenericParams, Indices, ElementTy,
-                                       StaticLoc, Flags, Kind, addressorKind,
-                                       storage, this, AccessorKeywordLoc);
+    auto accessor = createAccessorFunc(Loc, ValueNamePattern, GenericParams,
+                                       Indices, ElementTy, StaticLoc, Flags,
+                                       Kind, addressorKind, storage, this, Loc);
     accessor->getAttrs() = Attributes;
 
     // Collect this accessor and detect conflicts.
@@ -4218,95 +4232,27 @@ bool Parser::parseGetSetImpl(ParseDeclOptions Flags,
     }
 
     // There's no body in the limited syntax.
-    if (parsingLimitedSyntax) {
-      LastValidLoc = Loc;
+    if (parsingLimitedSyntax)
       continue;
-    }
-
-    // Set up the syntax nodes for parsing the accessor body.
-    SyntaxParsingContext BlockCtx(SyntaxContext, SyntaxKind::CodeBlock);
-    if (AccessorKeywordLoc.isInvalid()) {
-      // If the keyword is absent, we shouldn't make these sub-nodes.
-      BlockCtx.setTransparent();
-      AccessorCtx.setTransparent();
-    }
-
-    SourceLoc LBLoc = isImplicitGet ? VarLBLoc : Tok.getLoc();
 
     // It's okay not to have a body if there's an external asm name.
-    if (!isImplicitGet && !consumeIf(tok::l_brace)) {
+    if (!Tok.is(tok::l_brace)) {
       // _silgen_name'd accessors don't need bodies.
       if (!Attributes.hasAttribute<SILGenNameAttr>()) {
         diagnose(Tok, diag::expected_lbrace_accessor,
                  getAccessorNameForDiagnostic(accessor, /*article*/ false));
-        return true;
+        Invalid = true;
+        break;
       }
-      BlockCtx.setTransparent();
-      LastValidLoc = Loc;
       continue;
     }
 
-    // Parse the body.
-    Scope S(this, ScopeKind::FunctionBody);
-    if (auto *P = accessor->getImplicitSelfDecl())
-      addToScope(P);
-    addParametersToScope(accessor->getParameters());
-
-    if (accessor->isGeneric())
-      for (auto *GP : accessor->getGenericParams()->getParams())
-        addToScope(GP);
-
-    // Establish the new context.
-    ParseFunctionBody CC(*this, accessor);
-    setLocalDiscriminatorToParamList(accessor->getParameters());
-
-    // Parse the body.
-    SmallVector<ASTNode, 16> Entries;
-    {
-      llvm::SaveAndRestore<bool> T(IsParsingInterfaceTokens, false);
-      if (!isDelayedParsingEnabled()) {
-        if (Context.Stats)
-          Context.Stats->getFrontendCounters().NumFunctionsParsed++;
-
-        parseBraceItems(Entries);
-      } else {
-        consumeGetSetBody(accessor, LBLoc);
-      }
-    }
-
-    SourceLoc RBLoc;
-    if (!isImplicitGet) {
-      parseMatchingToken(tok::r_brace, RBLoc, diag::expected_rbrace_in_getset,
-                         LBLoc);
-    } else {
-      RBLoc = Tok.is(tok::r_brace) ? Tok.getLoc() : PreviousLoc;
-    }
-
-    if (!isDelayedParsingEnabled()) {
-      BraceStmt *Body = BraceStmt::create(Context, LBLoc, Entries, RBLoc);
-      accessor->setBody(Body);
-    }
-    LastValidLoc = RBLoc;
+    parseAbstractFunctionBody(accessor);
   }
-
-  return false;
-}
-
-bool Parser::parseGetSet(ParseDeclOptions Flags,
-                         GenericParamList *GenericParams,
-                         ParameterList *Indices,
-                         TypeLoc ElementTy, ParsedAccessors &accessors,
-                         AbstractStorageDecl *storage,
-                         SourceLoc StaticLoc) {
-  SyntaxParsingContext AccessorsCtx(SyntaxContext, SyntaxKind::AccessorBlock);
-  accessors.LBLoc = consumeToken(tok::l_brace);
-  SourceLoc LastValidLoc = accessors.LBLoc;
-  bool Invalid = parseGetSetImpl(Flags, GenericParams, Indices, ElementTy,
-                                 accessors, storage, LastValidLoc, StaticLoc,
-                                 accessors.LBLoc);
-
+  backtrack->cancelBacktrack();
+  backtrack.reset();
   // Collect all explicit accessors to a list.
-  AccessorsCtx.collectNodesInPlace(SyntaxKind::AccessorList);
+  AccessorListCtx.collectNodesInPlace(SyntaxKind::AccessorList);
   // Parse the final '}'.
   if (Invalid)
     skipUntil(tok::r_brace);

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -146,12 +146,7 @@ private:
           CodeCompletionFactory->createCodeCompletionCallbacks(TheParser));
       TheParser.setCodeCompletionCallbacks(CodeCompletion.get());
     }
-    bool Parsed = false;
-    if (isa<AccessorDecl>(AFD)) {
-      TheParser.parseAccessorBodyDelayed(AFD);
-      Parsed = true;
-    }
-    if (!Parsed && ParserState.hasFunctionBodyState(AFD))
+    if (ParserState.hasFunctionBodyState(AFD))
       TheParser.parseAbstractFunctionBodyDelayed(AFD);
 
     if (CodeCompletion)

--- a/lib/Parse/PersistentParserState.cpp
+++ b/lib/Parse/PersistentParserState.cpp
@@ -45,28 +45,6 @@ bool PersistentParserState::hasFunctionBodyState(AbstractFunctionDecl *AFD) {
   return DelayedFunctionBodies.find(AFD) != DelayedFunctionBodies.end();
 }
 
-void PersistentParserState::delayAccessorBodyParsing(AbstractFunctionDecl *AFD,
-                                                     SourceRange BodyRange,
-                                                     SourceLoc PreviousLoc,
-                                                     SourceLoc LBLoc) {
-  std::unique_ptr<AccessorBodyState> State;
-  State.reset(new AccessorBodyState(BodyRange, PreviousLoc,
-                                    ScopeInfo.saveCurrentScope(), LBLoc));
-  assert(DelayedAccessorBodies.find(AFD) == DelayedAccessorBodies.end() &&
-         "Already recorded state for this body");
-  DelayedAccessorBodies[AFD] = std::move(State);
-}
-
-std::unique_ptr<PersistentParserState::AccessorBodyState>
-PersistentParserState::takeAccessorBodyState(AbstractFunctionDecl *AFD) {
-  assert(AFD->getBodyKind() == AbstractFunctionDecl::BodyKind::Unparsed);
-  DelayedAccessorBodiesTy::iterator I = DelayedAccessorBodies.find(AFD);
-  assert(I != DelayedAccessorBodies.end() && "State should be saved");
-  std::unique_ptr<AccessorBodyState> State = std::move(I->second);
-  DelayedAccessorBodies.erase(I);
-  return State;
-}
-
 void PersistentParserState::delayDecl(DelayedDeclKind Kind,
                                       unsigned Flags,
                                       DeclContext *ParentContext,

--- a/test/IDE/reconstruct_type_from_mangled_name.swift
+++ b/test/IDE/reconstruct_type_from_mangled_name.swift
@@ -317,8 +317,6 @@ struct HasGenericSubscript<T> {
       return t as! U
     }
 
-    // FIXME
-    // CHECK: dref: FAILURE	for 'U'
     // CHECK: decl: set {}	for '' usr=s:14swift_ide_test19HasGenericSubscriptVyqd__xcluis
     set {}
   }

--- a/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
@@ -107,12 +107,12 @@ class C <MemberDeclBlock>{<MemberDeclListItem><FunctionDecl>
   private </DeclModifier>deinit <CodeBlock>{}</CodeBlock></DeinitializerDecl></MemberDeclListItem><MemberDeclListItem><SubscriptDecl><DeclModifier>
 
   internal </DeclModifier>subscript<ParameterClause>(<FunctionParameter>x: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier></FunctionParameter>) </ParameterClause><ReturnClause>-> <SimpleTypeIdentifier>Int </SimpleTypeIdentifier></ReturnClause><AccessorBlock>{ <AccessorDecl>get <CodeBlock>{} </CodeBlock></AccessorDecl><AccessorDecl>set <CodeBlock>{} </CodeBlock></AccessorDecl>}</AccessorBlock></SubscriptDecl></MemberDeclListItem><MemberDeclListItem><SubscriptDecl>
-  subscript<ParameterClause>() </ParameterClause><ReturnClause>-> <SimpleTypeIdentifier>Int </SimpleTypeIdentifier></ReturnClause><AccessorBlock>{ <ReturnStmt>return <IntegerLiteralExpr>1 </IntegerLiteralExpr></ReturnStmt>}</AccessorBlock></SubscriptDecl></MemberDeclListItem><MemberDeclListItem><VariableDecl>
+  subscript<ParameterClause>() </ParameterClause><ReturnClause>-> <SimpleTypeIdentifier>Int </SimpleTypeIdentifier></ReturnClause><CodeBlock>{ <ReturnStmt>return <IntegerLiteralExpr>1 </IntegerLiteralExpr></ReturnStmt>}</CodeBlock></SubscriptDecl></MemberDeclListItem><MemberDeclListItem><VariableDecl>
 
-  var <PatternBinding><IdentifierPattern>x</IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier></TypeAnnotation><AccessorBlock>{<FunctionCallExpr><IdentifierExpr>
+  var <PatternBinding><IdentifierPattern>x</IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier></TypeAnnotation><CodeBlock>{<FunctionCallExpr><IdentifierExpr>
     address </IdentifierExpr><ClosureExpr>{ <FunctionCallExpr><IdentifierExpr>fatalError</IdentifierExpr>() </FunctionCallExpr>}</ClosureExpr></FunctionCallExpr><FunctionCallExpr><IdentifierExpr>
     unsafeMutableAddress </IdentifierExpr><ClosureExpr>{ <FunctionCallExpr><IdentifierExpr>fatalError</IdentifierExpr>() </FunctionCallExpr>}</ClosureExpr></FunctionCallExpr>
-  }</AccessorBlock></PatternBinding></VariableDecl></MemberDeclListItem>
+  }</CodeBlock></PatternBinding></VariableDecl></MemberDeclListItem>
 }</MemberDeclBlock></ClassDecl><ProtocolDecl>
 
 protocol PP <MemberDeclBlock>{<MemberDeclListItem><AssociatedtypeDecl>
@@ -290,9 +290,9 @@ class C <MemberDeclBlock>{<MemberDeclListItem><VariableDecl>
     @objc </Attribute>didSet <CodeBlock>{}</CodeBlock></AccessorDecl><AccessorDecl>
     willSet<AccessorParameter>(newValue)</AccessorParameter><CodeBlock>{ }</CodeBlock></AccessorDecl>
   }</AccessorBlock></PatternBinding></VariableDecl></MemberDeclListItem><MemberDeclListItem><VariableDecl>
-  var <PatternBinding><IdentifierPattern>a </IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier></TypeAnnotation><AccessorBlock>{<ReturnStmt>
+  var <PatternBinding><IdentifierPattern>a </IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier></TypeAnnotation><CodeBlock>{<ReturnStmt>
     return <IntegerLiteralExpr>3</IntegerLiteralExpr></ReturnStmt>
-  }</AccessorBlock></PatternBinding></VariableDecl></MemberDeclListItem>
+  }</CodeBlock></PatternBinding></VariableDecl></MemberDeclListItem>
 }</MemberDeclBlock></ClassDecl><ProtocolDecl>
 
 protocol P <MemberDeclBlock>{<MemberDeclListItem><VariableDecl>
@@ -302,7 +302,7 @@ protocol P <MemberDeclBlock>{<MemberDeclListItem><VariableDecl>
 
 private </DeclModifier><DeclModifier>final </DeclModifier>class D <MemberDeclBlock>{<MemberDeclListItem><VariableDecl><Attribute>
   @objc</Attribute><DeclModifier>
-  static </DeclModifier><DeclModifier>private </DeclModifier>var <PatternBinding><IdentifierPattern>a</IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier></TypeAnnotation><InitializerClause>= <IntegerLiteralExpr>3 </IntegerLiteralExpr></InitializerClause><AccessorBlock>{ <ReturnStmt>return <IntegerLiteralExpr>3 </IntegerLiteralExpr></ReturnStmt>}</AccessorBlock>, </PatternBinding><PatternBinding><IdentifierPattern>b</IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier></TypeAnnotation>, </PatternBinding><PatternBinding><IdentifierPattern>c </IdentifierPattern><InitializerClause>= <IntegerLiteralExpr>4</IntegerLiteralExpr></InitializerClause>, </PatternBinding><PatternBinding><IdentifierPattern>d </IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier></TypeAnnotation><AccessorBlock>{ <AccessorDecl>get <CodeBlock>{} </CodeBlock></AccessorDecl><AccessorDecl>get <CodeBlock>{}</CodeBlock></AccessorDecl>}</AccessorBlock>, </PatternBinding><PatternBinding><TuplePattern>(<TuplePatternElement><IdentifierPattern>a</IdentifierPattern>, </TuplePatternElement><TuplePatternElement><IdentifierPattern>b</IdentifierPattern></TuplePatternElement>)</TuplePattern><TypeAnnotation>: <TupleType>(<TupleTypeElement><SimpleTypeIdentifier>Int</SimpleTypeIdentifier>, </TupleTypeElement><TupleTypeElement><SimpleTypeIdentifier>Int</SimpleTypeIdentifier></TupleTypeElement>)</TupleType></TypeAnnotation></PatternBinding></VariableDecl></MemberDeclListItem><MemberDeclListItem><VariableDecl>
+  static </DeclModifier><DeclModifier>private </DeclModifier>var <PatternBinding><IdentifierPattern>a</IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier></TypeAnnotation><InitializerClause>= <IntegerLiteralExpr>3 </IntegerLiteralExpr></InitializerClause><CodeBlock>{ <ReturnStmt>return <IntegerLiteralExpr>3 </IntegerLiteralExpr></ReturnStmt>}</CodeBlock>, </PatternBinding><PatternBinding><IdentifierPattern>b</IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier></TypeAnnotation>, </PatternBinding><PatternBinding><IdentifierPattern>c </IdentifierPattern><InitializerClause>= <IntegerLiteralExpr>4</IntegerLiteralExpr></InitializerClause>, </PatternBinding><PatternBinding><IdentifierPattern>d </IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier></TypeAnnotation><AccessorBlock>{ <AccessorDecl>get <CodeBlock>{} </CodeBlock></AccessorDecl><AccessorDecl>get <CodeBlock>{}</CodeBlock></AccessorDecl>}</AccessorBlock>, </PatternBinding><PatternBinding><TuplePattern>(<TuplePatternElement><IdentifierPattern>a</IdentifierPattern>, </TuplePatternElement><TuplePatternElement><IdentifierPattern>b</IdentifierPattern></TuplePatternElement>)</TuplePattern><TypeAnnotation>: <TupleType>(<TupleTypeElement><SimpleTypeIdentifier>Int</SimpleTypeIdentifier>, </TupleTypeElement><TupleTypeElement><SimpleTypeIdentifier>Int</SimpleTypeIdentifier></TupleTypeElement>)</TupleType></TypeAnnotation></PatternBinding></VariableDecl></MemberDeclListItem><MemberDeclListItem><VariableDecl>
   let <PatternBinding><TuplePattern>(<TuplePatternElement><IdentifierPattern>a</IdentifierPattern>, </TuplePatternElement><TuplePatternElement><IdentifierPattern>b</IdentifierPattern></TuplePatternElement>) </TuplePattern><InitializerClause>= <TupleExpr>(<TupleElement><IntegerLiteralExpr>1</IntegerLiteralExpr>,</TupleElement><TupleElement><IntegerLiteralExpr>2</IntegerLiteralExpr></TupleElement>)</TupleExpr></InitializerClause>, </PatternBinding><PatternBinding><WildcardPattern>_ </WildcardPattern><InitializerClause>= <IntegerLiteralExpr>4 </IntegerLiteralExpr></InitializerClause><AccessorBlock>{}</AccessorBlock></PatternBinding></VariableDecl></MemberDeclListItem><MemberDeclListItem><FunctionDecl>
 
   func patternTests<FunctionSignature><ParameterClause>() </ParameterClause></FunctionSignature><CodeBlock>{<ForInStmt>
@@ -418,9 +418,9 @@ func statementTests<FunctionSignature><ParameterClause>() </ParameterClause></Fu
 // MARK: - ExtensionDecl
 
 extension <SimpleTypeIdentifier>ext </SimpleTypeIdentifier><MemberDeclBlock>{<MemberDeclListItem><VariableDecl>
-  var <PatternBinding><IdentifierPattern>s</IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier></TypeAnnotation><AccessorBlock>{<ReturnStmt>
+  var <PatternBinding><IdentifierPattern>s</IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier></TypeAnnotation><CodeBlock>{<ReturnStmt>
     return <IntegerLiteralExpr>42</IntegerLiteralExpr></ReturnStmt>
-  }</AccessorBlock></PatternBinding></VariableDecl></MemberDeclListItem>
+  }</CodeBlock></PatternBinding></VariableDecl></MemberDeclListItem>
 }</MemberDeclBlock></ExtensionDecl><ExtensionDecl><Attribute>
 
 @available(<AvailabilityArgument>*, </AvailabilityArgument><AvailabilityArgument>unavailable</AvailabilityArgument>)</Attribute><DeclModifier>

--- a/utils/gyb_syntax_support/DeclNodes.py
+++ b/utils/gyb_syntax_support/DeclNodes.py
@@ -443,7 +443,10 @@ DECL_NODES = [
              Child('GenericWhereClause', kind='GenericWhereClause',
                    is_optional=True),
              # the body is not necessary inside a protocol definition
-             Child('Accessor', kind='AccessorBlock', is_optional=True),
+             Child('Accessor', kind='Syntax', is_optional=True,
+                   node_choices=[
+                      Child('Accessors', kind='AccessorBlock'),
+                      Child('Getter', kind='CodeBlock')]),
          ]),
 
     # access-level-modifier -> 'private' | 'private' '(' 'set' ')'
@@ -516,10 +519,7 @@ DECL_NODES = [
     Node('AccessorBlock', kind="Syntax", traits=['Braced'],
          children=[
              Child('LeftBrace', kind='LeftBraceToken'),
-             Child('AccessorListOrStmtList', kind='Syntax',
-                   node_choices=[
-                      Child('Accessors', kind='AccessorList'),
-                      Child('Statements', kind='CodeBlockItemList')]),
+             Child('Accessors', kind='AccessorList'),
              Child('RightBrace', kind='RightBraceToken'),
          ]),
 
@@ -530,7 +530,10 @@ DECL_NODES = [
              Child('Pattern', kind='Pattern'),
              Child('TypeAnnotation', kind='TypeAnnotation', is_optional=True),
              Child('Initializer', kind='InitializerClause', is_optional=True),
-             Child('Accessor', kind='AccessorBlock', is_optional=True),
+             Child('Accessor', kind='Syntax', is_optional=True,
+                   node_choices=[
+                      Child('Accessors', kind='AccessorBlock'),
+                      Child('Getter', kind='CodeBlock')]),
              Child('TrailingComma', kind='CommaToken', is_optional=True),
          ]),
 


### PR DESCRIPTION
Use `parseAbstractFunctionBody()`(introduced in #19018) to parse accessor body as well. This simplifies the implementation, and makes `parseAbstractFunctionBody()` the single point of parsing body of every `AbstractFunctionDecl` types.

Also, since `parseAbstractFunctionBody()` automatically handles delayed parsing by `delayFunctionBodyParsing()`, we no longer use delayed parsing facilities specific for accessor bodies.