### PR TITLE
Force deabstraction of functions that take or return Tensors if referred in code.

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -4518,7 +4518,7 @@ bool TFPartition::partitionFunction(
   // isolation.
   LLVM_DEBUG(llvm::dbgs() << "Processing SIL function " << hostFn->getName()
                           << " in TFPartition::partitionFunction().\n");
-  if (!tfc.shouldBePartitioned(hostFn))
+  if (!tfc.shouldBePartitioned(hostFn, /*forceTFFunctions=*/true))
     return false;
 
   LLVM_DEBUG(llvm::dbgs() << "  " << hostFn->getName()

--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -626,11 +626,6 @@ tf::createTensorToInt1Inst(SILValue value, SILBuilder &builder,
 // TensorFunctionClassifier Implementation
 //===----------------------------------------------------------------------===//
 
-/// Return true if the specified function is the top-level context that
-/// tensor partitioning should be applied to.  This returns false (for
-/// example) for inlined functions that take and return tensors, since we
-/// know that they are either unreachable or will be inlined into any
-/// clients that use them.
 bool TensorFunctionClassifier::shouldBePartitioned(SILFunction *fn,
                                                    bool forceTFFunctions) {
   // Ignore transparent functions.
@@ -710,7 +705,7 @@ bool TensorFunctionClassifier::shouldBePartitioned(SILFunction *fn,
       // Return true if it is referenced somewhere.
       // TODO: There might be a better check other than fn->getRefCount() > 0.
       // See the clean up code in TFDeabstraction::inlineCalls() function.
-      return (fn->getRefCount() > 0);
+      return fn->getRefCount() > 0;
     } else {
       return false;
     }

--- a/lib/SILOptimizer/Mandatory/TFUtilities.h
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.h
@@ -277,7 +277,11 @@ public:
   /// example) for inlined functions that take and return tensors, since we
   /// know that they are either unreachable or will be inlined into any
   /// clients that use them.
-  bool shouldBePartitioned(SILFunction *fn);
+  ///
+  /// If the flag forceTFFunctions is true, it forces partitioning of functions
+  /// that operate on Tensor values irrespective of whether they are inlinable,
+  /// private, etc.
+  bool shouldBePartitioned(SILFunction *fn, bool forceTFFunctions = false);
 
   /// Return true if the specified function type has TensorFlow values in its
   /// argument or result list (and do so recursively, if `fnType` has an

--- a/lib/SILOptimizer/Mandatory/TFUtilities.h
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.h
@@ -278,10 +278,9 @@ public:
   /// know that they are either unreachable or will be inlined into any
   /// clients that use them.
   ///
-  /// If the flag forceTFFunctions is true, it forces partitioning of functions
-  /// that operate on Tensor values irrespective of whether they are inlinable,
-  /// private, etc.
-  bool shouldBePartitioned(SILFunction *fn, bool forceTFFunctions = false);
+  /// If the flag forceTFFunctions is true, forces partitioning of functions
+  /// that operate on Tensors even if it would have been rejected otherwise.
+  bool shouldBePartitioned(SILFunction *fn, bool forceTFFunctions);
 
   /// Return true if the specified function type has TensorFlow values in its
   /// argument or result list (and do so recursively, if `fnType` has an

--- a/test/TensorFlow/deabstraction_finished.swift
+++ b/test/TensorFlow/deabstraction_finished.swift
@@ -285,3 +285,23 @@ public func testExtractTupleDTypeList() {
 // CHECK: {{.*}}testExtractTupleDTypeList
 // CHECK: graph_op "TensorSliceDataset,L,e,e"({{.*}} : $TensorHandle<Int32>, {{.*}} : $TensorHandle<Int32>) {Toutput_types: [$AccelerableByTensorFlow.Protocol: $Int32, $Int32], output_shapes: [$TensorShape: ([$Int32: ])], __device: "/device:CPU:0"} : $VariantHandle
 
+
+// Tests that private functions operating on Tensors are partitioned
+// if they are only referred in code.  In this case, addOne should be
+// partitioned, but not getZero.
+//
+// expected-warning @+1 {{'x' implicitly copied to the accelerator}}
+private func addOne(_ x : Tensor<Float>) -> Tensor<Float> {
+  // expected-note @+1 {{value used here}}
+  return x + Tensor<Float>(1.0)
+}
+private func getZero() -> Tensor<Float> { return Tensor<Float>(0.0) }
+
+public func getTensorAndAddOneFunction() -> (Tensor<Float>, (Tensor<Float>) -> Tensor<Float>) {
+  let x = Tensor<Float>(1.0)
+  return (x * x, addOne)
+}
+
+// CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}addOne{{.*}}
+// CHECK-NOT: --- TFPartition Accelerator Result: {{.*}}getZero{{.*}}
+// CHECK: --- TFPartition Accelerator Result: {{.*}}getTensorAndAddOneFunction{{.*}}


### PR DESCRIPTION
This is a somewhat hacky patch to deal with [SR-8589](https://bugs.swift.org/browse/SR-8589) related to the Jupyter tutoral. In the REPL mode (both in the in-build swift and lldb -r), the SIL module for a REPL expr is thrown away after lowering to LLVM IR. Consequently, when processing subsequent lines, TFDeabstraction does not see the body of some functions being invoked, which causes some functions not to be partitioned. 

This PR performs a second round of deabstraction (and subsequent partitioning) of functions taking and returning TensorValues if they are still referred in the code after the first round. 

BTW, this is not only relevant to Jupyter tutorial. We will encounter this if we allow linking to other swift-tensorflow binaries. We will need to think about how to deal with such cases in general.

@mhong, when I simply removed the condition that checks if a function operates on tensors, some tests started failing as attributes were no longer const-evaluable. That is why I am sending this instead of what we discussed. 

