### PR TITLE
[SILGen] Make #function printing more consistent.

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -4883,7 +4883,7 @@ getMagicFunctionString(SILGenFunction &SGF) {
          && "asking for #function but we don't have a function name?!");
   if (SGF.MagicFunctionString.empty()) {
     llvm::raw_string_ostream os(SGF.MagicFunctionString);
-    SGF.MagicFunctionName.printPretty(os);
+    SGF.MagicFunctionName.print(os);
   }
   return SGF.MagicFunctionString;
 }

--- a/test/SILGen/default_arguments.swift
+++ b/test/SILGen/default_arguments.swift
@@ -131,7 +131,7 @@ class Foo {
   }
 
   // CHECK-LABEL: sil hidden @$S17default_arguments3FooCyS2icig
-  // CHECK:         string_literal utf16 "subscript"
+  // CHECK:         string_literal utf16 "subscript(_:)"
   subscript(x: Int) -> Int {
     testMagicLiterals()
     closure { testMagicLiterals() }
@@ -160,7 +160,7 @@ func testSelectorCall(_ x: Int, withMagicLiterals y: Int) {
 }
 
 // CHECK-LABEL: sil hidden @$S17default_arguments32testSelectorCallWithUnnamedPieceyySi_SitF
-// CHECK:         string_literal utf16 "testSelectorCallWithUnnamedPiece"
+// CHECK:         string_literal utf16 "testSelectorCallWithUnnamedPiece(_:_:)"
 func testSelectorCallWithUnnamedPiece(_ x: Int, _ y: Int) {
   testMagicLiterals()
 }


### PR DESCRIPTION
Print parens and "_:" in cases where a function has no named
parameters.

We already print the parens in cases with no parameters, and the "_:"
for unnamed parameters in cases where there are already named
parameters.

Fixes: rdar://problem/19785368
