### PR TITLE
[stdlib] NFC: Fix deprecation warning related to `index(of:)`

### DIFF
--- a/stdlib/private/SwiftPrivate/IO.swift
+++ b/stdlib/private/SwiftPrivate/IO.swift
@@ -25,7 +25,7 @@ public struct _FDInputStream {
 
   public mutating func getline() -> String? {
     if let newlineIndex =
-      _buffer[0..<_bufferUsed].index(of: UInt8(Unicode.Scalar("\n").value)) {
+      _buffer[0..<_bufferUsed].firstIndex(of: UInt8(Unicode.Scalar("\n").value)) {
       let result = String(decoding: _buffer[0..<newlineIndex], as: UTF8.self)
       _buffer.removeSubrange(0...newlineIndex)
       _bufferUsed -= newlineIndex + 1


### PR DESCRIPTION
`index(of:)` has been replaced with `firstIndex(of:)`.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
