### PR TITLE
[Batch Mode] Merge pull request #18489 from davidungar/rdar-42314665-fix-batch-mode-diag-trunctation

### DIFF
--- a/lib/AST/DiagnosticConsumer.cpp
+++ b/lib/AST/DiagnosticConsumer.cpp
@@ -35,58 +35,68 @@ llvm::SMLoc DiagnosticConsumer::getRawLoc(SourceLoc loc) {
 
 LLVM_ATTRIBUTE_UNUSED
 static bool hasDuplicateFileNames(
-    ArrayRef<FileSpecificDiagnosticConsumer::ConsumerPair> consumers) {
+    ArrayRef<FileSpecificDiagnosticConsumer::Subconsumer> subconsumers) {
   llvm::StringSet<> seenFiles;
-  for (const auto &consumerPair : consumers) {
-    if (consumerPair.first.empty()) {
-      // We can handle multiple consumers that aren't associated with any file,
-      // because they only collect diagnostics that aren't in any of the special
-      // files. This isn't an important use case to support, but also SmallSet
-      // doesn't handle empty strings anyway!
+  for (const auto &subconsumer : subconsumers) {
+    if (subconsumer.getInputFileName().empty()) {
+      // We can handle multiple subconsumers that aren't associated with any
+      // file, because they only collect diagnostics that aren't in any of the
+      // special files. This isn't an important use case to support, but also
+      // SmallSet doesn't handle empty strings anyway!
       continue;
     }
 
-    bool isUnique = seenFiles.insert(consumerPair.first).second;
+    bool isUnique = seenFiles.insert(subconsumer.getInputFileName()).second;
     if (!isUnique)
       return true;
   }
   return false;
 }
 
+std::unique_ptr<DiagnosticConsumer>
+FileSpecificDiagnosticConsumer::consolidateSubconsumers(
+    SmallVectorImpl<Subconsumer> &subconsumers) {
+  if (subconsumers.empty())
+    return nullptr;
+  if (subconsumers.size() == 1)
+    return std::move(subconsumers.front()).consumer;
+  // Cannot use return
+  // llvm::make_unique<FileSpecificDiagnosticConsumer>(subconsumers); because
+  // the constructor is private.
+  return std::unique_ptr<DiagnosticConsumer>(
+      new FileSpecificDiagnosticConsumer(subconsumers));
+}
+
 FileSpecificDiagnosticConsumer::FileSpecificDiagnosticConsumer(
-    SmallVectorImpl<ConsumerPair> &consumers)
-  : SubConsumers(std::move(consumers)) {
-  assert(!SubConsumers.empty() &&
+    SmallVectorImpl<Subconsumer> &subconsumers)
+    : Subconsumers(std::move(subconsumers)) {
+  assert(!Subconsumers.empty() &&
          "don't waste time handling diagnostics that will never get emitted");
-  assert(!hasDuplicateFileNames(SubConsumers) &&
-         "having multiple consumers for the same file is not implemented");
+  assert(!hasDuplicateFileNames(Subconsumers) &&
+         "having multiple subconsumers for the same file is not implemented");
 }
 
 void FileSpecificDiagnosticConsumer::computeConsumersOrderedByRange(
     SourceManager &SM) {
   // Look up each file's source range and add it to the "map" (to be sorted).
-  for (const ConsumerPair &pair : SubConsumers) {
-    if (pair.first.empty())
+  for (const unsigned subconsumerIndex: indices(Subconsumers)) {
+    const Subconsumer &subconsumer = Subconsumers[subconsumerIndex];
+    if (subconsumer.getInputFileName().empty())
       continue;
 
-    Optional<unsigned> bufferID = SM.getIDForBufferIdentifier(pair.first);
+    Optional<unsigned> bufferID =
+        SM.getIDForBufferIdentifier(subconsumer.getInputFileName());
     assert(bufferID.hasValue() && "consumer registered for unknown file");
     CharSourceRange range = SM.getRangeForBuffer(bufferID.getValue());
     ConsumersOrderedByRange.emplace_back(
-        ConsumerSpecificInformation(range, pair.second.get()));
+        ConsumerAndRange(range, subconsumerIndex));
   }
 
   // Sort the "map" by buffer /end/ location, for use with std::lower_bound
   // later. (Sorting by start location would produce the same sort, since the
   // ranges must not be overlapping, but since we need to check end locations
   // later it's consistent to sort by that here.)
-  std::sort(ConsumersOrderedByRange.begin(), ConsumersOrderedByRange.end(),
-            [](const ConsumerSpecificInformation &left,
-               const ConsumerSpecificInformation &right) -> bool {
-              auto compare = std::less<const char *>();
-              return compare(getRawLoc(left.range.getEnd()).getPointer(),
-                             getRawLoc(right.range.getEnd()).getPointer());
-            });
+  std::sort(ConsumersOrderedByRange.begin(), ConsumersOrderedByRange.end());
 
   // Check that the ranges are non-overlapping. If the files really are all
   // distinct, this should be trivially true, but if it's ever not we might end
@@ -94,16 +104,16 @@ void FileSpecificDiagnosticConsumer::computeConsumersOrderedByRange(
   assert(ConsumersOrderedByRange.end() ==
              std::adjacent_find(ConsumersOrderedByRange.begin(),
                                 ConsumersOrderedByRange.end(),
-                                [](const ConsumerSpecificInformation &left,
-                                   const ConsumerSpecificInformation &right) {
-                                  return left.range.overlaps(right.range);
+                                [](const ConsumerAndRange &left,
+                                   const ConsumerAndRange &right) {
+                                  return left.overlaps(right);
                                 }) &&
          "overlapping ranges despite having distinct files");
 }
 
-Optional<FileSpecificDiagnosticConsumer::ConsumerSpecificInformation *>
-FileSpecificDiagnosticConsumer::consumerSpecificInformationForLocation(
-    SourceManager &SM, SourceLoc loc) const {
+Optional<FileSpecificDiagnosticConsumer::Subconsumer *>
+FileSpecificDiagnosticConsumer::subconsumerForLocation(SourceManager &SM,
+                                                       SourceLoc loc) {
   // Diagnostics with invalid locations always go to every consumer.
   if (loc.isInvalid())
     return None;
@@ -119,11 +129,13 @@ FileSpecificDiagnosticConsumer::consumerSpecificInformationForLocation(
     // source buffers are loaded in yet. In that case we return None, rather
     // than trying to build a nonsensical map (and actually crashing since we
     // can't find buffers for the inputs).
-    assert(!SubConsumers.empty());
-    if (!SM.getIDForBufferIdentifier(SubConsumers.begin()->first).hasValue()) {
-      assert(llvm::none_of(SubConsumers, [&](const ConsumerPair &pair) {
-            return SM.getIDForBufferIdentifier(pair.first).hasValue();
-          }));
+    assert(!Subconsumers.empty());
+    if (!SM.getIDForBufferIdentifier(Subconsumers.begin()->getInputFileName())
+             .hasValue()) {
+      assert(llvm::none_of(Subconsumers, [&](const Subconsumer &subconsumer) {
+        return SM.getIDForBufferIdentifier(subconsumer.getInputFileName())
+            .hasValue();
+      }));
       return None;
     }
     auto *mutableThis = const_cast<FileSpecificDiagnosticConsumer*>(this);
@@ -134,19 +146,17 @@ FileSpecificDiagnosticConsumer::consumerSpecificInformationForLocation(
   // that /might/ contain 'loc'. Specifically, since the ranges are sorted
   // by end location, it's looking for the first range where the end location
   // is greater than or equal to 'loc'.
-  const ConsumerSpecificInformation *possiblyContainingRangeIter =
-      std::lower_bound(
-          ConsumersOrderedByRange.begin(), ConsumersOrderedByRange.end(), loc,
-          [](const ConsumerSpecificInformation &entry, SourceLoc loc) -> bool {
-            auto compare = std::less<const char *>();
-            return compare(getRawLoc(entry.range.getEnd()).getPointer(),
-                           getRawLoc(loc).getPointer());
-          });
+  const ConsumerAndRange *possiblyContainingRangeIter = std::lower_bound(
+      ConsumersOrderedByRange.begin(), ConsumersOrderedByRange.end(), loc,
+      [](const ConsumerAndRange &entry, SourceLoc loc) -> bool {
+        return entry.endsAfter(loc);
+      });
 
   if (possiblyContainingRangeIter != ConsumersOrderedByRange.end() &&
-      possiblyContainingRangeIter->range.contains(loc)) {
-    return const_cast<ConsumerSpecificInformation *>(
-        possiblyContainingRangeIter);
+      possiblyContainingRangeIter->contains(loc)) {
+    auto *consumerAndRangeForLocation =
+        const_cast<ConsumerAndRange *>(possiblyContainingRangeIter);
+    return &(*this)[*consumerAndRangeForLocation];
   }
 
   return None;
@@ -159,34 +169,25 @@ void FileSpecificDiagnosticConsumer::handleDiagnostic(
 
   HasAnErrorBeenConsumed |= Kind == DiagnosticKind::Error;
 
-  Optional<ConsumerSpecificInformation *> consumerSpecificInfo;
+  Optional<FileSpecificDiagnosticConsumer::Subconsumer *> subconsumer;
   switch (Kind) {
   case DiagnosticKind::Error:
   case DiagnosticKind::Warning:
   case DiagnosticKind::Remark:
-    consumerSpecificInfo = consumerSpecificInformationForLocation(SM, Loc);
-    ConsumerSpecificInfoForSubsequentNotes = consumerSpecificInfo;
+    subconsumer = subconsumerForLocation(SM, Loc);
+    SubconsumerForSubsequentNotes = subconsumer;
     break;
   case DiagnosticKind::Note:
-    consumerSpecificInfo = ConsumerSpecificInfoForSubsequentNotes;
+    subconsumer = SubconsumerForSubsequentNotes;
     break;
   }
-  if (!consumerSpecificInfo.hasValue()) {
-    for (auto &subConsumer : SubConsumers) {
-      if (subConsumer.second) {
-        subConsumer.second->handleDiagnostic(SM, Loc, Kind, FormatString,
+  if (subconsumer.hasValue()) {
+    subconsumer.getValue()->handleDiagnostic(SM, Loc, Kind, FormatString,
                                              FormatArgs, Info);
-      }
-    }
     return;
   }
-  if (!consumerSpecificInfo.getValue()->consumer)
-    return; // Suppress non-primary diagnostic in batch mode.
-
-  consumerSpecificInfo.getValue()->consumer->handleDiagnostic(
-      SM, Loc, Kind, FormatString, FormatArgs, Info);
-  consumerSpecificInfo.getValue()->hasAnErrorBeenEmitted |=
-      Kind == DiagnosticKind::Error;
+  for (auto &subconsumer : Subconsumers)
+    subconsumer.handleDiagnostic(SM, Loc, Kind, FormatString, FormatArgs, Info);
 }
 
 bool FileSpecificDiagnosticConsumer::finishProcessing() {
@@ -196,19 +197,18 @@ bool FileSpecificDiagnosticConsumer::finishProcessing() {
   // behavior.
 
   bool hadError = false;
-  for (auto &subConsumer : SubConsumers)
-    hadError |= subConsumer.second && subConsumer.second->finishProcessing();
+  for (auto &subconsumer : Subconsumers)
+    hadError |= subconsumer.getConsumer() &&
+                subconsumer.getConsumer()->finishProcessing();
   return hadError;
 }
 
 void FileSpecificDiagnosticConsumer::
-    tellSubconsumersToInformDriverOfIncompleteBatchModeCompilation() const {
+    tellSubconsumersToInformDriverOfIncompleteBatchModeCompilation() {
   if (!HasAnErrorBeenConsumed)
     return;
-  for (auto &info : ConsumersOrderedByRange) {
-    if (!info.hasAnErrorBeenEmitted && info.consumer)
-      info.consumer->informDriverOfIncompleteBatchModeCompilation();
-  }
+  for (auto &info : ConsumersOrderedByRange)
+    (*this)[info].informDriverOfIncompleteBatchModeCompilation();
 }
 
 void NullDiagnosticConsumer::handleDiagnostic(


### PR DESCRIPTION
<!-- What's in this pull request? -->
Explanation:  Fixes batch mode bug where all diagnostic outputs could be truncated, leaving the user with no diagnostics.
Scope of issue: User gets no diagnostics when all errors are present in non-primaries.
Origination:  Initial implementation of batch mode.
Risk: Should be minimal, but I could be wrong.
Reviewed by: Jordan Rose
Testing: Normal regression tests.
Radar: rdar://43033749, clone of rdar://42314665.


<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
rdar://43033749

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
