### PR TITLE
[AutoDiff] Generalize differentiable types using DifferentiableVectorNumeric protocol

### DIFF
--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -134,6 +134,12 @@ extension Tensor : VectorNumeric where Scalar : Numeric {
   }
 }
 
+extension Tensor : DifferentiableVectorNumeric
+  where ScalarElement : FloatingPoint {
+  public typealias Tangent = Tensor
+  public typealias Cotangent = Tensor
+}
+
 public extension Tensor where Scalar : Numeric {
   /// Adds two tensors and stores the result in the left-hand-side variable.
   /// - Note: `+=` supports broadcasting.

--- a/test/AutoDiff/generic_real_vector.swift
+++ b/test/AutoDiff/generic_real_vector.swift
@@ -2,7 +2,7 @@
 // XFAIL: *
 
 @_fixed_layout
-public struct Vector<T : Numeric> : VectorNumeric {
+public struct Vector<T> : VectorNumeric {
   public var x: T
   public var y: T
 
@@ -39,9 +39,9 @@ public func fakeAdj<T>(lhs: Vector<T>, rhs: Vector<T>, y: Vector<T>, seed: Vecto
   abort()
 }
 
-public func callGenericFunctionOnConcrete(_ x: Vector<Float>) {
-  func foo(x: Vector<Float>, y: Vector<Float>) -> Vector<Float> {
-    return x + y
+public func test1() {
+  func foo(_ x: Vector<Float>) -> Vector<Float> {
+    return x + x
   }
   _ = #gradient(foo)
 }

--- a/test/AutoDiff/generic_real_vector.swift
+++ b/test/AutoDiff/generic_real_vector.swift
@@ -2,7 +2,7 @@
 // XFAIL: *
 
 @_fixed_layout
-public struct Vector<T> : VectorNumeric {
+public struct Vector<T : Numeric> : VectorNumeric {
   public var x: T
   public var y: T
 
@@ -39,9 +39,9 @@ public func fakeAdj<T>(lhs: Vector<T>, rhs: Vector<T>, y: Vector<T>, seed: Vecto
   abort()
 }
 
-public func test1() {
-  func foo(_ x: Vector<Float>) -> Vector<Float> {
-    return x + x
+public func callGenericFunctionOnConcrete(_ x: Vector<Float>) {
+  func foo(x: Vector<Float>, y: Vector<Float>) -> Vector<Float> {
+    return x + y
   }
   _ = #gradient(foo)
 }


### PR DESCRIPTION
This patch changes how we consider a vector space to be differentiable in the AD API.

Previously, our differentiability rule stated that for all `VectorNumeric`-conforming types whose `ScalarElement` conforms to `FloatingPoint`, those types support differentiation. However, this has a fundamental limitation: it requires the original space and the adjoint space to be the same manifold, that is, parameters to a differentiable function have the same type as the vector-Jacobian products. This is not future-proof and is inconsistent with the compiler design (see #18977).

This patch adds protocol `DifferentiableVectorNumeric` that refines `VectorNumeric`. Conforming types must specify the tangent space and the cotangent space. In the `TensorFlow.Tensor` case, its tangent space and cotangent space are just itself.
```swift
public protocol DifferentiableVectorNumeric : VectorNumeric where ScalarElement : FloatingPoint {
  associatedtype Tangent : VectorNumeric where Tangent.ScalarElement == ScalarElement
  associatedtype Cotangent : VectorNumeric where Cotangent.ScalarElement == ScalarElement
  var tangent: Tangent { get }
  var cotangent: Cotangent { get }
}
```