### PR TITLE
build: only search for ICU if building the stdlib/sdk overlay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -866,11 +866,13 @@ endfunction()
 # package lookup.  Otherwise, rely on the paths specified by the user.  These
 # need to be defined when cross-compiling.
 if(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-  swift_icu_variables_set("${SWIFT_HOST_VARIANT_SDK_default}"
-                          "${SWIFT_HOST_VARIANT_ARCH_default}"
-                          ICU_CONFIGURED)
-  if("${SWIFT_PATH_TO_LIBICU_BUILD}" STREQUAL "" AND NOT ${ICU_CONFIGURED})
-    find_package(ICU REQUIRED COMPONENTS uc i18n)
+  if(SWIFT_BUILD_STDLIB OR SWIFT_BUILD_SDK_OVERLAY)
+    swift_icu_variables_set("${SWIFT_HOST_VARIANT_SDK_default}"
+                            "${SWIFT_HOST_VARIANT_ARCH_default}"
+                            ICU_CONFIGURED)
+    if("${SWIFT_PATH_TO_LIBICU_BUILD}" STREQUAL "" AND NOT ${ICU_CONFIGURED})
+      find_package(ICU REQUIRED COMPONENTS uc i18n)
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
When building just the tools, the ICU search is not needed as the compiler and
the tools do not use ICU themselves.  This enables cross-compiling just the
swift compiler.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
