### PR TITLE
[AutoDiff] Support differentiating w.r.t. not all parameters

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -97,7 +97,6 @@ static void addMandatoryOptPipeline(SILPassPipelinePlan &P,
   addDefiniteInitialization(P);
   P.addClosureLifetimeFixup();
   P.addOwnershipModelEliminator();
-  P.addDifferentiation();
   P.addMandatoryInlining();
   P.addMandatorySILLinker();
   P.addPredictableMemoryOptimizations();
@@ -114,6 +113,7 @@ static void addMandatoryOptPipeline(SILPassPipelinePlan &P,
   P.addSplitNonCondBrCriticalEdges();
 
   // SWIFT_ENABLE_TENSORFLOW
+  P.addDifferentiation();
   P.addTFDeabstraction();
 }
 

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -97,6 +97,7 @@ static void addMandatoryOptPipeline(SILPassPipelinePlan &P,
   addDefiniteInitialization(P);
   P.addClosureLifetimeFixup();
   P.addOwnershipModelEliminator();
+  P.addDifferentiation();
   P.addMandatoryInlining();
   P.addMandatorySILLinker();
   P.addPredictableMemoryOptimizations();
@@ -113,7 +114,6 @@ static void addMandatoryOptPipeline(SILPassPipelinePlan &P,
   P.addSplitNonCondBrCriticalEdges();
 
   // SWIFT_ENABLE_TENSORFLOW
-  P.addDifferentiation();
   P.addTFDeabstraction();
 }
 

--- a/test/AutoDiff/builtin_math.sil
+++ b/test/AutoDiff/builtin_math.sil
@@ -67,26 +67,26 @@ bb0(%0 : @trivial $Builtin.FPIEEE32):
   return %ret : $()
 }
 
-// CHECK-LABEL: struct simple_mul__Type {
+// CHECK-LABEL: struct simple_mul__Type__src_0_wrt_0_1 {
 // CHECK:   @sil_stored var v_0: Builtin.FPIEEE32
 // CHECK: }
 
-// CHECK-LABEL: struct simple_div__Type {
+// CHECK-LABEL: struct simple_div__Type__src_0_wrt_0_1 {
 // CHECK:   @sil_stored var v_0: Builtin.FPIEEE32
 // CHECK: }
 
-// CHECK-LABEL: struct chain_rule__Type {
+// CHECK-LABEL: struct chain_rule__Type__src_0_wrt_0_1 {
 // CHECK:   @sil_stored var v_0: Builtin.FPIEEE32
 // CHECK:   @sil_stored var v_1: Builtin.FPIEEE32
 // CHECK: }
 
-// CHECK-LABEL: struct add_literals__Type {
+// CHECK-LABEL: struct add_literals__Type__src_0_wrt_0_1 {
 // CHECK:   @sil_stored var v_0: Builtin.FPIEEE32
 // CHECK:   @sil_stored var v_1: Builtin.FPIEEE32
 // CHECK:   @sil_stored var v_2: Builtin.FPIEEE32
 // CHECK: }
 
-// CHECK-LABEL: struct fanout__Type {
+// CHECK-LABEL: struct fanout__Type__src_0_wrt_0_1 {
 // CHECK:   @sil_stored var v_0: Builtin.FPIEEE32
 // CHECK:   @sil_stored var v_1: Builtin.FPIEEE32
 // CHECK:   @sil_stored var v_2: Builtin.FPIEEE32
@@ -100,18 +100,18 @@ bb0(%0 : @trivial $Builtin.FPIEEE32):
 // CHECK-LABEL: @simple_mul__primal_src_0_wrt_0_1
 // CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32):
 // CHECK:   %2 = builtin "fmul_FPIEEE32"(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
-// CHECK:   %3 = struct $simple_mul__Type (%2 : $Builtin.FPIEEE32)
-// CHECK:   %4 = tuple (%3 : $simple_mul__Type, %2 : $Builtin.FPIEEE32)
-// CHECK:   return %4 : $(simple_mul__Type, Builtin.FPIEEE32)
+// CHECK:   %3 = struct $simple_mul__Type__src_0_wrt_0_1 (%2 : $Builtin.FPIEEE32)
+// CHECK:   %4 = tuple (%3 : $simple_mul__Type__src_0_wrt_0_1, %2 : $Builtin.FPIEEE32)
+// CHECK:   return %4 : $(simple_mul__Type__src_0_wrt_0_1, Builtin.FPIEEE32)
 // CHECK: }
 
 // CHECK-LABEL: sil @chain_rule__primal_src_0_wrt_0_1
 // CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32):
 // CHECK:   %2 = builtin "fneg_FPIEEE32"(%0 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
 // CHECK:   %3 = builtin "fmul_FPIEEE32"(%1 : $Builtin.FPIEEE32, %2 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
-// CHECK:   %4 = struct $chain_rule__Type (%2 : $Builtin.FPIEEE32, %3 : $Builtin.FPIEEE32)
-// CHECK:   %5 = tuple (%4 : $chain_rule__Type, %3 : $Builtin.FPIEEE32)
-// CHECK:   return %5 : $(chain_rule__Type, Builtin.FPIEEE32)
+// CHECK:   %4 = struct $chain_rule__Type__src_0_wrt_0_1 (%2 : $Builtin.FPIEEE32, %3 : $Builtin.FPIEEE32)
+// CHECK:   %5 = tuple (%4 : $chain_rule__Type__src_0_wrt_0_1, %3 : $Builtin.FPIEEE32)
+// CHECK:   return %5 : $(chain_rule__Type__src_0_wrt_0_1, Builtin.FPIEEE32)
 // CHECK: }
 
 // CHECK-LABEL: @add_literals__primal_src_0_wrt_0_1
@@ -120,9 +120,9 @@ bb0(%0 : @trivial $Builtin.FPIEEE32):
 // CHECK:   %3 = builtin "fmul_FPIEEE32"(%1 : $Builtin.FPIEEE32, %2 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
 // CHECK:   %4 = float_literal $Builtin.FPIEEE32, 0x64
 // CHECK:   %5 = builtin "fsub_FPIEEE32"(%4 : $Builtin.FPIEEE32, %3 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
-// CHECK:   %6 = struct $add_literals__Type (%2 : $Builtin.FPIEEE32, %3 : $Builtin.FPIEEE32, %5 : $Builtin.FPIEEE32)
-// CHECK:   %7 = tuple (%6 : $add_literals__Type, %5 : $Builtin.FPIEEE32)
-// CHECK:   return %7 : $(add_literals__Type, Builtin.FPIEEE32)
+// CHECK:   %6 = struct $add_literals__Type__src_0_wrt_0_1 (%2 : $Builtin.FPIEEE32, %3 : $Builtin.FPIEEE32, %5 : $Builtin.FPIEEE32)
+// CHECK:   %7 = tuple (%6 : $add_literals__Type__src_0_wrt_0_1, %5 : $Builtin.FPIEEE32)
+// CHECK:   return %7 : $(add_literals__Type__src_0_wrt_0_1, Builtin.FPIEEE32)
 // CHECK: }
 
 // CHECK-LABEL: @fanout__primal_src_0_wrt_0_1
@@ -130,13 +130,13 @@ bb0(%0 : @trivial $Builtin.FPIEEE32):
 // CHECK:   %2 = builtin "fmul_FPIEEE32"(%0 : $Builtin.FPIEEE32, %0 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
 // CHECK:   %3 = builtin "fmul_FPIEEE32"(%1 : $Builtin.FPIEEE32, %2 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
 // CHECK:   %4 = builtin "fmul_FPIEEE32"(%0 : $Builtin.FPIEEE32, %2 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
-// CHECK:   %5 = struct $fanout__Type (%2 : $Builtin.FPIEEE32, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32)
-// CHECK:   %6 = tuple (%5 : $fanout__Type, %4 : $Builtin.FPIEEE32)
-// CHECK:   return %6 : $(fanout__Type, Builtin.FPIEEE32)
+// CHECK:   %5 = struct $fanout__Type__src_0_wrt_0_1 (%2 : $Builtin.FPIEEE32, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32)
+// CHECK:   %6 = tuple (%5 : $fanout__Type__src_0_wrt_0_1, %4 : $Builtin.FPIEEE32)
+// CHECK:   return %6 : $(fanout__Type__src_0_wrt_0_1, Builtin.FPIEEE32)
 // CHECK: }
 
 // CHECK-LABEL: @simple_mul__adjoint_src_0_wrt_0_1
-// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32, %2 : $simple_mul__Type, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32):
+// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32, %2 : $simple_mul__Type__src_0_wrt_0_1, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32):
 // CHECK:   %5 = builtin "fmul_FPIEEE32"(%4 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
 // CHECK:   %6 = builtin "fmul_FPIEEE32"(%4 : $Builtin.FPIEEE32, %0 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
 // CHECK:   %7 = tuple (%5 : $Builtin.FPIEEE32, %6 : $Builtin.FPIEEE32)
@@ -144,7 +144,7 @@ bb0(%0 : @trivial $Builtin.FPIEEE32):
 // CHECK: }
 
 // CHECK-LABEL: @simple_div__adjoint_src_0_wrt_0_1
-// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32, %2 : $simple_div__Type, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32):
+// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32, %2 : $simple_div__Type__src_0_wrt_0_1, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32):
 // CHECK:   %5 = builtin "fdiv_FPIEEE32"(%4 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
 // CHECK:   %6 = builtin "fneg_FPIEEE32"(%0 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
 // CHECK:   %7 = builtin "fmul_FPIEEE32"(%1 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
@@ -155,8 +155,8 @@ bb0(%0 : @trivial $Builtin.FPIEEE32):
 // CHECK: }
 
 // CHECK-LABEL: @chain_rule__adjoint_src_0_wrt_0_1
-// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32, %2 : $chain_rule__Type, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32):
-// CHECK:   %5 = struct_extract %2 : $chain_rule__Type, #chain_rule__Type.v_0
+// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32, %2 : $chain_rule__Type__src_0_wrt_0_1, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32):
+// CHECK:   %5 = struct_extract %2 : $chain_rule__Type__src_0_wrt_0_1, #chain_rule__Type__src_0_wrt_0_1.v_0
 // CHECK:   %6 = builtin "fmul_FPIEEE32"(%4 : $Builtin.FPIEEE32, %5 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
 // CHECK:   %7 = builtin "fmul_FPIEEE32"(%4 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
 // CHECK:   %8 = builtin "fneg_FPIEEE32"(%7 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
@@ -165,9 +165,9 @@ bb0(%0 : @trivial $Builtin.FPIEEE32):
 // CHECK: }
 
 // CHECK-LABEL: @add_literals__adjoint_src_0_wrt_0_1
-// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32, %2 : $add_literals__Type, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32):
+// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32, %2 : $add_literals__Type__src_0_wrt_0_1, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32):
 // CHECK:   %5 = builtin "fneg_FPIEEE32"(%4 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
-// CHECK:   %6 = struct_extract %2 : $add_literals__Type, #add_literals__Type.v_0
+// CHECK:   %6 = struct_extract %2 : $add_literals__Type__src_0_wrt_0_1, #add_literals__Type__src_0_wrt_0_1.v_0
 // CHECK:   %7 = builtin "fmul_FPIEEE32"(%5 : $Builtin.FPIEEE32, %6 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
 // CHECK:   %8 = builtin "fmul_FPIEEE32"(%5 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
 // CHECK:   %9 = builtin "fneg_FPIEEE32"(%8 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
@@ -176,8 +176,8 @@ bb0(%0 : @trivial $Builtin.FPIEEE32):
 // CHECK: }
 
 // CHECK-LABEL: @fanout__adjoint_src_0_wrt_0_1
-// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32, %2 : $fanout__Type, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32):
-// CHECK:   %5 = struct_extract %2 : $fanout__Type, #fanout__Type.v_0
+// CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32, %2 : $fanout__Type__src_0_wrt_0_1, %3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32):
+// CHECK:   %5 = struct_extract %2 : $fanout__Type__src_0_wrt_0_1, #fanout__Type__src_0_wrt_0_1.v_0
 // CHECK:   %6 = builtin "fmul_FPIEEE32"(%4 : $Builtin.FPIEEE32, %5 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
 // CHECK:   %7 = builtin "fmul_FPIEEE32"(%4 : $Builtin.FPIEEE32, %0 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
 // CHECK:   %8 = builtin "fmul_FPIEEE32"(%7 : $Builtin.FPIEEE32, %0 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32

--- a/test/AutoDiff/nested_calls.sil
+++ b/test/AutoDiff/nested_calls.sil
@@ -41,12 +41,12 @@ bb0(%0 : @trivial $Float):
   return %6 : $Float
 }
 
