### PR TITLE
Guard verifyCriticalEdges with #ifndef NDEBUG.

### DIFF
--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -4861,6 +4861,10 @@ void SILFunction::verify(bool SingleFunction) const {
 }
 
 void SILFunction::verifyCriticalEdges() const {
+#ifdef NDEBUG
+  if (!getModule().getOptions().VerifyAll)
+    return;
+#endif
   SILVerifier(*this, /*SingleFunction=*/true).verifyBranches(this);
 }
 


### PR DESCRIPTION
This could noticeably improve compile time in Release builds.

Once we eliminate all calls to splitAllCriticalEdges, the we can even
remove this verification in asserts builds since normal SIL
verification will catch the issues.
