### PR TITLE
Basic: guard against `nullptr` for `env`

### DIFF
--- a/lib/Basic/Program.cpp
+++ b/lib/Basic/Program.cpp
@@ -34,7 +34,9 @@ int swift::ExecuteInPlace(const char *Program, const char **args,
 
   return result;
 #else
-  llvm::ArrayRef<llvm::StringRef> Env = llvm::toStringRefArray(env);
+  llvm::Optional<llvm::ArrayRef<llvm::StringRef>> Env = llvm::None;
+  if (env)
+    Env = llvm::toStringRefArray(env);
   int result =
       llvm::sys::ExecuteAndWait(Program, llvm::toStringRefArray(args), Env);
   if (result >= 0)


### PR DESCRIPTION
`env` is a default'ed parameter.  In some cases it may be passed a `nullptr`,
which is not a valid parameter to `llvm::toStringRefArray`.  Guard against this
case.  This allows the swift compiler to work again on Windows!

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
