### PR TITLE
[Standard library] Downgrade non-ABI ABI FIXMEs to FIXMEs.

### DIFF
--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -37,16 +37,10 @@
 ///   `c.index(after: c.index(before: i)) == i`.
 public protocol BidirectionalCollection: Collection
 where SubSequence: BidirectionalCollection, Indices: BidirectionalCollection {
-  // FIXME(ABI): Associated type inference requires this.
+  // FIXME: Only needed for associated type inference.
   override associatedtype Element
-
-  // FIXME(ABI): Associated type inference requires this.
   override associatedtype Index
-
-  // FIXME(ABI): Associated type inference requires this.
   override associatedtype SubSequence
-
-  // FIXME(ABI): Associated type inference requires this.
   override associatedtype Indices
 
   /// Returns the position immediately before the given index.
@@ -230,13 +224,9 @@ where SubSequence: BidirectionalCollection, Indices: BidirectionalCollection {
   /// - Complexity: O(1)
   override subscript(bounds: Range<Index>) -> SubSequence { get }
 
-  // FIXME(ABI): Associated type inference requires this.
+  // FIXME: Only needed for associated type inference.
   override subscript(position: Index) -> Element { get }
-
-  // FIXME(ABI): Associated type inference requires this.
   override var startIndex: Index { get }
-
-  // FIXME(ABI): Associated type inference requires this.
   override var endIndex: Index { get }
 }
 

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -338,7 +338,7 @@ public protocol Collection: Sequence where SubSequence: Collection {
   @available(*, deprecated/*, obsoleted: 5.0*/, message: "all index distances are now of type Int")
   typealias IndexDistance = Int  
 
-  // FIXME(ABI): Associated type inference requires this.
+  // FIXME: Associated type inference requires this.
   override associatedtype Element
 
   /// A type that represents a position in the collection.
@@ -378,9 +378,9 @@ public protocol Collection: Sequence where SubSequence: Collection {
   /// type.
   associatedtype Iterator = IndexingIterator<Self>
 
-  // FIXME(ABI)#179 (Type checker): Needed here so that the `Iterator` is properly deduced from
-  // a custom `makeIterator()` function.  Otherwise we get an
-  // `IndexingIterator`. <rdar://problem/21539115>
+  // FIXME: Only needed for associated type inference. Otherwise,
+  // we get an `IndexingIterator` rather than properly deducing the
+  // Iterator type from makeIterator(). <rdar://problem/21539115>
   /// Returns an iterator over the elements of the collection.
   override func makeIterator() -> Iterator
 

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -60,13 +60,9 @@
 public protocol MutableCollection: Collection
 where SubSequence: MutableCollection
 {
-  // FIXME(ABI): Associated type inference requires this.
+  // FIXME: Associated type inference requires these.
   override associatedtype Element
-
-  // FIXME(ABI): Associated type inference requires this.
   override associatedtype Index
-
-  // FIXME(ABI): Associated type inference requires this.
   override associatedtype SubSequence
 
   /// Accesses the element at the specified position.

--- a/stdlib/public/core/RandomAccessCollection.swift
+++ b/stdlib/public/core/RandomAccessCollection.swift
@@ -33,16 +33,10 @@
 public protocol RandomAccessCollection: BidirectionalCollection
 where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection
 {
-  // FIXME(ABI): Associated type inference requires this.
+  // FIXME: Associated type inference requires these.
   override associatedtype Element
-
-  // FIXME(ABI): Associated type inference requires this.
   override associatedtype Index
-
-  // FIXME(ABI): Associated type inference requires this.
   override associatedtype SubSequence
-
-  // FIXME(ABI): Associated type inference requires this.
   override associatedtype Indices
 
   /// The indices that are valid for subscripting the collection, in ascending
@@ -89,13 +83,9 @@ where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection
   /// - Complexity: O(1)
   override subscript(bounds: Range<Index>) -> SubSequence { get }
 
-  // FIXME(ABI): Associated type inference requires this.
+  // FIXME: Associated type inference requires these.
   override subscript(position: Index) -> Element { get }
-
-  // FIXME(ABI): Associated type inference requires this.
   override var startIndex: Index { get }
-
-  // FIXME(ABI): Associated type inference requires this.
   override var endIndex: Index { get }
 
   /// Returns the position immediately before the given index.

--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -63,7 +63,7 @@
 /// provide your own custom implementation.
 public protocol RangeReplaceableCollection : Collection
   where SubSequence : RangeReplaceableCollection {
-  // FIXME(ABI): Associated type inference requires this.
+  // FIXME: Associated type inference requires this.
   override associatedtype SubSequence
 
   //===--- Fundamental Requirements ---------------------------------------===//
@@ -362,10 +362,8 @@ public protocol RangeReplaceableCollection : Collection
   mutating func removeAll(
     where shouldBeRemoved: (Element) throws -> Bool) rethrows
 
-  // FIXME(ABI): Associated type inference requires this.
+  // FIXME: Associated type inference requires these.
   override subscript(bounds: Index) -> Element { get }
-
-  // FIXME(ABI): Associated type inference requires this.
   override subscript(bounds: Range<Index>) -> SubSequence { get }
 }
 


### PR DESCRIPTION
Now that we have removed overriding protocol requirements from witness
tables, they no longer have any effect on the ABI. Replace the FIXME
(ABI) comments with normal FIXMEs: there is no more ABI work to do
here.
