### PR TITLE
Reinstate "[Foundation] Collapse (SignedInteger|UnsignedInteger) reqts into FixedWidthInteger"

### DIFF
--- a/stdlib/public/core/ErrorType.swift
+++ b/stdlib/public/core/ErrorType.swift
@@ -211,16 +211,14 @@ extension Error {
   }
 }
 
-extension Error where Self: RawRepresentable, Self.RawValue: SignedInteger {
+extension Error where Self: RawRepresentable, Self.RawValue: FixedWidthInteger {
   // The error code of Error with integral raw values is the raw value.
   public var _code: Int {
-    return numericCast(self.rawValue)
-  }
-}
+    if Self.RawValue.isSigned {
+      return numericCast(self.rawValue)
+    }
 
-extension Error where Self: RawRepresentable, Self.RawValue: UnsignedInteger {
-  // The error code of Error with integral raw values is the raw value.
-  public var _code: Int {
-    return numericCast(self.rawValue)
+    let uintValue: UInt = numericCast(self.rawValue)
+    return Int(bitPattern: uintValue)
   }
 }

--- a/test/stdlib/Error.swift
+++ b/test/stdlib/Error.swift
@@ -1,4 +1,6 @@
-// RUN: %target-run-simple-swift
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -o %t/Error -DPTR_SIZE_%target-ptrsize -module-name main %s
+// RUN: %target-run %t/Error
 // REQUIRES: executable_test
 
 import StdlibUnittest
@@ -141,6 +143,21 @@ ErrorTests.test("existential in lvalue") {
     expectEqual(0, e?._code)
   }
   expectEqual(0, LifetimeTracked.instances)
+}
+
+enum UnsignedError: UInt, Error {
+#if PTR_SIZE_64
+case negativeOne = 0xFFFFFFFFFFFFFFFF
+#elseif PTR_SIZE_32
+case negativeOne = 0xFFFFFFFF
+#else
+#error ("Unknown pointer size")
+#endif
+}
+
+ErrorTests.test("unsigned raw value") {
+  let negOne: Error = UnsignedError.negativeOne
+  expectEqual(-1, negOne._code)
 }
 
 runAllTests()

--- a/test/stdlib/ErrorBridged.swift
+++ b/test/stdlib/ErrorBridged.swift
@@ -1,4 +1,6 @@
-// RUN: %target-run-simple-swift-swift3
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -o %t/ErrorBridged -DPTR_SIZE_%target-ptrsize -module-name main -swift-version 3 %s
+// RUN: %target-run %t/ErrorBridged
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
@@ -608,6 +610,14 @@ enum DefaultCustomizedError3 : UInt, CustomNSError {
   case bad = 9
   case worse = 115
 
+  #if PTR_SIZE_64
+  case dreadful = 0xFFFFFFFFFFFFFFFF
+#elseif PTR_SIZE_32
+  case dreadful = 0xFFFFFFFF
+#else
+#error ("Unknown pointer size")
+#endif
+  
   static var errorDomain: String {
     return "customized3"
   }
@@ -623,6 +633,7 @@ ErrorBridgingTests.test("Default-customized via CustomNSError") {
   expectEqual(1, (DefaultCustomizedError1.worse as NSError).code)
   expectEqual(13, (DefaultCustomizedError2.worse as NSError).code)
   expectEqual(115, (DefaultCustomizedError3.worse as NSError).code)
+  expectEqual(-1, (DefaultCustomizedError3.dreadful as NSError).code)
   expectEqual("main.DefaultCustomizedError1", (DefaultCustomizedError1.worse as NSError).domain)
   expectEqual("customized3", (DefaultCustomizedError3.worse as NSError).domain)
   expectEqual("main.DefaultCustomizedParent.ChildError", (DefaultCustomizedParent.ChildError.foo as NSError).domain)

--- a/validation-test/Reflection/reflect_nested.swift
+++ b/validation-test/Reflection/reflect_nested.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_nested
+// RUN: %target-run %target-swift-reflection-test %t/reflect_nested 2>&1 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// REQUIRES: objc_interop
+// REQUIRES: executable_test
+
+import SwiftReflectionTest
+
+class OuterGeneric<T> {
+  class Inner {
+    class Innermost<U> {
+      var x: T
+      var y: U
+
+      init(x: T, y: U) {
+        self.x = x
+        self.y = y
+      }
+    }
+  }
+}
+
+var obj = OuterGeneric.Inner.Innermost(x: 17, y: "hello")
+
+reflect(object: obj)
+
+// CHECK-64: Reflecting an object.
+// CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-64: Type reference:
+// CHECK-64: (bound_generic_class reflect_nested.OuterGeneric.Inner.Innermost
+// CHECK-64-NEXT: (struct Swift.Int)
+// CHECK-64-NEXT: (struct Swift.String)
+
+// CHECK-32: Reflecting an object.
+// CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-32: Type reference:
+// CHECK-32: (bound_generic_class reflect_nested.OuterGeneric.Inner.Innermost
+// CHECK-32-NEXT: (struct Swift.Int)
+// CHECK-32-NEXT: (struct Swift.String)
+
+doneReflecting()
+
+// CHECK-64: Done.
+
+// CHECK-32: Done.


### PR DESCRIPTION
Reverts apple/swift#19050, reinstating https://github.com/apple/swift-corelibs-foundation/pull/1675.