### PR TITLE
Honor #sourceLocation filenames in several more places

### DIFF
--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -39,7 +39,7 @@ class SourceManager {
   /// to speed up stats.
   mutable llvm::StringMap<clang::vfs::Status> StatusCache;
 
-  // #line directive handling.
+  // \c #sourceLocation directive handling.
   struct VirtualFile {
     CharSourceRange Range;
     std::string Name;
@@ -112,17 +112,17 @@ public:
   /// Adds a memory buffer to the SourceManager, taking ownership of it.
   unsigned addNewSourceBuffer(std::unique_ptr<llvm::MemoryBuffer> Buffer);
 
-  /// Add a #line-defined virtual file region.
+  /// Add a \c #sourceLocation-defined virtual file region.
   ///
   /// By default, this region continues to the end of the buffer.
   ///
   /// \returns True if the new file was added, false if the file already exists.
   /// The name and line offset must match exactly in that case.
   ///
-  /// \sa closeVirtualFile.
+  /// \sa closeVirtualFile
   bool openVirtualFile(SourceLoc loc, StringRef name, int lineOffset);
 
-  /// Close a #line-defined virtual file region.
+  /// Close a \c #sourceLocation-defined virtual file region.
   void closeVirtualFile(SourceLoc end);
 
   /// Creates a copy of a \c MemoryBuffer and adds it to the \c SourceManager,
@@ -143,6 +143,11 @@ public:
   /// Returns the identifier for the buffer with the given ID.
   ///
   /// \p BufferID must be a valid buffer ID.
+  ///
+  /// This should not be used for displaying information about the \e contents
+  /// of a buffer, since lines within the buffer may be marked as coming from
+  /// other files using \c #sourceLocation. Use #getDisplayNameForLoc instead
+  /// in that case.
   StringRef getIdentifierForBuffer(unsigned BufferID) const;
 
   /// \brief Returns a SourceRange covering the entire specified buffer.
@@ -175,26 +180,16 @@ public:
   /// Returns a buffer identifier suitable for display to the user containing
   /// the given source location.
   ///
-  /// This respects #line directives and the 'use-external-names' directive in
-  /// VFS overlay files.
+  /// This respects \c #sourceLocation directives and the 'use-external-names'
+  /// directive in VFS overlay files. If you need an on-disk file name, use
+  /// #getIdentifierForBuffer instead.
   StringRef getDisplayNameForLoc(SourceLoc Loc) const;
-
-  /// Returns the identifier string for the buffer containing the given source
-  /// location.
-  ///
-  /// This respects #line directives.
-  StringRef getBufferIdentifierForLoc(SourceLoc Loc) const {
-    if (auto VFile = getVirtualFile(Loc))
-      return VFile->Name;
-    else
-      return getIdentifierForBuffer(findBufferContainingLoc(Loc));
-  }
 
   /// Returns the line and column represented by the given source location.
   ///
   /// If \p BufferID is provided, \p Loc must come from that source buffer.
   ///
-  /// This respects #line directives.
+  /// This respects \c #sourceLocation directives.
   std::pair<unsigned, unsigned>
   getLineAndColumn(SourceLoc Loc, unsigned BufferID = 0) const {
     assert(Loc.isValid());
@@ -209,7 +204,7 @@ public:
   ///
   /// If \p BufferID is provided, \p Loc must come from that source buffer.
   ///
-  /// This does not respect #line directives.
+  /// This does not respect \c #sourceLocation directives.
   unsigned getLineNumber(SourceLoc Loc, unsigned BufferID = 0) const {
     assert(Loc.isValid());
     return LLVMSourceMgr.FindLineNumber(Loc.Value, BufferID);

--- a/lib/IDE/CommentConversion.cpp
+++ b/lib/IDE/CommentConversion.cpp
@@ -317,8 +317,7 @@ void CommentToXMLConverter::visitDocComment(const DocComment *DC) {
     auto Loc = D->getLoc();
     if (Loc.isValid()) {
       const auto &SM = D->getASTContext().SourceMgr;
-      unsigned BufferID = SM.findBufferContainingLoc(Loc);
-      StringRef FileName = SM.getIdentifierForBuffer(BufferID);
+      StringRef FileName = SM.getDisplayNameForLoc(Loc);
       auto LineAndColumn = SM.getLineAndColumn(Loc);
       OS << " file=\"";
       appendWithXMLEscaping(OS, FileName);

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -904,8 +904,7 @@ public:
   }
 
   void replaceText(SourceManager &SM, CharSourceRange Range, StringRef Text) {
-    auto BufferId = SM.getIDForBufferIdentifier(SM.
-      getBufferIdentifierForLoc(Range.getStart())).getValue();
+    auto BufferId = SM.findBufferContainingLoc(Range.getStart());
     if (BufferId == InterestedId) {
       HasChange = true;
       auto StartLoc = SM.getLocOffsetInBuffer(Range.getStart(), BufferId);

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2579,12 +2579,11 @@ static const char *findStartOfLine(const char *bufStart, const char *current) {
 }
 
 SourceLoc Lexer::getLocForStartOfToken(SourceManager &SM, SourceLoc Loc) {
-  Optional<unsigned> BufferIdOp = SM.getIDForBufferIdentifier(SM.
-    getBufferIdentifierForLoc(Loc));
-  if (!BufferIdOp.hasValue())
+  if (!Loc.isValid())
     return SourceLoc();
-  return getLocForStartOfToken(SM, BufferIdOp.getValue(),
-    SM.getLocOffsetInBuffer(Loc, BufferIdOp.getValue()));
+  unsigned BufferId = SM.findBufferContainingLoc(Loc);
+  return getLocForStartOfToken(SM, BufferId,
+                               SM.getLocOffsetInBuffer(Loc, BufferId));
 }
 
 SourceLoc Lexer::getLocForStartOfToken(SourceManager &SM, unsigned BufferID,

--- a/lib/SIL/OptimizationRemark.cpp
+++ b/lib/SIL/OptimizationRemark.cpp
@@ -162,10 +162,9 @@ template <> struct MappingTraits<SourceLoc> {
     assert(io.outputting() && "input not yet implemented");
 
     SourceManager *SM = static_cast<SourceManager *>(io.getContext());
-    unsigned BufferID = SM->findBufferContainingLoc(Loc);
-    StringRef File = SM->getIdentifierForBuffer(BufferID);
+    StringRef File = SM->getDisplayNameForLoc(Loc);
     unsigned Line, Col;
-    std::tie(Line, Col) = SM->getLineAndColumn(Loc, BufferID);
+    std::tie(Line, Col) = SM->getLineAndColumn(Loc);
 
     io.mapRequired("File", File);
     io.mapRequired("Line", Line);

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -144,8 +144,7 @@ auto SILGenFunction::emitSourceLocationArgs(SourceLoc sourceLoc,
   unsigned line = 0;
   unsigned column = 0;
   if (sourceLoc.isValid()) {
-    unsigned bufferID = ctx.SourceMgr.findBufferContainingLoc(sourceLoc);
-    filename = ctx.SourceMgr.getIdentifierForBuffer(bufferID);
+    filename = ctx.SourceMgr.getDisplayNameForLoc(sourceLoc);
     std::tie(line, column) = ctx.SourceMgr.getLineAndColumn(sourceLoc);
   }
   

--- a/test/Driver/opt-record.swift
+++ b/test/Driver/opt-record.swift
@@ -8,30 +8,33 @@
 
 var a: Int = 1
 
+#sourceLocation(file: "custom.swuft", line: 2000)
 func foo() {
   a = 2
 }
+#sourceLocation() // reset
 
 public func bar() {
+  foo()
   // YAML:      --- !Passed
   // YAML-NEXT: Pass:            sil-inliner
   // YAML-NEXT: Name:            sil.Inlined
   // YAML-NEXT: DebugLoc:
   // YAML-NEXT:   File:            {{.*}}opt-record.swift
-  // YAML-NEXT:   Line:            42
+  // YAML-NEXT:   Line:            [[@LINE-6]]
   // YAML-NEXT:   Column:          3
   // YAML-NEXT: Function:        'bar()'
   // YAML-NEXT: Args:
   // YAML-NEXT:   - Callee:          '"optrecordmod.foo()"'
   // YAML-NEXT:     DebugLoc:
-  // YAML-NEXT:       File:            {{.*}}opt-record.swift
-  // YAML-NEXT:       Line:            11
+  // YAML-NEXT:       File:            custom.swuft
+  // YAML-NEXT:       Line:            2000
   // YAML-NEXT:       Column:          6
   // YAML-NEXT:   - String:          ' inlined into '
   // YAML-NEXT:   - Caller:          '"optrecordmod.bar()"'
   // YAML-NEXT:     DebugLoc:
   // YAML-NEXT:       File:            {{.*}}opt-record.swift
-  // YAML-NEXT:       Line:            15
+  // YAML-NEXT:       Line:            [[@LINE-20]]
   // YAML-NEXT:       Column:          13
   // YAML-NEXT:   - String:          ' (cost = '
   // YAML-NEXT:   - Cost:            '{{.*}}'
@@ -39,5 +42,4 @@ public func bar() {
   // YAML-NEXT:   - Benefit:         '{{.*}}'
   // YAML-NEXT:   - String:          ')'
   // YAML-NEXT: ...
-  foo()
 }

--- a/test/IDE/comment_attach.swift
+++ b/test/IDE/comment_attach.swift
@@ -216,6 +216,11 @@ func weirdBlockDocComment() {}
 // ###line 1010
 func docCommentWithGybLineNumber() {}
 
+#sourceLocation(file: "custom.swuft", line: 2000)
+/// Oooh, custom!
+func customSourceLocation() {}
+#sourceLocation() // reset
+
 /**
 func unterminatedBlockDocComment() {}
 
@@ -307,3 +312,4 @@ func unterminatedBlockDocComment() {}
 // CHECK-NEXT: comment_attach.swift:207:6: Func/emptyBlockDocComment RawComment=[/***/]
 // CHECK-NEXT: comment_attach.swift:210:6: Func/weirdBlockDocComment RawComment=[/**/]
 // CHECK-NEXT: comment_attach.swift:217:6: Func/docCommentWithGybLineNumber RawComment=[/// docCommentWithGybLineNumber Aaa.\n/// Bbb.\n/// Ccc.\n]
+// CHECK-NEXT: custom.swuft:2001:6: Func/customSourceLocation RawComment=[/// Oooh, custom!\n]

--- a/test/Inputs/comment_to_something_conversion.swift
+++ b/test/Inputs/comment_to_something_conversion.swift
@@ -492,3 +492,10 @@ public func localizationKeyShouldNotAppearInDocComments2() {}
 /// - TAG: TAG_C
 public func tags() {}
 // CHECK: DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>tags()</Name><USR>s:14comment_to_xml4tagsyyF</USR><Declaration>public func tags()</Declaration><CommentParts><Abstract><Para>Brief.</Para></Abstract><Tags><Tag>Tag_A</Tag><Tag>Tag B</Tag><Tag>Dedupe tag</Tag><Tag>TAG_C</Tag></Tags><Discussion><Para>Intentional break</Para></Discussion></CommentParts></Function>]
+
+
+#sourceLocation(file: "custom.swuft", line: 20)
+/// Oooh, custom!
+public func customLocation() {}
+// CHECK: DocCommentAsXML=[<Function file="custom.swuft" line="21" column="{{.*}}"><Name>customLocation()</Name><USR>s:14comment_to_xml14customLocationyyF</USR><Declaration>public func customLocation()</Declaration><CommentParts><Abstract><Para>Oooh, custom!</Para></Abstract></CommentParts></Function>]
+#sourceLocation() // reset

--- a/test/SILGen/optional.swift
+++ b/test/SILGen/optional.swift
@@ -107,7 +107,7 @@ func crash_on_dealloc(_ dict : [Int : [Int]] = [:]) {
 func use_unwrapped(_: Int) {}
 
 // CHECK-LABEL: sil hidden @$S8optional15explicit_unwrap{{[_0-9a-zA-Z]*}}F
-// CHECK:         [[FILESTR:%.*]] = string_literal utf8 "
+// CHECK:         [[FILESTR:%.*]] = string_literal utf8 "{{.*}}optional.swift"
 // CHECK-NEXT:         [[FILESIZ:%.*]] = integer_literal $Builtin.Word, 
 // CHECK-NEXT:         [[FILEASC:%.*]] = integer_literal $Builtin.Int1, 
 // CHECK-NEXT:         [[LINE:%.*]] = integer_literal $Builtin.Word, 
@@ -120,7 +120,7 @@ func explicit_unwrap(_ value: Int?) {
 }
 
 // CHECK-LABEL: sil hidden @$S8optional19explicit_iuo_unwrap{{[_0-9a-zA-Z]*}}F
-// CHECK:         [[FILESTR:%.*]] = string_literal utf8 "
+// CHECK:         [[FILESTR:%.*]] = string_literal utf8 "{{.*}}optional.swift"
 // CHECK-NEXT:         [[FILESIZ:%.*]] = integer_literal $Builtin.Word, 
 // CHECK-NEXT:         [[FILEASC:%.*]] = integer_literal $Builtin.Int1, 
 // CHECK-NEXT:         [[LINE:%.*]] = integer_literal $Builtin.Word, 
@@ -133,7 +133,7 @@ func explicit_iuo_unwrap(_ value: Int!) {
 }
 
 // CHECK-LABEL: sil hidden @$S8optional19implicit_iuo_unwrap{{[_0-9a-zA-Z]*}}F
-// CHECK:         [[FILESTR:%.*]] = string_literal utf8 "
+// CHECK:         [[FILESTR:%.*]] = string_literal utf8 "{{.*}}optional.swift"
 // CHECK-NEXT:         [[FILESIZ:%.*]] = integer_literal $Builtin.Word, 
 // CHECK-NEXT:         [[FILEASC:%.*]] = integer_literal $Builtin.Int1, 
 // CHECK-NEXT:         [[LINE:%.*]] = integer_literal $Builtin.Word, 
@@ -143,4 +143,19 @@ func explicit_iuo_unwrap(_ value: Int!) {
 // CHECK:         apply [[PRECOND]]([[FILESTR]], [[FILESIZ]], [[FILEASC]], [[LINE]], [[IMPLICIT]])
 func implicit_iuo_unwrap(_ value: Int!) {
   use_unwrapped(value)
+}
+
+// CHECK-LABEL: sil hidden @$S8optional34implicit_iuo_unwrap_sourceLocation{{[_0-9a-zA-Z]*}}F
+// CHECK:         [[FILESTR:%.*]] = string_literal utf8 "custom.swuft"
+// CHECK-NEXT:         [[FILESIZ:%.*]] = integer_literal $Builtin.Word, 
+// CHECK-NEXT:         [[FILEASC:%.*]] = integer_literal $Builtin.Int1, 
+// CHECK-NEXT:         [[LINE:%.*]] = integer_literal $Builtin.Word, 2000
+// CHECK-NEXT:         [[COLUMN:%.*]] = integer_literal $Builtin.Word, 
+// CHECK-NEXT:         [[IMPLICIT:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK:         [[PRECOND:%.*]] = function_ref @$Ss30_diagnoseUnexpectedNilOptional{{[_0-9a-zA-Z]*}}F
+// CHECK:         apply [[PRECOND]]([[FILESTR]], [[FILESIZ]], [[FILEASC]], [[LINE]], [[IMPLICIT]])
+func implicit_iuo_unwrap_sourceLocation(_ value: Int!) {
+#sourceLocation(file: "custom.swuft", line: 2000)
+  use_unwrapped(value)
+#sourceLocation() // reset
 }

--- a/test/SourceKit/CompileNotifications/Inputs/parse-error-with-sourceLocation.swift
+++ b/test/SourceKit/CompileNotifications/Inputs/parse-error-with-sourceLocation.swift
@@ -1,0 +1,3 @@
+#sourceLocation(file: "custom.swuft", line: 2000)
+func 1() {}
+#sourceLocation() // reset

--- a/test/SourceKit/CompileNotifications/diagnostics.swift
+++ b/test/SourceKit/CompileNotifications/diagnostics.swift
@@ -17,6 +17,18 @@
 // PARSE-NEXT:   }
 // PARSE-NEXT: ]
 
+// RUN: %sourcekitd-test -req=track-compiles == -req=sema %S/Inputs/parse-error-with-sourceLocation.swift -- %S/Inputs/parse-error-with-sourceLocation.swift | %FileCheck %s -check-prefix=PARSE-WITH-SOURCELOCATION
+// PARSE-WITH-SOURCELOCATION: key.notification: source.notification.compile-did-finish
+// PARSE-WITH-SOURCELOCATION-NEXT: key.diagnostics: [
+// PARSE-WITH-SOURCELOCATION-NEXT:   {
+// PARSE-WITH-SOURCELOCATION-NEXT:     key.line: 2000
+// PARSE-WITH-SOURCELOCATION-NEXT:     key.column: 6
+// PARSE-WITH-SOURCELOCATION-NEXT:     key.filepath: "custom.swuft"
+// PARSE-WITH-SOURCELOCATION-NEXT:     key.severity: source.diagnostic.severity.error
+// PARSE-WITH-SOURCELOCATION-NEXT:     key.description: "function name
+// PARSE-WITH-SOURCELOCATION-NEXT:   }
+// PARSE-WITH-SOURCELOCATION-NEXT: ]
+
 // Diagnostic from other file.
 // RUN: %sourcekitd-test -req=track-compiles == -req=sema %s -- %s %S/Inputs/parse-error.swift | %FileCheck %s -check-prefix=PARSE
 

--- a/test/SourceKit/CursorInfo/cursor_info_param.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_param.swift
@@ -1,0 +1,45 @@
+func simpleParams(a: Int, b theB: Int) {}
+
+struct AccessorTest {
+  subscript(a: Int, b theB: Int) -> Int { return a }
+  var prop: Int {
+    get { return 0 }
+    set(v) {}
+  }
+}
+
+#sourceLocation(file: "custom.swuft", line: 2000)
+func customSourceLocation(a: Int) {}
+#sourceLocation()
+
+// RUN: %sourcekitd-test -req=cursor -pos=1:19 %s -- %s | %FileCheck -check-prefix=CHECK-FUNC-A %s
+// CHECK-FUNC-A: s:17cursor_info_param12simpleParams1a1bySi_SitFACL_Sivp
+// CHECK-FUNC-A: PARENT OFFSET: 5
+
+// RUN: %sourcekitd-test -req=cursor -pos=1:27 %s -- %s | %FileCheck -check-prefix=CHECK-FUNC-B %s
+// CHECK-FUNC-B: s:17cursor_info_param12simpleParams1a1bySi_SitF{{$}}
+
+// RUN: %sourcekitd-test -req=cursor -pos=1:29 %s -- %s | %FileCheck -check-prefix=CHECK-FUNC-THEB %s
+// CHECK-FUNC-THEB: s:17cursor_info_param12simpleParams1a1bySi_SitF4theBL_Sivp
+// CHECK-FUNC-THEB-NOT: PARENT OFFSET
+
+// RUN: %sourcekitd-test -req=cursor -pos=4:13 %s -- %s | %FileCheck -check-prefix=CHECK-SUBSCRIPT-A %s
+// FIXME: This USR is wrong; see https://bugs.swift.org/browse/SR-8660.
+// CHECK-SUBSCRIPT-A: s:17cursor_info_param12AccessorTestV1aL_Sivp
+// CHECK-SUBSCRIPT-A: PARENT OFFSET: 67
+
+// RUN: %sourcekitd-test -req=cursor -pos=4:21 %s -- %s | %FileCheck -check-prefix=CHECK-SUBSCRIPT-B %s
+// CHECK-SUBSCRIPT-B: s:17cursor_info_param12AccessorTestV
+
+// RUN: %sourcekitd-test -req=cursor -pos=4:23 %s -- %s | %FileCheck -check-prefix=CHECK-SUBSCRIPT-THEB %s
+// FIXME: This USR is wrong; see https://bugs.swift.org/browse/SR-8660.
+// CHECK-SUBSCRIPT-THEB: s:17cursor_info_param12AccessorTestV4theBL_Sivp
+// CHECK-SUBSCRIPT-THEB-NOT: PARENT OFFSET
+
+// RUN: %sourcekitd-test -req=cursor -pos=7:9 %s -- %s | %FileCheck -check-prefix=CHECK-SETTER-V %s
+// CHECK-SETTER-V: s:17cursor_info_param12AccessorTestV4propSivs1vL_Sivp
+// CHECK-SETTER-V: PARENT OFFSET: 161
+
+// RUN: %sourcekitd-test -req=cursor -pos=12:27 %s -- %s | %FileCheck -check-prefix=CHECK-CUSTOM-SOURCELOCATION %s
+// CHECK-CUSTOM-SOURCELOCATION: s:17cursor_info_param20customSourceLocation1aySi_tFACL_Sivp
+// CHECK-CUSTOM-SOURCELOCATION: PARENT OFFSET: 233

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -146,7 +146,7 @@ void EditorDiagConsumer::handleDiagnostic(
 
     SKInfo.Offset = SM.getLocOffsetInBuffer(Loc, BufferID);
     std::tie(SKInfo.Line, SKInfo.Column) = SM.getLineAndColumn(Loc, BufferID);
-    SKInfo.Filename = SM.getIdentifierForBuffer(BufferID);
+    SKInfo.Filename = SM.getDisplayNameForLoc(Loc);
 
     for (auto R : Info.Ranges) {
       if (R.isInvalid() || SM.findBufferContainingLoc(R.getStart()) != BufferID)

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -684,8 +684,7 @@ getParamParentNameOffset(const ValueDecl *VD, SourceLoc Cursor) {
   if (Loc.isInvalid())
     return None;
   auto &SM = VD->getASTContext().SourceMgr;
-  return SM.getLocOffsetInBuffer(Loc, SM.getIDForBufferIdentifier(SM.
-    getBufferIdentifierForLoc(Loc)).getValue());
+  return SM.getLocOffsetInBuffer(Loc, SM.findBufferContainingLoc(Loc));
 }
 
 /// Returns true for failure to resolve.

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2142,11 +2142,6 @@ public:
   ASTCommentPrinter(SourceManager &SM, XMLValidator &TheXMLValidator)
       : OS(llvm::outs()), SM(SM), TheXMLValidator(TheXMLValidator) {}
 
-  StringRef getBufferIdentifier(SourceLoc Loc) {
-    unsigned BufferID = SM.findBufferContainingLoc(Loc);
-    return SM.getIdentifierForBuffer(BufferID);
-  }
-
   void printWithEscaping(StringRef Str) {
     for (char C : Str) {
       switch (C) {
@@ -2285,7 +2280,7 @@ public:
       SourceLoc Loc = D->getLoc();
       if (Loc.isValid()) {
         auto LineAndColumn = SM.getLineAndColumn(Loc);
-        OS << getBufferIdentifier(VD->getLoc())
+        OS << SM.getDisplayNameForLoc(VD->getLoc())
            << ":" << LineAndColumn.first << ":" << LineAndColumn.second << ": ";
       }
       OS << Decl::getKindName(VD->getKind()) << "/";
@@ -2302,7 +2297,7 @@ public:
       SourceLoc Loc = D->getLoc();
       if (Loc.isValid()) {
         auto LineAndColumn = SM.getLineAndColumn(Loc);
-        OS << getBufferIdentifier(D->getLoc())
+        OS << SM.getDisplayNameForLoc(D->getLoc())
         << ":" << LineAndColumn.first << ":" << LineAndColumn.second << ": ";
       }
       OS << Decl::getKindName(D->getKind()) << "/";

--- a/unittests/Parse/LexerTests.cpp
+++ b/unittests/Parse/LexerTests.cpp
@@ -635,6 +635,29 @@ TEST_F(LexerTest, getLocForStartOfToken) {
   }
 }
 
+TEST_F(LexerTest, getLocForStartOfTokenWithCustomSourceLocation) {
+  const char *Source =
+      "aaa \n"
+      // This next line is exactly 50 bytes to make it easy to compare with the
+      // previous test.
+      "#sourceLocation(file: \"custom-50.swuft\", line: 9)\n"
+      " \tbbb \"hello\" \"-\\(val)-\"";
+
+  unsigned BufferID = SourceMgr.addMemBufferCopy(Source);
+
+  // First is character offset, second is its token offset.
+  unsigned Offs[][2] =
+    { {1, 0}, {2, 0}, {3, 3}, {4, 4},
+      {56, 56}, {59, 57}, {64, 61},
+      // interpolated string
+      {70, 69}, {73, 73}, {74, 73}, {75, 73}, {76, 76}, {77, 69} };
+
+  for (auto Pair : Offs) {
+    ASSERT_EQ(Lexer::getLocForStartOfToken(SourceMgr, BufferID, Pair[0]),
+              SourceMgr.getLocForOffset(BufferID, Pair[1]));
+  }
+}
+
 TEST_F(LexerTest, NestedSubLexers) {
   const char *Source = "aaa0 bbb1 ccc2 ddd3 eee4 fff5 ggg6";
 


### PR DESCRIPTION
The general principle here is "if you're going to show line/column, you want a display filename, not a buffer identifier". Follow-up to #19022; thanks to @davidungar and @CodaFi for reminding me to go check on other issues.

Review requests:
- @anemet for the optimization record change
- @nkcsgexi for the IDE/SourceKit/Parse changes
- @DougGregor for the run-time error message change

I filed [SR-8662](https://bugs.swift.org/browse/SR-8662) for a case where SourceKit may or may not be doing the wrong thing. There are also still a few suspicious uses of `getIdentifierForBuffer` that I'm not sure about, all of which happen to be in @nkcsgexi's components:

- swift::writeEditsInJson is using offsets rather than line/column numbers, but I'm not sure what it would want to do for `#sourceLocation` or the VFS

- swift::ide::getLocationInfo is also using offsets rather than line/column numbers, but "location info" sounds like something that needs to be displayed to the user

- FixitApplyDiagnosticConsumer::handleDiagnostic is going to rewrite buffers directly, but it's unclear whether doing that is the right thing for code using `#sourceLocation` (similar to [SR-8662](https://bugs.swift.org/browse/SR-8662), but for migration).

- GroupNameCollectorFromJson::getGroupNameInternal is only used when building the standard library, but it should probably honor `#sourceLocation`. I just didn't want to touch it without being sure, and it's not immediately relevant.