### PR TITLE
[benchmark] Report Quantiles from Benchmark_O and a TON of Gardening

### DIFF
--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -434,7 +434,7 @@ class BenchmarkDoctor(object):
         measurements = dict(
             [('{0} {1} i{2}{3}'.format(benchmark, o, i, suffix),
               self.driver.run(benchmark, num_samples=s, num_iters=i,
-                              verbose=True))
+                              verbose=True, measure_memory=True))
              for o in opts
              for s, i in run_args
              for suffix in list('abcde')

--- a/benchmark/scripts/compare_perf_tests.py
+++ b/benchmark/scripts/compare_perf_tests.py
@@ -141,20 +141,24 @@ class PerformanceTestSamples(object):
         """Maximum sampled value."""
         return self.samples[-1].runtime
 
+    def _quantile_index(self, q, i):
+        """Return index of the element nearest to the i-th q-quantile."""
+        return int(round((self.count - 1) / float(q) * float(i)))
+
     @property
     def median(self):
         """Median sampled value."""
-        return self.samples[self.count / 2].runtime
+        return self.samples[self._quantile_index(2, 1)].runtime
 
     @property
     def q1(self):
         """First Quartile (25th Percentile)."""
-        return self.samples[self.count / 4].runtime
+        return self.samples[self._quantile_index(4, 1)].runtime
 
     @property
     def q3(self):
         """Third Quartile (75th Percentile)."""
-        return self.samples[(self.count / 2) + (self.count / 4)].runtime
+        return self.samples[self._quantile_index(4, 3)].runtime
 
     @property
     def iqr(self):

--- a/benchmark/scripts/test_Benchmark_Driver.py
+++ b/benchmark/scripts/test_Benchmark_Driver.py
@@ -476,10 +476,10 @@ class TestBenchmarkDoctor(unittest.TestCase):
             # 5x i1 series, with 300 μs runtime its possible to take 4098
             # samples/s, but it should be capped at 2k
             ([(_run('B1', num_samples=2048, num_iters=1,
-                    verbose=True), _PTR(min=300))] * 5) +
+                    verbose=True, measure_memory=True), _PTR(min=300))] * 5) +
             # 5x i2 series
             ([(_run('B1', num_samples=2048, num_iters=2,
-                    verbose=True), _PTR(min=300))] * 5)
+                    verbose=True, measure_memory=True), _PTR(min=300))] * 5)
         ))
         doctor = BenchmarkDoctor(self.args, driver)
         with captured_output() as (out, _):

--- a/benchmark/scripts/test_compare_perf_tests.py
+++ b/benchmark/scripts/test_compare_perf_tests.py
@@ -75,10 +75,10 @@ class TestPerformanceTestSamples(unittest.TestCase):
             self.samples, (1000, 1000, 1000, 1000, 1000))
         self.samples.add(Sample(2, 1, 1100))
         self.assertEqualFiveNumberSummary(
-            self.samples, (1000, 1000, 1100, 1100, 1100))
+            self.samples, (1000, 1000, 1000, 1100, 1100))
         self.samples.add(Sample(3, 1, 1050))
         self.assertEqualFiveNumberSummary(
-            self.samples, (1000, 1050, 1050, 1100, 1100))
+            self.samples, (1000, 1000, 1050, 1100, 1100))
         self.samples.add(Sample(4, 1, 1025))
         self.assertEqualFiveNumberSummary(
             self.samples, (1000, 1025, 1050, 1050, 1100))

--- a/benchmark/scripts/test_compare_perf_tests.py
+++ b/benchmark/scripts/test_compare_perf_tests.py
@@ -369,7 +369,6 @@ Running AngryPhonebook for 3 samples.
     Sample 0,11812
     Measuring with scale 90.
     Sample 1,13898
-    Measuring with scale 91.
     Sample 2,11467
 1,AngryPhonebook,3,11467,13898,12392,1315,11812
 Running Array2D for 3 samples.
