### PR TITLE
[Parse] Store local typealiases, they matter for type reconstruction.

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3607,7 +3607,7 @@ parseDeclTypeAlias(Parser::ParseDeclOptions Flags, DeclAttributes &Attributes) {
   auto *TAD = new (Context) TypeAliasDecl(TypeAliasLoc, EqualLoc, Id, IdLoc,
                                           /*genericParams*/nullptr,
                                           CurDeclContext);
-
+  setLocalDiscriminator(TAD);
   ParserResult<TypeRepr> UnderlyingTy;
 
   if (Tok.is(tok::colon) || Tok.is(tok::equal)) {

--- a/test/IDE/local_types.swift
+++ b/test/IDE/local_types.swift
@@ -38,11 +38,12 @@ public func singleFunc() {
     case sfgei(Int)
   }
 
-  // We'll need to handle this if we start saving alias types.
-  // NEGATIVE-NOT: AliasAAA
+  // CHECK-DAG: AliasAAA
   typealias SingleFuncAliasAAA = Int
+  // We don't handle generic typealiases correctly quite yet.
+  // Re-enable this when <rdar://problem/43110802> is fixed.
   // NEGATIVE-NOT: AliasGGG
-  typealias GenericAliasGGG<T> = (T, T)
+  //typealias GenericAliasGGG<T> = (T, T)
 }
 
 public func singleFuncWithDuplicates(_ fake: Bool) {

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1627,6 +1627,7 @@ static int doPrintLocalTypes(const CompilerInvocation &InitInvok,
       case NodeKind::Class:
       case NodeKind::Enum:
       case NodeKind::OtherNominalType:
+      case NodeKind::TypeAlias:
         break;
 
       case NodeKind::BoundGenericStructure:


### PR DESCRIPTION
Fixes <rdar://problem/42446693>

(Thanks to Jordan for pointing out the solution)
