### PR TITLE
[sil] Eliminate the src parameter from end_borrow.

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -63,13 +63,6 @@ struct ErrorBehaviorKind {
 /// use with SILPasses. It uses the actual checker as an internal PImpl detail
 /// so types/etc do not leak.
 struct OwnershipChecker {
-  /// The module that we are in.
-  SILModule &Mod;
-
-  /// A cache of dead-end basic blocks that we use to determine if we can
-  /// ignore "leaks".
-  DeadEndBlocks &DEBlocks;
-
   /// The list of regular users from the last run of the checker.
   SmallVector<SILInstruction *, 16> RegularUsers;
 
@@ -79,6 +72,18 @@ struct OwnershipChecker {
   /// The live blocks for the SILValue we processed. This can be used to
   /// determine if a block is in the "live" region of our SILInstruction.
   SmallPtrSet<SILBasicBlock *, 32> LiveBlocks;
+
+  /// The list of implicit regular users from the last run of the checker.
+  ///
+  /// This is used to encode end of scope like instructions.
+  SmallVector<SILInstruction *, 4> ImplicitRegularUsers;
+
+  /// The module that we are in.
+  SILModule &Mod;
+
+  /// A cache of dead-end basic blocks that we use to determine if we can
+  /// ignore "leaks".
+  DeadEndBlocks &DEBlocks;
 
   bool checkValue(SILValue Value);
 };

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -716,10 +716,15 @@ public:
     return lowering.emitStore(*this, Loc, Src, DestAddr, Qualifier);
   }
 
+  EndBorrowInst *createEndBorrow(SILLocation loc, SILValue borrowedValue) {
+    return insert(new (getModule())
+                      EndBorrowInst(getSILDebugLocation(loc), borrowedValue));
+  }
+
   EndBorrowInst *createEndBorrow(SILLocation Loc, SILValue BorrowedValue,
                                  SILValue OriginalValue) {
-    return insert(new (getModule()) EndBorrowInst(
-        getSILDebugLocation(Loc), BorrowedValue, OriginalValue));
+    return insert(new (getModule())
+                      EndBorrowInst(getSILDebugLocation(Loc), BorrowedValue));
   }
 
   EndBorrowArgumentInst *createEndBorrowArgument(SILLocation Loc,

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -773,10 +773,9 @@ void SILCloner<ImplClass>::visitStoreBorrowInst(StoreBorrowInst *Inst) {
 template <typename ImplClass>
 void SILCloner<ImplClass>::visitEndBorrowInst(EndBorrowInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
-  doPostProcess(
-      Inst, getBuilder().createEndBorrow(getOpLocation(Inst->getLoc()),
-                                         getOpValue(Inst->getBorrowedValue()),
-                                         getOpValue(Inst->getOriginalValue())));
+  doPostProcess(Inst, getBuilder().createEndBorrow(
+                          getOpLocation(Inst->getLoc()),
+                          getOpValue(Inst->getOperand()), SILValue()));
 }
 
 template <typename ImplClass>

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t VERSION_MINOR = 440; // Last change: removed materializeForSet
+const uint16_t VERSION_MINOR = 441; // Last change: remove end_borrow src arg
 
 using DeclIDField = BCFixed<31>;
 

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -2681,6 +2681,7 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     UNARY_INSTRUCTION(DestroyValue)
     UNARY_INSTRUCTION(CondFail)
     UNARY_INSTRUCTION(EndBorrowArgument)
+    UNARY_INSTRUCTION(EndBorrow)
     UNARY_INSTRUCTION(DestructureStruct)
     UNARY_INSTRUCTION(DestructureTuple)
     REFCOUNTING_INSTRUCTION(UnmanagedReleaseValue)
@@ -3392,36 +3393,6 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
 
     ResultVal = B.createStore(InstLoc, getLocalValue(From, ValType, InstLoc, B),
                               AddrVal, Qualifier);
-    break;
-  }
-
-  case SILInstructionKind::EndBorrowInst: {
-    UnresolvedValueName BorrowedFromName, BorrowedValueName;
-    SourceLoc ToLoc;
-    Identifier ToToken;
-    SILType BorrowedFromTy, BorrowedValueTy;
-
-    if (parseValueName(BorrowedValueName) ||
-        parseSILIdentifier(ToToken, ToLoc, diag::expected_tok_in_sil_instr,
-                           "from") ||
-        parseValueName(BorrowedFromName) ||
-        P.parseToken(tok::colon, diag::expected_sil_colon_value_ref) ||
-        parseSILType(BorrowedValueTy) ||
-        P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
-        parseSILType(BorrowedFromTy) || parseSILDebugLocation(InstLoc, B))
-      return true;
-
-    if (ToToken.str() != "from") {
-      P.diagnose(ToLoc, diag::expected_tok_in_sil_instr, "from");
-      return true;
-    }
-
-    SILValue BorrowedValue =
-        getLocalValue(BorrowedValueName, BorrowedValueTy, InstLoc, B);
-    SILValue BorrowedFrom =
-        getLocalValue(BorrowedFromName, BorrowedFromTy, InstLoc, B);
-
-    ResultVal = B.createEndBorrow(InstLoc, BorrowedValue, BorrowedFrom);
     break;
   }
 

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -790,11 +790,6 @@ StoreBorrowInst::StoreBorrowInst(SILDebugLocation DebugLoc, SILValue Src,
     : InstructionBase(DebugLoc, Dest->getType()),
       Operands(this, Src, Dest) {}
 
-EndBorrowInst::EndBorrowInst(SILDebugLocation DebugLoc, SILValue Src,
-                             SILValue Dest)
-    : InstructionBase(DebugLoc),
-      Operands(this, Src, Dest) {}
-
 EndBorrowArgumentInst::EndBorrowArgumentInst(SILDebugLocation DebugLoc,
                                              SILArgument *Arg)
     : UnaryInstructionBase(DebugLoc, SILValue(Arg)) {}

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1275,10 +1275,7 @@ public:
   }
 
   void visitEndBorrowInst(EndBorrowInst *EBI) {
-    *this << Ctx.getID(EBI->getBorrowedValue()) << " from "
-          << Ctx.getID(EBI->getOriginalValue()) << " : "
-          << EBI->getBorrowedValue()->getType() << ", "
-          << EBI->getOriginalValue()->getType();
+    *this << getIDAndType(EBI->getOperand());
   }
 
   void visitEndBorrowArgumentInst(EndBorrowArgumentInst *EBAI) {

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1531,13 +1531,6 @@ public:
     require(
         F.hasQualifiedOwnership(),
         "Inst with qualified ownership in a function that is not qualified");
-    // We allow for end_borrow to express relationships in between addresses and
-    // values, but we require that the types are the same ignoring value
-    // category.
-    require(EBI->getBorrowedValue()->getType().getObjectType() ==
-                EBI->getOriginalValue()->getType().getObjectType(),
-            "end_borrow can only relate the same types ignoring value "
-            "category");
   }
 
   template <class AI>

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1642,6 +1642,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
   UNARY_INSTRUCTION(DeinitExistentialAddr)
   UNARY_INSTRUCTION(DeinitExistentialValue)
   UNARY_INSTRUCTION(EndBorrowArgument)
+  UNARY_INSTRUCTION(EndBorrow)
   UNARY_INSTRUCTION(DestroyAddr)
   UNARY_INSTRUCTION(Return)
   UNARY_INSTRUCTION(Throw)
@@ -1747,15 +1748,6 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
     SILType ValType = addrType.getObjectType();
     ResultVal = Builder.createStoreBorrow(Loc, getLocalValue(ValID, ValType),
                                           getLocalValue(ValID2, addrType));
-    break;
-  }
-  case SILInstructionKind::EndBorrowInst: {
-    SILValue BorrowSource, BorrowDest;
-    BorrowSource = getLocalValue(
-        ValID, getSILType(MF->getType(TyID), (SILValueCategory)TyCategory));
-    BorrowDest = getLocalValue(
-        ValID2, getSILType(MF->getType(TyID2), (SILValueCategory)TyCategory2));
-    ResultVal = Builder.createEndBorrow(Loc, BorrowSource, BorrowDest);
     break;
   }
   case SILInstructionKind::BeginAccessInst: {

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1216,6 +1216,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
   case SILInstructionKind::RetainValueAddrInst:
   case SILInstructionKind::UnmanagedRetainValueInst:
   case SILInstructionKind::EndBorrowArgumentInst:
+  case SILInstructionKind::EndBorrowInst:
   case SILInstructionKind::CopyValueInst:
   case SILInstructionKind::DestroyValueInst:
   case SILInstructionKind::ReleaseValueInst:
@@ -1559,24 +1560,6 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
              S.addTypeRef(CI->getDest()->getType().getASTType()),
              (unsigned)CI->getDest()->getType().getCategory(),
              llvm::makeArrayRef(listOfValues));
-    break;
-  }
-
-  case SILInstructionKind::EndBorrowInst: {
-    unsigned abbrCode = SILAbbrCodes[SILTwoOperandsLayout::Code];
-    unsigned Attr = 0;
-    auto *EBI = cast<EndBorrowInst>(&SI);
-    SILValue BorrowedValue = EBI->getBorrowedValue();
-    SILValue OriginalValue = EBI->getOriginalValue();
-
-    SILTwoOperandsLayout::emitRecord(
-        Out, ScratchRecord, abbrCode, (unsigned)SI.getKind(), Attr,
-        S.addTypeRef(BorrowedValue->getType().getASTType()),
-        (unsigned)BorrowedValue->getType().getCategory(),
-        addValueRef(BorrowedValue),
-        S.addTypeRef(OriginalValue->getType().getASTType()),
-        (unsigned)OriginalValue->getType().getCategory(),
-        addValueRef(OriginalValue));
     break;
   }
 

--- a/test/ClangImporter/optional.swift
+++ b/test/ClangImporter/optional.swift
@@ -18,7 +18,7 @@ class A {
 // CHECK:      [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
 // CHECK:      [[T0:%.*]] = function_ref @$S8optional1AC3fooSSSgyF
 // CHECK-NEXT: [[T1:%.*]] = apply [[T0]]([[BORROWED_SELF_COPY]])
-// CHECK-NEXT: end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+// CHECK-NEXT: end_borrow [[BORROWED_SELF_COPY]]
 // CHECK-NEXT: destroy_value [[SELF_COPY]]
 // CHECK-NEXT: switch_enum [[T1]] : $Optional<String>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 //
@@ -28,7 +28,7 @@ class A {
 // CHECK-NEXT: [[BORROWED_STR:%.*]] = begin_borrow [[STR]]
 // CHECK-NEXT: [[T1:%.*]] = apply [[T0]]([[BORROWED_STR]])
 // CHECK-NEXT: enum $Optional<NSString>, #Optional.some!enumelt.1, [[T1]]
-// CHECK-NEXT: end_borrow [[BORROWED_STR:%.*]] from [[STR]]
+// CHECK-NEXT: end_borrow [[BORROWED_STR:%.*]]
 // CHECK-NEXT: destroy_value [[STR]]
 // CHECK-NEXT: br
 //   Nothing branch: inject nothing into result.
@@ -68,8 +68,8 @@ class A {
 // CHECK:      [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
 // CHECK:      [[T1:%.*]] = function_ref @$S8optional1AC3bar1xySSSg_tF
 // CHECK-NEXT: [[T2:%.*]] = apply [[T1]]([[BORROWED_T0]], [[BORROWED_SELF_COPY]])
-// CHECK-NEXT: end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
-// CHECK-NEXT: end_borrow [[BORROWED_T0]] from [[T0]]
+// CHECK-NEXT: end_borrow [[BORROWED_SELF_COPY]]
+// CHECK-NEXT: end_borrow [[BORROWED_T0]]
 // CHECK-NEXT: destroy_value [[T0]]
 // CHECK-NEXT: destroy_value [[SELF_COPY]]
 // CHECK-NEXT: return [[T2]] : $()

--- a/test/IRGen/objc_dealloc.sil
+++ b/test/IRGen/objc_dealloc.sil
@@ -43,7 +43,7 @@ bb0(%0 : @owned $SwiftGizmo):
   %3 = begin_borrow %0 : $SwiftGizmo
   %4 = ref_element_addr %3 : $SwiftGizmo, #SwiftGizmo.x      // user: %4
   destroy_addr %4 : $*X                           // id: %4
-  end_borrow %3 from %0 : $SwiftGizmo, $SwiftGizmo
+  end_borrow %3 : $SwiftGizmo
   %5 = unchecked_ref_cast %0 : $SwiftGizmo to $Builtin.NativeObject // user: %6
   return %5 : $Builtin.NativeObject              // id: %6
 }
@@ -53,7 +53,7 @@ bb0(%0 : @unowned $SwiftGizmo):
   %1 = begin_borrow %0 : $SwiftGizmo
   %2 = ref_element_addr %1 : $SwiftGizmo, #SwiftGizmo.x      // user: %2
   %3 = load [copy] %2 : $*X                              // users: %4, %3
-  end_borrow %1 from %0 : $SwiftGizmo, $SwiftGizmo
+  end_borrow %1 : $SwiftGizmo
   return %3 : $X                                  // id: %4
 }
 
@@ -64,7 +64,7 @@ bb0(%0 : @unowned $X, %1 : @unowned $SwiftGizmo):
   %4 = begin_borrow %3 : $SwiftGizmo
   %5 = ref_element_addr %4 : $SwiftGizmo, #SwiftGizmo.x      // user: %5
   assign %2 to %5 : $*X                           // id: %5
-  end_borrow %4 from %3 : $SwiftGizmo, $SwiftGizmo
+  end_borrow %4 : $SwiftGizmo
   destroy_value %3 : $SwiftGizmo                 // id: %6
   %7 = tuple ()                                   // user: %8
   return %7 : $()                                 // id: %8
@@ -95,7 +95,7 @@ bb0(%0 : @unowned $SwiftGizmo):
   %3 = begin_borrow %0 : $SwiftGizmo
   %4 = ref_element_addr %3 : $SwiftGizmo, #SwiftGizmo.x      // user: %4
   destroy_addr %4 : $*X                           // id: %4
-  end_borrow %3 from %0 : $SwiftGizmo, $SwiftGizmo
+  end_borrow %3 : $SwiftGizmo
 
   // Call super -dealloc.
   // CHECK: [[SUPER:%[a-zA-Z0-9]+]] = bitcast [[SGIZMO]]* [[SGIZMOVAL]] to [[GIZMO]]*

--- a/test/SIL/Parser/borrow.sil
+++ b/test/SIL/Parser/borrow.sil
@@ -10,24 +10,24 @@ import Builtin
 // CHECK: begin_borrow [[ARG2]]
 // CHECK: [[MEM:%.*]] = alloc_stack $Builtin.NativeObject
 // CHECK: store_borrow [[ARG2]] to [[MEM]] : $*Builtin.NativeObject
-// CHECK: end_borrow [[ARG1]] from [[ARG2]] : $*Builtin.NativeObject, $Builtin.NativeObject
-// CHECK: end_borrow [[ARG2]] from [[ARG1]] : $Builtin.NativeObject, $*Builtin.NativeObject
-// CHECK: end_borrow [[ARG1]] from [[ARG1]] : $*Builtin.NativeObject, $*Builtin.NativeObject
-// CHECK: end_borrow [[ARG2]] from [[ARG2]] : $Builtin.NativeObject, $Builtin.NativeObject
+// CHECK: end_borrow [[ARG1]] : $*Builtin.NativeObject
+// CHECK: end_borrow [[ARG2]] : $Builtin.NativeObject
+// CHECK: end_borrow [[ARG1]] : $*Builtin.NativeObject
+// CHECK: end_borrow [[ARG2]] : $Builtin.NativeObject
 sil @borrow_test : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
 bb0(%0 : @trivial $*Builtin.NativeObject, %1 : @unowned $Builtin.NativeObject):
   %2 = begin_borrow %1 : $Builtin.NativeObject
-  end_borrow %2 from %1 : $Builtin.NativeObject, $Builtin.NativeObject
+  end_borrow %2 : $Builtin.NativeObject
 
   %3 = alloc_stack $Builtin.NativeObject
   store_borrow %1 to %3 : $*Builtin.NativeObject
-  end_borrow %3 from %1 : $*Builtin.NativeObject, $Builtin.NativeObject
+  end_borrow %3 : $*Builtin.NativeObject
   dealloc_stack %3 : $*Builtin.NativeObject
 
-  end_borrow %0 from %1 : $*Builtin.NativeObject, $Builtin.NativeObject
-  end_borrow %1 from %0 : $Builtin.NativeObject, $*Builtin.NativeObject
-  end_borrow %0 from %0 : $*Builtin.NativeObject, $*Builtin.NativeObject
-  end_borrow %1 from %1 : $Builtin.NativeObject, $Builtin.NativeObject
+  end_borrow %0 : $*Builtin.NativeObject
+  end_borrow %1 : $Builtin.NativeObject
+  end_borrow %0 : $*Builtin.NativeObject
+  end_borrow %1 : $Builtin.NativeObject
   %4 = tuple()
   return %4 : $()
 }

--- a/test/SIL/Serialization/borrow.sil
+++ b/test/SIL/Serialization/borrow.sil
@@ -14,24 +14,24 @@ import Builtin
 // CHECK: begin_borrow [[ARG2]]
 // CHECK: [[MEM:%.*]] = alloc_stack $Builtin.NativeObject
 // CHECK: store_borrow [[ARG2]] to [[MEM]] : $*Builtin.NativeObject
-// CHECK: end_borrow [[ARG1]] from [[ARG2]] : $*Builtin.NativeObject, $Builtin.NativeObject
-// CHECK: end_borrow [[ARG2]] from [[ARG1]] : $Builtin.NativeObject, $*Builtin.NativeObject
-// CHECK: end_borrow [[ARG1]] from [[ARG1]] : $*Builtin.NativeObject, $*Builtin.NativeObject
-// CHECK: end_borrow [[ARG2]] from [[ARG2]] : $Builtin.NativeObject, $Builtin.NativeObject
+// CHECK: end_borrow [[ARG1]] : $*Builtin.NativeObject
+// CHECK: end_borrow [[ARG2]] : $Builtin.NativeObject
+// CHECK: end_borrow [[ARG1]] : $*Builtin.NativeObject
+// CHECK: end_borrow [[ARG2]] : $Builtin.NativeObject
 sil [serialized] @borrow_test : $@convention(thin) (@in Builtin.NativeObject, Builtin.NativeObject) -> () {
 bb0(%0 : @trivial $*Builtin.NativeObject, %1 : @unowned $Builtin.NativeObject):
   %2 = begin_borrow %1 : $Builtin.NativeObject
-  end_borrow %2 from %1 : $Builtin.NativeObject, $Builtin.NativeObject
+  end_borrow %2 : $Builtin.NativeObject
 
   %3 = alloc_stack $Builtin.NativeObject
   store_borrow %1 to %3 : $*Builtin.NativeObject
-  end_borrow %3 from %1 : $*Builtin.NativeObject, $Builtin.NativeObject
+  end_borrow %3 : $*Builtin.NativeObject
   dealloc_stack %3 : $*Builtin.NativeObject
 
-  end_borrow %0 from %1 : $*Builtin.NativeObject, $Builtin.NativeObject
-  end_borrow %1 from %0 : $Builtin.NativeObject, $*Builtin.NativeObject
-  end_borrow %0 from %0 : $*Builtin.NativeObject, $*Builtin.NativeObject
-  end_borrow %1 from %1 : $Builtin.NativeObject, $Builtin.NativeObject
+  end_borrow %0 : $*Builtin.NativeObject
+  end_borrow %1 : $Builtin.NativeObject
+  end_borrow %0 : $*Builtin.NativeObject
+  end_borrow %1 : $Builtin.NativeObject
   %4 = tuple()
   return %4 : $()
 }

--- a/test/SIL/ownership-verifier/cond_br_crash.sil
+++ b/test/SIL/ownership-verifier/cond_br_crash.sil
@@ -61,7 +61,7 @@ bb2:
 // CHECK: Found use after free?!
 // CHECK: Value:   %0 = argument of bb0 : $Builtin.NativeObject
 // CHECK: Consuming User:   cond_br undef, bb1(%0 : $Builtin.NativeObject), bb2
-// CHECK: Non Consuming User:   end_borrow %3 from %0 : $Builtin.NativeObject, $Builtin.NativeObject
+// CHECK: Non Consuming User:   end_borrow %3 : $Builtin.NativeObject
 // CHECK: Block: bb1
 sil @test3 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
@@ -69,7 +69,7 @@ bb0(%0 : @owned $Builtin.NativeObject):
 
 bb1(%1 : @owned $Builtin.NativeObject):
   %2 = begin_borrow %0 : $Builtin.NativeObject
-  end_borrow %2 from %0 : $Builtin.NativeObject, $Builtin.NativeObject
+  end_borrow %2 : $Builtin.NativeObject
   destroy_value %1 : $Builtin.NativeObject
   br bb2
 

--- a/test/SIL/ownership-verifier/cond_br_no_crash.sil
+++ b/test/SIL/ownership-verifier/cond_br_no_crash.sil
@@ -54,7 +54,7 @@ bb3:
 sil @test3 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
-  end_borrow %1 from %0 : $Builtin.NativeObject, $Builtin.NativeObject
+  end_borrow %1 : $Builtin.NativeObject
   cond_br undef, bb1(%0 : $Builtin.NativeObject), bb2
 
 bb1(%2 : @owned $Builtin.NativeObject):

--- a/test/SIL/ownership-verifier/definite_init.sil
+++ b/test/SIL/ownership-verifier/definite_init.sil
@@ -322,7 +322,7 @@ bb0(%0 : @owned $RootClassWithIVars, %1 : @trivial $Builtin.Int32):
   assign %1 to %13 : $*Builtin.Int32
   %14 = tuple_element_addr %12 : $*(Builtin.Int32, Builtin.Int32), 1
   assign %1 to %14 : $*Builtin.Int32
-  end_borrow %4 from %3 : $RootClassWithIVars, $RootClassWithIVars
+  end_borrow %4 : $RootClassWithIVars
   return %3 : $RootClassWithIVars
 }
 
@@ -349,7 +349,7 @@ bb0(%0 : @owned $DerivedClassWithIVars):
   %8 = load_borrow %3 : $*DerivedClassWithIVars
   %9 = ref_element_addr %8 : $DerivedClassWithIVars, #DerivedClassWithIVars.a
   assign %7 to %9 : $*Builtin.Int32
-  end_borrow %8 from %3 : $DerivedClassWithIVars, $*DerivedClassWithIVars
+  end_borrow %8 : $DerivedClassWithIVars
 
   %11 = load [take] %3 : $*DerivedClassWithIVars
   %13 = upcast %11 : $DerivedClassWithIVars to $RootClassWithIVars
@@ -428,7 +428,7 @@ bb0(%0 : @owned $RootClassWithNontrivialStoredProperties):
   %5 = begin_borrow %4 : $RootClassWithNontrivialStoredProperties
   %2 = ref_element_addr %5 : $RootClassWithNontrivialStoredProperties, #RootClassWithNontrivialStoredProperties.x
   assign %1 to %2 : $*SomeClass
-  end_borrow %5 from %4 : $RootClassWithNontrivialStoredProperties, $RootClassWithNontrivialStoredProperties
+  end_borrow %5 : $RootClassWithNontrivialStoredProperties
   destroy_value %4 : $RootClassWithNontrivialStoredProperties
   %13 = tuple ()
   return %13 : $()
@@ -456,7 +456,7 @@ bb0(%0 : @owned $DerivedClassWithNontrivialStoredProperties):
   %9 = load_borrow %4 : $*DerivedClassWithNontrivialStoredProperties
   %10 = ref_element_addr %9 : $DerivedClassWithNontrivialStoredProperties, #DerivedClassWithNontrivialStoredProperties.a
   assign %8 to %10 : $*SomeClass
-  end_borrow %9 from %4 : $DerivedClassWithNontrivialStoredProperties, $*DerivedClassWithNontrivialStoredProperties
+  end_borrow %9 : $DerivedClassWithNontrivialStoredProperties
 
   destroy_addr %4 : $*DerivedClassWithNontrivialStoredProperties
   dealloc_stack %1 : $*DerivedClassWithNontrivialStoredProperties
@@ -509,14 +509,14 @@ bb0(%0 : @owned $DerivedClassWithIVars, %i : @trivial $Builtin.Int32):
   %8 = load_borrow %3 : $*DerivedClassWithIVars
   %9 = ref_element_addr %8 : $DerivedClassWithIVars, #DerivedClassWithIVars.a
   assign %i to %9 : $*Builtin.Int32
-  end_borrow %8 from %3 : $DerivedClassWithIVars, $*DerivedClassWithIVars
+  end_borrow %8 : $DerivedClassWithIVars
 
   %a = load [take] %3 : $*DerivedClassWithIVars
   %b = upcast %a : $DerivedClassWithIVars to $RootClassWithIVars
   %borrowed_b = begin_borrow %b : $RootClassWithIVars
   %c = ref_element_addr %borrowed_b : $RootClassWithIVars, #RootClassWithIVars.x
   load [trivial] %c : $*Builtin.Int32
-  end_borrow %borrowed_b from %b : $RootClassWithIVars, $RootClassWithIVars
+  end_borrow %borrowed_b : $RootClassWithIVars
   %14 = function_ref @superinit : $@convention(method) (@owned RootClassWithIVars) -> @owned RootClassWithIVars
   %15 = apply %14(%b) : $@convention(method) (@owned RootClassWithIVars) -> @owned RootClassWithIVars
 

--- a/test/SIL/ownership-verifier/false_positive_leaks.sil
+++ b/test/SIL/ownership-verifier/false_positive_leaks.sil
@@ -28,7 +28,7 @@ bb0(%0 : @owned $Builtin.NativeObject):
   store_borrow %2 to %1 : $*Builtin.NativeObject
   %3 = function_ref @in_guaranteed_user : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
   apply %3(%1) : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
-  end_borrow %2 from %0 : $Builtin.NativeObject, $Builtin.NativeObject
+  end_borrow %2 : $Builtin.NativeObject
   dealloc_stack %1 : $*Builtin.NativeObject
   br bb1
 

--- a/test/SIL/ownership-verifier/opaque_use_verifier.sil
+++ b/test/SIL/ownership-verifier/opaque_use_verifier.sil
@@ -32,7 +32,7 @@ bb0(%0 : @owned $T):
   %2 = copy_value %1 : $T
   %9 = function_ref @opaque_identity : $@convention(thin) <T> (@in T) -> @out T
   %11 = apply %9<T>(%2) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
-  end_borrow %1 from %0 : $T, $T
+  end_borrow %1 : $T
   destroy_value %0 : $T
   return %11 : $T
 }
@@ -42,7 +42,7 @@ bb0(%0 : @owned $T):
   %1 = begin_borrow %0 : $T
   %9 = function_ref @opaque_copy : $@convention(thin) <T> (@in_guaranteed T) -> @out T
   %11 = apply %9<T>(%1) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> @out τ_0_0
-  end_borrow %1 from %0 : $T, $T
+  end_borrow %1 : $T
   destroy_value %0 : $T
   return %11 : $T
 }
@@ -53,7 +53,7 @@ bb0(%0 : @guaranteed $T):
   %2 = begin_borrow %1 : $T
   %3 = function_ref @opaque_copy : $@convention(thin) <T> (@in_guaranteed T) -> @out T
   %4 = apply %3<T>(%2) : $@convention(thin) <T> (@in_guaranteed T) -> @out T
-  end_borrow %2 from %1 : $T, $T
+  end_borrow %2 : $T
   destroy_value %1 : $T
   return %4 : $T
 }
@@ -74,7 +74,7 @@ bb0(%0 : @owned $AnyObject):
   %9 = copy_value %8 : $AnyObject
   %10 = unconditional_checked_cast_value %9 : $AnyObject to $@thick AnyObject.Type
   %11 = apply %6(%10) : $@convention(thin) (@thick AnyObject.Type) -> ()
-  end_borrow %8 from %0 : $AnyObject, $AnyObject
+  end_borrow %8 : $AnyObject
   destroy_value %0 : $AnyObject
   %18 = tuple ()
   return %18 : $()

--- a/test/SIL/ownership-verifier/over_consume.sil
+++ b/test/SIL/ownership-verifier/over_consume.sil
@@ -112,14 +112,14 @@ bb0(%0 : @guaranteed $Builtin.NativeObject):
 // CHECK-LABEL: Function: 'use_after_end_borrow'
 // CHECK: Found use after free?!
 // CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
-// CHECK: Consuming User:   end_borrow %1 from %0 : $Builtin.NativeObject, $Builtin.NativeObject
+// CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject
 // CHECK: Non Consuming User:   %4 = apply %2(%1) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
 // CHECK: Block: bb0
 sil @use_after_end_borrow : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
   %2 = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
-  end_borrow %1 from %0 : $Builtin.NativeObject, $Builtin.NativeObject
+  end_borrow %1 : $Builtin.NativeObject
   apply %2(%1) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
   destroy_value %0 : $Builtin.NativeObject
   %9999 = tuple()
@@ -133,14 +133,14 @@ bb0(%0 : @owned $Builtin.NativeObject):
 // CHECK: Found use after free?!
 // CHECK: Value:   %0 = argument of bb0 : $Builtin.NativeObject
 // CHECK: Consuming User:   destroy_value %0 : $Builtin.NativeObject
-// CHECK: Non Consuming User:   end_borrow %1 from %0 : $Builtin.NativeObject, $Builtin.NativeObject
+// CHECK: Non Consuming User:   end_borrow %1 : $Builtin.NativeObject
 // CHECK: Block: bb0
 sil @destroy_before_end_borrow : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
   %2 = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
   destroy_value %0 : $Builtin.NativeObject
-  end_borrow %1 from %0 : $Builtin.NativeObject, $Builtin.NativeObject
+  end_borrow %1 : $Builtin.NativeObject
   %9999 = tuple()
   return %9999 : $()
 }
@@ -223,7 +223,7 @@ bb3:
 // CHECK-LABEL: Function: 'switch_enum_guaranteed_arg_outlives_original_value'
 // CHECK: Found use after free?!
 // CHECK: Value:   %1 = begin_borrow %0 : $Optional<Builtin.NativeObject>
