### PR TITLE
Resilient witness tables use method descriptors

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -1635,9 +1635,8 @@ struct TargetProtocolRequirement {
   /// is also to uniquely identify the requirement in resilient witness
   /// tables, which is why it appears here.
   ///
-  /// This forms the basis of our mechanism to hide witness table offsets
-  /// from clients, both when calling protocol requirements and when
-  /// defining witness tables.
+  /// This allows clients to call protocol requirements without depending
+  /// on the witness table offset of the requirement.
   ///
   /// Will be null if the protocol is not resilient.
   RelativeDirectPointer<void, /*nullable*/ true> Function;
@@ -1923,11 +1922,11 @@ using GenericBoxHeapMetadata = TargetGenericBoxHeapMetadata<InProcess>;
 ///
 /// This is accomplished by emitting an order-independent series of
 /// relative pointer pairs, consisting of a protocol requirement together
-/// with a witness. The requirement is identified by an indirect relative
-/// pointer to the protocol dispatch thunk.
+/// with a witness. The requirement is identified by an indirectable relative
+/// pointer to the protocol requirement descriptor.
 template <typename Runtime>
 struct TargetResilientWitness {
-  RelativeIndirectPointer<void> Function;
+  RelativeIndirectablePointer<TargetProtocolRequirement<Runtime>> Requirement;
   RelativeDirectPointer<void> Witness;
 };
 using ResilientWitness = TargetResilientWitness<InProcess>;

--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -1630,17 +1630,6 @@ struct TargetProtocolRequirement {
   ProtocolRequirementFlags Flags;
   // TODO: name, type
 
-  /// A function pointer to a global symbol which is used by client code
-  /// to invoke the protocol requirement from a witness table. This pointer
-  /// is also to uniquely identify the requirement in resilient witness
-  /// tables, which is why it appears here.
-  ///
-  /// This allows clients to call protocol requirements without depending
-  /// on the witness table offset of the requirement.
-  ///
-  /// Will be null if the protocol is not resilient.
-  RelativeDirectPointer<void, /*nullable*/ true> Function;
-
   /// The optional default implementation of the protocol.
   RelativeDirectPointer<void, /*nullable*/ true> DefaultImplementation;
 };

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2583,28 +2583,6 @@ IRGenModule::getAddrOfLLVMVariableOrGOTEquivalent(LinkEntity entity,
   return {gotEquivalent, ConstantReference::Indirect};
 }
 
-/// Get or create a "GOT equivalent" llvm::GlobalVariable, if applicable.
-///
-/// Creates a private, unnamed constant containing the address of another
-/// function. LLVM can replace relative references to this variable with
-/// relative references to the GOT entry for the function in the object file.
-ConstantReference
-IRGenModule::getFunctionGOTEquivalent(LinkEntity entity,
-                                      llvm::Function *func) {
-  auto &gotEntry = GlobalGOTEquivalents[entity];
-  if (gotEntry) {
-    return {gotEntry, ConstantReference::Indirect};
-  }
-
-  // Use it as the initializer for an anonymous constant. LLVM can treat this as
-  // equivalent to the global's GOT entry.
-  llvm::SmallString<64> name;
-  entity.mangle(name);
-  auto gotEquivalent = createGOTEquivalent(*this, func, name);
-  gotEntry = gotEquivalent;
-  return {gotEquivalent, ConstantReference::Indirect};
-}
-
 static TypeEntityReference
 getTypeContextDescriptorEntityReference(IRGenModule &IGM,
                                         NominalTypeDecl *decl) {

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1845,12 +1845,12 @@ static llvm::Constant *emitResilientWitnessTable(IRGenModule &IGM,
       continue;
 
     auto declRef = entry.getMethodWitness().Requirement;
-    auto entity = LinkEntity::forDispatchThunk(declRef);
-    auto *func = IGM.getAddrOfDispatchThunk(declRef,
-                                            NotForDefinition);
-    auto requirement = IGM.getFunctionGOTEquivalent(entity, func);
-
-    table.addIndirectRelativeAddress(requirement);
+    auto requirement =
+      IGM.getAddrOfLLVMVariableOrGOTEquivalent(
+        LinkEntity::forMethodDescriptor(declRef),
+        IGM.getPointerAlignment(),
+        IGM.ProtocolRequirementStructTy);
+    table.addRelativeAddress(requirement);
 
     SILFunction *Func = entry.getMethodWitness().Witness;
     llvm::Constant *witness;

--- a/lib/IRGen/GenThunk.cpp
+++ b/lib/IRGen/GenThunk.cpp
@@ -95,7 +95,7 @@ static FunctionPointer lookupMethod(IRGenFunction &IGF,
   return emitVirtualMethodValue(IGF, metadata, declRef, funcTy);
 }
 
-llvm::Function *IRGenModule::emitDispatchThunk(SILDeclRef declRef) {
+void IRGenModule::emitDispatchThunk(SILDeclRef declRef) {
   auto *f = getAddrOfDispatchThunk(declRef, ForDefinition);
 
   IRGenFunction IGF(*this, f);
@@ -112,8 +112,6 @@ llvm::Function *IRGenModule::emitDispatchThunk(SILDeclRef declRef) {
     IGF.Builder.CreateRetVoid();
   else
     IGF.Builder.CreateRet(result);
-
-  return f;
 }
 
 llvm::GlobalValue *IRGenModule::defineMethodDescriptor(SILDeclRef declRef,

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -235,7 +235,6 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
   ProtocolRequirementStructTy =
       createStructType(*this, "swift.protocol_requirement", {
     Int32Ty,                // flags
-    Int32Ty,                // thunk
     Int32Ty                 // default implementation
   });
   

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1144,7 +1144,7 @@ public:
   llvm::Function *getAddrOfDispatchThunk(SILDeclRef declRef,
                                          ForDefinition_t forDefinition);
 
-  llvm::Function *emitDispatchThunk(SILDeclRef declRef);
+  void emitDispatchThunk(SILDeclRef declRef);
 
   llvm::GlobalValue *defineAlias(LinkEntity entity,
                                  llvm::Constant *definition);

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1283,10 +1283,6 @@ public:
        llvm::Type *defaultType,
        ConstantReference::Directness forceIndirect = ConstantReference::Direct);
 
-  ConstantReference
-  getFunctionGOTEquivalent(LinkEntity entity,
-                           llvm::Function *func);
-
   llvm::Constant *
   emitRelativeReference(ConstantReference target,
                         llvm::Constant *base,

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3597,12 +3597,11 @@ static void initializeResilientWitnessTable(GenericWitnessTable *genericTable,
       continue;
     }
 
-    void *fn = reqt.Function.get();
     void *impl = reqt.DefaultImplementation.get();
 
     // Find the witness if there is one, otherwise we use the default.
     for (auto &witness : witnesses) {
-      if (witness.Function.get() == fn) {
+      if (witness.Requirement.get() == &reqt) {
         impl = witness.Witness.get();
         break;
       }

--- a/test/IRGen/protocol_metadata.swift
+++ b/test/IRGen/protocol_metadata.swift
@@ -101,17 +101,17 @@ protocol Comprehensive {
 // CHECK-SAME: i32 11,
 // CHECK-SAME: i32 trunc
 // CHECK-SAME: [6 x i8]* [[COMPREHENSIVE_ASSOC_NAME]]
-// CHECK-SAME:   %swift.protocol_requirement { i32 7, i32 0, i32 0 },
-// CHECK-SAME:   %swift.protocol_requirement { i32 8, i32 0, i32 0 },
-// CHECK-SAME:   %swift.protocol_requirement { i32 2, i32 0, i32 0 },
-// CHECK-SAME:   %swift.protocol_requirement { i32 17, i32 0, i32 0 },
-// CHECK-SAME:   %swift.protocol_requirement { i32 1, i32 0, i32 0 },
-// CHECK-SAME:   %swift.protocol_requirement { i32 19, i32 0, i32 0 },
-// CHECK-SAME:   %swift.protocol_requirement { i32 20, i32 0, i32 0 },
-// CHECK-SAME:   %swift.protocol_requirement { i32 22, i32 0, i32 0 },
-// CHECK-SAME:   %swift.protocol_requirement { i32 3, i32 0, i32 0 },
-// CHECK-SAME:   %swift.protocol_requirement { i32 4, i32 0, i32 0 },
-// CHECK-SAME:   %swift.protocol_requirement { i32 6, i32 0, i32 0 }
+// CHECK-SAME:   %swift.protocol_requirement { i32 7, i32 0 },
+// CHECK-SAME:   %swift.protocol_requirement { i32 8, i32 0 },
+// CHECK-SAME:   %swift.protocol_requirement { i32 2, i32 0 },
+// CHECK-SAME:   %swift.protocol_requirement { i32 17, i32 0 },
+// CHECK-SAME:   %swift.protocol_requirement { i32 1, i32 0 },
+// CHECK-SAME:   %swift.protocol_requirement { i32 19, i32 0 },
+// CHECK-SAME:   %swift.protocol_requirement { i32 20, i32 0 },
+// CHECK-SAME:   %swift.protocol_requirement { i32 22, i32 0 },
+// CHECK-SAME:   %swift.protocol_requirement { i32 3, i32 0 },
+// CHECK-SAME:   %swift.protocol_requirement { i32 4, i32 0 },
+// CHECK-SAME:   %swift.protocol_requirement { i32 6, i32 0 }
 
 
 func reify_metadata<T>(_ x: T) {}

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -158,10 +158,10 @@ protocol InternalProtocol {
 
 // CHECK-SAME: internal constant {
 
-// CHECK-SAME: @"{{got.|__imp_}}$S18resilient_protocol24ProtocolWithRequirementsP5firstyyFTj"
+// CHECK-SAME: @"{{got.|__imp_}}$S18resilient_protocol24ProtocolWithRequirementsP5firstyyFTq"
 // CHECK-SAME: @firstWitness
 
-// CHECK-SAME: @"{{got.|__imp_}}$S18resilient_protocol24ProtocolWithRequirementsP6secondyyFTj"
+// CHECK-SAME: @"{{got.|__imp_}}$S18resilient_protocol24ProtocolWithRequirementsP6secondyyFTq"
 // CHECK-SAME: @secondWitness
 
 // CHECK-SAME: }

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -55,36 +55,26 @@ import resilient_protocol
 // CHECK-SAME:   @"$S19protocol_resilience17ResilientProtocolMp"
 
 // Protocol requirements
-// CHECK-SAME:   %swift.protocol_requirement { i32 7, i32 0, i32 0 },
-// CHECK-SAME:   %swift.protocol_requirement { i32 8, i32 0, i32 0 },
+// CHECK-SAME:   %swift.protocol_requirement { i32 7, i32 0 },
+// CHECK-SAME:   %swift.protocol_requirement { i32 8, i32 0 },
+
+// CHECK-SAME:   %swift.protocol_requirement { i32 17, i32 0 },
+
+// CHECK-SAME:   %swift.protocol_requirement { i32 17, i32 0 },
 
 // CHECK-SAME:   %swift.protocol_requirement { i32 17,
-// CHECK-SAME:     i32{{ | trunc \(i64 }}sub ([[INT]] ptrtoint (void (%swift.opaque*, %swift.type*, i8**)* @"$S19protocol_resilience17ResilientProtocolP10noDefaultAyyFTj" to [[INT]]),
-// CHECK-SAME:     i32 0
-// CHECK-SAME:   },
-
-// CHECK-SAME:   %swift.protocol_requirement { i32 17,
-// CHECK-SAME:     i32{{ | trunc \(i64 }}sub ([[INT]] ptrtoint (void (%swift.opaque*, %swift.type*, i8**)* @"$S19protocol_resilience17ResilientProtocolP10noDefaultByyFTj" to [[INT]]),
-// CHECK-SAME:     i32 0
-// CHECK-SAME:   },
-
-// CHECK-SAME:   %swift.protocol_requirement { i32 17,
-// CHECK-SAME:     i32{{ | trunc \(i64 }}sub ([[INT]] ptrtoint (void (%swift.opaque*, %swift.type*, i8**)* @"$S19protocol_resilience17ResilientProtocolP8defaultCyyFTj" to [[INT]]),
 // CHECK-SAME:     i32{{ | trunc \(i64 }}sub ([[INT]] ptrtoint (void (%swift.opaque*, %swift.type*, i8**)* @defaultC to [[INT]]),
 // CHECK-SAME:   },
 
 // CHECK-SAME:   %swift.protocol_requirement { i32 17,
-// CHECK-SAME:     i32{{ | trunc \(i64 }}sub ([[INT]] ptrtoint (void (%swift.opaque*, %swift.type*, i8**)* @"$S19protocol_resilience17ResilientProtocolP8defaultDyyFTj" to [[INT]]),
 // CHECK-SAME:     i32{{ | trunc \(i64 }}sub ([[INT]] ptrtoint (void (%swift.opaque*, %swift.type*, i8**)* @defaultD to [[INT]]),
 // CHECK-SAME:   },
 
 // CHECK-SAME:   %swift.protocol_requirement { i32 1,
-// CHECK-SAME:     i32{{ | trunc \(i64 }}sub ([[INT]] ptrtoint (void (%swift.type*, %swift.type*, i8**)* @"$S19protocol_resilience17ResilientProtocolP8defaultEyyFZTj" to [[INT]]),
 // CHECK-SAME:     i32{{ | trunc \(i64 }}sub ([[INT]] ptrtoint (void (%swift.type*, %swift.type*, i8**)* @defaultE to [[INT]]),
 // CHECK-SAME:   },
 
 // CHECK-SAME:   %swift.protocol_requirement { i32 1,
-// CHECK-SAME:     i32{{ | trunc \(i64 }}sub ([[INT]] ptrtoint (void (%swift.type*, %swift.type*, i8**)* @"$S19protocol_resilience17ResilientProtocolP8defaultFyyFZTj" to [[INT]]),
 // CHECK-SAME:     i32{{ | trunc \(i64 }}sub ([[INT]] ptrtoint (void (%swift.type*, %swift.type*, i8**)* @defaultF to [[INT]]),
 // CHECK-SAME:   }
 // CHECK-SAME: }


### PR DESCRIPTION
One nice consequence of this is that protocol method descriptors no longer have to reference the dispatch thunk.