### PR TITLE
Default implementation of isMultiple(of:) on BinaryInteger

### DIFF
--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -1239,6 +1239,16 @@ extension BinaryInteger {
     -> (quotient: Self, remainder: Self) {
     return (self / rhs, self % rhs)
   }
+  
+  @inlinable
+  public func isMultiple(of other: Self) -> Bool {
+    // Nothing but zero is a multiple of zero.
+    if other == 0 { return self == 0 }
+    // Do the test in terms of magnitude, which guarantees there are no other
+    // edge cases. If we write this as `self % other` instead, it could trap
+    // for types that are not symmetric around zero.
+    return self.magnitude % other.magnitude == 0
+  }
 
 //===----------------------------------------------------------------------===//
 //===--- Homogeneous ------------------------------------------------------===//
@@ -2776,16 +2786,6 @@ extension FixedWidthInteger {
     lhs = _nonMaskingRightShift(lhs, shift)
   }
 
-  @inlinable
-  public func isMultiple(of other: Self) -> Bool {
-    // Nothing but zero is a multiple of zero.
-    if other == 0 { return self == 0 }
-    // Special case to avoid overflow on .min / -1 for signed types.
-    if Self.isSigned && other == -1 { return true }
-    // Having handled those special cases, this is safe.
-    return self % other == 0
-  }
-
   @inlinable // FIXME(sil-serialize-all)
   @inline(__always)
   public static func _nonMaskingRightShift(_ lhs: Self, _ rhs: Int) -> Self {
@@ -3623,6 +3623,16 @@ extension SignedInteger where Self : FixedWidthInteger {
   @_transparent
   public static var min: Self {
     return (-1 as Self) &<< Self._highBitIndex
+  }
+  
+  @inlinable
+  public func isMultiple(of other: Self) -> Bool {
+    // Nothing but zero is a multiple of zero.
+    if other == 0 { return self == 0 }
+    // Special case to avoid overflow on .min / -1 for signed types.
+    if other == -1 { return true }
+    // Having handled those special cases, this is safe.
+    return self % other == 0
   }
 }
 

--- a/test/Prototypes/BigInt.swift
+++ b/test/Prototypes/BigInt.swift
@@ -729,11 +729,6 @@ public struct _BigInt<Word: FixedWidthInteger & UnsignedInteger> :
     let r = x._internalDivide(by: rhs)
     return (x, r)
   }
-  
-  public func isMultiple(of other: _BigInt) -> Bool {
-    if other == 0 { return self == 0 }
-    return self % other == 0
-  }
 
   public static func &=(lhs: inout _BigInt, rhs: _BigInt) {
     var lhsTemp = lhs._dataAsTwosComplement()

--- a/test/stdlib/Integers.swift.gyb
+++ b/test/stdlib/Integers.swift.gyb
@@ -148,10 +148,6 @@ extension MockBinaryInteger : BinaryInteger {
     return _value.trailingZeroBitCount
   }
 
-  func isMultiple(of other: MockBinaryInteger<T>) -> Bool {
-    return _value.isMultiple(of: other._value)
-  }
-
   static func + (
     lhs: MockBinaryInteger<T>, rhs: MockBinaryInteger<T>
   ) -> MockBinaryInteger<T> {


### PR DESCRIPTION
In order to provide source compatibility with existing user types conforming to BinaryInteger, we want to have a default implementation available. It's somewhat difficult to provide a good default implementation that correctly handles arbitrary non-symmetrical ranges in the face of negative divisors, so fall back on testing divisibility of the magnitudes, which avoids the problem.

On the plus side, this default implementation works fine for types conforming to `UnsignedInteger`, which lets us move the `FixedWidthInteger` implementation down to `FixedWidthInteger & SignedInteger`, and simplify it in the process.