### PR TITLE
Unfail DebugInfo/local-vars.swift.gyb

### DIFF
--- a/test/DebugInfo/local-vars.swift.gyb
+++ b/test/DebugInfo/local-vars.swift.gyb
@@ -1,4 +1,3 @@
-// XFAIL: linux
 // An end-to-end test to ensure local variables have debug info.  This
 // test only verifies that the variables show up in the debug info at
 // all. There are other tests testing liveness and representation.


### PR DESCRIPTION
After fixing llvm-dwarfdump's verifier we need to re-enable this test. 