### PR TITLE
[InterfaceGen] Print private/internal properties

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -322,6 +322,9 @@ struct PrintOptions {
   /// for optionals that are nested within other optionals.
   bool PrintOptionalAsImplicitlyUnwrapped = false;
 
+  /// Replaces the name of private and internal properties of types with '_'.
+  bool OmitNameOfInaccessibleProperties = false;
+
   /// \brief Print dependent types as references into this generic environment.
   GenericEnvironment *GenericEnv = nullptr;
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -64,6 +64,11 @@ void PrintOptions::clearSynthesizedExtension() {
   TransformContext.reset();
 }
 
+static bool contributesToParentTypeStorage(const AbstractStorageDecl *ASD) {
+  return ASD->getDeclContext()->isTypeContext() && ASD->hasStorage() &&
+         !ASD->isStatic();
+}
+
 PrintOptions PrintOptions::printTextualInterfaceFile() {
   PrintOptions result;
   result.PrintLongAttrsOnSeparateLines = true;
@@ -71,6 +76,7 @@ PrintOptions PrintOptions::printTextualInterfaceFile() {
   result.PrintIfConfig = false;
   result.FullyQualifiedTypes = true;
   result.SkipImports = true;
+  result.OmitNameOfInaccessibleProperties = true;
 
   class ShouldPrintForTextualInterface : public ShouldPrintChecker {
     bool shouldPrint(const Decl *D, const PrintOptions &options) override {
@@ -79,8 +85,14 @@ PrintOptions PrintOptions::printTextualInterfaceFile() {
         AccessScope accessScope =
             VD->getFormalAccessScope(/*useDC*/nullptr,
                                      /*treatUsableFromInlineAsPublic*/true);
-        if (!accessScope.isPublic())
+        if (!accessScope.isPublic()) {
+          // We do want to print private stored properties, without their
+          // original names present.
+          if (auto *ASD = dyn_cast<AbstractStorageDecl>(VD))
+            if (contributesToParentTypeStorage(ASD))
+              return true;
           return false;
+        }
       }
 
       // Skip typealiases that just redeclare generic parameters.
@@ -821,7 +833,13 @@ void PrintAST::printPattern(const Pattern *pattern) {
 
   case PatternKind::Named: {
     auto named = cast<NamedPattern>(pattern);
-    recordDeclLoc(named->getDecl(), [&]{
+    auto decl = named->getDecl();
+    recordDeclLoc(decl, [&]{
+      if (Options.OmitNameOfInaccessibleProperties &&
+          contributesToParentTypeStorage(decl) &&
+          decl->getFormalAccess() < AccessLevel::Public)
+        Printer << "_";
+      else
         Printer.printName(named->getBoundName());
       });
     break;
@@ -1360,6 +1378,12 @@ bool ShouldPrintChecker::shouldPrint(const Decl *D,
     // Enum elements are printed as part of the EnumCaseDecl, unless they were
     // imported without source info.
     return !EED->getSourceRange().isValid();
+  }
+
+  if (auto *ASD = dyn_cast<AbstractStorageDecl>(D)) {
+    if (Options.OmitNameOfInaccessibleProperties &&
+        contributesToParentTypeStorage(ASD))
+      return true;
   }
 
   // Skip declarations that are not accessible.

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -65,8 +65,11 @@ void PrintOptions::clearSynthesizedExtension() {
 }
 
 static bool contributesToParentTypeStorage(const AbstractStorageDecl *ASD) {
-  return ASD->getDeclContext()->isTypeContext() && ASD->hasStorage() &&
-         !ASD->isStatic();
+  auto *DC = ASD->getDeclContext()->getAsDecl();
+  if (!DC) return false;
+  auto *ND = dyn_cast<NominalTypeDecl>(DC);
+  if (!ND) return false;
+  return !ND->isResilient() && ASD->hasStorage() && !ASD->isStatic();
 }
 
 PrintOptions PrintOptions::printTextualInterfaceFile() {

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -994,6 +994,11 @@ static void addOpaqueAccessorToStorage(TypeChecker &TC,
 
 static void addExpectedOpaqueAccessorsToStorage(TypeChecker &TC,
                                                 AbstractStorageDecl *storage) {
+  // Nameless vars from interface files should not have any accessors.
+  // TODO: Replace this check with a broader check that all storage decls
+  //       from interface files have all their accessors up front.
+  if (storage->getBaseName().empty())
+    return;
   storage->visitExpectedOpaqueAccessors([&](AccessorKind kind) {
     // If the accessor is already present, there's nothing to do.
     if (storage->getAccessor(kind))

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -945,16 +945,8 @@ static void checkRedeclaration(TypeChecker &tc, ValueDecl *current) {
 
 /// Does the context allow pattern bindings that don't bind any variables?
 static bool contextAllowsPatternBindingWithoutVariables(DeclContext *dc) {
-  
-  // Property decls in type context must bind variables unless in a module
-  // interface, where private members don't bind variables but contribute
-  // to storage.
-  if (dc->isTypeContext()) {
-    if (auto SF = dc->getParentSourceFile())
-      if (SF->Kind == SourceFileKind::Interface)
-        return true;
+  if (dc->isTypeContext())
     return false;
-  }
   
   // Global variable decls must bind variables, except in scripts.
   if (dc->isModuleScopeContext()) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -946,9 +946,15 @@ static void checkRedeclaration(TypeChecker &tc, ValueDecl *current) {
 /// Does the context allow pattern bindings that don't bind any variables?
 static bool contextAllowsPatternBindingWithoutVariables(DeclContext *dc) {
   
-  // Property decls in type context must bind variables.
-  if (dc->isTypeContext())
+  // Property decls in type context must bind variables unless in a module
+  // interface, where private members don't bind variables but contribute
+  // to storage.
+  if (dc->isTypeContext()) {
+    if (auto SF = dc->getParentSourceFile())
+      if (SF->Kind == SourceFileKind::Interface)
+        return true;
     return false;
+  }
   
   // Global variable decls must bind variables, except in scripts.
   if (dc->isModuleScopeContext()) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -945,6 +945,8 @@ static void checkRedeclaration(TypeChecker &tc, ValueDecl *current) {
 
 /// Does the context allow pattern bindings that don't bind any variables?
 static bool contextAllowsPatternBindingWithoutVariables(DeclContext *dc) {
+  
+  // Property decls in type context must bind variables.
   if (dc->isTypeContext())
     return false;
   

--- a/test/ModuleInterface/private-stored-member-type-layout.swift
+++ b/test/ModuleInterface/private-stored-member-type-layout.swift
@@ -26,7 +26,7 @@
 import PrivateStoredMembers
 #endif
 
-// CHECK-EXEC: define swiftcc void @"$S{{[^ ]+}}8makeUseryyF"() #0 {
+// CHECK-EXEC: swiftcc void @"$S{{[^ ]+}}8makeUseryyF"() #0 {
 public func makeUser() {
   let ptr = UnsafeMutablePointer<MyStruct>.allocate(capacity: 1)
   // CHECK-EXEC: %.publicEndVar = getelementptr inbounds [[MYSTRUCT]], [[MYSTRUCT]]* %{{[0-9]+}}, i32 0, i32 [[PUBLIC_END_VAR_IDX:9]]

--- a/test/ModuleInterface/private-stored-member-type-layout.swift
+++ b/test/ModuleInterface/private-stored-member-type-layout.swift
@@ -1,0 +1,53 @@
+// RUN: %empty-directory(%t)
+
+// Check that importing this module creates the right types
+
+// RUN: %target-swift-frontend -emit-interface-path %t/private-stored-members.swiftinterface -module-name PrivateStoredMembers -emit-module -o %t/PrivateStoredMembers.swiftmodule %S/private-stored-members.swift
+// RUN: %target-swift-frontend -emit-ir %s -I %t 2>&1 -DSHOULD_IMPORT | %FileCheck %s --check-prefix CHECK-EXEC --check-prefix CHECK
+
+// Check that the types are also correct when importing a module created from an interface
+
+// RUN: %target-swift-frontend -emit-module -o %t/PrivateStoredMembers.swiftmodule -module-name PrivateStoredMembers %t/private-stored-members.swiftinterface -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend -emit-ir %s -I %t 2>&1 -DSHOULD_IMPORT | %FileCheck %s --check-prefix CHECK-EXEC --check-prefix CHECK
+
+// Check the types generated when the source file is the primary file, and ensure they're the same layout.
+
+// RUN: %target-swift-frontend -emit-ir %S/private-stored-members.swift %s 2>&1 -module-name main | %FileCheck %s --check-prefix CHECK-MAIN --check-prefix CHECK-EXEC
+
+// These two appear out-of-order between run lines
+
+// CHECK-DAG: [[MYCLASS:%T20PrivateStoredMembers7MyClassC]] = type opaque
+// CHECK-DAG: [[MYSTRUCT:%T20PrivateStoredMembers8MyStructV]] = type <{ %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V }>
+
+// CHECK-MAIN-DAG: [[MYCLASS:%T4main7MyClassC]] = type <{ %swift.refcounted, %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V }>
+// CHECK-MAIN-DAG: [[MYSTRUCT:%T4main8MyStructV]] = type <{ %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V, %TSb, [7 x i8], %Ts5Int64V }>
+
+#if SHOULD_IMPORT
+import PrivateStoredMembers
+#endif
+
+// CHECK-EXEC: define swiftcc void @"$S{{[^ ]+}}8makeUseryyF"() #0 {
+public func makeUser() {
+  let ptr = UnsafeMutablePointer<MyStruct>.allocate(capacity: 1)
+  // CHECK-EXEC: %.publicEndVar = getelementptr inbounds [[MYSTRUCT]], [[MYSTRUCT]]* %{{[0-9]+}}, i32 0, i32 [[PUBLIC_END_VAR_IDX:9]]
+  // CHECK-EXEC: %.publicEndVar._value = getelementptr inbounds %Ts5Int64V, %Ts5Int64V* %.publicEndVar, i32 0, i32 0
+  // CHECK-EXEC: store i64 4, i64* %.publicEndVar._value
+  ptr.pointee.publicEndVar = 4
+
+  // CHECK-EXEC: %.publicEndVar1 = getelementptr inbounds [[MYSTRUCT]], [[MYSTRUCT]]* %{{[0-9]+}}, i32 0, i32 [[PUBLIC_END_VAR_IDX]]
+  // CHECK-EXEC: %.publicEndVar1._value = getelementptr inbounds %Ts5Int64V, %Ts5Int64V* %.publicEndVar1, i32 0, i32 0
+  // CHECK-EXEC: [[PUBLIC_END_VAR_LOAD:%[0-9]+]] = load i64, i64* %.publicEndVar1._value, align 8
+
+  // CHECK-EXEC: %.publicVar = getelementptr inbounds [[MYSTRUCT]], [[MYSTRUCT]]* %{{[0-9]+}}, i32 0, i32 0
+  // CHECK-EXEC: %.publicVar._value = getelementptr inbounds %Ts5Int64V, %Ts5Int64V* %.publicVar, i32 0, i32 0
+  // CHECK-EXEC: store i64 [[PUBLIC_END_VAR_LOAD]], i64* %.publicVar._value, align 8
+  ptr.pointee.publicVar = ptr.pointee.publicEndVar
+  ptr.deallocate()
+
+  // CHECK-EXEC: %[[MYCLASS_INIT:[0-9]+]] = call swiftcc [[MYCLASS]]* @"$S{{[^ ]+}}7MyClassCACycfC"(%swift.type* swiftself %{{[0-9]+}})
+  let myClass = MyClass()
+
+  // These are uninteresting as they just call into the standard getter and setter.
+  myClass.publicEndVar = 4
+  myClass.publicVar = myClass.publicEndVar
+}

--- a/test/ModuleInterface/private-stored-members.swift
+++ b/test/ModuleInterface/private-stored-members.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// R UN: %target-swift-frontend -emit-module -o %t/Test~partial.swiftmodule -module-name Test -primary-file %s
-// R UN: %target-swift-frontend -merge-modules -emit-module -o %t/Test.swiftmodule %t/Test~partial.swiftmodule
-// R UN: %target-swift-ide-test -print-module -module-to-print=Test -source-filename=x -I %t | %FileCheck %s
+// RUN: %target-swift-frontend -emit-module -o %t/Test~partial.swiftmodule -module-name Test -primary-file %s
+// RUN: %target-swift-frontend -merge-modules -emit-module -o %t/Test.swiftmodule %t/Test~partial.swiftmodule
+// RUN: %target-swift-ide-test -print-module -module-to-print=Test -source-filename=x -I %t | %FileCheck %s
 
 // RUN: %target-swift-frontend -emit-interface-path %t.swiftinterface -enable-resilience -emit-module -o /dev/null %s
 // RUN: %FileCheck %s < %t.swiftinterface

--- a/test/ModuleInterface/private-stored-members.swift
+++ b/test/ModuleInterface/private-stored-members.swift
@@ -16,25 +16,25 @@
 // CHECK: struct MyStruct {{{$}}
 // RESILIENT: struct MyStruct {{{$}}
 public struct MyStruct {
-// CHECK-NEXT: var publicVar: Int{{$}}
-// RESILIENT-NEXT: var publicVar: Int{{$}}
-  public var publicVar: Int
+// CHECK-NEXT: var publicVar: Int64{{$}}
+// RESILIENT-NEXT: var publicVar: Int64{{$}}
+  public var publicVar: Int64
 
 // CHECK-NEXT: let publicLet: Bool{{$}}
 // RESILIENT-NEXT: let publicLet: Bool{{$}}
   public let publicLet: Bool
 
-// CHECK-NEXT: internal var _: String{{$}}
-// RESILIENT-NOT: internal var _: String{{$}}
-  var internalVar: String
+// CHECK-NEXT: internal var _: Int64{{$}}
+// RESILIENT-NOT: internal var _: Int64{{$}}
+  var internalVar: Int64
 
 // CHECK-NEXT: internal let _: Bool{{$}}
 // RESILIENT-NOT: internal let _: Bool{{$}}
   let internalLet: Bool
 
-// CHECK-NEXT: private var _: String{{$}}
-// RESILIENT-NOT: private var _: String{{$}}
-  private var privateVar: String
+// CHECK-NEXT: private var _: Int64{{$}}
+// RESILIENT-NOT: private var _: Int64{{$}}
+  private var privateVar: Int64
 
 // CHECK-NEXT: private let _: Bool{{$}}
 // RESILIENT-NOT: private let _: Bool{{$}}
@@ -42,13 +42,17 @@ public struct MyStruct {
 
 // CHECK-NOT: private var
 // RESILIENT-NOT: private var
-  private var computedPrivateVar: String {
-    return "computedPrivateVar"
+  private var computedPrivateVar: Int64 {
+    return 0
   }
 
 // CHECK-NOT: private static var
 // RESILIENT-NOT: private static var
-  private static var staticPrivateVar: String = ""
+  private static var staticPrivateVar: Int64 = 0
+
+// CHECK-NEXT: var publicEndVar: Int64{{$}}
+// RESILIENT-NEXT: var publicEndVar: Int64{{$}}
+  public var publicEndVar: Int64 = 0
 
 // CHECK: }{{$}}
 // RESILIENT: }{{$}}
@@ -57,25 +61,25 @@ public struct MyStruct {
 // CHECK: class MyClass {{{$}}
 // RESILIENT: class MyClass {{{$}}
 public class MyClass {
-// CHECK-NEXT: var publicVar: Int{{$}}
-// RESILIENT-NEXT: var publicVar: Int{{$}}
-  public var publicVar: Int = 0
+// CHECK-NEXT: var publicVar: Int64{{$}}
+// RESILIENT-NEXT: var publicVar: Int64{{$}}
+  public var publicVar: Int64 = 0
 
 // CHECK-NEXT: let publicLet: Bool{{$}}
 // RESILIENT-NEXT: let publicLet: Bool{{$}}
   public let publicLet: Bool = true
 
-// CHECK-NEXT: internal var _: String{{$}}
-// RESILIENT-NOT: internal var _: String{{$}}
-  var internalVar: String = ""
+// CHECK-NEXT: internal var _: Int64{{$}}
+// RESILIENT-NOT: internal var _: Int64{{$}}
+  var internalVar: Int64 = 0
 
 // CHECK-NEXT: internal let _: Bool{{$}}
 // RESILIENT-NOT: internal let _: Bool{{$}}
   let internalLet: Bool = true
 
-// CHECK-NEXT: private var _: String{{$}}
-// RESILIENT-NOT: private var _: String{{$}}
-  private var privateVar: String = ""
+// CHECK-NEXT: private var _: Int64{{$}}
+// RESILIENT-NOT: private var _: Int64{{$}}
+  private var privateVar: Int64 = 0
 
 // CHECK-NEXT: private let _: Bool{{$}}
 // RESILIENT-NOT: private let _: Bool{{$}}
@@ -83,13 +87,19 @@ public class MyClass {
 
 // CHECK-NOT: private var
 // RESILIENT-NOT: private var
-  private var computedPrivateVar: String {
-    return "computedPrivateVar"
+  private var computedPrivateVar: Int64 {
+    return 0
   }
 
 // CHECK-NOT: private static var
 // RESILIENT-NOT: private static var
-  private static var staticPrivateVar: String = ""
+  private static var staticPrivateVar: Int64 = 0
+
+// CHECK-NEXT: var publicEndVar: Int64{{$}}
+// RESILIENT-NEXT: var publicEndVar: Int64{{$}}
+  public var publicEndVar: Int64 = 0
+
+  public init() {}
 
 // CHECK: }{{$}}
 // RESILIENT: }{{$}}

--- a/test/ModuleInterface/private-stored-members.swift
+++ b/test/ModuleInterface/private-stored-members.swift
@@ -1,0 +1,69 @@
+// RUN: %empty-directory(%t)
+// R UN: %target-swift-frontend -emit-module -o %t/Test~partial.swiftmodule -module-name Test -primary-file %s
+// R UN: %target-swift-frontend -merge-modules -emit-module -o %t/Test.swiftmodule %t/Test~partial.swiftmodule
+// R UN: %target-swift-ide-test -print-module -module-to-print=Test -source-filename=x -I %t | %FileCheck %s
+
+// RUN: %target-swift-frontend -emit-interface-path %t.swiftinterface -enable-resilience -emit-module -o /dev/null %s
+// RUN: %FileCheck %s < %t.swiftinterface
+
+// CHECK: struct MyStruct {{{$}}
+public struct MyStruct {
+// CHECK-NEXT: var publicVar: Int{{$}}
+  public var publicVar: Int
+
+// CHECK-NEXT: let publicLet: Bool{{$}}
+  public let publicLet: Bool
+
+// CHECK-NEXT: internal var _: String{{$}}
+  var internalVar: String
+
+// CHECK-NEXT: internal let _: Bool{{$}}
+  let internalLet: Bool
+
+// CHECK-NEXT: private var _: String{{$}}
+  private var privateVar: String
+
+// CHECK-NEXT: private let _: Bool{{$}}
+  private let privateLet: Bool
+
+// CHECK-NOT: private var
+  private var computedPrivateVar: String {
+    return "computedPrivateVar"
+  }
+
+// CHECK-NOT: private static var
+  private static var staticPrivateVar: String = ""
+
+// CHECK: }{{$}}
+}
+
+// CHECK: class MyClass {{{$}}
+public class MyClass {
+// CHECK-NEXT: public var publicVar: Int{{$}}
+  public var publicVar: Int = 0
+
+// CHECK-NEXT: public let publicLet: Bool{{$}}
+  public let publicLet: Bool = true
+
+// CHECK-NEXT: internal var _: String{{$}}
+  var internalVar: String = ""
+
+// CHECK-NEXT: internal let _: Bool{{$}}
+  let internalLet: Bool = true
+
+// CHECK-NEXT: private var _: String{{$}}
+  private var privateVar: String = ""
+
+// CHECK-NEXT: private let _: Bool{{$}}
+  private let privateLet: Bool = true
+
+// CHECK-NOT: private var
+  private var computedPrivateVar: String {
+    return "computedPrivateVar"
+  }
+
+// CHECK-NOT: private static var
+  private static var staticPrivateVar: String = ""
+
+// CHECK: }{{$}}
+}

--- a/test/ModuleInterface/private-stored-members.swift
+++ b/test/ModuleInterface/private-stored-members.swift
@@ -1,69 +1,96 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/Test~partial.swiftmodule -module-name Test -primary-file %s
-// RUN: %target-swift-frontend -merge-modules -emit-module -o %t/Test.swiftmodule %t/Test~partial.swiftmodule
-// RUN: %target-swift-ide-test -print-module -module-to-print=Test -source-filename=x -I %t | %FileCheck %s
 
-// RUN: %target-swift-frontend -emit-interface-path %t.swiftinterface -enable-resilience -emit-module -o /dev/null %s
+// RUN: %target-swift-frontend -emit-interface-path %t.swiftinterface -emit-module -o /dev/null %s
 // RUN: %FileCheck %s < %t.swiftinterface
 
+// RUN: %target-swift-frontend -emit-interface-path %t-resilient.swiftinterface -enable-resilience -emit-module -o /dev/null %s
+// RUN: %FileCheck %s --check-prefix RESILIENT < %t-resilient.swiftinterface
+
+// RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule %t.swiftinterface -disable-objc-attr-requires-foundation-module
+// FIXME(rdar44144435): %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -emit-interface-path - | %FileCheck %s
+
+// RUN: %target-swift-frontend -emit-module -o %t/TestResilient.swiftmodule -enable-resilience %t.swiftinterface -disable-objc-attr-requires-foundation-module
+// FIXME(rdar44144435): %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -enable-resilience -emit-interface-path - | %FileCheck %s
+
+
 // CHECK: struct MyStruct {{{$}}
+// RESILIENT: struct MyStruct {{{$}}
 public struct MyStruct {
 // CHECK-NEXT: var publicVar: Int{{$}}
+// RESILIENT-NEXT: var publicVar: Int{{$}}
   public var publicVar: Int
 
 // CHECK-NEXT: let publicLet: Bool{{$}}
+// RESILIENT-NEXT: let publicLet: Bool{{$}}
   public let publicLet: Bool
 
 // CHECK-NEXT: internal var _: String{{$}}
+// RESILIENT-NOT: internal var _: String{{$}}
   var internalVar: String
 
 // CHECK-NEXT: internal let _: Bool{{$}}
+// RESILIENT-NOT: internal let _: Bool{{$}}
   let internalLet: Bool
 
 // CHECK-NEXT: private var _: String{{$}}
+// RESILIENT-NOT: private var _: String{{$}}
   private var privateVar: String
 
 // CHECK-NEXT: private let _: Bool{{$}}
+// RESILIENT-NOT: private let _: Bool{{$}}
   private let privateLet: Bool
 
 // CHECK-NOT: private var
+// RESILIENT-NOT: private var
   private var computedPrivateVar: String {
     return "computedPrivateVar"
   }
 
 // CHECK-NOT: private static var
+// RESILIENT-NOT: private static var
   private static var staticPrivateVar: String = ""
 
 // CHECK: }{{$}}
+// RESILIENT: }{{$}}
 }
 
 // CHECK: class MyClass {{{$}}
+// RESILIENT: class MyClass {{{$}}
 public class MyClass {
-// CHECK-NEXT: public var publicVar: Int{{$}}
+// CHECK-NEXT: var publicVar: Int{{$}}
+// RESILIENT-NEXT: var publicVar: Int{{$}}
   public var publicVar: Int = 0
 
-// CHECK-NEXT: public let publicLet: Bool{{$}}
+// CHECK-NEXT: let publicLet: Bool{{$}}
+// RESILIENT-NEXT: let publicLet: Bool{{$}}
   public let publicLet: Bool = true
 
 // CHECK-NEXT: internal var _: String{{$}}
+// RESILIENT-NOT: internal var _: String{{$}}
   var internalVar: String = ""
 
 // CHECK-NEXT: internal let _: Bool{{$}}
+// RESILIENT-NOT: internal let _: Bool{{$}}
   let internalLet: Bool = true
 
 // CHECK-NEXT: private var _: String{{$}}
+// RESILIENT-NOT: private var _: String{{$}}
   private var privateVar: String = ""
 
 // CHECK-NEXT: private let _: Bool{{$}}
+// RESILIENT-NOT: private let _: Bool{{$}}
   private let privateLet: Bool = true
 
 // CHECK-NOT: private var
+// RESILIENT-NOT: private var
   private var computedPrivateVar: String {
     return "computedPrivateVar"
   }
 
 // CHECK-NOT: private static var
+// RESILIENT-NOT: private static var
   private static var staticPrivateVar: String = ""
 
 // CHECK: }{{$}}
+// RESILIENT: }{{$}}
 }


### PR DESCRIPTION
All properties which contribute to the storage of a type should be
printed, and their names should be hidden from interfaces. Print them
with '_' as their name, and teach the parser to recognize these special
patterns when parsing interface files.

Partially resolves rdar://43810647