@@ -389,7 +388,7 @@ Totals,2"""
         )
         self.assertEquals(r.num_samples, r.samples.num_samples)
         self.assertEquals(results[0].samples.all_samples,
-                          [(0, 78, 11812), (1, 90, 13898), (2, 91, 11467)])
+                          [(0, 78, 11812), (1, 90, 13898), (2, 90, 11467)])
 
         r = results[1]
         self.assertEquals(

--- a/benchmark/scripts/test_compare_perf_tests.py
+++ b/benchmark/scripts/test_compare_perf_tests.py
@@ -78,10 +78,10 @@ class TestPerformanceTestSamples(unittest.TestCase):
             self.samples, (1000, 1000, 1100, 1100, 1100))
         self.samples.add(Sample(3, 1, 1050))
         self.assertEqualFiveNumberSummary(
-            self.samples, (1000, 1000, 1050, 1050, 1100))
+            self.samples, (1000, 1050, 1050, 1100, 1100))
         self.samples.add(Sample(4, 1, 1025))
         self.assertEqualFiveNumberSummary(
-            self.samples, (1000, 1025, 1050, 1100, 1100))
+            self.samples, (1000, 1025, 1050, 1050, 1100))
         self.samples.add(Sample(5, 1, 1075))
         self.assertEqualFiveNumberSummary(
             self.samples, (1000, 1025, 1050, 1075, 1100))
@@ -156,11 +156,12 @@ class TestPerformanceTestSamples(unittest.TestCase):
         self.samples.add(Sample(0, 2, 23))
         self.samples.add(Sample(1, 2, 18))
         self.samples.add(Sample(2, 2, 18))
+        self.samples.add(Sample(3, 2, 18))
         self.assertEquals(self.samples.iqr, 0)
 
         self.samples.exclude_outliers()
 
-        self.assertEquals(self.samples.count, 2)
+        self.assertEquals(self.samples.count, 3)
         self.assertEqualStats(
             (self.samples.min, self.samples.max), (18, 18))
 

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -80,7 +80,7 @@ struct TestConfig {
 
   /// After we run the tests, should the harness sleep to allow for utilities
   /// like leaks that require a PID to run on the test harness.
-  let afterRunSleep: Int?
+  let afterRunSleep: UInt32?
 
   /// The list of tests to run.
   let tests: [(index: String, info: BenchmarkInfo)]
@@ -92,8 +92,9 @@ struct TestConfig {
     struct PartialTestConfig {
       var delim: String?
       var tags, skipTags: Set<BenchmarkCategory>?
-      var numSamples, afterRunSleep: Int?
+      var numSamples: Int?
       var fixedNumIters: UInt?
+      var afterRunSleep: UInt32?
       var sampleTime: Double?
       var verbose: Bool?
       var logMemory: Bool?
@@ -142,7 +143,7 @@ struct TestConfig {
                   parser: tags)
     p.addArgument("--sleep", \.afterRunSleep,
                   help: "number of seconds to sleep after benchmarking",
-                  parser: { Int($0) })
+                  parser: { UInt32($0) })
     p.addArgument("--list", \.action, defaultValue: .listTests,
                   help: "don't run the tests, just log the list of test \n" +
                         "numbers, names and tags (respects specified filters)")
@@ -521,7 +522,7 @@ public func main() {
   case .run:
     runBenchmarks(config)
     if let x = config.afterRunSleep {
-      sleep(UInt32(x))
+      sleep(x)
     }
   }
 }

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -258,15 +258,16 @@ final class Timer {
   }
 
   func diffTimeInNanoSeconds(from start_ticks: TimeT, to end_ticks: TimeT) -> UInt64 {
+    let oneSecond = 1_000_000_000 // ns
     var elapsed_ticks = timespec(tv_sec: 0, tv_nsec: 0)
     if end_ticks.tv_nsec - start_ticks.tv_nsec < 0 {
       elapsed_ticks.tv_sec = end_ticks.tv_sec - start_ticks.tv_sec - 1
-      elapsed_ticks.tv_nsec = end_ticks.tv_nsec - start_ticks.tv_nsec + 1000000000
+      elapsed_ticks.tv_nsec = end_ticks.tv_nsec - start_ticks.tv_nsec + oneSecond
     } else {
       elapsed_ticks.tv_sec = end_ticks.tv_sec - start_ticks.tv_sec
       elapsed_ticks.tv_nsec = end_ticks.tv_nsec - start_ticks.tv_nsec
     }
-    return UInt64(elapsed_ticks.tv_sec) * UInt64(1000000000) + UInt64(elapsed_ticks.tv_nsec)
+    return UInt64(elapsed_ticks.tv_sec) * UInt64(oneSecond) + UInt64(elapsed_ticks.tv_nsec)
   }
 #else
   typealias TimeT = UInt64

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -454,7 +454,7 @@ func runBench(_ test: BenchmarkInfo, _ c: TestConfig) -> BenchResults? {
                       min: samples.first!, max: samples.last!,
                       mean: UInt64(stats.mean),
                       sd: UInt64(stats.standardDeviation),
-                      median: samples[samples.count / 2],
+                      median: samples[(samples.count - 1) / 2],
                       maxRSS: UInt64(sampler.measureMemoryUsage()))
 }
 

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -252,22 +252,22 @@ final class Timer {
   typealias TimeT = timespec
 
   func getTime() -> TimeT {
-    var ticks = timespec(tv_sec: 0, tv_nsec: 0)
-    clock_gettime(CLOCK_REALTIME, &ticks)
-    return ticks
+    var ts = timespec(tv_sec: 0, tv_nsec: 0)
+    clock_gettime(CLOCK_REALTIME, &ts)
+    return ts
   }
 
-  func diffTimeInNanoSeconds(from start_ticks: TimeT, to end_ticks: TimeT) -> UInt64 {
+  func diffTimeInNanoSeconds(from start: TimeT, to end: TimeT) -> UInt64 {
     let oneSecond = 1_000_000_000 // ns
-    var elapsed_ticks = timespec(tv_sec: 0, tv_nsec: 0)
-    if end_ticks.tv_nsec - start_ticks.tv_nsec < 0 {
-      elapsed_ticks.tv_sec = end_ticks.tv_sec - start_ticks.tv_sec - 1
-      elapsed_ticks.tv_nsec = end_ticks.tv_nsec - start_ticks.tv_nsec + oneSecond
+    var elapsed = timespec(tv_sec: 0, tv_nsec: 0)
+    if end.tv_nsec - start.tv_nsec < 0 {
+      elapsed.tv_sec = end.tv_sec - start.tv_sec - 1
+      elapsed.tv_nsec = end.tv_nsec - start.tv_nsec + oneSecond
     } else {
-      elapsed_ticks.tv_sec = end_ticks.tv_sec - start_ticks.tv_sec
-      elapsed_ticks.tv_nsec = end_ticks.tv_nsec - start_ticks.tv_nsec
+      elapsed.tv_sec = end.tv_sec - start.tv_sec
+      elapsed.tv_nsec = end.tv_nsec - start.tv_nsec
     }
-    return UInt64(elapsed_ticks.tv_sec) * UInt64(oneSecond) + UInt64(elapsed_ticks.tv_nsec)
+    return UInt64(elapsed.tv_sec) * UInt64(oneSecond) + UInt64(elapsed.tv_nsec)
   }
 #else
   typealias TimeT = UInt64
@@ -281,9 +281,9 @@ final class Timer {
     return mach_absolute_time()
   }
 
-  func diffTimeInNanoSeconds(from start_ticks: TimeT, to end_ticks: TimeT) -> UInt64 {
-    let elapsed_ticks = end_ticks - start_ticks
-    return elapsed_ticks * UInt64(info.numer) / UInt64(info.denom)
+  func diffTimeInNanoSeconds(from start: TimeT, to end: TimeT) -> UInt64 {
+    let elapsed = end - start
+    return elapsed * UInt64(info.numer) / UInt64(info.denom)
   }
 #endif
 }
@@ -448,7 +448,7 @@ func runBench(_ test: BenchmarkInfo, _ c: TestConfig) -> BenchResults? {
     } else {
       scale = 1
     }
-    // save result in microseconds or k-ticks
+    // save result in microseconds
     samples[s] = elapsed_time / UInt64(scale) / 1000
     if c.verbose {
       print("    Sample \(s),\(samples[s])")

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -305,6 +305,10 @@ final class Timer {
 final class SampleRunner {
   let timer = Timer()
   let baseline = SampleRunner.getResourceUtilization()
+extension UInt64 {
+  var microseconds: Int { return Int(self / 1000) }
+}
+
   let c: TestConfig
   var start, end, lastYield: Timer.TimeT
   let schedulerQuantum = UInt64(10_000_000) // nanoseconds (== 10ms, macos)
@@ -375,7 +379,7 @@ final class SampleRunner {
     if (spent + nextSampleEstimate < schedulerQuantum) {
         start = timer.getTime()
     } else {
-        logVerbose("    Yielding again after estimated \(spent/1000) us")
+        logVerbose("    Yielding after ~\(spent.microseconds) μs")
         let now = yield()
         (start, lastYield) = (now, now)
     }
@@ -409,8 +413,7 @@ final class SampleRunner {
     name.withCString { p in stopTrackingObjects(p) }
 #endif
 
-    // Convert to μs and compute the average sample time per iteration.
-    return Int(lastSampleTime / 1000) / numIters
+    return lastSampleTime.microseconds / numIters
   }
 
   func logVerbose(_ msg: @autoclosure () -> String) {

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -302,15 +302,16 @@ final class Timer {
 #endif
 }
 
-final class SampleRunner {
-  let timer = Timer()
-  let baseline = SampleRunner.getResourceUtilization()
 extension UInt64 {
   var microseconds: Int { return Int(self / 1000) }
 }
 
+/// Performance test runner that measures benchmarks and reports the results.
+final class TestRunner {
   let c: TestConfig
+  let timer = Timer()
   var start, end, lastYield: Timer.TimeT
+  let baseline = TestRunner.getResourceUtilization()
   let schedulerQuantum = UInt64(10_000_000) // nanoseconds (== 10ms, macos)
 
   init(_ config: TestConfig) {
@@ -356,7 +357,7 @@ extension UInt64 {
   /// benchmark. That's why we don't worry about reseting the `baseline` in
   /// `resetMeasurements`.
   func measureMemoryUsage() -> Int {
-    let current = SampleRunner.getResourceUtilization()
+    let current = TestRunner.getResourceUtilization()
     let maxRSS = current.ru_maxrss - baseline.ru_maxrss
     let pages = { maxRSS / sysconf(_SC_PAGESIZE) }
     func deltaEquation(_ stat: KeyPath<rusage, Int>) -> String {
@@ -520,7 +521,7 @@ public func main() {
       print(testDescription)
     }
   case .run:
-    SampleRunner(config).runBenchmarks()
+    TestRunner(config).runBenchmarks()
     if let x = config.afterRunSleep {
       sleep(x)
     }

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -174,8 +174,8 @@ struct TestConfig {
   ///
   /// - Parameters:
   ///   - registeredBenchmarks: List of all performance tests to be filtered.
-  ///   - specifiedTests: List of explicitly specified tests to run. These can be
-  ///     specified either by a test name or a test number.
+  ///   - specifiedTests: List of explicitly specified tests to run. These can
+  ///     be specified either by a test name or a test number.
   ///   - tags: Run tests tagged with all of these categories.
   ///   - skipTags: Don't run tests tagged with any of these categories.
   /// - Returns: An array of test number and benchmark info tuples satisfying
@@ -394,7 +394,7 @@ func runBench(_ test: BenchmarkInfo, _ c: TestConfig) -> BenchResults? {
   // the platform and we should skip it.
   guard let testFn = test.runFunction else {
     if c.verbose {
-	print("Skipping unsupported benchmark \(test.name)!")
+      print("Skipping unsupported benchmark \(test.name)!")
     }
     return nil
   }
@@ -503,9 +503,9 @@ public func main() {
   case .listTests:
     print("#\(config.delim)Test\(config.delim)[Tags]")
     for (index, t) in config.tests {
-    let testDescription = [String(index), t.name, t.tags.sorted().description]
-      .joined(separator: config.delim)
-    print(testDescription)
+      let testDescription = [index, t.name, t.tags.sorted().description]
+        .joined(separator: config.delim)
+      print(testDescription)
     }
   case .run:
     runBenchmarks(config)

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -247,14 +247,16 @@ func stopTrackingObjects(_: UnsafePointer<CChar>) -> Int
 
 #endif
 
-#if os(Linux)
 final class Timer {
+#if os(Linux)
   typealias TimeT = timespec
+
   func getTime() -> TimeT {
     var ticks = timespec(tv_sec: 0, tv_nsec: 0)
     clock_gettime(CLOCK_REALTIME, &ticks)
     return ticks
   }
+
   func diffTimeInNanoSeconds(from start_ticks: TimeT, to end_ticks: TimeT) -> UInt64 {
     var elapsed_ticks = timespec(tv_sec: 0, tv_nsec: 0)
     if end_ticks.tv_nsec - start_ticks.tv_nsec < 0 {
@@ -266,23 +268,24 @@ final class Timer {
     }
     return UInt64(elapsed_ticks.tv_sec) * UInt64(1000000000) + UInt64(elapsed_ticks.tv_nsec)
   }
-}
 #else
-final class Timer {
   typealias TimeT = UInt64
   var info = mach_timebase_info_data_t(numer: 0, denom: 0)
+
   init() {
     mach_timebase_info(&info)
   }
+
   func getTime() -> TimeT {
     return mach_absolute_time()
   }
+
   func diffTimeInNanoSeconds(from start_ticks: TimeT, to end_ticks: TimeT) -> UInt64 {
     let elapsed_ticks = end_ticks - start_ticks
     return elapsed_ticks * UInt64(info.numer) / UInt64(info.denom)
   }
-}
 #endif
+}
 
 final class SampleRunner {
   let timer = Timer()

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -229,10 +229,6 @@ struct Stats {
     }
 }
 
-func internalMedian(_ inputs: [UInt64]) -> UInt64 {
-  return inputs.sorted()[inputs.count / 2]
-}
-
 #if SWIFT_RUNTIME_ENABLE_LEAK_CHECKER
 
 @_silgen_name("_swift_leaks_startTrackingObjects")
@@ -451,13 +447,14 @@ func runBench(_ test: BenchmarkInfo, _ c: TestConfig) -> BenchResults? {
   }
   test.tearDownFunction?()
 
+  samples.sort()
   let stats = samples.reduce(into: Stats(), Stats.collect)
 
   return BenchResults(sampleCount: UInt64(samples.count),
-                      min: samples.min()!, max: samples.max()!,
+                      min: samples.first!, max: samples.last!,
                       mean: UInt64(stats.mean),
                       sd: UInt64(stats.standardDeviation),
-                      median: internalMedian(samples),
+                      median: samples[samples.count / 2],
                       maxRSS: UInt64(sampler.measureMemoryUsage()))
 }
 

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -92,7 +92,7 @@ struct TestConfig {
     struct PartialTestConfig {
       var delim: String?
       var tags, skipTags: Set<BenchmarkCategory>?
-      var numSamples: Int?
+      var numSamples: UInt?
       var fixedNumIters: UInt?
       var afterRunSleep: UInt32?
       var sampleTime: Double?
@@ -119,7 +119,7 @@ struct TestConfig {
     let p = ArgumentParser(into: PartialTestConfig())
     p.addArgument("--num-samples", \.numSamples,
                   help: "number of samples to take per benchmark; default: 1",
-                  parser: { Int($0) })
+                  parser: { UInt($0) })
     p.addArgument("--num-iters", \.fixedNumIters,
                   help: "number of iterations averaged in the sample;\n" +
                         "default: auto-scaled to measure for `sample-time`",
@@ -155,7 +155,7 @@ struct TestConfig {
     delim = c.delim ?? ","
     sampleTime = c.sampleTime ?? 1.0
     fixedNumIters = c.fixedNumIters ?? 0
-    numSamples = c.numSamples ?? 1
+    numSamples = Int(c.numSamples ?? 1)
     verbose = c.verbose ?? false
     logMemory = c.logMemory ?? false
     afterRunSleep = c.afterRunSleep

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -407,21 +407,20 @@ final class SampleRunner {
 
 /// Invoke the benchmark entry point and return the run time in milliseconds.
 func runBench(_ test: BenchmarkInfo, _ c: TestConfig) -> BenchResults? {
+  func logVerbose(_ msg: @autoclosure () -> String) {
+    if c.verbose { print(msg()) }
+  }
   var samples = [Int](repeating: 0, count: c.numSamples)
 
   // Before we do anything, check that we actually have a function to
   // run. If we don't it is because the benchmark is not supported on
   // the platform and we should skip it.
   guard let testFn = test.runFunction else {
-    if c.verbose {
-      print("Skipping unsupported benchmark \(test.name)!")
-    }
+    logVerbose("Skipping unsupported benchmark \(test.name)!")
     return nil
   }
 
-  if c.verbose {
-    print("Running \(test.name) for \(c.numSamples) samples.")
-  }
+  logVerbose("Running \(test.name) for \(c.numSamples) samples.")
 
   let sampler = SampleRunner(c)
   test.setUpFunction?()
@@ -438,9 +437,7 @@ func runBench(_ test: BenchmarkInfo, _ c: TestConfig) -> BenchResults? {
         /// Number of iterations to make `testFn` run for the desired time.
         scale = timePerSample / elapsed_time
       } else {
-        if c.verbose {
-          print("    Warning: elapsed time is 0. This can be safely ignored if the body is empty.")
-        }
+        logVerbose("    Warning: elapsed time is 0!")
         scale = 1
       }
     } else {
@@ -457,16 +454,12 @@ func runBench(_ test: BenchmarkInfo, _ c: TestConfig) -> BenchResults? {
 
     // Rerun the test with the computed scale factor.
     if scale > 1 {
-      if c.verbose {
-        print("    Measuring with scale \(scale).")
-      }
+      logVerbose("    Measuring with scale \(scale).")
       elapsed_time = sampler.measure(test.name, fn: testFn, numIters: scale)
     }
 
     samples[s] = elapsed_time
-    if c.verbose {
-      print("    Sample \(s),\(samples[s])")
-    }
+    logVerbose("    Sample \(s),\(samples[s])")
   }
   test.tearDownFunction?()
 

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -426,39 +426,39 @@ func runBench(_ test: BenchmarkInfo, _ c: TestConfig) -> BenchResults? {
   test.setUpFunction?()
 
   for s in 0..<c.numSamples {
-    var scale : Int
-    var elapsed_time : Int = 0
+    var numIters : Int
+    var time: Int = 0
     if c.fixedNumIters == 0 {
-      elapsed_time = sampler.measure(test.name, fn: testFn, numIters: 1)
+      time = sampler.measure(test.name, fn: testFn, numIters: 1)
 
-      if elapsed_time > 0 {
+      if time > 0 {
         let usPerSecond = 1_000_000.0 // microseconds (μs)
         let timePerSample = Int(c.sampleTime * usPerSecond)
         /// Number of iterations to make `testFn` run for the desired time.
-        scale = timePerSample / elapsed_time
+        numIters = timePerSample / time
       } else {
         logVerbose("    Warning: elapsed time is 0!")
-        scale = 1
+        numIters = 1
       }
     } else {
       // Compute the scaling factor if a fixed c.fixedNumIters is not specified.
-      scale = c.fixedNumIters
-      if scale == 1 {
-        elapsed_time = sampler.measure(test.name, fn: testFn, numIters: 1)
+      numIters = c.fixedNumIters
+      if numIters == 1 {
+        time = sampler.measure(test.name, fn: testFn, numIters: 1)
       }
     }
     // Make integer overflow less likely on platforms where Int is 32 bits wide.
     // FIXME: Switch BenchmarkInfo to use Int64 for the iteration scale, or fix
     // benchmarks to not let scaling get off the charts.
-    scale = min(scale, Int.max / 10_000)
+    numIters = min(numIters, Int.max / 10_000)
 
     // Rerun the test with the computed scale factor.
-    if scale > 1 {
-      logVerbose("    Measuring with scale \(scale).")
-      elapsed_time = sampler.measure(test.name, fn: testFn, numIters: scale)
+    if numIters > 1 {
+      logVerbose("    Measuring with scale \(numIters).")
+      time = sampler.measure(test.name, fn: testFn, numIters: numIters)
     }
 
-    samples[s] = elapsed_time
+    samples[s] = time
     logVerbose("    Sample \(s),\(samples[s])")
   }
   test.tearDownFunction?()

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -32,8 +32,14 @@ struct BenchResults {
   }
 
   /// Return sample at index nearest to the `quantile`.
+  ///
+  /// Explicitly uses round-half-to-even rounding algorithm to match the
+  /// behavior of numpy's quantile(interpolation='nearest') and quantile
+  /// estimate type R-3, SAS-2. See:
+  /// https://en.wikipedia.org/wiki/Quantile#Estimating_quantiles_from_a_sample
   subscript(_ quantile: Double) -> T {
-    let index = Int((Double(samples.count - 1) * quantile).rounded())
+    let index = Int(
+      (Double(samples.count - 1) * quantile).rounded(.toNearestOrEven))
     return samples[index]
   }
 

--- a/test/benchmark/Benchmark_Driver.test-sh
+++ b/test/benchmark/Benchmark_Driver.test-sh
@@ -9,3 +9,7 @@
 // RUN:                 | %FileCheck %s --check-prefix RUNJUSTONCE
 // RUNJUSTONCE-LABEL: Ackermann
 // RUNJUSTONCE-NOT: Ackermann
+
+// RUN: %Benchmark_Driver check 1 \
+// RUN:                 | %FileCheck %s --check-prefix DOCTORCHECK
+// DOCTORCHECK: Ackermann

--- a/test/benchmark/Benchmark_O.test.md
+++ b/test/benchmark/Benchmark_O.test.md
@@ -132,7 +132,6 @@ LOGMEMORY: #,TEST,SAMPLES,MIN(us),MAX(us),MEAN(us),SD(us),MEDIAN(us),MAX_RSS(B)
 LOGVERBOSE-LABEL: Running Ackermann for 2 samples.
 LOGVERBOSE: Measuring with scale {{[0-9]+}}.
 LOGVERBOSE: Sample 0,{{[0-9]+}}
-LOGVERBOSE: Measuring with scale {{[0-9]+}}.
 LOGVERBOSE: Sample 1,{{[0-9]+}}
 MEASUREENV: MAX_RSS {{[0-9]+}} - {{[0-9]+}} = {{[0-9]+}} ({{[0-9]+}} pages)
 MEASUREENV: ICS {{[0-9]+}} - {{[0-9]+}} = {{[0-9]+}}

--- a/test/benchmark/Benchmark_O.test.md
+++ b/test/benchmark/Benchmark_O.test.md
@@ -135,12 +135,15 @@ VENTILES: VH(μs),VI(μs),VJ(μs),MAX(μs)
 Reports detailed information during measurement, including configuration
 details, environmental statistics (memory used and number of context switches)
 and all individual samples. We'll reuse this test to check arguments that
-modify the reported columns: `--memory` and `--quantile` to end with *one less*
-number in the benchmark summary, compared to normal format.
+modify the reported columns: `--memory`, `--quantile` and `--delta` to end with
+*one less* number in the benchmark summary, compared to normal format. Given
+that we are taking only 2 samples, the MEDIAN and MAX will be the same number.
+With the `--delta` option this means that 𝚫MAX is zero, so the penultimate
+number will be omitted from the output, giving us 2 consecutive delimiters (,,).
 
 ````
 RUN: %Benchmark_O 1 Ackermann 1 AngryPhonebook \
-RUN:              --verbose --num-samples=2 --memory --quantile=2 \
+RUN:              --verbose --num-samples=2 --memory --quantile=2 --delta \
 RUN:              | %FileCheck %s --check-prefix RUNJUSTONCE \
 RUN:                              --check-prefix CONFIG \
 RUN:                              --check-prefix LOGVERBOSE \
@@ -149,7 +152,7 @@ RUN:                              --check-prefix LOGFORMAT
 CONFIG: NumSamples: 2
 CONFIG: Tests Filter: ["1", "Ackermann", "1", "AngryPhonebook"]
 CONFIG: Tests to run: Ackermann, AngryPhonebook
-LOGFORMAT: #,TEST,SAMPLES,MIN(μs),MEDIAN(μs),MAX(μs),MAX_RSS(B)
+LOGFORMAT: #,TEST,SAMPLES,MIN(μs),𝚫MEDIAN,𝚫MAX,MAX_RSS(B)
 LOGVERBOSE-LABEL: Running Ackermann for 2 samples.
 LOGVERBOSE: Measuring with scale {{[0-9]+}}.
 LOGVERBOSE: Sample 0,{{[0-9]+}}
@@ -159,7 +162,7 @@ MEASUREENV: ICS {{[0-9]+}} - {{[0-9]+}} = {{[0-9]+}}
 MEASUREENV: VCS {{[0-9]+}} - {{[0-9]+}} = {{[0-9]+}}
 RUNJUSTONCE-LABEL: 1,Ackermann
 RUNJUSTONCE-NOT: 1,Ackermann
-LOGFORMAT: ,{{[0-9]+}},{{[0-9]+}},{{[0-9]+}},{{[0-9]+}},{{[0-9]+}}
+LOGFORMAT: ,{{[0-9]+}},{{[0-9]+}},{{[0-9]+}},,{{[0-9]+}}
 LOGVERBOSE-LABEL: Running AngryPhonebook for 2 samples.
 ````
 


### PR DESCRIPTION
This PR adds a support to modify benchmark log format to report [quantiles](https://en.wikipedia.org/wiki/Quantile) in the test summary, specified by the [**`--quantile`** argument](https://github.com/apple/swift/blob/1f465b9bf7feb975a914995bb9f524289800f810/benchmark/utils/DriverUtils.swift#L131-L134).

The default benchmark result reports statistics of a normal distribution — mean and standard deviation. Unfortunately the samples from our benchmarks are [*not normally distributed*](https://palimondo.github.io/robust-microbench/analysis.html). To get a better picture of the underlying probability distribution, this PR adds support for reporting quantiles.

This gives better subsample of the measurements in the summary, without need to resort to the use of a full verbose mode, which might be unnecessarily slow.

Example to get the [five-number summary](https://en.wikipedia.org/wiki/Five-number_summary):

````
$ ./Benchmark_O --num-iters=1 --num-samples=5 --quantile=4 170
#,TEST,SAMPLES,MIN(μs),Q1(μs),Q2(μs),Q3(μs),MAX(μs)
170,DropFirstArray,5,171,171,171,175,215

Total performance tests executed: 1
````

Additionally the `--quantile` argument can be combined with the [**`--delta`** option](https://github.com/apple/swift/pull/19097/commits/313dfda5a488876d730d0f8aa7c521381ba9ac0d), which will apply [delta encoding](https://en.wikipedia.org/wiki/Delta_encoding) to the quantiles, and omit `0`s from the output, resulting in a concise human as well as machine readable format that gives us good picture of the underlying probability distribution of the samples:

````
$ ./Benchmark_O --num-iters=1 --num-samples=200 --quantile=20 --delta 170 171 184 185
#,TEST,SAMPLES,MIN(μs),𝚫V1,𝚫V2,𝚫V3,𝚫V4,𝚫V5,𝚫V6,𝚫V7,𝚫V8,𝚫V9,𝚫VA,𝚫VB,𝚫VC,𝚫VD,𝚫VE,𝚫VF,𝚫VG,𝚫VH,𝚫VI,𝚫VJ,𝚫MAX
170,DropFirstArray,200,171,,,,,,,,,,,,,,,,,1,2,6,83
171,DropFirstArrayLazy,200,168,,,,,,,,,,,,,,,,,,2,92,235
184,DropLastArray,200,55,,,,,,,,,,,,,,,,1,,,4,738
185,DropLastArrayLazy,200,65,,,,,,,,,,,,,,,,,1,1,24,3922

Total performance tests executed: 4
````

There was a significant amount of technical debt in the main sampling loop manifesting as `if-else` spaghetti code 🍝 and a lot of explicit conversions between various integer types with overly specific widths. The code has been cleaned up to use the [default currency type `Int`](https://docs.swift.org/swift-book/LanguageGuide/TheBasics.html#ID324) where appropriate. Improved conformance with [Swift Naming Guidelines](https://swift.org/documentation/api-design-guidelines/#general-conventions):
* Prefer methods and properties to free functions
* Follow case conventions

----

The functionality of the pre-existing features of `Benchmark_O` remains unchanged, with the exception of the spelling of the time unit in the log header, which is changed from **`(us)`** to **`(μs)`**. The new default header is now the same as in the output from `Benchmark_Driver`:
````
#,TEST,SAMPLES,MIN(μs),MAX(μs),MEAN(μs),SD(μs),MEDIAN(μs)
````
Note: `LogParser` is currently ignoring the header, I'm highlighting this change just to be extra careful, in case there are other (Apple-internal?) clients that parse the log output from `Benchmark_O`.

----

I've structured the PR as a series of small, incremental changes with detailed descriptions in the commit messages, it is therefore best [**reviewed sequentially by individual commits**](https://github.com/apple/swift/pull/19097/commits/e6cff27babdd404e955451c80b11752346ec9cbc).