### PR TITLE
[IDE] Un-XFAIL test/IDE/coloring.swift

### DIFF
--- a/test/IDE/coloring.swift
+++ b/test/IDE/coloring.swift
@@ -1,6 +1,5 @@
 // RUN: %target-swift-ide-test -syntax-coloring -source-filename %s | %FileCheck %s
 // RUN: %target-swift-ide-test -syntax-coloring -typecheck -source-filename %s | %FileCheck %s
-// XFAIL: broken_std_regex
 
 enum List<T> {
   case Nil


### PR DESCRIPTION
I believe this should solve the build failure in https://ci.swift.org/job/oss-swift-incremental-RA-linux-ubuntu-14_04/5719. 

The builds were previously not failing because the entire test was disabled on Linux since it was also run using `swift-swiftsyntax-test` which wasn't available on Linux.