### PR TITLE
[AutoDiff] Remove constraints that require Tangent and Cotangent's ScalarElement to equal Self.ScalarElement

### DIFF
--- a/stdlib/public/core/AutoDiff.swift
+++ b/stdlib/public/core/AutoDiff.swift
@@ -69,11 +69,9 @@ public protocol DifferentiableVectorNumeric : VectorNumeric
   where ScalarElement : FloatingPoint {
   /// The tangent space of the vector space represented by the enclosing type.
   associatedtype Tangent : VectorNumeric
-    where Tangent.ScalarElement == ScalarElement
 
   /// The cotangent space of the vector space represented by the enclosing type.
   associatedtype Cotangent : VectorNumeric
-    where Cotangent.ScalarElement == ScalarElement
 
   var tangent: Tangent { get }
 


### PR DESCRIPTION
Address a use case I mentioned in #19112.