### PR TITLE
autodiff conformance lookup fixes

### DIFF
--- a/test/TensorFlow/tensor_autodiff.swift
+++ b/test/TensorFlow/tensor_autodiff.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O -emit-llvm %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s
 // XFAIL: *
 
 import TensorFlow

--- a/test/TensorFlow/tensor_primitive_autodiff.swift
+++ b/test/TensorFlow/tensor_primitive_autodiff.swift
@@ -1,14 +1,13 @@
-// RUN: %target-swift-frontend -O -emit-llvm %s | %FileCheck %s
-// XFAIL: *
+// RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s
 
 import TensorFlow
 
 @differentiable(reverse, adjoint: dConcreteTanh)
-func concreteTanh(_ x: Tensor<Float>) -> Tensor<Float> {
+public func concreteTanh(_ x: Tensor<Float>) -> Tensor<Float> {
   return tanh(x)
 }
 
-func dConcreteTanh(_ x: Tensor<Float>, tanhx: Tensor<Float>, seed: Tensor<Float>) -> Tensor<Float> {
+public func dConcreteTanh(_ x: Tensor<Float>, tanhx: Tensor<Float>, seed: Tensor<Float>) -> Tensor<Float> {
   return seed * (1 - tanhx * tanhx)
 }
 


### PR DESCRIPTION
Fixes two problems:

Problem 1. The original conformance lookup code used ASTContext.getConformance, which actually creates a new conformance (unless you manage to pass it a pointer to the actual extension declaring the conformance that you're looking for). So the original code was returning a new empty conformance. Fixed by using `targetTypeDecl->lookupConformance`.

Problem 2. The lookup finds a conformance of Tensor<Scalar> to VectorNumeric, where Scalar is generic. So when createApply tries to use that conformance to figure out some types, it gets a generic type that it doesn't know how to deal with. Fixed by specializing the conformance using `astCtx.getSpecializedConformance`.

In `tensor_primitive_autodiff`, the gradients get deabstracted and extracted so CHECK-ing their bodies would probably be quite fragile. I couldn't quickly think of a way to fix that, so I'll just leave better testing of tensor autodiff for later.

`tensor_autodiff` still fails with:
```
swift: /usr/local/google/home/marcrasi/swift-base/swift/lib/SILOptimizer/Analysis/Analysis.cpp:33: static void swift::SILAnalysis::verifyFunction(swift::SILFunction *): Assertion `F->isDefinition() && "Can't analyze external functions"' failed.
#0 0x0000000003d7e1d4 PrintStackTraceSignalHandler(void*) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift+0x3d7e1d4)
#1 0x0000000003d7c452 llvm::sys::RunSignalHandlers() (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift+0x3d7c452)
#2 0x0000000003d7e382 SignalHandler(int) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift+0x3d7e382)
#3 0x00007fdba0a2a0c0 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x110c0)
#4 0x00007fdb9a87bfcf gsignal (/lib/x86_64-linux-gnu/libc.so.6+0x32fcf)
#5 0x00007fdb9a87d3fa abort (/lib/x86_64-linux-gnu/libc.so.6+0x343fa)
#6 0x00007fdb9a874e37 (/lib/x86_64-linux-gnu/libc.so.6+0x2be37)
#7 0x00007fdb9a874ee2 (/lib/x86_64-linux-gnu/libc.so.6+0x2bee2)
#8 0x0000000000ea7012 (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift+0xea7012)
#9 0x0000000000fe6110 (anonymous namespace)::Differentiation::run() (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift+0xfe6110)
#10 0x0000000000cd43ea swift::SILPassManager::runModulePass(unsigned int) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift+0xcd43ea)
#11 0x0000000000cd4cb7 swift::SILPassManager::execute() (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift+0xcd4cb7)
#12 0x00000000005b3b68 swift::SILPassManager::executePassPipelinePlan(swift::SILPassPipelinePlan const&) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift+0x5b3b68)
#13 0x0000000000cdbb4d swift::runSILDiagnosticPasses(swift::SILModule&) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift+0xcdbb4d)
#14 0x00000000004daecd performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift+0x4daecd)
#15 0x00000000004d6f31 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift+0x4d6f31)
#16 0x000000000048a558 main (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift+0x48a558)
#17 0x00007fdb9a8692b1 __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x202b1)
#18 0x000000000048877a _start (/usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift+0x48877a)
Stack dump:
0.	Program arguments: /usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/bin/swift -frontend -target x86_64-unknown-linux-gnu -module-cache-path /usr/local/google/home/marcrasi/swift-base/build/buildbot_linux/swift-linux-x86_64/swift-test-results/x86_64-unknown-linux-gnu/clang-module-cache -swift-version 4 -emit-sil /usr/local/google/home/marcrasi/swift-base/swift/test/TensorFlow/tensor_autodiff.swift 
1.	While running pass #50 SILModuleTransform "Differentiation".
```