### PR TITLE
Remove ParenType-preserving hacks

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3073,13 +3073,6 @@ BEGIN_CAN_TYPE_WRAPPER(FunctionType, AnyFunctionType)
     return CanFunctionType(cast<FunctionType>(getPointer()->withExtInfo(info)));
   }
 END_CAN_TYPE_WRAPPER(FunctionType, AnyFunctionType)
-  
-/// Break an argument type into an array of \c AnyFunctionType::Params.
-///
-/// \param type The type to decompose.
-/// \param argumentLabels The argument labels to use.
-SmallVector<AnyFunctionType::Param, 4>
-decomposeArgType(Type type, ArrayRef<Identifier> argumentLabels);
 
 /// Map the given parameter list onto a bitvector describing whether
 /// the argument type at each index has a default argument associated with

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1942,14 +1942,13 @@ public:
     void verifyChecked(TupleShuffleExpr *E) {
       PrettyStackTraceExpr debugStack(Ctx, "verifying TupleShuffleExpr", E);
 
-      TupleType *TT = E->getType()->getAs<TupleType>();
-      TupleType *SubTT = E->getSubExpr()->getType()->getAs<TupleType>();
       auto getSubElementType = [&](unsigned i) {
         if (E->isSourceScalar()) {
           assert(i == 0);
           return E->getSubExpr()->getType();
         } else {
-          return SubTT->getElementType(i);
+          return (E->getSubExpr()->getType()->castTo<TupleType>()
+                   ->getElementType(i));
         }
       };
 
@@ -1959,7 +1958,7 @@ public:
           assert(i == 0);
           return E->getType()->getWithoutParens();
         } else {
-          return TT->getElementType(i);
+          return E->getType()->castTo<TupleType>()->getElementType(i);
         }
       };
 
@@ -1970,7 +1969,8 @@ public:
         if (subElem == TupleShuffleExpr::DefaultInitialize)
           continue;
         if (subElem == TupleShuffleExpr::Variadic) {
-          varargsType = TT->getElement(i).getVarargBaseTy();
+          varargsType = (E->getType()->castTo<TupleType>()
+                          ->getElement(i).getVarargBaseTy());
           break;
         }
         if (subElem == TupleShuffleExpr::CallerDefaultInitialize) {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -742,64 +742,6 @@ Type TypeBase::replaceCovariantResultType(Type newResultType,
   return FunctionType::get(inputType, resultType, fnType->getExtInfo());
 }
 
-SmallVector<AnyFunctionType::Param, 4>
-swift::decomposeArgType(Type type, ArrayRef<Identifier> argumentLabels) {
-  SmallVector<AnyFunctionType::Param, 4> result;
-  switch (type->getKind()) {
-  case TypeKind::Tuple: {
-    auto tupleTy = cast<TupleType>(type.getPointer());
-    
-    // If we have one argument label but a tuple argument with > 1 element,
-    // put the whole tuple into the argument.
-    // FIXME: This horribleness is due to the mis-modeling of arguments as
-    // ParenType or TupleType.
-    if (argumentLabels.size() == 1 && tupleTy->getNumElements() > 1) {
-      // Break out to do the default thing below.
-      break;
-    }
-    
-    for (auto i : range(0, tupleTy->getNumElements())) {
-      const auto &elt = tupleTy->getElement(i);
-      assert(!(elt.getParameterFlags().isAutoClosure() ||
-              elt.getParameterFlags().isVariadic()) &&
-             "Vararg or autoclosure argument tuple doesn't make sense");
-      result.push_back(AnyFunctionType::Param(elt.getRawType(),
-                                              argumentLabels[i],
-                                              elt.getParameterFlags()));
-    }
-    return result;
-  }
-    
-  case TypeKind::Paren: {
-    auto parenTy = cast<ParenType>(type.getPointer());
-    result.push_back(AnyFunctionType::Param(parenTy->getUnderlyingType()->getInOutObjectType(),
-                                            Identifier(),
-                                            parenTy->getParameterFlags()));
-    return result;
-  }
-
-  // If `Void` has been explicitly specified, resulting decomposition
-  // should be empty, just like empty tuple would be.
-  case TypeKind::NameAlias: {
-    auto &ctx = type->getASTContext();
-    auto *typealias = cast<NameAliasType>(type.getPointer());
-    if (typealias->getDecl() == ctx.getVoidDecl())
-      return result;
-    break;
-  }
-
-  default:
-    // Default behavior below; inject the argument as the sole parameter.
-    break;
-  }
-  
-  // Just inject this parameter.
-  assert(result.empty() && (argumentLabels.size() == 1));
-  result.push_back(AnyFunctionType::Param(type->getInOutObjectType(), argumentLabels[0],
-                                          ParameterTypeFlags().withInOut(type->is<InOutType>())));
-  return result;
-}
-
 llvm::SmallBitVector
 swift::computeDefaultMap(ArrayRef<AnyFunctionType::Param> params,
                          const ValueDecl *paramOwner, unsigned level) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5217,7 +5217,7 @@ static Type getMetatypeSuperclass(Type t, TypeChecker &tc) {
                                           metaTy->getInstanceType(),
                                           tc));
 
