### PR TITLE
Use uninitialized dealloc in swift_deallocError

### DIFF
--- a/stdlib/public/runtime/ErrorObjectNative.cpp
+++ b/stdlib/public/runtime/ErrorObjectNative.cpp
@@ -94,7 +94,7 @@ swift::swift_allocError(const swift::Metadata *type,
 void
 swift::swift_deallocError(SwiftError *error, const Metadata *type) {
   auto sizeAndAlign = _getErrorAllocatedSizeAndAlignmentMask(type);
-  swift_deallocObject(error, sizeAndAlign.first, sizeAndAlign.second);
+  swift_deallocUninitializedObject(error, sizeAndAlign.first, sizeAndAlign.second);
 }
 
 void

--- a/test/stdlib/Error.swift
+++ b/test/stdlib/Error.swift
@@ -160,5 +160,25 @@ ErrorTests.test("unsigned raw value") {
   expectEqual(-1, negOne._code)
 }
 
+ErrorTests.test("test dealloc empty error box") {
+  struct Foo<T>: Error { let value: T }
+
+  func makeFoo<T>() throws -> Foo<T> {
+    throw Foo(value: "makeFoo throw error")
+  }
+
+  func makeError<T>(of: T.Type) throws -> Error {
+    return try makeFoo() as Foo<T>
+  }
+
+  do {
+    _ = try makeError(of: Int.self)
+  } catch let foo as Foo<String> {
+    expectEqual(foo.value, "makeFoo throw error")
+  } catch {
+    expectUnreachableCatch(error)
+  }
+}
+
 runAllTests()
 


### PR DESCRIPTION
Current of implementation `swift_deallocError` produce assertion in code like this
```
import Foundation

func empty(_ error: Error?) {
}

func crash(_ error: NSError?) {
  empty(error)
}

crash(nil)
```

Assertion is here https://github.com/apple/swift/blob/master/stdlib/public/runtime/HeapObject.cpp#L678
```
assert(object->refCounts.isDeiniting());
```

When swift_deallocError called box have unowned count = 1, strong count = 0 and deiniting = false.

I am not sure is it correct way to avoid assertion, and would it work properlly in all cases. So would be cool if somebody looks into this.
