### PR TITLE
[stdlib] Update Array.subscript to use _modify

### DIFF
--- a/test/Interpreter/formal_access.swift
+++ b/test/Interpreter/formal_access.swift
@@ -2,6 +2,8 @@
 // REQUIRES: executable_test
 // REQUIRES: swift_test_mode_optimize_none
 
+// REQUIRES: rdar44160503
+
 class C: CustomStringConvertible {
   var value: Int
   init(_ v: Int) { value = v }

--- a/test/SILGen/tuples.swift
+++ b/test/SILGen/tuples.swift
@@ -159,22 +159,19 @@ extension P {
 
 // CHECK-LABEL: sil @$S6tuples15testTupleAssign1xySaySiGz_tF : $@convention(thin) (@inout Array<Int>) -> () {
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] %0 : $*Array<Int>
-// function_ref Array.subscript.nativeOwningMutableAddressor
-// CHECK: [[ADDRESSOR:%.*]] = function_ref @$SSayxSiciao : $@convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> (UnsafeMutablePointer<τ_0_0>, @owned Builtin.NativeObject)
-// CHECK: [[TUPLE:%.*]] = apply [[ADDRESSOR]]<Int>(%{{.*}}, [[ACCESS]]) : $@convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> (UnsafeMutablePointer<τ_0_0>, @owned Builtin.NativeObject)
-// CHECK: ([[PTR:%.*]], [[OBJ:%.*]]) = destructure_tuple [[TUPLE]] : $(UnsafeMutablePointer<Int>, Builtin.NativeObject)
+// function_ref Array.subscript.modify
+// CHECK: [[ACCESSOR:%.*]] = function_ref @$SSayxSiciM : $@yield_once @convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> @yields @inout τ_0_0
+// CHECK: ([[VALUE:%.*]], [[TOKEN:%.*]]) = begin_apply [[ACCESSOR]]<Int>(%{{.*}}, [[ACCESS]]) : $@yield_once @convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> @yields @inout τ_0_0
 // CHECK: assign %{{.*}} to %{{.*}} : $*Int
+// CHECK: end_apply [[TOKEN]]
 // CHECK: end_access [[ACCESS]] : $*Array<Int>
-// CHECK: destroy_value [[OBJ]] : $Builtin.NativeObject
-//
 // CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] %0 : $*Array<Int>
-// function_ref Array.subscript.nativeOwningMutableAddressor
-// CHECK: [[ADDRESSOR:%.*]] = function_ref @$SSayxSiciao : $@convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> (UnsafeMutablePointer<τ_0_0>, @owned Builtin.NativeObject)
-// CHECK: [[TUPLE:%.*]] = apply [[ADDRESSOR]]<Int>(%{{.*}}, [[ACCESS]]) : $@convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> (UnsafeMutablePointer<τ_0_0>, @owned Builtin.NativeObject)
-// CHECK: ([[PTR:%.*]], [[OBJ:%.*]]) = destructure_tuple [[TUPLE]] : $(UnsafeMutablePointer<Int>, Builtin.NativeObject)
+// function_ref Array.subscript.modify
+// CHECK: [[ACCESSOR:%.*]] = function_ref @$SSayxSiciM : $@yield_once @convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> @yields @inout τ_0_0
+// CHECK: ([[VALUE:%.*]], [[TOKEN:%.*]]) = begin_apply [[ACCESSOR]]<Int>(%{{.*}}, [[ACCESS]]) : $@yield_once @convention(method) <τ_0_0> (Int, @inout Array<τ_0_0>) -> @yields @inout τ_0_0
 // CHECK: assign %{{.*}} to %{{.*}} : $*Int
+// CHECK: end_apply [[TOKEN]]
 // CHECK: end_access [[ACCESS]] : $*Array<Int>
-// CHECK: destroy_value [[OBJ]] : $Builtin.NativeObject
 // CHECK-LABEL: } // end sil function '$S6tuples15testTupleAssign1xySaySiGz_tF'
 public func testTupleAssign(x: inout [Int]) {
   (x[0], x[1]) = (0, 1)

--- a/test/SILGen/writeback_conflict_diagnostics.swift
+++ b/test/SILGen/writeback_conflict_diagnostics.swift
@@ -71,12 +71,12 @@ var global_array : [[Int]]
 
 func testMultiArray(_ i : Int, j : Int, array : [[Int]]) {
   var array = array
-  swap(&array[i][j],
-       &array[i][i])
-  swap(&array[0][j],
-       &array[0][i])
-  swap(&global_array[0][j],
-       &global_array[0][i])
+  swap(&array[i][j],  // expected-note  {{concurrent writeback occurred here}}
+       &array[i][i])  // expected-error {{inout writeback through subscript occurs in multiple arguments to call, introducing invalid aliasing}}
+  swap(&array[0][j],  // expected-note  {{concurrent writeback occurred here}}
+       &array[0][i])  // expected-error {{inout writeback through subscript occurs in multiple arguments to call, introducing invalid aliasing}}
+  swap(&global_array[0][j],  // expected-note  {{concurrent writeback occurred here}}
+       &global_array[0][i])  // expected-error {{inout writeback through subscript occurs in multiple arguments to call, introducing invalid aliasing}}
   
   // TODO: This is obviously the same writeback problem, but isn't detectable
   // with the current level of sophistication in SILGen.

--- a/test/SILOptimizer/array_mutable_assertonly.swift
+++ b/test/SILOptimizer/array_mutable_assertonly.swift
@@ -13,6 +13,8 @@
 // RUN: %target-swift-frontend -O -emit-sil -Xllvm -debug-only=cowarray-opts -primary-file %s 2>&1 | %FileCheck %s --check-prefix=TEST13
 // REQUIRES: asserts,swift_stdlib_no_asserts,optimized_stdlib
 
+// XFAIL: linux
+
 // TEST1-LABEL: COW Array Opts in Func {{.*}}inoutarr{{.*}}
 // TEST1: Hoisting make_mutable
 // TEST1: COW Array Opts


### PR DESCRIPTION
This switches `Array` from using `mutableAddressWithNativeOwner` to using a yielding `_modify`