### PR TITLE
[SIL] Shrink SILLocation and SILDebugScope to (hopefully) improve memory usage

### DIFF
--- a/include/swift/SIL/SILLocation.h
+++ b/include/swift/SIL/SILLocation.h
@@ -107,7 +107,8 @@ protected:
     UnderlyingLocation() : DebugInfoLoc({}) {}
     UnderlyingLocation(ASTNodeTy N) : ASTNode(N) {}
     UnderlyingLocation(SourceLoc L) : SILFileLoc(L) {}
-    UnderlyingLocation(DebugLoc D) : DebugInfoLoc(D) {}
+    UnderlyingLocation(DebugLoc D)
+        : DebugInfoLoc({D.Filename.data(), D.Line, D.Column}) {}
     struct ASTNodeLoc {
       ASTNodeLoc(ASTNodeTy N) : Primary(N) {}
       /// Primary AST location, always used for diagnostics.
@@ -122,11 +123,19 @@ protected:
     SourceLoc SILFileLoc;
 
     /// A deserialized source location.
-    DebugLoc DebugInfoLoc;
+    struct CompactDebugLoc {
+      const char *FilenameData;
+      unsigned Line;
+      unsigned Column;
+    } DebugInfoLoc;
   } Loc;
 
   /// The kind of this SIL location.
   unsigned KindData;
+
+  /// Extra data that's not in UnderlyingLocation to keep the size of
+  /// SILLocation down.
+  unsigned ExtraStorageData = 0;
 
   enum {
     LocationKindBits = 3,
@@ -216,9 +225,8 @@ protected:
   }
 
   SILLocation(DebugLoc L, LocationKind K, unsigned Flags = 0)
