### PR TITLE
[AutoDiff] Not checkpoint inactive values from the original function

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -1455,9 +1455,6 @@ enum class ActivityFlags : unsigned {
 };
 
 using Activity = OptionSet<ActivityFlags>;
-static inline Activity operator|(ActivityFlags lhs, ActivityFlags rhs) {
-  return Activity(unsigned(lhs) | unsigned(rhs));
-}
 
 /// Result of activity analysis on a function. Accepts queries for whether a
 /// value is "varied", "useful" or "active" against certain differentiation

--- a/test/AutoDiff/generic_real_vector.swift
+++ b/test/AutoDiff/generic_real_vector.swift
@@ -2,7 +2,7 @@
 // XFAIL: *
 
 @_fixed_layout
-public struct Vector<T : Numeric> : VectorNumeric {
+public struct Vector<T> : VectorNumeric {
   public var x: T
   public var y: T
 
@@ -39,9 +39,9 @@ public func fakeAdj<T>(lhs: Vector<T>, rhs: Vector<T>, y: Vector<T>, seed: Vecto
   abort()
 }
 
-public func callGenericFunctionOnConcrete(_ x: Vector<Float>) {
-  func foo(x: Vector<Float>, y: Vector<Float>) -> Vector<Float> {
-    return x + y
+public func test1() {
+  func foo(_ x: Vector<Float>) -> Vector<Float> {
+    return x + x
   }
   _ = #gradient(foo)
 }

--- a/test/AutoDiff/generic_real_vector.swift
+++ b/test/AutoDiff/generic_real_vector.swift
@@ -2,7 +2,7 @@
 // XFAIL: *
 
 @_fixed_layout
-public struct Vector<T> : VectorNumeric {
+public struct Vector<T : Numeric> : VectorNumeric {
   public var x: T
   public var y: T
 
@@ -39,9 +39,9 @@ public func fakeAdj<T>(lhs: Vector<T>, rhs: Vector<T>, y: Vector<T>, seed: Vecto
   abort()
 }
 
-public func test1() {
-  func foo(_ x: Vector<Float>) -> Vector<Float> {
-    return x + x
+public func callGenericFunctionOnConcrete(_ x: Vector<Float>) {
+  func foo(x: Vector<Float>, y: Vector<Float>) -> Vector<Float> {
+    return x + y
   }
   _ = #gradient(foo)
 }

--- a/test/AutoDiff/primalgen.swift
+++ b/test/AutoDiff/primalgen.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s
+
+import TensorFlow
+
+@inline(never)
+func print<T>(_ x: T) {
+  Swift.print(x)
+}
+
+func squared(_ x: Float) -> Float {
+  print("test output")
+  return x * x
+}
+
+#gradient(squared)(20)
+
+// CHECK-LABEL: sil hidden @{{.*}}squared{{.*}}__primal_src_0_wrt_0
+// CHECK: [[PV:%.*]] = struct ${{.*}}squared{{.*}}__Type ({{.*}} : $Builtin.FPIEEE32)
+// CHECK: [[RESULT:%.*]] = tuple ([[PV]] : $$S9primalgen7squaredyS2fF__Type, {{.*}} : $Float)
+// CHECK: return %19 : $(${{.*}}squared{{.*}}__Type, Float)


### PR DESCRIPTION
* Teach AD not to checkpoint inactive values from the original function.
*  Refactor activity analysis lookup to produce an option set.

Resolves [SR-8685](https://bugs.swift.org/browse/SR-8685).