-  return tc.getSuperClassOf(t);
+  return t->getSuperclass();
 }
 
 Expr *ExprRewriter::coerceSuperclass(Expr *expr, Type toType,
@@ -6545,9 +6545,9 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
   // conversion restriction in this case?
   if (fromType->mayHaveSuperclass() &&
       toType->getClassOrBoundGenericClass()) {
-    for (auto fromSuperClass = tc.getSuperClassOf(fromType);
+    for (auto fromSuperClass = fromType->getSuperclass();
          fromSuperClass;
-         fromSuperClass = tc.getSuperClassOf(fromSuperClass)) {
+         fromSuperClass = fromSuperClass->getSuperclass()) {
       if (fromSuperClass->isEqual(toType)) {
         return coerceSuperclass(expr, toType, locator);
       }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1251,9 +1251,9 @@ ConstraintSystem::matchSuperclassTypes(Type type1, Type type2,
   TypeMatchOptions subflags = getDefaultDecompositionOptions(flags);
 
   auto classDecl2 = type2->getClassOrBoundGenericClass();
-  for (auto super1 = TC.getSuperClassOf(type1);
+  for (auto super1 = type1->getSuperclass();
        super1;
-       super1 = TC.getSuperClassOf(super1)) {
+       super1 = super1->getSuperclass()) {
     if (super1->getClassOrBoundGenericClass() != classDecl2)
       continue;
 
@@ -4607,7 +4607,7 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
 
     auto instance1 = type1->castTo<ExistentialMetatypeType>()->getInstanceType();
     auto instance2 = type2->castTo<MetatypeType>()->getInstanceType();
-    auto superclass1 = TC.getSuperClassOf(instance1);
+    auto superclass1 = instance1->getSuperclass();
 
     if (!superclass1)
       return SolutionKind::Error;

--- a/lib/Sema/CalleeCandidateInfo.h
+++ b/lib/Sema/CalleeCandidateInfo.h
@@ -206,9 +206,6 @@ namespace swift {
                       ArrayRef<AnyFunctionType::Param> actualArgs);
     
     void filterListArgs(ArrayRef<AnyFunctionType::Param> actualArgs);
-    void filterList(Type actualArgsType, ArrayRef<Identifier> argLabels) {
-      return filterListArgs(decomposeArgType(actualArgsType, argLabels));
-    }
     void filterList(ClosenessPredicate predicate);
     void filterContextualMemberList(Expr *argExpr);
     

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -683,26 +683,12 @@ bool ConstraintSystem::isAnyHashableType(Type type) {
   return false;
 }
 
-static Type withParens(ConstraintSystem &cs, Type type, ParenType *parenType) {
-  auto flags = parenType->getParameterFlags().withInOut(type->is<InOutType>());
-  return ParenType::get(cs.getASTContext(), type->getInOutObjectType(), flags);
-}
-
 Type ConstraintSystem::getFixedTypeRecursive(Type type,
                                              TypeMatchOptions &flags,
-                                             bool wantRValue,
-                                             bool retainParens) {
+                                             bool wantRValue) {
 
   if (wantRValue)
     type = type->getRValueType();
-
-  if (auto *parenTy = dyn_cast<ParenType>(type.getPointer())) {
-    if (retainParens) {
-      auto fixed = getFixedTypeRecursive(parenTy->getUnderlyingType(), flags,
-                                         wantRValue, retainParens);
-      return withParens(*this, fixed, parenTy);
-    }
-  }
 
   if (auto depMemType = type->getAs<DependentMemberType>()) {
     if (!depMemType->getBase()->isTypeVariableOrMember()) return type;
@@ -715,12 +701,12 @@ Type ConstraintSystem::getFixedTypeRecursive(Type type,
     // new constraint.
     flags |= TMF_GenerateConstraints;
 
-    return getFixedTypeRecursive(newType, flags, wantRValue, retainParens);
+    return getFixedTypeRecursive(newType, flags, wantRValue);
   }
 
   if (auto typeVar = type->getAs<TypeVariableType>()) {
     if (auto fixed = getFixedType(typeVar))
-      return getFixedTypeRecursive(fixed, flags, wantRValue, retainParens);
+      return getFixedTypeRecursive(fixed, flags, wantRValue);
 
     return getRepresentative(typeVar);
   }

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2027,12 +2027,9 @@ public:
   ///
   /// \param wantRValue Whether this routine should look through
   /// lvalues at each step.
-  ///
-  /// param retainParens Whether to retain parentheses.
-  Type getFixedTypeRecursive(Type type, bool wantRValue,
-                             bool retainParens = false) {
+  Type getFixedTypeRecursive(Type type, bool wantRValue) {
     TypeMatchOptions flags = None;
-    return getFixedTypeRecursive(type, flags, wantRValue, retainParens);
+    return getFixedTypeRecursive(type, flags, wantRValue);
   }
 
   /// Retrieve the fixed type corresponding to a given type variable,
@@ -2047,11 +2044,8 @@ public:
   ///
   /// \param wantRValue Whether this routine should look through
   /// lvalues at each step.
-  ///
-  /// param retainParens Whether to retain parentheses.
   Type getFixedTypeRecursive(Type type, TypeMatchOptions &flags,
-                             bool wantRValue,
-                             bool retainParens = false);
+                             bool wantRValue);
 
   /// Determine whether the given type variable occurs within the given type.
   ///

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3173,16 +3173,6 @@ Type TypeChecker::substMemberTypeWithBase(ModuleDecl *module,
   return resultType;
 }
 
-Type TypeChecker::getSuperClassOf(Type type) {
-  if (auto *parenTy = dyn_cast<ParenType>(type.getPointer())) {
-    auto superclassTy = getSuperClassOf(parenTy->getUnderlyingType());
-    if (!superclassTy)
-      return Type();
-    return ParenType::get(Context, superclassTy);
-  }
-  return type->getSuperclass();
-}
-
 namespace {
 
 class UnsupportedProtocolVisitor

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -969,10 +969,6 @@ public:
   static Type substMemberTypeWithBase(ModuleDecl *module, TypeDecl *member,
                                       Type baseTy, bool useArchetypes = true);
 
-  /// \brief Retrieve the superclass type of the given type, or a null type if
-  /// the type has no supertype.
-  Type getSuperClassOf(Type type);
-
   /// \brief Determine whether one type is a subtype of another.
   ///
   /// \param t1 The potential subtype.


### PR DESCRIPTION
One of the last remaining bits of badness in the constraint solver regarding the function type representation. Instead of matching the input argument tuples of function types, let's directly walk the parameters pair-wise.

This means that various hacks that were put in from Swift 3 onward to preserve ParenType sugar when matching when matching types can go away. The solver no longer cares about ParenType.