### PR TITLE
 SILGen: Preserve function argument debug info for arguments needing a…

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1270,7 +1270,7 @@ public:
   /// Returns the name of the source variable, if it is stored in the
   /// instruction.
   StringRef getName(const char *buf) const;
-  bool isLet() const  { return Bits.Data.Constant; }
+  bool isLet() const { return Bits.Data.Constant; }
 
   Optional<SILDebugVariable> get(VarDecl *VD, const char *buf) const {
     if (!Bits.Data.HasValue)

--- a/test/DebugInfo/alloc_stack_arg.swift
+++ b/test/DebugInfo/alloc_stack_arg.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s
+public func snd<T, U>(_ t : (T, U)) -> U {
+  let (_, y) = t
+  return y
+}
+
+// Test that the alloc_stack's argument number is preserved.
+// CHECK-NOT: !DILocalVariable(name: "t"
+// CHECK: !DILocalVariable(name: "t", arg: 1
+// CHECK-NOT: !DILocalVariable(name: "t"

--- a/test/SILGen/let_decls.swift
+++ b/test/SILGen/let_decls.swift
@@ -344,12 +344,11 @@ func testDebugValue(_ a : Int, b : SimpleProtocol) -> Int {
 // CHECK-LABEL: sil hidden @{{.*}}testAddressOnlyTupleArgument
 func testAddressOnlyTupleArgument(_ bounds: (start: SimpleProtocol, pastEnd: Int)) {
 // CHECK:       bb0(%0 : @trivial $*SimpleProtocol, %1 : @trivial $Int):
-// CHECK-NEXT:    %2 = alloc_stack $(start: SimpleProtocol, pastEnd: Int), let, name "bounds"
+// CHECK-NEXT:    %2 = alloc_stack $(start: SimpleProtocol, pastEnd: Int), let, name "bounds", argno 1
 // CHECK-NEXT:    %3 = tuple_element_addr %2 : $*(start: SimpleProtocol, pastEnd: Int), 0
 // CHECK-NEXT:    copy_addr %0 to [initialization] %3 : $*SimpleProtocol
 // CHECK-NEXT:    %5 = tuple_element_addr %2 : $*(start: SimpleProtocol, pastEnd: Int), 1
 // CHECK-NEXT:    store %1 to [trivial] %5 : $*Int
-// CHECK-NEXT:    debug_value_addr %2
 // CHECK-NEXT:    destroy_addr %2 : $*(start: SimpleProtocol, pastEnd: Int)
 // CHECK-NEXT:    dealloc_stack %2 : $*(start: SimpleProtocol, pastEnd: Int)
 }


### PR DESCRIPTION
…lloc_stack

This fixes a logic error in the existing code that cause these
function arguments to appear twice, once as local variable and once as
formal parameter.

rdar://problem/37410759
