### PR TITLE
[index] Make sure to walk the accessor bodies of local properties

### DIFF
--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -515,7 +515,12 @@ private:
 void IndexSwiftASTWalker::visitDeclContext(DeclContext *Context) {
   IsModuleFile = false;
   isSystemModule = Context->getParentModule()->isSystemModule();
+  auto accessor = dyn_cast<AccessorDecl>(Context);
+  if (accessor)
+    ManuallyVisitedAccessorStack.push_back(accessor);
   walk(Context);
+  if (accessor)
+    ManuallyVisitedAccessorStack.pop_back();
 }
 
 void IndexSwiftASTWalker::visitModule(ModuleDecl &Mod, StringRef KnownHash) {

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -151,6 +151,7 @@ class IndexSwiftASTWalker : public SourceEntityWalker {
   };
   SmallVector<Entity, 6> EntitiesStack;
   SmallVector<Expr *, 8> ExprStack;
+  SmallVector<const AccessorDecl *, 4> ManuallyVisitedAccessorStack;
   bool Cancelled = false;
 
   struct NameAndUSR {
@@ -253,7 +254,10 @@ public:
       : IdxConsumer(IdxConsumer), SrcMgr(Ctx.SourceMgr), BufferID(BufferID),
         enableWarnings(IdxConsumer.enableWarnings()) {}
 
-  ~IndexSwiftASTWalker() override { assert(Cancelled || EntitiesStack.empty()); }
+  ~IndexSwiftASTWalker() override {
+    assert(Cancelled || EntitiesStack.empty());
+    assert(Cancelled || ManuallyVisitedAccessorStack.empty());
+  }
 
   void visitModule(ModuleDecl &Mod, StringRef Hash);
   void visitDeclContext(DeclContext *DC);
@@ -270,8 +274,8 @@ private:
     if (AvailableAttr::isUnavailable(D))
       return false;
     if (auto *AD = dyn_cast<AccessorDecl>(D)) {
-      auto *Parent = getParentDecl();
-      if (Parent && Parent != AD->getStorage())
+      if (ManuallyVisitedAccessorStack.empty() ||
+          ManuallyVisitedAccessorStack.back() != AD)
         return false; // already handled as part of the var decl.
     }
     if (auto *VD = dyn_cast<ValueDecl>(D)) {
@@ -957,13 +961,29 @@ bool IndexSwiftASTWalker::report(ValueDecl *D) {
              accessor->getAccessorKind() == AccessorKind::Set))
           continue;
 
+        ManuallyVisitedAccessorStack.push_back(accessor);
         SourceEntityWalker::walk(cast<Decl>(accessor));
+        ManuallyVisitedAccessorStack.pop_back();
         if (Cancelled)
           return false;
       }
     } else if (auto NTD = dyn_cast<NominalTypeDecl>(D)) {
       if (!reportInheritedTypeRefs(NTD->getInherited(), NTD))
         return false;
+    }
+  } else {
+    // Even if we don't record a local property we still need to walk its
+    // accessor bodies.
+    if (auto StoreD = dyn_cast<AbstractStorageDecl>(D)) {
+      for (auto accessor : StoreD->getAllAccessors()) {
+        if (accessor->isImplicit())
+          continue;
+        ManuallyVisitedAccessorStack.push_back(accessor);
+        SourceEntityWalker::walk(cast<Decl>(accessor));
+        ManuallyVisitedAccessorStack.pop_back();
+        if (Cancelled)
+          return false;
+      }
     }
   }
 

--- a/test/Index/expressions.swift
+++ b/test/Index/expressions.swift
@@ -15,3 +15,33 @@ func test(_ o: P1?) {
     test(o)
   }
 }
+
+func foo() {} // CHECK: [[@LINE]]:6 | function/Swift | foo() | [[foo_USR:.*]] | Def
+
+func test1() { // CHECK: [[@LINE]]:6 | function/Swift | test1() | [[test1_USR:.*]] | Def
+  func local_func() {
+    // FIXME: Saying that 'test1' is the caller of 'foo' is inaccurate, but we'd need
+    // to switch to recording local symbols in order to model this properly.
+    foo() // CHECK: [[@LINE]]:5 | function/Swift | foo() | [[foo_USR]] | Ref,Call,RelCall,RelCont | rel: 1
+      // CHECK-NEXT: RelCall,RelCont | function/Swift | test1() | [[test1_USR]]
+  }
+
+  var local_prop: Int {
+    get {
+      foo() // CHECK: [[@LINE]]:7 | function/Swift | foo() | [[foo_USR]] | Ref,Call,RelCall,RelCont | rel: 1
+        // CHECK-NEXT: RelCall,RelCont | function/Swift | test1() | [[test1_USR]]
+      return 0
+    }
+    set {
+      foo() // CHECK: [[@LINE]]:7 | function/Swift | foo() | [[foo_USR]] | Ref,Call,RelCall,RelCont | rel: 1
+        // CHECK-NEXT: RelCall,RelCont | function/Swift | test1() | [[test1_USR]]
+    }
+  }
+
+  struct LocalS {
+    func meth() {
+      foo() // CHECK: [[@LINE]]:7 | function/Swift | foo() | [[foo_USR]] | Ref,Call,RelCall,RelCont | rel: 1
+        // CHECK-NEXT: RelCall,RelCont | function/Swift | test1() | [[test1_USR]]
+    }
+  }
+}

--- a/test/Index/kinds.swift
+++ b/test/Index/kinds.swift
@@ -247,3 +247,11 @@ _ = ImplCtors()
 // CHECK: [[@LINE-1]]:5 | constructor/Swift | init() | [[ImplCtors_init_USR]] | Ref,Call | rel: 0
 _ = ImplCtors(x:0)
 // CHECK: [[@LINE-1]]:5 | constructor/Swift | init(x:) | [[ImplCtors_init_with_param_USR]] | Ref,Call | rel: 0
+
+var globalCompProp: Int // CHECK: [[@LINE]]:5 | variable/Swift | [[globalCompProp:.*]] | Def
+{ // CHECK: [[@LINE]]:1 | function/acc-get/Swift | getter:globalCompProp |
+  // CHECK-NEXT: RelChild,RelAcc | variable/Swift | [[globalCompProp]]
+  // Check that the accessor def is not showing up twice.
+  // CHECK-NOT: [[@LINE-3]]:1 | function/acc-get/Swift
+  return 0
+}


### PR DESCRIPTION
Otherwise we'll miss global symbols references.
rdar://42301005
