### PR TITLE
Annotate Foundation overlay with __shared/__owned

### DIFF
--- a/stdlib/public/SDK/Foundation/AffineTransform.swift
+++ b/stdlib/public/SDK/Foundation/AffineTransform.swift
@@ -33,7 +33,7 @@ public struct AffineTransform : ReferenceConvertible, Hashable, CustomStringConv
         self.tY = tY
     }
     
-    fileprivate init(reference: NSAffineTransform) {
+    fileprivate init(reference: __shared NSAffineTransform) {
         m11 = reference.transformStruct.m11
         m12 = reference.transformStruct.m12
         m21 = reference.transformStruct.m21

--- a/stdlib/public/SDK/Foundation/Boxing.swift
+++ b/stdlib/public/SDK/Foundation/Boxing.swift
@@ -19,7 +19,7 @@ internal final class _MutableHandle<MutableType : NSObject>
   where MutableType : NSCopying {
     fileprivate var _pointer : MutableType
     
-    init(reference : MutableType) {
+    init(reference : __shared MutableType) {
         _pointer = reference.copy() as! MutableType
     }
     

--- a/stdlib/public/SDK/Foundation/Calendar.swift
+++ b/stdlib/public/SDK/Foundation/Calendar.swift
@@ -97,7 +97,7 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
     /// Returns a new Calendar.
     ///
     /// - parameter identifier: The kind of calendar to use.
-    public init(identifier: Identifier) {
+    public init(identifier: __shared Identifier) {
         let result = __NSCalendarCreate(Calendar._toNSCalendarIdentifier(identifier))
         _handle = _MutableHandle(adoptingReference: result as! NSCalendar)
         _autoupdating = false

--- a/stdlib/public/SDK/Foundation/Calendar.swift
+++ b/stdlib/public/SDK/Foundation/Calendar.swift
@@ -106,7 +106,7 @@ public struct Calendar : Hashable, Equatable, ReferenceConvertible, _MutableBoxi
     // MARK: -
     // MARK: Bridging
     
-    fileprivate init(reference : NSCalendar) {
+    fileprivate init(reference : __shared NSCalendar) {
         _handle = _MutableHandle(reference: reference)
         if __NSCalendarIsAutoupdating(reference) {
             _autoupdating = true

--- a/stdlib/public/SDK/Foundation/CharacterSet.swift
+++ b/stdlib/public/SDK/Foundation/CharacterSet.swift
@@ -415,7 +415,7 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
         }
     }
 
-    fileprivate init(_bridged characterSet: NSCharacterSet) {
+    fileprivate init(_bridged characterSet: __shared NSCharacterSet) {
         _storage = _CharacterSetStorage(immutableReference: characterSet.copy() as! CFCharacterSet)
     }
     

--- a/stdlib/public/SDK/Foundation/CharacterSet.swift
+++ b/stdlib/public/SDK/Foundation/CharacterSet.swift
@@ -390,7 +390,7 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
     /// Initialize with the characters in the given string.
     ///
     /// - parameter string: The string content to inspect for characters.
-    public init(charactersIn string: String) {
+    public init(charactersIn string: __shared String) {
         _storage = _CharacterSetStorage(immutableReference: CFCharacterSetCreateWithCharactersInString(nil, string as CFString))
     }
     
@@ -398,7 +398,7 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
     ///
     /// This method is useful for creating a character set object with data from a file or other external data source.
     /// - parameter data: The bitmap representation.
-    public init(bitmapRepresentation data: Data) {
+    public init(bitmapRepresentation data: __shared Data) {
         _storage = _CharacterSetStorage(immutableReference: CFCharacterSetCreateWithBitmapRepresentation(nil, data as CFData))
     }
     
@@ -406,7 +406,7 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
     ///
     /// Returns `nil` if there was an error reading the file.
     /// - parameter file: The file to read.
-    public init?(contentsOfFile file: String) {
+    public init?(contentsOfFile file: __shared String) {
         do {
             let data = try Data(contentsOf: URL(fileURLWithPath: file), options: .mappedIfSafe)
             _storage = _CharacterSetStorage(immutableReference: CFCharacterSetCreateWithBitmapRepresentation(nil, data as CFData))
@@ -427,7 +427,7 @@ public struct CharacterSet : ReferenceConvertible, Equatable, Hashable, SetAlgeb
         _storage = _uncopiedStorage
     }
 
-    fileprivate init(_builtIn: CFCharacterSetPredefinedSet) {
+    fileprivate init(_builtIn: __shared CFCharacterSetPredefinedSet) {
         _storage = _CharacterSetStorage(immutableReference: CFCharacterSetGetPredefined(_builtIn))
     }
     

--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -1178,7 +1178,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - parameter url: The `URL` to read.
     /// - parameter options: Options for the read operation. Default value is `[]`.
     /// - throws: An error in the Cocoa domain, if `url` cannot be read.
-    public init(contentsOf url: URL, options: Data.ReadingOptions = []) throws {
+    public init(contentsOf url: __shared URL, options: __shared Data.ReadingOptions = []) throws {
         let d = try NSData(contentsOf: url, options: ReadingOptions(rawValue: options.rawValue))
         _backing = _DataStorage(immutableReference: d, offset: 0)
         _sliceRange = 0..<d.length
@@ -1189,7 +1189,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// Returns nil when the input is not recognized as valid Base-64.
     /// - parameter base64String: The string to parse.
     /// - parameter options: Encoding options. Default value is `[]`.
-    public init?(base64Encoded base64String: String, options: Data.Base64DecodingOptions = []) {
+    public init?(base64Encoded base64String: __shared String, options: __shared Data.Base64DecodingOptions = []) {
         if let d = NSData(base64Encoded: base64String, options: Base64DecodingOptions(rawValue: options.rawValue)) {
             _backing = _DataStorage(immutableReference: d, offset: 0)
             _sliceRange = 0..<d.length
@@ -1204,7 +1204,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     ///
     /// - parameter base64Data: Base-64, UTF-8 encoded input data.
     /// - parameter options: Decoding options. Default value is `[]`.
-    public init?(base64Encoded base64Data: Data, options: Data.Base64DecodingOptions = []) {
+    public init?(base64Encoded base64Data: __shared Data, options: __shared Data.Base64DecodingOptions = []) {
         if let d = NSData(base64Encoded: base64Data, options: Base64DecodingOptions(rawValue: options.rawValue)) {
             _backing = _DataStorage(immutableReference: d, offset: 0)
             _sliceRange = 0..<d.length

--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -1220,7 +1220,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// If the resulting value is mutated, then `Data` will invoke the `mutableCopy()` function on the reference to copy the contents. You may customize the behavior of that function if you wish to return a specialized mutable subclass.
     ///
     /// - parameter reference: The instance of `NSData` that you wish to wrap. This instance will be copied by `struct Data`.
-    public init(referencing reference: NSData) {
+    public init(referencing reference: __shared NSData) {
 #if DEPLOYMENT_RUNTIME_SWIFT
         let providesConcreteBacking = reference._providesConcreteBacking()
 #else

--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -1178,7 +1178,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// - parameter url: The `URL` to read.
     /// - parameter options: Options for the read operation. Default value is `[]`.
     /// - throws: An error in the Cocoa domain, if `url` cannot be read.
-    public init(contentsOf url: __shared URL, options: __shared Data.ReadingOptions = []) throws {
+    public init(contentsOf url: __shared URL, options: Data.ReadingOptions = []) throws {
         let d = try NSData(contentsOf: url, options: ReadingOptions(rawValue: options.rawValue))
         _backing = _DataStorage(immutableReference: d, offset: 0)
         _sliceRange = 0..<d.length
@@ -1189,7 +1189,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// Returns nil when the input is not recognized as valid Base-64.
     /// - parameter base64String: The string to parse.
     /// - parameter options: Encoding options. Default value is `[]`.
-    public init?(base64Encoded base64String: __shared String, options: __shared Data.Base64DecodingOptions = []) {
+    public init?(base64Encoded base64String: __shared String, options: Data.Base64DecodingOptions = []) {
         if let d = NSData(base64Encoded: base64String, options: Base64DecodingOptions(rawValue: options.rawValue)) {
             _backing = _DataStorage(immutableReference: d, offset: 0)
             _sliceRange = 0..<d.length
@@ -1204,7 +1204,7 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     ///
     /// - parameter base64Data: Base-64, UTF-8 encoded input data.
     /// - parameter options: Decoding options. Default value is `[]`.
-    public init?(base64Encoded base64Data: __shared Data, options: __shared Data.Base64DecodingOptions = []) {
+    public init?(base64Encoded base64Data: __shared Data, options: Data.Base64DecodingOptions = []) {
         if let d = NSData(base64Encoded: base64Data, options: Base64DecodingOptions(rawValue: options.rawValue)) {
             _backing = _DataStorage(immutableReference: d, offset: 0)
             _sliceRange = 0..<d.length

--- a/stdlib/public/SDK/Foundation/DateComponents.swift
+++ b/stdlib/public/SDK/Foundation/DateComponents.swift
@@ -269,7 +269,7 @@ public struct DateComponents : ReferenceConvertible, Hashable, Equatable, _Mutab
     
     // MARK: - Bridging Helpers
     
-    fileprivate init(reference: NSDateComponents) {
+    fileprivate init(reference: __shared NSDateComponents) {
         _handle = _MutableHandle(reference: reference)
     }
 

--- a/stdlib/public/SDK/Foundation/Decimal.swift
+++ b/stdlib/public/SDK/Foundation/Decimal.swift
@@ -452,7 +452,7 @@ extension Decimal {
 }
 
 extension Decimal : CustomStringConvertible {
-    public init?(string: String, locale: Locale? = nil) {
+    public init?(string: __shared String, locale: __shared Locale? = nil) {
         let scan = Scanner(string: string)
         var theDecimal = Decimal()
         scan.locale = locale

--- a/stdlib/public/SDK/Foundation/IndexPath.swift
+++ b/stdlib/public/SDK/Foundation/IndexPath.swift
@@ -684,7 +684,7 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
     
     // MARK: - Bridging Helpers
     
-    fileprivate init(nsIndexPath: ReferenceType) {
+    fileprivate init(nsIndexPath: __shared ReferenceType) {
         let count = nsIndexPath.length
         if count == 0 {
             _indexes = []

--- a/stdlib/public/SDK/Foundation/IndexPath.swift
+++ b/stdlib/public/SDK/Foundation/IndexPath.swift
@@ -156,7 +156,7 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
             }
         }
         
-        mutating func append(contentsOf other: [Int]) {
+        mutating func append(contentsOf other: __owned [Int]) {
             switch self {
             case .empty:
                 switch other.count {

--- a/stdlib/public/SDK/Foundation/IndexSet.swift
+++ b/stdlib/public/SDK/Foundation/IndexSet.swift
@@ -661,7 +661,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
         return _handle.reference
     }
     
-    fileprivate init(reference: NSIndexSet) {
+    fileprivate init(reference: __shared NSIndexSet) {
         _handle = _MutablePairHandle(reference)
     }
 }

--- a/stdlib/public/SDK/Foundation/JSONEncoder.swift
+++ b/stdlib/public/SDK/Foundation/JSONEncoder.swift
@@ -387,7 +387,7 @@ fileprivate struct _JSONEncodingStorage {
         return array
     }
 
-    fileprivate mutating func push(container: NSObject) {
+    fileprivate mutating func push(container: __owned NSObject) {
         self.containers.append(container)
     }
 
@@ -961,7 +961,7 @@ fileprivate class _JSONReferencingEncoder : _JSONEncoder {
 
     /// Initializes `self` by referencing the given dictionary container in the given encoder.
     fileprivate init(referencing encoder: _JSONEncoder,
-                     key: CodingKey, convertedKey: CodingKey, wrapping dictionary: NSMutableDictionary) {
+                     key: CodingKey, convertedKey: __shared CodingKey, wrapping dictionary: NSMutableDictionary) {
         self.encoder = encoder
         self.reference = .dictionary(dictionary, convertedKey.stringValue)
         super.init(options: encoder.options, codingPath: encoder.codingPath)
@@ -1273,7 +1273,7 @@ fileprivate struct _JSONDecodingStorage {
         return self.containers.last!
     }
 
-    fileprivate mutating func push(container: Any) {
+    fileprivate mutating func push(container: __owned Any) {
         self.containers.append(container)
     }
 
@@ -1616,7 +1616,7 @@ fileprivate struct _JSONKeyedDecodingContainer<K : CodingKey> : KeyedDecodingCon
         return _JSONUnkeyedDecodingContainer(referencing: self.decoder, wrapping: array)
     }
 
-    private func _superDecoder(forKey key: CodingKey) throws -> Decoder {
+    private func _superDecoder(forKey key: __owned CodingKey) throws -> Decoder {
         self.decoder.codingPath.append(key)
         defer { self.decoder.codingPath.removeLast() }
 

--- a/stdlib/public/SDK/Foundation/Locale.swift
+++ b/stdlib/public/SDK/Foundation/Locale.swift
@@ -52,7 +52,7 @@ public struct Locale : Hashable, Equatable, ReferenceConvertible {
         _autoupdating = false
     }
     
-    fileprivate init(reference: NSLocale) {
+    fileprivate init(reference: __shared NSLocale) {
         _wrapped = reference.copy() as! NSLocale
         if __NSLocaleIsAutoupdating(reference) {
             _autoupdating = true

--- a/stdlib/public/SDK/Foundation/NSArray.swift
+++ b/stdlib/public/SDK/Foundation/NSArray.swift
@@ -30,7 +30,7 @@ extension Array : _ObjectiveCBridgeable {
   ///
   /// The provided `NSArray` will be copied to ensure that the copy can
   /// not be mutated by other code.
-  internal init(_cocoaArray: NSArray) {
+  internal init(_cocoaArray: __shared NSArray) {
     assert(_isBridgedVerbatimToObjectiveC(Element.self),
       "Array can be backed by NSArray only when the element type can be bridged verbatim to Objective-C")
     // FIXME: We would like to call CFArrayCreateCopy() to avoid doing an
@@ -153,7 +153,7 @@ extension NSArray {
   /// Discussion: After an immutable array has been initialized in
   /// this way, it cannot be modified.
   @nonobjc
-  public convenience init(array anArray: NSArray) {
+  public convenience init(array anArray: __shared NSArray) {
     self.init(array: anArray as Array)
   }
 }

--- a/stdlib/public/SDK/Foundation/NSDictionary.swift
+++ b/stdlib/public/SDK/Foundation/NSDictionary.swift
@@ -34,7 +34,7 @@ extension Dictionary {
   ///
   /// The provided `NSDictionary` will be copied to ensure that the copy can
   /// not be mutated by other code.
-  public init(_cocoaDictionary: _NSDictionary) {
+  public init(_cocoaDictionary: __shared _NSDictionary) {
     assert(
       _isBridgedVerbatimToObjectiveC(Key.self) &&
       _isBridgedVerbatimToObjectiveC(Value.self),
@@ -165,7 +165,7 @@ extension NSDictionary : Sequence {
       return nil
     }
 
-    internal init(_ _dict: NSDictionary) {
+    internal init(_ _dict: __shared NSDictionary) {
       _fastIterator = NSFastEnumerationIterator(_dict)
     }
   }
@@ -219,7 +219,7 @@ extension NSDictionary {
   ///   than the original receiver--containing the keys and values
   ///   found in `otherDictionary`.
   @objc(_swiftInitWithDictionary_NSDictionary:)
-  public convenience init(dictionary otherDictionary: NSDictionary) {
+  public convenience init(dictionary otherDictionary: __shared NSDictionary) {
     // FIXME(performance)(compiler limitation): we actually want to do just
     // `self = otherDictionary.copy()`, but Swift does not have factory
     // initializers right now.

--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -398,7 +398,7 @@ extension _BridgedNSError {
 extension _BridgedNSError where Self.RawValue: FixedWidthInteger {
   public var _code: Int { return Int(rawValue) }
 
-  public init?(_bridgedNSError: NSError) {
+  public init?(_bridgedNSError: __shared NSError) {
     if _bridgedNSError.domain != Self._nsErrorDomain {
       return nil
     }

--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -359,7 +359,7 @@ extension CFError : Error {
 public protocol _ObjectiveCBridgeableError : Error {
   /// Produce a value of the error type corresponding to the given NSError,
   /// or return nil if it cannot be bridged.
-  init?(_bridgedNSError: NSError)
+  init?(_bridgedNSError: __shared NSError)
 }
 
 /// A hook for the runtime to use _ObjectiveCBridgeableError in order to

--- a/stdlib/public/SDK/Foundation/NSExpression.swift
+++ b/stdlib/public/SDK/Foundation/NSExpression.swift
@@ -15,7 +15,7 @@
 extension NSExpression {
   // + (NSExpression *) expressionWithFormat:(NSString *)expressionFormat, ...;
   public
-  convenience init(format expressionFormat: String, _ args: CVarArg...) {
+  convenience init(format expressionFormat: __shared String, _ args: CVarArg...) {
     let va_args = getVaList(args)
     self.init(format: expressionFormat, arguments: va_args)
   }

--- a/stdlib/public/SDK/Foundation/NSNumber.swift
+++ b/stdlib/public/SDK/Foundation/NSNumber.swift
@@ -15,15 +15,15 @@ import CoreGraphics
 
 extension Int8 : _ObjectiveCBridgeable {
     @available(swift, deprecated: 4, renamed: "init(truncating:)")
-    public init(_ number: NSNumber) {
+    public init(_ number: __shared NSNumber) {
         self = number.int8Value
     }
 
-    public init(truncating number: NSNumber) {
+    public init(truncating number: __shared NSNumber) {
         self = number.int8Value
     }
 
-    public init?(exactly number: NSNumber) {
+    public init?(exactly number: __shared NSNumber) {
         let value = number.int8Value
         guard NSNumber(value: value) == number else { return nil }
         self = value
@@ -56,15 +56,15 @@ extension Int8 : _ObjectiveCBridgeable {
 
 extension UInt8 : _ObjectiveCBridgeable {
     @available(swift, deprecated: 4, renamed: "init(truncating:)")
-    public init(_ number: NSNumber) {
+    public init(_ number: __shared NSNumber) {
         self = number.uint8Value
     }
 
-    public init(truncating number: NSNumber) {
+    public init(truncating number: __shared NSNumber) {
         self = number.uint8Value
     }
 
-    public init?(exactly number: NSNumber) {
+    public init?(exactly number: __shared NSNumber) {
         let value = number.uint8Value
         guard NSNumber(value: value) == number else { return nil }
         self = value
@@ -97,15 +97,15 @@ extension UInt8 : _ObjectiveCBridgeable {
 
 extension Int16 : _ObjectiveCBridgeable {
     @available(swift, deprecated: 4, renamed: "init(truncating:)")
-    public init(_ number: NSNumber) {
+    public init(_ number: __shared NSNumber) {
         self = number.int16Value
     }
 
-    public init(truncating number: NSNumber) {
+    public init(truncating number: __shared NSNumber) {
         self = number.int16Value
     }
 
-    public init?(exactly number: NSNumber) {
+    public init?(exactly number: __shared NSNumber) {
         let value = number.int16Value
         guard NSNumber(value: value) == number else { return nil }
         self = value
@@ -138,15 +138,15 @@ extension Int16 : _ObjectiveCBridgeable {
 
 extension UInt16 : _ObjectiveCBridgeable {
     @available(swift, deprecated: 4, renamed: "init(truncating:)")
-    public init(_ number: NSNumber) {
+    public init(_ number: __shared NSNumber) {
         self = number.uint16Value
     }
 
-    public init(truncating number: NSNumber) {
+    public init(truncating number: __shared NSNumber) {
         self = number.uint16Value
     }
 
-    public init?(exactly number: NSNumber) {
+    public init?(exactly number: __shared NSNumber) {
         let value = number.uint16Value
         guard NSNumber(value: value) == number else { return nil }
         self = value
@@ -179,15 +179,15 @@ extension UInt16 : _ObjectiveCBridgeable {
 
 extension Int32 : _ObjectiveCBridgeable {
     @available(swift, deprecated: 4, renamed: "init(truncating:)")
-    public init(_ number: NSNumber) {
+    public init(_ number: __shared NSNumber) {
         self = number.int32Value
     }
 
-    public init(truncating number: NSNumber) {
+    public init(truncating number: __shared NSNumber) {
         self = number.int32Value
     }
 
-    public init?(exactly number: NSNumber) {
+    public init?(exactly number: __shared NSNumber) {
         let value = number.int32Value
         guard NSNumber(value: value) == number else { return nil }
         self = value
@@ -220,15 +220,15 @@ extension Int32 : _ObjectiveCBridgeable {
 
 extension UInt32 : _ObjectiveCBridgeable {
     @available(swift, deprecated: 4, renamed: "init(truncating:)")
-    public init(_ number: NSNumber) {
+    public init(_ number: __shared NSNumber) {
         self = number.uint32Value
     }
 
-    public init(truncating number: NSNumber) {
+    public init(truncating number: __shared NSNumber) {
         self = number.uint32Value
     }
 
-    public init?(exactly number: NSNumber) {
+    public init?(exactly number: __shared NSNumber) {
         let value = number.uint32Value
         guard NSNumber(value: value) == number else { return nil }
         self = value
@@ -261,15 +261,15 @@ extension UInt32 : _ObjectiveCBridgeable {
 
 extension Int64 : _ObjectiveCBridgeable {
     @available(swift, deprecated: 4, renamed: "init(truncating:)")
-    public init(_ number: NSNumber) {
+    public init(_ number: __shared NSNumber) {
         self = number.int64Value
     }
 
-    public init(truncating number: NSNumber) {
+    public init(truncating number: __shared NSNumber) {
         self = number.int64Value
     }
 
-    public init?(exactly number: NSNumber) {
+    public init?(exactly number: __shared NSNumber) {
         let value = number.int64Value
         guard NSNumber(value: value) == number else { return nil }
         self = value
@@ -302,15 +302,15 @@ extension Int64 : _ObjectiveCBridgeable {
 
 extension UInt64 : _ObjectiveCBridgeable {
     @available(swift, deprecated: 4, renamed: "init(truncating:)")
-    public init(_ number: NSNumber) {
+    public init(_ number: __shared NSNumber) {
         self = number.uint64Value
     }
 
-    public init(truncating number: NSNumber) {
+    public init(truncating number: __shared NSNumber) {
         self = number.uint64Value
     }
 
-    public init?(exactly number: NSNumber) {
+    public init?(exactly number: __shared NSNumber) {
         let value = number.uint64Value
         guard NSNumber(value: value) == number else { return nil }
         self = value
@@ -343,15 +343,15 @@ extension UInt64 : _ObjectiveCBridgeable {
 
 extension Int : _ObjectiveCBridgeable {
     @available(swift, deprecated: 4, renamed: "init(truncating:)")
-    public init(_ number: NSNumber) {
+    public init(_ number: __shared NSNumber) {
         self = number.intValue
     }
 
-    public init(truncating number: NSNumber) {
+    public init(truncating number: __shared NSNumber) {
         self = number.intValue
     }
 
-    public init?(exactly number: NSNumber) {
+    public init?(exactly number: __shared NSNumber) {
         let value = number.intValue
         guard NSNumber(value: value) == number else { return nil }
         self = value
@@ -384,15 +384,15 @@ extension Int : _ObjectiveCBridgeable {
 
 extension UInt : _ObjectiveCBridgeable {
     @available(swift, deprecated: 4, renamed: "init(truncating:)")
-    public init(_ number: NSNumber) {
+    public init(_ number: __shared NSNumber) {
         self = number.uintValue
     }
 
-    public init(truncating number: NSNumber) {
+    public init(truncating number: __shared NSNumber) {
         self = number.uintValue
     }
 
-    public init?(exactly number: NSNumber) {
+    public init?(exactly number: __shared NSNumber) {
         let value = number.uintValue
         guard NSNumber(value: value) == number else { return nil }
         self = value
@@ -425,15 +425,15 @@ extension UInt : _ObjectiveCBridgeable {
 
 extension Float : _ObjectiveCBridgeable {
     @available(swift, deprecated: 4, renamed: "init(truncating:)")
-    public init(_ number: NSNumber) {
+    public init(_ number: __shared NSNumber) {
         self = number.floatValue
     }
 
-    public init(truncating number: NSNumber) {
+    public init(truncating number: __shared NSNumber) {
         self = number.floatValue
     }
 
-    public init?(exactly number: NSNumber) {
+    public init?(exactly number: __shared NSNumber) {
         let type = number.objCType.pointee
         if type == 0x49 || type == 0x4c || type == 0x51 {
             guard let result = Float(exactly: number.uint64Value) else { return nil }
@@ -477,15 +477,15 @@ extension Float : _ObjectiveCBridgeable {
 
 extension Double : _ObjectiveCBridgeable {
     @available(swift, deprecated: 4, renamed: "init(truncating:)")
-    public init(_ number: NSNumber) {
+    public init(_ number: __shared NSNumber) {
         self = number.doubleValue
     }
 
-    public init(truncating number: NSNumber) {
+    public init(truncating number: __shared NSNumber) {
         self = number.doubleValue
     }
 
-    public init?(exactly number: NSNumber) {
+    public init?(exactly number: __shared NSNumber) {
         let type = number.objCType.pointee
         if type == 0x51 {
             guard let result = Double(exactly: number.uint64Value) else { return nil }
@@ -531,15 +531,15 @@ extension Double : _ObjectiveCBridgeable {
 
 extension Bool : _ObjectiveCBridgeable {
     @available(swift, deprecated: 4, renamed: "init(truncating:)")
-    public init(_ number: NSNumber) {
+    public init(_ number: __shared NSNumber) {
         self = number.boolValue
     }
 
-    public init(truncating number: NSNumber) {
+    public init(truncating number: __shared NSNumber) {
         self = number.boolValue
     }
 
-    public init?(exactly number: NSNumber) {
+    public init?(exactly number: __shared NSNumber) {
         if number === kCFBooleanTrue as NSNumber || NSNumber(value: 1) == number {
             self = true
         } else if number === kCFBooleanFalse as NSNumber || NSNumber(value: 0) == number {
@@ -582,15 +582,15 @@ extension Bool : _ObjectiveCBridgeable {
 
 extension CGFloat : _ObjectiveCBridgeable {
     @available(swift, deprecated: 4, renamed: "init(truncating:)")
-    public init(_ number: NSNumber) {
+    public init(_ number: __shared NSNumber) {
         self.init(CGFloat.NativeType(truncating: number))
     }
 
-    public init(truncating number: NSNumber) {
+    public init(truncating number: __shared NSNumber) {
         self.init(CGFloat.NativeType(truncating: number))
     }
 
-    public init?(exactly number: NSNumber) {
+    public init?(exactly number: __shared NSNumber) {
         var nativeValue: CGFloat.NativeType? = 0
         guard CGFloat.NativeType._conditionallyBridgeFromObjectiveC(number, result: &nativeValue) else { return nil }
         self.init(nativeValue!)

--- a/stdlib/public/SDK/Foundation/NSObject.swift
+++ b/stdlib/public/SDK/Foundation/NSObject.swift
@@ -81,7 +81,7 @@ fileprivate extension NSObject {
     
     @nonobjc static var keyPathTableLock = NSLock()
     
-    @nonobjc fileprivate static func _bridgeKeyPath(_ keyPath:AnyKeyPath) -> String {
+    @nonobjc fileprivate static func _bridgeKeyPath(_ keyPath: __owned AnyKeyPath) -> String {
         guard let keyPathString = keyPath._kvcKeyPathString else { fatalError("Could not extract a String from KeyPath \(keyPath)") }
         _KVOKeyPathBridgeMachinery.keyPathTableLock.lock()
         defer { _KVOKeyPathBridgeMachinery.keyPathTableLock.unlock() }
@@ -199,27 +199,27 @@ public extension _KeyValueCodingAndObserving {
         return result
     }
     
-    public func willChangeValue<Value>(for keyPath: KeyPath<Self, Value>) {
+    public func willChangeValue<Value>(for keyPath: __owned KeyPath<Self, Value>) {
         (self as! NSObject).willChangeValue(forKey: _bridgeKeyPathToString(keyPath))
     }
     
-    public func willChange<Value>(_ changeKind: NSKeyValueChange, valuesAt indexes: IndexSet, for keyPath: KeyPath<Self, Value>) {
+    public func willChange<Value>(_ changeKind: NSKeyValueChange, valuesAt indexes: IndexSet, for keyPath: __owned KeyPath<Self, Value>) {
         (self as! NSObject).willChange(changeKind, valuesAt: indexes, forKey: _bridgeKeyPathToString(keyPath))
     }
     
-    public func willChangeValue<Value>(for keyPath: KeyPath<Self, Value>, withSetMutation mutation: NSKeyValueSetMutationKind, using set: Set<Value>) -> Void {
+    public func willChangeValue<Value>(for keyPath: __owned KeyPath<Self, Value>, withSetMutation mutation: NSKeyValueSetMutationKind, using set: Set<Value>) -> Void {
         (self as! NSObject).willChangeValue(forKey: _bridgeKeyPathToString(keyPath), withSetMutation: mutation, using: set)
     }
     
-    public func didChangeValue<Value>(for keyPath: KeyPath<Self, Value>) {
+    public func didChangeValue<Value>(for keyPath: __owned KeyPath<Self, Value>) {
         (self as! NSObject).didChangeValue(forKey: _bridgeKeyPathToString(keyPath))
     }
     
-    public func didChange<Value>(_ changeKind: NSKeyValueChange, valuesAt indexes: IndexSet, for keyPath: KeyPath<Self, Value>) {
+    public func didChange<Value>(_ changeKind: NSKeyValueChange, valuesAt indexes: IndexSet, for keyPath: __owned KeyPath<Self, Value>) {
         (self as! NSObject).didChange(changeKind, valuesAt: indexes, forKey: _bridgeKeyPathToString(keyPath))
     }
     
-    public func didChangeValue<Value>(for keyPath: KeyPath<Self, Value>, withSetMutation mutation: NSKeyValueSetMutationKind, using set: Set<Value>) -> Void {
+    public func didChangeValue<Value>(for keyPath: __owned KeyPath<Self, Value>, withSetMutation mutation: NSKeyValueSetMutationKind, using set: Set<Value>) -> Void {
         (self as! NSObject).didChangeValue(forKey: _bridgeKeyPathToString(keyPath), withSetMutation: mutation, using: set)
     }
 }

--- a/stdlib/public/SDK/Foundation/NSPredicate.swift
+++ b/stdlib/public/SDK/Foundation/NSPredicate.swift
@@ -15,7 +15,7 @@
 extension NSPredicate {
   // + (NSPredicate *)predicateWithFormat:(NSString *)predicateFormat, ...;
   public
-  convenience init(format predicateFormat: String, _ args: CVarArg...) {
+  convenience init(format predicateFormat: __shared String, _ args: CVarArg...) {
     let va_args = getVaList(args)
     self.init(format: predicateFormat, arguments: va_args)
   }

--- a/stdlib/public/SDK/Foundation/NSRange.swift
+++ b/stdlib/public/SDK/Foundation/NSRange.swift
@@ -37,7 +37,7 @@ extension NSRange : CustomStringConvertible, CustomDebugStringConvertible {
 }
 
 extension NSRange {
-    public init?(_ string: String) {
+    public init?(_ string: __shared String) {
         var savedLocation = 0
         if string.isEmpty {
             // fail early if the string is empty
@@ -178,7 +178,7 @@ extension Range where Bound == Int {
 }
 
 extension Range where Bound == String.Index {
-  public init?(_ range: NSRange, in string: String) {
+  public init?(_ range: NSRange, in string: __shared String) {
     let u = string.utf16
     guard range.location != NSNotFound,
       let start = u.index(u.startIndex, offsetBy: range.location, limitedBy: u.endIndex),

--- a/stdlib/public/SDK/Foundation/NSSet.swift
+++ b/stdlib/public/SDK/Foundation/NSSet.swift
@@ -17,7 +17,7 @@ extension Set {
   ///
   /// The provided `NSSet` will be copied to ensure that the copy can
   /// not be mutated by other code.
-  public init(_cocoaSet: _NSSet) {
+  public init(_cocoaSet: __shared _NSSet) {
     assert(_isBridgedVerbatimToObjectiveC(Element.self),
       "Set can be backed by NSSet _variantStorage only when the member type can be bridged verbatim to Objective-C")
     // FIXME: We would like to call CFSetCreateCopy() to avoid doing an
@@ -164,7 +164,7 @@ extension NSSet {
   ///   `set`. The returned set might be different than the original
   ///   receiver.
   @nonobjc
-  public convenience init(set anSet: NSSet) {
+  public convenience init(set anSet: __shared NSSet) {
     // FIXME(performance)(compiler limitation): we actually want to do just
     // `self = anSet.copy()`, but Swift does not have factory
     // initializers right now.

--- a/stdlib/public/SDK/Foundation/NSString.swift
+++ b/stdlib/public/SDK/Foundation/NSString.swift
@@ -54,7 +54,7 @@ extension NSString : _HasCustomAnyHashableRepresentation {
 }
 
 extension NSString {
-  public convenience init(format: NSString, _ args: CVarArg...) {
+  public convenience init(format: __shared NSString, _ args: CVarArg...) {
     // We can't use withVaList because 'self' cannot be captured by a closure
     // before it has been initialized.
     let va_args = getVaList(args)
@@ -62,7 +62,7 @@ extension NSString {
   }
 
   public convenience init(
-    format: NSString, locale: Locale?, _ args: CVarArg...
+    format: __shared NSString, locale: Locale?, _ args: CVarArg...
   ) {
     // We can't use withVaList because 'self' cannot be captured by a closure
     // before it has been initialized.
@@ -102,7 +102,7 @@ extension NSString {
   ///   characters from `aString`. The returned object may be different
   ///   from the original receiver.
   @nonobjc
-  public convenience init(string aString: NSString) {
+  public convenience init(string aString: __shared NSString) {
     self.init(string: aString as String)
   }
 }

--- a/stdlib/public/SDK/Foundation/NSStringAPI.swift
+++ b/stdlib/public/SDK/Foundation/NSStringAPI.swift
@@ -187,7 +187,7 @@ extension String {
   /// - Parameters:
   ///   - bytes: A sequence of bytes to interpret using `encoding`.
   ///   - encoding: The ecoding to use to interpret `bytes`.
-  public init? <S: Sequence>(bytes: S, encoding: Encoding)
+  public init? <S: Sequence>(bytes: __shared S, encoding: Encoding)
     where S.Iterator.Element == UInt8 {
     let byteArray = Array(bytes)
     if let ns = NSString(
@@ -267,7 +267,7 @@ extension String {
   /// Produces a string created by reading data from the file at a
   /// given path interpreted using a given encoding.
   public init(
-    contentsOfFile path: String,
+    contentsOfFile path: __shared String,
     encoding enc: Encoding
   ) throws {
     let ns = try NSString(contentsOfFile: path, encoding: enc.rawValue)
@@ -283,7 +283,7 @@ extension String {
   /// a given path and returns by reference the encoding used to
   /// interpret the file.
   public init(
-    contentsOfFile path: String,
+    contentsOfFile path: __shared String,
     usedEncoding: inout Encoding
   ) throws {
     var enc: UInt = 0
@@ -293,7 +293,7 @@ extension String {
   }
 
   public init(
-    contentsOfFile path: String
+    contentsOfFile path: __shared String
   ) throws {
     let ns = try NSString(contentsOfFile: path, usedEncoding: nil)
     self = String._unconditionallyBridgeFromObjectiveC(ns)
@@ -308,7 +308,7 @@ extension String {
   /// interpreted using a given encoding.  Errors are written into the
   /// inout `error` argument.
   public init(
-    contentsOf url: URL,
+    contentsOf url: __shared URL,
     encoding enc: Encoding
   ) throws {
     let ns = try NSString(contentsOf: url, encoding: enc.rawValue)
@@ -324,7 +324,7 @@ extension String {
   /// and returns by reference the encoding used to interpret the
   /// data.  Errors are written into the inout `error` argument.
   public init(
-    contentsOf url: URL,
+    contentsOf url: __shared URL,
     usedEncoding: inout Encoding
   ) throws {
     var enc: UInt = 0
@@ -334,7 +334,7 @@ extension String {
   }
 
   public init(
-    contentsOf url: URL
+    contentsOf url: __shared URL
   ) throws {
     let ns = try NSString(contentsOf: url, usedEncoding: nil)
     self = String._unconditionallyBridgeFromObjectiveC(ns)
@@ -365,7 +365,7 @@ extension String {
 
   /// Returns a `String` initialized by converting given `data` into
   /// Unicode characters using a given `encoding`.
-  public init?(data: Data, encoding: Encoding) {
+  public init?(data: __shared Data, encoding: Encoding) {
     guard let s = NSString(data: data, encoding: encoding.rawValue) else { return nil }
     self = String._unconditionallyBridgeFromObjectiveC(s)
   }
@@ -375,7 +375,7 @@ extension String {
   /// Returns a `String` object initialized by using a given
   /// format string as a template into which the remaining argument
   /// values are substituted.
-  public init(format: String, _ arguments: CVarArg...) {
+  public init(format: __shared String, _ arguments: CVarArg...) {
     self = String(format: format, arguments: arguments)
   }
 
@@ -386,7 +386,7 @@ extension String {
   /// Returns a `String` object initialized by using a given
   /// format string as a template into which the remaining argument
   /// values are substituted according to the user's default locale.
-  public init(format: String, arguments: [CVarArg]) {
+  public init(format: __shared String, arguments: __shared [CVarArg]) {
     self = String(format: format, locale: nil, arguments: arguments)
   }
 
@@ -395,7 +395,7 @@ extension String {
   /// Returns a `String` object initialized by using a given
   /// format string as a template into which the remaining argument
   /// values are substituted according to given locale information.
-  public init(format: String, locale: Locale?, _ args: CVarArg...) {
+  public init(format: __shared String, locale: __shared Locale?, _ args: CVarArg...) {
     self = String(format: format, locale: locale, arguments: args)
   }
 
@@ -407,7 +407,7 @@ extension String {
   /// Returns a `String` object initialized by using a given
   /// format string as a template into which the remaining argument
   /// values are substituted according to given locale information.
-  public init(format: String, locale: Locale?, arguments: [CVarArg]) {
+  public init(format: __shared String, locale: __shared Locale?, arguments: __shared [CVarArg]) {
 #if DEPLOYMENT_RUNTIME_SWIFT
     self = withVaList(arguments) {
       String._unconditionallyBridgeFromObjectiveC(

--- a/stdlib/public/SDK/Foundation/PersonNameComponents.swift
+++ b/stdlib/public/SDK/Foundation/PersonNameComponents.swift
@@ -21,7 +21,7 @@ public struct PersonNameComponents : ReferenceConvertible, Hashable, Equatable, 
         _handle = _MutableHandle(adoptingReference: NSPersonNameComponents())
     }
     
-    fileprivate init(reference: NSPersonNameComponents) {
+    fileprivate init(reference: __shared NSPersonNameComponents) {
         _handle = _MutableHandle(reference: reference)
     }
 

--- a/stdlib/public/SDK/Foundation/PlistEncoder.swift
+++ b/stdlib/public/SDK/Foundation/PlistEncoder.swift
@@ -205,7 +205,7 @@ fileprivate struct _PlistEncodingStorage {
         return array
     }
 
-    fileprivate mutating func push(container: NSObject) {
+    fileprivate mutating func push(container: __owned NSObject) {
         self.containers.append(container)
     }
 
@@ -751,7 +751,7 @@ fileprivate struct _PlistDecodingStorage {
         return self.containers.last!
     }
 
-    fileprivate mutating func push(container: Any) {
+    fileprivate mutating func push(container: __owned Any) {
         self.containers.append(container)
     }
 
@@ -1067,7 +1067,7 @@ fileprivate struct _PlistKeyedDecodingContainer<K : CodingKey> : KeyedDecodingCo
         return _PlistUnkeyedDecodingContainer(referencing: self.decoder, wrapping: array)
     }
 
-    private func _superDecoder(forKey key: CodingKey) throws -> Decoder {
+    private func _superDecoder(forKey key: __owned CodingKey) throws -> Decoder {
         self.decoder.codingPath.append(key)
         defer { self.decoder.codingPath.removeLast() }
 

--- a/stdlib/public/SDK/Foundation/TimeZone.swift
+++ b/stdlib/public/SDK/Foundation/TimeZone.swift
@@ -50,7 +50,7 @@ public struct TimeZone : Hashable, Equatable, ReferenceConvertible {
     /// An example identifier is "America/Los_Angeles".
     ///
     /// If `identifier` is an unknown identifier, then returns `nil`.
-    public init?(identifier: String) {
+    public init?(identifier: __shared String) {
         if let r = NSTimeZone(name: identifier) {
             _wrapped = r
             _autoupdating = false
@@ -83,7 +83,7 @@ public struct TimeZone : Hashable, Equatable, ReferenceConvertible {
     ///
     /// - parameter abbreviation: The abbreviation for the time zone.
     /// - returns: A time zone identified by abbreviation determined by resolving the abbreviation to an identifier using the abbreviation dictionary and then returning the time zone for that identifier. Returns `nil` if there is no match for abbreviation.
-    public init?(abbreviation: String) {
+    public init?(abbreviation: __shared String) {
         if let r = NSTimeZone(abbreviation: abbreviation) {
             _wrapped = r
             _autoupdating = false

--- a/stdlib/public/SDK/Foundation/URL.swift
+++ b/stdlib/public/SDK/Foundation/URL.swift
@@ -536,7 +536,7 @@ public struct URL : ReferenceConvertible, Equatable {
     /// Initialize with string.
     ///
     /// Returns `nil` if a `URL` cannot be formed with the string (for example, if the string contains characters that are illegal in a URL, or is an empty string).
-    public init?(string: String) {
+    public init?(string: __shared String) {
         guard !string.isEmpty else { return nil }
         
         if let inner = NSURL(string: string) {
@@ -549,7 +549,7 @@ public struct URL : ReferenceConvertible, Equatable {
     /// Initialize with string, relative to another URL.
     ///
     /// Returns `nil` if a `URL` cannot be formed with the string (for example, if the string contains characters that are illegal in a URL, or is an empty string).
-    public init?(string: String, relativeTo url: URL?) {
+    public init?(string: __shared String, relativeTo url: __shared URL?) {
         guard !string.isEmpty else { return nil }
         
         if let inner = NSURL(string: string, relativeTo: url) {
@@ -564,7 +564,7 @@ public struct URL : ReferenceConvertible, Equatable {
     /// If an empty string is used for the path, then the path is assumed to be ".".
     /// - note: This function avoids an extra file system access to check if the file URL is a directory. You should use it if you know the answer already.
     @available(macOS 10.11, iOS 9.0, *)
-    public init(fileURLWithPath path: String, isDirectory: Bool, relativeTo base: URL?) {
+    public init(fileURLWithPath path: __shared String, isDirectory: Bool, relativeTo base: __shared URL?) {
         _url = URL._converted(from: NSURL(fileURLWithPath: path.isEmpty ? "." : path, isDirectory: isDirectory, relativeTo: base))
     }
     
@@ -572,7 +572,7 @@ public struct URL : ReferenceConvertible, Equatable {
     ///
     /// If an empty string is used for the path, then the path is assumed to be ".".
     @available(macOS 10.11, iOS 9.0, *)
-    public init(fileURLWithPath path: String, relativeTo base: URL?) {
+    public init(fileURLWithPath path: __shared String, relativeTo base: __shared URL?) {
         _url = URL._converted(from: NSURL(fileURLWithPath: path.isEmpty ? "." : path, relativeTo: base))
     }
     
@@ -580,14 +580,14 @@ public struct URL : ReferenceConvertible, Equatable {
     ///
     /// If an empty string is used for the path, then the path is assumed to be ".".
     /// - note: This function avoids an extra file system access to check if the file URL is a directory. You should use it if you know the answer already.
-    public init(fileURLWithPath path: String, isDirectory: Bool) {
+    public init(fileURLWithPath path: __shared String, isDirectory: Bool) {
         _url = URL._converted(from: NSURL(fileURLWithPath: path.isEmpty ? "." : path, isDirectory: isDirectory))
     }
     
     /// Initializes a newly created file URL referencing the local file or directory at path.
     ///
     /// If an empty string is used for the path, then the path is assumed to be ".".
-    public init(fileURLWithPath path: String) {
+    public init(fileURLWithPath path: __shared String) {
         _url = URL._converted(from: NSURL(fileURLWithPath: path.isEmpty ? "." : path))
     }
     
@@ -595,7 +595,7 @@ public struct URL : ReferenceConvertible, Equatable {
     ///
     /// If the data representation is not a legal URL string as ASCII bytes, the URL object may not behave as expected. If the URL cannot be formed then this will return nil.
     @available(macOS 10.11, iOS 9.0, *)
-    public init?(dataRepresentation: Data, relativeTo url: URL?, isAbsolute: Bool = false) {
+    public init?(dataRepresentation: __shared Data, relativeTo url: __shared URL?, isAbsolute: Bool = false) {
         guard dataRepresentation.count > 0 else { return nil }
         
         if isAbsolute {
@@ -607,7 +607,7 @@ public struct URL : ReferenceConvertible, Equatable {
 
     /// Initializes a URL that refers to a location specified by resolving bookmark data.
     @available(swift, obsoleted: 4.2)
-    public init?(resolvingBookmarkData data: Data, options: BookmarkResolutionOptions = [], relativeTo url: URL? = nil, bookmarkDataIsStale: inout Bool) throws {
+    public init?(resolvingBookmarkData data: __shared Data, options: BookmarkResolutionOptions = [], relativeTo url: __shared URL? = nil, bookmarkDataIsStale: inout Bool) throws {
         var stale : ObjCBool = false
         _url = URL._converted(from: try NSURL(resolvingBookmarkData: data, options: options, relativeTo: url, bookmarkDataIsStale: &stale))
         bookmarkDataIsStale = stale.boolValue
@@ -615,7 +615,7 @@ public struct URL : ReferenceConvertible, Equatable {
 
     /// Initializes a URL that refers to a location specified by resolving bookmark data.
     @available(swift, introduced: 4.2)
-    public init(resolvingBookmarkData data: Data, options: BookmarkResolutionOptions = [], relativeTo url: URL? = nil, bookmarkDataIsStale: inout Bool) throws {
+    public init(resolvingBookmarkData data: __shared Data, options: BookmarkResolutionOptions = [], relativeTo url: __shared URL? = nil, bookmarkDataIsStale: inout Bool) throws {
         var stale : ObjCBool = false
         _url = URL._converted(from: try NSURL(resolvingBookmarkData: data, options: options, relativeTo: url, bookmarkDataIsStale: &stale))
         bookmarkDataIsStale = stale.boolValue
@@ -623,12 +623,12 @@ public struct URL : ReferenceConvertible, Equatable {
     
     /// Creates and initializes an NSURL that refers to the location specified by resolving the alias file at url. If the url argument does not refer to an alias file as defined by the NSURLIsAliasFileKey property, the NSURL returned is the same as url argument. This method fails and returns nil if the url argument is unreachable, or if the original file or directory could not be located or is not reachable, or if the original file or directory is on a volume that could not be located or mounted. The URLBookmarkResolutionWithSecurityScope option is not supported by this method.
     @available(macOS 10.10, iOS 8.0, *)
-    public init(resolvingAliasFileAt url: URL, options: BookmarkResolutionOptions = []) throws {
+    public init(resolvingAliasFileAt url: __shared URL, options: BookmarkResolutionOptions = []) throws {
         self.init(reference: try NSURL(resolvingAliasFileAt: url, options: options))
     }
 
     /// Initializes a newly created URL referencing the local file or directory at the file system representation of the path. File system representation is a null-terminated C string with canonical UTF-8 encoding.
-    public init(fileURLWithFileSystemRepresentation path: UnsafePointer<Int8>, isDirectory: Bool, relativeTo baseURL: URL?) {
+    public init(fileURLWithFileSystemRepresentation path: UnsafePointer<Int8>, isDirectory: Bool, relativeTo baseURL: __shared URL?) {
         _url = URL._converted(from: NSURL(fileURLWithFileSystemRepresentation: path, isDirectory: isDirectory, relativeTo: baseURL))
     }
     

--- a/stdlib/public/SDK/Foundation/URL.swift
+++ b/stdlib/public/SDK/Foundation/URL.swift
@@ -47,7 +47,7 @@ public struct URLResourceValues {
         return (_values[key] as? NSNumber)?.intValue
     }
     
-    private mutating func _set(_ key : URLResourceKey, newValue : Any?) {
+    private mutating func _set(_ key : URLResourceKey, newValue : __owned Any?) {
         _keys.insert(key)
         _values[key] = newValue
     }
@@ -1175,7 +1175,7 @@ public struct URL : ReferenceConvertible, Equatable {
         }
     }
     
-    fileprivate init(reference: NSURL) {
+    fileprivate init(reference: __shared NSURL) {
         _url = URL._converted(from: reference).copy() as! NSURL
     }
     

--- a/stdlib/public/SDK/Foundation/URLComponents.swift
+++ b/stdlib/public/SDK/Foundation/URLComponents.swift
@@ -28,7 +28,7 @@ public struct URLComponents : ReferenceConvertible, Hashable, Equatable, _Mutabl
     /// Initialize with the components of a URL.
     ///
     /// If resolvingAgainstBaseURL is `true` and url is a relative URL, the components of url.absoluteURL are used. If the url string from the URL is malformed, nil is returned.
-    public init?(url: URL, resolvingAgainstBaseURL resolve: Bool) {
+    public init?(url: __shared URL, resolvingAgainstBaseURL resolve: Bool) {
         guard let result = NSURLComponents(url: url, resolvingAgainstBaseURL: resolve) else { return nil }
         _handle = _MutableHandle(adoptingReference: result)
     }
@@ -36,7 +36,7 @@ public struct URLComponents : ReferenceConvertible, Hashable, Equatable, _Mutabl
     /// Initialize with a URL string.
     ///
     /// If the URLString is malformed, nil is returned.
-    public init?(string: String) {
+    public init?(string: __shared String) {
         guard let result = NSURLComponents(string: string) else { return nil }
         _handle = _MutableHandle(adoptingReference: result)
     }
@@ -394,7 +394,7 @@ public struct URLQueryItem : ReferenceConvertible, Hashable, Equatable {
     
     fileprivate var _queryItem : NSURLQueryItem
     
-    public init(name: String, value: String?) {
+    public init(name: __shared String, value: __shared String?) {
         _queryItem = NSURLQueryItem(name: name, value: value)
     }
     

--- a/stdlib/public/SDK/Foundation/URLComponents.swift
+++ b/stdlib/public/SDK/Foundation/URLComponents.swift
@@ -306,7 +306,7 @@ public struct URLComponents : ReferenceConvertible, Hashable, Equatable, _Mutabl
     
     // MARK: - Bridging
     
-    fileprivate init(reference: NSURLComponents) {
+    fileprivate init(reference: __shared NSURLComponents) {
         _handle = _MutableHandle(reference: reference)
     }
     
@@ -398,7 +398,7 @@ public struct URLQueryItem : ReferenceConvertible, Hashable, Equatable {
         _queryItem = NSURLQueryItem(name: name, value: value)
     }
     
-    fileprivate init(reference: NSURLQueryItem) { _queryItem = reference.copy() as! NSURLQueryItem }
+    fileprivate init(reference: __shared NSURLQueryItem) { _queryItem = reference.copy() as! NSURLQueryItem }
     fileprivate var reference : NSURLQueryItem { return _queryItem }
     
     public var name : String {

--- a/stdlib/public/SDK/Foundation/URLRequest.swift
+++ b/stdlib/public/SDK/Foundation/URLRequest.swift
@@ -41,7 +41,7 @@ public struct URLRequest : ReferenceConvertible, Equatable, Hashable {
         _handle = _MutableHandle(adoptingReference: NSMutableURLRequest(url: url, cachePolicy: cachePolicy, timeoutInterval: timeoutInterval))
     }
 
-    fileprivate init(_bridged request: NSURLRequest) {
+    fileprivate init(_bridged request: __shared NSURLRequest) {
         _handle = _MutableHandle(reference: request.mutableCopy() as! NSMutableURLRequest)
     }
     

--- a/stdlib/public/SDK/Foundation/UUID.swift
+++ b/stdlib/public/SDK/Foundation/UUID.swift
@@ -30,7 +30,7 @@ public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConv
         }
     }
     
-    fileprivate init(reference: NSUUID) {
+    fileprivate init(reference: __shared NSUUID) {
         var bytes: uuid_t = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
         withUnsafeMutablePointer(to: &bytes) {
             $0.withMemoryRebound(to: UInt8.self, capacity: 16) {

--- a/stdlib/public/SDK/Foundation/UUID.swift
+++ b/stdlib/public/SDK/Foundation/UUID.swift
@@ -43,7 +43,7 @@ public struct UUID : ReferenceConvertible, Hashable, Equatable, CustomStringConv
     /// Create a UUID from a string such as "E621E1F8-C36C-495A-93FC-0C247A3E6E5F".
     /// 
     /// Returns nil for invalid strings.
-    public init?(uuidString string: String) {
+    public init?(uuidString string: __shared String) {
         let res = withUnsafeMutablePointer(to: &uuid) {
             $0.withMemoryRebound(to: UInt8.self, capacity: 16) {
                 return uuid_parse(string, $0)


### PR DESCRIPTION
**What's in this pull request?**
Annotates portions of the Foundation overlay with the appropriate `__shared`/`__owned` annotations following the patterns we use (resolving rdar://problem/34989766). I looked at every declared `func` and `init` within our overlay and annotated all methods as appropriate. ~~~A search of all stored `var`s shows no necessary changes AFAICT as we don't expose reference types from our Swift APIs.~~~ (Since `var` types cannot be annotated for ownership, there's nothing for us to do in the cases where `var`s should be `__shared`.)

Overall the changes mostly revolve around bridging:

* We often `copy()` the passed `NS` type before holding onto it as a reference to preserve value semantics, and in those cases, the parameter should be `__shared` as we don't hold on to the original. (AFAIK, `copy()` should help enforce the right refcounting in the case where `copy()` returns `self`.)
* In other cases, we create an `NS` type out of the Swift type via bridging (which copies as well) and hold on to the `NS` type

There are a few cases where `init` parameters go unused (such as in `String.init?(contentsOf:)`), and some cases around `KeyPath` where we appear to not store the given `KeyPath` but it actually ends up stored in a global table.