-      : Loc(L), KindData(K | Flags) {
-    setStorageKind(DebugInfoKind);
-    assert(isDebugInfoLoc());
+      : KindData(K | Flags) {
+    setDebugInfoLoc(L);
   }
   /// @}
 
@@ -268,7 +276,7 @@ public:
   bool isNull() const {
     switch (getStorageKind()) {
     case ASTNodeKind:   return Loc.ASTNode.Primary.isNull();
-    case DebugInfoKind: return Loc.DebugInfoLoc.Filename.empty();
+    case DebugInfoKind: return ExtraStorageData == 0;
     case SILFileKind:   return Loc.SILFileLoc.isInvalid();
     default:            return true;
     }
@@ -339,7 +347,10 @@ public:
 
   /// Populate this empty SILLocation with a DebugLoc.
   void setDebugInfoLoc(DebugLoc L) {
-    Loc.DebugInfoLoc = L;
+    ExtraStorageData = L.Filename.size();
+    assert(ExtraStorageData == L.Filename.size() &&
+           "file name is longer than 32 bits");
+    Loc = L;
     setStorageKind(DebugInfoKind);
   }
 
@@ -427,7 +438,8 @@ public:
   }
   DebugLoc getDebugInfoLoc() const {
     assert(isDebugInfoLoc());
-    return Loc.DebugInfoLoc;
+    return DebugLoc(Loc.DebugInfoLoc.Line, Loc.DebugInfoLoc.Column,
+                    StringRef(Loc.DebugInfoLoc.FilenameData, ExtraStorageData));
   }
 
   /// Fingerprint a DebugLoc for use in a DenseMap.
@@ -441,7 +453,7 @@ public:
 
   /// Return the decoded debug location.
   LLVM_NODISCARD DebugLoc decodeDebugLoc(const SourceManager &SM) const {
-    return isDebugInfoLoc() ? Loc.DebugInfoLoc
+    return isDebugInfoLoc() ? getDebugInfoLoc()
                             : decode(getDebugSourceLoc(), SM);
   }
 

--- a/include/swift/SILOptimizer/Utils/GenericCloner.h
+++ b/include/swift/SILOptimizer/Utils/GenericCloner.h
@@ -52,8 +52,10 @@ public:
                 StringRef NewName,
                 CloneCollector::CallbackType Callback)
     : SuperTy(*initCloned(FuncBuilder, F, Serialized, ReInfo, NewName), *F,
-	      ParamSubs), FuncBuilder(FuncBuilder), ReInfo(ReInfo), Callback(Callback) {
-    assert(F->getDebugScope()->Parent != getCloned()->getDebugScope()->Parent);
+              ParamSubs),
+      FuncBuilder(FuncBuilder), ReInfo(ReInfo), Callback(Callback) {
+    assert(F->getDebugScope()->getParent() !=
+           getCloned()->getDebugScope()->getParent());
   }
   /// Clone and remap the types in \p F according to the substitution
   /// list in \p Subs. Parameters are re-abstracted (changed from indirect to

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -862,7 +862,7 @@ public:
   static bool isInlinedGeneric(VarDecl *VarDecl, const SILDebugScope *DS) {
     if (DebugInfoInlinedGenerics)
       return false;
-    if (!DS->InlinedCallSite)
+    if (!DS->getInlinedCallSite())
       return false;
     if (VarDecl->hasType())
       return VarDecl->getType()->hasArchetype();
@@ -3688,7 +3688,8 @@ void IRGenSILFunction::visitDebugValueInst(DebugValueInst *i) {
   if (isa<SILUndef>(SILVal)) {
     // We cannot track the location of inlined error arguments because it has no
     // representation in SIL.
-    if (!i->getDebugScope()->InlinedCallSite && VarInfo->Name == "$error") {
+    if (!i->getDebugScope()->getInlinedCallSite() &&
+        VarInfo->Name == "$error") {
       auto funcTy = CurSILFn->getLoweredFunctionType();
       emitErrorResultVar(funcTy->getErrorResult(), i);
     }

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -6407,6 +6407,6 @@ bool SILParserTUState::parseSILScope(Parser &P) {
     return true;
   }
 
-  Scope = new (M) SILDebugScope(Loc, ParentFn, Parent, InlinedAt);
+  Scope = new (M, InlinedAt) SILDebugScope(Loc, ParentFn, Parent, InlinedAt);
   return false;
 }

--- a/lib/SIL/SILInstruction.cpp
+++ b/lib/SIL/SILInstruction.cpp
@@ -41,8 +41,8 @@ const SILDebugScope *SILInstruction::getDebugScope() const {
 }
 
 void SILInstruction::setDebugScope(SILBuilder &B, const SILDebugScope *DS) {
-  if (getDebugScope() && getDebugScope()->InlinedCallSite)
-    assert(DS->InlinedCallSite && "throwing away inlined scope info");
+  if (getDebugScope() && getDebugScope()->getInlinedCallSite())
+    assert(DS->getInlinedCallSite() && "throwing away inlined scope info");
 
   assert(DS->getParentFunction() == getFunction() &&
          "scope belongs to different function");

--- a/lib/SIL/SILLocation.cpp
+++ b/lib/SIL/SILLocation.cpp
@@ -20,6 +20,8 @@
 
 using namespace swift;
 
+static_assert(sizeof(SILLocation) == 3*sizeof(void *),
+              "SILLocation must stay small");
 
 SourceLoc SILLocation::getSourceLoc() const {
   if (isSILFile())

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -711,19 +711,19 @@ public:
       return;
 
     if (!Ctx.hasScopeID(DS)) {
-      printDebugScope(DS->Parent.dyn_cast<const SILDebugScope *>(), SM);
-      printDebugScope(DS->InlinedCallSite, SM);
+      printDebugScope(DS->getParent().dyn_cast<const SILDebugScope *>(), SM);
+      printDebugScope(DS->getInlinedCallSite(), SM);
       unsigned ID = Ctx.assignScopeID(DS);
       *this << "sil_scope " << ID << " { ";
       printDebugLocRef(DS->Loc, SM, false);
       *this << " parent ";
-      if (auto *F = DS->Parent.dyn_cast<SILFunction *>())
+      if (auto *F = DS->getParent().dyn_cast<SILFunction *>())
         *this << "@" << F->getName() << " : $" << F->getLoweredFunctionType();
       else {
-        auto *PS = DS->Parent.get<const SILDebugScope *>();
+        auto *PS = DS->getParent().get<const SILDebugScope *>();
         *this << Ctx.getScopeID(PS);
       }
-      if (auto *CS = DS->InlinedCallSite)
+      if (auto *CS = DS->getInlinedCallSite())
         *this << " inlined_at " << Ctx.getScopeID(CS);
       *this << " }\n";
     }
@@ -805,7 +805,7 @@ public:
 
     // Print inlined-at location, if any.
     const SILDebugScope *CS = DS;
-    while ((CS = CS->InlinedCallSite)) {
+    while ((CS = CS->getInlinedCallSite())) {
       *this << ": ";
       if (auto *InlinedF = CS->getInlinedFunction())
         *this << demangleSymbol(InlinedF->getName());
@@ -2955,18 +2955,18 @@ void SILDebugScope::dump(SourceManager &SM, llvm::raw_ostream &OS,
   OS << "\n";
   OS.indent(Indent + 2);
   OS << " parent: ";
-  if (auto *P = Parent.dyn_cast<const SILDebugScope *>()) {
+  if (auto *P = getParent().dyn_cast<const SILDebugScope *>()) {
     P->dump(SM, OS, Indent + 2);
     OS.indent(Indent + 2);
   }
-  else if (auto *F = Parent.dyn_cast<SILFunction *>())
+  else if (auto *F = getParent().dyn_cast<SILFunction *>())
     OS << "@" << F->getName();
   else
     OS << "nullptr";
 
   OS << "\n";
   OS.indent(Indent + 2);
-  if (auto *CS = InlinedCallSite) {
+  if (auto *CS = getInlinedCallSite()) {
     OS << "inlinedCallSite: ";
     CS->dump(SM, OS, Indent + 2);
     OS.indent(Indent + 2);

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -594,7 +594,7 @@ public:
 
     auto *DebugScope = F.getDebugScope();
     require(DebugScope, "All SIL functions must have a debug scope");
-    require(DebugScope->Parent.get<SILFunction *>() == &F,
+    require(DebugScope->getParent().get<SILFunction *>() == &F,
             "Scope of SIL function points to different function");
   }
 
@@ -820,7 +820,7 @@ public:
     // for each argument slot. This catches SIL transformations
     // that accidentally remove inline information (stored in the SILDebugScope)
     // from debug-variable-carrying instructions.
-    if (!DS->InlinedCallSite) {
+    if (!DS->getInlinedCallSite()) {
       Optional<SILDebugVariable> VarInfo;
       if (auto *DI = dyn_cast<AllocStackInst>(I))
         VarInfo = DI->getVarInfo();
@@ -4717,8 +4717,7 @@ public:
         const SILDebugScope *Tmp = Previous;
         assert(Tmp && "scope can't be null");
         while (Tmp) {
-          PointerUnion<const SILDebugScope *, SILFunction *> Parent =
-              Tmp->Parent;
+          SILDebugScope::ParentType Parent = Tmp->getParent();
           auto *ParentScope = Parent.dyn_cast<const SILDebugScope *>();
           if (!ParentScope)
             break;

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -608,7 +608,7 @@ void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
   // Do the last bit work to finalize the thunk.
   OwnedToGuaranteedFinalizeThunkFunction(Builder, F);
 
-  assert(F->getDebugScope()->Parent != NewF->getDebugScope()->Parent);
+  assert(F->getDebugScope()->getParent() != NewF->getDebugScope()->getParent());
 }
 
 // Run the optimization.

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -315,7 +315,8 @@ ClosureCloner::ClosureCloner(SILOptFunctionBuilder &FuncBuilder,
   : SILClonerWithScopes<ClosureCloner>(
       *initCloned(FuncBuilder, Orig, Serialized, ClonedName, PromotableIndices)),
     Orig(Orig), PromotableIndices(PromotableIndices) {
-  assert(Orig->getDebugScope()->Parent != getCloned()->getDebugScope()->Parent);
+  assert(Orig->getDebugScope()->getParent() !=
+         getCloned()->getDebugScope()->getParent());
 }
 
 /// Compute the SILParameterInfo list for the new cloned closure.

--- a/lib/SILOptimizer/IPO/CapturePropagation.cpp
+++ b/lib/SILOptimizer/IPO/CapturePropagation.cpp
@@ -278,7 +278,8 @@ SILFunction *CapturePropagation::specializeConstClosure(PartialApplyInst *PAI,
   });
   CapturePropagationCloner cloner(OrigF, NewF, PAI->getSubstitutionMap());
   cloner.cloneBlocks(PAI->getArguments());
-  assert(OrigF->getDebugScope()->Parent != NewF->getDebugScope()->Parent);
+  assert(OrigF->getDebugScope()->getParent() !=
+         NewF->getDebugScope()->getParent());
   return NewF;
 }
 

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -177,7 +177,7 @@ const SILDebugScope *GenericCloner::remapScope(const SILDebugScope *DS) {
     return it->second;
 
   auto &M = getBuilder().getModule();
-  auto *ParentFunction = DS->Parent.dyn_cast<SILFunction *>();
+  auto *ParentFunction = DS->getParent().dyn_cast<SILFunction *>();
   if (ParentFunction == &Original)
     ParentFunction = getCloned();
   else if (ParentFunction)
@@ -185,10 +185,12 @@ const SILDebugScope *GenericCloner::remapScope(const SILDebugScope *DS) {
         FuncBuilder, M, ParentFunction, SubsMap,
         Original.getLoweredFunctionType()->getGenericSignature());
 
-  auto *ParentScope = DS->Parent.dyn_cast<const SILDebugScope *>();
+  auto *ParentScope = DS->getParent().dyn_cast<const SILDebugScope *>();
+  const SILDebugScope *InlinedCallSite = remapScope(DS->getInlinedCallSite());
   auto *RemappedScope =
-      new (M) SILDebugScope(DS->Loc, ParentFunction, remapScope(ParentScope),
-                            remapScope(DS->InlinedCallSite));
+      new (M, InlinedCallSite) SILDebugScope(DS->Loc, ParentFunction,
+                                             remapScope(ParentScope),
+                                             InlinedCallSite);
   RemappedScopeCache.insert({DS, RemappedScope});
   return RemappedScope;
 }


### PR DESCRIPTION
Reorganize the fields in SILLocation to shrink it to three words, then use `TrailingObjects` to shrink SILDebugScopes without inline info to four words. I'm not sure if the latter is a win but the former probably always is.

This is motivated by looking at an Instruments trace of memory usage throughout generating the swiftmodule for the standard library (up through SIL optimization). It turns out about 5% of the persistent memory was SILDebugScopes, which are BumpPtrAllocated and thus not destroyed when not in use. I suspect that's higher than what a normal project would see, but it was still a chunk of work I could bite off.

(Be warned that taking that Instruments trace required about 12 minutes and 10GB of memory, when the normal swiftmodule generation takes less than 2 minutes and 1GB.)