### PR TITLE
test: enable IRGen.generic_casts on all targets

### DIFF
--- a/test/IRGen/c_functions.swift
+++ b/test/IRGen/c_functions.swift
@@ -1,13 +1,13 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -import-objc-header %S/Inputs/c_functions.h -primary-file %s -emit-ir | %FileCheck %s -check-prefix CHECK -check-prefix %target-cpu
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-objc-interop -import-objc-header %S/Inputs/c_functions.h -primary-file %s -emit-ir | %FileCheck %s -check-prefix CHECK -check-prefix %target-cpu
 
 // This is deliberately not a SIL test so that we can test SILGen too.
 
 // CHECK-LABEL: define hidden swiftcc void @"$S11c_functions14testOverloadedyyF"
 func testOverloaded() {
-  // CHECK: call void @{{_Z10overloadedv|"\\01\?overloaded@@\$\$J0YAXXZ"}}()
+  // CHECK: call void @{{_Z10overloadedv|"\?overloaded@@\$\$J0YAXXZ"}}()
   overloaded()
-  // CHECK: call void @{{_Z10overloadedi|"\\01\?overloaded@@\$\$J0YAXH@Z"}}(i32{{( signext)?}} 42)
+  // CHECK: call void @{{_Z10overloadedi|"\?overloaded@@\$\$J0YAXH@Z"}}(i32{{( signext)?}} 42)
   overloaded(42)
   // CHECK: call void @{{.*}}test_my_log
   test_my_log()

--- a/test/IRGen/generic_casts.swift
+++ b/test/IRGen/generic_casts.swift
@@ -1,23 +1,32 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir -enable-objc-interop -disable-objc-attr-requires-foundation-module | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir -enable-objc-interop -disable-objc-attr-requires-foundation-module | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-%target-object-format
 
 // REQUIRES: CPU=x86_64
-
-// FIXME: rdar://problem/19648117 Needs splitting objc parts out
-// XFAIL: linux
 
 import Foundation
 import gizmo
 
 // -- Protocol records for cast-to ObjC protocols
 // CHECK: @_PROTOCOL__TtP13generic_casts10ObjCProto1_ = private constant
-// CHECK: @"\01l_OBJC_LABEL_PROTOCOL_$__TtP13generic_casts10ObjCProto1_" = weak hidden global i8* bitcast ({{.*}} @_PROTOCOL__TtP13generic_casts10ObjCProto1_ to i8*), section "__DATA,__objc_protolist,coalesced,no_dead_strip"
-// CHECK: @"\01l_OBJC_PROTOCOL_REFERENCE_$__TtP13generic_casts10ObjCProto1_" = weak hidden global i8* bitcast ({{.*}} @_PROTOCOL__TtP13generic_casts10ObjCProto1_ to i8*), section "__DATA,__objc_protorefs,coalesced,no_dead_strip"
+// CHECK: @"\01l_OBJC_LABEL_PROTOCOL_$__TtP13generic_casts10ObjCProto1_" = weak hidden global i8* bitcast ({{.*}} @_PROTOCOL__TtP13generic_casts10ObjCProto1_ to i8*)
+// CHECK-coff: section ".objc_protolist$B"
+// CHECK-elf: section ".data"
+// CHECK-macho: section "__DATA,__objc_protolist,coalesced,no_dead_strip"
+// CHECK: @"\01l_OBJC_PROTOCOL_REFERENCE_$__TtP13generic_casts10ObjCProto1_" = weak hidden global i8* bitcast ({{.*}} @_PROTOCOL__TtP13generic_casts10ObjCProto1_ to i8*)
+// CHECK-coff: section ".objc_protorefs$B"
+// CHECK-elf: section ".data"
+// CHECK-macho: section "__DATA,__objc_protorefs,coalesced,no_dead_strip"
 
 // CHECK: @_PROTOCOL_NSRuncing = private constant
-// CHECK: @"\01l_OBJC_LABEL_PROTOCOL_$_NSRuncing" = weak hidden global i8* bitcast ({{.*}} @_PROTOCOL_NSRuncing to i8*), section "__DATA,__objc_protolist,coalesced,no_dead_strip"
-// CHECK: @"\01l_OBJC_PROTOCOL_REFERENCE_$_NSRuncing" = weak hidden global i8* bitcast ({{.*}} @_PROTOCOL_NSRuncing to i8*), section "__DATA,__objc_protorefs,coalesced,no_dead_strip"
+// CHECK: @"\01l_OBJC_LABEL_PROTOCOL_$_NSRuncing" = weak hidden global i8* bitcast ({{.*}} @_PROTOCOL_NSRuncing to i8*)
+// CHECK-coff: section ".objc_protolist$B"
+// CHECK-elf: section ".data"
+// CHECK-macho: section "__DATA,__objc_protolist,coalesced,no_dead_strip"
+// CHECK: @"\01l_OBJC_PROTOCOL_REFERENCE_$_NSRuncing" = weak hidden global i8* bitcast ({{.*}} @_PROTOCOL_NSRuncing to i8*)
+// CHECK-coff: section ".objc_protorefs$B"
+// CHECK-elf: section ".data"
+// CHECK-macho: section "__DATA,__objc_protorefs,coalesced,no_dead_strip"
 
 // CHECK: @_PROTOCOLS__TtC13generic_casts10ObjCClass2 = private constant { i64, [1 x i8*] } {
 // CHECK:   i64 1, 

--- a/test/IRGen/protocol_accessor_multifile.swift
+++ b/test/IRGen/protocol_accessor_multifile.swift
@@ -2,7 +2,7 @@
 // RUN: %FileCheck %s < %t.ll
 // RUN: %FileCheck -check-prefix NEGATIVE %s < %t.ll
 
-// CHECK: @"$S27protocol_accessor_multifile5ProtoMp" = external global
+// CHECK: @"$S27protocol_accessor_multifile5ProtoMp" = external {{(dllimport )?}}global
 // NEGATIVE-NOT: @"$S27protocol_accessor_multifile10ClassProtoMp" =
 
 // CHECK-LABEL: define{{.*}} void @"$S27protocol_accessor_multifile14useExistentialyyF"()


### PR DESCRIPTION
Adjust the test for ELF and COFF targets as well.  This allows us to get
additional test coverage and reduces the number of failing tests on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
