### PR TITLE
Add a new counter that queries malloc.

### DIFF
--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -83,6 +83,9 @@ FRONTEND_STATISTIC(Frontend, NumProcessFailures)
 /// Total instructions-executed count in each frontend process.
 FRONTEND_STATISTIC(Frontend, NumInstructionsExecuted)
 
+/// Maximum number of bytes allocated via malloc.
+FRONTEND_STATISTIC(Frontend, MaxMallocUsage)
+
 /// Number of source buffers visible in the source manager.
 FRONTEND_STATISTIC(AST, NumSourceBuffers)
 

--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -632,7 +632,8 @@ UnifiedStatsReporter::~UnifiedStatsReporter()
     }
   }
 
-  updateProcessWideFrontendCounters(getFrontendCounters());
+  if (FrontendCounters)
+    updateProcessWideFrontendCounters(getFrontendCounters());
 
   // NB: Timer needs to be Optional<> because it needs to be destructed early;
   // LLVM will complain about double-stopping a timer if you tear down a


### PR DESCRIPTION
Recording the "memory usage" of Swift systematically is pretty hard: most of the metrics we can find are either too noisy, miss a lot of allocations, or both. Malloc keeps its own maximum-allocated stats which are .. well, not especially stable run-over-run either, but they're a bit more signal. Combined with Driver.ChildrenMaxRSS and AST.NumASTBytesAllocated it should help give us _some_ signal.