-// CHECK-LABEL: struct func_to_diff__Type {
-// CHECK-NEXT:   @sil_stored var pv_0: nested_func_without_diffattr__Type
+// CHECK-LABEL: struct func_to_diff__Type__src_0_wrt_0 {
+// CHECK-NEXT:   @sil_stored var pv_0: nested_func_without_diffattr__Type__src_0_wrt_0
 // CHECK-NEXT:   @sil_stored var v_0: Float
 // CHECK-NEXT: }
 
-// CHECK-LABEL: struct nested_func_without_diffattr__Type {
+// CHECK-LABEL: struct nested_func_without_diffattr__Type__src_0_wrt_0 {
 // CHECK-NEXT:   @sil_stored var pv_0: Float
 // CHECK-NEXT:   @sil_stored var v_0: Float
 // CHECK-NEXT: }
@@ -77,27 +77,27 @@ bb0(%0 : @trivial $Float):
 // CHECK:   return %0 : $Float
 // CHECK: }
 
-// CHECK-LABEL: @func_to_diff__primal_src_0_wrt_0 : $@convention(thin) (Float) -> (@owned func_to_diff__Type, Float) {
+// CHECK-LABEL: @func_to_diff__primal_src_0_wrt_0 : $@convention(thin) (Float) -> (@owned func_to_diff__Type__src_0_wrt_0, Float) {
 // CHECK: bb0(%0 : $Float):
