### PR TITLE
Pass the indices for writeback-conflict diagnostics on coroutines

### DIFF
--- a/lib/SILGen/ArgumentSource.h
+++ b/lib/SILGen/ArgumentSource.h
@@ -317,6 +317,8 @@ public:
 
   bool isObviouslyEqual(const ArgumentSource &other) const;
 
+  ArgumentSource copyForDiagnostics() const;
+
   void dump() const;
   void dump(raw_ostream &os, unsigned indent = 0) const;
 
@@ -426,6 +428,8 @@ public:
   PreparedArguments copy(SILGenFunction &SGF, SILLocation loc) const;
 
   bool isObviouslyEqual(const PreparedArguments &other) const;
+
+  PreparedArguments copyForDiagnostics() const;
 };
 
 } // end namespace Lowering

--- a/lib/SILGen/RValue.cpp
+++ b/lib/SILGen/RValue.cpp
@@ -813,3 +813,13 @@ SILType RValue::getLoweredImplodedTupleType(SILGenFunction &SGF) const & {
     return loweredType.getAddressType();
   return loweredType.getObjectType();
 }
+
+RValue RValue::copyForDiagnostics() const {
+  assert(!isInSpecialState());
+  assert(isComplete());
+  RValue result(type);
+  for (auto value : values)
+    result.values.push_back(value);
+  result.elementsToBeAdded = 0;
+  return result;
+}

--- a/lib/SILGen/RValue.h
+++ b/lib/SILGen/RValue.h
@@ -355,6 +355,8 @@ public:
   /// Borrow all subvalues of the rvalue.
   RValue borrow(SILGenFunction &SGF, SILLocation loc) const &;
 
+  RValue copyForDiagnostics() const;
+
   static bool areObviouslySameValue(SILValue lhs, SILValue rhs);
   bool isObviouslyEqual(const RValue &rhs) const;
 

--- a/test/SILGen/writeback_conflict_diagnostics.swift
+++ b/test/SILGen/writeback_conflict_diagnostics.swift
@@ -111,3 +111,19 @@ func testMultiArrayWithoutAddressors(
   swap(&global_array_without_addressors[0][j], &array[j][i])  // ok
 }
 
+// rdar://43802132
+struct ArrayWithReadModify<T> {
+  init(value: T) { self.property = value }
+  var property: T
+  subscript(i: Int) -> T {
+    _read { yield property }
+    _modify { yield &property }
+  }
+}
+
+func testArrayWithReadModify<T>(array: ArrayWithReadModify<T>) {
+  var copy = array
+  swap(&copy[0], &copy[1])
+  swap(&copy[0], // expected-note {{concurrent writeback occurred here}}
+       &copy[0]) // expected-error {{inout writeback through subscript occurs in multiple arguments to call}}
+}


### PR DESCRIPTION
To do this, I had to introduce a way to unsafely copy an argument list for the purposes of diagnostics.

rdar:://43802132

Partially unblocks #18974.