### PR TITLE
SILOptimizer: handle copies in LetPropertiesOpt.

### DIFF
--- a/test/SILOptimizer/let_properties_opts.swift
+++ b/test/SILOptimizer/let_properties_opts.swift
@@ -354,3 +354,25 @@ public func useInitializers() -> StructWithPublicAndInternalLetProperties {
 public func useInitializers() -> StructWithPublicAndInternalAndPrivateLetProperties {
   return StructWithPublicAndInternalAndPrivateLetProperties(1, 1)
 }
+
+struct RACStruct {
+    private let end = 27
+    
+    var startIndex: Int { return 0 }
+
+
+    // CHECK-LABEL: RACStruct.endIndex.getter
+    // CHECK-NEXT: sil hidden @{{.*}}endIndexSivg
+    // CHECK-NEXT: bb0
+    // CHECK-NEXT:   %1 = integer_literal $Builtin.Int{{.*}}, 27
+    // CHECK-NEXT:   %2 = struct $Int (%1 : $Builtin.Int{{.*}})
+    // CHECK-NEXT:   return %2 : $Int
+    var endIndex: Int { return end }
+    
+    subscript(_ bitIndex: Int) -> Bool {
+        get { return false }
+        set { }
+    }
+}
+
+extension RACStruct : RandomAccessCollection {}

--- a/test/SILOptimizer/optionset.swift
+++ b/test/SILOptimizer/optionset.swift
@@ -16,6 +16,7 @@ public struct TestOptions: OptionSet {
 // CHECK-NEXT: bb0:
 // CHECK-NEXT:   integer_literal {{.*}}, 15
 // CHECK-NEXT:   struct $Int
+// CHECK-NEXT:   debug_value
 // CHECK-NEXT:   struct $TestOptions
 // CHECK-NEXT:   return
 public func returnTestOptions() -> TestOptions {
@@ -26,6 +27,7 @@ public func returnTestOptions() -> TestOptions {
 // CHECK-NEXT:   global_addr
 // CHECK-NEXT:   integer_literal {{.*}}, 15
 // CHECK-NEXT:   struct $Int
+// CHECK-NEXT:   debug_value
 // CHECK-NEXT:   struct $TestOptions
 // CHECK-NEXT:   store
 // CHECK-NEXT:   tuple

--- a/test/SILOptimizer/specialize_unconditional_checked_cast.swift
+++ b/test/SILOptimizer/specialize_unconditional_checked_cast.swift
@@ -100,6 +100,7 @@ ArchetypeToConcreteConvertUInt8(t: f)
 // CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast31ArchetypeToConcreteConvertUInt8{{[_0-9a-zA-Z]*}}3Not{{.*}}Tg5 : $@convention(thin) (NotUInt8) -> NotUInt8 {
 // CHECK: bb0
 // CHECK-NEXT: debug_value %0
+// CHECK-NEXT: debug_value %0
 // CHECK-NEXT: return %0
 
 // x -> y where y is a class but x is not.

--- a/test/SILOptimizer/sroa.sil
+++ b/test/SILOptimizer/sroa.sil
@@ -56,6 +56,23 @@ bb0(%0 : $S1):
   return %6 : $()
 }
 
+// CHECK-LABEL: sil @dont_sroa_without_benefit : $@convention(thin) (S1) -> S1
+// CHECK:      bb0
+// CHECK-NEXT:   alloc_stack $S1
+// CHECK-NEXT:   store %0 to %1 : $*S1
+// CHECK-NEXT:   load %1 : $*S1
+// CHECK-NEXT:   dealloc_stack %1 : $*S1
+// CHECK-NEXT:   return
+sil @dont_sroa_without_benefit : $@convention(thin) (S1) -> S1 {
+bb0(%0 : $S1):
+  %1 = alloc_stack $S1
+  store %0 to %1 : $*S1
+  %3 = load %1 : $*S1
+  dealloc_stack %1 : $*S1
+  return %3 : $S1
+}
+
+
 ///////////////////////////////
 // Struct With Struct Fields //
 ///////////////////////////////


### PR DESCRIPTION
When the initializer of a property is analyzed we now don't bail if such a property is copied from another instance of a struct/class.

This fixes a strange performance regression with constant let properties in structs which conform to an unrelated protocol.

This PR also includes a required improvement in SROA: only do SROA when it has a benefit.

SR-7713
rdar://problem/40332203