-// CHECK:   %1 = struct $nested_func_without_diffattr__Type (%0 : $Float, %0 : $Float)
-// CHECK:   %2 = struct $func_to_diff__Type (%1 : $nested_func_without_diffattr__Type, %0 : $Float)
-// CHECK:   %3 = tuple (%2 : $func_to_diff__Type, %0 : $Float)
-// CHECK:   return %3 : $(func_to_diff__Type, Float)
+// CHECK:   %1 = struct $nested_func_without_diffattr__Type__src_0_wrt_0 (%0 : $Float, %0 : $Float)
+// CHECK:   %2 = struct $func_to_diff__Type__src_0_wrt_0 (%1 : $nested_func_without_diffattr__Type__src_0_wrt_0, %0 : $Float)
+// CHECK:   %3 = tuple (%2 : $func_to_diff__Type__src_0_wrt_0, %0 : $Float)
+// CHECK:   return %3 : $(func_to_diff__Type__src_0_wrt_0, Float)
 // CHECK: }
 
-// CHECK-LABEL: @nested_func_without_diffattr__primal_src_0_wrt_0 : $@convention(thin) (Float) -> (@owned nested_func_without_diffattr__Type, Float) {
+// CHECK-LABEL: @nested_func_without_diffattr__primal_src_0_wrt_0 : $@convention(thin) (Float) -> (@owned nested_func_without_diffattr__Type__src_0_wrt_0, Float) {
 // CHECK: bb0(%0 : $Float):
