### PR TITLE
[SourceKit] Set CustomBufferKind while serializing the syntax tree

### DIFF
--- a/include/swift/Basic/ByteTreeSerialization.h
+++ b/include/swift/Basic/ByteTreeSerialization.h
@@ -232,13 +232,16 @@ private:
 
 public:
   /// Write a binary serialization of \p Object to \p StreamWriter, prefixing
-  /// the stream by the specified ProtocolVersion.
+  /// the stream by the specified ProtocolVersion. If \p InitialOffset is
+  /// specified the first \p InitialOffset bytes will be left empty in the
+  /// Stream so that the caller can populate them.
   template <typename T>
   typename std::enable_if<has_ObjectTraits<T>::value, void>::type
   static write(ExponentialGrowthAppendingBinaryByteStream &Stream,
                uint32_t ProtocolVersion, const T &Object,
-               UserInfoMap &UserInfo) {
+               UserInfoMap &UserInfo, size_t InitialOffset = 0) {
     llvm::BinaryStreamWriter StreamWriter(Stream);
+    StreamWriter.setOffset(InitialOffset);
     ByteTreeWriter Writer(Stream, StreamWriter, UserInfo);
 
     auto Error = Writer.writeRaw(ProtocolVersion);

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1782,7 +1782,7 @@ void SwiftEditorDocument::parse(ImmutableTextSnapshotRef Snapshot,
   CompInv.setMainFileSyntaxParsingCache(SyntaxCache);
   // When reuse parts of the syntax tree from a SyntaxParsingCache, not
   // all tokens are visited and thus token collection is invalid
-  CompInv.getLangOptions().CollectParsedToken = (SyntaxCache == nullptr);
+  CompInv.getLangOptions().CollectParsedToken = !BuildSyntaxTree;
   // Access to Impl.SyntaxInfo is guarded by Impl.AccessMtx
   Impl.SyntaxInfo.reset(
     new SwiftDocumentSyntaxInfo(CompInv, Snapshot, Args, Impl.FilePath));

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal.h
@@ -87,6 +87,11 @@ public:
     Dictionary setDictionary(SourceKit::UIdent Key);
     void setCustomBuffer(SourceKit::UIdent Key, CustomBufferKind Kind,
                          std::unique_ptr<llvm::MemoryBuffer> MemBuf);
+    /// Set raw data for the specified \p Key. It is assumed that the data that
+    /// is being set has already been prefixed with the correct
+    /// \c CustomBufferKind.
+    void setCustomRawData(SourceKit::UIdent Key, CustomBufferKind Kind,
+                          void *Data, size_t Size);
 
   private:
     void *Impl = nullptr;

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
@@ -273,6 +273,14 @@ void ResponseBuilder::Dictionary::setCustomBuffer(
   xpc_release(xdata);
 }
 
+void ResponseBuilder::Dictionary::setCustomRawData(SourceKit::UIdent Key,
+                                                   CustomBufferKind Kind,
+                                                   void *Data, size_t Size) {
+  xpc_object_t xdata = xpc_data_create(Data, Size);
+  xpc_dictionary_set_value(Impl, Key.c_str(), xdata);
+  xpc_release(xdata);
+}
+
 ResponseBuilder::Dictionary ResponseBuilder::Array::appendDictionary() {
   xpc_object_t dict = xpc_dictionary_create(nullptr, nullptr, 0);
   xpc_array_append_value(Impl, dict);


### PR DESCRIPTION
This saves one `memcpy` that was previously necessary to add the `CustomBufferKind` as a prefix to the XPC object.