### PR TITLE
[CSBindings] Don't record duplicate bindings for opened nominal types

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -224,23 +224,20 @@ void ConstraintSystem::PotentialBindings::addPotentialBinding(
 
 bool ConstraintSystem::PotentialBindings::isViable(
     PotentialBinding &binding) const {
-  // Prevent against checking against the same bound generic type
+  // Prevent against checking against the same opened nominal type
   // over and over again. Doing so means redundant work in the best
   // case. In the worst case, we'll produce lots of duplicate solutions
   // for this constraint system, which is problematic for overload
   // resolution.
   auto type = binding.BindingType;
   if (type->hasTypeVariable()) {
-    auto *BGT = type->getAs<BoundGenericType>();
-    if (!BGT)
+    auto *NTD = type->getAnyNominal();
+    if (!NTD)
       return true;
 
     for (auto &existing : Bindings) {
-      auto existingBGT = existing.BindingType->getAs<BoundGenericType>();
-      if (!existingBGT)
-        continue;
-
-      if (BGT != existingBGT && BGT->getDecl() == existingBGT->getDecl())
+      auto *existingNTD = existing.BindingType->getAnyNominal();
+      if (existingNTD && NTD == existingNTD)
         return false;
     }
   }

--- a/validation-test/Sema/type_checker_perf/fast/rdar19181998_nominals.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19181998_nominals.swift.gyb
@@ -1,0 +1,19 @@
+// RUN: %scale-test --begin 1 --end 30 --step 1 --select incrementScopeCounter %s
+// REQUIRES: OS=macosx
+// REQUIRES: asserts
+
+struct A<T> {
+  struct B {
+    init(_: T) {}
+  }
+}
+
+public func test(_ fn: @escaping () -> Void) {}
+test {
+  let _ = [
+%for i in range(0, N):
+      A.B(1),
+%end
+      A.B(1.0)
+    ]
+}


### PR DESCRIPTION
Otherwise it would result in checking the same type multiple times
and results in worse pontential binding picks.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
