### PR TITLE
runtime: make the weak definition also inline'd

### DIFF
--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -57,6 +57,7 @@ set(swift_runtime_sources
     ImageInspectionELF.cpp
     ImageInspectionCOFF.cpp
     KnownMetadata.cpp
+    LLVMSupport.cpp
     Metadata.cpp
     MetadataLookup.cpp
     MutexPThread.cpp

--- a/stdlib/public/runtime/LLVMSupport.cpp
+++ b/stdlib/public/runtime/LLVMSupport.cpp
@@ -1,0 +1,23 @@
+//===--- LLVMSupport.cpp - Swift Language ABI Metadata Support ------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// ADT uses report_bad_alloc_error to report an error when it can't allocate
+// elements for a data structure. The swift runtime uses ADT without linking
+// against libSupport, so here we provide a stub to make sure we don't fail
+// to link.
+#if defined(swiftCore_EXPORTS)
+namespace llvm {
+void __attribute__((__weak__, __visibility__("hidden")))
+report_bad_alloc_error(const char *Reason, bool GenCrashDiag) {}
+} // end namespace llvm
+#endif
+

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -333,14 +333,4 @@ public:
 
 } // end namespace swift
 
-// ADT uses report_bad_alloc_error to report an error when it can't allocate
-// elements for a data structure. The swift runtime uses ADT without linking
-// against libSupport, so here we provide a stub to make sure we don't fail
-// to link. Give it `weak` linkage so, in case the `strong` definition of
-// the function is available, that has precedence.
-namespace llvm {
-  __attribute__((weak))
-  void report_bad_alloc_error(const char *Reason, bool GenCrashDiag) {};
-} // end namespace llvm
-
 #endif /* SWIFT_RUNTIME_PRIVATE_H */


### PR DESCRIPTION
Use the reserved spelling for the weak attribute.  Furthermore, mark the
definition as inline.  THis is needed to build the runtime on Windows where
there are multiply defined instances of the function as weak function
definitions are not supported in the PE/COFF model.  Since the `Private.h`
header usage is limited to the runtime, which does not link against the LLVM
Support library, the strong definition will never be present anyways and so this
maintains the status quo.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
