### PR TITLE
#tfop: Support unknown shape list forming from an aggregate metatype

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -2337,7 +2337,7 @@ void TFDeabstraction::formGraphOp(SILTensorOpInfo &opInfo,
         SmallVector<SymbolicValue, 8> dtypes;
         if (!collectInnermostTensorFlowDTypes(constValue.getMetatypeValue(),
                                               dtypes))
-          return diagnoseInvalidAttr("not a TensorFlow value type or an "
+          return diagnoseInvalidAttr("requires a TensorFlow value type or an "
                                      "aggregate of TensorFlow value types");
         // Drop '$array' from the attribute name.
         currentAttr.name = context.getIdentifier(operandClass.first);
@@ -2363,7 +2363,7 @@ void TFDeabstraction::formGraphOp(SILTensorOpInfo &opInfo,
       auto type = constValue.getMetatypeValue();
       SmallVector<Type, 8> tfValueTypes;
       if (!tf::flattenTensorFlowValueAggregate(type, tfValueTypes))
-        return diagnoseInvalidAttr("not a TensorFlow value type or an "
+        return diagnoseInvalidAttr("requires a TensorFlow value type or an "
                                    "aggregate or TensorFlow value types");
       // Drop '$unknownShapeList' from the attribute name.
       currentAttr.name = context.getIdentifier(operandClass.first);

--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -2334,10 +2334,11 @@ void TFDeabstraction::formGraphOp(SILTensorOpInfo &opInfo,
       if (constValue.getKind() == SymbolicValue::Array)
         break;
       if (constValue.getKind() == SymbolicValue::Metatype) {
-        SmallVector<SymbolicValue, 8> metatypes;
+        SmallVector<SymbolicValue, 8> dtypes;
         if (!collectInnermostTensorFlowDTypes(constValue.getMetatypeValue(),
-                                              metatypes))
-          return diagnoseInvalidAttr("not an aggregate of TensorFlow values");
+                                              dtypes))
+          return diagnoseInvalidAttr("not a TensorFlow value type or an "
+                                     "aggregate of TensorFlow value types");
         // Drop '$array' from the attribute name.
         currentAttr.name = context.getIdentifier(operandClass.first);
         // Replace the single metatype with a list of metatypes each
@@ -2345,7 +2346,7 @@ void TFDeabstraction::formGraphOp(SILTensorOpInfo &opInfo,
         auto *dtypeProto =
             context.getProtocol(KnownProtocolKind::AccelerableByTensorFlow);
         currentAttr.value = SymbolicValue::getArray(
-            metatypes, dtypeProto->getInterfaceType()->getCanonicalType(),
+            dtypes, dtypeProto->getInterfaceType()->getCanonicalType(),
             context.getAllocator());
         break;
       }
@@ -2356,6 +2357,29 @@ void TFDeabstraction::formGraphOp(SILTensorOpInfo &opInfo,
       if (getIntArrayProduct(constValue) < 0)
         return; // error already emitted.
       break;
+    case SILTensorOpInfo::OperandClass::UnknownShapeList: {
+      if (constValue.getKind() != SymbolicValue::Metatype)
+        return diagnoseInvalidAttr("requires a metatype");
+      auto type = constValue.getMetatypeValue();
+      SmallVector<Type, 8> tfValueTypes;
+      if (!tf::flattenTensorFlowValueAggregate(type, tfValueTypes))
+        return diagnoseInvalidAttr("not a TensorFlow value type or an "
+                                   "aggregate or TensorFlow value types");
+      // Drop '$unknownShapeList' from the attribute name.
+      currentAttr.name = context.getIdentifier(operandClass.first);
+      auto tensorShapeType =
+          context.getTensorShapeDecl()->getDeclaredInterfaceType();
+      auto tensorShapeOptional =
+          BoundGenericType::get(context.getOptionalDecl(), Type(),
+                                {tensorShapeType})->getCanonicalType();
+      // Create a list of nils representing unknown shape.
+      SmallVector<SymbolicValue, 8> nils(
+          tfValueTypes.size(),
+          SymbolicValue::getEnum(context.getOptionalNoneDecl()));
+      currentAttr.value = SymbolicValue::getArray(nils, tensorShapeOptional,
+                                                  context.getAllocator());
+      break;
+    }
     case SILTensorOpInfo::OperandClass::Tensor:
       if (constValue.getKind() == SymbolicValue::Integer ||
           constValue.getKind() == SymbolicValue::Float   ||

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -2163,6 +2163,9 @@ TFGraphFunctionLowering::visitGraphOperationInst(GraphOperationInst *inst) {
       TF_SetAttrShape(op, name.c_str(), shape.data(), rank);
       break;
     }
+    case SILTensorOpInfo::OperandClass::UnknownShapeList:
+      llvm_unreachable("UnknownShapeList should have been eliminated by "
+                       "deabstraction");
     case SILTensorOpInfo::OperandClass::Array: // Handled as 'normal'
       llvm_unreachable("This is a legacy class that shouldn't happen");
     }

--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -382,6 +382,8 @@ const char *SILTensorOpInfo::getOperandClassSuffix(OperandClass opClass) {
     return "$tensor";
   case OperandClass::Shape:
     return "$shape";
+  case OperandClass::UnknownShapeList:
+    return "$unknownShapeList";
   case OperandClass::Array:
     return "$array";
   case OperandClass::Out:
@@ -397,6 +399,7 @@ SILTensorOpInfo::getOperandClass(StringRef suffix) {
       .Case("", OperandClass::Normal)
       .Case("tensor", OperandClass::Tensor)
       .Case("shape", OperandClass::Shape)
+      .Case("unknownShapeList", OperandClass::UnknownShapeList)
       .Case("array", OperandClass::Array)
       .Case("out", OperandClass::Out)
       .Default(None);

--- a/lib/SILOptimizer/Mandatory/TFUtilities.h
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.h
@@ -115,7 +115,7 @@ struct SILTensorOpInfo {
   /// input that is an array of tensors.  An integer attribute may be either
   /// a Tensor value or an integer-encoded DType, etc.
   enum class OperandClass {
-    /// This marks the following sorts of things:
+    /// Indicates one of the following:
     /// 1) A normal tensor input: the value is a TensorHandle.
     /// 2) An normal attribute (without modifier).
     /// 3) A tensor or shape attribute (need a modifier for proper lowering).
@@ -123,18 +123,31 @@ struct SILTensorOpInfo {
     ///    lowering).
     Input,
 
-    Normal, // No modifier.
-    Tensor, // This array or scalar should be turned into a TF_Tensor.
-    Shape,  // This array of integers is a shape specifier.
+    /// No modifier.
+    Normal,
 
-    Array,  // This marks a normal array value, the value is a metatype.
+    /// Indicates that the array or scalar should be turned into a TF_Tensor.
+    Tensor,
 
-    // An operand specifying the address where an indirect output should be
-    // stored.  This occurs when the tfop exists in a context where its output
-    // is address-only.  Deabstraction eliminates Out operands before forming
-    // graph_ops, by rewriting the tfop to return the value directly.  This
-    // rewriting is possible because tfop outputs must always be loadable in
-    // deabstraction scopes.
+    /// Indicates that the array of integers should be interpreted as a shape.
+    Shape,
+
+    /// Indicates the metatype of a TensorFlow value type or an aggregate of
+    /// TensorFlow value types should be turned into a list of unknown shapes.
+    UnknownShapeList,
+
+    /// Indicates that the operand should be interpreted as an array. When
+    /// applied to the metatype of a TensorFlow value type or an aggregate of
+    /// TensorFlow value types, it will be flattened into an array of dtypes of
+    /// each TensorFlow value type as a Normal operand.
+    Array,
+
+    /// An operand specifying the address where an indirect output should be
+    /// stored.  This occurs when the tfop exists in a context where its output
+    /// is address-only.  Deabstraction eliminates Out operands before forming
+    /// graph_ops, by rewriting the tfop to return the value directly.  This
+    /// rewriting is possible because tfop outputs must always be loadable in
+    /// deabstraction scopes.
     Out,
   };
 

--- a/test/TensorFlow/deabstraction_finished.swift
+++ b/test/TensorFlow/deabstraction_finished.swift
@@ -257,10 +257,7 @@ public func testTensorFlowClosures(_ a: Float) -> Tensor<Int32>{
 // } // end sil function '[[NAME]]'
 
 public func testExtractDTypeList() {
-  struct Foo {
-    let a: Tensor<Float>
-    let b: Tensor<Float>
-  }
+  struct Foo { let a, b: Tensor<Float> }
   let elements = Foo(a: Tensor([1]), b: Tensor([2]))
   // TODO: Support heterogeneous input lists so that we can replace b's dtype with something else.
   // TODO: Support unpacking a struct value into an input list so that we can replace
@@ -271,7 +268,6 @@ public func testExtractDTypeList() {
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testExtractDTypeList{{.*}}
-// CHECK: {{.*}}testExtractDTypeList
 // CHECK: graph_op "TensorSliceDataset,L,e,e"({{.*}} : $TensorHandle<Float>, {{.*}} : $TensorHandle<Float>) {Toutput_types: [$AccelerableByTensorFlow.Protocol: $Float, $Float], output_shapes: [$TensorShape: ([$Int32: ])], __device: "/device:CPU:0"} : $VariantHandle
 
 public func testExtractTupleDTypeList() {
@@ -282,6 +278,15 @@ public func testExtractTupleDTypeList() {
 }
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testExtractTupleDTypeList{{.*}}
-// CHECK: {{.*}}testExtractTupleDTypeList
 // CHECK: graph_op "TensorSliceDataset,L,e,e"({{.*}} : $TensorHandle<Int32>, {{.*}} : $TensorHandle<Int32>) {Toutput_types: [$AccelerableByTensorFlow.Protocol: $Int32, $Int32], output_shapes: [$TensorShape: ([$Int32: ])], __device: "/device:CPU:0"} : $VariantHandle
 
+public func testExtractUnknownShapeList() {
+  struct Foo { let a, b: Tensor<Float> }
+  let elements = Foo(a: Tensor([1]), b: Tensor([2]))
+  let _: VariantHandle = #tfop("TensorSliceDataset", [elements.a, elements.b],
+                               Toutput_types: [Float.self, Float.self],
+                               output_shapes$unknownShapeList: Foo.self)
+}
+
+// CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testExtractUnknownShapeList{{.*}}
+// CHECK: graph_op "TensorSliceDataset,L,e,e"({{.*}} : $TensorHandle<Float>, {{.*}} : $TensorHandle<Float>) {Toutput_types: [$Float.Type: $Float, $Float], output_shapes: [$Optional<TensorShape>: #Optional.none!enumelt, #Optional.none!enumelt], __device: "/device:CPU:0"} : $VariantHandle

--- a/test/TensorFlow/diagnostics_with_deabstraction_error.swift
+++ b/test/TensorFlow/diagnostics_with_deabstraction_error.swift
@@ -50,7 +50,7 @@ public func testExtractDTypeList () {
     let a: Int
     let b: Tensor<Float>
   }
-  // expected-error @+1 {{not an aggregate of TensorFlow values}}
+  // expected-error @+1 {{requires a TensorFlow value type or an aggregate of TensorFlow value types}}
   let _: VariantHandle = #tfop("TensorSliceDataset", [] as [TensorHandle<Float>],
                                Toutput_types$array: Foo.self,
                                output_shapes: [TensorShape()])


### PR DESCRIPTION
Given an aggregate type `Foo` and a `#tfop` attribute with `#unknownShapeList` suffix taking `Foo.self`:
```swift
struct Foo {
    let x, y: Tensor<Float>
    let z: (Tensor<Int32>, Tensor<Double>)
}

#tfop("TensorSliceDataset", ..., element_shapes$unknownShapeList: Foo.self)
```

TFDeabstraction canonicalizes this into
```swift
#tfop("TensorSliceDataset", ..., element_shapes: [nil, nil, nil, nil] as [TensorShape?])
```

Resolving [SR-8650](https://bugs.swift.org/browse/SR-8650), this is one of the last two steps towards [SR-8638](https://bugs.swift.org/browse/SR-8638). The final step is finishing [SR-8573](https://bugs.swift.org/browse/SR-8573).

This patch also cleans up and extends the doc comments on `OperandClass`.