### PR TITLE
[test] Yet more tweaks to remote-run

### DIFF
--- a/test/remote-run/custom-options.test-sh
+++ b/test/remote-run/custom-options.test-sh
@@ -3,6 +3,11 @@ RUN: %utils/remote-run -n --remote-dir /xyz-REMOTE -o FIRST_OPT -o SECOND_OPT --
 CHECK: /usr/bin/ssh -n
 CHECK-DAG: -p 12345
 CHECK-DAG: -o FIRST_OPT -o SECOND_OPT
+CHECK-SAME: some_user@some_host -- '/usr/bin/env' '/bin/rm' '-rf' '{{.+}}-REMOTE/output'
+
+CHECK-NEXT: /usr/bin/ssh -n
+CHECK-DAG: -p 12345
+CHECK-DAG: -o FIRST_OPT -o SECOND_OPT
 CHECK-SAME: some_user@some_host -- '/usr/bin/env' '/bin/mkdir' '-p' '{{.+}}-REMOTE/output/nested'
 
 CHECK-NEXT: /usr/bin/sftp

--- a/test/remote-run/identity.test-sh
+++ b/test/remote-run/identity.test-sh
@@ -3,6 +3,11 @@ RUN: %utils/remote-run -n --remote-dir /xyz-REMOTE -i spiderman --output-prefix 
 CHECK: /usr/bin/ssh -n
 CHECK-DAG: -p 12345
 CHECK-DAG: -i spiderman
+CHECK-SAME: some_user@some_host -- '/usr/bin/env' '/bin/rm' '-rf' '{{.+}}-REMOTE/output'
+
+CHECK-NEXT: /usr/bin/ssh -n
+CHECK-DAG: -p 12345
+CHECK-DAG: -i spiderman
 CHECK-SAME: some_user@some_host -- '/usr/bin/env' '/bin/mkdir' '-p' '{{.+}}-REMOTE/output/nested'
 
 CHECK-NEXT: /usr/bin/sftp

--- a/utils/remote-run
+++ b/utils/remote-run
@@ -28,7 +28,7 @@ class CommandRunner(object):
 
     @staticmethod
     def _dirnames(files):
-        return list(set(os.path.dirname(f) for f in files))
+        return sorted(set(os.path.dirname(f) for f in files))
 
     def popen(self, command, **kwargs):
         if self.verbose:
@@ -195,15 +195,20 @@ def main():
     runner.dry_run = args.dry_run
     runner.verbose = args.verbose or args.dry_run
 
+    assert not args.remote_dir == '/'
+
     upload_files = dict()
     download_files = dict()
+    remote_test_specific_dir = None
     if args.input_prefix:
+        assert not args.remote_input_prefix.startswith("..")
         remote_dir = os.path.join(args.remote_dir, args.remote_input_prefix)
         input_files = find_transfers(args.command, args.input_prefix, 
                                      remote_dir)
         assert not any(upload_files.has_key(f) for f in input_files)
         upload_files.update(input_files)
     if args.output_prefix:
+        assert not args.remote_output_prefix.startswith("..")
         remote_dir = os.path.join(args.remote_dir, args.remote_output_prefix)
         test_files = find_transfers(args.command, args.output_prefix, 
                                     remote_dir)
@@ -211,7 +216,11 @@ def main():
         upload_files.update(test_files)
         assert not any(download_files.has_key(f) for f in test_files)
         download_files.update(test_files)
+        remote_test_specific_dir = remote_dir
 
+    if remote_test_specific_dir:
+        assert remote_test_specific_dir.startswith(args.remote_dir)
+        runner.run_remote(['/bin/rm', '-rf', remote_test_specific_dir])
     if upload_files:
         runner.send(upload_files)
 

--- a/validation-test/Reflection/lit.local.cfg
+++ b/validation-test/Reflection/lit.local.cfg
@@ -2,9 +2,9 @@
 config.substitutions = list(config.substitutions)
 
 config.substitutions.insert(0, ("%target-run-reflection-test",
-    # Link %target-swift-reflection-test into %t to convince %target-run to copy
+    # Copy %target-swift-reflection-test into %t to convince %target-run to copy
     # it, then use DYLD_LIBRARY_PATH to make sure it can find SwiftRemoteMirrors
     # from its new location when /not/ run remotely.
-    ("ln %target-swift-reflection-test %t/swift-reflection-test && "
+    ("cp %target-swift-reflection-test %t/swift-reflection-test && "
         "env %env-DYLD_LIBRARY_PATH=%platform-module-dir/../ %target-run "
         " %t/swift-reflection-test")))


### PR DESCRIPTION
Follow-up to #18966 and #19098 to continue improving the behavior of remote-run:

- Clear out `%t` on the remote machine, so we don't run into artifacts from the last run.
- Copy `%target-swift-reflection-test` into `%t` instead of using a hard link. The problem with hard links is that they can be overwritten when the test fails, which would then truncate the original executable to an empty file!