### PR TITLE
[stdlib] JAFIA

### DIFF
--- a/stdlib/public/SwiftOnoneSupport/SwiftOnoneSupport.swift
+++ b/stdlib/public/SwiftOnoneSupport/SwiftOnoneSupport.swift
@@ -13,8 +13,7 @@
 //===----------------------------------------------------------------------===//
 import Swift
 
-@_frozen // FIXME(sil-serialize-all)
-@usableFromInline // FIXME(sil-serialize-all)
+@_frozen // enum
 internal enum _Prespecialize {
   // Create specializations for the arrays of most
   // popular builtin integer and floating point types.

--- a/stdlib/public/SwiftOnoneSupport/SwiftOnoneSupport.swift
+++ b/stdlib/public/SwiftOnoneSupport/SwiftOnoneSupport.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 import Swift
 
-@_frozen // enum
 internal enum _Prespecialize {
   // Create specializations for the arrays of most
   // popular builtin integer and floating point types.

--- a/stdlib/public/core/DropWhile.swift
+++ b/stdlib/public/core/DropWhile.swift
@@ -12,21 +12,21 @@
 
 /// A sequence whose elements consist of the elements that follow the initial
 /// consecutive elements of some base sequence that satisfy a given predicate.
-@_fixed_layout // FIXME(sil-serialize-all)
+@_fixed_layout // lazy-performance
 public struct LazyDropWhileSequence<Base: Sequence> {
   public typealias Element = Base.Element
   
   /// Create an instance with elements `transform(x)` for each element
   /// `x` of base.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   internal init(_base: Base, predicate: @escaping (Element) -> Bool) {
     self._base = _base
     self._predicate = predicate
   }
 
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // lazy-performance
   internal var _base: Base
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // lazy-performance
   internal let _predicate: (Element) -> Bool
 }
 
@@ -37,27 +37,27 @@ extension LazyDropWhileSequence {
   /// This is the associated iterator for the `LazyDropWhileSequence`,
   /// `LazyDropWhileCollection`, and `LazyDropWhileBidirectionalCollection`
   /// types.
-  @_fixed_layout // FIXME(sil-serialize-all)
+  @_fixed_layout // lazy-performance
   public struct Iterator {
     public typealias Element = Base.Element
     
-    @inlinable // FIXME(sil-serialize-all)
+    @inlinable // lazy-performance
     internal init(_base: Base.Iterator, predicate: @escaping (Element) -> Bool) {
       self._base = _base
       self._predicate = predicate
     }
 
-    @usableFromInline // FIXME(sil-serialize-all)
+    @usableFromInline // lazy-performance
     internal var _predicateHasFailed = false
-    @usableFromInline // FIXME(sil-serialize-all)
+    @usableFromInline // lazy-performance
     internal var _base: Base.Iterator
-    @usableFromInline // FIXME(sil-serialize-all)
+    @usableFromInline // lazy-performance
     internal let _predicate: (Element) -> Bool
   }
 }
 
 extension LazyDropWhileSequence.Iterator: IteratorProtocol {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public mutating func next() -> Element? {
     // Once the predicate has failed for the first time, the base iterator
     // can be used for the rest of the elements.
@@ -83,7 +83,7 @@ extension LazyDropWhileSequence: Sequence {
   /// Returns an iterator over the elements of this sequence.
   ///
   /// - Complexity: O(1).
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func makeIterator() -> Iterator {
     return Iterator(_base: _base.makeIterator(), predicate: _predicate)
   }
@@ -101,7 +101,7 @@ extension LazySequenceProtocol {
   ///   its argument and returns `true` if the element should be skipped or
   ///   `false` otherwise. Once `predicate` returns `false` it will not be
   ///   called again.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func drop(
     while predicate: @escaping (Elements.Element) -> Bool
   ) -> LazyDropWhileSequence<Self.Elements> {
@@ -119,19 +119,19 @@ extension LazySequenceProtocol {
 ///   performance given by the `Collection` protocol. Be aware, therefore,
 ///   that general operations on lazy collections may not have the
 ///   documented complexity.
-@_fixed_layout // FIXME(sil-serialize-all)
+@_fixed_layout // lazy-performance
 public struct LazyDropWhileCollection<Base: Collection> {
   public typealias Element = Base.Element
   
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   internal init(_base: Base, predicate: @escaping (Element) -> Bool) {
     self._base = _base
     self._predicate = predicate
   }
 
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // lazy-performance
   internal var _base: Base
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // lazy-performance
   internal let _predicate: (Element) -> Bool
 }
 
@@ -141,7 +141,7 @@ extension LazyDropWhileCollection: Sequence {
   /// Returns an iterator over the elements of this sequence.
   ///
   /// - Complexity: O(1).
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func makeIterator() -> Iterator {
     return Iterator(_base: _base.makeIterator(), predicate: _predicate)
   }
@@ -152,12 +152,12 @@ extension LazyDropWhileCollection {
 
   /// A position in a `LazyDropWhileCollection` or
   /// `LazyDropWhileBidirectionalCollection` instance.
-  @_fixed_layout // FIXME(sil-serialize-all)
+  @_fixed_layout // lazy-performance
   public struct Index {
     /// The position corresponding to `self` in the underlying collection.
     public let base: Base.Index
 
-    @inlinable // FIXME(sil-serialize-all)
+    @inlinable // lazy-performance
     internal init(_base: Base.Index) {
       self.base = _base
     }
@@ -165,7 +165,7 @@ extension LazyDropWhileCollection {
 }
 
 extension LazyDropWhileCollection.Index: Equatable, Comparable {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public static func == (
     lhs: LazyDropWhileCollection<Base>.Index,
     rhs: LazyDropWhileCollection<Base>.Index
@@ -173,7 +173,7 @@ extension LazyDropWhileCollection.Index: Equatable, Comparable {
     return lhs.base == rhs.base
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public static func < (
     lhs: LazyDropWhileCollection<Base>.Index,
     rhs: LazyDropWhileCollection<Base>.Index
@@ -201,7 +201,7 @@ extension LazyDropWhileCollection.Index: Hashable where Base.Index: Hashable {
 }
 
 extension LazyDropWhileCollection: Collection {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public var startIndex: Index {
     var index = _base.startIndex
     while index != _base.endIndex && _predicate(_base[index]) {
@@ -210,19 +210,19 @@ extension LazyDropWhileCollection: Collection {
     return Index(_base: index)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public var endIndex: Index {
     return Index(_base: _base.endIndex)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func index(after i: Index) -> Index {
     _precondition(i.base < _base.endIndex, "Can't advance past endIndex")
     return Index(_base: _base.index(after: i.base))
   }
 
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public subscript(position: Index) -> Element {
     return _base[position.base]
   }
@@ -232,7 +232,7 @@ extension LazyDropWhileCollection: LazyCollectionProtocol { }
 
 extension LazyDropWhileCollection: BidirectionalCollection 
 where Base: BidirectionalCollection {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func index(before i: Index) -> Index {
     _precondition(i > startIndex, "Can't move before startIndex")
     return Index(_base: _base.index(before: i.base))
@@ -247,7 +247,7 @@ extension LazyCollectionProtocol {
   ///   as its argument and returns `true` if the element should be skipped or
   ///   `false` otherwise. Once `predicate` returns `false` it will not be
   ///   called again.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func drop(
     while predicate: @escaping (Elements.Element) -> Bool
   ) -> LazyDropWhileCollection<Self.Elements> {

--- a/stdlib/public/core/Filter.swift
+++ b/stdlib/public/core/Filter.swift
@@ -18,17 +18,17 @@
 ///   is a `LazyFilterSequence`.
 @_fixed_layout // lazy-performance
 public struct LazyFilterSequence<Base: Sequence> {
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // lazy-performance
   internal var _base: Base
 
   /// The predicate used to determine which elements produced by
   /// `base` are also produced by `self`.
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // lazy-performance
   internal let _predicate: (Base.Element) -> Bool
 
   /// Creates an instance consisting of the elements `x` of `base` for
   /// which `isIncluded(x) == true`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public // @testable
   init(_base base: Base, _ isIncluded: @escaping (Base.Element) -> Bool) {
     self._base = base

--- a/stdlib/public/core/Join.swift
+++ b/stdlib/public/core/Join.swift
@@ -17,16 +17,16 @@ public struct JoinedSequence<Base : Sequence> where Base.Element : Sequence {
 
   public typealias Element = Base.Element.Element
   
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // lazy-performance
   internal var _base: Base
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // lazy-performance
   internal var _separator: ContiguousArray<Element>
 
   /// Creates an iterator that presents the elements of the sequences
   /// traversed by `base`, concatenated using `separator`.
   ///
   /// - Complexity: O(`separator.count`).
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public init<Separator : Sequence>(base: Base, separator: Separator)
     where Separator.Element == Element {
     self._base = base

--- a/stdlib/public/core/MigrationSupport.swift
+++ b/stdlib/public/core/MigrationSupport.swift
@@ -330,6 +330,9 @@ extension _ExpressibleByColorLiteral {
   }
 }
 
+@available(swift, deprecated: 5.0, renamed: "KeyValuePairs")
+public typealias DictionaryLiteral<Key, Value> = KeyValuePairs<Key, Value>
+
 extension LazySequenceProtocol {
   /// Returns the non-`nil` results of mapping the given transformation over
   /// this sequence.

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -524,7 +524,6 @@ extension Mirror {
 ///     let pairs = IntPairs([1: 2, 1: 1, 3: 4, 2: 1])
 ///     print(pairs.elements)
 ///     // Prints "[(1, 2), (1, 1), (3, 4), (2, 1)]"
-@_fixed_layout // FIXME(sil-serialize-all)
 public struct KeyValuePairs<Key, Value> : ExpressibleByDictionaryLiteral {
   /// Creates a new `KeyValuePairs` instance from the given dictionary
   /// literal.
@@ -534,7 +533,6 @@ public struct KeyValuePairs<Key, Value> : ExpressibleByDictionaryLiteral {
   public init(dictionaryLiteral elements: (Key, Value)...) {
     self._elements = elements
   }
-  @usableFromInline // FIXME(sil-serialize-all)
   internal let _elements: [(Key, Value)]
 }
 
@@ -547,7 +545,6 @@ extension KeyValuePairs : RandomAccessCollection {
   ///
   /// If the `KeyValuePairs` instance is empty, `startIndex` is equal to
   /// `endIndex`.
-  @inlinable // FIXME(sil-serialize-all)
   public var startIndex: Int { return 0 }
 
   /// The collection's "past the end" position---that is, the position one
@@ -555,7 +552,6 @@ extension KeyValuePairs : RandomAccessCollection {
   ///
   /// If the `KeyValuePairs` instance is empty, `endIndex` is equal to
   /// `startIndex`.
-  @inlinable // FIXME(sil-serialize-all)
   public var endIndex: Int { return _elements.endIndex }
 
   // FIXME(ABI)#174 (Type checker): a typealias is needed to prevent <rdar://20248032>
@@ -569,7 +565,6 @@ extension KeyValuePairs : RandomAccessCollection {
   ///   must be a valid index of the collection that is not equal to the
   ///   `endIndex` property.
   /// - Returns: The key-value pair at position `position`.
-  @inlinable // FIXME(sil-serialize-all)
   public subscript(position: Int) -> Element {
     return _elements[position]
   }
@@ -615,7 +610,6 @@ extension String {
   ///
   ///     print(String(describing: p))
   ///     // Prints "(21, 30)"
-  @inlinable // FIXME(sil-serialize-all)
   public init<Subject>(describing instance: Subject) {
     self.init()
     _print_unlocked(instance, &self)
@@ -665,7 +659,6 @@ extension String {
   ///
   ///     print(String(reflecting: p))
   ///     // Prints "Point(x: 21, y: 30)"
-  @inlinable // FIXME(sil-serialize-all)
   public init<Subject>(reflecting subject: Subject) {
     self.init()
     _debugPrint_unlocked(subject, &self)

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -538,9 +538,6 @@ public struct KeyValuePairs<Key, Value> : ExpressibleByDictionaryLiteral {
   internal let _elements: [(Key, Value)]
 }
 
-@available(swift, deprecated: 5.0, renamed: "KeyValuePairs")
-public typealias DictionaryLiteral<Key, Value> = KeyValuePairs<Key, Value>
-
 /// `Collection` conformance that allows `KeyValuePairs` to
 /// interoperate with the rest of the standard library.
 extension KeyValuePairs : RandomAccessCollection {

--- a/stdlib/public/core/OptionSet.swift
+++ b/stdlib/public/core/OptionSet.swift
@@ -142,7 +142,7 @@ extension OptionSet {
   /// - Parameter other: An option set.
   /// - Returns: A new option set made up of the elements contained in this
   ///   set, in `other`, or in both.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public func union(_ other: Self) -> Self {
     var r: Self = Self(rawValue: self.rawValue)
     r.formUnion(other)
@@ -169,7 +169,7 @@ extension OptionSet {
   /// - Parameter other: An option set.
   /// - Returns: A new option set with only the elements contained in both this
   ///   set and `other`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public func intersection(_ other: Self) -> Self {
     var r = Self(rawValue: self.rawValue)
     r.formIntersection(other)
@@ -182,7 +182,7 @@ extension OptionSet {
   /// - Parameter other: An option set.
   /// - Returns: A new option set with only the elements contained in either
   ///   this set or `other`, but not in both.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public func symmetricDifference(_ other: Self) -> Self {
     var r = Self(rawValue: self.rawValue)
     r.formSymmetricDifference(other)
@@ -212,7 +212,7 @@ extension OptionSet where Element == Self {
   /// - Parameter member: The element to look for in the option set.
   /// - Returns: `true` if the option set contains `member`; otherwise,
   ///   `false`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public func contains(_ member: Self) -> Bool {
     return self.isSuperset(of: member)
   }
@@ -237,7 +237,7 @@ extension OptionSet where Element == Self {
   /// - Returns: `(true, newMember)` if `newMember` was not contained in
   ///   `self`. Otherwise, returns `(false, oldMember)`, where `oldMember` is
   ///   the member of the set equal to `newMember`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   @discardableResult
   public mutating func insert(
     _ newMember: Element
@@ -283,7 +283,7 @@ extension OptionSet where Element == Self {
   /// - Parameter member: The element of the set to remove.
   /// - Returns: The intersection of `[member]` and the set, if the
   ///   intersection was nonempty; otherwise, `nil`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   @discardableResult
   public mutating func remove(_ member: Element) -> Element? {
     let r = isSuperset(of: member) ? Optional(member) : nil
@@ -303,7 +303,7 @@ extension OptionSet where Element == Self {
   ///
   /// - Returns: The intersection of `[newMember]` and the set if the
   ///   intersection was nonempty; otherwise, `nil`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   @discardableResult
   public mutating func update(with newMember: Element) -> Element? {
     let r = self.intersection(newMember)
@@ -330,7 +330,7 @@ extension OptionSet where RawValue : FixedWidthInteger {
   /// Creates an empty option set.
   ///
   /// This initializer creates an option set with a raw value of zero.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public init() {
     self.init(rawValue: 0)
   }
@@ -341,7 +341,7 @@ extension OptionSet where RawValue : FixedWidthInteger {
   /// two sets' raw values.
   ///
   /// - Parameter other: An option set.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public mutating func formUnion(_ other: Self) {
     self = Self(rawValue: self.rawValue | other.rawValue)
   }
@@ -353,7 +353,7 @@ extension OptionSet where RawValue : FixedWidthInteger {
   /// two sets' raw values.
   ///
   /// - Parameter other: An option set.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public mutating func formIntersection(_ other: Self) {
     self = Self(rawValue: self.rawValue & other.rawValue)
   }
@@ -365,7 +365,7 @@ extension OptionSet where RawValue : FixedWidthInteger {
   /// sets' raw values.
   ///
   /// - Parameter other: An option set.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public mutating func formSymmetricDifference(_ other: Self) {
     self = Self(rawValue: self.rawValue ^ other.rawValue)
   }

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -75,9 +75,7 @@ public protocol TextOutputStream {
 }
 
 extension TextOutputStream {
-  @inlinable // FIXME(sil-serialize-all)
   public mutating func _lock() {}
-  @inlinable // FIXME(sil-serialize-all)
   public mutating func _unlock() {}
 }
 
@@ -278,7 +276,6 @@ internal func _getEnumCaseName<T>(_ value: T) -> UnsafePointer<CChar>?
 internal func _opaqueSummary(_ metadata: Any.Type) -> UnsafePointer<CChar>?
 
 /// Do our best to print a value that cannot be printed directly.
-@inlinable // FIXME(sil-serialize-all)
 @_semantics("optimize.sil.specialize.generic.never")
 internal func _adHocPrint_unlocked<T, TargetStream : TextOutputStream>(
     _ value: T, _ mirror: Mirror, _ target: inout TargetStream,
@@ -460,7 +457,6 @@ public func _debugPrint_unlocked<T, TargetStream : TextOutputStream>(
   _adHocPrint_unlocked(value, mirror, &target, isDebugPrint: true)
 }
 
-@inlinable // FIXME(sil-serialize-all)
 @_semantics("optimize.sil.specialize.generic.never")
 internal func _dumpPrint_unlocked<T, TargetStream : TextOutputStream>(
     _ value: T, _ mirror: Mirror, _ target: inout TargetStream

--- a/stdlib/public/core/PrefixWhile.swift
+++ b/stdlib/public/core/PrefixWhile.swift
@@ -13,19 +13,19 @@
 
 /// A sequence whose elements consist of the initial consecutive elements of
 /// some base sequence that satisfy a given predicate.
-@_fixed_layout // FIXME(sil-serialize-all)
+@_fixed_layout // lazy-performance
 public struct LazyPrefixWhileSequence<Base: Sequence> {
   public typealias Element = Base.Element
   
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   internal init(_base: Base, predicate: @escaping (Element) -> Bool) {
     self._base = _base
     self._predicate = predicate
   }
 
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // lazy-performance
   internal var _base: Base
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // lazy-performance
   internal let _predicate: (Element) -> Bool
 }
 
@@ -37,18 +37,18 @@ extension LazyPrefixWhileSequence {
   /// This is the associated iterator for the `LazyPrefixWhileSequence`,
   /// `LazyPrefixWhileCollection`, and `LazyPrefixWhileBidirectionalCollection`
   /// types.
-  @_fixed_layout // FIXME(sil-serialize-all)
+  @_fixed_layout // lazy-performance
   public struct Iterator {
     public typealias Element = Base.Element
 
-    @usableFromInline // FIXME(sil-serialize-all)
+    @usableFromInline // lazy-performance
     internal var _predicateHasFailed = false
-    @usableFromInline // FIXME(sil-serialize-all)
+    @usableFromInline // lazy-performance
     internal var _base: Base.Iterator
-    @usableFromInline // FIXME(sil-serialize-all)
+    @usableFromInline // lazy-performance
     internal let _predicate: (Element) -> Bool
 
-    @inlinable // FIXME(sil-serialize-all)
+    @inlinable // lazy-performance
     internal init(_base: Base.Iterator, predicate: @escaping (Element) -> Bool) {
       self._base = _base
       self._predicate = predicate
@@ -57,7 +57,7 @@ extension LazyPrefixWhileSequence {
 }
 
 extension LazyPrefixWhileSequence.Iterator: IteratorProtocol, Sequence {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public mutating func next() -> Element? {
     // Return elements from the base iterator until one fails the predicate.
     if !_predicateHasFailed, let nextElement = _base.next() {
@@ -74,7 +74,7 @@ extension LazyPrefixWhileSequence.Iterator: IteratorProtocol, Sequence {
 extension LazyPrefixWhileSequence: Sequence {
   public typealias SubSequence = AnySequence<Element> // >:(
   
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func makeIterator() -> Iterator {
     return Iterator(_base: _base.makeIterator(), predicate: _predicate)
   }
@@ -92,7 +92,7 @@ extension LazySequenceProtocol {
   ///   its argument and returns `true` if the element should be included or
   ///   `false` otherwise. Once `predicate` returns `false` it will not be
   ///   called again.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func prefix(
     while predicate: @escaping (Elements.Element) -> Bool
   ) -> LazyPrefixWhileSequence<Self.Elements> {
@@ -109,27 +109,27 @@ extension LazySequenceProtocol {
 ///   the usual performance given by the `Collection` protocol. Be aware,
 ///   therefore, that general operations on `${Self}` instances may not have
 ///   the documented complexity.
-@_fixed_layout // FIXME(sil-serialize-all)
+@_fixed_layout // lazy-performance
 public struct LazyPrefixWhileCollection<Base: Collection> {
   public typealias Element = Base.Element
   public typealias SubSequence = Slice<LazyPrefixWhileCollection<Base>>
   
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   internal init(_base: Base, predicate: @escaping (Element) -> Bool) {
     self._base = _base
     self._predicate = predicate
   }
 
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // lazy-performance
   internal var _base: Base
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // lazy-performance
   internal let _predicate: (Element) -> Bool
 }
 
 extension LazyPrefixWhileCollection: Sequence {
   public typealias Iterator = LazyPrefixWhileSequence<Base>.Iterator
   
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func makeIterator() -> Iterator {
     return Iterator(_base: _base.makeIterator(), predicate: _predicate)
   }
@@ -138,7 +138,7 @@ extension LazyPrefixWhileCollection: Sequence {
 extension LazyPrefixWhileCollection {
   /// A position in the base collection of a `LazyPrefixWhileCollection` or the
   /// end of that collection.
-  @_frozen // FIXME(sil-serialize-all)
+  @_frozen // lazy-performance
   @usableFromInline
   internal enum _IndexRepresentation {
     case index(Base.Index)
@@ -147,14 +147,14 @@ extension LazyPrefixWhileCollection {
   
   /// A position in a `LazyPrefixWhileCollection` or
   /// `LazyPrefixWhileBidirectionalCollection` instance.
-  @_fixed_layout // FIXME(sil-serialize-all)
+  @_fixed_layout // lazy-performance
   public struct Index {
     /// The position corresponding to `self` in the underlying collection.
-    @usableFromInline // FIXME(sil-serialize-all)
+    @usableFromInline // lazy-performance
     internal let _value: _IndexRepresentation
 
     /// Creates a new index wrapper for `i`.
-    @inlinable // FIXME(sil-serialize-all)
+    @inlinable // lazy-performance
     internal init(_ i: Base.Index) {
       self._value = .index(i)
     }
@@ -162,7 +162,7 @@ extension LazyPrefixWhileCollection {
     /// Creates a new index that can represent the `endIndex` of a
     /// `LazyPrefixWhileCollection<Base>`. This is not the same as a wrapper
     /// around `Base.endIndex`.
-    @inlinable // FIXME(sil-serialize-all)
+    @inlinable // lazy-performance
     internal init(endOf: Base) {
       self._value = .pastEnd
     }
@@ -170,7 +170,7 @@ extension LazyPrefixWhileCollection {
 }
 
 extension LazyPrefixWhileCollection.Index: Comparable {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public static func == (
     lhs: LazyPrefixWhileCollection<Base>.Index, 
     rhs: LazyPrefixWhileCollection<Base>.Index
@@ -185,7 +185,7 @@ extension LazyPrefixWhileCollection.Index: Comparable {
     }
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public static func < (
     lhs: LazyPrefixWhileCollection<Base>.Index, 
     rhs: LazyPrefixWhileCollection<Base>.Index
@@ -219,12 +219,12 @@ extension LazyPrefixWhileCollection.Index: Hashable where Base.Index: Hashable {
 }
 
 extension LazyPrefixWhileCollection: Collection {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public var startIndex: Index {
     return Index(_base.startIndex)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public var endIndex: Index {
     // If the first element of `_base` satisfies the predicate, there is at
     // least one element in the lazy collection: Use the explicit `.pastEnd` index.
@@ -237,7 +237,7 @@ extension LazyPrefixWhileCollection: Collection {
     return startIndex
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func index(after i: Index) -> Index {
     _precondition(i != endIndex, "Can't advance past endIndex")
     guard case .index(let i) = i._value else {
@@ -250,7 +250,7 @@ extension LazyPrefixWhileCollection: Collection {
     return Index(nextIndex)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public subscript(position: Index) -> Element {
     switch position._value {
     case .index(let i):
@@ -263,7 +263,7 @@ extension LazyPrefixWhileCollection: Collection {
 
 extension LazyPrefixWhileCollection: BidirectionalCollection
 where Base: BidirectionalCollection {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func index(before i: Index) -> Index {
     switch i._value {
     case .index(let i):
@@ -303,7 +303,7 @@ extension LazyCollectionProtocol {
   ///   as its argument and returns `true` if the element should be included
   ///   or `false` otherwise. Once `predicate` returns `false` it will not be
   ///   called again.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // lazy-performance
   public func prefix(
     while predicate: @escaping (Element) -> Bool
   ) -> LazyPrefixWhileCollection<Elements> {

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -762,7 +762,7 @@ extension Comparable {
 ///     let word2 = "grisly"
 ///     let changes = countLetterChanges(word1[...], word2[...])
 ///     // changes == 2
-@_frozen // FIXME(sil-serialize-all)
+@_frozen // namespace
 public enum UnboundedRange_ {
   // FIXME: replace this with a computed var named `...` when the language makes
   // that possible.
@@ -771,7 +771,6 @@ public enum UnboundedRange_ {
   ///
   /// The unbounded range operator (`...`) is valid only within a collection's
   /// subscript.
-  @inlinable // FIXME(sil-serialize-all)
   public static postfix func ... (_: UnboundedRange_) -> () {
     fatalError("uncallable")
   }
@@ -844,7 +843,7 @@ extension MutableCollection {
     }
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   public subscript(x: UnboundedRange) -> SubSequence {
     get {
       return self[startIndex...]

--- a/stdlib/public/core/SequenceWrapper.swift
+++ b/stdlib/public/core/SequenceWrapper.swift
@@ -27,12 +27,12 @@ protocol _SequenceWrapper : Sequence {
 }
 
 extension _SequenceWrapper  {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public var underestimatedCount: Int {
     return _base.underestimatedCount
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public func _preprocessingPass<R>(
     _ preprocess: () throws -> R
   ) rethrows -> R? {
@@ -41,12 +41,12 @@ extension _SequenceWrapper  {
 }
 
 extension _SequenceWrapper where Iterator == Base.Iterator {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public func makeIterator() -> Iterator {
     return self._base.makeIterator()
   }
   
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   @discardableResult
   public func _copyContents(
     initializing buf: UnsafeMutableBufferPointer<Element>
@@ -56,33 +56,33 @@ extension _SequenceWrapper where Iterator == Base.Iterator {
 }
 
 extension _SequenceWrapper {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public func map<T>(
     _ transform: (Element) throws -> T
 ) rethrows -> [T] {
     return try _base.map(transform)
   }
   
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public func filter(
     _ isIncluded: (Element) throws -> Bool
   ) rethrows -> [Element] {
     return try _base.filter(isIncluded)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public func forEach(_ body: (Element) throws -> Void) rethrows {
     return try _base.forEach(body)
   }
   
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public func _customContainsEquatableElement(
     _ element: Element
   ) -> Bool? { 
     return _base._customContainsEquatableElement(element)
   }
   
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public func _copyToContiguousArray()
     -> ContiguousArray<Element> {
     return _base._copyToContiguousArray()
@@ -90,38 +90,38 @@ extension _SequenceWrapper {
 }
 
 extension _SequenceWrapper where SubSequence == Base.SubSequence {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public func dropFirst(_ n: Int) -> SubSequence {
     return _base.dropFirst(n)
   }
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public func dropLast(_ n: Int) -> SubSequence {
     return _base.dropLast(n)
   }
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public func prefix(_ maxLength: Int) -> SubSequence {
     return _base.prefix(maxLength)
   }
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public func suffix(_ maxLength: Int) -> SubSequence {
     return _base.suffix(maxLength)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public func drop(
     while predicate: (Element) throws -> Bool
   ) rethrows -> SubSequence {
     return try _base.drop(while: predicate)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public func prefix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> SubSequence {
     return try _base.prefix(while: predicate)
   }
   
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public func split(
     maxSplits: Int, omittingEmptySubsequences: Bool,
     whereSeparator isSeparator: (Element) throws -> Bool

--- a/stdlib/public/core/Slice.swift
+++ b/stdlib/public/core/Slice.swift
@@ -79,12 +79,12 @@
 ///   collection type, don't use `Slice` as its subsequence type. Instead,
 ///   define your own subsequence type that takes your index invalidation
 ///   requirements into account.
-@_fixed_layout // FIXME(sil-serialize-all)
+@_fixed_layout // generic-performance
 public struct Slice<Base: Collection> {
   public var _startIndex: Base.Index
   public var _endIndex: Base.Index
 
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // generic-performance
   internal var _base: Base
 
   /// Creates a view into the given collection that allows access to elements
@@ -106,7 +106,7 @@ public struct Slice<Base: Collection> {
   /// - Parameters:
   ///   - base: The collection to create a view into.
   ///   - bounds: The range of indices to allow access to in the new slice.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public init(base: Base, bounds: Range<Base.Index>) {
     self._base = base
     self._startIndex = bounds.lowerBound
@@ -131,7 +131,7 @@ public struct Slice<Base: Collection> {
   ///     // Prints "10"
   ///     print(singleDigits == singleNonZeroDigits.base)
   ///     // Prints "true"
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public var base: Base {
     return _base
   }
@@ -144,17 +144,17 @@ extension Slice: Collection {
   public typealias SubSequence = Slice<Base>
   public typealias Iterator = IndexingIterator<Slice<Base>>
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public var startIndex: Index {
     return _startIndex
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public var endIndex: Index {
     return _endIndex
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public subscript(index: Index) -> Base.Element {
     get {
       _failEarlyRangeCheck(index, bounds: startIndex..<endIndex)
@@ -162,7 +162,7 @@ extension Slice: Collection {
     }
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public subscript(bounds: Range<Index>) -> Slice<Base> {
     get {
       _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)
@@ -174,25 +174,25 @@ extension Slice: Collection {
     return _base.indices[_startIndex..<_endIndex]
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public func index(after i: Index) -> Index {
     // FIXME: swift-3-indexing-model: range check.
     return _base.index(after: i)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public func formIndex(after i: inout Index) {
     // FIXME: swift-3-indexing-model: range check.
     _base.formIndex(after: &i)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public func index(_ i: Index, offsetBy n: Int) -> Index {
     // FIXME: swift-3-indexing-model: range check.
     return _base.index(i, offsetBy: n)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public func index(
     _ i: Index, offsetBy n: Int, limitedBy limit: Index
   ) -> Index? {
@@ -200,31 +200,31 @@ extension Slice: Collection {
     return _base.index(i, offsetBy: n, limitedBy: limit)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public func distance(from start: Index, to end: Index) -> Int {
     // FIXME: swift-3-indexing-model: range check.
     return _base.distance(from: start, to: end)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public func _failEarlyRangeCheck(_ index: Index, bounds: Range<Index>) {
     _base._failEarlyRangeCheck(index, bounds: bounds)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public func _failEarlyRangeCheck(_ range: Range<Index>, bounds: Range<Index>) {
     _base._failEarlyRangeCheck(range, bounds: bounds)
   }
 }
 
 extension Slice: BidirectionalCollection where Base: BidirectionalCollection {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public func index(before i: Index) -> Index {
     // FIXME: swift-3-indexing-model: range check.
     return _base.index(before: i)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public func formIndex(before i: inout Index) {
     // FIXME: swift-3-indexing-model: range check.
     _base.formIndex(before: &i)
@@ -233,7 +233,7 @@ extension Slice: BidirectionalCollection where Base: BidirectionalCollection {
 
 
 extension Slice: MutableCollection where Base: MutableCollection {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public subscript(index: Index) -> Base.Element {
     get {
       _failEarlyRangeCheck(index, bounds: startIndex..<endIndex)
@@ -248,7 +248,7 @@ extension Slice: MutableCollection where Base: MutableCollection {
     }
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public subscript(bounds: Range<Index>) -> Slice<Base> {
     get {
       _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)
@@ -265,28 +265,28 @@ extension Slice: RandomAccessCollection where Base: RandomAccessCollection { }
 
 extension Slice: RangeReplaceableCollection
   where Base: RangeReplaceableCollection {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public init() {
     self._base = Base()
     self._startIndex = _base.startIndex
     self._endIndex = _base.endIndex
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public init(repeating repeatedValue: Base.Element, count: Int) {
     self._base = Base(repeating: repeatedValue, count: count)
     self._startIndex = _base.startIndex
     self._endIndex = _base.endIndex
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public init<S>(_ elements: S) where S: Sequence, S.Element == Base.Element {
     self._base = Base(elements)
     self._startIndex = _base.startIndex
     self._endIndex = _base.endIndex
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public mutating func replaceSubrange<C>(
     _ subRange: Range<Index>, with newElements: C
   ) where C : Collection, C.Element == Base.Element {
@@ -303,7 +303,7 @@ extension Slice: RangeReplaceableCollection
     _endIndex = _base.index(_startIndex, offsetBy: newSliceCount)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public mutating func insert(_ newElement: Base.Element, at i: Index) {
     // FIXME: swift-3-indexing-model: range check.
     let sliceOffset = _base.distance(from: _base.startIndex, to: _startIndex)
@@ -313,7 +313,7 @@ extension Slice: RangeReplaceableCollection
     _endIndex = _base.index(_startIndex, offsetBy: newSliceCount)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public mutating func insert<S>(contentsOf newElements: S, at i: Index)
   where S: Collection, S.Element == Base.Element {
 
@@ -325,7 +325,7 @@ extension Slice: RangeReplaceableCollection
     _endIndex = _base.index(_startIndex, offsetBy: newSliceCount)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public mutating func remove(at i: Index) -> Base.Element {
     // FIXME: swift-3-indexing-model: range check.
     let sliceOffset = _base.distance(from: _base.startIndex, to: _startIndex)
@@ -336,7 +336,7 @@ extension Slice: RangeReplaceableCollection
     return result
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public mutating func removeSubrange(_ bounds: Range<Index>) {
     // FIXME: swift-3-indexing-model: range check.
     let sliceOffset = _base.distance(from: _base.startIndex, to: _startIndex)
@@ -351,7 +351,7 @@ extension Slice: RangeReplaceableCollection
 extension Slice
   where Base: RangeReplaceableCollection, Base: BidirectionalCollection {
   
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public mutating func replaceSubrange<C>(
     _ subRange: Range<Index>, with newElements: C
   ) where C : Collection, C.Element == Base.Element {
@@ -378,7 +378,7 @@ extension Slice
     }
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public mutating func insert(_ newElement: Base.Element, at i: Index) {
     // FIXME: swift-3-indexing-model: range check.
     if i == _base.startIndex {
@@ -398,7 +398,7 @@ extension Slice
     }
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public mutating func insert<S>(contentsOf newElements: S, at i: Index)
   where S : Collection, S.Element == Base.Element {
     // FIXME: swift-3-indexing-model: range check.
@@ -421,7 +421,7 @@ extension Slice
     }
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public mutating func remove(at i: Index) -> Base.Element {
     // FIXME: swift-3-indexing-model: range check.
     if i == _base.startIndex {
@@ -443,7 +443,7 @@ extension Slice
     }
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public mutating func removeSubrange(_ bounds: Range<Index>) {
     // FIXME: swift-3-indexing-model: range check.
     if bounds.lowerBound == _base.startIndex {

--- a/stdlib/public/core/StaticString.swift
+++ b/stdlib/public/core/StaticString.swift
@@ -130,7 +130,7 @@ public struct StaticString
   ///   `withUTF8Buffer(invoke:)` method. The pointer argument is valid only
   ///   for the duration of the method's execution.
   /// - Returns: The return value, if any, of the `body` closure.
-  @inlinable // FIXME(sil-serialize-all)
+  @_transparent
   public func withUTF8Buffer<R>(
     _ body: (UnsafeBufferPointer<UInt8>) -> R) -> R {
     if hasPointerRepresentation {
@@ -187,7 +187,6 @@ public struct StaticString
       : (0x1 as UInt8)._value
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   @_effects(readonly)
   @_transparent
   public init(_builtinUnicodeScalarLiteral value: Builtin.Int32) {
@@ -198,14 +197,12 @@ public struct StaticString
   ///
   /// Do not call this initializer directly. It may be used by the compiler
   /// when you initialize a static string with a Unicode scalar.
-  @inlinable // FIXME(sil-serialize-all)
   @_effects(readonly)
   @_transparent
   public init(unicodeScalarLiteral value: StaticString) {
     self = value
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   @_effects(readonly)
   @_transparent
   public init(
@@ -225,14 +222,12 @@ public struct StaticString
   ///
   /// Do not call this initializer directly. It may be used by the compiler
   /// when you initialize a static string using an extended grapheme cluster.
-  @inlinable // FIXME(sil-serialize-all)
   @_effects(readonly)
   @_transparent
   public init(extendedGraphemeClusterLiteral value: StaticString) {
     self = value
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   @_effects(readonly)
   @_transparent
   public init(
@@ -250,7 +245,6 @@ public struct StaticString
   ///
   /// Do not call this initializer directly. It may be used by the compiler
   /// when you initialize a static string using a string literal.
-  @inlinable // FIXME(sil-serialize-all)
   @_effects(readonly)
   @_transparent
   public init(stringLiteral value: StaticString) {
@@ -258,7 +252,6 @@ public struct StaticString
   }
 
   /// A string representation of the static string.
-  @inlinable // FIXME(sil-serialize-all)
   public var description: String {
     return withUTF8Buffer { (buffer) in
       if isASCII {

--- a/stdlib/public/core/UnfoldSequence.swift
+++ b/stdlib/public/core/UnfoldSequence.swift
@@ -38,7 +38,7 @@
 ///   returns the next element.
 /// - Returns: A sequence that starts with `first` and continues with every
 ///   value returned by passing the previous element to `next`.
-@inlinable // FIXME(sil-serialize-all)
+@inlinable // generic-performance
 public func sequence<T>(first: T, next: @escaping (T) -> T?) -> UnfoldFirstSequence<T> {
   // The trivial implementation where the state is the next value to return
   // has the downside of being unnecessarily eager (it evaluates `next` one
@@ -83,7 +83,7 @@ public func sequence<T>(first: T, next: @escaping (T) -> T?) -> UnfoldFirstSeque
 /// - Parameter next: A closure that accepts an `inout` state and returns the
 ///   next element of the sequence.
 /// - Returns: A sequence that yields each successive value from `next`.
-@inlinable // FIXME(sil-serialize-all)
+@inlinable // generic-performance
 public func sequence<T, State>(state: State, next: @escaping (inout State) -> T?)
   -> UnfoldSequence<T, State> {
   return UnfoldSequence(_state: state, _next: next)
@@ -100,9 +100,9 @@ public typealias UnfoldFirstSequence<T> = UnfoldSequence<T, (T?, Bool)>
 ///
 /// Instances of `UnfoldSequence` are created with the functions
 /// `sequence(first:next:)` and `sequence(state:next:)`.
-@_fixed_layout // FIXME(sil-serialize-all)
+@_fixed_layout // generic-performance
 public struct UnfoldSequence<Element, State> : Sequence, IteratorProtocol {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public mutating func next() -> Element? {
     guard !_done else { return nil }
     if let elt = _next(&_state) {
@@ -113,16 +113,16 @@ public struct UnfoldSequence<Element, State> : Sequence, IteratorProtocol {
     }
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   internal init(_state: State, _next: @escaping (inout State) -> Element?) {
     self._state = _state
     self._next = _next
   }
 
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // generic-performance
   internal var _state: State
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // generic-performance
   internal let _next: (inout State) -> Element?
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // generic-performance
   internal var _done = false
 }

--- a/stdlib/public/core/Unmanaged.swift
+++ b/stdlib/public/core/Unmanaged.swift
@@ -89,7 +89,7 @@ public struct Unmanaged<Instance : AnyObject> {
   /// and you know that you're not responsible for releasing the result.
   ///
   /// - Returns: The object referenced by this `Unmanaged` instance.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // unsafe-performance
   public func takeUnretainedValue() -> Instance {
     return _value
   }
@@ -101,7 +101,7 @@ public struct Unmanaged<Instance : AnyObject> {
   /// and you know that you're responsible for releasing the result.
   ///
   /// - Returns: The object referenced by this `Unmanaged` instance.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // unsafe-performance
   public func takeRetainedValue() -> Instance {
     let result = _value
     release()
@@ -200,7 +200,7 @@ public struct Unmanaged<Instance : AnyObject> {
   ///      }
   ///    }
   ///  }
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // unsafe-performance
   public func _withUnsafeGuaranteedRef<Result>(
     _ body: (Instance) throws -> Result
   ) rethrows -> Result {

--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -41,7 +41,7 @@
 ///   - sequence2: The second sequence or collection to zip.
 /// - Returns: A sequence of tuple pairs, where the elements of each pair are
 ///   corresponding elements of `sequence1` and `sequence2`.
-@inlinable // FIXME(sil-serialize-all)
+@inlinable // generic-performance
 public func zip<Sequence1, Sequence2>(
   _ sequence1: Sequence1, _ sequence2: Sequence2
 ) -> Zip2Sequence<Sequence1, Sequence2> {
@@ -67,16 +67,16 @@ public func zip<Sequence1, Sequence2>(
 ///     // Prints "two: 2
 ///     // Prints "three: 3"
 ///     // Prints "four: 4"
-@_fixed_layout // FIXME(sil-serialize-all)
+@_fixed_layout // generic-performance
 public struct Zip2Sequence<Sequence1 : Sequence, Sequence2 : Sequence> {
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // generic-performance
   internal let _sequence1: Sequence1
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // generic-performance
   internal let _sequence2: Sequence2
 
   /// Creates an instance that makes pairs of elements from `sequence1` and
   /// `sequence2`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public // @testable
   init(_sequence1 sequence1: Sequence1, _sequence2 sequence2: Sequence2) {
     (_sequence1, _sequence2) = (sequence1, sequence2)
@@ -85,17 +85,17 @@ public struct Zip2Sequence<Sequence1 : Sequence, Sequence2 : Sequence> {
 
 extension Zip2Sequence {
   /// An iterator for `Zip2Sequence`.
-  @_fixed_layout // FIXME(sil-serialize-all)
+  @_fixed_layout // generic-performance
   public struct Iterator {
-    @usableFromInline // FIXME(sil-serialize-all)
+    @usableFromInline // generic-performance
     internal var _baseStream1: Sequence1.Iterator
-    @usableFromInline // FIXME(sil-serialize-all)
+    @usableFromInline // generic-performance
     internal var _baseStream2: Sequence2.Iterator
-    @usableFromInline // FIXME(sil-serialize-all)
+    @usableFromInline // generic-performance
     internal var _reachedEnd: Bool = false
 
     /// Creates an instance around a pair of underlying iterators.
-    @inlinable // FIXME(sil-serialize-all)
+    @inlinable // generic-performance
     internal init(
     _ iterator1: Sequence1.Iterator, 
     _ iterator2: Sequence2.Iterator
@@ -113,7 +113,7 @@ extension Zip2Sequence.Iterator: IteratorProtocol {
   /// exists.
   ///
   /// Once `nil` has been returned, all subsequent calls return `nil`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public mutating func next() -> Element? {
     // The next() function needs to track if it has reached the end.  If we
     // didn't, and the first sequence is longer than the second, then when we
@@ -139,7 +139,7 @@ extension Zip2Sequence: Sequence {
   public typealias Element = (Sequence1.Element, Sequence2.Element)
 
   /// Returns an iterator over the elements of this sequence.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // generic-performance
   public func makeIterator() -> Iterator {
     return Iterator(
       _sequence1.makeIterator(),


### PR DESCRIPTION
* Marking more lazy and generic code that needs specialization
* Move `DictionaryLiteral` typealias to compatibility shims file
* `StaticString` had lots of inlinable-but-also-transparent methods
* The `UnboundedRange` hack doesn't need inlining
* `KeyValuePairs` probably doesn't need to be inlined
* `Unmanaged` needs inlining for unsafe performance reasons
* Output stream methods don't need to be inlined
