### PR TITLE
Sema: Fix regression with tuple conversions from recent changes

### DIFF
--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -758,16 +758,18 @@ Comparison TypeChecker::compareDeclarations(DeclContext *dc,
 }
 
 static Type getUnlabeledType(Type type, ASTContext &ctx) {
-  if (auto *tupleType = dyn_cast<TupleType>(type.getPointer())) {
-    SmallVector<TupleTypeElt, 8> elts;
-    for (auto elt : tupleType->getElements()) {
-      elts.push_back(elt.getWithoutName());
+  return type.transform([&](Type type) -> Type {
+    if (auto *tupleType = dyn_cast<TupleType>(type.getPointer())) {
+      SmallVector<TupleTypeElt, 8> elts;
+      for (auto elt : tupleType->getElements()) {
+        elts.push_back(elt.getWithoutName());
+      }
+
+      return TupleType::get(elts, ctx);
     }
 
-    return TupleType::get(elts, ctx);
-  }
-
-  return type;
+    return type;
+  });
 }
 
 SolutionCompareResult ConstraintSystem::compareSolutions(

--- a/test/Constraints/tuple.swift
+++ b/test/Constraints/tuple.swift
@@ -245,3 +245,10 @@ func microwave() -> Dinner {
   let d: Dinner? = nil
   return (n: d) // expected-error{{cannot convert return expression of type '(n: Dinner?)' to return type 'Dinner'}}
 }
+
+// Tuple conversion with an optional
+func f(b: Bool) -> (a: Int, b: String)? {
+  let x = 3
+  let y = ""
+  return b ? (x, y) : nil
+}


### PR DESCRIPTION
61152e658561edec7cff85049d872abf31c766cc introduced a behavior change that was caught neither by our test suite nor the source compatibility tests.