### PR TITLE
[test] Fix target-based reflection tests for real

### DIFF
--- a/validation-test/Reflection/existentials.swift
+++ b/validation-test/Reflection/existentials.swift
@@ -1,17 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/existentials
 // RUN: %target-codesign %t/existentials
-
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/existentials | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/existentials | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 /*
    This file pokes at the swift_reflection_projectExistential API

--- a/validation-test/Reflection/functions.swift
+++ b/validation-test/Reflection/functions.swift
@@ -2,19 +2,13 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/functions
 // RUN: %target-codesign %t/functions
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/functions | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/functions | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 // FIXME: Should not require objc_interop -- please put Objective-C-specific
 // testcases in functions_objc.swift
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 /*
    This file pokes at the swift_reflection_infoForInstance() API

--- a/validation-test/Reflection/functions_objc.swift
+++ b/validation-test/Reflection/functions_objc.swift
@@ -3,16 +3,10 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/functions
 // RUN: %target-codesign %t/functions
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/functions | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/functions | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import SwiftReflectionTest
 import Foundation

--- a/validation-test/Reflection/inherits_NSObject.swift
+++ b/validation-test/Reflection/inherits_NSObject.swift
@@ -2,16 +2,10 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/inherits_NSObject
 // RUN: %target-codesign %t/inherits_NSObject
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/inherits_NSObject | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/inherits_NSObject | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import Foundation
 import simd

--- a/validation-test/Reflection/inherits_ObjCClasses.swift
+++ b/validation-test/Reflection/inherits_ObjCClasses.swift
@@ -4,17 +4,11 @@
 // RUN: %target-build-swift -I %S/Inputs/ObjCClasses/ -lswiftSwiftReflectionTest %t/ObjCClasses.o %s -o %t/inherits_ObjCClasses
 // RUN: %target-codesign %t/inherits_ObjCClasses
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/inherits_ObjCClasses | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/inherits_ObjCClasses | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import simd
 import ObjCClasses

--- a/validation-test/Reflection/inherits_Swift.swift
+++ b/validation-test/Reflection/inherits_Swift.swift
@@ -2,17 +2,11 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/inherits_Swift
 // RUN: %target-codesign %t/inherits_Swift
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/inherits_Swift | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/inherits_Swift | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/lit.local.cfg
+++ b/validation-test/Reflection/lit.local.cfg
@@ -1,0 +1,10 @@
+# Make a local copy of the substitutions.
+config.substitutions = list(config.substitutions)
+
+config.substitutions.insert(0, ("%target-run-reflection-test",
+    # Link %target-swift-reflection-test into %t to convince %target-run to copy
+    # it, then use DYLD_LIBRARY_PATH to make sure it can find SwiftRemoteMirrors
+    # from its new location when /not/ run remotely.
+    ("ln %target-swift-reflection-test %t/swift-reflection-test && "
+        "env %env-DYLD_LIBRARY_PATH=%platform-module-dir/../ %target-run "
+        " %t/swift-reflection-test")))

--- a/validation-test/Reflection/reflect_Array.swift
+++ b/validation-test/Reflection/reflect_Array.swift
@@ -2,16 +2,10 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Array
 // RUN: %target-codesign %t/reflect_Array
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/reflect_Array | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/reflect_Array | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Bool.swift
+++ b/validation-test/Reflection/reflect_Bool.swift
@@ -2,16 +2,10 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Bool
 // RUN: %target-codesign %t/reflect_Bool
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/reflect_Bool | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/reflect_Bool | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Character.swift
+++ b/validation-test/Reflection/reflect_Character.swift
@@ -2,16 +2,10 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Character
 // RUN: %target-codesign %t/reflect_Character
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/reflect_Character | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/reflect_Character | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Dictionary.swift
+++ b/validation-test/Reflection/reflect_Dictionary.swift
@@ -2,16 +2,10 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Dictionary
 // RUN: %target-codesign %t/reflect_Dictionary
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/reflect_Dictionary | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/reflect_Dictionary | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Double.swift
+++ b/validation-test/Reflection/reflect_Double.swift
@@ -2,16 +2,10 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Double
 // RUN: %target-codesign %t/reflect_Double
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/reflect_Double | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/reflect_Double | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Float.swift
+++ b/validation-test/Reflection/reflect_Float.swift
@@ -2,16 +2,10 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Float
 // RUN: %target-codesign %t/reflect_Float
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/reflect_Float | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/reflect_Float | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Int.swift
+++ b/validation-test/Reflection/reflect_Int.swift
@@ -2,16 +2,10 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Int
 // RUN: %target-codesign %t/reflect_Int
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/reflect_Int | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/reflect_Int | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Int16.swift
+++ b/validation-test/Reflection/reflect_Int16.swift
@@ -2,16 +2,10 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Int16
 // RUN: %target-codesign %t/reflect_Int16
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/reflect_Int16 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/reflect_Int16 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Int32.swift
+++ b/validation-test/Reflection/reflect_Int32.swift
@@ -2,16 +2,10 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Int32
 // RUN: %target-codesign %t/reflect_Int32
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/reflect_Int32 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/reflect_Int32 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Int64.swift
+++ b/validation-test/Reflection/reflect_Int64.swift
@@ -2,16 +2,10 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Int64
 // RUN: %target-codesign %t/reflect_Int64
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/reflect_Int64 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/reflect_Int64 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_Int8.swift
+++ b/validation-test/Reflection/reflect_Int8.swift
@@ -2,16 +2,10 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Int8
 // RUN: %target-codesign %t/reflect_Int8
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/reflect_Int8 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/reflect_Int8 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_NSArray.swift
+++ b/validation-test/Reflection/reflect_NSArray.swift
@@ -2,16 +2,10 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_NSArray
 // RUN: %target-codesign %t/reflect_NSArray
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/reflect_NSArray | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/reflect_NSArray | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import SwiftReflectionTest
 import Foundation

--- a/validation-test/Reflection/reflect_NSNumber.swift
+++ b/validation-test/Reflection/reflect_NSNumber.swift
@@ -2,16 +2,10 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_NSNumber
 // RUN: %target-codesign %t/reflect_NSNumber
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/reflect_NSNumber | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/reflect_NSNumber | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import SwiftReflectionTest
 import Foundation

--- a/validation-test/Reflection/reflect_NSSet.swift
+++ b/validation-test/Reflection/reflect_NSSet.swift
@@ -2,16 +2,10 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_NSSet
 // RUN: %target-codesign %t/reflect_NSSet
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/reflect_NSSet | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/reflect_NSSet | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import SwiftReflectionTest
 import Foundation

--- a/validation-test/Reflection/reflect_NSString.swift
+++ b/validation-test/Reflection/reflect_NSString.swift
@@ -2,16 +2,10 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_NSString
 // RUN: %target-codesign %t/reflect_NSString
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/reflect_NSString | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/reflect_NSString | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import SwiftReflectionTest
 import Foundation

--- a/validation-test/Reflection/reflect_Set.swift
+++ b/validation-test/Reflection/reflect_Set.swift
@@ -2,16 +2,10 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Set
 // RUN: %target-codesign %t/reflect_Set
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/reflect_Set | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/reflect_Set | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_String.swift
+++ b/validation-test/Reflection/reflect_String.swift
@@ -2,16 +2,10 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_String
 // RUN: %target-codesign %t/reflect_String
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/reflect_String | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/reflect_String | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_UInt.swift
+++ b/validation-test/Reflection/reflect_UInt.swift
@@ -2,16 +2,10 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_UInt
 // RUN: %target-codesign %t/reflect_UInt
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/reflect_UInt | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/reflect_UInt | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_UInt16.swift
+++ b/validation-test/Reflection/reflect_UInt16.swift
@@ -2,16 +2,10 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_UInt16
 // RUN: %target-codesign %t/reflect_UInt16
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/reflect_UInt16 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/reflect_UInt16 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_UInt32.swift
+++ b/validation-test/Reflection/reflect_UInt32.swift
@@ -2,16 +2,10 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_UInt32
 // RUN: %target-codesign %t/reflect_UInt32
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/reflect_UInt32 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/reflect_UInt32 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_UInt64.swift
+++ b/validation-test/Reflection/reflect_UInt64.swift
@@ -2,16 +2,10 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_UInt64
 // RUN: %target-codesign %t/reflect_UInt64
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/reflect_UInt64 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/reflect_UInt64 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_UInt8.swift
+++ b/validation-test/Reflection/reflect_UInt8.swift
@@ -2,16 +2,10 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_UInt8
 // RUN: %target-codesign %t/reflect_UInt8
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/reflect_UInt8 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/reflect_UInt8 | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_empty_class.swift
+++ b/validation-test/Reflection/reflect_empty_class.swift
@@ -2,16 +2,10 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_empty_class
 // RUN: %target-codesign %t/reflect_empty_class
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/reflect_empty_class | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/reflect_empty_class | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_existential.swift
+++ b/validation-test/Reflection/reflect_existential.swift
@@ -2,16 +2,10 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_existential
 // RUN: %target-codesign %t/reflect_existential
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/reflect_existential | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/reflect_existential | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import SwiftReflectionTest
 

--- a/validation-test/Reflection/reflect_multiple_types.swift
+++ b/validation-test/Reflection/reflect_multiple_types.swift
@@ -2,16 +2,10 @@
 // RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_multiple_types
 // RUN: %target-codesign %t/reflect_multiple_types
 
-// Link %target-swift-reflection-test into %t to convince %target-run to copy
-// it.
-// RUN: ln -s %target-swift-reflection-test %t/swift-reflection-test
-// RUN: %target-run %t/swift-reflection-test %t/reflect_multiple_types | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run-reflection-test %t/reflect_multiple_types | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-
-// FIXME: Handle different forms of %target-run more robustly
-// REQUIRES: OS=macosx
 
 import SwiftReflectionTest
 import Foundation


### PR DESCRIPTION
Follow-up to #19031, itself a response to mistakes in #18966.

- Hard-link `%target-swift-reflection-test` into `%t/` for `%target-run` implementations that copy executables, like remote-run.
- Use `DYLD_LIBRARY_PATH` to undo that for `%target-run` implementations that run the executable in place (host and simulators)

rdar://problem/43809613