### PR TITLE
Basic: use new signature for `ExecuteNoWait`

### DIFF
--- a/lib/Basic/Default/TaskQueue.inc
+++ b/lib/Basic/Default/TaskQueue.inc
@@ -24,6 +24,8 @@
 
 #include "swift/Basic/LLVM.h"
 
+#include "llvm/ADT/StringExtras.h"
+
 using namespace llvm::sys;
 
 namespace swift {
@@ -92,13 +94,15 @@ bool TaskQueue::execute(TaskBeganCallback Began, TaskFinishedCallback Finished,
     SmallVector<const char *, 128> Argv;
     Argv.push_back(T->ExecPath);
     Argv.append(T->Args.begin(), T->Args.end());
-    Argv.push_back(0);
+    Argv.push_back(nullptr);
 
-    const char *const *envp = T->Env.empty() ? nullptr : T->Env.data();
+    llvm::Optional<llvm::ArrayRef<llvm::StringRef>> Envp =
+        T->Env.empty() ? decltype(Envp)(None)
+                       : decltype(Envp)(llvm::toStringRefArray(T->Env.data()));
 
     bool ExecutionFailed = false;
-    ProcessInfo PI = ExecuteNoWait(T->ExecPath, Argv.data(),
-                                   (const char **)envp,
+    ProcessInfo PI = ExecuteNoWait(T->ExecPath,
+                                   llvm::toStringRefArray(Argv.data()), Envp,
                                    /*redirects*/None, /*memoryLimit*/0,
                                    /*ErrMsg*/nullptr, &ExecutionFailed);
     if (ExecutionFailed) {


### PR DESCRIPTION
Adjust the remaining instance of the `ExecuteNoWait` to use the
llvm::ArrayRef<StringRef> without an implicit conversion.  This allows swiftc to
build on Windows once again.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