-// CHECK: Consuming User:   end_borrow %1 from %0 : $Optional<Builtin.NativeObject>, $Optional<Builtin.NativeObject>
+// CHECK: Consuming User:   end_borrow %1 : $Optional<Builtin.NativeObject>
 // CHECK: Non Consuming User:   end_borrow_argument %3 : $Builtin.NativeObject
 // CHECK: Block: bb1
 sil @switch_enum_guaranteed_arg_outlives_original_value : $@convention(thin) (@owned Optional<Builtin.NativeObject>) -> () {
@@ -232,12 +232,12 @@ bb0(%0 : @owned $Optional<Builtin.NativeObject>):
   switch_enum %1 : $Optional<Builtin.NativeObject>, case #Optional.some!enumelt.1: bb1, case #Optional.none!enumelt: bb2
 
 bb1(%2 : @guaranteed $Builtin.NativeObject):
-  end_borrow %1 from %0 : $Optional<Builtin.NativeObject>, $Optional<Builtin.NativeObject>
+  end_borrow %1 : $Optional<Builtin.NativeObject>
   end_borrow_argument %2 : $Builtin.NativeObject
   br bb3
 
 bb2:
-  end_borrow %1 from %0 : $Optional<Builtin.NativeObject>, $Optional<Builtin.NativeObject>
+  end_borrow %1 : $Optional<Builtin.NativeObject>
   br bb3
 
 bb3:
@@ -401,7 +401,7 @@ bb3:
 // CHECK-LABEL: Function: 'checked_cast_br_guaranteed_arg_outlives_original_value'
 // CHECK: Found use after free?!
 // CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
-// CHECK: Consuming User:   end_borrow %1 from %0 : $Builtin.NativeObject, $Builtin.NativeObject
+// CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject
 // CHECK: Non Consuming User:   end_borrow_argument %7 : $Builtin.NativeObject
 // CHECK: Block: bb2
 sil @checked_cast_br_guaranteed_arg_outlives_original_value : $@convention(thin) (@owned Builtin.NativeObject) -> () {
@@ -411,11 +411,11 @@ bb0(%0 : @owned $Builtin.NativeObject):
 
 bb1(%2 : @guaranteed $SuperKlass):
   end_borrow_argument %2 : $SuperKlass
-  end_borrow %1 from %0 : $Builtin.NativeObject, $Builtin.NativeObject
+  end_borrow %1 : $Builtin.NativeObject
   br bb3
 
 bb2(%3 : @guaranteed $Builtin.NativeObject):
-  end_borrow %1 from %0 : $Builtin.NativeObject, $Builtin.NativeObject
+  end_borrow %1 : $Builtin.NativeObject
   end_borrow_argument %3 : $Builtin.NativeObject
   br bb3
 

--- a/test/SIL/ownership-verifier/subobject_borrowing.sil
+++ b/test/SIL/ownership-verifier/subobject_borrowing.sil
@@ -44,7 +44,7 @@ bb0(%0 : @owned $B):
   %3 = struct_extract %2 : $A, #A.ptr
   %4 = function_ref @guaranteed_use_of_nativeobject : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
   apply %4(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
-  end_borrow %1 from %0 : $B, $B
+  end_borrow %1 : $B
   destroy_value %0 : $B
   %9999 = tuple()
   return %9999 : $()
@@ -56,14 +56,14 @@ bb0(%0 : @owned $B):
 // CHECK-LABEL: Function: 'value_subobject_with_use_after_end_borrow'
 // CHECK: Found use after free?!
 // CHECK: Value:   %1 = begin_borrow %0 : $B
-// CHECK: Consuming User:   end_borrow %1 from %0 : $B, $B
+// CHECK: Consuming User:   end_borrow %1 : $B
 // CHECK: Non Consuming User:   %4 = struct_extract %2 : $A, #A.ptr
 // CHECK: Block: bb0
 sil @value_subobject_with_use_after_end_borrow : $@convention(thin) (@owned B) -> () {
 bb0(%0 : @owned $B):
   %1 = begin_borrow %0 : $B
   %2 = struct_extract %1 : $B, #B.a1
-  end_borrow %1 from %0 : $B, $B
+  end_borrow %1 : $B
   %3 = struct_extract %2 : $A, #A.ptr
   destroy_value %0 : $B
   %9999 = tuple()
@@ -93,7 +93,7 @@ bb0(%0 : @owned $B):
   %4 = unchecked_enum_data %3 : $Optional<(Builtin.NativeObject, Builtin.NativeObject)>, #Optional.some!enumelt.1
   %5 = tuple_extract %4 : $(Builtin.NativeObject, Builtin.NativeObject), 1
   destroy_value %5 : $Builtin.NativeObject
-  end_borrow %1 from %0 : $B, $B
+  end_borrow %1 : $B
   destroy_value %0 : $B
   %9999 = tuple()
   return %9999 : $()
@@ -102,7 +102,7 @@ bb0(%0 : @owned $B):
 // CHECK-LABEL: Function: 'value_different_subobject_kinds_multiple_levels'
 // CHECK: Found use after free?!
 // CHECK: Value:   %1 = begin_borrow %0 : $B
-// CHECK: Consuming User:   end_borrow %1 from %0 : $B, $B
+// CHECK: Consuming User:   end_borrow %1 : $B
 // CHECK: Non Consuming User:   %6 = tuple_extract %4 : $(Builtin.NativeObject, Builtin.NativeObject), 1
 // CHECK: Block: bb0
 sil @value_different_subobject_kinds_multiple_levels : $@convention(thin) (@owned B) -> () {
@@ -111,7 +111,7 @@ bb0(%0 : @owned $B):
   %2 = struct_extract %1 : $B, #B.a1
   %3 = struct_extract %2 : $A, #A.ptr2
   %4 = unchecked_enum_data %3 : $Optional<(Builtin.NativeObject, Builtin.NativeObject)>, #Optional.some!enumelt.1
-  end_borrow %1 from %0 : $B, $B
+  end_borrow %1 : $B
   %5 = tuple_extract %4 : $(Builtin.NativeObject, Builtin.NativeObject), 1
   destroy_value %0 : $B
   %9999 = tuple()

--- a/test/SIL/ownership-verifier/unreachable_code.sil
+++ b/test/SIL/ownership-verifier/unreachable_code.sil
@@ -135,13 +135,13 @@ bb0(%0 : @owned $Builtin.NativeObject):
   cond_br undef, bb1, bb2
 
 bb1:
-  end_borrow %1 from %0 : $Builtin.NativeObject, $Builtin.NativeObject
+  end_borrow %1 : $Builtin.NativeObject
   destroy_value %0 : $Builtin.NativeObject
   %9999 = tuple()
   return %9999 : $()
 
 bb2:
-  end_borrow %1 from %0 : $Builtin.NativeObject, $Builtin.NativeObject
+  end_borrow %1 : $Builtin.NativeObject
   br bb3
 
 bb3:

--- a/test/SIL/ownership-verifier/use_verifier.sil
+++ b/test/SIL/ownership-verifier/use_verifier.sil
@@ -95,6 +95,12 @@ class RefWithInt {
 
 struct EmptyStruct {}
 
+class RefWithRef {
+  var value: RefWithRef
+
+  init()
+}
+
 ////////////////
 // Test Cases //
 ////////////////
@@ -111,6 +117,15 @@ bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1 = alloc_stack $Builtin.NativeObject
   store_borrow %0 to %1 : $*Builtin.NativeObject
   dealloc_stack %1 : $*Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil @load_borrow_from_class : $@convention(thin) (@guaranteed RefWithRef) -> () {
+bb0(%0 : @guaranteed $RefWithRef):
+  %1 = ref_element_addr %0 : $RefWithRef, #RefWithRef.value
+  %2 = load_borrow %1 : $*RefWithRef
+  end_borrow %2 : $RefWithRef
   %9999 = tuple()
   return %9999 : $()
 }
@@ -157,7 +172,7 @@ bb0(%0 : @owned $Builtin.NativeObject, %1 : @unowned $Builtin.NativeObject):
   apply %2(%0) : $@convention(thin) (Builtin.NativeObject) -> ()
   %3 = begin_borrow %0 : $Builtin.NativeObject
   apply %2(%3) : $@convention(thin) (Builtin.NativeObject) -> ()
-  end_borrow %3 from %0 : $Builtin.NativeObject, $Builtin.NativeObject
+  end_borrow %3 : $Builtin.NativeObject
   destroy_value %0 : $Builtin.NativeObject
   apply %2(%1) : $@convention(thin) (Builtin.NativeObject) -> ()
   %9999 = tuple()
@@ -168,7 +183,7 @@ sil @forwarding_guaranteed_nonfunction_values_doesnt_end_lifetime : $@convention
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
   %2 = unchecked_ref_cast %1 : $Builtin.NativeObject to $SuperKlass
-  end_borrow %1 from %0 : $Builtin.NativeObject, $Builtin.NativeObject
+  end_borrow %1 : $Builtin.NativeObject
   destroy_value %0 : $Builtin.NativeObject
   %9999 = tuple()
   return %9999 : $()
@@ -276,7 +291,7 @@ sil @ref_element_addr_test : $@convention(thin) (@owned RefWithInt) -> () {
 bb0(%0 : @owned $RefWithInt):
   %1 = begin_borrow %0 : $RefWithInt
   %2 = ref_element_addr %1 : $RefWithInt, #RefWithInt.value
-  end_borrow %1 from %0 : $RefWithInt, $RefWithInt
+  end_borrow %1 : $RefWithInt
   destroy_value %0 : $RefWithInt
   %9999 = tuple()
   return %9999 : $()
@@ -296,7 +311,7 @@ bb0(%0 : @owned $Ref):
   %1 = builtin "unsafeGuaranteed"(%0 : $Ref) : $(Ref, Builtin.Int8)
   %2 = begin_borrow %1 : $(Ref, Builtin.Int8)
   %3 = tuple_extract %2 : $(Ref, Builtin.Int8), 1
-  end_borrow %2 from %1 : $(Ref, Builtin.Int8), $(Ref, Builtin.Int8)
+  end_borrow %2 : $(Ref, Builtin.Int8)
   builtin "unsafeGuaranteedEnd"(%3 : $Builtin.Int8) : $()
   destroy_value %1 : $(Ref, Builtin.Int8)
   %9999 = tuple()
@@ -309,7 +324,7 @@ bb0(%0 : @owned $Optional<Builtin.NativeObject>):
   unchecked_enum_data %1 : $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1
   unchecked_enum_data %1 : $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1
   unchecked_enum_data %1 : $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1
-  end_borrow %1 from %0 : $Optional<Builtin.NativeObject>, $Optional<Builtin.NativeObject>
+  end_borrow %1 : $Optional<Builtin.NativeObject>
   %2 = unchecked_enum_data %0 : $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1
   return %2 : $Builtin.NativeObject
 }
@@ -331,7 +346,7 @@ bb0:
   end_unpaired_access [dynamic] %11 : $*Builtin.UnsafeValueBuffer
   begin_unpaired_access [read] [dynamic] %21 : $*Builtin.Int32, %11 : $*Builtin.UnsafeValueBuffer
   end_unpaired_access [dynamic] %11 : $*Builtin.UnsafeValueBuffer
-  end_borrow %011 from %01 : $RefWithInt, $RefWithInt
+  end_borrow %011 : $RefWithInt
   dealloc_stack %11 : $*Builtin.UnsafeValueBuffer
   destroy_value %01 : $RefWithInt
 
@@ -459,11 +474,11 @@ bb0(%0 : @owned $Builtin.NativeObject):
 
 bb1(%3 : @guaranteed $Builtin.NativeObject):
   end_borrow_argument %3 : $Builtin.NativeObject
-  end_borrow %1 from %0 : $Builtin.NativeObject, $Builtin.NativeObject
+  end_borrow %1 : $Builtin.NativeObject
   br bb3
 
 bb2:
-  end_borrow %1 from %0 : $Builtin.NativeObject, $Builtin.NativeObject
+  end_borrow %1 : $Builtin.NativeObject
   br bb3
 
 bb3:
@@ -486,7 +501,7 @@ bb2:
   br bb3
 
 bb3:
-  end_borrow %1 from %0 : $Builtin.NativeObject, $Builtin.NativeObject
+  end_borrow %1 : $Builtin.NativeObject
   destroy_value %0 : $Builtin.NativeObject
   %9999 = tuple()
   return %9999 : $()
@@ -506,7 +521,7 @@ bb2:
   br bb3
 
 bb3:
-  end_borrow %2 from %1 : $Optional<Builtin.NativeObject>, $Optional<Builtin.NativeObject>
+  end_borrow %2 : $Optional<Builtin.NativeObject>
   destroy_value %1 : $Optional<Builtin.NativeObject>
   %9999 = tuple()
   return %9999 : $()
@@ -846,7 +861,7 @@ bb4:
 bb5(%6 : @guaranteed $ThreeDifferingPayloadEnum):
   %7 = copy_value %6 : $ThreeDifferingPayloadEnum
   end_borrow_argument %6 : $ThreeDifferingPayloadEnum
-  end_borrow %1 from %0 : $Builtin.NativeObject, $Builtin.NativeObject
+  end_borrow %1 : $Builtin.NativeObject
   br bb6(%7 : $ThreeDifferingPayloadEnum)
 
 bb6(%8 : @owned $ThreeDifferingPayloadEnum):
@@ -926,11 +941,11 @@ bb0(%0 : @owned $(Builtin.NativeObject, Builtin.Int32), %1 : @owned $NonTrivialS
   // First test guaranteed
   %2 = begin_borrow %0 : $(Builtin.NativeObject, Builtin.Int32)
   (%3, %4) = destructure_tuple %2 : $(Builtin.NativeObject, Builtin.Int32)
-  end_borrow %2 from %0 : $(Builtin.NativeObject, Builtin.Int32), $(Builtin.NativeObject, Builtin.Int32)
+  end_borrow %2 : $(Builtin.NativeObject, Builtin.Int32)
 
   %5 = begin_borrow %1 : $NonTrivialStructWithTrivialField
   (%6, %7) = destructure_struct %5 : $NonTrivialStructWithTrivialField
-  end_borrow %5 from %1 : $NonTrivialStructWithTrivialField, $NonTrivialStructWithTrivialField
+  end_borrow %5 : $NonTrivialStructWithTrivialField
 
   // Then test destructive.
   (%8, %9) = destructure_tuple %0 : $(Builtin.NativeObject, Builtin.Int32)
@@ -962,7 +977,7 @@ bb0(%0 : @owned $SwiftKlassP):
   %cast = unchecked_ref_cast %2 : $@opened("3B64717A-E2B3-11E6-9646-985AEB89C610") SwiftKlassP to $Builtin.NativeObject
   %3 = witness_method $@opened("3B64717A-E2B3-11E6-9646-985AEB89C610") SwiftKlassP, #SwiftKlassP.foo!1, %2 : $@opened("3B64717A-E2B3-11E6-9646-985AEB89C610") SwiftKlassP : $@convention(witness_method: SwiftKlassP) <τ_0_0 where τ_0_0 : SwiftKlassP> (@guaranteed τ_0_0) -> ()
   apply %3<@opened("3B64717A-E2B3-11E6-9646-985AEB89C610") SwiftKlassP>(%2) : $@convention(witness_method: SwiftKlassP) <τ_0_0 where τ_0_0 : SwiftKlassP> (@guaranteed τ_0_0) -> ()
-  end_borrow %1 from %0 : $SwiftKlassP, $SwiftKlassP
+  end_borrow %1 : $SwiftKlassP
   destroy_value %0 : $SwiftKlassP
   %9999 = tuple()
   return %9999 : $()

--- a/test/SILGen/accessors.swift
+++ b/test/SILGen/accessors.swift
@@ -46,7 +46,7 @@ func test0(_ ref: A) {
 // CHECK-NEXT: // function_ref accessors.OrdinarySub.subscript.getter : (Swift.Int) -> Swift.Int
 // CHECK-NEXT: [[T1:%.*]] = function_ref @$S9accessors11OrdinarySubVyS2icig
 // CHECK-NEXT: [[VALUE:%.*]] = apply [[T1]]([[INDEX1]], [[T0]])
-// CHECK-NEXT: end_borrow [[T0]] from [[TEMP]]
+// CHECK-NEXT: end_borrow [[T0]]
 // CHECK-NEXT: destroy_addr [[TEMP]]
 //   Formal access to LHS.
 // CHECK-NEXT: [[T0:%.*]] = class_method [[ARG]] : $A, #A.array!modify.1

--- a/test/SILGen/assignment.swift
+++ b/test/SILGen/assignment.swift
@@ -27,7 +27,7 @@ func test1() {
   // CHECK: [[C:%.*]] = apply [[CTOR]]([[T0]]) : $@convention(method) (@thick C.Type) -> @owned C
   // CHECK: [[SETTER:%.*]] = class_method [[BORROWED_D]] : $D,  #D.child!setter.1
   // CHECK: apply [[SETTER]]([[C]], [[BORROWED_D]])
-  // CHECK: end_borrow [[BORROWED_D]] from [[D]]
+  // CHECK: end_borrow [[BORROWED_D]]
   // CHECK: destroy_value [[D]]
   D().child = C()
 }

--- a/test/SILGen/borrow.swift
+++ b/test/SILGen/borrow.swift
@@ -23,7 +23,7 @@ func useD(_ d: D) {}
 // CHECK:   [[OFFSET:%.*]] = ref_element_addr [[BORROWED_CLASS]]
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [dynamic] [[OFFSET]] : $*D
 // CHECK:   [[LOADED_VALUE:%.*]] = load [copy] [[ACCESS]]
-// CHECK:   end_borrow [[BORROWED_CLASS]] from [[CLASS]]
+// CHECK:   end_borrow [[BORROWED_CLASS]]
 // CHECK:   destroy_value [[CLASS]]
 // CHECK:   [[BORROWED_LOADED_VALUE:%.*]] = begin_borrow [[LOADED_VALUE]]
 // CHECK:   [[FUNC:%.*]] = function_ref @$S6borrow4useD{{.*}} : $@convention(thin) (@guaranteed D) -> ()

--- a/test/SILGen/cf_members.swift
+++ b/test/SILGen/cf_members.swift
@@ -45,7 +45,7 @@ public func foo(_ x: Double) {
   let a: (Double) -> Struct1 = Struct1.init(value:)
   // CHECK: apply [[BORROWED_A2]]([[X]])
   // CHECK: destroy_value [[A_COPY]]
-  // CHECK: end_borrow [[BORROWED_A]] from [[A]]
+  // CHECK: end_borrow [[BORROWED_A]]
   z = a(x)
 
   // TODO: Support @convention(c) references that only capture thin metatype
@@ -74,7 +74,7 @@ public func foo(_ x: Double) {
   let c: (Double) -> Struct1 = z.translate(radians:)
   // CHECK: apply [[BORROWED_C2]]([[X]])
   // CHECK: destroy_value [[C_COPY]]
-  // CHECK: end_borrow [[BORROWED_C]] from [[C]]
+  // CHECK: end_borrow [[BORROWED_C]]
   z = c(x)
   // CHECK: [[THUNK:%.*]] = function_ref [[THUNK_NAME]]
   // CHECK: [[THICK:%.*]] = thin_to_thick_function [[THUNK]]
@@ -111,7 +111,7 @@ public func foo(_ x: Double) {
   let f = z.scale
   // CHECK: apply [[BORROWED_F2]]([[X]])
   // CHECK: destroy_value [[F_COPY]]
-  // CHECK: end_borrow [[BORROWED_F]] from [[F]]
+  // CHECK: end_borrow [[BORROWED_F]]
   z = f(x)
   // CHECK: [[THUNK:%.*]] = function_ref @$SSo10IAMStruct1V5scaleyABSdFTcTO
   // CHECK: thin_to_thick_function [[THUNK]]
@@ -167,7 +167,7 @@ public func foo(_ x: Double) {
   let i = Struct1.staticMethod
   // CHECK: apply [[BORROWED_I2]]()
   // CHECK: destroy_value [[I_COPY]]
-  // CHECK: end_borrow [[BORROWED_I]] from [[I]]
+  // CHECK: end_borrow [[BORROWED_I]]
   y = i()
 
   // TODO: Support @convention(c) references that only capture thin metatype

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -384,7 +384,7 @@ func closeOverLetLValue() {
 // CHECK:   [[INT_IN_CLASS_ADDR:%.*]] = ref_element_addr [[BORROWED_LOADED_CLASS]] : $ClassWithIntProperty, #ClassWithIntProperty.x
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [dynamic] [[INT_IN_CLASS_ADDR]] : $*Int
 // CHECK:   [[INT_IN_CLASS:%.*]] = load [trivial] [[ACCESS]] : $*Int
-// CHECK:   end_borrow [[BORROWED_LOADED_CLASS]] from [[TMP_CLASS_ADDR]]
+// CHECK:   end_borrow [[BORROWED_LOADED_CLASS]]
 // CHECK:   destroy_addr [[TMP_CLASS_ADDR]] : $*ClassWithIntProperty
 // CHECK:   dealloc_stack %1 : $*ClassWithIntProperty
 // CHECK:   return [[INT_IN_CLASS]]
@@ -396,7 +396,7 @@ func closeOverLetLValue() {
 // GUARANTEED:   [[COPY:%.*]] = copy_value %0 : $ClassWithIntProperty
 // GUARANTEED:   store [[COPY]] to [init] [[TMP]] : $*ClassWithIntProperty
 // GUARANTEED:   [[BORROWED:%.*]] = load_borrow [[TMP]]
-// GUARANTEED:   end_borrow [[BORROWED]] from [[TMP]]
+// GUARANTEED:   end_borrow [[BORROWED]]
 // GUARANTEED:   destroy_addr [[TMP]]
 // GUARANTEED: } // end sil function '$S8closures18closeOverLetLValueyyFSiyXEfU_'
 
@@ -498,7 +498,7 @@ class SuperSub : SuperBase {
   // CHECK:   apply [[B]]()
 	// CHECK:   end_borrow [[B]]
   // CHECK:   destroy_value [[PA_COPY]]
-  // CHECK:   end_borrow [[BORROWED_PA]] from [[PA]]
+  // CHECK:   end_borrow [[BORROWED_PA]]
   // CHECK:   destroy_value [[PA]]
   // CHECK: } // end sil function '$S8closures8SuperSubC1cyyF'
   func c() {
@@ -531,7 +531,7 @@ class SuperSub : SuperBase {
   // CHECK:   apply [[B]]()
   // CHECK:   end_borrow [[B]]
   // CHECK:   destroy_value [[PA_COPY]]
-  // CHECK:   end_borrow [[BORROWED_PA]] from [[PA]]
+  // CHECK:   end_borrow [[BORROWED_PA]]
   // CHECK:   destroy_value [[PA]]
   // CHECK: } // end sil function '$S8closures8SuperSubC1dyyF'
   func d() {
@@ -575,7 +575,7 @@ class SuperSub : SuperBase {
     // CHECK:   apply [[B]]() : $@callee_guaranteed () -> ()
     // CHECK:   end_borrow [[B]]
     // CHECK:   destroy_value [[PA_COPY]]
-    // CHECK:   end_borrow [[BORROWED_PA]] from [[PA]]
+    // CHECK:   end_borrow [[BORROWED_PA]]
     // CHECK:   destroy_value [[PA]]
     // CHECK: } // end sil function '[[INNER_FUNC_NAME1]]'
     func e1() {
@@ -682,7 +682,7 @@ class SuperSub : SuperBase {
 // CHECK:         [[UNOWNED_SELF:%.*]] = load_borrow [[PB]]
 // -- strong +2, unowned +1
 // CHECK:         [[SELF:%.*]] = copy_unowned_value [[UNOWNED_SELF]]
-// CHECK:         end_borrow [[UNOWNED_SELF]] from [[PB]]
+// CHECK:         end_borrow [[UNOWNED_SELF]]
 // CHECK:         [[UNOWNED_SELF2:%.*]] = ref_to_unowned [[SELF]]
 // -- strong +2, unowned +2
 // CHECK:         [[UNOWNED_SELF2_COPY:%.*]] = copy_value [[UNOWNED_SELF2]]

--- a/test/SILGen/closures_callee_guaranteed.swift
+++ b/test/SILGen/closures_callee_guaranteed.swift
@@ -10,10 +10,10 @@ import Swift
 //   @callee_guaranteed.
 //   [[B2:%.*]] = begin_borrow [[C1]] : $@noescape @callee_guaranteed () -> Int
 //   [[R:%.*]] = apply [[B2]]() : $@noescape @callee_guaranteed () -> Int
-//   end_borrow [[B2]] from [[C1]] : $@noescape @callee_guaranteed () -> Int, $@noescape @callee_guaranteed () -> Int
+//   end_borrow [[B2]] : $@noescape @callee_guaranteed () -> Int
 //
 //   destroy_value [[C1]] : $@noescape @callee_guaranteed () -> Int
-//   end_borrow [[B1]] from %0 : $@noescape @callee_guaranteed () -> Int, $@noescape @callee_guaranteed () -> Int
+//   end_borrow [[B1]] : $@noescape @callee_guaranteed () -> Int
 //   destroy_value %0 : $@noescape @callee_guaranteed () -> Int
 //   return [[R]] : $Int
 public func apply(_ f : () -> Int) -> Int {

--- a/test/SILGen/collection_subtype_downcast.swift
+++ b/test/SILGen/collection_subtype_downcast.swift
@@ -36,7 +36,7 @@ func ==(lhs: S, rhs: S) -> Bool {
 // CHECK: [[FN:%.*]] = function_ref @$Ss30_dictionaryDownCastConditionalySDyq0_q1_GSgSDyxq_GSHRzSHR0_r2_lF
 // CHECK: [[BORROWED_ARG_COPY:%.*]] = begin_borrow [[ARG_COPY]]
 // CHECK: [[RESULT:%.*]] = apply [[FN]]<S, Any, S, Int>([[BORROWED_ARG_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned Optional<Dictionary<τ_0_2, τ_0_3>>
-// CHECK: end_borrow [[BORROWED_ARG_COPY]] from [[ARG_COPY]]
+// CHECK: end_borrow [[BORROWED_ARG_COPY]]
 // CHECK: destroy_value [[ARG_COPY]]
 // CHECK: return [[RESULT]]
 func dict_downcast(dict: [S: Any]) -> [S: Int]? {

--- a/test/SILGen/collection_subtype_upcast.swift
+++ b/test/SILGen/collection_subtype_upcast.swift
@@ -11,7 +11,7 @@ struct S { var x, y: Int }
 // CHECK: [[FN:%.*]] = function_ref @$Ss15_arrayForceCastySayq_GSayxGr0_lF
 // CHECK: [[BORROWED_ARG_COPY:%.*]] = begin_borrow [[ARG_COPY]]
 // CHECK: [[RESULT:%.*]] = apply [[FN]]<S, Any>([[BORROWED_ARG_COPY]]) : $@convention(thin) <τ_0_0, τ_0_1> (@guaranteed Array<τ_0_0>) -> @owned Array<τ_0_1>
-// CHECK: end_borrow [[BORROWED_ARG_COPY]] from [[ARG_COPY]]
+// CHECK: end_borrow [[BORROWED_ARG_COPY]]
 // CHECK: destroy_value [[ARG_COPY]]
 // CHECK: return [[RESULT]]
 func array_upcast(array: [S]) -> [Any] {

--- a/test/SILGen/default_constructor.swift
+++ b/test/SILGen/default_constructor.swift
@@ -61,7 +61,7 @@ class E {
 // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [dynamic] [[IREF]] : $*Int64
 // CHECK-NEXT: assign [[VALUE]] to [[WRITE]] : $*Int64
 // CHECK-NEXT: end_access [[WRITE]] : $*Int64
-// CHECK-NEXT: end_borrow [[BORROWED_SELF]] from [[SELF]]
+// CHECK-NEXT: end_borrow [[BORROWED_SELF]]
 // CHECK-NEXT: [[SELF_COPY:%.*]] = copy_value [[SELF]]
 // CHECK-NEXT: destroy_value [[SELF]]
 // CHECK-NEXT: return [[SELF_COPY]] : $E

--- a/test/SILGen/downcast_reabstraction.swift
+++ b/test/SILGen/downcast_reabstraction.swift
@@ -21,7 +21,7 @@ func condFunctionFromAny(_ x: Any) {
 // CHECK:         [[SUBST_VAL:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACT]]([[ORIG_VAL]])
 // CHECK:         [[BORROW:%.*]] = begin_borrow [[SUBST_VAL]]
 // CHECK:         apply [[BORROW]]()
-// CHECK:         end_borrow [[BORROW]] from [[SUBST_VAL]]
+// CHECK:         end_borrow [[BORROW]]
 // CHECK:         destroy_value [[SUBST_VAL]]
 func uncondFunctionFromAny(_ x: Any) {
   (x as! () -> ())()

--- a/test/SILGen/dynamic_lookup.swift
+++ b/test/SILGen/dynamic_lookup.swift
@@ -185,7 +185,7 @@ func opt_to_property(_ obj: AnyObject) {
   // GUARANTEED:   [[BOUND_METHOD:%[0-9]+]] = partial_apply [callee_guaranteed] [[METHOD]]([[RAWOBJ_SELF_COPY]])
   // GUARANTEED:   [[BEGIN_BORROW:%.*]] = begin_borrow [[BOUND_METHOD]]
   // GUARANTEED:   [[VALUE:%[0-9]+]] = apply [[BEGIN_BORROW]]
-  // GUARANTEED:   end_borrow [[BEGIN_BORROW]] from [[BOUND_METHOD]]
+  // GUARANTEED:   end_borrow [[BEGIN_BORROW]]
   // GUARANTEED:   [[VALUETEMP:%.*]] = init_enum_data_addr [[OPTTEMP]]
   // GUARANTEED:   store [[VALUE]] to [trivial] [[VALUETEMP]]
   // GUARANTEED:   inject_enum_addr [[OPTTEMP]]{{.*}}some
@@ -253,7 +253,7 @@ func direct_to_subscript(_ obj: AnyObject, i: Int) {
   // GUARANTEED:   [[GETTER_WITH_SELF:%[0-9]+]] = partial_apply [callee_guaranteed] [[GETTER]]([[OBJ_REF_COPY]])
   // GUARANTEED:   [[BORROW:%.*]] = begin_borrow [[GETTER_WITH_SELF]]
   // GUARANTEED:   [[RESULT:%[0-9]+]] = apply [[BORROW]]([[I]])
-  // GUARANTEED:   end_borrow [[BORROW]] from [[GETTER_WITH_SELF]]
+  // GUARANTEED:   end_borrow [[BORROW]]
   // GUARANTEED:   [[RESULTTEMP:%.*]] = init_enum_data_addr [[OPTTEMP]]
   // GUARANTEED:   store [[RESULT]] to [trivial] [[RESULTTEMP]]
   // GUARANTEED:   inject_enum_addr [[OPTTEMP]]{{.*}}some

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -122,13 +122,13 @@ func dont_return<T>(_ argument: T) throws -> T {
 // CHECK-NEXT: debug_value
 // CHECK-NEXT: [[BORROWED_T0:%.*]] = begin_borrow [[T0]]
 // CHECK-NEXT: [[T0_COPY:%.*]] = copy_value [[BORROWED_T0]]
-// CHECK-NEXT: end_borrow [[BORROWED_T0]] from [[T0]]
+// CHECK-NEXT: end_borrow [[BORROWED_T0]]
 // CHECK-NEXT: destroy_value [[T0]]
 // CHECK-NEXT: destroy_value [[T0_ORIG]]
 // CHECK-NEXT: dealloc_stack [[DEST_TEMP]]
 // CHECK-NEXT: destroy_addr [[SRC_TEMP]]
 // CHECK-NEXT: dealloc_stack [[SRC_TEMP]]
-// CHECK-NEXT: end_borrow [[BORROWED_ERROR]] from [[ERROR]]
+// CHECK-NEXT: end_borrow [[BORROWED_ERROR]]
 // CHECK-NEXT: destroy_value [[ERROR]]
 // CHECK-NEXT: br [[RETURN]]([[T0_COPY]] : $Cat)
 
@@ -153,7 +153,7 @@ func dont_return<T>(_ argument: T) throws -> T {
 // CHECK-NEXT: [[T1:%.*]] = metatype $@thick Cat.Type
 // CHECK:      [[T0:%.*]] = function_ref @$S6errors3Cat{{.*}} : $@convention(method) (@thick Cat.Type) -> @owned Cat
 // CHECK-NEXT: [[T2:%.*]] = apply [[T0]]([[T1]])
-// CHECK-NEXT: end_borrow [[BORROWED_ERROR]] from [[ERROR]]
+// CHECK-NEXT: end_borrow [[BORROWED_ERROR]]
 // CHECK-NEXT: destroy_value [[ERROR]] : $Error
 // CHECK-NEXT: br [[RETURN]]([[T2]] : $Cat)
 
@@ -217,7 +217,7 @@ class HasThrowingInit {
 // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [dynamic] [[T1]] : $*Int
 // CHECK-NEXT: assign %0 to [[WRITE]] : $*Int
 // CHECK-NEXT: end_access [[WRITE]]
-// CHECK-NEXT: end_borrow [[BORROWED_T0]] from [[T0]]
+// CHECK-NEXT: end_borrow [[BORROWED_T0]]
 // CHECK-NEXT: [[T0_RET:%.*]] = copy_value [[T0]]
 // CHECK-NEXT: destroy_value [[T0]]
 // CHECK-NEXT: return [[T0_RET]] : $HasThrowingInit
@@ -270,11 +270,11 @@ struct DoomedStruct : Doomed {
 // CHECK-NEXT: try_apply [[T0]]([[BORROWED_SELF]])
 // CHECK:    bb1([[T0:%.*]] : @trivial $()):
 // CHECK:      [[T0:%.*]] = tuple ()
-// CHECK:      end_borrow [[BORROWED_SELF]] from %0
+// CHECK:      end_borrow [[BORROWED_SELF]]
 // CHECK:      return [[T0]] : $()
 // CHECK:    bb2([[T0:%.*]] : @owned $Error):
 // CHECK:      builtin "willThrow"([[T0]] : $Error)
-// CHECK:      end_borrow [[BORROWED_SELF]] from %0
+// CHECK:      end_borrow [[BORROWED_SELF]]
 // CHECK:      throw [[T0]] : $Error
 class DoomedClass : Doomed {
   func check() throws {}
@@ -294,7 +294,7 @@ struct HappyStruct : Doomed {
 // CHECK:      [[T0:%.*]] = class_method [[SELF]] : $HappyClass, #HappyClass.check!1 : (HappyClass) -> () -> (), $@convention(method) (@guaranteed HappyClass) -> ()
 // CHECK:      [[T1:%.*]] = apply [[T0]]([[SELF]])
 // CHECK:      [[T1:%.*]] = tuple ()
-// CHECK:      end_borrow [[SELF]] from %0
+// CHECK:      end_borrow [[SELF]]
 // CHECK:      return [[T1]] : $()
 class HappyClass : Doomed {
   func check() {}
@@ -455,7 +455,7 @@ func test_variadic(_ cat: Cat) throws {
 // CHECK:         [[TAKE_FN:%.*]] = function_ref @$S6errors14take_many_catsyyAA3CatCd_tKF : $@convention(thin) (@guaranteed Array<Cat>) -> @error Error
 // CHECK-NEXT:    try_apply [[TAKE_FN]]([[BORROWED_ARRAY]]) : $@convention(thin) (@guaranteed Array<Cat>) -> @error Error, normal [[NORM_CALL:bb[0-9]+]], error [[ERR_CALL:bb[0-9]+]]
 // CHECK:       [[NORM_CALL]]([[T0:%.*]] : @trivial $()):
-// CHECK-NEXT:    end_borrow [[BORROWED_ARRAY]] from [[ARRAY]]
+// CHECK-NEXT:    end_borrow [[BORROWED_ARRAY]]
 // CHECK-NEXT:    destroy_value [[ARRAY]]
 // CHECK-NEXT:    [[T0:%.*]] = tuple ()
 // CHECK-NEXT:    return
@@ -512,7 +512,7 @@ class BaseThrowingInit : HasThrowingInit {
 // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [dynamic] [[T1]] : $*Int
 // CHECK-NEXT: assign %1 to [[WRITE]]
 // CHECK-NEXT: end_access [[WRITE]]
-// CHECK-NEXT: end_borrow [[T0]] from [[PB]]
+// CHECK-NEXT: end_borrow [[T0]]
 //   Super delegation.
 // CHECK-NEXT: [[T0:%.*]] = load [take] [[PB]]
 // CHECK-NEXT: [[T2:%.*]] = upcast [[T0]] : $BaseThrowingInit to $HasThrowingInit
@@ -563,13 +563,13 @@ func supportStructure<B: Buildable>(_ b: inout B, name: String) throws {
 
 // CHECK: [[BB_NORMAL]]
 // CHECK:   end_apply [[TOKEN]]
-// CHECK:   end_borrow [[BORROWED_INDEX_COPY]] from [[INDEX_COPY]]
+// CHECK:   end_borrow [[BORROWED_INDEX_COPY]]
 // CHECK:   destroy_value [[INDEX_COPY]] : $String
 // CHECK:   return
 
 // CHECK: [[BB_ERROR]]([[ERROR:%.*]] : @owned $Error):
 // CHECK:   abort_apply [[TOKEN]]
-// CHECK:   end_borrow [[BORROWED_INDEX_COPY]] from [[INDEX_COPY]]
+// CHECK:   end_borrow [[BORROWED_INDEX_COPY]]
 // CHECK:   destroy_value [[INDEX_COPY]] : $String
 // CHECK:   throw [[ERROR]]
 
@@ -604,7 +604,7 @@ func supportStructure(_ b: inout Bridge, name: String) throws {
 // CHECK-NEXT: [[T0:%.*]] = apply [[GETTER]]([[BORROWED_INDEX_COPY_1]], [[BASE]])
 // CHECK-NEXT: end_borrow [[BORROWED_INDEX_COPY_1]]
 // CHECK-NEXT: store [[T0]] to [init] [[TEMP]]
-// CHECK-NEXT: end_borrow [[BASE]] from [[WRITE]]
+// CHECK-NEXT: end_borrow [[BASE]]
 // CHECK:      [[SUPPORT:%.*]] = function_ref @$S6errors5PylonV7supportyyKF
 // CHECK-NEXT: try_apply [[SUPPORT]]([[TEMP]]) : {{.*}}, normal [[BB_NORMAL:bb[0-9]+]], error [[BB_ERROR:bb[0-9]+]]
 

--- a/test/SILGen/expressions.swift
+++ b/test/SILGen/expressions.swift
@@ -631,7 +631,7 @@ func loadIgnoredLValueForceUnwrap(_ a: inout NonTrivialStruct) -> NonTrivialStru
 // CHECK-NEXT: // function_ref NonTrivialStruct.x.getter
 // CHECK-NEXT: [[GETTER:%[0-9]+]] = function_ref @$S{{[_0-9a-zA-Z]*}}vg : $@convention(method) (@guaranteed NonTrivialStruct) -> @owned Optional<NonTrivialStruct>
 // CHECK-NEXT: [[X:%[0-9]+]] = apply [[GETTER]]([[BORROW]])
-// CHECK-NEXT: end_borrow [[BORROW]] from [[READ]]
+// CHECK-NEXT: end_borrow [[BORROW]]
 // CHECK-NEXT: end_access [[READ]]
 // CHECK-NEXT: switch_enum [[X]] : $Optional<NonTrivialStruct>, case #Optional.some!enumelt.1: bb2, case #Optional.none!enumelt: bb1
 // CHECK: bb1:
@@ -657,7 +657,7 @@ func loadIgnoredLValueThroughForceUnwrap(_ a: inout NonTrivialStruct?) -> NonTri
 // CHECK-NEXT: // function_ref NonTrivialStruct.x.getter
 // CHECK-NEXT: [[GETTER:%[0-9]+]] = function_ref @$S{{[_0-9a-zA-Z]*}}vg : $@convention(method) (@guaranteed NonTrivialStruct) -> @owned Optional<NonTrivialStruct>
 // CHECK-NEXT: [[X:%[0-9]+]] = apply [[GETTER]]([[BORROW]])
-// CHECK-NEXT: end_borrow [[BORROW]] from [[UNWRAPPED]]
+// CHECK-NEXT: end_borrow [[BORROW]]
 // CHECK-NEXT: end_access [[READ]]
 // CHECK-NEXT: switch_enum [[X]] : $Optional<NonTrivialStruct>, case #Optional.some!enumelt.1: bb4, case #Optional.none!enumelt: bb3
 // CHECK: bb3:

--- a/test/SILGen/force_cast_chained_optional.swift
+++ b/test/SILGen/force_cast_chained_optional.swift
@@ -27,7 +27,7 @@ class D: C {}
 // CHECK:   [[BORROWED_BAR:%.*]] = begin_borrow [[BAR]]
 // CHECK:   [[METHOD:%.*]] = class_method [[BORROWED_BAR]] : $Bar, #Bar.bas!getter.1 : (Bar) -> () -> C?, $@convention(method) (@guaranteed Bar) ->
 // CHECK:   apply [[METHOD]]([[BORROWED_BAR]])
-// CHECK:   end_borrow [[BORROWED_BAR]] from [[BAR]]
+// CHECK:   end_borrow [[BORROWED_BAR]]
 // CHECK:   unconditional_checked_cast {{%.*}} : $C to $D
 //
 // CHECK: [[TRAP]]:

--- a/test/SILGen/foreign_errors.swift
+++ b/test/SILGen/foreign_errors.swift
@@ -104,7 +104,7 @@ extension NSObject {
 // CHECK:   [[BORROWED_RESULT:%.*]] = begin_borrow [[RESULT]]
 // CHECK:   [[T1:%.*]] = apply [[T0]]([[BORROWED_RESULT]])
 // CHECK:   [[T2:%.*]] = enum $Optional<NSString>, #Optional.some!enumelt.1, [[T1]] : $NSString
-// CHECK:   end_borrow [[BORROWED_RESULT]] from [[RESULT]]
+// CHECK:   end_borrow [[BORROWED_RESULT]]
 // CHECK:   destroy_value [[RESULT]]  
 // CHECK:   br bb6([[T2]] : $Optional<NSString>)
 //
@@ -131,7 +131,7 @@ extension NSObject {
 // CHECK:   br bb6([[T0]] : $Optional<NSString>)
 //
 // CHECK: bb6([[T0:%.*]] : @owned $Optional<NSString>):
-// CHECK:   end_borrow [[BORROWED_ARG1]] from [[ARG1]]
+// CHECK:   end_borrow [[BORROWED_ARG1]]
 // CHECK:   destroy_value [[ARG1]]
 // CHECK:   return [[T0]] : $Optional<NSString>
 
@@ -204,7 +204,7 @@ class VeryErrorProne : ErrorProne {
 // CHECK: [[BORROWED_T1:%.*]] = begin_borrow [[T1]]
 // CHECK-NEXT: [[DOWNCAST_BORROWED_T1:%.*]] = unchecked_ref_cast [[BORROWED_T1]] : $ErrorProne to $VeryErrorProne
 // CHECK-NEXT: [[T2:%.*]] = objc_super_method [[DOWNCAST_BORROWED_T1]] : $VeryErrorProne, #ErrorProne.init!initializer.1.foreign : (ErrorProne.Type) -> (Any?) throws -> ErrorProne, $@convention(objc_method) (Optional<AnyObject>, Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @owned ErrorProne) -> @owned Optional<ErrorProne>
-// CHECK:      end_borrow [[BORROWED_T1]] from [[T1]]
+// CHECK:      end_borrow [[BORROWED_T1]]
 // CHECK:      apply [[T2]]([[ARG1_COPY]], {{%.*}}, [[T1]])
 
 // rdar://21051021

--- a/test/SILGen/function_conversion_objc.swift
+++ b/test/SILGen/function_conversion_objc.swift
@@ -63,7 +63,7 @@ func funcToBlock(_ x: @escaping () -> ()) -> @convention(block) () -> () {
 // CHECK:   [[COPIED_2:%.*]] = copy_value [[BORROWED_COPIED]]
 // CHECK:   [[THUNK:%.*]] = function_ref @$SIeyB_Ieg_TR
 // CHECK:   [[FUNC:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[COPIED_2]])
-// CHECK:   end_borrow [[BORROWED_COPIED]] from [[COPIED]]
+// CHECK:   end_borrow [[BORROWED_COPIED]]
 // CHECK:   destroy_value [[COPIED]]
 // CHECK-NOT:   destroy_value [[ARG]]
 // CHECK:   return [[FUNC]]

--- a/test/SILGen/functions.swift
+++ b/test/SILGen/functions.swift
@@ -157,7 +157,7 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: [[I:%[0-9]+]] = load [trivial] [[READI]]
   // CHECK: [[METHOD:%[0-9]+]] = class_method [[BORROWED_C]] : {{.*}}, #SomeClass.method!1
   // CHECK: apply [[METHOD]]([[I]], [[BORROWED_C]])
-  // CHECK: end_borrow [[BORROWED_C]] from [[C]]
+  // CHECK: end_borrow [[BORROWED_C]]
   // CHECK: destroy_value [[C]]
   c.method(i)
 
@@ -174,7 +174,7 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: [[I:%[0-9]+]] = load [trivial] [[READI]]
   // CHECK: [[METHOD:%[0-9]+]] = class_method [[BORROWED_C]] : {{.*}}, #SomeClass.method!1
   // CHECK: apply [[METHOD]]([[I]], [[BORROWED_C]])
-  // CHECK: end_borrow [[BORROWED_C]] from [[C]]
+  // CHECK: end_borrow [[BORROWED_C]]
   // CHECK: destroy_value [[C]]
   SomeClass.method(c)(i)
 
@@ -197,7 +197,7 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
   // CHECK: [[GETTER:%[0-9]+]] = class_method {{.*}} : $SomeClass, #SomeClass.someProperty!getter.1
   // CHECK: apply [[GETTER]]([[BORROWED_C]])
-  // CHECK: end_borrow [[BORROWED_C]] from [[C]]
+  // CHECK: end_borrow [[BORROWED_C]]
   // CHECK: destroy_value [[C]]
   i = c.someProperty
 
@@ -208,7 +208,7 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
   // CHECK: [[SETTER:%[0-9]+]] = class_method [[BORROWED_C]] : $SomeClass, #SomeClass.someProperty!setter.1 : (SomeClass) -> (Builtin.Int64) -> ()
   // CHECK: apply [[SETTER]]([[I]], [[BORROWED_C]])
-  // CHECK: end_borrow [[BORROWED_C]] from [[C]]
+  // CHECK: end_borrow [[BORROWED_C]]
   // CHECK: destroy_value [[C]]
   c.someProperty = i
 
@@ -221,7 +221,7 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
   // CHECK: [[GETTER:%[0-9]+]] = class_method [[BORROWED_C]] : $SomeClass, #SomeClass.subscript!getter.1 : (SomeClass) -> (Builtin.Int64, Builtin.Int64) -> Builtin.Int64, $@convention(method) (Builtin.Int64, Builtin.Int64, @guaranteed SomeClass) -> Builtin.Int64
   // CHECK: apply [[GETTER]]([[J]], [[K]], [[BORROWED_C]])
-  // CHECK: end_borrow [[BORROWED_C]] from [[C]]
+  // CHECK: end_borrow [[BORROWED_C]]
   // CHECK: destroy_value [[C]]
   i = c[j, k]
 
@@ -236,7 +236,7 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: [[BORROWED_C:%.*]] = begin_borrow [[C]]
   // CHECK: [[SETTER:%[0-9]+]] = class_method [[BORROWED_C]] : $SomeClass, #SomeClass.subscript!setter.1 : (SomeClass) -> (Builtin.Int64, Builtin.Int64, Builtin.Int64) -> (), $@convention(method) (Builtin.Int64, Builtin.Int64, Builtin.Int64, @guaranteed SomeClass) -> ()
   // CHECK: apply [[SETTER]]([[K]], [[I]], [[J]], [[BORROWED_C]])
-  // CHECK: end_borrow [[BORROWED_C]] from [[C]]
+  // CHECK: end_borrow [[BORROWED_C]]
   // CHECK: destroy_value [[C]]
   c[i, j] = k
 
@@ -289,7 +289,7 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: [[TMPI:%.*]] = alloc_stack $Builtin.Int64
   // CHECK: [[METHOD_GEN:%[0-9]+]] = class_method [[BORROWED_G]] : {{.*}}, #SomeGeneric.method!1
   // CHECK: apply [[METHOD_GEN]]<{{.*}}>([[TMPR]], [[TMPI]], [[BORROWED_G]])
-  // CHECK: end_borrow [[BORROWED_G]] from [[G]]
+  // CHECK: end_borrow [[BORROWED_G]]
   // CHECK: destroy_value [[G]]
   g.method(i)
 
@@ -300,7 +300,7 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: [[TMPJ:%.*]] = alloc_stack $Builtin.Int64
   // CHECK: [[METHOD_GEN:%[0-9]+]] = class_method [[BORROWED_G]] : {{.*}}, #SomeGeneric.generic!1
   // CHECK: apply [[METHOD_GEN]]<{{.*}}>([[TMPR]], [[TMPJ]], [[BORROWED_G]])
-  // CHECK: end_borrow [[BORROWED_G]] from [[G]]
+  // CHECK: end_borrow [[BORROWED_G]]
   // CHECK: destroy_value [[G]]
   g.generic(j)
 
@@ -311,7 +311,7 @@ func calls(_ i:Int, j:Int, k:Int) {
   // CHECK: [[TMPK:%.*]] = alloc_stack $Builtin.Int64
   // CHECK: [[METHOD_GEN:%[0-9]+]] = class_method [[BORROWED_C]] : {{.*}}, #SomeClass.generic!1
   // CHECK: apply [[METHOD_GEN]]<{{.*}}>([[TMPR]], [[TMPK]], [[BORROWED_C]])
-  // CHECK: end_borrow [[BORROWED_C]] from [[C]]
+  // CHECK: end_borrow [[BORROWED_C]]
   // CHECK: destroy_value [[C]]
   c.generic(k)
 

--- a/test/SILGen/generic_property_base_lifetime.swift
+++ b/test/SILGen/generic_property_base_lifetime.swift
@@ -21,7 +21,7 @@ protocol ProtocolB {
 // CHECK:   [[BORROWED_PROJECTION_COPY:%.*]] = begin_borrow [[PROJECTION_COPY]]
 // CHECK:   [[WITNESS_METHOD:%.*]] = witness_method $@opened({{.*}}) ProtocolA, #ProtocolA.intProp!getter.1 : {{.*}}, [[PROJECTION]]
 // CHECK:   [[RESULT:%.*]] = apply [[WITNESS_METHOD]]<@opened{{.*}}>([[BORROWED_PROJECTION_COPY]])
-// CHECK:   end_borrow [[BORROWED_PROJECTION_COPY]] from [[PROJECTION_COPY]]
+// CHECK:   end_borrow [[BORROWED_PROJECTION_COPY]]
 // CHECK:   destroy_value [[PROJECTION_COPY]]
 // CHECK:   return [[RESULT]]
 // CHECK: } // end sil function '$S30generic_property_base_lifetime21getIntPropExistentialySiAA9ProtocolA_pF'
@@ -36,7 +36,7 @@ func getIntPropExistential(_ a: ProtocolA) -> Int {
 // CHECK:   [[BORROWED_PROJECTION_COPY:%.*]] = begin_borrow [[PROJECTION_COPY]]
 // CHECK:   [[WITNESS_METHOD:%.*]] = witness_method $@opened({{.*}}) ProtocolA, #ProtocolA.intProp!setter.1 : {{.*}}, [[PROJECTION]]
 // CHECK:   apply [[WITNESS_METHOD]]<@opened{{.*}}>({{%.*}}, [[BORROWED_PROJECTION_COPY]])
-// CHECK:   end_borrow [[BORROWED_PROJECTION_COPY]] from [[PROJECTION_COPY]]
+// CHECK:   end_borrow [[BORROWED_PROJECTION_COPY]]
 // CHECK:   destroy_value [[PROJECTION_COPY]]
 // CHECK: } // end sil function '$S30generic_property_base_lifetime21setIntPropExistentialyyAA9ProtocolA_pF'
 func setIntPropExistential(_ a: ProtocolA) {

--- a/test/SILGen/guaranteed_self.swift
+++ b/test/SILGen/guaranteed_self.swift
@@ -282,7 +282,7 @@ class C: Fooable, Barrable {
   // CHECK:         [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:         [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
   // CHECK:         apply {{.*}}({{.*}}, [[BORROWED_SELF_COPY]])
-  // CHECK:         end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+  // CHECK:         end_borrow [[BORROWED_SELF_COPY]]
   // CHECK:         destroy_value [[SELF_COPY]]
   // CHECK-NOT:     destroy_value [[SELF_COPY]]
   // CHECK-NOT:     destroy_value [[SELF]]
@@ -302,7 +302,7 @@ class C: Fooable, Barrable {
   // CHECK:         [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:         [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
   // CHECK:         apply {{.*}}([[BORROWED_SELF_COPY]])
-  // CHECK:         end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+  // CHECK:         end_borrow [[BORROWED_SELF_COPY]]
   // CHECK:         destroy_value [[SELF_COPY]]
   // CHECK-NOT:     destroy_value [[SELF]]
   // CHECK-NOT:     destroy_value [[SELF_COPY]]
@@ -312,7 +312,7 @@ class C: Fooable, Barrable {
   // CHECK:         [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:         [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
   // CHECK:         apply {{.*}} [[BORROWED_SELF_COPY]]
-  // CHECK:         end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+  // CHECK:         end_borrow [[BORROWED_SELF_COPY]]
   // CHECK:         destroy_value [[SELF_COPY]]
   // CHECK-NOT:     destroy_value [[SELF_COPY]]
   // CHECK-NOT:     destroy_value [[SELF]]
@@ -459,7 +459,7 @@ class LetFieldClass {
   // CHECK:      [[BORROWED_KRAKEN:%.*]] = begin_borrow [[KRAKEN]]
   // CHECK: [[DESTROY_SHIP_FUN:%.*]] = function_ref @$S15guaranteed_self11destroyShipyyAA6KrakenCF : $@convention(thin) (@guaranteed Kraken) -> ()
   // CHECK-NEXT: apply [[DESTROY_SHIP_FUN]]([[BORROWED_KRAKEN]])
-  // CHECK-NEXT: end_borrow [[BORROWED_KRAKEN]] from [[KRAKEN]]
+  // CHECK-NEXT: end_borrow [[BORROWED_KRAKEN]]
   // CHECK-NEXT: [[KRAKEN_BOX:%.*]] = alloc_box ${ var Kraken }
   // CHECK-NEXT: [[PB:%.*]] = project_box [[KRAKEN_BOX]]
   // CHECK-NEXT: [[KRAKEN_ADDR:%.*]] = ref_element_addr [[CLS]] : $LetFieldClass, #LetFieldClass.letk
@@ -492,14 +492,14 @@ class LetFieldClass {
   // CHECK-NEXT: [[BORROWED_KRAKEN:%.*]] = begin_borrow [[KRAKEN]]
   // CHECK-NEXT: [[KRAKEN_METH:%.*]] = class_method [[BORROWED_KRAKEN]]
   // CHECK-NEXT: apply [[KRAKEN_METH]]([[BORROWED_KRAKEN]])
-  // CHECK-NEXT: end_borrow [[BORROWED_KRAKEN]] from [[KRAKEN]]
+  // CHECK-NEXT: end_borrow [[BORROWED_KRAKEN]]
   // CHECK-NEXT: destroy_value [[KRAKEN]]
   // CHECK-NEXT: [[KRAKEN_GETTER_FUN:%.*]] = class_method [[CLS]] : $LetFieldClass, #LetFieldClass.vark!getter.1 : (LetFieldClass) -> () -> Kraken, $@convention(method) (@guaranteed LetFieldClass) -> @owned Kraken
   // CHECK-NEXT: [[KRAKEN:%.*]] = apply [[KRAKEN_GETTER_FUN]]([[CLS]])
   // CHECK:      [[BORROWED_KRAKEN:%.*]] = begin_borrow [[KRAKEN]]
   // CHECK: [[DESTROY_SHIP_FUN:%.*]] = function_ref @$S15guaranteed_self11destroyShipyyAA6KrakenCF : $@convention(thin) (@guaranteed Kraken) -> ()
   // CHECK-NEXT: apply [[DESTROY_SHIP_FUN]]([[BORROWED_KRAKEN]])
-  // CHECK-NEXT: end_borrow [[BORROWED_KRAKEN]] from [[KRAKEN]]
+  // CHECK-NEXT: end_borrow [[BORROWED_KRAKEN]]
   // CHECK-NEXT: [[KRAKEN_BOX:%.*]] = alloc_box ${ var Kraken }
   // CHECK-NEXT: [[PB:%.*]] = project_box [[KRAKEN_BOX]]
   // CHECK-NEXT: [[KRAKEN_GETTER_FUN:%.*]] = class_method [[CLS]] : $LetFieldClass, #LetFieldClass.vark!getter.1 : (LetFieldClass) -> () -> Kraken, $@convention(method) (@guaranteed LetFieldClass) -> @owned Kraken

--- a/test/SILGen/if_while_binding.swift
+++ b/test/SILGen/if_while_binding.swift
@@ -26,7 +26,7 @@ func if_no_else() {
   // CHECK:   [[BORROWED_VAL:%.*]] = begin_borrow [[VAL]]
   // CHECK:   [[A:%.*]] = function_ref @$S16if_while_binding1a
   // CHECK:   apply [[A]]([[BORROWED_VAL]])
-  // CHECK:   end_borrow [[BORROWED_VAL]] from [[VAL]]
+  // CHECK:   end_borrow [[BORROWED_VAL]]
   // CHECK:   destroy_value [[VAL]]
   // CHECK:   br [[CONT]]
     a(x)
@@ -50,7 +50,7 @@ func if_else_chain() {
   // CHECK:   [[BORROWED_VAL:%.*]] = begin_borrow [[VAL]]
   // CHECK:   [[A:%.*]] = function_ref @$S16if_while_binding1a
   // CHECK:   apply [[A]]([[BORROWED_VAL]])
-  // CHECK:   end_borrow [[BORROWED_VAL]] from [[VAL]]
+  // CHECK:   end_borrow [[BORROWED_VAL]]
   // CHECK:   destroy_value [[VAL]]
   // CHECK:   br [[CONT_X:bb[0-9]+]]
     a(x)
@@ -162,7 +162,7 @@ func while_loop_multi() {
     // CHECK:   [[BORROWED_A:%.*]] = begin_borrow [[A]]
     // CHECK:   [[A_COPY:%.*]] = copy_value [[BORROWED_A]]
     // CHECK:   debug_value [[A_COPY]] : $String, let, name "c"
-    // CHECK:   end_borrow [[BORROWED_A]] from [[A]]
+    // CHECK:   end_borrow [[BORROWED_A]]
     // CHECK:   destroy_value [[A_COPY]]
     // CHECK:   destroy_value [[B]]
     // CHECK:   destroy_value [[A]]
@@ -301,7 +301,7 @@ func if_leading_boolean(_ a : Int) {
   // CHECK:   [[BORROWED_B:%.*]] = begin_borrow [[B]]
   // CHECK:   [[B_COPY:%.*]] = copy_value [[BORROWED_B]]
   // CHECK:   debug_value [[B_COPY]] : $String, let, name "c"
-  // CHECK:   end_borrow [[BORROWED_B]] from [[B]]
+  // CHECK:   end_borrow [[BORROWED_B]]
   // CHECK:   destroy_value [[B_COPY]]
   // CHECK:   destroy_value [[B]]
   // CHECK:   br [[IFDONE]]

--- a/test/SILGen/implicitly_unwrapped_optional.swift
+++ b/test/SILGen/implicitly_unwrapped_optional.swift
@@ -75,7 +75,7 @@ func sr3758() {
   // CHECK: = apply [[BORROWED_CALLEE]]({{%.+}}) : $@callee_guaranteed (@in_guaranteed Optional<Any>) -> ()
   // CHECK: end_borrow [[BORROWED_CALLEE]]
   // destroy_value [[CALLEE]]
-  // CHECK: end_borrow [[BORROWED_F]] from [[F]]
+  // CHECK: end_borrow [[BORROWED_F]]
   // CHECK: destroy_value [[F]]
   let f: ((Any?) -> Void) = { (arg: Any!) in }
   f(nil)

--- a/test/SILGen/import_as_member.swift
+++ b/test/SILGen/import_as_member.swift
@@ -48,7 +48,7 @@ public func useClass(d: Double, opts: SomeClass.Options) {
   // CHECK: [[BORROWED_OBJ:%.*]] = begin_borrow [[OBJ]]
   // CHECK: [[APPLY_FN:%[0-9]+]] = function_ref @IAMSomeClassApplyOptions : $@convention(c) (SomeClass, SomeClass.Options) -> ()
   // CHECK: apply [[APPLY_FN]]([[BORROWED_OBJ]], [[OPTS]])
-  // CHECK: end_borrow [[BORROWED_OBJ]] from [[OBJ]]
+  // CHECK: end_borrow [[BORROWED_OBJ]]
   // CHECK: destroy_value [[OBJ]]
   o.applyOptions(opts)
 }

--- a/test/SILGen/initializers.swift
+++ b/test/SILGen/initializers.swift
@@ -595,7 +595,7 @@ class ThrowDerivedClass : ThrowBaseClass {
   // CHECK:   [[CANARY_ACCESS:%.*]] = begin_access [modify] [dynamic] [[CANARY_ADDR]]
   // CHECK:   assign [[OPT_CANARY]] to [[CANARY_ACCESS]]
   // CHECK:   end_access [[CANARY_ACCESS]]
-  // CHECK:   end_borrow [[SELF]] from [[PROJ]]
+  // CHECK:   end_borrow [[SELF]]
   //
   // Now we perform the unwrap.
   // CHECK:   [[UNWRAP_FN:%.*]] = function_ref @$S21failable_initializers6unwrapyS2iKF : $@convention(thin)
@@ -639,7 +639,7 @@ class ThrowDerivedClass : ThrowBaseClass {
   // CHECK:   [[CANARY_ACCESS:%.*]] = begin_access [modify] [dynamic] [[CANARY_ADDR]]
   // CHECK:   assign [[OPT_CANARY]] to [[CANARY_ACCESS]]
   // CHECK:   end_access [[CANARY_ACCESS]]
-  // CHECK:   end_borrow [[SELF]] from [[PROJ]]
+  // CHECK:   end_borrow [[SELF]]
   //
   // Now we begin argument emission where we perform the unwrap.
   // CHECK:   [[SELF:%.*]] = load [take] [[PROJ]]

--- a/test/SILGen/lifetime.swift
+++ b/test/SILGen/lifetime.swift
@@ -409,7 +409,7 @@ class Foo<T> {
     // CHECK: [[THIS_Y_1:%.*]] = tuple_element_addr [[WRITE]] : $*(Int, Ref), 1
     // CHECK: assign [[Y_EXTRACTED_1]] to [[THIS_Y_1]]
     // CHECK: end_access [[WRITE]] : $*(Int, Ref)
-    // CHECK: end_borrow [[BORROWED_THIS]] from [[THIS]]
+    // CHECK: end_borrow [[BORROWED_THIS]]
 
     // -- Initialization for w
     // CHECK: [[Z_FUNC:%.*]] = function_ref @$S{{.*}}8lifetime3FooC1wAA3RefCvpfi : $@convention(thin) <τ_0_0> () -> @owned Ref
@@ -418,14 +418,14 @@ class Foo<T> {
     // CHECK: [[THIS_Z:%.*]] = ref_element_addr [[BORROWED_THIS]]
     // CHECK: [[WRITE:%.*]] = begin_access [modify] [dynamic] [[THIS_Z]] : $*Ref
     // CHECK: assign [[Z_RESULT]] to [[WRITE]]
-    // CHECK: end_borrow [[BORROWED_THIS]] from [[THIS]]
+    // CHECK: end_borrow [[BORROWED_THIS]]
 
     // -- Initialization for x
     // CHECK: [[BORROWED_THIS:%.*]] = begin_borrow [[THIS]]
     // CHECK: [[THIS_X:%[0-9]+]] = ref_element_addr [[BORROWED_THIS]] : {{.*}}, #Foo.x
     // CHECK: [[WRITE:%.*]] = begin_access [modify] [dynamic] [[THIS_X]] : $*Int
     // CHECK: assign {{.*}} to [[WRITE]]
-    // CHECK: end_borrow [[BORROWED_THIS]] from [[THIS]]
+    // CHECK: end_borrow [[BORROWED_THIS]]
 
     x = bar()
 
@@ -467,7 +467,7 @@ class Foo<T> {
     // CHECK:   assign {{.*}} to [[THIS_Y_1]] : $*Int
     // CHECK:   [[THIS_Y_2:%.*]] = tuple_element_addr [[WRITE]] : $*(Int, Ref), 1
     // CHECK:   assign {{.*}} to [[THIS_Y_2]] : $*Ref
-    // CHECK:   end_borrow [[BORROWED_THIS]] from [[THIS]]
+    // CHECK:   end_borrow [[BORROWED_THIS]]
 
     // -- Then we create a box that we will use to perform a copy_addr into #Foo.x a bit later.
     // CHECK:   [[CHIADDR:%[0-9]+]] = alloc_box ${ var Int }, var, name "chi"
@@ -479,7 +479,7 @@ class Foo<T> {
     // CHECK:   [[THIS_Z:%.*]] = ref_element_addr [[BORROWED_THIS]] : {{.*}}, #Foo.z
     // CHECK:   [[WRITE:%.*]] = begin_access [modify] [dynamic] [[THIS_Z]] : $*T
     // CHECK:   copy_addr [take] {{.*}} to [[WRITE]]
-    // CHECK:   end_borrow [[BORROWED_THIS]] from [[THIS]]
+    // CHECK:   end_borrow [[BORROWED_THIS]]
 
     // -- Then initialize #Foo.x using the earlier stored value of CHI to THIS_Z.
     x = chi
@@ -489,7 +489,7 @@ class Foo<T> {
     // CHECK:   [[THIS_X:%[0-9]+]] = ref_element_addr [[BORROWED_THIS]] : {{.*}}, #Foo.x
     // CHECK:   [[WRITE:%.*]] = begin_access [modify] [dynamic] [[THIS_X]] : $*Int
     // CHECK:   assign [[X]] to [[WRITE]]
-    // CHECK:   end_borrow [[BORROWED_THIS]] from [[THIS]]
+    // CHECK:   end_borrow [[BORROWED_THIS]]
 
     // -- cleanup chi
     // CHECK: destroy_value [[CHIADDR]]
@@ -546,7 +546,7 @@ class Foo<T> {
   // CHECK:   [[DESTROYING_REF:%[0-9]+]] = function_ref @$S8lifetime3FooCfd : $@convention(method) <τ_0_0> (@guaranteed Foo<τ_0_0>) -> @owned Builtin.NativeObject
   // CHECK-NEXT:   [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
   // CHECK-NEXT:   [[RESULT_SELF:%[0-9]+]] = apply [[DESTROYING_REF]]<T>([[BORROWED_SELF]]) : $@convention(method) <τ_0_0> (@guaranteed Foo<τ_0_0>) -> @owned Builtin.NativeObject
-  // CHECK-NEXT:   end_borrow [[BORROWED_SELF]] from [[SELF]]
+  // CHECK-NEXT:   end_borrow [[BORROWED_SELF]]
   // CHECK-NEXT:   end_lifetime [[SELF]]
   // CHECK-NEXT:   [[SELF:%[0-9]+]] = unchecked_ref_cast [[RESULT_SELF]] : $Builtin.NativeObject to $Foo<T>
   // CHECK-NEXT:   dealloc_ref [[SELF]] : $Foo<T>
@@ -565,7 +565,7 @@ class FooSubclass<T> : Foo<T> {
   // CHECK: [[BASE_DTOR:%[0-9]+]] = function_ref @$S8lifetime3FooCfd : $@convention(method) <τ_0_0> (@guaranteed Foo<τ_0_0>) -> @owned Builtin.NativeObject
   // CHECK: [[PTR:%.*]] = apply [[BASE_DTOR]]<T>([[BASE]])
   // CHECK: [[BORROWED_PTR:%.*]] = begin_borrow [[PTR]]
-  // CHECK: end_borrow [[BORROWED_PTR]] from [[PTR]]
+  // CHECK: end_borrow [[BORROWED_PTR]]
   // CHECK: return [[PTR]]
   
 
@@ -612,7 +612,7 @@ class ImplicitDtorDerived<T> : ImplicitDtor {
   // CHECK: [[CAST_BORROWED_PTR:%.*]] = unchecked_ref_cast [[BORROWED_PTR]] : $Builtin.NativeObject to $ImplicitDtorDerived<T>
   // CHECK: [[ZADDR:%[0-9]+]] = ref_element_addr [[CAST_BORROWED_PTR]] : {{.*}}, #ImplicitDtorDerived.z
   // CHECK: destroy_addr [[ZADDR]]
-  // CHECK: end_borrow [[BORROWED_PTR]] from [[PTR]]
+  // CHECK: end_borrow [[BORROWED_PTR]]
   // -- epilog
   // CHECK-NOT: unchecked_ref_cast
   // CHECK-NOT: unchecked_ownership_conversion

--- a/test/SILGen/local_recursion.swift
+++ b/test/SILGen/local_recursion.swift
@@ -22,7 +22,7 @@ func local_recursion(_ x: Int, y: Int) {
   // CHECK: apply [[B]]([[Y]])
   // CHECK: end_borrow [[B]]
   // CHECK: destroy_value [[CLOSURE_COPY]]
-  // CHECK: end_borrow [[BORROWED_CLOSURE]] from [[CLOSURE]]
+  // CHECK: end_borrow [[BORROWED_CLOSURE]]
   sr(y)
 
   func mutually_recursive_1(_ a: Int) {
@@ -59,7 +59,7 @@ func local_recursion(_ x: Int, y: Int) {
   // CHECK: apply [[B]]([[X]])
   // CHECK: end_borrow [[B]]
   // CHECK: destroy_value [[CLOSURE_COPY]]
-  // CHECK: end_borrow [[BORROWED_CLOSURE]] from [[CLOSURE]]
+  // CHECK: end_borrow [[BORROWED_CLOSURE]]
   tc(x)
 
   // CHECK: [[CLOSURE_REF:%.*]] = function_ref @$S15local_recursionAA_1yySi_SitFySiXEfU_
@@ -77,7 +77,7 @@ func local_recursion(_ x: Int, y: Int) {
   // CHECK: apply [[B]]([[X]])
   // CHECK: end_borrow [[B]]
   // CHECK: destroy_value [[CLOSURE_COPY]]
-  // CHECK: end_borrow [[BORROWED_CLOSURE]] from [[CLOSURE]]
+  // CHECK: end_borrow [[BORROWED_CLOSURE]]
   let f: (Int) -> () = {
     self_recursive($0)
     transitive_capture_2($0)

--- a/test/SILGen/modify.swift
+++ b/test/SILGen/modify.swift
@@ -80,7 +80,7 @@ extension Derived : Abstractable {}
 // CHECK-NEXT: dealloc_stack [[SUB_ADDR]]
 // CHECK-NEXT: end_apply [[TOKEN]]
 // CHECK-NEXT: tuple ()
-// CHECK-NEXT: end_borrow [[T0]] from %0
+// CHECK-NEXT: end_borrow [[T0]]
 // CHECK-NEXT: return
 
 // CHECK-LABEL: sil private [transparent] [thunk] @$S6modify7DerivedCAA12AbstractableA2aDP19finalStoredFunction6ResultQzycvMTW
@@ -106,7 +106,7 @@ extension Derived : Abstractable {}
 // CHECK-NEXT: dealloc_stack [[SUB_ADDR]]
 // CHECK-NEXT: end_apply [[TOKEN]]
 // CHECK-NEXT: tuple ()
-// CHECK-NEXT: end_borrow [[T0]] from %0
+// CHECK-NEXT: end_borrow [[T0]]
 // CHECK-NEXT: return
 
 // CHECK-LABEL: sil private [transparent] [thunk] @$S6modify7DerivedCAA12AbstractableA2aDP14staticFunction6ResultQzycvMZTW

--- a/test/SILGen/modify_accessor.swift
+++ b/test/SILGen/modify_accessor.swift
@@ -68,7 +68,7 @@ class SetterSynthesisFromModify {
 // CHECK-NEXT:    ([[FIELD:%.*]], [[TOKEN:%.*]]) = begin_apply [[MODIFYFN]](%1)
 // CHECK-NEXT:    assign [[VALUE]] to [[FIELD]] : $*String
 // CHECK-NEXT:    end_apply [[TOKEN]]
-// CHECK-NEXT:    end_borrow [[VALUE_BORROW]] from %0 : $String
+// CHECK-NEXT:    end_borrow [[VALUE_BORROW]]
 // CHECK-NEXT:    destroy_value %0 : $String
 // CHECK-NEXT:    [[RET:%.*]] = tuple ()
 // CHECK-NEXT:    return [[RET]] : $()

--- a/test/SILGen/nested_generics.swift
+++ b/test/SILGen/nested_generics.swift
@@ -232,7 +232,7 @@ class SubclassOfInner<T, U> : OuterRing<T>.InnerRing<U> {
 // CHECK:   [[METHOD:%[0-9]+]] = class_method [[SELF_COPY_VAL]] : $OuterRing<τ_0_0>.InnerRing<τ_1_0>, #OuterRing.InnerRing.method!1 : <T><U><V> (OuterRing<T>.InnerRing<U>) -> (T, U, V) -> (T, U, V), $@convention(method) <τ_0_0><τ_1_0><τ_2_0> (@in_guaranteed τ_0_0, @in_guaranteed τ_1_0, @in_guaranteed τ_2_0, @guaranteed OuterRing<τ_0_0>.InnerRing<τ_1_0>) -> (@out τ_0_0, @out τ_1_0, @out τ_2_0)
 // CHECK:   apply [[METHOD]]<τ_0_0, τ_1_0, τ_2_0>([[T]], [[U]], [[V]], [[TOut]], [[UOut]], [[VOut]], [[SELF_COPY_VAL]]) : $@convention(method) <τ_0_0><τ_1_0><τ_2_0> (@in_guaranteed τ_0_0, @in_guaranteed τ_1_0, @in_guaranteed τ_2_0, @guaranteed OuterRing<τ_0_0>.InnerRing<τ_1_0>) -> (@out τ_0_0, @out τ_1_0, @out τ_2_0)
 // CHECK:   [[RESULT:%[0-9]+]] = tuple ()
-// CHECK:   end_borrow [[SELF_COPY_VAL]] from [[SELF]]
+// CHECK:   end_borrow [[SELF_COPY_VAL]]
 // CHECK:   return [[RESULT]] : $()
 
 // CHECK: sil_witness_table hidden <Spices> Deli<Spices>.Pepperoni: CuredMeat module nested_generics {

--- a/test/SILGen/newtype.swift
+++ b/test/SILGen/newtype.swift
@@ -29,8 +29,8 @@ func createErrorDomain(str: String) -> ErrorDomain {
 // CHECK-RAW: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB_BOX]]
 // CHECK-RAW: [[RAWVALUE_ADDR:%[0-9]+]] = struct_element_addr [[WRITE]]
 // CHECK-RAW: assign [[BRIDGED]] to [[RAWVALUE_ADDR]]
-// CHECK-RAW: end_borrow [[BORROWED_COPIED_STR]] from [[COPIED_STR]]
-// CHECK-RAW: end_borrow [[BORROWED_STR]] from [[STR]]
+// CHECK-RAW: end_borrow [[BORROWED_COPIED_STR]]
+// CHECK-RAW: end_borrow [[BORROWED_STR]]
 
 func getRawValue(ed: ErrorDomain) -> String {
   return ed.rawValue

--- a/test/SILGen/objc_blocks_bridging.swift
+++ b/test/SILGen/objc_blocks_bridging.swift
@@ -19,7 +19,7 @@ import Foundation
   // CHECK:         [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
   // CHECK:         [[NATIVE:%.*]] = function_ref @$S20objc_blocks_bridging3FooC3foo{{[_0-9a-zA-Z]*}}F : $@convention(method) (@noescape @callee_guaranteed (Int) -> Int, Int, @guaranteed Foo) -> Int
   // CHECK:         apply [[NATIVE]]([[CONVERT]], {{.*}}, [[BORROWED_SELF_COPY]])
-  // CHECK:         end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+  // CHECK:         end_borrow [[BORROWED_SELF_COPY]]
   // CHECK: } // end sil function '$S20objc_blocks_bridging3FooC3foo_1xS3iXE_SitFTo'
   @objc dynamic func foo(_ f: (Int) -> Int, x: Int) -> Int {
     return f(x)
@@ -36,7 +36,7 @@ import Foundation
   // CHECK:         [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
   // CHECK:         [[NATIVE:%.*]] = function_ref @$S20objc_blocks_bridging3FooC3bar{{[_0-9a-zA-Z]*}}F : $@convention(method) (@noescape @callee_guaranteed (@guaranteed String) -> @owned String, @guaranteed String, @guaranteed Foo) -> @owned String
   // CHECK:         apply [[NATIVE]]([[CONVERT]], {{%.*}}, [[BORROWED_SELF_COPY]])
-  // CHECK:         end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+  // CHECK:         end_borrow [[BORROWED_SELF_COPY]]
   // CHECK: } // end sil function '$S20objc_blocks_bridging3FooC3bar_1xS3SXE_SStFTo'
   @objc dynamic func bar(_ f: (String) -> String, x: String) -> String {
     return f(x)
@@ -60,7 +60,7 @@ import Foundation
   // CHECK:         [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
   // CHECK:         [[NATIVE:%.*]] = function_ref @$S20objc_blocks_bridging3FooC3bas{{[_0-9a-zA-Z]*}}F : $@convention(method) (@noescape @callee_guaranteed (@guaranteed Optional<String>) -> @owned Optional<String>, @guaranteed Optional<String>, @guaranteed Foo) -> @owned Optional<String>
   // CHECK:         apply [[NATIVE]]([[CONVERT]], {{%.*}}, [[BORROWED_SELF_COPY]])
-  // CHECK:         end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+  // CHECK:         end_borrow [[BORROWED_SELF_COPY]]
   @objc dynamic func bas(_ f: (String?) -> String?, x: String?) -> String? {
     return f(x)
   }
@@ -71,7 +71,7 @@ import Foundation
   // CHECK:         [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
   // CHECK:         [[NATIVE:%.*]] = function_ref @$S20objc_blocks_bridging3FooC16cFunctionPointer{{[_0-9a-zA-Z]*}}F
   // CHECK:         apply [[NATIVE]]([[F]], [[X]], [[BORROWED_SELF_COPY]])
-  // CHECK:         end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+  // CHECK:         end_borrow [[BORROWED_SELF_COPY]]
   // CHECK:         destroy_value [[SELF_COPY]]
   @objc dynamic func cFunctionPointer(_ fp: @convention(c) (Int) -> Int, x: Int) -> Int {
     _ = fp(x)

--- a/test/SILGen/objc_bridging.swift
+++ b/test/SILGen/objc_bridging.swift
@@ -235,7 +235,7 @@ func callSetBar(_ s: String) {
 // CHECK:   [[BORROWED_NATIVE:%.*]] = begin_borrow [[NATIVE]]
 // CHECK:   [[BRIDGED:%.*]] = apply [[STRING_TO_NSSTRING]]([[BORROWED_NATIVE]])
 // CHECK:   [[OPT_BRIDGED:%.*]] = enum $Optional<NSString>, #Optional.some!enumelt.1, [[BRIDGED]]
-// CHECK:   end_borrow [[BORROWED_NATIVE]] from [[NATIVE]]
+// CHECK:   end_borrow [[BORROWED_NATIVE]]
 // CHECK:   [[SET_BAR:%.*]] = function_ref @setBar
 // CHECK:   apply [[SET_BAR]]([[OPT_BRIDGED]])
 // CHECK:   destroy_value [[OPT_BRIDGED]]
@@ -282,12 +282,12 @@ class Bas : NSObject {
   // CHECK:   // function_ref objc_bridging.Bas.strRealProp.getter
   // CHECK:   [[PROPIMPL:%.*]] = function_ref @$S13objc_bridging3BasC11strRealPropSSvg
   // CHECK:   [[PROP_COPY:%.*]] = apply [[PROPIMPL]]([[BORROWED_THIS_COPY]]) : $@convention(method) (@guaranteed Bas) -> @owned String
-  // CHECK:   end_borrow [[BORROWED_THIS_COPY]] from [[THIS_COPY]]
+  // CHECK:   end_borrow [[BORROWED_THIS_COPY]]
   // CHECK:   destroy_value [[THIS_COPY]]
   // CHECK:   [[STRING_TO_NSSTRING:%.*]] = function_ref @$SSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF
   // CHECK:   [[BORROWED_PROP_COPY:%.*]] = begin_borrow [[PROP_COPY]]
   // CHECK:   [[NSSTR:%.*]] = apply [[STRING_TO_NSSTRING]]([[BORROWED_PROP_COPY]])
-  // CHECK:   end_borrow [[BORROWED_PROP_COPY]] from [[PROP_COPY]]
+  // CHECK:   end_borrow [[BORROWED_PROP_COPY]]
   // CHECK:   destroy_value [[PROP_COPY]]
   // CHECK:   return [[NSSTR]]
   // CHECK: }
@@ -310,7 +310,7 @@ class Bas : NSObject {
   // CHECK:   [[BORROWED_THIS_COPY:%.*]] = begin_borrow [[THIS_COPY]]
   // CHECK:   [[SETIMPL:%.*]] = function_ref @$S13objc_bridging3BasC11strRealPropSSvs
   // CHECK:   apply [[SETIMPL]]([[STR]], [[BORROWED_THIS_COPY]])
-  // CHECK:   end_borrow [[BORROWED_THIS_COPY]] from [[THIS_COPY]]
+  // CHECK:   end_borrow [[BORROWED_THIS_COPY]]
   // CHECK:   destroy_value [[THIS_COPY]]
   // CHECK: } // end sil function '$S13objc_bridging3BasC11strRealPropSSvsTo'
 
@@ -332,12 +332,12 @@ class Bas : NSObject {
   // CHECK:   [[BORROWED_THIS_COPY:%.*]] = begin_borrow [[THIS_COPY]]
   // CHECK:   [[GETTER:%.*]] = function_ref @$S13objc_bridging3BasC11strFakePropSSvg
   // CHECK:   [[STR:%.*]] = apply [[GETTER]]([[BORROWED_THIS_COPY]])
-  // CHECK:   end_borrow [[BORROWED_THIS_COPY]] from [[THIS_COPY]]
+  // CHECK:   end_borrow [[BORROWED_THIS_COPY]]
   // CHECK:   destroy_value [[THIS_COPY]]
   // CHECK:   [[STRING_TO_NSSTRING:%.*]] = function_ref @$SSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF
   // CHECK:   [[BORROWED_STR:%.*]] = begin_borrow [[STR]]
   // CHECK:   [[NSSTR:%.*]] = apply [[STRING_TO_NSSTRING]]([[BORROWED_STR]])
-  // CHECK:   end_borrow [[BORROWED_STR]] from [[STR]]
+  // CHECK:   end_borrow [[BORROWED_STR]]
   // CHECK:   destroy_value [[STR]]
   // CHECK:   return [[NSSTR]]
   // CHECK: }
@@ -352,7 +352,7 @@ class Bas : NSObject {
   // CHECK:   [[BORROWED_THIS_COPY:%.*]] = begin_borrow [[THIS_COPY]]
   // CHECK:   [[SETTER:%.*]] = function_ref @$S13objc_bridging3BasC11strFakePropSSvs
   // CHECK:   apply [[SETTER]]([[STR]], [[BORROWED_THIS_COPY]])
-  // CHECK:   end_borrow [[BORROWED_THIS_COPY]] from [[THIS_COPY]]
+  // CHECK:   end_borrow [[BORROWED_THIS_COPY]]
   // CHECK:   destroy_value [[THIS_COPY]]
   // CHECK: } // end sil function '$S13objc_bridging3BasC11strFakePropSSvsTo'
 
@@ -380,12 +380,12 @@ class Bas : NSObject {
   // CHECK:   [[BORROWED_THIS_COPY:%.*]] = begin_borrow [[THIS_COPY]]
   // CHECK:   [[METHOD:%.*]] = function_ref @$S13objc_bridging3BasC9strResultSSyF
   // CHECK:   [[STR:%.*]] = apply [[METHOD]]([[BORROWED_THIS_COPY]])
-  // CHECK:   end_borrow [[BORROWED_THIS_COPY]] from [[THIS_COPY]]
+  // CHECK:   end_borrow [[BORROWED_THIS_COPY]]
   // CHECK:   destroy_value [[THIS_COPY]]
   // CHECK:   [[STRING_TO_NSSTRING:%.*]] = function_ref @$SSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF
   // CHECK:   [[BORROWED_STR:%.*]] = begin_borrow [[STR]]
   // CHECK:   [[NSSTR:%.*]] = apply [[STRING_TO_NSSTRING]]([[BORROWED_STR]])
-  // CHECK:   end_borrow [[BORROWED_STR]] from [[STR]]
+  // CHECK:   end_borrow [[BORROWED_STR]]
   // CHECK:   destroy_value [[STR]]
   // CHECK:   return [[NSSTR]]
   // CHECK: }
@@ -401,7 +401,7 @@ class Bas : NSObject {
   // CHECK:   [[BORROWED_THIS_COPY:%.*]] = begin_borrow [[THIS_COPY]]
   // CHECK:   [[METHOD:%.*]] = function_ref @$S13objc_bridging3BasC6strArgyySSF
   // CHECK:   apply [[METHOD]]([[BORROWED_STR]], [[BORROWED_THIS_COPY]])
-  // CHECK:   end_borrow [[BORROWED_THIS_COPY]] from [[THIS_COPY]]
+  // CHECK:   end_borrow [[BORROWED_THIS_COPY]]
   // CHECK:   destroy_value [[THIS_COPY]]
   // CHECK: } // end sil function '$S13objc_bridging3BasC6strArgyySSFTo'
 
@@ -434,7 +434,7 @@ class Bas : NSObject {
   // CHECK:   [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
   // CHECK:   [[SWIFT_FN:%[0-9]+]] = function_ref @$S13objc_bridging3BasC8arrayArgyySayyXlGF : $@convention(method) (@guaranteed Array<AnyObject>, @guaranteed Bas) -> ()
   // CHECK:   [[RESULT:%[0-9]+]] = apply [[SWIFT_FN]]([[BORROWED_ARRAY]], [[BORROWED_SELF_COPY]]) : $@convention(method) (@guaranteed Array<AnyObject>, @guaranteed Bas) -> ()
-  // CHECK:   end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+  // CHECK:   end_borrow [[BORROWED_SELF_COPY]]
   // CHECK:   destroy_value [[SELF_COPY]] : $Bas
   // CHECK:   return [[RESULT]] : $()
   @objc func arrayArg(_ array: [AnyObject]) { }
@@ -445,12 +445,12 @@ class Bas : NSObject {
   // CHECK:   [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
   // CHECK:   [[SWIFT_FN:%[0-9]+]] = function_ref @$S13objc_bridging3BasC11arrayResultSayyXlGyF : $@convention(method) (@guaranteed Bas) -> @owned Array<AnyObject>
   // CHECK:   [[ARRAY:%[0-9]+]] = apply [[SWIFT_FN]]([[BORROWED_SELF_COPY]]) : $@convention(method) (@guaranteed Bas) -> @owned Array<AnyObject>
-  // CHECK:   end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+  // CHECK:   end_borrow [[BORROWED_SELF_COPY]]
   // CHECK:   destroy_value [[SELF_COPY]]
   // CHECK:   [[CONV_FN:%[0-9]+]] = function_ref @$SSa10FoundationE19_bridgeToObjectiveCSo7NSArrayCyF
   // CHECK:   [[BORROWED_ARRAY:%.*]] = begin_borrow [[ARRAY]]
   // CHECK:   [[NSARRAY:%[0-9]+]] = apply [[CONV_FN]]<AnyObject>([[BORROWED_ARRAY]]) : $@convention(method) <τ_0_0> (@guaranteed Array<τ_0_0>) -> @owned NSArray
-  // CHECK:   end_borrow [[BORROWED_ARRAY]] from [[ARRAY]]
+  // CHECK:   end_borrow [[BORROWED_ARRAY]]
   // CHECK:   destroy_value [[ARRAY]]
   // CHECK:   return [[NSARRAY]]
   @objc func arrayResult() -> [AnyObject] { return [] }
@@ -470,7 +470,7 @@ func applyStringBlock(_ f: @convention(block) (String) -> String, x: String) -> 
   // CHECK:   [[STRING_TO_NSSTRING:%.*]] = function_ref @$SSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF
   // CHECK:   [[BORROWED_STRING_COPY:%.*]] = begin_borrow [[STRING_COPY]]
   // CHECK:   [[NSSTR:%.*]] = apply [[STRING_TO_NSSTRING]]([[BORROWED_STRING_COPY]]) : $@convention(method) (@guaranteed String)
-  // CHECK:   end_borrow [[BORROWED_STRING_COPY]] from [[STRING_COPY]]
+  // CHECK:   end_borrow [[BORROWED_STRING_COPY]]
   // CHECK:   destroy_value [[STRING_COPY]]
   // CHECK:   [[RESULT_NSSTR:%.*]] = apply [[BLOCK_COPY_COPY]]([[NSSTR]]) : $@convention(block) @noescape (NSString) -> @autoreleased NSString
   // CHECK:   destroy_value [[NSSTR]]
@@ -595,7 +595,7 @@ func updateFridgeTemp(_ home: APPHouse, delta: Double) {
   // XCHECK: [[OBJC_ARG:%[0-9]+]] = apply [[BRIDGE_TO_FN]]([[FRIDGE]])
   // XCHECK: apply [[SETTER]]([[OBJC_ARG]], [[BORROWED_HOME]]) : $@convention(objc_method) (APPRefrigerator, APPHouse) -> ()
   // XCHECK: destroy_value [[OBJC_ARG]]
-  // XCHECK: end_borrow [[BORROWED_HOME]] from [[HOME]]
+  // XCHECK: end_borrow [[BORROWED_HOME]]
   // XCHECK: destroy_value [[HOME]]
   home.fridge.temperature += delta
 }

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -44,7 +44,7 @@ func passingToId<T: CP, U>(receiver: NSIdLover,
   // CHECK:   [[BORROWED_STRING_COPY:%.*]] = begin_borrow [[STRING_COPY]]
   // CHECK:   [[BRIDGED:%.*]] = apply [[BRIDGE_STRING]]([[BORROWED_STRING_COPY]])
   // CHECK:   [[ANYOBJECT:%.*]] = init_existential_ref [[BRIDGED]] : $NSString : $NSString, $AnyObject
-  // CHECK:   end_borrow [[BORROWED_STRING_COPY]] from [[STRING_COPY]]
+  // CHECK:   end_borrow [[BORROWED_STRING_COPY]]
   // CHECK:   destroy_value [[STRING_COPY]]
   // CHECK:   [[METHOD:%.*]] = objc_method [[SELF]]
   // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
@@ -152,7 +152,7 @@ func passingToId<T: CP, U>(receiver: NSIdLover,
   // CHECK:   [[BORROWED_OPT_STRING_COPY:%.*]] = begin_borrow [[OPT_STRING_COPY]]
   // CHECK:   store_borrow [[BORROWED_OPT_STRING_COPY]] to [[TMP]]
   // CHECK:   [[ANYOBJECT:%.*]] = apply [[BRIDGE_OPTIONAL]]<String>([[TMP]])
-  // CHECK:   end_borrow [[BORROWED_OPT_STRING_COPY]] from [[OPT_STRING_COPY]]
+  // CHECK:   end_borrow [[BORROWED_OPT_STRING_COPY]]
   // CHECK:   [[METHOD:%.*]] = objc_method [[SELF]] : $NSIdLover,
   // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
   receiver.takesId(optionalA)
@@ -163,7 +163,7 @@ func passingToId<T: CP, U>(receiver: NSIdLover,
   // CHECK:   [[BORROWED_OPT_NSSTRING_COPY:%.*]] = begin_borrow [[OPT_NSSTRING_COPY]]
   // CHECK:   store_borrow [[BORROWED_OPT_NSSTRING_COPY]] to [[TMP]]
   // CHECK:   [[ANYOBJECT:%.*]] = apply [[BRIDGE_OPTIONAL]]<NSString>([[TMP]])
-  // CHECK:   end_borrow [[BORROWED_OPT_NSSTRING_COPY]] from [[OPT_NSSTRING]]
+  // CHECK:   end_borrow [[BORROWED_OPT_NSSTRING_COPY]]
   // CHECK:   [[METHOD:%.*]] = objc_method [[SELF]] : $NSIdLover,
   // CHECK:   apply [[METHOD]]([[ANYOBJECT]], [[SELF]])
   receiver.takesId(optionalB)
@@ -252,7 +252,7 @@ func passingToNullableId<T: CP, U>(receiver: NSIdLover,
   // CHECK: [[BRIDGED:%.*]] = apply [[BRIDGE_STRING]]([[BORROWED_STRING_COPY]])
   // CHECK: [[ANYOBJECT:%.*]] = init_existential_ref [[BRIDGED]] : $NSString : $NSString, $AnyObject
   // CHECK: [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[ANYOBJECT]]
-  // CHECK: end_borrow [[BORROWED_STRING_COPY]] from [[STRING_COPY]]
+  // CHECK: end_borrow [[BORROWED_STRING_COPY]]
   // CHECK: destroy_value [[STRING_COPY]]
   // CHECK: [[METHOD:%.*]] = objc_method [[SELF]]
   // CHECK: apply [[METHOD]]([[OPT_ANYOBJECT]], [[SELF]])
@@ -370,7 +370,7 @@ func passingToNullableId<T: CP, U>(receiver: NSIdLover,
   // CHECK:   [[BRIDGED:%.*]] = apply [[BRIDGE_STRING]]([[BORROWED_STRING_DATA]])
   // CHECK:   [[ANYOBJECT:%.*]] = init_existential_ref [[BRIDGED]] : $NSString : $NSString, $AnyObject
   // CHECK:   [[OPT_ANYOBJECT:%.*]] = enum {{.*}} [[ANYOBJECT]]
-  // CHECK:   end_borrow [[BORROWED_STRING_DATA]] from [[STRING_DATA]]
+  // CHECK:   end_borrow [[BORROWED_STRING_DATA]]
   // CHECK:   destroy_value [[STRING_DATA]]
   // CHECK:   br [[JOIN:bb.*]]([[OPT_ANYOBJECT]]
   //
@@ -429,7 +429,7 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK:   [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
   // CHECK:   [[NATIVE_IMP:%.*]] = function_ref @$S17objc_bridging_any12SwiftIdLoverC18methodReturningAnyypyF
   // CHECK:   apply [[NATIVE_IMP]]([[NATIVE_RESULT]], [[BORROWED_SELF_COPY]])
-  // CHECK:   end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+  // CHECK:   end_borrow [[BORROWED_SELF_COPY]]
   // CHECK:   destroy_value [[SELF_COPY]]
   // CHECK:   [[OPEN_RESULT:%.*]] = open_existential_addr immutable_access [[NATIVE_RESULT]]
 	// CHECK:   [[TMP:%.*]] = alloc_stack
@@ -469,7 +469,7 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-NEXT:  // function_ref
   // CHECK-NEXT:  [[METHOD:%.*]] = function_ref @$S17objc_bridging_any12SwiftIdLoverC017methodTakingBlockH3AnyyyyypXEF
   // CHECK-NEXT:  [[RESULT:%.*]] = apply [[METHOD]]([[THUNK_CVT]], [[BORROWED_SELF_COPY]])
-  // CHECK-NEXT:  end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+  // CHECK-NEXT:  end_borrow [[BORROWED_SELF_COPY]]
   // CHECK-NEXT:  destroy_value [[THUNK]]
   // CHECK-NEXT:  destroy_value [[SELF_COPY]]
   // CHECK-NEXT:  return [[RESULT]]
@@ -500,7 +500,7 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-NEXT:  // function_ref
   // CHECK-NEXT:  [[METHOD:%.*]] = function_ref @$S17objc_bridging_any12SwiftIdLoverC29methodReturningBlockTakingAnyyypcyF
   // CHECK-NEXT:  [[RESULT:%.*]] = apply [[METHOD:%.*]]([[BORROWED_SELF_COPY]])
-  // CHECK-NEXT:  end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+  // CHECK-NEXT:  end_borrow [[BORROWED_SELF_COPY]]
   // CHECK-NEXT:  destroy_value [[SELF_COPY]]
   // CHECK-NEXT:  [[BLOCK_STORAGE:%.*]] = alloc_stack $@block_storage @callee_guaranteed (@in_guaranteed Any) -> ()
   // CHECK-NEXT:  [[BLOCK_STORAGE_ADDR:%.*]] = project_block_storage [[BLOCK_STORAGE]]
@@ -523,7 +523,7 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-NEXT:  store [[OPENED_ANY]] to [init] [[INIT]]
   // CHECK-NEXT:  [[BORROW_FUN:%.*]] =  begin_borrow [[FUNCTION]]
   // CHECK-NEXT:  apply [[BORROW_FUN]]([[RESULT]])
-  // CHECK-NEXT:  end_borrow [[BORROW_FUN]] from [[FUNCTION]]
+  // CHECK-NEXT:  end_borrow [[BORROW_FUN]]
   // CHECK-NEXT:  [[VOID:%.*]] = tuple ()
   // CHECK-NEXT:  destroy_addr [[RESULT]]
   // CHECK-NEXT:  dealloc_stack [[RESULT]]
@@ -548,7 +548,7 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-NEXT:  // function_ref
   // CHECK-NEXT:  [[METHOD:%.*]] = function_ref @$S17objc_bridging_any12SwiftIdLoverC29methodTakingBlockReturningAnyyyypyXEF
   // CHECK-NEXT:  [[RESULT:%.*]] = apply [[METHOD]]([[THUNK_CVT]], [[BORROWED_ANY_COPY]])
-  // CHECK-NEXT:  end_borrow [[BORROWED_ANY_COPY]] from [[ANY_COPY]]
+  // CHECK-NEXT:  end_borrow [[BORROWED_ANY_COPY]]
   // CHECK-NEXT:  destroy_value [[THUNK]]
   // CHECK-NEXT:  destroy_value [[ANY_COPY]]
   // CHECK-NEXT:  return [[RESULT]]
@@ -579,7 +579,7 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-NEXT:  // function_ref
   // CHECK-NEXT:  [[METHOD:%.*]] = function_ref @$S17objc_bridging_any12SwiftIdLoverC020methodReturningBlockH3AnyypycyF
   // CHECK-NEXT:  [[FUNCTION:%.*]] = apply [[METHOD]]([[BORROWED_SELF_COPY]])
-  // CHECK-NEXT:  end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+  // CHECK-NEXT:  end_borrow [[BORROWED_SELF_COPY]]
   // CHECK-NEXT:  destroy_value [[SELF_COPY]]
   // CHECK-NEXT:  [[BLOCK_STORAGE:%.*]] = alloc_stack $@block_storage @callee_guaranteed () -> @out Any
   // CHECK-NEXT:  [[BLOCK_STORAGE_ADDR:%.*]] = project_block_storage [[BLOCK_STORAGE]]
@@ -599,7 +599,7 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-NEXT:  [[RESULT:%.*]] = alloc_stack $Any
   // CHECK-NEXT:  [[BORROW_FUN:%.*]] = begin_borrow [[FUNCTION]]
   // CHECK-NEXT:  apply [[BORROW_FUN]]([[RESULT]])
-  // CHECK-NEXT:  end_borrow [[BORROW_FUN]] from [[FUNCTION]]
+  // CHECK-NEXT:  end_borrow [[BORROW_FUN]]
   // CHECK-NEXT:  [[OPENED:%.*]] = open_existential_addr immutable_access [[RESULT]] : $*Any to $*[[OPENED_TYPE:@opened.*Any]],
   // CHECK:       [[TMP:%.*]] = alloc_stack $[[OPENED_TYPE]]
   // CHECK:       copy_addr [[OPENED]] to [initialization] [[TMP]]

--- a/test/SILGen/objc_currying.swift
+++ b/test/SILGen/objc_currying.swift
@@ -66,7 +66,7 @@ func curry_bridged(_ x: CurryTest) -> (String?) -> String? {
 // CHECK:   [[BORROWED_STRING:%.*]] = begin_borrow [[STRING]]
 // CHECK:   [[NSSTRING:%.*]] = apply [[BRIDGING_FUNC]]([[BORROWED_STRING]])
 // CHECK:   [[OPT_NSSTRING:%.*]] = enum $Optional<NSString>, #Optional.some!enumelt.1, [[NSSTRING]] : $NSString
-// CHECK:   end_borrow [[BORROWED_STRING]] from [[STRING]]
+// CHECK:   end_borrow [[BORROWED_STRING]]
 // CHECK:   destroy_value [[STRING]]
 // CHECK:   br bb3([[OPT_NSSTRING]] : $Optional<NSString>)
 

--- a/test/SILGen/objc_dealloc.swift
+++ b/test/SILGen/objc_dealloc.swift
@@ -27,7 +27,7 @@ class SwiftGizmo : Gizmo {
     // CHECK-NEXT:   [[BORROWED_UPCAST_SELF:%.*]] = begin_borrow [[UPCAST_SELF]]
     // CHECK-NEXT:   [[DOWNCAST_BORROWED_UPCAST_SELF:%.*]] = unchecked_ref_cast [[BORROWED_UPCAST_SELF]] : $Gizmo to $SwiftGizmo
     // CHECK-NEXT:   objc_super_method [[DOWNCAST_BORROWED_UPCAST_SELF]] : $SwiftGizmo
-    // CHECK-NEXT:   end_borrow [[BORROWED_UPCAST_SELF]] from [[UPCAST_SELF]]
+    // CHECK-NEXT:   end_borrow [[BORROWED_UPCAST_SELF]]
     // CHECK:   return
     super.init()
   }
@@ -73,7 +73,7 @@ class SwiftGizmo : Gizmo {
   // CHECK-NEXT:   [[WRITE:%.*]] = begin_access [modify] [dynamic] [[X]] : $*X
   // CHECK-NEXT:   assign [[XOBJ]] to [[WRITE]] : $*X
   // CHECK-NEXT:   end_access [[WRITE]] : $*X
-  // CHECK-NEXT:   end_borrow [[BORROWED_SELF]] from [[SELF]]
+  // CHECK-NEXT:   end_borrow [[BORROWED_SELF]]
   // CHECK-NEXT:   return [[SELF]] : $SwiftGizmo
 
   // Objective-C IVar destroyer (i.e., -.cxx_destruct)
@@ -83,7 +83,7 @@ class SwiftGizmo : Gizmo {
   // CHECK-NEXT: [[SELF_BORROW:%.*]] = begin_borrow [[SELF]]
   // CHECK-NEXT: [[X:%[0-9]+]] = ref_element_addr [[SELF_BORROW]] : $SwiftGizmo, #SwiftGizmo.x
   // CHECK-NEXT: destroy_addr [[X]] : $*X
-  // CHECK-NEXT: end_borrow [[SELF_BORROW]] from [[SELF]]
+  // CHECK-NEXT: end_borrow [[SELF_BORROW]]
   // CHECK-NEXT: [[RESULT:%[0-9]+]] = tuple ()
   // CHECK-NEXT: return [[RESULT]] : $()
 }

--- a/test/SILGen/objc_dictionary_bridging.swift
+++ b/test/SILGen/objc_dictionary_bridging.swift
@@ -24,7 +24,7 @@ import gizmo
     // CHECK:   [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
     // CHECK:   [[SWIFT_FN:%[0-9]+]] = function_ref @$S24objc_dictionary_bridging3FooC23bridge_Dictionary_param{{[_0-9a-zA-Z]*}}F
     // CHECK:   [[RESULT:%[0-9]+]] = apply [[SWIFT_FN]]([[BORROWED_DICT]], [[BORROWED_SELF_COPY]]) : $@convention(method) (@guaranteed Dictionary<Foo, Foo>, @guaranteed Foo) -> ()
-    // CHECK:   end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+    // CHECK:   end_borrow [[BORROWED_SELF_COPY]]
     // CHECK:   destroy_value [[SELF_COPY]]
     // CHECK:   return [[RESULT]] : $()
   }
@@ -38,13 +38,13 @@ import gizmo
     // CHECK:   [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
     // CHECK:   [[SWIFT_FN:%[0-9]+]] = function_ref @$S24objc_dictionary_bridging3FooC24bridge_Dictionary_result{{[_0-9a-zA-Z]*}}F : $@convention(method) (@guaranteed Foo) -> @owned Dictionary<Foo, Foo>
     // CHECK:   [[DICT:%[0-9]+]] = apply [[SWIFT_FN]]([[BORROWED_SELF_COPY]]) : $@convention(method) (@guaranteed Foo) -> @owned Dictionary<Foo, Foo>
-    // CHECK:   end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+    // CHECK:   end_borrow [[BORROWED_SELF_COPY]]
     // CHECK:   destroy_value [[SELF_COPY]]
 
     // CHECK:   [[CONVERTER:%[0-9]+]] = function_ref @$SSD10FoundationE19_bridgeToObjectiveCSo12NSDictionaryCyF
     // CHECK:   [[BORROWED_DICT:%.*]] = begin_borrow [[DICT]]
     // CHECK:   [[NSDICT:%[0-9]+]] = apply [[CONVERTER]]<Foo, Foo>([[BORROWED_DICT]]) : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned NSDictionary
-    // CHECK:   end_borrow [[BORROWED_DICT]] from [[DICT]]
+    // CHECK:   end_borrow [[BORROWED_DICT]]
     // CHECK:   destroy_value [[DICT]]
     // CHECK:   return [[NSDICT]] : $NSDictionary
   }
@@ -60,12 +60,12 @@ import gizmo
   // CHECK:   [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
   // CHECK:   [[GETTER:%[0-9]+]] = function_ref @$S24objc_dictionary_bridging3FooC8propertySDyA2CSo8NSObjectCSH10Foundationg_Gvg : $@convention(method) (@guaranteed Foo) -> @owned Dictionary<Foo, Foo>
   // CHECK:   [[DICT:%[0-9]+]] = apply [[GETTER]]([[BORROWED_SELF_COPY]]) : $@convention(method) (@guaranteed Foo) -> @owned Dictionary<Foo, Foo>
-  // CHECK:   end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+  // CHECK:   end_borrow [[BORROWED_SELF_COPY]]
   // CHECK:   destroy_value [[SELF_COPY]]
   // CHECK:   [[CONVERTER:%[0-9]+]] = function_ref @$SSD10FoundationE19_bridgeToObjectiveCSo12NSDictionaryCyF
   // CHECK:   [[BORROWED_DICT:%.*]] = begin_borrow [[DICT]]
   // CHECK:   [[NSDICT:%[0-9]+]] = apply [[CONVERTER]]<Foo, Foo>([[BORROWED_DICT]]) : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned NSDictionary
-  // CHECK:   end_borrow [[BORROWED_DICT]] from [[DICT]]
+  // CHECK:   end_borrow [[BORROWED_DICT]]
   // CHECK:   destroy_value [[DICT]]
   // CHECK:   return [[NSDICT]] : $NSDictionary
   // CHECK: } // end sil function
@@ -83,7 +83,7 @@ import gizmo
   // CHECK:   [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
   // CHECK:   [[SETTER:%[0-9]+]] = function_ref @$S24objc_dictionary_bridging3FooC8propertySDyA2CSo8NSObjectCSH10Foundationg_Gvs : $@convention(method) (@owned Dictionary<Foo, Foo>, @guaranteed Foo) -> ()
   // CHECK:   [[RESULT:%[0-9]+]] = apply [[SETTER]]([[DICT]], [[BORROWED_SELF_COPY]]) : $@convention(method) (@owned Dictionary<Foo, Foo>, @guaranteed Foo) -> ()
-  // CHECK:   end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+  // CHECK:   end_borrow [[BORROWED_SELF_COPY]]
   // CHECK:   destroy_value [[SELF_COPY]]
   // CHECK:   return [[RESULT]] : $()
 

--- a/test/SILGen/objc_error.swift
+++ b/test/SILGen/objc_error.swift
@@ -115,7 +115,7 @@ class MyNSError : NSError {
 // CHECK:   [[EXISTENTIAL_REF:%.*]] = init_existential_ref [[UPCAST]]
 // CHECK:   [[BORROWED_EXISTENTIAL_REF:%.*]] = begin_borrow [[EXISTENTIAL_REF]]
 // CHECK:   [[COPY_BORROWED_EXISTENTIAL_REF:%.*]] = copy_value [[BORROWED_EXISTENTIAL_REF]]
-// CHECK:   end_borrow [[BORROWED_EXISTENTIAL_REF]] from [[EXISTENTIAL_REF]]
+// CHECK:   end_borrow [[BORROWED_EXISTENTIAL_REF]]
 // CHECK:   destroy_value [[EXISTENTIAL_REF]]
 // CHECK:   return [[COPY_BORROWED_EXISTENTIAL_REF]]
 // CHECK: } // end sil function '$S10objc_error14eraseMyNSError{{[_0-9a-zA-Z]*}}F'

--- a/test/SILGen/objc_extensions.swift
+++ b/test/SILGen/objc_extensions.swift
@@ -22,7 +22,7 @@ extension Sub {
     // CHECK: [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
     // CHECK: [[GETTER_FUNC:%.*]] = function_ref @$S15objc_extensions3SubC4propSSSgvg : $@convention(method) (@guaranteed Sub) -> @owned Optional<String>
     // CHECK: apply [[GETTER_FUNC]]([[BORROWED_SELF_COPY]])
-    // CHECK: end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+    // CHECK: end_borrow [[BORROWED_SELF_COPY]]
     // CHECK: destroy_value [[SELF_COPY]]
     // CHECK: } // end sil function '$S15objc_extensions3SubC4propSSSgvgTo'
 
@@ -53,7 +53,7 @@ extension Sub {
     // CHECK:   [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
     // CHECK:   [[NORMAL_FUNC:%.*]] = function_ref @$S15objc_extensions3SubC4propSSSgvs : $@convention(method) (@owned Optional<String>, @guaranteed Sub) -> ()
     // CHECK:   apply [[NORMAL_FUNC]]([[BRIDGED_NEW_VALUE]], [[BORROWED_SELF_COPY]])
-    // CHECK:   end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+    // CHECK:   end_borrow [[BORROWED_SELF_COPY]]
     // CHECK:   destroy_value [[SELF_COPY]]
     // CHECK: } // end sil function '$S15objc_extensions3SubC4propSSSgvsTo'
 
@@ -68,7 +68,7 @@ extension Sub {
     // CHECK:   [[BORROWED_UPCAST_SELF_COPY:%.*]] = begin_borrow [[UPCAST_SELF_COPY]]
     // CHECK:   [[CAST_BACK:%.*]] = unchecked_ref_cast [[BORROWED_UPCAST_SELF_COPY]] : $Base to $Sub
     // CHECK:   [[GET_SUPER_METHOD:%.*]] = objc_super_method [[CAST_BACK]] : $Sub, #Base.prop!getter.1.foreign : (Base) -> () -> String?, $@convention(objc_method) (Base) -> @autoreleased Optional<NSString>
-    // CHECK:   end_borrow [[BORROWED_UPCAST_SELF_COPY]] from [[UPCAST_SELF_COPY]]
+    // CHECK:   end_borrow [[BORROWED_UPCAST_SELF_COPY]]
     // CHECK:   [[OLD_NSSTRING:%.*]] = apply [[GET_SUPER_METHOD]]([[UPCAST_SELF_COPY]])
 
     // CHECK: bb3([[OLD_NSSTRING_BRIDGED:%.*]] : @owned $Optional<String>):
@@ -93,7 +93,7 @@ extension Sub {
     // This is an identity cast that should be eliminated by SILGen peepholes.
     // CHECK:    [[DIDSET_NOTIFIER:%.*]] = function_ref @$S15objc_extensions3SubC4propSSSgvW : $@convention(method) (@guaranteed Optional<String>, @guaranteed Sub) -> ()
     // CHECK:    apply [[DIDSET_NOTIFIER]]([[BORROWED_OLD_NSSTRING_BRIDGED]], [[SELF]])
-    // CHECK:    end_borrow [[BORROWED_OLD_NSSTRING_BRIDGED]] from [[OLD_NSSTRING_BRIDGED]]
+    // CHECK:    end_borrow [[BORROWED_OLD_NSSTRING_BRIDGED]]
     // CHECK:    destroy_value [[OLD_NSSTRING_BRIDGED]]
     // CHECK:    destroy_value [[NEW_VALUE]]
     // CHECK: } // end sil function '$S15objc_extensions3SubC4propSSSgvs'
@@ -142,7 +142,7 @@ class SubSub : Sub {
   // CHECK:   [[BORROWED_UPCAST_SELF_COPY:%.*]] = begin_borrow [[UPCAST_SELF_COPY]]
   // CHECK:   [[DOWNCAST:%.*]] = unchecked_ref_cast [[BORROWED_UPCAST_SELF_COPY]] : $Sub to $SubSub
   // CHECK:   objc_super_method [[DOWNCAST]] : $SubSub, #Sub.objCBaseMethod!1.foreign : (Sub) -> () -> (), $@convention(objc_method) (Sub) -> ()
-  // CHECK:   end_borrow [[BORROWED_UPCAST_SELF_COPY]] from [[UPCAST_SELF_COPY]]
+  // CHECK:   end_borrow [[BORROWED_UPCAST_SELF_COPY]]
   // CHECK: } // end sil function '$S15objc_extensions03SubC0C14objCBaseMethodyyF'
   override func objCBaseMethod() {
     super.objCBaseMethod()
@@ -157,14 +157,14 @@ extension SubSub {
   // CHECK:   [[BORROWED_UPCAST_SELF_COPY_1:%.*]] = begin_borrow [[UPCAST_SELF_COPY_1]]
   // CHECK:   [[DOWNCAST_BORROWED_UPCAST_SELF_COPY_1:%.*]] = unchecked_ref_cast [[BORROWED_UPCAST_SELF_COPY_1]] : $Sub to $SubSub
   // CHECK:   = objc_super_method [[DOWNCAST_BORROWED_UPCAST_SELF_COPY_1]] : $SubSub, #Sub.otherProp!getter.1.foreign
-  // CHECK:   end_borrow [[BORROWED_UPCAST_SELF_COPY_1]] from [[UPCAST_SELF_COPY_1]]
+  // CHECK:   end_borrow [[BORROWED_UPCAST_SELF_COPY_1]]
 
   // CHECK:   [[SELF_COPY_2:%.*]] = copy_value [[SELF]]
   // CHECK:   [[UPCAST_SELF_COPY_2:%.*]] = upcast [[SELF_COPY_2]] : $SubSub to $Sub
   // CHECK:   [[BORROWED_UPCAST_SELF_COPY_2:%.*]] = begin_borrow [[UPCAST_SELF_COPY_2]]
   // CHECK:   [[DOWNCAST_BORROWED_UPCAST_SELF_COPY_2:%.*]] = unchecked_ref_cast [[BORROWED_UPCAST_SELF_COPY_2]] : $Sub to $SubSub
   // CHECK:   = objc_super_method [[DOWNCAST_BORROWED_UPCAST_SELF_COPY_2]] : $SubSub, #Sub.otherProp!setter.1.foreign
-  // CHECK:   end_borrow [[BORROWED_UPCAST_SELF_COPY_2]] from [[UPCAST_SELF_COPY_2]]
+  // CHECK:   end_borrow [[BORROWED_UPCAST_SELF_COPY_2]]
   // CHECK: } // end sil function '$S15objc_extensions03SubC0C9otherPropSSvs'
   @objc override var otherProp: String {
     didSet {

--- a/test/SILGen/objc_factory_init.swift
+++ b/test/SILGen/objc_factory_init.swift
@@ -29,7 +29,7 @@ extension Hive {
   // CHECK:   store [[OLD_HIVE]] to [init] [[PB_BOX]]
   // CHECK:   [[BORROWED_SELF:%.*]] = load_borrow [[PB_BOX]]
   // CHECK:   [[META:%[0-9]+]] = value_metatype $@thick Hive.Type, [[BORROWED_SELF]] : $Hive
-  // CHECK:   end_borrow [[BORROWED_SELF]] from [[PB_BOX]]
+  // CHECK:   end_borrow [[BORROWED_SELF]]
   // CHECK:   [[OBJC_META:%[0-9]+]] = thick_to_objc_metatype [[META]] : $@thick Hive.Type to $@objc_metatype Hive.Type
   // CHECK:   [[BORROWED_QUEEN:%.*]] = begin_borrow [[QUEEN]]
   // CHECK:   [[COPIED_BORROWED_QUEEN:%.*]] = copy_value [[BORROWED_QUEEN]]
@@ -37,7 +37,7 @@ extension Hive {
   // CHECK:   [[FACTORY:%[0-9]+]] = objc_method [[OBJC_META]] : $@objc_metatype Hive.Type, #Hive.init!allocator.1.foreign : (Hive.Type) -> (Bee?) -> Hive?, $@convention(objc_method) (Optional<Bee>, @objc_metatype Hive.Type) -> @autoreleased Optional<Hive>
   // CHECK:   [[NEW_HIVE:%.*]] = apply [[FACTORY]]([[OPT_COPIED_BORROWED_QUEEN]], [[OBJC_META]]) : $@convention(objc_method) (Optional<Bee>, @objc_metatype Hive.Type) -> @autoreleased Optional<Hive>
   // CHECK:   destroy_value [[OPT_COPIED_BORROWED_QUEEN]]
-  // CHECK:   end_borrow [[BORROWED_QUEEN]] from [[QUEEN]]
+  // CHECK:   end_borrow [[BORROWED_QUEEN]]
   // CHECK:   switch_enum [[NEW_HIVE]] : $Optional<Hive>, case #Optional.some!enumelt.1: [[SOME_BB:bb[0-9]+]]
   //
   // CHECK: [[SOME_BB]]([[NEW_HIVE:%.*]] : @owned $Hive):
@@ -87,7 +87,7 @@ class SubHive : Hive {
   // CHECK:   [[BORROWED_SELF:%.*]] = load_borrow [[PB_BOX]]
   // CHECK:   [[UPCAST_BORROWED_SELF:%.*]] = upcast [[BORROWED_SELF]] : $SubHive to $Hive
   // CHECK:   [[METATYPE:%.*]] = value_metatype $@thick Hive.Type, [[UPCAST_BORROWED_SELF:%.*]]
-  // CHECK:   end_borrow [[BORROWED_SELF]] from [[PB_BOX]]
+  // CHECK:   end_borrow [[BORROWED_SELF]]
   // CHECK:   [[OBJC_METATYPE:%.*]] = thick_to_objc_metatype [[METATYPE]]
   // CHECK:   [[QUEEN:%.*]] = unchecked_ref_cast {{.*}} : $Bee to $Optional<Bee>
   // CHECK:   [[HIVE_INIT_FN:%.*]] = objc_method [[OBJC_METATYPE]] : $@objc_metatype Hive.Type, #Hive.init!allocator.1.foreign

--- a/test/SILGen/objc_metatypes.swift
+++ b/test/SILGen/objc_metatypes.swift
@@ -15,7 +15,7 @@ class A {
     // CHECK:   [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
     // CHECK:   [[NATIVE_FOO:%[0-9]+]] = function_ref @$S14objc_metatypes1AC3foo{{[_0-9a-zA-Z]*}}F
     // CHECK:   [[NATIVE_RESULT:%[0-9]+]] = apply [[NATIVE_FOO]]([[M_AS_THICK]], [[BORROWED_SELF_COPY]]) : $@convention(method) (@thick ObjCClass.Type, @guaranteed A) -> @thick ObjCClass.Type
-    // CHECK:   end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+    // CHECK:   end_borrow [[BORROWED_SELF_COPY]]
     // CHECK:   destroy_value [[SELF_COPY]]
     // CHECK:   [[OBJC_RESULT:%[0-9]+]] = thick_to_objc_metatype [[NATIVE_RESULT]] : $@thick ObjCClass.Type to $@objc_metatype ObjCClass.Type
     // CHECK:   return [[OBJC_RESULT]] : $@objc_metatype ObjCClass.Type

--- a/test/SILGen/objc_ownership_conventions.swift
+++ b/test/SILGen/objc_ownership_conventions.swift
@@ -174,7 +174,7 @@ func applyBlock(_ f: @convention(block) (Gizmo) -> Gizmo, x: Gizmo) -> Gizmo {
   // CHECK:       [[BLOCK_COPY_COPY:%.*]] = copy_value [[BORROWED_BLOCK_COPY]]
   // CHECK:       [[RESULT:%.*]] = apply [[BLOCK_COPY_COPY]]([[ARG]])
   // CHECK:       destroy_value [[BLOCK_COPY_COPY]]
-  // CHECK:       end_borrow [[BORROWED_BLOCK_COPY]] from [[BLOCK_COPY]]
+  // CHECK:       end_borrow [[BORROWED_BLOCK_COPY]]
   // CHECK-NOT:       destroy_value [[ARG]]
   // CHECK:       destroy_value [[BLOCK_COPY]]
   // CHECK-NOT:       destroy_value [[BLOCK]]

--- a/test/SILGen/objc_properties.swift
+++ b/test/SILGen/objc_properties.swift
@@ -42,7 +42,7 @@ class A {
     // CHECK: [[WRITE:%.*]] = begin_access [modify] [dynamic] [[SELF_A]] : $*Int
     // CHECK: assign %1 to [[WRITE]]
     // CHECK: end_access [[WRITE]] : $*Int
-    // CHECK: end_borrow [[BORROWED_SELF]] from [[SELF]]
+    // CHECK: end_borrow [[BORROWED_SELF]]
     prop = x
 
     // CHECK: objc_method
@@ -163,7 +163,7 @@ class HasUnmanaged : NSObject {
   // CHECK:     [[BORROWED_CLS_COPY:%.*]] = begin_borrow [[CLS_COPY]]
   // CHECK:     [[NATIVE:%.+]] = function_ref @$S15objc_properties12HasUnmanagedC3refs0D0VyyXlGSgvg
   // CHECK:     [[RESULT:%.+]] = apply [[NATIVE]]([[BORROWED_CLS_COPY]])
-  // CHECK:     end_borrow [[BORROWED_CLS_COPY]] from [[CLS_COPY]]
+  // CHECK:     end_borrow [[BORROWED_CLS_COPY]]
   // CHECK-NOT: {{(retain|release)}}
   // CHECK:     destroy_value [[CLS_COPY]] : $HasUnmanaged
   // CHECK-NOT: {{(retain|release)}}
@@ -177,7 +177,7 @@ class HasUnmanaged : NSObject {
   // CHECK-NEXT: // function_ref
   // CHECK-NEXT: [[NATIVE:%.+]] = function_ref @$S15objc_properties12HasUnmanagedC3refs0D0VyyXlGSgvs
   // CHECK-NEXT: [[RESULT:%.*]] = apply [[NATIVE]]([[NEW_VALUE]], [[BORROWED_SELF_COPY]])
-  // CHECK-NEXT: end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+  // CHECK-NEXT: end_borrow [[BORROWED_SELF_COPY]]
   // CHECK-NEXT: destroy_value [[SELF_COPY]] : $HasUnmanaged
   // CHECK-NEXT: return [[RESULT:%.*]]
   // CHECK: } // end sil function '$S15objc_properties12HasUnmanagedC3refs0D0VyyXlGSgvsTo'
@@ -200,7 +200,7 @@ class NonObjCClassWithObjCProperty {
   // CHECK: ([[OBJECT:%.*]], [[TOKEN:%.*]]) = begin_apply [[MODIFY]]([[ARG]])
   // CHECK: [[LOADED_OBJECT:%.*]] = load_borrow [[OBJECT]]
   // CHECK: [[UNMANAGED_OBJECT:%.*]] = ref_to_unmanaged [[LOADED_OBJECT]] : $NSObject to $@sil_unmanaged NSObject
-  // CHECK: end_borrow [[LOADED_OBJECT]] from [[OBJECT]]
+  // CHECK: end_borrow [[LOADED_OBJECT]]
   func useProperty() {
     useAutoreleasingUnsafeMutablePointer(&property)
   }

--- a/test/SILGen/objc_set_bridging.swift
+++ b/test/SILGen/objc_set_bridging.swift
@@ -24,7 +24,7 @@ import gizmo
     // CHECK:   [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
     // CHECK:   [[SWIFT_FN:%[0-9]+]] = function_ref @$S17objc_set_bridging3FooC16bridge_Set_param{{[_0-9a-zA-Z]*}}F : $@convention(method) (@guaranteed Set<Foo>, @guaranteed Foo) -> ()
     // CHECK:   [[RESULT:%[0-9]+]] = apply [[SWIFT_FN]]([[BORROWED_SET]], [[BORROWED_SELF_COPY]]) : $@convention(method) (@guaranteed Set<Foo>, @guaranteed Foo) -> ()
-    // CHECK:   end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+    // CHECK:   end_borrow [[BORROWED_SELF_COPY]]
     // CHECK:   destroy_value [[SELF_COPY]]
     // CHECK:   return [[RESULT]] : $()
   }
@@ -38,12 +38,12 @@ import gizmo
     // CHECK:   [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
     // CHECK:   [[SWIFT_FN:%[0-9]+]] = function_ref @$S17objc_set_bridging3FooC17bridge_Set_result{{[_0-9a-zA-Z]*}}F : $@convention(method) (@guaranteed Foo) -> @owned Set<Foo>
     // CHECK:   [[SET:%[0-9]+]] = apply [[SWIFT_FN]]([[BORROWED_SELF_COPY]]) : $@convention(method) (@guaranteed Foo) -> @owned Set<Foo>
-    // CHECK:   end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+    // CHECK:   end_borrow [[BORROWED_SELF_COPY]]
     // CHECK:   destroy_value [[SELF_COPY]]
     // CHECK:   [[CONVERTER:%[0-9]+]] = function_ref @$SSh10FoundationE19_bridgeToObjectiveCSo5NSSetCyF
     // CHECK:   [[BORROWED_SET:%.*]] = begin_borrow [[SET]]
     // CHECK:   [[NSSET:%[0-9]+]] = apply [[CONVERTER]]<Foo>([[BORROWED_SET]]) : $@convention(method) <τ_0_0 where τ_0_0 : Hashable> (@guaranteed Set<τ_0_0>) -> @owned NSSet
-    // CHECK:   end_borrow [[BORROWED_SET]] from [[SET]]
+    // CHECK:   end_borrow [[BORROWED_SET]]
     // CHECK:   destroy_value [[SET]]
     // CHECK:   return [[NSSET]] : $NSSet
   }
@@ -58,12 +58,12 @@ import gizmo
   // CHECK:   [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
   // CHECK:   [[GETTER:%[0-9]+]] = function_ref @$S17objc_set_bridging3FooC8property{{[_0-9a-zA-Z]*}}vg : $@convention(method) (@guaranteed Foo) -> @owned Set<Foo>
   // CHECK:   [[SET:%[0-9]+]] = apply [[GETTER]]([[BORROWED_SELF_COPY]]) : $@convention(method) (@guaranteed Foo) -> @owned Set<Foo>
-  // CHECK:   end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+  // CHECK:   end_borrow [[BORROWED_SELF_COPY]]
   // CHECK:   destroy_value [[SELF_COPY]]
   // CHECK:   [[CONVERTER:%[0-9]+]] = function_ref @$SSh10FoundationE19_bridgeToObjectiveCSo5NSSetCyF
   // CHECK:   [[BORROWED_SET:%.*]] = begin_borrow [[SET]]
   // CHECK:   [[NSSET:%[0-9]+]] = apply [[CONVERTER]]<Foo>([[BORROWED_SET]]) : $@convention(method) <τ_0_0 where τ_0_0 : Hashable> (@guaranteed Set<τ_0_0>) -> @owned NSSet
-  // CHECK:   end_borrow [[BORROWED_SET]] from [[SET]]
+  // CHECK:   end_borrow [[BORROWED_SET]]
   // CHECK:   destroy_value [[SET]]
   // CHECK:   return [[NSSET]] : $NSSet
   // CHECK: } // end sil function '$S17objc_set_bridging3FooC8property{{[_0-9a-zA-Z]*}}vgTo'
@@ -80,7 +80,7 @@ import gizmo
   // CHECK:   [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
   // CHECK:   [[SETTER:%[0-9]+]] = function_ref @$S17objc_set_bridging3FooC8property{{[_0-9a-zA-Z]*}}vs : $@convention(method) (@owned Set<Foo>, @guaranteed Foo) -> ()
   // CHECK:   [[RESULT:%[0-9]+]] = apply [[SETTER]]([[SET]], [[BORROWED_SELF_COPY]]) : $@convention(method) (@owned Set<Foo>, @guaranteed Foo) -> ()
-  // CHECK:   end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+  // CHECK:   end_borrow [[BORROWED_SELF_COPY]]
   // CHECK:   destroy_value [[SELF_COPY]] : $Foo
   // CHECK:   return [[RESULT]] : $()
   

--- a/test/SILGen/objc_thunks.swift
+++ b/test/SILGen/objc_thunks.swift
@@ -17,8 +17,8 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   // function_ref objc_thunks.Hoozit.typical
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$S11objc_thunks6HoozitC7typical_1ySo5GizmoCSi_AGtF : $@convention(method) (Int, @guaranteed Gizmo, @guaranteed Hoozit) -> @owned Gizmo
   // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[X]], [[BORROWED_Y_COPY]], [[BORROWED_THIS_COPY]]) {{.*}} line:[[@LINE-9]]:14:auto_gen
-  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]] from [[THIS_COPY]]
-  // CHECK-NEXT:   end_borrow [[BORROWED_Y_COPY]] from [[Y_COPY]]
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
+  // CHECK-NEXT:   end_borrow [[BORROWED_Y_COPY]]
   // CHECK-NEXT:   destroy_value [[THIS_COPY]] : $Hoozit
   // CHECK-NEXT:   destroy_value [[Y_COPY]]
   // CHECK-NEXT:   return [[RES]] : $Gizmo{{.*}} line:[[@LINE-14]]:14:auto_gen
@@ -32,7 +32,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$S11objc_thunks6HoozitC4forkyyF : $@convention(method) (@guaranteed Hoozit) -> ()
   // CHECK-NEXT:   apply [[NATIVE]]([[BORROWED_THIS]])
-  // CHECK-NEXT:   end_borrow [[BORROWED_THIS]] from [[THIS]]
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS]]
   // CHECK-NEXT:   destroy_value [[THIS]]
   // CHECK-NEXT:   return
   // CHECK-NEXT: }
@@ -59,7 +59,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$S11objc_thunks6HoozitC7copyFooSo5GizmoCyF : $@convention(method) (@guaranteed Hoozit) -> @owned Gizmo
   // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[BORROWED_THIS_COPY]])
-  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]] from [[THIS_COPY]]
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
   // CHECK-NEXT:   destroy_value [[THIS_COPY]]
   // CHECK-NEXT:   return [[RES]]
   // CHECK-NEXT: }
@@ -73,7 +73,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$S11objc_thunks6HoozitC14mutableCopyFooSo5GizmoCyF : $@convention(method) (@guaranteed Hoozit) -> @owned Gizmo
   // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[BORROWED_THIS_COPY]])
-  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]] from [[THIS_COPY]]
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
   // CHECK-NEXT:   destroy_value [[THIS_COPY]]
   // CHECK-NEXT:   return [[RES]]
   // CHECK-NEXT: }
@@ -89,7 +89,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$S11objc_thunks6HoozitC5copy8So5GizmoCyF : $@convention(method) (@guaranteed Hoozit) -> @owned Gizmo
   // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[BORROWED_THIS_COPY]])
-  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]] from [[THIS_COPY]]
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
   // CHECK-NEXT:   destroy_value [[THIS_COPY]]
   // CHECK-NEXT:   return [[RES]]
   // CHECK-NEXT: }
@@ -103,7 +103,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$S11objc_thunks6HoozitC13makeDuplicateSo5GizmoCyF : $@convention(method) (@guaranteed Hoozit) -> @owned Gizmo
   // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[BORROWED_THIS_COPY]])
-  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]] from [[THIS_COPY]]
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
   // CHECK-NEXT:   destroy_value [[THIS_COPY]]
   // CHECK-NEXT:   return [[RES]]
   // CHECK-NEXT: }
@@ -118,7 +118,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$S11objc_thunks6HoozitC7initFooSo5GizmoCyF : $@convention(method) (@guaranteed Hoozit) -> @owned Gizmo
   // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[BORROWED_THIS_COPY]])
-  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]] from [[THIS_COPY]]
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
   // CHECK-NEXT:   destroy_value [[THIS_COPY]]
   // CHECK-NEXT:   return [[RES]]
   // CHECK-NEXT: }
@@ -132,7 +132,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   // function_ref objc_thunks.Hoozit.typicalProperty.getter
   // CHECK-NEXT:   [[GETIMPL:%.*]] = function_ref @$S11objc_thunks6HoozitC15typicalPropertySo5GizmoCvg
   // CHECK-NEXT:   [[RES:%.*]] = apply [[GETIMPL]]([[BORROWED_SELF_COPY]])
-  // CHECK-NEXT:   end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+  // CHECK-NEXT:   end_borrow [[BORROWED_SELF_COPY]]
   // CHECK-NEXT:   destroy_value [[SELF_COPY]]
   // CHECK-NEXT:   return [[RES]] : $Gizmo
   // CHECK-NEXT: }
@@ -155,7 +155,7 @@ class Hoozit : Gizmo {
   // CHECK:   // function_ref objc_thunks.Hoozit.typicalProperty.setter
   // CHECK:   [[FR:%.*]] = function_ref @$S11objc_thunks6HoozitC15typicalPropertySo5GizmoCvs
   // CHECK:   [[RES:%.*]] = apply [[FR]]([[VALUE_COPY]], [[BORROWED_THIS_COPY]])
-  // CHECK:   end_borrow [[BORROWED_THIS_COPY]] from [[THIS_COPY]]
+  // CHECK:   end_borrow [[BORROWED_THIS_COPY]]
   // CHECK:   destroy_value [[THIS_COPY]]
   // CHECK:   return [[RES]] : $(), loc {{.*}}, scope {{.*}} // id: {{.*}} line:[[@LINE-34]]:13:auto_gen
   // CHECK: } // end sil function '$S11objc_thunks6HoozitC15typicalPropertySo5GizmoCvsTo'
@@ -168,7 +168,7 @@ class Hoozit : Gizmo {
   // CHECK:   [[WRITE:%.*]] = begin_access [modify] [dynamic] [[ADDR]] : $*Gizmo
   // CHECK:   assign [[ARG0_COPY]] to [[WRITE]] : $*Gizmo
   // CHECK:   end_access [[WRITE]] : $*Gizmo
-  // CHECK:   end_borrow [[BORROWED_ARG0]] from [[ARG0]]
+  // CHECK:   end_borrow [[BORROWED_ARG0]]
   // CHECK:   destroy_value [[ARG0]]
   // CHECK: } // end sil function '$S11objc_thunks6HoozitC15typicalPropertySo5GizmoCvs'
 
@@ -182,7 +182,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   // function_ref objc_thunks.Hoozit.copyProperty.getter
   // CHECK-NEXT:   [[FR:%.*]] = function_ref @$S11objc_thunks6HoozitC12copyPropertySo5GizmoCvg
   // CHECK-NEXT:   [[RES:%.*]] = apply [[FR]]([[BORROWED_SELF_COPY]])
-  // CHECK-NEXT:   end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+  // CHECK-NEXT:   end_borrow [[BORROWED_SELF_COPY]]
   // CHECK-NEXT:   destroy_value [[SELF_COPY]]
   // CHECK-NEXT:   return [[RES]]
   // CHECK-NEXT: }
@@ -204,7 +204,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   // function_ref objc_thunks.Hoozit.copyProperty.setter
   // CHECK-NEXT:   [[FR:%.*]] = function_ref @$S11objc_thunks6HoozitC12copyPropertySo5GizmoCvs
   // CHECK-NEXT:   [[RES:%.*]] = apply [[FR]]([[VALUE_COPY]], [[BORROWED_THIS_COPY]])
-  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]] from [[THIS_COPY]]
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
   // CHECK-NEXT:   destroy_value [[THIS_COPY]]
   // CHECK-NEXT:   return [[RES]]
 
@@ -216,7 +216,7 @@ class Hoozit : Gizmo {
   // CHECK:   [[WRITE:%.*]] = begin_access [modify] [dynamic] [[ADDR]] : $*Gizmo
   // CHECK:   assign [[ARG1_COPY]] to [[WRITE]]
   // CHECK:   end_access [[WRITE]] : $*Gizmo
-  // CHECK:   end_borrow [[BORROWED_ARG1]] from [[ARG1]]
+  // CHECK:   end_borrow [[BORROWED_ARG1]]
   // CHECK:   destroy_value [[ARG1]]
   // CHECK: } // end sil function '$S11objc_thunks6HoozitC12copyPropertySo5GizmoCvs'
 
@@ -229,7 +229,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$S11objc_thunks6HoozitC10roPropertySo5GizmoCvg : $@convention(method) (@guaranteed Hoozit) -> @owned Gizmo
   // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[BORROWED_THIS_COPY]])
-  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]] from [[THIS_COPY]]
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
   // CHECK-NEXT:   destroy_value [[THIS_COPY]] : $Hoozit
   // CHECK-NEXT:   return [[RES]] : $Gizmo
   // CHECK-NEXT: } // end sil function '$S11objc_thunks6HoozitC10roPropertySo5GizmoCvgTo'
@@ -255,7 +255,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$S11objc_thunks6HoozitC10rwPropertySo5GizmoCvs : $@convention(method) (@owned Gizmo, @guaranteed Hoozit) -> ()
   // CHECK-NEXT:   apply [[NATIVE]]([[VALUE_COPY]], [[BORROWED_THIS_COPY]])
-  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]] from [[THIS_COPY]]
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
   // CHECK-NEXT:   destroy_value [[THIS_COPY]]
   // CHECK-NEXT:   return
   // CHECK-NEXT: }
@@ -274,7 +274,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$S11objc_thunks6HoozitC14copyRWPropertySo5GizmoCvg : $@convention(method) (@guaranteed Hoozit) -> @owned Gizmo
   // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[BORROWED_THIS_COPY]])
-  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]] from [[THIS_COPY]]
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
   // CHECK-NEXT:   destroy_value [[THIS_COPY]]
   // CHECK-NOT:    return
   // CHECK-NEXT:   return [[RES]]
@@ -289,7 +289,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$S11objc_thunks6HoozitC14copyRWPropertySo5GizmoCvs : $@convention(method) (@owned Gizmo, @guaranteed Hoozit) -> ()
   // CHECK-NEXT:   apply [[NATIVE]]([[VALUE_COPY]], [[BORROWED_THIS_COPY]])
-  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]] from [[THIS_COPY]]
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
   // CHECK-NEXT:   destroy_value [[THIS_COPY]]
   // CHECK-NEXT:   return
   // CHECK-NEXT: }
@@ -303,7 +303,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$S11objc_thunks6HoozitC12initPropertySo5GizmoCvg : $@convention(method) (@guaranteed Hoozit) -> @owned Gizmo
   // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[BORROWED_THIS_COPY]])
-  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]] from [[THIS_COPY]]
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
   // CHECK-NEXT:   destroy_value [[THIS_COPY]]
   // CHECK-NEXT:   return [[RES]]
   // CHECK-NEXT: }
@@ -317,7 +317,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$S11objc_thunks6HoozitC12initPropertySo5GizmoCvs : $@convention(method) (@owned Gizmo, @guaranteed Hoozit) -> ()
   // CHECK-NEXT:   apply [[NATIVE]]([[VALUE_COPY]], [[BORROWED_THIS_COPY]])
-  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]] from [[THIS_COPY]]
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
   // CHECK-NEXT:   destroy_value [[THIS_COPY]]
   // CHECK-NEXT:   return
   // CHECK-NEXT: }
@@ -334,7 +334,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$S11objc_thunks6HoozitC12propComputedSo5GizmoCvg : $@convention(method) (@guaranteed Hoozit) -> @owned Gizmo
   // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[BORROWED_THIS_COPY]])
-  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]] from [[THIS_COPY]]
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
   // CHECK-NEXT:   destroy_value [[THIS_COPY]]
   // CHECK-NEXT:   return [[RES]]
   // CHECK-NEXT: }
@@ -348,7 +348,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$S11objc_thunks6HoozitC12propComputedSo5GizmoCvs : $@convention(method) (@owned Gizmo, @guaranteed Hoozit) -> ()
   // CHECK-NEXT:   apply [[NATIVE]]([[VALUE_COPY]], [[BORROWED_THIS_COPY]])
-  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]] from [[THIS_COPY]]
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
   // CHECK-NEXT:   destroy_value [[THIS_COPY]]
   // CHECK-NEXT:   return
   // CHECK-NEXT: }
@@ -366,7 +366,7 @@ class Hoozit : Gizmo {
   // CHECK: [[BORROWED_GIZMO:%.*]] = begin_borrow [[GIZMO]]
   // CHECK: [[CAST_BORROWED_GIZMO:%.*]] = unchecked_ref_cast [[BORROWED_GIZMO]] : $Gizmo to $Hoozit
   // CHECK: [[SUPERMETHOD:%[0-9]+]] = objc_super_method [[CAST_BORROWED_GIZMO]] : $Hoozit, #Gizmo.init!initializer.1.foreign : (Gizmo.Type) -> (Int) -> Gizmo?, $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
-  // CHECK-NEXT: end_borrow [[BORROWED_GIZMO]] from [[GIZMO]]
+  // CHECK-NEXT: end_borrow [[BORROWED_GIZMO]]
   // CHECK-NEXT: [[SELF_REPLACED:%[0-9]+]] = apply [[SUPERMETHOD]](%0, [[X:%[0-9]+]]) : $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
   // CHECK-NOT: unconditional_checked_cast downcast [[SELF_REPLACED]] : $Gizmo to $Hoozit
   // CHECK: unchecked_ref_cast
@@ -386,7 +386,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT: // function_ref
   // CHECK-NEXT: [[NATIVE:%[0-9]+]] = function_ref @$S11objc_thunks6HoozitCyACSicig : $@convention(method) (Int, @guaranteed Hoozit) -> @owned Hoozit
   // CHECK-NEXT: [[RESULT:%[0-9]+]] = apply [[NATIVE]]([[I]], [[BORROWED_SELF_COPY]]) : $@convention(method) (Int, @guaranteed Hoozit) -> @owned Hoozit
-  // CHECK-NEXT: end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+  // CHECK-NEXT: end_borrow [[BORROWED_SELF_COPY]]
   // CHECK-NEXT: destroy_value [[SELF_COPY]]
   // CHECK-NEXT: return [[RESULT]] : $Hoozit
   get {
@@ -401,7 +401,7 @@ class Hoozit : Gizmo {
   // CHECK:   [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
   // CHECK:   [[NATIVE:%[0-9]+]] = function_ref @$S11objc_thunks6HoozitCyACSicis : $@convention(method) (@owned Hoozit, Int, @guaranteed Hoozit) -> ()
   // CHECK:   [[RESULT:%[0-9]+]] = apply [[NATIVE]]([[VALUE_COPY]], [[I]], [[BORROWED_SELF_COPY]]) : $@convention(method) (@owned Hoozit, Int, @guaranteed Hoozit) -> ()
-  // CHECK:   end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+  // CHECK:   end_borrow [[BORROWED_SELF_COPY]]
   // CHECK:   destroy_value [[SELF_COPY]]
   // CHECK:   return [[RESULT]] : $()
   // CHECK: } // end sil function '$S11objc_thunks6HoozitCyACSicisTo'
@@ -417,7 +417,7 @@ class Wotsit<T> : Gizmo {
   // CHECK-NEXT: // function_ref
   // CHECK-NEXT: [[NATIVE:%.*]] = function_ref @$S11objc_thunks6WotsitC5plainyyF : $@convention(method) <τ_0_0> (@guaranteed Wotsit<τ_0_0>) -> ()
   // CHECK-NEXT: [[RESULT:%.*]] = apply [[NATIVE]]<T>([[BORROWED_SELF_COPY]]) : $@convention(method) <τ_0_0> (@guaranteed Wotsit<τ_0_0>) -> ()
-  // CHECK-NEXT: end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+  // CHECK-NEXT: end_borrow [[BORROWED_SELF_COPY]]
   // CHECK-NEXT: destroy_value [[SELF_COPY]] : $Wotsit<T>
   // CHECK-NEXT: return [[RESULT]] : $()
   // CHECK-NEXT: }
@@ -439,13 +439,13 @@ class Wotsit<T> : Gizmo {
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$S11objc_thunks6WotsitC11descriptionSSvg : $@convention(method) <τ_0_0> (@guaranteed Wotsit<τ_0_0>) -> @owned String
   // CHECK-NEXT:   [[RESULT:%.*]] = apply [[NATIVE:%.*]]<T>([[BORROWED_SELF_COPY]]) : $@convention(method) <τ_0_0> (@guaranteed Wotsit<τ_0_0>) -> @owned String
-  // CHECK-NEXT:   end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
+  // CHECK-NEXT:   end_borrow [[BORROWED_SELF_COPY]]
   // CHECK-NEXT:   destroy_value [[SELF_COPY]] : $Wotsit<T>
   // CHECK-NEXT:   // function_ref
   // CHECK-NEXT:   [[BRIDGE:%.*]] = function_ref @$SSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF
   // CHECK-NEXT:   [[BORROWED_RESULT:%.*]] = begin_borrow [[RESULT]]
   // CHECK-NEXT:   [[NSRESULT:%.*]] = apply [[BRIDGE]]([[BORROWED_RESULT]]) : $@convention(method) (@guaranteed String) -> @owned NSString
-  // CHECK-NEXT:   end_borrow [[BORROWED_RESULT]] from [[RESULT]]
+  // CHECK-NEXT:   end_borrow [[BORROWED_RESULT]]
   // CHECK-NEXT:   destroy_value [[RESULT]]
   // CHECK-NEXT:   return [[NSRESULT]] : $NSString
   // CHECK-NEXT: }
@@ -590,5 +590,5 @@ func testObjCNoescapeThunk() {
 // CHECK-NEXT:  [[T2:%.*]] = load_borrow [[T1]]
 // CHECK-NEXT:  [[T3:%.*]] = apply [[T2]]()
 // CHECK-NEXT:  [[T4:%.*]] = tuple ()
-// CHECK-NEXT:  end_borrow [[T2]] from [[T1]]
+// CHECK-NEXT:  end_borrow [[T2]]
 // CHECK-NEXT:  return [[T4]]

--- a/test/SILGen/objc_witnesses.swift
+++ b/test/SILGen/objc_witnesses.swift
@@ -28,7 +28,7 @@ class Phoûx : NSObject, Fooable {
 // CHECK:         [[VALUE:%.*]] = load_borrow [[IN_ADDR]]
 // CHECK:         [[CLS_METHOD:%.*]] = class_method [[VALUE]] : $Phoûx, #Phoûx.foo!1
 // CHECK:         apply [[CLS_METHOD]]([[VALUE]])
-// CHECK:         end_borrow [[VALUE]] from [[IN_ADDR]]
+// CHECK:         end_borrow [[VALUE]]
 
 protocol Bells {
   init(bellsOn: Int)

--- a/test/SILGen/opaque_ownership.swift
+++ b/test/SILGen/opaque_ownership.swift
@@ -31,7 +31,7 @@ public protocol Decoder {
 // CHECK:  [[OPENED2:%.*]] = open_existential_value [[BORROW2]] : $UnkeyedDecodingContainer to $@opened("{{.*}}") UnkeyedDecodingContainer
 // CHECK:  [[WT2:%.*]] = witness_method $@opened("{{.*}}") UnkeyedDecodingContainer, #UnkeyedDecodingContainer.isAtEnd!getter.1 : <Self where Self : UnkeyedDecodingContainer> (Self) -> () -> Builtin.Int1, [[OPENED2]] : $@opened("{{.*}}") UnkeyedDecodingContainer : $@convention(witness_method: UnkeyedDecodingContainer) <τ_0_0 where τ_0_0 : UnkeyedDecodingContainer> (@in_guaranteed τ_0_0) -> Builtin.Int1
 // CHECK:  [[RET2:%.*]] = apply [[WT2]]<@opened("{{.*}}") UnkeyedDecodingContainer>([[OPENED2]]) : $@convention(witness_method: UnkeyedDecodingContainer) <τ_0_0 where τ_0_0 : UnkeyedDecodingContainer> (@in_guaranteed τ_0_0) -> Builtin.Int1
-// CHECK:  end_borrow [[BORROW2]] from [[RET1]] : $UnkeyedDecodingContainer, $UnkeyedDecodingContainer
+// CHECK:  end_borrow [[BORROW2]] : $UnkeyedDecodingContainer
 // CHECK:  destroy_value [[RET1]] : $UnkeyedDecodingContainer
 // CHECK-NOT:  destroy_value %0 : $Decoder
 // CHECK:  return [[RET2]] : $Builtin.Int1
@@ -175,7 +175,7 @@ public enum FloatingPointSign: Int64 {
 // CHECK-OSX:   [[VAL:%.*]] = open_existential_value [[BORROW2]] : $Any to $@opened
 // CHECK-OSX:   [[COPY2:%.*]] = copy_value [[VAL]] : $@opened
 // CHECK-OSX:   destroy_value [[COPY2]] : $@opened
-// CHECK-OSX:   end_borrow [[BORROW2]] from [[COPY]] : $Any, $Any
+// CHECK-OSX:   end_borrow [[BORROW2]] : $Any
 // CHECK-OSX:   destroy_value [[COPY]] : $Any
 // CHECK-OSX-NOT:   destroy_value %0 : $Any
 // CHECK-OSX:   return undef : $AnyObject
@@ -195,7 +195,7 @@ public protocol Error {}
 // CHECK-OSX: [[VAL:%.*]] = open_existential_box_value [[BORROW]] : $Error to $@opened
 // CHECK-OSX: [[COPY:%.*]] = copy_value [[VAL]] : $@opened
 // CHECK-OSX: [[ANY:%.*]] = init_existential_value [[COPY]] : $@opened
-// CHECK-OSX: end_borrow [[BORROW]] from %{{.*}} : $Error, $Error
+// CHECK-OSX: end_borrow [[BORROW]] : $Error
 // CHECK-OSX-LABEL: } // end sil function '$Ss3foo1eys5Error_pSg_tF'
 public func foo(e: Error?) {
   if let u = e {
@@ -240,7 +240,7 @@ public struct EnumIter<Base : IP> : IP, Seq {
 // CHECK:  [[BORROW:%.*]] = begin_borrow [[COPY]] : $Base
 // CHECK:  [[WT:%.*]] = witness_method $Base, #Seq.makeIterator!1 : <Self where Self : Seq> (Self) -> () -> Self.Iterator : $@convention(witness_method: Seq) <τ_0_0 where τ_0_0 : Seq> (@in_guaranteed τ_0_0) -> @out τ_0_0.Iterator
 // CHECK:  [[ITER:%.*]] = apply [[WT]]<Base>([[BORROW]]) : $@convention(witness_method: Seq) <τ_0_0 where τ_0_0 : Seq> (@in_guaranteed τ_0_0) -> @out τ_0_0.Iterator
-// CHECK:  end_borrow [[BORROW]] from [[COPY]] : $Base, $Base
+// CHECK:  end_borrow [[BORROW]] : $Base
 // CHECK:  destroy_value [[COPY]] : $Base
 // CHECK: [[FN:%.*]] = function_ref @$Ss8EnumIterV5_baseAByxGx_tcfC : $@convention(method) <τ_0_0 where τ_0_0 : IP> (@in τ_0_0, @thin EnumIter<τ_0_0>.Type) -> @out EnumIter<τ_0_0>
 // CHECK:  [[RET:%.*]] = apply [[FN]]<Base.Iterator>([[ITER]], [[MT]]) : $@convention(method) <τ_0_0 where τ_0_0 : IP> (@in τ_0_0, @thin EnumIter<τ_0_0>.Type) -> @out EnumIter<τ_0_0>

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -167,7 +167,7 @@ enum AddressOnlyEnum {
 // CHECK: %[[APY:.*]] = apply %{{.*}}<Any>(%{{.*}}) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
 // CHECK: %[[BRW:.*]] = begin_borrow %[[APY]]
 // CHECK: %[[TPL:.*]] = tuple_extract %[[BRW]] : $(Array<Any>, Builtin.RawPointer), 1
-// CHECK: end_borrow %[[BRW]] from %[[APY]] : $(Array<Any>, Builtin.RawPointer), $(Array<Any>, Builtin.RawPointer)
+// CHECK: end_borrow %[[BRW]] : $(Array<Any>, Builtin.RawPointer)
 // CHECK: destroy_value %[[APY]]
 // CHECK: %[[PTR:.*]] = pointer_to_address %[[TPL]] : $Builtin.RawPointer to [strict] $*Any
 // CHECK: [[IOPAQUE:%.*]] = init_existential_value %{{.*}} : $Int, $Int, $Any
@@ -205,9 +205,9 @@ func s030______assigninout<T>(_ a: inout T, _ b: T) {
 // CHECK:   [[GEN:%.*]] = tuple_extract [[BORROWED_CPY]] : $(Int, T), 1
 // CHECK:   [[COPY_GEN:%.*]] = copy_value [[GEN]]
 // CHECK:   destroy_value [[COPY_GEN]]
-// CHECK:   end_borrow [[BORROWED_CPY]] from [[CPY]]
+// CHECK:   end_borrow [[BORROWED_CPY]]
 // CHECK:   destroy_value [[CPY]]
-// CHECK:   end_borrow [[BORROWED_ARG1]] from [[TPL]] : $(Int, T), $(Int, T)
+// CHECK:   end_borrow [[BORROWED_ARG1]] : $(Int, T)
 // CHECK:   destroy_value [[TPL]] : $(Int, T)
 // CHECK:   return [[INT]]
 // CHECK-LABEL: } // end sil function '$S20opaque_values_silgen21s040___tupleReturnIntyS2i_xt_tlF'
@@ -319,7 +319,7 @@ struct s110___GuaranteedSelf : Foo {
 // CHECK:   [[COPY_ARG1:%.*]] = copy_value [[ARG]] : $T
 // CHECK:   [[BORROWED_ARG2:%.*]] = begin_borrow [[COPY_ARG1]]
 // CHECK:   [[COPY_ARG2:%.*]] = copy_value [[BORROWED_ARG2]] : $T
-// CHECK:   end_borrow [[BORROWED_ARG2]] from [[COPY_ARG1]]
+// CHECK:   end_borrow [[BORROWED_ARG2]]
 // CHECK:   return [[COPY_ARG2]] : $T
 // CHECK-LABEL: } // end sil function '$S20opaque_values_silgen21s120______returnValueyxxlF'
 func s120______returnValue<T>(_ x: T) -> T {
@@ -399,7 +399,7 @@ func s160_______callAnyArg() {
 // CHECK:   [[INT_CAST:%.*]] = unconditional_checked_cast_value [[INT_ARG]] : $Int to $T
 // CHECK:   [[CAST_BORROW:%.*]] = begin_borrow [[INT_CAST]] : $T
 // CHECK:   [[RETURN_VAL:%.*]] = copy_value [[CAST_BORROW]] : $T
-// CHECK:   end_borrow [[CAST_BORROW]] from [[INT_CAST]] : $T, $T
+// CHECK:   end_borrow [[CAST_BORROW]] : $T
 // CHECK:   destroy_value [[INT_CAST]] : $T
 // CHECK:   return [[RETURN_VAL]] : $T
 // CHECK-LABEL: } // end sil function '$S20opaque_values_silgen21s170____force_convertxylF'
@@ -1151,7 +1151,7 @@ public func s020_______assignToVar() {
 // CHECK:   [[RET_VAL0:%.*]] = tuple_extract [[TUPLE_BORROW]] : $(Int, T), 0
 // CHECK:   [[TUPLE_EXTRACT:%.*]] = tuple_extract [[TUPLE_BORROW]] : $(Int, T), 1
 // CHECK:   [[RET_VAL1:%.*]] = copy_value [[TUPLE_EXTRACT]] : $T
-// CHECK:   end_borrow [[TUPLE_BORROW]] from [[TUPLE_APPLY]] : $(Int, T), $(Int, T)
+// CHECK:   end_borrow [[TUPLE_BORROW]] : $(Int, T)
 // CHECK:   destroy_value [[TUPLE_APPLY]] : $(Int, T)
 // CHECK:   [[RET_VAL_TUPLE:%.*]] = tuple ([[RET_VAL0]] : $Int, [[RET_VAL1]] : $T)
 // CHECK:   return [[RET_VAL_TUPLE]] : $(Int, T)

--- a/test/SILGen/partial_apply_super.swift
+++ b/test/SILGen/partial_apply_super.swift
@@ -164,7 +164,7 @@ class ChildToResilientOutsideParent : ResilientOutsideParent {
   // CHECK:   [[BORROWED_CASTED_SELF_COPY:%.*]] = begin_borrow [[CASTED_SELF_COPY]]
   // CHECK:   [[DOWNCAST_BORROWED_CASTED_SELF_COPY:%.*]] = unchecked_ref_cast [[BORROWED_CASTED_SELF_COPY]]
   // CHECK:   [[SUPER_METHOD:%.*]] = super_method [[DOWNCAST_BORROWED_CASTED_SELF_COPY]] : $ResilientOutsideParent, #ResilientOutsideParent.method!1 : (ResilientOutsideParent) -> () -> (), $@convention(method) (@guaranteed ResilientOutsideParent) -> ()
-  // CHECK:   end_borrow [[BORROWED_CASTED_SELF_COPY]] from [[CASTED_SELF_COPY]]
+  // CHECK:   end_borrow [[BORROWED_CASTED_SELF_COPY]]
   // CHECK:   [[PARTIAL_APPLY:%.*]] = partial_apply [callee_guaranteed] [[SUPER_METHOD]]([[CASTED_SELF_COPY]]) : $@convention(method) (@guaranteed ResilientOutsideParent) -> ()
   // CHECK:   [[CONVERT:%.*]] = convert_escape_to_noescape [not_guaranteed] [[PARTIAL_APPLY]]
   // CHECK:   [[DOFOO:%.*]] = function_ref @$S19partial_apply_super5doFooyyyyXEF : $@convention(thin) (@noescape @callee_guaranteed () -> ()) -> ()
@@ -197,7 +197,7 @@ class GrandchildToFixedOutsideChild : OutsideChild {
   // CHECK:     [[BORROWED_CASTED_SELF_COPY:%.*]] = begin_borrow [[CASTED_SELF_COPY]]
   // CHECK:     [[DOWNCAST_BORROWED_CASTED_SELF_COPY:%.*]] = unchecked_ref_cast [[BORROWED_CASTED_SELF_COPY]]
   // CHECK:     [[SUPER_METHOD:%.*]] = super_method [[DOWNCAST_BORROWED_CASTED_SELF_COPY]] : $OutsideChild, #OutsideChild.method!1 : (OutsideChild) -> () -> (), $@convention(method) (@guaranteed OutsideChild) -> ()
-  // CHECK:     end_borrow [[BORROWED_CASTED_SELF_COPY]] from [[CASTED_SELF_COPY]]
+  // CHECK:     end_borrow [[BORROWED_CASTED_SELF_COPY]]
   // CHECK:     [[PARTIAL_APPLY:%.*]] = partial_apply [callee_guaranteed] [[SUPER_METHOD]]([[CASTED_SELF_COPY]]) : $@convention(method) (@guaranteed OutsideChild) -> ()
   // CHECK:     [[CONVERT:%.*]] = convert_escape_to_noescape [not_guaranteed] [[PARTIAL_APPLY]]
   // CHECK:     [[DOFOO:%.*]] = function_ref @$S19partial_apply_super5doFooyyyyXEF : $@convention(thin) (@noescape @callee_guaranteed () -> ()) -> ()
@@ -230,7 +230,7 @@ class GrandchildToResilientOutsideChild : ResilientOutsideChild {
   // CHECK:     [[BORROWED_CASTED_SELF_COPY:%.*]] = begin_borrow [[CASTED_SELF_COPY]]
   // CHECK:     [[DOWNCAST_BORROWED_CASTED_SELF_COPY:%.*]] = unchecked_ref_cast [[BORROWED_CASTED_SELF_COPY]]
   // CHECK:     [[SUPER_METHOD:%.*]] = super_method [[DOWNCAST_BORROWED_CASTED_SELF_COPY]] : $ResilientOutsideChild, #ResilientOutsideChild.method!1 : (ResilientOutsideChild) -> () -> (), $@convention(method) (@guaranteed ResilientOutsideChild) -> ()
-  // CHEC:      end_borrow [[BORROWED_CASTED_SELF_COPY]] from [[CASTED_SELF_COPY]]
+  // CHEC:      end_borrow [[BORROWED_CASTED_SELF_COPY]]
   // CHECK:     [[PARTIAL_APPLY:%.*]] = partial_apply [callee_guaranteed] [[SUPER_METHOD]]([[CASTED_SELF_COPY]]) : $@convention(method) (@guaranteed ResilientOutsideChild) -> ()
   // CHECK:     [[CONVERT:%.*]] = convert_escape_to_noescape [not_guaranteed] [[PARTIAL_APPLY]]
   // CHECK:     [[DOFOO:%.*]] = function_ref @$S19partial_apply_super5doFooyyyyXEF : $@convention(thin) (@noescape @callee_guaranteed () -> ()) -> ()
@@ -263,7 +263,7 @@ class GenericChildToFixedGenericOutsideParent<A> : GenericOutsideParent<A> {
   // CHECK:     [[BORROWED_CASTED_SELF_COPY:%.*]] = begin_borrow [[CASTED_SELF_COPY]]
   // CHECK:     [[DOWNCAST_BORROWED_CASTED_SELF_COPY:%.*]] = unchecked_ref_cast [[BORROWED_CASTED_SELF_COPY]]
   // CHECK:     [[SUPER_METHOD:%.*]] = super_method [[DOWNCAST_BORROWED_CASTED_SELF_COPY]] : $GenericOutsideParent<A>, #GenericOutsideParent.method!1 : <A> (GenericOutsideParent<A>) -> () -> (), $@convention(method) <τ_0_0> (@guaranteed GenericOutsideParent<τ_0_0>) -> ()
-  // CHECK:     end_borrow [[BORROWED_CASTED_SELF_COPY]] from [[CASTED_SELF_COPY]]
+  // CHECK:     end_borrow [[BORROWED_CASTED_SELF_COPY]]
   // CHECK:     [[PARTIAL_APPLY:%.*]] = partial_apply [callee_guaranteed] [[SUPER_METHOD]]<A>([[CASTED_SELF_COPY]]) : $@convention(method) <τ_0_0> (@guaranteed GenericOutsideParent<τ_0_0>) -> ()
   // CHECK:     [[CONVERT:%.*]] = convert_escape_to_noescape [not_guaranteed] [[PARTIAL_APPLY]]
   // CHECK:     [[DOFOO:%.*]] = function_ref @$S19partial_apply_super5doFooyyyyXEF : $@convention(thin) (@noescape @callee_guaranteed () -> ()) -> ()
@@ -296,7 +296,7 @@ class GenericChildToResilientGenericOutsideParent<A> : ResilientGenericOutsidePa
   // CHECK:     [[BORROWED_CASTED_SELF_COPY:%.*]] = begin_borrow [[CASTED_SELF_COPY]]
   // CHECK:     [[DOWNCAST_BORROWED_CASTED_SELF_COPY:%.*]] = unchecked_ref_cast [[BORROWED_CASTED_SELF_COPY]]
   // CHECK:     [[SUPER_METHOD:%.*]] = super_method [[DOWNCAST_BORROWED_CASTED_SELF_COPY]] : $ResilientGenericOutsideParent<A>, #ResilientGenericOutsideParent.method!1 : <A> (ResilientGenericOutsideParent<A>) -> () -> (), $@convention(method) <τ_0_0> (@guaranteed ResilientGenericOutsideParent<τ_0_0>) -> ()
-  // CHECK:     end_borrow [[BORROWED_CASTED_SELF_COPY]] from [[CASTED_SELF_COPY]]
+  // CHECK:     end_borrow [[BORROWED_CASTED_SELF_COPY]]
   // CHECK:     [[PARTIAL_APPLY:%.*]] = partial_apply [callee_guaranteed] [[SUPER_METHOD]]<A>([[CASTED_SELF_COPY]]) : $@convention(method) <τ_0_0> (@guaranteed ResilientGenericOutsideParent<τ_0_0>) -> ()
   // CHECK:     [[CONVERT:%.*]] = convert_escape_to_noescape [not_guaranteed] [[PARTIAL_APPLY]]
   // CHECK:     [[DOFOO:%.*]] = function_ref @$S19partial_apply_super5doFooyyyyXEF : $@convention(thin) (@noescape @callee_guaranteed () -> ()) -> ()

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -141,7 +141,7 @@ func physical_struct_rvalue() -> Int {
   // CHECK: [[STRUCT:%[0-9]+]] = apply [[FUNC]]()
   // CHECK: [[BORROWED_STRUCT:%.*]] = begin_borrow [[STRUCT]]
   // CHECK: [[RET:%[0-9]+]] = struct_extract [[BORROWED_STRUCT]] : $Val, #Val.y
-  // CHECK: end_borrow [[BORROWED_STRUCT]] from [[STRUCT]]
+  // CHECK: end_borrow [[BORROWED_STRUCT]]
   // CHECK: destroy_value [[STRUCT]]
   // CHECK: return [[RET]]
 }
@@ -211,7 +211,7 @@ func logical_struct_in_reftype_set(_ value: inout Val, z1: Int) {
   // CHECK: ([[T0:%.*]], [[T1:%.*]]) = destructure_tuple [[V_R_VP_Z_TUPLE]]
   // CHECK: store [[T0]] to [trivial] [[A0]]
   // CHECK: store [[T1]] to [trivial] [[A1]]
-  // CHECK: end_borrow [[LD]] from [[VAL_REF_VAL_PROP_MAT]]
+  // CHECK: end_borrow [[LD]]
   // -- write to val.ref.val_prop.z_tuple.1
   // CHECK: [[V_R_VP_Z_TUPLE_1:%[0-9]+]] = tuple_element_addr [[V_R_VP_Z_TUPLE_MAT]] : {{.*}}, 1
   // CHECK: assign [[Z1]] to [[V_R_VP_Z_TUPLE_1]]
@@ -247,7 +247,7 @@ func tuple_in_logical_struct_set(_ value: inout Val, z1: Int) {
   // CHECK: ([[T0:%.*]], [[T1:%.*]]) = destructure_tuple [[Z_TUPLE]]
   // CHECK: store [[T0]] to [trivial] [[A0]]
   // CHECK: store [[T1]] to [trivial] [[A1]]
-  // CHECK: end_borrow [[VAL1]] from [[WRITE]]
+  // CHECK: end_borrow [[VAL1]]
   // CHECK: [[Z_TUPLE_1:%[0-9]+]] = tuple_element_addr [[Z_TUPLE_MATERIALIZED]] : {{.*}}, 1
   // CHECK: assign [[Z1]] to [[Z_TUPLE_1]]
   // CHECK: [[Z_TUPLE_MODIFIED:%[0-9]+]] = load [trivial] [[Z_TUPLE_MATERIALIZED]]
@@ -1184,7 +1184,7 @@ public class DerivedClassWithPublicProperty : BaseClassWithInternalProperty {
 // CHECK-NEXT:    [[BORROWED_SUPER:%.*]] = begin_borrow [[SUPER]]
 // CHECK-NEXT:    [[DOWNCAST_BORROWED_SUPER:%.*]] = unchecked_ref_cast [[BORROWED_SUPER]] : $BaseClassWithInternalProperty to $DerivedClassWithPublicProperty
 // CHECK-NEXT:    [[METHOD:%.*]] = super_method [[DOWNCAST_BORROWED_SUPER]] : $DerivedClassWithPublicProperty, #BaseClassWithInternalProperty.x!getter.1 : (BaseClassWithInternalProperty) -> () -> (), $@convention(method) (@guaranteed BaseClassWithInternalProperty) -> ()
-// CHECK-NEXT:    end_borrow [[BORROWED_SUPER]] from [[SUPER]]
+// CHECK-NEXT:    end_borrow [[BORROWED_SUPER]]
 // CHECK-NEXT:    [[RESULT:%.*]] = apply [[METHOD]]([[SUPER]]) : $@convention(method) (@guaranteed BaseClassWithInternalProperty) -> ()
 // CHECK-NEXT:    destroy_value [[SUPER]] : $BaseClassWithInternalProperty
 // CHECK: } // end sil function '$S10properties30DerivedClassWithPublicPropertyC1xytvg'

--- a/test/SILGen/protocol_class_refinement.swift
+++ b/test/SILGen/protocol_class_refinement.swift
@@ -73,7 +73,7 @@ func getObjectUID<T: ObjectUID>(x: T) -> (Int, Int, Int, Int) {
   // -- call secondNextCLSID from class-constrained protocol ext
   // CHECK: [[SET_SECONDNEXT:%.*]] = function_ref @$S25protocol_class_refinement9ObjectUIDPAAE15secondNextCLSIDSivs
   // CHECK: apply [[SET_SECONDNEXT]]<T>([[UID]], [[BORROWED_X1]])
-  // CHECK: end_borrow [[BORROWED_X1]] from [[X1]]
+  // CHECK: end_borrow [[BORROWED_X1]]
   // CHECK: destroy_value [[X1]]
   x.secondNextCLSID = x.uid()
   return (x.iid, x.clsid, x.nextCLSID, x.secondNextCLSID)

--- a/test/SILGen/protocol_extensions.swift
+++ b/test/SILGen/protocol_extensions.swift
@@ -702,7 +702,7 @@ extension InitRequirement {
     // CHECK-NEXT: [[ARG_COPY_CAST:%.*]] = upcast [[ARG_COPY]]
     // CHECK:      [[DELEGATEE:%.*]] = witness_method $Self, #InitRequirement.init!allocator.1 : {{.*}} : $@convention(witness_method: InitRequirement) <τ_0_0 where τ_0_0 : InitRequirement> (@owned C, @thick τ_0_0.Type) -> @out τ_0_0
     // CHECK-NEXT: apply [[DELEGATEE]]<Self>([[SELF_BOX]], [[ARG_COPY_CAST]], [[SELF_TYPE]])
-    // CHECK-NEXT: end_borrow [[BORROWED_ARG]] from [[ARG]]
+    // CHECK-NEXT: end_borrow [[BORROWED_ARG]]
     // CHECK-NEXT: copy_addr [take] [[SELF_BOX]] to [[SELF_BOX_ADDR]]
     // CHECK-NEXT: dealloc_stack [[SELF_BOX]]
     // CHECK-NEXT: copy_addr [[SELF_BOX_ADDR]] to [initialization] [[OUT]]
@@ -723,7 +723,7 @@ extension InitRequirement {
     // CHECK-NEXT: [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
     // CHECK:      [[DELEGATEE:%.*]] = function_ref @$S19protocol_extensions15InitRequirementPAAE1dxAA1DC_tcfC
     // CHECK-NEXT: apply [[DELEGATEE]]<Self>([[SELF_BOX]], [[ARG_COPY]], [[SELF_TYPE]])
-    // CHECK-NEXT: end_borrow [[BORROWED_ARG]] from [[ARG]]
+    // CHECK-NEXT: end_borrow [[BORROWED_ARG]]
     // CHECK-NEXT: copy_addr [take] [[SELF_BOX]] to [[SELF_BOX_ADDR]]
     // CHECK-NEXT: dealloc_stack [[SELF_BOX]]
     // CHECK-NEXT: copy_addr [[SELF_BOX_ADDR]] to [initialization] [[OUT]]
@@ -745,7 +745,7 @@ extension InitRequirement {
     // CHECK-NEXT: [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
     // CHECK:      [[DELEGATEE:%.*]] = witness_method $Self, #InitRequirement.init!allocator.1
     // CHECK-NEXT: apply [[DELEGATEE]]<Self>([[SELF_BOX]], [[ARG_COPY]], [[SELF_TYPE]])
-    // CHECK-NEXT: end_borrow [[BORROWED_ARG]] from [[ARG]]
+    // CHECK-NEXT: end_borrow [[BORROWED_ARG]]
     // CHECK-NEXT: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[SELF_BOX_ADDR]]
     // CHECK-NEXT: copy_addr [take] [[SELF_BOX]] to [[ACCESS]]
     // CHECK-NEXT: end_access [[ACCESS]]
@@ -770,7 +770,7 @@ extension ClassInitRequirement {
   // CHECK:         [[ARG_COPY_CAST:%.*]] = upcast [[ARG_COPY]]
   // CHECK:         [[DELEGATEE:%.*]] = witness_method $Self, #ClassInitRequirement.init!allocator.1 : {{.*}} : $@convention(witness_method: ClassInitRequirement) <τ_0_0 where τ_0_0 : ClassInitRequirement> (@owned C, @thick τ_0_0.Type) -> @owned τ_0_0
   // CHECK:         apply [[DELEGATEE]]<Self>([[ARG_COPY_CAST]], [[SELF_TYPE]])
-  // CHECK:         end_borrow [[BORROWED_ARG]] from [[ARG]]
+  // CHECK:         end_borrow [[BORROWED_ARG]]
   
   // CHECK: } // end sil function '$S19protocol_extensions20ClassInitRequirementPAAE{{[_0-9a-zA-Z]*}}fC'
   init(d: D) {
@@ -800,8 +800,8 @@ extension ObjCInitRequirement {
   // CHECK:         [[BORROWED_ARG_2_UPCAST:%.*]] = upcast [[BORROWED_ARG_2]]
   // CHECK:         [[WITNESS:%.*]] = objc_method [[SELF]] : $Self, #ObjCInitRequirement.init!initializer.1.foreign : {{.*}}, $@convention(objc_method) <τ_0_0 where τ_0_0 : ObjCInitRequirement> (OC, OC, @owned τ_0_0) -> @owned τ_0_0
   // CHECK:         apply [[WITNESS]]<Self>([[BORROWED_ARG_1_UPCAST]], [[BORROWED_ARG_2_UPCAST]], [[SELF]])
-  // CHECK:         end_borrow [[BORROWED_ARG_2]] from [[ARG]]
-  // CHECK:         end_borrow [[BORROWED_ARG_1]] from [[ARG]]
+  // CHECK:         end_borrow [[BORROWED_ARG_2]]
+  // CHECK:         end_borrow [[BORROWED_ARG_1]]
   // CHECK: } // end sil function '$S19protocol_extensions19ObjCInitRequirementPAAE{{[_0-9a-zA-Z]*}}fC'
   init(d: OD) {
     self.init(c: d, d: d)

--- a/test/SILGen/protocols.swift
+++ b/test/SILGen/protocols.swift
@@ -259,7 +259,7 @@ class ClassWithGetter : PropertyWithGetter {
 // CHECK-NEXT: [[CCOPY_LOADED:%.*]] = load_borrow %0
 // CHECK-NEXT: [[FUN:%.*]] = class_method [[CCOPY_LOADED]] : $ClassWithGetter, #ClassWithGetter.a!getter.1 : (ClassWithGetter) -> () -> Int, $@convention(method) (@guaranteed ClassWithGetter) -> Int
 // CHECK-NEXT: apply [[FUN]]([[CCOPY_LOADED]])
-// CHECK-NEXT: end_borrow [[CCOPY_LOADED]] from %0
+// CHECK-NEXT: end_borrow [[CCOPY_LOADED]]
 // CHECK-NEXT: return
 
 class ClassWithGetterSetter : PropertyWithGetterSetter, PropertyWithGetter {
@@ -282,7 +282,7 @@ class ClassWithGetterSetter : PropertyWithGetterSetter, PropertyWithGetter {
 // CHECK-NEXT: [[CCOPY_LOADED:%.*]] = load_borrow %0
 // CHECK-NEXT: [[FUN:%.*]] = class_method [[CCOPY_LOADED]] : $ClassWithGetterSetter, #ClassWithGetterSetter.b!getter.1 : (ClassWithGetterSetter) -> () -> Int, $@convention(method) (@guaranteed ClassWithGetterSetter) -> Int
 // CHECK-NEXT: apply [[FUN]]([[CCOPY_LOADED]])
-// CHECK-NEXT: end_borrow [[CCOPY_LOADED]] from %0
+// CHECK-NEXT: end_borrow [[CCOPY_LOADED]]
 // CHECK-NEXT: return
 
 // Stored variables fulfilling property requirements
@@ -361,7 +361,7 @@ struct StructWithStoredClassProperty : PropertyWithGetter {
 // CHECK-NEXT: function_ref
 // CHECK-NEXT: [[FUN:%.*]] = function_ref @$S9protocols29StructWithStoredClassPropertyV1aSivg : $@convention(method) (@guaranteed StructWithStoredClassProperty) -> Int
 // CHECK-NEXT: apply [[FUN]]([[CCOPY_LOADED]])
-// CHECK-NEXT: end_borrow [[CCOPY_LOADED]] from %0
+// CHECK-NEXT: end_borrow [[CCOPY_LOADED]]
 // CHECK-NEXT: return
 
 // rdar://22676810

--- a/test/SILGen/reabstract-tuple.swift
+++ b/test/SILGen/reabstract-tuple.swift
@@ -32,7 +32,7 @@ class Box<T> {
 // CHECK:   [[THUNK2:%.*]] = function_ref @$SytytIegnr_Ieg_TR : $@convention(thin) (@guaranteed @callee_guaranteed (@in_guaranteed ()) -> @out ()) -> ()
 // CHECK:   [[PA2:%.*]] = partial_apply [callee_guaranteed] [[THUNK2]]([[TUPLEC_1]]) : $@convention(thin) (@guaranteed @callee_guaranteed (@in_guaranteed ()) -> @out ()) -> ()
 // CHECK:   destroy_value [[PA2]] : $@callee_guaranteed () -> ()    
-// CHECK:   end_borrow [[BORROW_CALL]] from %{{.*}} : $Box<(Int, () -> ())>, $Box<(Int, () -> ())>
+// CHECK:   end_borrow [[BORROW_CALL]] : $Box<(Int, () -> ())>
 // CHECK-LABEL: } // end sil function '$S4main7testBoxyyF'
 public func testBox() {
   let box = Box((22, { () in }))

--- a/test/SILGen/shared.swift
+++ b/test/SILGen/shared.swift
@@ -25,8 +25,8 @@ func owned_arguments(trivial : Int, value : ValueAggregate, ref : RefAggregate) 
   // CHECK: [[BORROW_REF_VAL:%[0-9]+]] = begin_borrow [[REF_VAL]] : $RefAggregate
   // CHECK: [[SHARED_FUNC:%[0-9]+]] = function_ref @$S6shared0A10_arguments7trivial5value3refySih_AA14ValueAggregateVhAA03RefG0ChtF
   // CHECK: {{%.*}} = apply [[SHARED_FUNC]]([[TRIVIAL_VAL]], [[BORROW_VALUE_VAL]], [[BORROW_REF_VAL]])
-  // CHECK: end_borrow [[BORROW_REF_VAL]] from [[REF_VAL]] : $RefAggregate, $RefAggregate
-  // CHECK: end_borrow [[BORROW_VALUE_VAL]] from [[VALUE_VAL]] : $ValueAggregate, $ValueAggregate
+  // CHECK: end_borrow [[BORROW_REF_VAL]] : $RefAggregate
+  // CHECK: end_borrow [[BORROW_VALUE_VAL]] : $ValueAggregate
   // CHECK: destroy_value [[REF_VAL]] : $RefAggregate
   // CHECK: destroy_value [[VALUE_VAL]] : $ValueAggregate
   // CHECK: } // end sil function '$S6shared15owned_arguments7trivial5value3refySi_AA14ValueAggregateVAA03RefH0CtF'
@@ -116,8 +116,8 @@ func owned_to_shared_conversion(_ f : (Int, ValueAggregate, RefAggregate) -> Voi
   // CHECK: [[BORROW_VALUE_VAL:%[0-9]+]] = begin_borrow [[VALUE_VAL]] : $ValueAggregate
   // CHECK: [[BORROW_REF_VAL:%[0-9]+]] = begin_borrow [[REF_VAL]] : $RefAggregate
   // CHECK: {{%.*}} = apply [[FUNC]]([[TRIVIAL_VAL]], [[BORROW_VALUE_VAL]], [[BORROW_REF_VAL]]) : $@noescape @callee_guaranteed (Int, @guaranteed ValueAggregate, @guaranteed RefAggregate) -> ()
-  // CHECK: end_borrow [[BORROW_REF_VAL]] from [[REF_VAL]] : $RefAggregate, $RefAggregate
-  // CHECK: end_borrow [[BORROW_VALUE_VAL]] from [[VALUE_VAL]] : $ValueAggregate, $ValueAggregate
+  // CHECK: end_borrow [[BORROW_REF_VAL]] : $RefAggregate
+  // CHECK: end_borrow [[BORROW_VALUE_VAL]] : $ValueAggregate
   // CHECK: destroy_value [[REF_VAL]] : $RefAggregate
   // CHECK: destroy_value [[VALUE_VAL]] : $ValueAggregate
   // CHECK: } // end sil function '$SSi6shared14ValueAggregateVAA03RefC0CIgygg_SiAcEIegyxx_TR'
@@ -149,8 +149,8 @@ struct Foo {
         // CHECK: [[BORROW_REF_VAL:%[0-9]+]] = begin_borrow [[REF_VAL]] : $RefAggregate
         // CHECK: [[SHARED_FUNC:%[0-9]+]] = function_ref @$S6shared3FooV21methodSharedArguments7trivial5value3refySih_AA14ValueAggregateVhAA03RefJ0ChtF
         // CHECK: {{%.*}} = apply [[SHARED_FUNC]]([[TRIVIAL_VAL]], [[BORROW_VALUE_VAL]], [[BORROW_REF_VAL]], [[SELF]])
-        // CHECK: end_borrow [[BORROW_REF_VAL]] from [[REF_VAL]] : $RefAggregate, $RefAggregate
-        // CHECK: end_borrow [[BORROW_VALUE_VAL]] from [[VALUE_VAL]] : $ValueAggregate, $ValueAggregate
+        // CHECK: end_borrow [[BORROW_REF_VAL]] : $RefAggregate
+        // CHECK: end_borrow [[BORROW_VALUE_VAL]] : $ValueAggregate
         // CHECK: destroy_value [[REF_VAL]] : $RefAggregate
         // CHECK: destroy_value [[VALUE_VAL]] : $ValueAggregate
         // CHECK: } // end sil function '$S6shared3FooV20methodOwnedArguments7trivial5value3refySi_AA14ValueAggregateVAA03RefJ0CtF'
@@ -174,8 +174,8 @@ struct Foo {
         // CHECK: [[BORROW_REF_VAL:%[0-9]+]] = begin_borrow [[REF_VAL]] : $RefAggregate
         // CHECK: [[SHARED_FUNC:%[0-9]+]] = function_ref @$S6shared3FooV21staticSharedArguments7trivial5value3refySih_AA14ValueAggregateVhAA03RefJ0ChtFZ
         // CHECK: {{%.*}} = apply [[SHARED_FUNC]]([[TRIVIAL_VAL]], [[BORROW_VALUE_VAL]], [[BORROW_REF_VAL]], [[SELF_METATYPE]])
-        // CHECK: end_borrow [[BORROW_REF_VAL]] from [[REF_VAL]] : $RefAggregate, $RefAggregate
-        // CHECK: end_borrow [[BORROW_VALUE_VAL]] from [[VALUE_VAL]] : $ValueAggregate, $ValueAggregate
+        // CHECK: end_borrow [[BORROW_REF_VAL]] : $RefAggregate
+        // CHECK: end_borrow [[BORROW_VALUE_VAL]] : $ValueAggregate
         // CHECK: destroy_value [[REF_VAL]] : $RefAggregate
         // CHECK: destroy_value [[VALUE_VAL]] : $ValueAggregate
         // CHECK: } // end sil function '$S6shared3FooV20staticOwnedArguments7trivial5value3refySi_AA14ValueAggregateVAA03RefJ0CtFZ'

--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -623,7 +623,7 @@ func testRequireOptional2(_ a : String?) -> String {
   // CHECK:  [[CONT_BB]]:
   // CHECK-NEXT:   [[BORROWED_STR:%.*]] = begin_borrow [[STR]]
   // CHECK-NEXT:   [[RETURN:%.*]] = copy_value [[BORROWED_STR]]
-  // CHECK-NEXT:   end_borrow [[BORROWED_STR]] from [[STR]]
+  // CHECK-NEXT:   end_borrow [[BORROWED_STR]]
   // CHECK-NEXT:   destroy_value [[STR]] : $String
   // CHECK-NEXT:   return [[RETURN]] : $String
 
@@ -669,7 +669,7 @@ func test_as_pattern(_ y : BaseClass) -> DerivedClass {
   // CHECK: [[CONT_BB]]:
   // CHECK-NEXT: [[BORROWED_PTR:%.*]] = begin_borrow [[PTR]]
   // CHECK-NEXT: [[RESULT:%.*]] = copy_value [[BORROWED_PTR]]
-  // CHECK-NEXT: end_borrow [[BORROWED_PTR]] from [[PTR]]
+  // CHECK-NEXT: end_borrow [[BORROWED_PTR]]
   // CHECK-NEXT: destroy_value [[PTR]] : $DerivedClass
   // CHECK-NEXT: return [[RESULT]] : $DerivedClass
   return result

--- a/test/SILGen/super.swift
+++ b/test/SILGen/super.swift
@@ -90,7 +90,7 @@ public class ChildToResilientParent : ResilientOutsideParent {
     // CHECK:   [[BORROW_UPCAST_SELF:%.*]] = begin_borrow [[UPCAST_SELF]]
     // CHECK:   [[CAST_BORROW_BACK_TO_BASE:%.*]] = unchecked_ref_cast [[BORROW_UPCAST_SELF]]
     // CHECK:   [[FUNC:%.*]] = super_method [[CAST_BORROW_BACK_TO_BASE]] : $ChildToResilientParent, #ResilientOutsideParent.method!1 : (ResilientOutsideParent) -> () -> (), $@convention(method) (@guaranteed ResilientOutsideParent) -> ()
-    // CHECK:   end_borrow [[BORROW_UPCAST_SELF]] from [[UPCAST_SELF]]
+    // CHECK:   end_borrow [[BORROW_UPCAST_SELF]]
     // CHECK:   apply [[FUNC]]([[UPCAST_SELF]])
     super.method()
   }
@@ -128,7 +128,7 @@ public class ChildToFixedParent : OutsideParent {
     // CHECK:   [[BORROWED_UPCAST_COPY_SELF:%.*]] = begin_borrow [[UPCAST_COPY_SELF]]
     // CHECK:   [[DOWNCAST_BORROWED_UPCAST_COPY_SELF:%.*]] = unchecked_ref_cast [[BORROWED_UPCAST_COPY_SELF]] : $OutsideParent to $ChildToFixedParent
     // CHECK:   [[FUNC:%.*]] = super_method [[DOWNCAST_BORROWED_UPCAST_COPY_SELF]] : $ChildToFixedParent, #OutsideParent.method!1 : (OutsideParent) -> () -> (), $@convention(method) (@guaranteed OutsideParent) -> ()
-    // CHECK:   end_borrow [[BORROWED_UPCAST_COPY_SELF]] from [[UPCAST_COPY_SELF]]
+    // CHECK:   end_borrow [[BORROWED_UPCAST_COPY_SELF]]
     // CHECK:   apply [[FUNC]]([[UPCAST_COPY_SELF]])
     super.method()
   }

--- a/test/SILGen/super_init_refcounting.swift
+++ b/test/SILGen/super_init_refcounting.swift
@@ -87,7 +87,7 @@ class Good: Foo {
   // CHECK:         [[DOWNCAST_BORROWED_SUPER:%.*]] = unchecked_ref_cast [[BORROWED_SUPER]] : $Foo to $Good
   // CHECK:         [[X_ADDR:%.*]] = ref_element_addr [[DOWNCAST_BORROWED_SUPER]] : $Good, #Good.x
   // CHECK:         [[X:%.*]] = load [trivial] [[X_ADDR]] : $*Int
-  // CHECK:         end_borrow [[BORROWED_SUPER]] from [[SUPER_OBJ]]
+  // CHECK:         end_borrow [[BORROWED_SUPER]]
   // CHECK:         [[SUPER_INIT:%.*]] = function_ref @$S22super_init_refcounting3FooCyACSicfc : $@convention(method) (Int, @owned Foo) -> @owned Foo
   // CHECK:         apply [[SUPER_INIT]]([[X]], [[SUPER_OBJ]])
   override init() {

--- a/test/SILGen/switch.swift
+++ b/test/SILGen/switch.swift
@@ -541,7 +541,7 @@ func test_isa_class_2(x: B) -> AnyObject {
   // CHECK:   [[BORROWED_CAST_D1_COPY:%.*]] = begin_borrow [[CAST_D1_COPY]]
   // CHECK:   [[CAST_D1_COPY_COPY:%.*]] = copy_value [[BORROWED_CAST_D1_COPY]]
   // CHECK:   [[RET:%.*]] = init_existential_ref [[CAST_D1_COPY_COPY]]
-  // CHECK:   end_borrow [[BORROWED_CAST_D1_COPY]] from [[CAST_D1_COPY]]
+  // CHECK:   end_borrow [[BORROWED_CAST_D1_COPY]]
   // CHECK:   destroy_value [[CAST_D1_COPY]]
   // CHECK:   destroy_value [[X_COPY]] : $B
   // CHECK:   br [[CONT:bb[0-9]+]]([[RET]] : $AnyObject)
@@ -564,7 +564,7 @@ func test_isa_class_2(x: B) -> AnyObject {
   // CHECK:   [[BORROWED_CAST_D2_COPY:%.*]] = begin_borrow [[CAST_D2_COPY]]
   // CHECK:   [[CAST_D2_COPY_COPY:%.*]] = copy_value [[BORROWED_CAST_D2_COPY]]
   // CHECK:   [[RET:%.*]] = init_existential_ref [[CAST_D2_COPY_COPY]]
-  // CHECK:   end_borrow [[BORROWED_CAST_D2_COPY]] from [[CAST_D2_COPY]]
+  // CHECK:   end_borrow [[BORROWED_CAST_D2_COPY]]
   // CHECK:   destroy_value [[CAST_D2_COPY]]
   // CHECK:   destroy_value [[X_COPY]]
   // CHECK:   br [[CONT]]([[RET]] : $AnyObject)
@@ -587,7 +587,7 @@ func test_isa_class_2(x: B) -> AnyObject {
   // CHECK:   [[BORROWED_CAST_E_COPY:%.*]] = begin_borrow [[CAST_E_COPY]]
   // CHECK:   [[CAST_E_COPY_COPY:%.*]] = copy_value [[BORROWED_CAST_E_COPY]]
   // CHECK:   [[RET:%.*]] = init_existential_ref [[CAST_E_COPY_COPY]]
-  // CHECK:   end_borrow [[BORROWED_CAST_E_COPY]] from [[CAST_E_COPY]]
+  // CHECK:   end_borrow [[BORROWED_CAST_E_COPY]]
   // CHECK:   destroy_value [[CAST_E_COPY]]
   // CHECK:   destroy_value [[X_COPY]] : $B
   // CHECK:   br [[CONT]]([[RET]] : $AnyObject)
@@ -610,7 +610,7 @@ func test_isa_class_2(x: B) -> AnyObject {
   // CHECK:   [[BORROWED_CAST_C_COPY:%.*]] = begin_borrow [[CAST_C_COPY]]
   // CHECK:   [[CAST_C_COPY_COPY:%.*]] = copy_value [[BORROWED_CAST_C_COPY]]
   // CHECK:   [[RET:%.*]] = init_existential_ref [[CAST_C_COPY_COPY]]
-  // CHECK:   end_borrow [[BORROWED_CAST_C_COPY]] from [[CAST_C_COPY]]
+  // CHECK:   end_borrow [[BORROWED_CAST_C_COPY]]
   // CHECK:   destroy_value [[CAST_C_COPY]]
   // CHECK:   destroy_value [[X_COPY]]
   // CHECK:   br [[CONT]]([[RET]] : $AnyObject)

--- a/test/SILGen/switch_var.swift
+++ b/test/SILGen/switch_var.swift
@@ -503,7 +503,7 @@ func test_mixed_let_var() {
   // CHECK:   [[BORROWED_VAL_COPY:%.*]] = begin_borrow [[VAL_COPY]]
   // CHECK:   [[B:%.*]] = function_ref @$S10switch_var1b1xySS_tF
   // CHECK:   apply [[B]]([[BORROWED_VAL_COPY]])
-  // CHECK:   end_borrow [[BORROWED_VAL_COPY]] from [[VAL_COPY]]
+  // CHECK:   end_borrow [[BORROWED_VAL_COPY]]
   // CHECK:   destroy_value [[VAL_COPY]]
   // CHECK:   destroy_value [[VAL]]
   // CHECK:   br [[CONT]]  

--- a/test/SILGen/tuples.swift
+++ b/test/SILGen/tuples.swift
@@ -149,7 +149,7 @@ extension P {
   // CHECK:   [[LOADED_CLASS:%.*]] = load_borrow [[ZERO_ADDR]]
   // CHECK:   [[ONE_ADDR:%.*]] = tuple_element_addr [[RVALUE]] : $*(index: C, value: Self), 1
   // CHECK:   apply {{.*}}([[ONE_ADDR]]) : $@convention(witness_method: P)
-  // CHECK:   end_borrow [[LOADED_CLASS]] from [[ZERO_ADDR]]
+  // CHECK:   end_borrow [[LOADED_CLASS]]
   // CHECK:   destroy_addr [[RVALUE]]
   // CHECK:   dealloc_stack [[RVALUE]]
   public static func immutableUse(tuple: (index: C, value: Self)) -> () {

--- a/test/SILGen/unowned.swift
+++ b/test/SILGen/unowned.swift
@@ -68,7 +68,7 @@ func test0(c c: C) {
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBX]]
   // CHECK:   [[T2:%.*]] = load_borrow [[READ]] : $*@sil_unowned C     
   // CHECK:   [[T3:%.*]] = copy_unowned_value  [[T2]] : $@sil_unowned C  
-  // CHECK:   end_borrow [[T2]] from [[READ]]
+  // CHECK:   end_borrow [[T2]]
   // CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[PBA]]
   // CHECK:   [[XP:%.*]] = struct_element_addr [[WRITE]] : $*A, #A.x
   // CHECK:   [[T4:%.*]] = ref_to_unowned [[T3]] : $C to $@sil_unowned C
@@ -93,12 +93,12 @@ func testunowned_local() -> C {
   // CHECK: [[tmp1_copy:%.*]] = copy_value [[tmp1]]
   // CHECK: store [[tmp1_copy]] to [init] [[PB_UC]]
   // CHECK: destroy_value [[C_COPY]]
-  // CHECK: end_borrow [[BORROWED_C]] from [[C]]
+  // CHECK: end_borrow [[BORROWED_C]]
   unowned let uc = c
 
   // CHECK: [[tmp2:%.*]] = load_borrow [[PB_UC]]
   // CHECK: [[tmp3:%.*]] = copy_unowned_value [[tmp2]]
-  // CHECK: end_borrow [[tmp2]] from [[PB_UC]]
+  // CHECK: end_borrow [[tmp2]]
   return uc
 
   // CHECK: destroy_value [[UC]]
@@ -144,8 +144,8 @@ class TestUnownedMember {
 // CHECK:   [[INVAL_COPY:%.*]] = copy_value [[INVAL]] : $@sil_unowned C
 // CHECK:   assign [[INVAL_COPY]] to [[FIELDPTR]] : $*@sil_unowned C
 // CHECK:   destroy_value [[ARG1_COPY]] : $C
-// CHECK:   end_borrow [[BORROWED_ARG1]] from [[ARG1]]
-// CHECK:   end_borrow [[BORROWED_SELF]] from [[SELF]]
+// CHECK:   end_borrow [[BORROWED_ARG1]]
+// CHECK:   end_borrow [[BORROWED_SELF]]
 // CHECK:   [[RET_SELF:%.*]] = copy_value [[SELF]]
 // CHECK:   destroy_value [[SELF]]
 // CHECK:   destroy_value [[ARG1]]

--- a/test/SILGen/value_ownership.swift
+++ b/test/SILGen/value_ownership.swift
@@ -28,7 +28,7 @@ struct Witness: OwnershipProto {
 // CHECK:         [[WITNESS_FUNC:%.*]] = function_ref @$S15value_ownership7WitnessV6elidedyySS_S2StF
 // CHECK:         [[BORROWOWNED2DEFAULT:%.*]] = begin_borrow [[OWNED2DEFAULT]] : $String
 // CHECK:         apply [[WITNESS_FUNC]]([[DEFAULT2DEFAULT]], [[SHARED2DEFAULT]], [[BORROWOWNED2DEFAULT]], [[LOAD_WITNESS]])
-// CHECK:         end_borrow [[BORROWOWNED2DEFAULT]] from [[OWNED2DEFAULT]] : $String, $String
+// CHECK:         end_borrow [[BORROWOWNED2DEFAULT]] : $String
 // CHECK:       } // end sil function '$S15value_ownership7WitnessVAA14OwnershipProtoA2aDP6elidedyySS_SShSSntFTW'
 
 // Check that the explicit witness' thunk doesn't copy or borrow

--- a/test/SILGen/weak.swift
+++ b/test/SILGen/weak.swift
@@ -77,7 +77,7 @@ class CC {
   // CHECK:    [[READ:%.*]] = begin_access [read] [dynamic] [[X]] : $*@sil_weak Optional<CC>
   // CHECK:    [[VALUE:%.*]] = load_weak [[READ]] : $*@sil_weak Optional<CC>
   // CHECK:    store [[VALUE]] to [init] [[PB]] : $*Optional<CC>
-  // CHECK:    end_borrow [[BORROWED_UNINIT_SELF]] from [[UNINIT_SELF]]
+  // CHECK:    end_borrow [[BORROWED_UNINIT_SELF]]
   // CHECK:    destroy_value [[FOO]]
   // CHECK: } // end sil function '$S4weak2CCC{{[_0-9a-zA-Z]*}}fc'
   init() {

--- a/test/SILGen/without_actually_escaping.swift
+++ b/test/SILGen/without_actually_escaping.swift
@@ -34,12 +34,12 @@ func letEscape(f: () -> ()) -> () -> () {
 // CHECK: bb1([[RES:%.*]] : @owned $@callee_guaranteed () -> ()):
 // CHECK:   [[ESCAPED:%.*]] = is_escaping_closure [[BORROW]]
 // CHECK:   cond_fail [[ESCAPED]] : $Builtin.Int1
-// CHECK:   end_borrow [[BORROW]] from [[MD]]
+// CHECK:   end_borrow [[BORROW]]
 // CHECK:   destroy_value [[MD]]
 // CHECK:   return [[RES]]
 //
 // CHECK: bb2([[ERR:%.*]] : @owned $Error):
-// CHECK:   end_borrow [[BORROW]] from [[MD]]
+// CHECK:   end_borrow [[BORROW]]
 // CHECK:   destroy_value [[MD]]
 // CHECK:   throw [[ERR]] : $Error
 // CHECK: }

--- a/test/SILGen/without_actually_escaping_block.swift
+++ b/test/SILGen/without_actually_escaping_block.swift
@@ -17,9 +17,9 @@ typealias Callback = @convention(block) () -> Void
 // CHECK:  [[B2:%.*]] = begin_borrow [[CVT]]
 // CHECK:  [[FN:%.*]] = function_ref @$S25without_actually_escaping9testBlock5blockyyyXB_tFyyyXBXEfU_
 // CHECK:  apply [[FN]]([[B2]])
-// CHECK:  end_borrow [[B2]] from [[CVT]]
+// CHECK:  end_borrow [[B2]]
 // CHECK:  destroy_value [[CVT]]
-// CHECK:  end_borrow [[B1]] from [[C1]]
+// CHECK:  end_borrow [[B1]]
 // CHECK:  destroy_value [[C1]]
 // CHECK:  return
 

--- a/test/SILGen/witnesses.swift
+++ b/test/SILGen/witnesses.swift
@@ -174,7 +174,7 @@ final class ConformingClass : X {
   // CHECK:    [[FUNC:%.*]] = function_ref @$S9witnesses15ConformingClassC9selfTypes{{[_0-9a-zA-Z]*}}F
   // CHECK:    [[FUNC_RESULT:%.*]] = apply [[FUNC]]([[ARG2_LOADED]], [[ARG3_LOADED]]) : $@convention(method) (@guaranteed ConformingClass, @guaranteed ConformingClass) -> @owned ConformingClass
   // CHECK:    store [[FUNC_RESULT]] to [init] [[ARG1]] : $*ConformingClass
-  // CHECK:    end_borrow [[ARG3_LOADED]] from [[ARG3]]
+  // CHECK:    end_borrow [[ARG3_LOADED]]
   // CHECK:  } // end sil function '$S9witnesses15ConformingClassCAA1XA2aDP9selfTypes{{[_0-9a-zA-Z]*}}FTW'
   func loadable(x: Loadable) -> Loadable { return x }
   func addrOnly(x: AddrOnly) -> AddrOnly { return x }
@@ -468,7 +468,7 @@ class PropertyRequirementWitnessFromBase : PropertyRequirementBase, PropertyRequ
   // CHECK-NEXT: yield [[RES]]
   // CHECK:      end_apply [[TOKEN]]
   // CHECK-NEXT: [[TUPLE:%.*]] = tuple ()
-  // CHECK-NEXT: end_borrow [[ARG2_LOADED]] from [[ARG2]]
+  // CHECK-NEXT: end_borrow [[ARG2_LOADED]]
   // CHECK-NEXT: return [[TUPLE]]
 
   // CHECK-LABEL: sil private [transparent] [thunk] @$S9witnesses34PropertyRequirementWitnessFromBaseCAA0bC0A2aDP6heightSivMZTW : {{.*}} {
@@ -488,7 +488,7 @@ class PropertyRequirementWitnessFromBase : PropertyRequirementBase, PropertyRequ
   // CHECK-NEXT: yield [[RES]]
   // CHECK:      end_apply [[TOKEN]]
   // CHECK-NEXT: [[TUPLE:%.*]] = tuple ()
-  // CHECK-NEXT: end_borrow [[ARG2_LOADED]] from [[ARG2]]
+  // CHECK-NEXT: end_borrow [[ARG2_LOADED]]
   // CHECK-NEXT: return [[TUPLE]]
 }
 
@@ -507,7 +507,7 @@ class CrashableBase {
 // CHECK-NEXT: [[FN:%.*]] = class_method [[BASE]] : $CrashableBase, #CrashableBase.crash!1 : (CrashableBase) -> () -> (), $@convention(method) (@guaranteed CrashableBase) -> ()
 // CHECK-NEXT: apply [[FN]]([[BASE]]) : $@convention(method) (@guaranteed CrashableBase) -> ()
 // CHECK-NEXT: [[RESULT:%.*]] = tuple ()
-// CHECK-NEXT: end_borrow [[SELF]] from %0
+// CHECK-NEXT: end_borrow [[SELF]]
 // CHECK-NEXT: return [[RESULT]] : $()
 
 class GenericCrashable<T> : CrashableBase, Crashable {}

--- a/test/SILGen/witnesses_inheritance.swift
+++ b/test/SILGen/witnesses_inheritance.swift
@@ -39,7 +39,7 @@ class B : A, Barrable {}
 // CHECK-NEXT:    [[A:%.*]] = upcast [[B]] : $B to $A
 // CHECK-NEXT:    [[METH:%.*]] = class_method [[A]] : $A, #A.bar!1
 // CHECK-NEXT:    apply [[METH]]([[A]]) : $@convention(method) (@guaranteed A) -> ()
-// CHECK:         end_borrow [[B]] from {{.*}}
+// CHECK:         end_borrow [[B]]
 
 // CHECK-LABEL: sil private [transparent] [thunk] @$S21witnesses_inheritance1BCAA8BarrableA2aDP9class_bar{{[_0-9a-zA-Z]*}}FZTW
 // CHECK:         upcast {{%.*}} : $@thick B.Type to $@thick A.Type

--- a/test/SILOptimizer/access_enforcement_selection.sil
+++ b/test/SILOptimizer/access_enforcement_selection.sil
@@ -211,7 +211,7 @@ sil @borrowClosure : $@convention(thin) () -> () {
   // closure is borrowed.
   %borrow = begin_borrow %closure : $@callee_guaranteed () -> ()
   %closure_copy = copy_value %borrow : $@callee_guaranteed () -> ()
-  end_borrow %borrow from %closure : $@callee_guaranteed () -> (), $@callee_guaranteed () -> ()
+  end_borrow %borrow : $@callee_guaranteed () -> ()
 
   destroy_value %closure_copy : $@callee_guaranteed () -> ()
   destroy_value %closure : $@callee_guaranteed () -> ()

--- a/test/SILOptimizer/access_marker_verify.swift
+++ b/test/SILOptimizer/access_marker_verify.swift
@@ -95,7 +95,7 @@ class SubHasInt : SuperHasInt {
 // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[ADR]] : $*Int
 // CHECK:   assign %{{.*}} to [[ACCESS]] : $*Int
 // CHECK:   end_access [[ACCESS]] : $*Int
-// CHECK:   end_borrow [[BORROW]] from [[UNINIT]] : $SuperHasInt, $SuperHasInt
+// CHECK:   end_borrow [[BORROW]] : $SuperHasInt
 // CHECK-NOT: begin_access
 // CHECK:   [[VAL:%.*]] = copy_value [[UNINIT]] : $SuperHasInt
 // CHECK:   destroy_value [[UNINIT]] : $SuperHasInt
@@ -115,7 +115,7 @@ class SubHasInt : SuperHasInt {
 // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[ADR]] : $*Int
 // CHECK:   assign %{{.*}} to [[ACCESS]] : $*Int
 // CHECK:   end_access [[ACCESS]] : $*Int
-// CHECK:   end_borrow [[BORROW]] from [[PROJ]] : $SubHasInt, $*SubHasInt
+// CHECK:   end_borrow [[BORROW]] : $SubHasInt
 // CHECK-NOT: begin_access
 // CHECK:   load [take] [[PROJ]] : $*SubHasInt
 // CHECK:   upcast %{{.*}} : $SubHasInt to $SuperHasInt
@@ -142,7 +142,7 @@ class SubHasInt : SuperHasInt {
 // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[ADR]] : $*Int
 // CHECK:   assign %0 to [[ACCESS]] : $*Int
 // CHECK:   end_access [[ACCESS]] : $*Int
-// CHECK:   end_borrow [[BORROW]] from [[PROJ]] : $SubHasInt, $*SubHasInt
+// CHECK:   end_borrow [[BORROW]] : $SubHasInt
 // CHECK-NOT: begin_access
 // CHECK:   load [take] [[PROJ]] : $*SubHasInt
 // CHECK:   upcast %{{.*}} : $SubHasInt to $SuperHasInt
@@ -761,7 +761,7 @@ class C : Abstractable {
 // CHECK-NEXT:   dealloc_stack [[TEMP]]
 // CHECK-NEXT:   end_apply [[TOKEN]]
 // CHECK-NEXT:   [[TUPLE:%.*]] = tuple ()
-// CHECK-NEXT:   end_borrow [[SELF]] from %0 : $C
+// CHECK-NEXT:   end_borrow [[SELF]] : $C
 // CHECK-NEXT:   return [[TUPLE]]
 
 // CHECK:      bb2:
@@ -772,7 +772,7 @@ class C : Abstractable {
 // CHECK-NEXT:   store [[THUNKED_NEW_FN]] to [init] [[ADDR]] :
 // CHECK-NEXT:   dealloc_stack [[TEMP]]
 // CHECK-NEXT:   abort_apply [[TOKEN]]
-// CHECK-NEXT:   end_borrow [[SELF]] from %0 : $C
+// CHECK-NEXT:   end_borrow [[SELF]] : $C
 // CHECK-NEXT:   unwind
 
 // --- writeback address-only.

--- a/test/SILOptimizer/access_summary_analysis.sil
+++ b/test/SILOptimizer/access_summary_analysis.sil
@@ -479,7 +479,7 @@ bb0(%0 : @trivial $*Int, %1 : @trivial $*Int, %2 : @trivial $*Int):
   %6 = begin_borrow %5 : $@callee_owned (Int) -> @error Error
   %7 = function_ref @takesGuaranteedNoEscapeClosureTakingArgumentThrowing : $@convention(thin) (@guaranteed @callee_owned (Int) -> @error Error) -> ()
   %8 = apply %7(%6) : $@convention(thin) (@guaranteed @callee_owned (Int) -> @error Error) -> ()
-  end_borrow %6 from %5 : $@callee_owned (Int) -> @error Error, $@callee_owned (Int) -> @error Error
+  end_borrow %6 : $@callee_owned (Int) -> @error Error
   destroy_value %5 : $@callee_owned (Int) -> @error Error
   %9999 = tuple ()
   return %9999 : $()
@@ -499,7 +499,7 @@ entry:
   %n2 = mark_dependence %n : $@noescape @callee_guaranteed () -> () on %e : $@callee_guaranteed () -> ()
   %f2 = function_ref @use : $@convention(thin) (@noescape @callee_guaranteed () -> ()) -> ()
   apply %f2(%n2) : $@convention(thin) (@noescape @callee_guaranteed () -> ()) -> ()
-  end_borrow %b from %e : $@callee_guaranteed () -> (), $@callee_guaranteed () -> ()
+  end_borrow %b : $@callee_guaranteed () -> ()
   destroy_value %e : $@callee_guaranteed () -> ()
   %t = tuple ()
   return %t : $()

--- a/test/SILOptimizer/capture_promotion_generic_context_ownership.sil
+++ b/test/SILOptimizer/capture_promotion_generic_context_ownership.sil
@@ -96,7 +96,7 @@ entry(%0 : @trivial $*R<T>, %1 : @trivial $*Int, %b : @owned $<τ_0_0> { var E<(
 bb1(%f : @owned $@callee_guaranteed (@in_guaranteed R<T>) -> @out Int):
   %bf = begin_borrow %f : $@callee_guaranteed (@in_guaranteed R<T>) -> @out Int
   apply %bf(%1, %0) : $@callee_guaranteed (@in_guaranteed R<T>) -> @out Int
-  end_borrow %bf from %f : $@callee_guaranteed (@in_guaranteed R<T>) -> @out Int , $@callee_guaranteed (@in_guaranteed R<T>) -> @out Int
+  end_borrow %bf : $@callee_guaranteed (@in_guaranteed R<T>) -> @out Int 
   destroy_value %f : $@callee_guaranteed (@in_guaranteed R<T>) -> @out Int
   br exit
 

--- a/test/SILOptimizer/capture_promotion_ownership.sil
+++ b/test/SILOptimizer/capture_promotion_ownership.sil
@@ -174,7 +174,7 @@ bb0:
 // CHECK:   [[METHOD_FOO:%.*]] = class_method [[ARG0_COPY]] : $Foo, #Foo.foo!1 : (Foo) -> () -> Int, $@convention(method) (@guaranteed Foo) -> Int
 // CHECK:   [[BORROWED_ARG0_COPY:%.*]] = begin_borrow [[ARG0_COPY]]
 // CHECK:   [[APPLY_FOO:%.*]] = apply [[METHOD_FOO]]([[BORROWED_ARG0_COPY]]) : $@convention(method) (@guaranteed Foo) -> Int
-// CHECK:   end_borrow [[BORROWED_ARG0_COPY]] from [[ARG0_COPY]]
+// CHECK:   end_borrow [[BORROWED_ARG0_COPY]]
 // CHECK:   destroy_value [[ARG0_COPY]]
 
 // CHECK: [[EXTRACT_BAZ_X:%.*]] = struct_extract [[ARG1]] : $Baz, #Baz.x
@@ -185,12 +185,12 @@ bb0:
 
 // The release of %2 is replaced by a release_value of the Baz argument, since
 // it is a non-trivial aggregate
-// CHECK: end_borrow [[ARG1]] from [[ORIGINAL_ARG1]]
+// CHECK: end_borrow [[ARG1]]
 // CHECK: destroy_value [[ORIGINAL_ARG1]] : $Baz
 
 // The release of %0 is replaced by a strong_release of the Foo argument, since
 // it is a reference type
-// CHECK: end_borrow [[ARG0]] from [[ORIGINAL_ARG0]]
+// CHECK: end_borrow [[ARG0]]
 // CHECK: destroy_value [[ORIGINAL_ARG0]]
 // CHECK: [[RESULT:%.*]] = tuple ([[RETVAL]] : $Int, [[EXTRACT_INT_VALUE]] : $Builtin.Int64)
 // CHECK: return [[RESULT]] : $(Int, Builtin.Int64)
@@ -208,7 +208,7 @@ bb0(%0 : @owned $<τ_0_0> { var τ_0_0 } <Foo>, %2 : @owned $<τ_0_0> { var τ_0
   %10 = class_method %8 : $Foo, #Foo.foo!1 : (Foo) -> () -> Int, $@convention(method) (@guaranteed Foo) -> Int
   %9 = begin_borrow %8 : $Foo
   %11 = apply %10(%9) : $@convention(method) (@guaranteed Foo) -> Int
-  end_borrow %9 from %8 : $Foo, $Foo
+  end_borrow %9 : $Foo
   destroy_value %8 : $Foo
   %12 = struct_element_addr %3 : $*Baz, #Baz.x
   %13 = load [trivial] %12 : $*Int
@@ -255,7 +255,7 @@ bb0(%0 : @owned $<τ_0_0> { var τ_0_0 } <Foo>):
   %10 = class_method %8 : $Foo, #Foo.foo!1 : (Foo) -> () -> Int, $@convention(method) (@guaranteed Foo) -> Int
   %9 = begin_borrow %8 : $Foo
   %11 = apply %10(%9) : $@convention(method) (@guaranteed Foo) -> Int
-  end_borrow %9 from %8 : $Foo, $Foo
+  end_borrow %9 : $Foo
   destroy_value %8 : $Foo
   %12 = function_ref @mutate_foo : $@convention(thin) (@inout Foo) -> ()
   %13 = apply %12(%1) : $@convention(thin) (@inout Foo) -> ()
@@ -320,7 +320,7 @@ bb0(%0: @trivial $*Int, %1 : @owned $<τ_0_0> { var τ_0_0 } <Foo>, %2 : @owned 
   %10 = class_method %8 : $Foo, #Foo.foo!1 : (Foo) -> () -> Int, $@convention(method) (@guaranteed Foo) -> Int
   %9 = begin_borrow %8 : $Foo
   %11 = apply %10(%9) : $@convention(method) (@guaranteed Foo) -> Int
-  end_borrow %9 from %8 : $Foo, $Foo
+  end_borrow %9 : $Foo
   destroy_value %8 : $Foo
   %12 = struct_element_addr %3 : $*Baz, #Baz.x
   %13 = load [trivial] %12 : $*Int
@@ -435,9 +435,9 @@ bb0:
 // CHECK:   [[BAR2_COPY:%.*]] = copy_value [[BAR2]]
 // CHECK:   [[BAR2_COPY_BORROW:%.*]] = begin_borrow [[BAR2_COPY]]
 // CHECK:   apply {{%.*}}([[BAR_COPY]], [[BAR2_COPY_BORROW]], [[X]])
-// CHECK:   end_borrow [[BAR2_COPY_BORROW]] from [[BAR2_COPY]]
+// CHECK:   end_borrow [[BAR2_COPY_BORROW]]
 // CHECK:   destroy_value [[BAR2_COPY]]
-// CHECK:   end_borrow [[BORROWED_BAZ]] from [[BAZ]]
+// CHECK:   end_borrow [[BORROWED_BAZ]]
 // CHECK:   destroy_value [[BAZ]]
 // CHECK: } // end sil function '$S23closure_projection_testTf2ni_n'
 sil @closure_projection_test : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Baz>, @owned <τ_0_0> { var τ_0_0 } <Baz>) -> () {
@@ -451,7 +451,7 @@ bb0(%0 : @owned $<τ_0_0> { var τ_0_0 } <Baz>, %1 : @owned $<τ_0_0> { var τ_0
   %7 = begin_borrow %6 : $Bar
   %8 = function_ref @destructured_baz_user : $@convention(thin) (@owned Bar, @guaranteed Bar, Int) -> ()
   apply %8(%5, %7, %4) : $@convention(thin) (@owned Bar, @guaranteed Bar, Int) -> ()
-  end_borrow %7 from %6 : $Bar, $Bar
+  end_borrow %7 : $Bar
   destroy_value %6 : $Bar
 
   %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <Baz>, 0
@@ -463,7 +463,7 @@ bb0(%0 : @owned $<τ_0_0> { var τ_0_0 } <Baz>, %1 : @owned $<τ_0_0> { var τ_0
   %14 = begin_borrow %13 : $Bar
   %15 = function_ref @destructured_baz_user : $@convention(thin) (@owned Bar, @guaranteed Bar, Int) -> ()
   apply %15(%12, %14, %11) : $@convention(thin) (@owned Bar, @guaranteed Bar, Int) -> ()
-  end_borrow %14 from %13 : $Bar, $Bar
+  end_borrow %14 : $Bar
   destroy_value %13 : $Bar
 
   destroy_value %1 : $<τ_0_0> { var τ_0_0 } <Baz>

--- a/test/SILOptimizer/capturepromotion-wrong-lexicalscope.swift
+++ b/test/SILOptimizer/capturepromotion-wrong-lexicalscope.swift
@@ -21,7 +21,7 @@
 // CHECK:   debug_value %13 : $@callee_guaranteed () -> Int, let, name "f", loc {{.*}}:33:7, scope 3
 // CHECK:   %15 = begin_borrow %13 : $@callee_guaranteed () -> Int, loc {{.*}}:34:10, scope 3
 // CHECK:   %16 = copy_value %15 : $@callee_guaranteed () -> Int, loc {{.*}}:34:10, scope 3
-// CHECK:   end_borrow %15 from %13 : $@callee_guaranteed () -> Int, $@callee_guaranteed () -> Int, loc {{.*}}:34:10, scope 3
+// CHECK:   end_borrow %15 : $@callee_guaranteed () -> Int
 // CHECK:   destroy_value %13 : $@callee_guaranteed () -> Int, loc {{.*}}:35:1, scope 3
 // CHECK:   destroy_value %0 : ${ var Int }, loc {{.*}}:35:1, scope 3
 // CHECK:   return %16 : $@callee_guaranteed () -> Int, loc {{.*}}:34:3, scope 3

--- a/test/SILOptimizer/definite_init_markuninitialized_derivedself.sil
+++ b/test/SILOptimizer/definite_init_markuninitialized_derivedself.sil
@@ -75,7 +75,7 @@ bb0(%0 : @owned $DerivedClassWithIVars):
   %8 = load_borrow %3 : $*DerivedClassWithIVars
   %9 = ref_element_addr %8 : $DerivedClassWithIVars, #DerivedClassWithIVars.a
   assign %7 to %9 : $*Int
-  end_borrow %8 from %3 : $DerivedClassWithIVars, $*DerivedClassWithIVars
+  end_borrow %8 : $DerivedClassWithIVars
 
   // Then perform the self.init call.
   %11 = load [take] %3 : $*DerivedClassWithIVars
@@ -190,13 +190,13 @@ bb0(%0 : @owned $DerivedClassWithNontrivialStoredProperties):
 // CHECK: [[SELF:%[0-9]+]] = load_borrow [[SELFBOX]]
 // CHECK: [[SELF_FIELD:%.*]] = ref_element_addr [[SELF]]
 // CHECK: store [[FIELD_VAL]] to [init] [[SELF_FIELD]]
-// CHECK: end_borrow [[SELF]] from [[SELFBOX]]
+// CHECK: end_borrow [[SELF]]
 //
 // Now we destroy the stored value.
 // CHECK: [[SELF:%[0-9]+]] = load_borrow [[SELFBOX]]
 // CHECK: [[SELF_FIELD:%.*]] = ref_element_addr [[SELF]]
 // CHECK: destroy_addr [[SELF_FIELD]]
-// CHECK: end_borrow [[SELF]] from [[SELFBOX]]
+// CHECK: end_borrow [[SELF]]
 //
 // And then perform dealloc_partial_ref.
 // CHECK: [[SELF:%[0-9]+]] = load [take] [[SELFBOX]]
@@ -214,7 +214,7 @@ bb0(%0 : @owned $DerivedClassWithNontrivialStoredProperties):
   %9 = load_borrow %4 : $*DerivedClassWithNontrivialStoredProperties
   %10 = ref_element_addr %9 : $DerivedClassWithNontrivialStoredProperties, #DerivedClassWithNontrivialStoredProperties.a
   assign %8 to %10 : $*SomeClass
-  end_borrow %9 from %4 : $DerivedClassWithNontrivialStoredProperties, $*DerivedClassWithNontrivialStoredProperties
+  end_borrow %9 : $DerivedClassWithNontrivialStoredProperties
 
   destroy_addr %4 : $*DerivedClassWithNontrivialStoredProperties
   dealloc_stack %1 : $*DerivedClassWithNontrivialStoredProperties
@@ -254,7 +254,7 @@ bb0(%0 : @owned $DerivedClassWithIVars, %i : @trivial $Int):
   %8 = load_borrow %3 : $*DerivedClassWithIVars
   %9 = ref_element_addr %8 : $DerivedClassWithIVars, #DerivedClassWithIVars.a
   assign %i to %9 : $*Int
-  end_borrow %8 from %3 : $DerivedClassWithIVars, $*DerivedClassWithIVars
+  end_borrow %8 : $DerivedClassWithIVars
 
   // Get the super.init function information, but don't apply it.
   %11 = load [take] %3 : $*DerivedClassWithIVars
@@ -267,7 +267,7 @@ bb0(%0 : @owned $DerivedClassWithIVars, %i : @trivial $Int):
   %13c = upcast %13b : $DerivedClassWithIVars to $RootClassWithIVars
   %13d = ref_element_addr %13c : $RootClassWithIVars, #RootClassWithIVars.x  // expected-error {{'self' used in property access 'x' before 'super.init' call}}
   load [trivial] %13d : $*Int
-  end_borrow %13a from %13 : $RootClassWithIVars, $RootClassWithIVars
+  end_borrow %13a : $RootClassWithIVars
 
   // Call super.init.
   %15 = apply %14(%13) : $@convention(method) (@owned RootClassWithIVars) -> @owned RootClassWithIVars

--- a/test/SILOptimizer/definite_init_markuninitialized_rootself.sil
+++ b/test/SILOptimizer/definite_init_markuninitialized_rootself.sil
@@ -32,12 +32,12 @@ bb0(%0 : @owned $RootClassWithIVars, %1 : @trivial $Int):
   %4 = begin_borrow %3 : $RootClassWithIVars
   %10 = ref_element_addr %4 : $RootClassWithIVars, #RootClassWithIVars.x
   assign %1 to %10 : $*Int
-  end_borrow %4 from %3 : $RootClassWithIVars, $RootClassWithIVars
+  end_borrow %4 : $RootClassWithIVars
 
   %5 = begin_borrow %3 : $RootClassWithIVars
   %11 = ref_element_addr %5 : $RootClassWithIVars, #RootClassWithIVars.y
   assign %1 to %11 : $*Int
-  end_borrow %5 from %3 : $RootClassWithIVars, $RootClassWithIVars
+  end_borrow %5 : $RootClassWithIVars
 
   %6 = begin_borrow %3 : $RootClassWithIVars
   %12 = ref_element_addr %6 : $RootClassWithIVars, #RootClassWithIVars.z
@@ -45,7 +45,7 @@ bb0(%0 : @owned $RootClassWithIVars, %1 : @trivial $Int):
   assign %1 to %13 : $*Int
   %14 = tuple_element_addr %12 : $*(Int, Int), 1
   assign %1 to %14 : $*Int
-  end_borrow %6 from %3 : $RootClassWithIVars, $RootClassWithIVars
+  end_borrow %6 : $RootClassWithIVars
 
   return %3 : $RootClassWithIVars
 }
@@ -58,18 +58,18 @@ bb0(%0 : @owned $RootClassWithIVars, %1 : @trivial $Int):
   %4 = begin_borrow %3 : $RootClassWithIVars
   %10 = ref_element_addr %4 : $RootClassWithIVars, #RootClassWithIVars.x
   assign %1 to %10 : $*Int
-  end_borrow %4 from %3 : $RootClassWithIVars, $RootClassWithIVars
+  end_borrow %4 : $RootClassWithIVars
 
   %5 = begin_borrow %3 : $RootClassWithIVars
   %11 = ref_element_addr %5 : $RootClassWithIVars, #RootClassWithIVars.y
   assign %1 to %11 : $*Int
-  end_borrow %5 from %3 : $RootClassWithIVars, $RootClassWithIVars
+  end_borrow %5 : $RootClassWithIVars
 
   %6 = begin_borrow %3 : $RootClassWithIVars
   %12 = ref_element_addr %6 : $RootClassWithIVars, #RootClassWithIVars.z
   %13 = tuple_element_addr %12 : $*(Int, Int), 0
   assign %1 to %13 : $*Int
-  end_borrow %6 from %3 : $RootClassWithIVars, $RootClassWithIVars
+  end_borrow %6 : $RootClassWithIVars
 
   return %3 : $RootClassWithIVars  // expected-error {{return from initializer without initializing all stored properties}}
 }
@@ -82,7 +82,7 @@ bb0(%0 : @owned $RootClassWithIVars, %1 : @trivial $Int):
   %4 = begin_borrow %3 : $RootClassWithIVars
   %11 = ref_element_addr %4 : $RootClassWithIVars, #RootClassWithIVars.y
   assign %1 to %11 : $*Int
-  end_borrow %4 from %3 : $RootClassWithIVars, $RootClassWithIVars
+  end_borrow %4 : $RootClassWithIVars
 
   return %3 : $RootClassWithIVars    // expected-error {{return from initializer without initializing all stored properties}}
 }
@@ -106,11 +106,11 @@ bb0(%0 : @owned $RootClassWithNontrivialStoredProperties):
 // CHECK: [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
 // CHECK: [[SELF_FIELD:%.*]] = ref_element_addr [[BORROWED_SELF]]
 // CHECK: store [[FIELD_VALUE]] to [init] [[SELF_FIELD]]
-// CHECK: end_borrow [[BORROWED_SELF]] from [[SELF]]
+// CHECK: end_borrow [[BORROWED_SELF]]
 // CHECK: [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
 // CHECK: [[SELF_FIELD:%.*]] = ref_element_addr [[BORROWED_SELF]]
 // CHECK: destroy_addr [[SELF_FIELD]]
-// CHECK: end_borrow [[BORROWED_SELF]] from [[SELF]]
+// CHECK: end_borrow [[BORROWED_SELF]]
 // CHECK: [[METATYPE:%[0-9]+]] = metatype $@thick RootClassWithNontrivialStoredProperties.Type
 // CHECK: dealloc_partial_ref [[SELF]] : $RootClassWithNontrivialStoredProperties, [[METATYPE]] : $@thick RootClassWithNontrivialStoredProperties.Type
 // CHECK: } // end sil function 'test_root_partial_release'
@@ -122,7 +122,7 @@ bb0(%0 : @owned $RootClassWithNontrivialStoredProperties):
   %5 = begin_borrow %4 : $RootClassWithNontrivialStoredProperties
   %2 = ref_element_addr %5 : $RootClassWithNontrivialStoredProperties, #RootClassWithNontrivialStoredProperties.x
   assign %1 to %2 : $*SomeClass
-  end_borrow %5 from %4 : $RootClassWithNontrivialStoredProperties, $RootClassWithNontrivialStoredProperties
+  end_borrow %5 : $RootClassWithNontrivialStoredProperties
 
   destroy_value %4 : $RootClassWithNontrivialStoredProperties
 

--- a/test/SILOptimizer/exclusivity_static_diagnostics.sil
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.sil
@@ -266,8 +266,8 @@ bb0(%0 : @unowned $ClassWithStoredProperty):
   %6 = begin_access [modify] [dynamic] %5 : $*Int
   end_access %6 : $*Int
   end_access %4 : $*Int
-  end_borrow %2 from %0 : $ClassWithStoredProperty, $ClassWithStoredProperty
-  end_borrow %1 from %0 : $ClassWithStoredProperty, $ClassWithStoredProperty
+  end_borrow %2 : $ClassWithStoredProperty
+  end_borrow %1 : $ClassWithStoredProperty
   destroy_value %0 : $ClassWithStoredProperty
   %7 = tuple ()
   return %7 : $()
@@ -624,7 +624,7 @@ bb0(%0 : @trivial $Int):
   %7 = begin_access [modify] [unknown] %3 : $*Int // expected-error {{overlapping accesses, but modification requires exclusive access; consider copying to a local variable}}
   %8 = apply %4(%7, %bconv) : $@convention(thin) (@inout Int, @noescape @guaranteed @callee_guaranteed (Int) -> ()) -> ()
   end_access %7: $*Int
-  end_borrow %bconv from %conv : $@callee_guaranteed @noescape (Int) -> (), $@callee_guaranteed @noescape (Int) -> ()
+  end_borrow %bconv : $@callee_guaranteed @noescape (Int) -> ()
   destroy_value %2 : ${ var Int }
   %9 = tuple ()
   return %9 : $()
@@ -1363,7 +1363,7 @@ bb0(%0 : @trivial $Int):
   %clauseF = function_ref @testWithoutActuallyEscapingBlockVerifyClause : $@convention(thin) (@guaranteed @convention(block) () -> ()) -> ()
   %call = apply %clauseF(%escapingF) : $@convention(thin) (@guaranteed @convention(block) () -> ()) -> ()
   destroy_value %escapingF : $@convention(block) () -> ()
-  end_borrow %borrow from %initblock : $@convention(block) () -> (), $@convention(block) () -> ()
+  end_borrow %borrow : $@convention(block) () -> ()
   destroy_value %initblock : $@convention(block) () -> ()
   destroy_value %box : ${ var Int }
   %v = tuple ()
@@ -1380,7 +1380,7 @@ bb0(%0 : @trivial $*@block_storage @callee_guaranteed () -> ()):
   %2 = load [copy] %1 : $*@callee_guaranteed () -> ()
   %3 = begin_borrow %2 : $@callee_guaranteed () -> ()
   %4 = apply %3() : $@callee_guaranteed () -> ()
-  end_borrow %3 from %2 : $@callee_guaranteed () -> (), $@callee_guaranteed () -> ()
+  end_borrow %3 : $@callee_guaranteed () -> ()
   %6 = tuple ()
   destroy_value %2 : $@callee_guaranteed () -> ()
   return %6 : $()
@@ -1393,7 +1393,7 @@ bb0(%0 : @guaranteed $@convention(block) () -> ()):
   %4 = copy_value %3 : $@convention(block) () -> ()
   %5 = apply %4() : $@convention(block) () -> ()
   destroy_value %4 : $@convention(block) () -> ()
-  end_borrow %3 from %1 : $@convention(block) () -> (), $@convention(block) () -> ()
+  end_borrow %3 : $@convention(block) () -> ()
   destroy_value %1 : $@convention(block) () -> ()
   %v = tuple ()
   return %v : $()

--- a/test/SILOptimizer/mandatory_inlining_ownership.sil
+++ b/test/SILOptimizer/mandatory_inlining_ownership.sil
@@ -22,7 +22,7 @@ bb(%0 : @guaranteed $C):
 // CHECK:   [[BORROW:%.*]] = begin_borrow %0 : $C
 // CHECK:   [[ADDR:%.*]] = ref_element_addr [[BORROW]] : $C, #C.i
 // CHECK:   [[VAL:%.*]] = load [trivial] [[ADDR]] : $*Builtin.Int64
-// CHECK:   end_borrow [[BORROW]] from %0 : $C, $C
+// CHECK:   end_borrow [[BORROW]] : $C
 // CHECK:   destroy_value %0 : $C
 // CHECK:   return [[VAL]] : $Builtin.Int64
 // CHECK-LABEL: } // end sil function 'callerWithOwned'
@@ -58,11 +58,11 @@ bb2:
 // CHECK:   [[ADDR:%.*]] = ref_element_addr [[BORROW]] : $C, #C.i
 // CHECK:   [[VAL:%.*]] = load [trivial] [[ADDR]] : $*Builtin.Int64
 // CHECK: bb{{.*}}([[RET:%.*]] : @trivial $Builtin.Int64):
-// CHECK:   end_borrow [[BORROW]] from %0 : $C, $C
+// CHECK:   end_borrow [[BORROW]] : $C
 // CHECK:   destroy_value %0 : $C
 // CHECK:   return [[RET]] : $Builtin.Int64
 // CHECK: bb{{.*}}([[ERR:%.*]] : @owned $Error):
-// CHECK:   end_borrow [[BORROW]] from %0 : $C, $C
+// CHECK:   end_borrow [[BORROW]] : $C
 // CHECK:   destroy_value %0 : $C
 // CHECK:   throw [[ERR]] : $Error
 // CHECK-LABEL: } // end sil function 'callerWithThrow'

--- a/test/SILOptimizer/ownership_model_eliminator.sil
+++ b/test/SILOptimizer/ownership_model_eliminator.sil
@@ -70,7 +70,7 @@ sil @borrow : $@convention(thin) (@in Builtin.NativeObject) -> () {
 bb0(%0 : @trivial $*Builtin.NativeObject):
   %1 = load_borrow %0 : $*Builtin.NativeObject
   %2 = unchecked_ref_cast %1 : $Builtin.NativeObject to $Builtin.NativeObject
-  end_borrow %1 from %0 : $Builtin.NativeObject, $*Builtin.NativeObject
+  end_borrow %1 : $Builtin.NativeObject
   %3 = tuple()
   return %3 : $()
 }
@@ -103,11 +103,11 @@ bb0(%0 : @owned $Builtin.NativeObject):
 sil @begin_borrow_store_borrow : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
-  end_borrow %1 from %0 : $Builtin.NativeObject, $Builtin.NativeObject
+  end_borrow %1 : $Builtin.NativeObject
   %2 = alloc_stack $Builtin.NativeObject
   %3 = begin_borrow %0 : $Builtin.NativeObject
   store_borrow %3 to %2 : $*Builtin.NativeObject
-  end_borrow %3 from %0 : $Builtin.NativeObject, $Builtin.NativeObject
+  end_borrow %3 : $Builtin.NativeObject
   dealloc_stack %2 : $*Builtin.NativeObject
   destroy_value %0 : $Builtin.NativeObject
   %9999 = tuple()

--- a/test/SILOptimizer/semantic-arc-opts.sil
+++ b/test/SILOptimizer/semantic-arc-opts.sil
@@ -70,7 +70,7 @@ bb0(%0 : @guaranteed $Builtin.NativeObject):
   %2 = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
   %3 = begin_borrow %1 : $Builtin.NativeObject
   apply %2(%3) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
-  end_borrow %3 from %1 : $Builtin.NativeObject, $Builtin.NativeObject
+  end_borrow %3 : $Builtin.NativeObject
   destroy_value %1 : $Builtin.NativeObject
   %9999 = tuple()
   return %9999 : $()
@@ -87,9 +87,9 @@ bb0(%0 : @guaranteed $Builtin.NativeObject):
   %2 = begin_borrow %1 : $Builtin.NativeObject
   %3 = copy_value %2 : $Builtin.NativeObject
   %4 = begin_borrow %3 : $Builtin.NativeObject
-  end_borrow %4 from %3 : $Builtin.NativeObject, $Builtin.NativeObject
+  end_borrow %4 : $Builtin.NativeObject
   destroy_value %3 : $Builtin.NativeObject
-  end_borrow %2 from %1 : $Builtin.NativeObject, $Builtin.NativeObject
+  end_borrow %2 : $Builtin.NativeObject
   destroy_value %1 : $Builtin.NativeObject
   %9999 = tuple()
   return %9999 : $()

--- a/utils/sil-mode.el
+++ b/utils/sil-mode.el
@@ -76,8 +76,7 @@
                   'words) . font-lock-keyword-face)
 
    ;; SIL Instructions - Borrowing
-   `(,(regexp-opt '("load_borrow" "begin_borrow" "store_borrow" "end_borrow_argument") 'words) . font-lock-keyword-face)
-   '("\\(end_borrow\\) %[[:alnum:]]+ \\(from\\)" (1 font-lock-keyword-face) (2 font-lock-keyword-face))
+   `(,(regexp-opt '("load_borrow" "begin_borrow" "store_borrow" "end_borrow_argument" "end_borrow") 'words) . font-lock-keyword-face)
 
    ;; SIL Instructions - Exclusivity
    `(,(regexp-opt '("begin_access" "end_access") 'words) . font-lock-keyword-face)


### PR DESCRIPTION
This does not eliminate the entrypoints on SILBuilder yet. I want to do this in
two parts so that it is functionally easier to disentangle changing the APIs
above SILBuilder and changing the underlying instruction itself.

rdar://33440767
