### PR TITLE
[ConstraintSystem] Add `BindingProducer` base type

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1982,8 +1982,8 @@ void DisjunctionChoice::attempt(ConstraintSystem &cs) const {
     propagateConversionInfo(cs);
 }
 
-bool DisjunctionChoice::isGenericOperator() const {
-  auto *decl = getOperatorDecl();
+bool DisjunctionChoice::isGenericOp(Constraint *choice) {
+  auto *decl = getOperatorDecl(choice);
   if (!decl)
     return false;
 
@@ -1991,8 +1991,8 @@ bool DisjunctionChoice::isGenericOperator() const {
   return interfaceType->is<GenericFunctionType>();
 }
 
-bool DisjunctionChoice::isSymmetricOperator() const {
-  auto *decl = getOperatorDecl();
+bool DisjunctionChoice::isSymmetricOp(Constraint *choice) {
+  auto *decl = getOperatorDecl(choice);
   if (!decl)
     return false;
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1792,7 +1792,7 @@ bool ConstraintSystem::solveForDisjunctionChoices(
   Optional<Score> bestNonGenericScore;
   Optional<std::pair<Constraint *, Score>> lastSolvedChoice;
 
-  DisjunctionChoiceProducer producer(choices, disjunctionLocator,
+  DisjunctionChoiceProducer producer(*this, choices, disjunctionLocator,
                                      isExplicitConversion);
 
   // Try each of the constraints within the disjunction.

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -527,13 +527,6 @@ bool ConstraintSystem::tryTypeVariableBindings(
   bool anySolved = false;
   bool sawFirstLiteralConstraint = false;
 
-  auto attemptTypeVarBinding = [&](TypeVariableBinding &binding) -> bool {
-    // Try to solve the system with typeVar := type
-    ConstraintSystem::SolverScope scope(*this);
-    binding.attempt(*this);
-    return !solveRec(solutions);
-  };
-
   if (TC.getLangOpts().DebugConstraintSolver) {
     auto &log = getASTContext().TypeCheckerDebug->getStream();
     log.indent(solverState->depth * 2) << "Initial bindings: ";
@@ -575,8 +568,12 @@ bool ConstraintSystem::tryTypeVariableBindings(
     if (binding->hasDefaultedProtocol())
       sawFirstLiteralConstraint = true;
 
-    if (attemptTypeVarBinding(*binding))
-      anySolved = true;
+    {
+      // Try to solve the system with typeVar := type
+      ConstraintSystem::SolverScope scope(*this);
+      binding->attempt(*this);
+      anySolved |= !solveRec(solutions);
+    }
 
     if (TC.getLangOpts().DebugConstraintSolver) {
       auto &log = getASTContext().TypeCheckerDebug->getStream();


### PR DESCRIPTION
Introduce a base `BindingProducer` type which can produce bindings
for both type variables and disjunctions.

It required some cleanup in the solver:

* Introduce more common functionality into `TypeBinding` such as `getIndex`, `isDisabled` etc.
* Extract logic for attempting individual choices into `solveForDisjunctionChoice`
* Remove all of the unnecessary information from `DisjunctionChoice`
* Convert auxiliary logic to operate on `TypeBinding` instead of `DisjunctionChoice`

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
