### PR TITLE
[WIP] Default implementation in protocols

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2312,6 +2312,10 @@ public:
   /// Asserts if this is not a member of a protocol.
   bool isProtocolRequirement() const;
 
+  /// Returns true if this member is a default implementation in a
+  /// protocol.
+  bool isDefaultImplInProtocol() const;
+
   /// Determine whether we have already checked whether this
   /// declaration is a redeclaration.
   bool alreadyCheckedRedeclaration() const { 

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -361,8 +361,6 @@ ERROR(expected_rbrace_protocol,none,
       "expected '}' in protocol", ())
 ERROR(protocol_setter_name,none,
       "setter in a protocol cannot have a name", ())
-ERROR(protocol_method_with_body,none,
-      "protocol methods must not have bodies", ())
 ERROR(protocol_init_with_body,none,
       "protocol initializers must not have bodies", ())
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1700,7 +1700,8 @@ ERROR(protocol_property_must_be_computed_var,none,
       "immutable property requirement must be declared as 'var' with a "
       "'{ get }' specifier", ())
 ERROR(protocol_property_must_be_computed,none,
-      "property in protocol must have explicit { get } or { get set } specifier",
+      "property in protocol must either have an explicit { get } specifier, "
+      "{ get set } specifier, or must be a computed property",
       ())
 NOTE(inherited_protocol_does_not_conform,none,
      "type %0 does not conform to inherited protocol %1", (Type, Type))

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2183,6 +2183,29 @@ bool ValueDecl::isProtocolRequirement() const {
   return true;
 }
 
+bool ValueDecl::isDefaultImplInProtocol() const {
+  if (isa<ProtocolDecl>(getDeclContext())) {
+    if (auto *func = dyn_cast<AbstractFunctionDecl>(this)) {
+      if (func->hasBody()) {
+        return true;
+      }
+    }
+    
+    if (auto *storage = dyn_cast<AbstractStorageDecl>(this)) {
+      if (storage->hasAnyAccessors()) {
+        auto accessors = storage->getAllAccessors();
+        
+        for (auto *accessor : accessors) {
+          if (accessor->hasBody())
+            return true;
+        }
+      }
+    }
+  }
+  
+  return false;
+}
+
 bool ValueDecl::hasInterfaceType() const {
   return !TypeAndAccess.getPointer().isNull();
 }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4238,7 +4238,8 @@ bool Parser::parseGetSet(ParseDeclOptions Flags,
       return parseImplicitGetter();
     }
     
-    // Protocols are eligible for default implementation
+    // If the next token is not the start of a body, this is no longer eligible
+    // for default implementation
     if (IsFirstAccessor && isEligibleForDefaultImpl) {
       if (!Tok.is(tok::l_brace))
         isEligibleForDefaultImpl = false;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5254,14 +5254,7 @@ Parser::parseDeclFunc(SourceLoc StaticLoc, StaticSpellingKind StaticSpelling,
   DefaultArgs.setFunctionContext(FD, FD->getParameters());
   setLocalDiscriminator(FD);
 
-  if (Flags.contains(PD_InProtocol)) {
-    if (Tok.is(tok::l_brace)) {
-      diagnose(Tok, diag::protocol_method_with_body);
-      skipSingle();
-    }
-  } else {
-    parseAbstractFunctionBody(FD);
-  }
+  parseAbstractFunctionBody(FD);
 
   // Exit the scope introduced for the generic parameters.
   GenericsScope.reset();

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5183,7 +5183,6 @@ static Callee getBaseAccessorFunctionRef(SILGenFunction &SGF,
 
   // If this is a method in a protocol, generate it as a protocol call.
   if (isa<ProtocolDecl>(decl->getDeclContext())) {
-    assert(!isDirectUse && "direct use of protocol accessor?");
     assert(!isSuper && "super call to protocol method?");
 
     return Callee::forWitnessMethod(

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -834,8 +834,15 @@ public:
   }
   void visitFuncDecl(FuncDecl *fd) {
     SGM.emitFunction(fd);
-    if (SGM.requiresObjCMethodEntryPoint(fd) && fd->isDefaultImplInProtocol())
-      SGM.emitObjCMethodThunk(fd);
+    
+    if (SGM.requiresObjCMethodEntryPoint(fd)) {
+      if (isa<ProtocolDecl>(fd->getDeclContext())) {
+        if (fd->isDefaultImplInProtocol())
+          SGM.emitObjCMethodThunk(fd);
+      } else {
+        SGM.emitObjCMethodThunk(fd);
+      }
+    }
   }
   void visitConstructorDecl(ConstructorDecl *cd) {
     SGM.emitConstructor(cd);
@@ -878,8 +885,14 @@ public:
   }
 
   void visitAbstractStorageDecl(AbstractStorageDecl *asd) {
-    if (asd->isObjC() && asd->isDefaultImplInProtocol())
-      SGM.emitObjCPropertyMethodThunks(asd);
+    if (asd->isObjC()) {
+      if (isa<ProtocolDecl>(asd->getDeclContext())) {
+        if (asd->isDefaultImplInProtocol())
+          SGM.emitObjCPropertyMethodThunks(asd);
+      } else {
+        SGM.emitObjCPropertyMethodThunks(asd);
+      }
+    }
     
     SGM.tryEmitPropertyDescriptor(asd);
   }

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -834,9 +834,7 @@ public:
   }
   void visitFuncDecl(FuncDecl *fd) {
     SGM.emitFunction(fd);
-    // FIXME: Default implementations in protocols.
-    if (SGM.requiresObjCMethodEntryPoint(fd) &&
-        !isa<ProtocolDecl>(fd->getDeclContext()))
+    if (SGM.requiresObjCMethodEntryPoint(fd) && fd->isDefaultImplInProtocol())
       SGM.emitObjCMethodThunk(fd);
   }
   void visitConstructorDecl(ConstructorDecl *cd) {
@@ -880,8 +878,7 @@ public:
   }
 
   void visitAbstractStorageDecl(AbstractStorageDecl *asd) {
-    // FIXME: Default implementations in protocols.
-    if (asd->isObjC() && !isa<ProtocolDecl>(asd->getDeclContext()))
+    if (asd->isObjC() && asd->isDefaultImplInProtocol())
       SGM.emitObjCPropertyMethodThunks(asd);
     
     SGM.tryEmitPropertyDescriptor(asd);

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -448,27 +448,24 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
       ProtocolDecl *inProtocolExtension2 = outerDC2->getExtendedProtocolDecl();
       
       // Check if decl1 is potentially a default implementation in a protocol
-      bool decl1IsDefaultImpl = false;
       if (!inProtocolExtension1) {
         if (decl1->isDefaultImplInProtocol()) {
           inProtocolExtension1 = outerDC1->getSelfProtocolDecl();
-          decl1IsDefaultImpl = true;
         }
       }
       
       // Do the same for decl2
-      bool decl2IsDefaultImpl = false;
       if (!inProtocolExtension2) {
         if (decl2->isDefaultImplInProtocol()) {
           inProtocolExtension2 = outerDC2->getSelfProtocolDecl();
-          decl2IsDefaultImpl = true;
         }
       }
       
       if (inProtocolExtension1 && inProtocolExtension2) {
         bool checkProtocolItself = false;
         
-        if (decl1IsDefaultImpl && decl2IsDefaultImpl) {
+        if (decl1->isDefaultImplInProtocol() &&
+            decl2->isDefaultImplInProtocol()) {
           checkProtocolItself = true;
         }
         

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -450,22 +450,18 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
       // Check if decl1 is potentially a default implementation in a protocol
       bool decl1IsDefaultImpl = false;
       if (!inProtocolExtension1) {
-        if (auto *afd = dyn_cast<AbstractFunctionDecl>(decl1)) {
-          if (afd->hasBody() && outerDC1->getSelfProtocolDecl()) {
-            inProtocolExtension1 = outerDC1->getSelfProtocolDecl();
-            decl1IsDefaultImpl = true;
-          }
+        if (decl1->isDefaultImplInProtocol()) {
+          inProtocolExtension1 = outerDC1->getSelfProtocolDecl();
+          decl1IsDefaultImpl = true;
         }
       }
       
       // Do the same for decl2
       bool decl2IsDefaultImpl = false;
       if (!inProtocolExtension2) {
-        if (auto *afd = dyn_cast<AbstractFunctionDecl>(decl2)) {
-          if (afd->hasBody() && outerDC2->getSelfProtocolDecl()) {
-            inProtocolExtension2 = outerDC2->getSelfProtocolDecl();
-            decl2IsDefaultImpl = true;
-          }
+        if (decl2->isDefaultImplInProtocol()) {
+          inProtocolExtension2 = outerDC2->getSelfProtocolDecl();
+          decl2IsDefaultImpl = true;
         }
       }
       

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -772,12 +772,8 @@ static void checkRedeclaration(TypeChecker &tc, ValueDecl *current) {
     // it is, check if other decl has a body in the protocol.
     bool skipProtocolExtensionCheck = false;
     
-    if (isa<ExtensionDecl>(currentDC) && isa<ProtocolDecl>(otherDC)) {
-      if (auto *afd = dyn_cast<AbstractFunctionDecl>(other)) {
-        if (afd->hasBody()) {
-          skipProtocolExtensionCheck = true;
-        }
-      }
+    if (isa<ExtensionDecl>(currentDC) && other->isDefaultImplInProtocol()) {
+      skipProtocolExtensionCheck = true;
     }
     
     if (!conflicting(currentSig, otherSig, skipProtocolExtensionCheck))

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -280,11 +280,8 @@ namespace {
       
       if (witness) {
         if (isa<ProtocolDecl>(witness->getDeclContext())) {
-          if (auto *afc = dyn_cast<AbstractFunctionDecl>(witness)) {
-            if (afc->hasBody()) {
-              addResult(witness);
-            }
-          }
+          if (witness->isDefaultImplInProtocol())
+            addResult(witness);
         } else {
           addResult(witness);
         }

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -190,17 +190,6 @@ namespace {
         }
       };
 
-      // Check if found is potentially a default implementation in a protocol.
-      bool foundIsDefaultImpl = false;
-
-      if (isa<ProtocolDecl>(foundDC)) {
-        if (auto *afd = dyn_cast<AbstractFunctionDecl>(found)) {
-          if (afd->hasBody()) {
-            foundIsDefaultImpl = true;
-          }
-        }
-      }
-
       // If this isn't a protocol member to be given special
       // treatment, just add the result.
       if (!Options.contains(NameLookupFlags::ProtocolMembers) ||
@@ -208,7 +197,7 @@ namespace {
           isa<GenericTypeParamDecl>(found) ||
           isa<TypeAliasDecl>(found) ||
           (isa<FuncDecl>(found) && cast<FuncDecl>(found)->isOperator()) ||
-          foundIsDefaultImpl) {
+          found->isDefaultImplInProtocol()) {
         addResult(found);
         return;
       }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1035,12 +1035,13 @@ bool WitnessChecker::findBestWitness(
     bestIdx = 0;
 
     for (auto witness : witnesses) {
-      // Don't match anything in a protocol.
-      // FIXME: When default implementations come along, we can try to match
-      // these when they're default implementations coming from another
-      // (unrelated) protocol.
+      // Check if witness may be a default implementation in a protocol.
       if (isa<ProtocolDecl>(witness->getDeclContext())) {
-        continue;
+        if (auto *afd = dyn_cast<AbstractFunctionDecl>(witness)) {
+          if (!afd->hasBody()) {
+            continue;
+          }
+        }
       }
 
       if (!witness->hasValidSignature()) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1037,11 +1037,8 @@ bool WitnessChecker::findBestWitness(
     for (auto witness : witnesses) {
       // Check if witness may be a default implementation in a protocol.
       if (isa<ProtocolDecl>(witness->getDeclContext())) {
-        if (auto *afd = dyn_cast<AbstractFunctionDecl>(witness)) {
-          if (!afd->hasBody()) {
-            continue;
-          }
-        }
+        if (!witness->isDefaultImplInProtocol())
+          continue;
       }
 
       if (!witness->hasValidSignature()) {
@@ -1060,6 +1057,10 @@ bool WitnessChecker::findBestWitness(
         bestIdx = matches.size();
       } else if (match.Kind == MatchKind::WitnessInvalid) {
         doNotDiagnoseMatches = true;
+      }
+
+      if (auto *proto = dyn_cast<ProtocolDecl>(match.Witness->getDeclContext())) {
+        anyFromUnconstrainedExtension = true;
       }
 
       if (auto *ext = dyn_cast<ExtensionDecl>(match.Witness->getDeclContext())){


### PR DESCRIPTION
Refer to: https://github.com/apple/swift/blob/master/docs/GenericsManifesto.md#default-implementations-in-protocols-

Forum Post: https://forums.swift.org/t/default-implementation-in-protocols/15794

This is an early working implementation for default implementations in protocols. This allows syntax like the following:

```swift
protocol Animal {
  func makeNoise() {
    print("Bark!")
  }
}

struct Dog: Animal {}

let sparky = Dog()
sparky.makeNoise() // Bark!
```

At the moment, this is pending a lot of tests, and syntax changes.

I'm welcome to feedback regarding improving the current implementation 😅 

cc: @DougGregor (You might be able to cc more people who might have an interest in this)