### PR TITLE
[MetadataReader] Rename `pointed` to `pointer` for consistency.

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -265,12 +265,12 @@ public:
     return start;
   }
 
-  /// Given a pointer to an address, attemp to read the pointed value.
-  Optional<StoredPointer> readPointedValue(StoredPointer Address) {
-    StoredPointer PointedVal;
-    if (!Reader->readInteger(RemoteAddress(Address), &PointedVal))
+  /// Given a pointer to an address, attemp to read the pointer value.
+  Optional<StoredPointer> readPointerValue(StoredPointer Address) {
+    StoredPointer PointerVal;
+    if (!Reader->readInteger(RemoteAddress(Address), &PointerVal))
       return None;
-    return Optional<StoredPointer>(PointedVal);
+    return Optional<StoredPointer>(PointerVal);
   }
 
   /// Given a pointer to the metadata, attempt to read the value

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -1166,10 +1166,10 @@ public:
 
   Result<std::pair<Type, RemoteAddress>>
   getDynamicTypeAndAddressClassExistential(RemoteAddress object) {
-    auto pointed = Reader.readPointedValue(object.getAddressData());
-    if (!pointed)
+    auto pointerval = Reader.readPointerValue(object.getAddressData());
+    if (!pointerval)
       return getFailure<std::pair<Type, RemoteAddress>>();
-    auto result = Reader.readMetadataFromInstance(*pointed);
+    auto result = Reader.readMetadataFromInstance(*pointerval);
     if (!result)
       return getFailure<std::pair<Type, RemoteAddress>>();
     auto typeResult = Reader.readTypeFromMetadata(result.getValue());
@@ -1181,11 +1181,11 @@ public:
 
   Result<std::pair<Type, RemoteAddress>>
   getDynamicTypeAndAddressErrorExistential(RemoteAddress object) {
-    auto pointed = Reader.readPointedValue(object.getAddressData());
-    if (!pointed)
+    auto pointerval = Reader.readPointerValue(object.getAddressData());
+    if (!pointerval)
       return getFailure<std::pair<Type, RemoteAddress>>();
     auto result =
-        Reader.readMetadataAndValueErrorExistential(RemoteAddress(*pointed));
+        Reader.readMetadataAndValueErrorExistential(RemoteAddress(*pointerval));
     if (!result)
       return getFailure<std::pair<Type, RemoteAddress>>();
     RemoteAddress metadataAddress = result->first;
@@ -1222,10 +1222,10 @@ public:
     // 1) Loading a pointer from the input address
     // 2) Reading it as metadata and resolving the type
     // 3) Wrapping the resolved type in an existential metatype.
-    auto pointed = Reader.readPointedValue(object.getAddressData());
-    if (!pointed)
+    auto pointerval = Reader.readPointerValue(object.getAddressData());
+    if (!pointerval)
       return getFailure<std::pair<Type, RemoteAddress>>();
-    auto typeResult = Reader.readTypeFromMetadata(*pointed);
+    auto typeResult = Reader.readTypeFromMetadata(*pointerval);
     if (!typeResult)
       return getFailure<std::pair<Type, RemoteAddress>>();
     auto wrappedType = ExistentialMetatypeType::get(typeResult);


### PR DESCRIPTION
Pointed out by John McCall in a previous review (I just procrastinated
to do it, until today).