-// CHECK:   %1 = struct $nested_func_without_diffattr__Type (%0 : $Float, %0 : $Float)
-// CHECK:   %2 = tuple (%1 : $nested_func_without_diffattr__Type, %0 : $Float)
-// CHECK:   return %2 : $(nested_func_without_diffattr__Type, Float)
+// CHECK:   %1 = struct $nested_func_without_diffattr__Type__src_0_wrt_0 (%0 : $Float, %0 : $Float)
+// CHECK:   %2 = tuple (%1 : $nested_func_without_diffattr__Type__src_0_wrt_0, %0 : $Float)
+// CHECK:   return %2 : $(nested_func_without_diffattr__Type__src_0_wrt_0, Float)
 // CHECK: }
 
-// CHECK-LABEL: @func_to_diff__adjoint_src_0_wrt_0 : $@convention(thin) (Float, func_to_diff__Type, Float, Float) -> Float {
-// CHECK: bb0(%0 : $Float, %1 : $func_to_diff__Type, %2 : $Float, %3 : $Float):
+// CHECK-LABEL: @func_to_diff__adjoint_src_0_wrt_0 : $@convention(thin) (Float, func_to_diff__Type__src_0_wrt_0, Float, Float) -> Float {
+// CHECK: bb0(%0 : $Float, %1 : $func_to_diff__Type__src_0_wrt_0, %2 : $Float, %3 : $Float):
 // CHECK:   return %3 : $Float
 // CHECK: }
 
