### PR TITLE
[AST/Diagnosis] Add originalType to UnresolvedType, similar to existing ErrorType support.

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -473,7 +473,7 @@ ASTContext::ASTContext(LangOptions &langOpts, SearchPathOptions &SearchPathOpts,
       new (*this, AllocationArena::Permanent)
         ErrorType(*this, Type(), RecursiveTypeProperties::HasError)),
     TheUnresolvedType(new (*this, AllocationArena::Permanent)
-                      UnresolvedType(*this)),
+                      UnresolvedType(this)),
     TheEmptyTupleType(TupleType::get(ArrayRef<TupleTypeElt>(), *this)),
     TheAnyType(ProtocolCompositionType::get(*this, ArrayRef<Type>(),
                                             /*HasExplicitAnyObject=*/false)),
@@ -2910,6 +2910,18 @@ Type ErrorType::get(Type originalType) {
   if (originalProperties.hasTypeVariable())
     properties |= RecursiveTypeProperties::HasTypeVariable;
   return entry = new (mem) ErrorType(ctx, originalType, properties);
+}
+
+Type UnresolvedType::get(Type originalType) {
+  assert(originalType);
+
+  auto originalProperties = originalType->getRecursiveProperties();
+  auto arena = getArena(originalProperties);
+
+  auto &ctx = originalType->getASTContext();
+  void *mem = ctx.Allocate(sizeof(UnresolvedType) + sizeof(Type),
+                           alignof(UnresolvedType), arena);
+  return new (mem) UnresolvedType(nullptr, originalType);
 }
 
 BuiltinIntegerType *BuiltinIntegerType::get(BuiltinIntegerWidth BitWidth,

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3253,8 +3253,11 @@ public:
   void visitUnresolvedType(UnresolvedType *T) {
     if (T->getASTContext().LangOpts.DebugConstraintSolver)
       Printer << "<<unresolvedtype>>";
-    else
+    else if (auto originalType = T->getOriginalType())
+      visit(originalType);
+    else {
       Printer << "_";
+    }
   }
 
   void visitBuiltinRawPointerType(BuiltinRawPointerType *T) {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1073,9 +1073,16 @@ CanType TypeBase::computeCanonicalType() {
 #define TYPE(id, parent)
 #include "swift/AST/TypeNodes.def"
   case TypeKind::Error:
-  case TypeKind::Unresolved:
   case TypeKind::TypeVariable:
     llvm_unreachable("these types are always canonical");
+
+  case TypeKind::Unresolved: {
+    auto unresolvedTy = cast<UnresolvedType>(this);
+    auto originalTy = unresolvedTy->getOriginalType();
+    assert(originalTy && "unresolved type without original should already be canonical");
+    Result = originalTy->getASTContext().TheUnresolvedType.getPointer();
+    break;
+  }
 
 #define SUGARED_TYPE(id, parent) \
   case TypeKind::id: \

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -64,12 +64,10 @@ namespace swift {
     
     if (!ty->hasTypeParameter() && !ty->hasArchetype()) return ty;
     
-    auto &ctx = ty->getASTContext();
-    
     return ty.transform([&](Type type) -> Type {
       if (type->is<ArchetypeType>() ||
           type->isTypeParameter())
-        return ctx.TheUnresolvedType;
+        return UnresolvedType::get(type);
       return type;
     });
   }

--- a/test/Constraints/enum_cases.swift
+++ b/test/Constraints/enum_cases.swift
@@ -55,7 +55,7 @@ bar_1(E.tuple) // Ok - it's going to be ((x: Int, y: Int))
 bar_2(G_E<String>.foo) // Ok
 bar_2(G_E<Int>.bar) // Ok
 bar_2(G_E<Int>.two) // expected-error {{cannot convert value of type '(Int, Int) -> G_E<Int>' to expected argument type '(_) -> G_E<_>'}}
-bar_2(G_E<Int>.tuple) // expected-error {{cannot convert value of type '((x: Int, y: Int)) -> G_E<Int>' to expected argument type '(_) -> G_E<_>'}}
+bar_2(G_E<Int>.tuple) // expected-error {{cannot convert value of type '((x: Int, y: Int)) -> G_E<Int>' to expected argument type '(T) -> G_E<T>'}}
 bar_3(G_E<Int>.tuple) // Ok
 
 // Regular enum case assigned as a value

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -32,5 +32,5 @@ class Demo {
 
 // FIXME: This error is better than it was, but the diagnosis should break it down more specifically to 'here's type.
 let some = Some(keyPath: \Demo.here)
-// expected-error@-1 {{cannot convert value of type 'ReferenceWritableKeyPath<Demo, (() -> Void)?>' to expected argument type 'KeyPath<_, ((_) -> Void)?>'}}
+// expected-error@-1 {{cannot convert value of type 'ReferenceWritableKeyPath<Demo, (() -> Void)?>' to expected argument type 'KeyPath<T, ((V) -> Void)?>'}}
 


### PR DESCRIPTION
This preserves more info (i.e. archetypes) for error messages found via the contextual type passed into `typeCheckChildIndependently()`. Showing `_` in a type during diagnoses when the problem isn't structural is very misleading. 

Inspired by [SR-8644](https://bugs.swift.org/browse/SR-8644), prior to this PR produces
```
error: cannot convert value of type '(U) -> Z?' to expected argument type '(_) -> _?'
```
after:
```
error: cannot convert value of type '(U) -> Z?' to expected argument type '(T) -> Z?'
```