### PR TITLE
[stdlib] Deprecate Collection.index(of:) and index(where:)

### DIFF
--- a/stdlib/public/core/CollectionAlgorithms.swift
+++ b/stdlib/public/core/CollectionAlgorithms.swift
@@ -72,13 +72,6 @@ extension Collection where Element : Equatable {
     }
     return nil
   }
-  
-  /// Returns the first index where the specified value appears in the
-  /// collection.
-  @inlinable
-  public func index(of _element: Element) -> Index? {
-    return firstIndex(of: _element)
-  }
 }
 
 extension Collection {
@@ -116,15 +109,6 @@ extension Collection {
       self.formIndex(after: &i)
     }
     return nil
-  }
-  
-  /// Returns the first index in which an element of the collection satisfies
-  /// the given predicate.
-  @inlinable
-  public func index(
-    where _predicate: (Element) throws -> Bool
-  ) rethrows -> Index? {
-    return try firstIndex(where: _predicate)
   }
 }
 

--- a/stdlib/public/core/MigrationSupport.swift
+++ b/stdlib/public/core/MigrationSupport.swift
@@ -1011,6 +1011,28 @@ extension Collection {
   }
 }
 
+extension Collection {
+  /// Returns the first index in which an element of the collection satisfies
+  /// the given predicate.
+  @available(swift, deprecated: 5.0, renamed: "firstIndex(where:)")
+  @inlinable
+  public func index(
+    where _predicate: (Element) throws -> Bool
+  ) rethrows -> Index? {
+    return try firstIndex(where: _predicate)
+  }
+}
+
+extension Collection where Element: Equatable {
+  /// Returns the first index where the specified value appears in the
+  /// collection.
+  @available(swift, deprecated: 5.0, renamed: "firstIndex(of:)")
+  @inlinable
+  public func index(of element: Element) -> Index? {
+    return firstIndex(of: element)
+  }
+}
+
 extension String.Index {
   @available(swift, deprecated: 3.2, obsoleted: 4.0)
   public init(_position: Int) {

--- a/test/stdlib/IndexOfRenaming.swift
+++ b/test/stdlib/IndexOfRenaming.swift
@@ -1,8 +1,8 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -swift-version 5
 
 let a = [10, 20, 30, 40, 50, 60]
 
-_ = a.index(of: 30)
+_ = a.index(of: 30) // expected-warning {{'index(of:)' is deprecated: renamed to 'firstIndex(of:)'}} expected-note {{use 'firstIndex(of:)' instead}}
 _ = a.firstIndex(of: 30)
-_ = a.index(where: { $0 > 30 })
+_ = a.index(where: { $0 > 30 }) // expected-warning {{'index(where:)' is deprecated: renamed to 'firstIndex(where:)'}} expected-note {{use 'firstIndex(where:)' instead}}
 _ = a.firstIndex(where: { $0 > 30 })


### PR DESCRIPTION
This should have been done for Swift 4.2 according to SE-0204, but
better later than never. Deprecating these methods as of Swift 5.0.

Also modfying the tests to check for the deprecation message.

Fixes: <rdar://problem/43694210>