-// CHECK-LABEL: @nested_func_without_diffattr__adjoint_src_0_wrt_0 : $@convention(thin) (Float, nested_func_without_diffattr__Type, Float, Float) -> Float {
-// CHECK: bb0(%0 : $Float, %1 : $nested_func_without_diffattr__Type, %2 : $Float, %3 : $Float):
+// CHECK-LABEL: @nested_func_without_diffattr__adjoint_src_0_wrt_0 : $@convention(thin) (Float, nested_func_without_diffattr__Type__src_0_wrt_0, Float, Float) -> Float {
+// CHECK: bb0(%0 : $Float, %1 : $nested_func_without_diffattr__Type__src_0_wrt_0, %2 : $Float, %3 : $Float):
 // CHECK:   return %3 : $Float
 // CHECK: }

--- a/test/AutoDiff/primalgen.swift
+++ b/test/AutoDiff/primalgen.swift
@@ -15,6 +15,6 @@ func squared(_ x: Float) -> Float {
 #gradient(squared)(20)
 
 // CHECK-LABEL: sil hidden @{{.*}}squared{{.*}}__primal_src_0_wrt_0
-// CHECK: [[PV:%.*]] = struct ${{.*}}squared{{.*}}__Type ({{.*}} : $Builtin.FPIEEE32)
-// CHECK: [[RESULT:%.*]] = tuple ([[PV]] : $$S9primalgen7squaredyS2fF__Type, {{.*}} : $Float)
-// CHECK: return %19 : $(${{.*}}squared{{.*}}__Type, Float)
+// CHECK: [[PV:%.*]] = struct ${{.*}}squared{{.*}}__Type__src_0_wrt_0 ({{.*}} : $Builtin.FPIEEE32)
+// CHECK: [[RESULT:%.*]] = tuple ([[PV]] : $$S9primalgen7squaredyS2fF__Type__src_0_wrt_0, {{.*}} : $Float)
+// CHECK: return %19 : $(${{.*}}squared{{.*}}__Type__src_0_wrt_0, Float)

--- a/test/AutoDiff/simple_math.swift
+++ b/test/AutoDiff/simple_math.swift
@@ -49,6 +49,8 @@ SimpleMathTests.test("FunctionCall") {
   }
   let dfoo = #gradient(foo)
   expectEqual((3, 9), dfoo(3, 4))
+  let dfoo_dx = #gradient(foo, wrt: .0)
+  expectEqual(3, dfoo_dx(3, 4))
 }
 
 runAllTests()

--- a/test/AutoDiff/simple_real_vector.swift
+++ b/test/AutoDiff/simple_real_vector.swift
@@ -56,9 +56,9 @@ public func test1() -> Vector {
 // CHECK:   apply [[CAN_GRAD]]({{.*}}, {{.*}})
 
 // CHECK-LABEL: sil private @{{.*}}test1{{.*}}foo{{.*}}__adjoint_src_0_wrt_0
-// CHECK: bb0(%0 : $Vector, %1 : ${{.*}}test1{{.*}}foo{{.*}}__Type, %2 : $Vector, %3 : $Vector):
-// CHECK:   %4 = struct_extract %1 : ${{.*}}test1{{.*}}foo{{.*}}__Type, #{{.*}}.pv_0
-// CHECK:   %5 = struct_extract %1 : ${{.*}}test1{{.*}}foo{{.*}}__Type, #{{.*}}.v_0
+// CHECK: bb0(%0 : $Vector, %1 : ${{.*}}test1{{.*}}foo{{.*}}__Type{{.*}}, %2 : $Vector, %3 : $Vector):
+// CHECK:   %4 = struct_extract %1 : ${{.*}}test1{{.*}}foo{{.*}}__Type{{.*}}, #{{.*}}.pv_0
+// CHECK:   %5 = struct_extract %1 : ${{.*}}test1{{.*}}foo{{.*}}__Type{{.*}}, #{{.*}}.v_0
 // CHECK:   %6 = alloc_stack $Vector
 // CHECK:   %7 = begin_access [init] [static] [no_nested_conflict] %6 : $*Vector
 // CHECK:   %8 = begin_access [init] [static] [no_nested_conflict] %7 : $*Vector


### PR DESCRIPTION
* When computing minimal differentiation indices for an `apply`, we must check whether a function argument is an argument being differentiated w.r.t. in the parent function. In that case, even though the value. For example:
    ```swift
    func f(x: Float, y: Float, z: Float) -> Float {
        g(x, 0, z)
          ^     ^
        These should be differentiated w.r.t. even when they are not ACTIVE per activity analysis.
    }
    ```
* Different differentiation indices should use different primal value structs.