### PR TITLE
Fix regression with 'dynamic' or 'NSManaged' properties witnessing protocol requirements

### DIFF
--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -451,6 +451,14 @@ IsSerialized_t SILDeclRef::isSerialized() const {
       }
     }
 
+    // 'read' and 'modify' accessors synthesized on-demand are serialized if
+    // visible outside the module.
+    if (auto fn = dyn_cast<FuncDecl>(d))
+      if (!isClangImported() &&
+          fn->hasForcedStaticDispatch() &&
+          fn->getEffectiveAccess() >= AccessLevel::Public)
+        return IsSerialized;
+
     dc = getDecl()->getInnermostDeclContext();
 
     // Enum element constructors are serialized if the enum is

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -337,6 +337,10 @@ static void maybeMarkTransparent(TypeChecker &TC, AccessorDecl *accessor) {
     if (classDecl->checkObjCAncestry() != ObjCClassKind::NonObjC)
       return;
 
+  // Accessors synthesized on-demand are never transaprent.
+  if (accessor->hasForcedStaticDispatch())
+    return;
+
   accessor->getAttrs().add(new (TC.Context) TransparentAttr(IsImplicit));
 }
 

--- a/test/SILGen/c_modify_linkage.swift
+++ b/test/SILGen/c_modify_linkage.swift
@@ -14,7 +14,7 @@ extension NSReferencePoint: Pointable {}
 // Make sure synthesized modify accessors have shared linkage
 // for properties imported from Clang.
 
-// CHECK-LABEL: sil shared [transparent] [serializable] @$SSo7NSPointV1ySfvM
+// CHECK-LABEL: sil shared [serializable] @$SSo7NSPointV1ySfvM
 
 // CHECK-LABEL: sil shared [serializable] @$SSo16NSReferencePointC1xSfvM
 

--- a/test/SILGen/modify_objc.swift
+++ b/test/SILGen/modify_objc.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -enable-objc-interop -import-objc-header %S/Inputs/modify_objc.h %s | %FileCheck %s
 // RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -enable-objc-interop -import-objc-header %S/Inputs/modify_objc.h %s -enable-resilience | %FileCheck %s --check-prefix=RESILIENT
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -enable-objc-interop -import-objc-header %S/Inputs/modify_objc.h %s -enable-testing | %FileCheck %s --check-prefix=TESTING
 
 // REQUIRES: objc_interop
 
@@ -55,7 +56,7 @@ class HasDynamicStoredProperty : ProtocolWithIntProperty {
   @objc dynamic var x: Int = 0
 }
 
-// CHECK-LABEL: sil shared [transparent] @$S11modify_objc24HasDynamicStoredPropertyC1xSivM : $@yield_once @convention(method) (@guaranteed HasDynamicStoredProperty) -> @yields @inout Int
+// CHECK-LABEL: sil shared @$S11modify_objc24HasDynamicStoredPropertyC1xSivM : $@yield_once @convention(method) (@guaranteed HasDynamicStoredProperty) -> @yields @inout Int
 // CHECK: objc_method %0 : $HasDynamicStoredProperty, #HasDynamicStoredProperty.x!getter.1.foreign
 // CHECK: yield
 // CHECK: objc_method %0 : $HasDynamicStoredProperty, #HasDynamicStoredProperty.x!setter.1.foreign
@@ -63,12 +64,13 @@ class HasDynamicStoredProperty : ProtocolWithIntProperty {
 // CHECK: objc_method %0 : $HasDynamicStoredProperty, #HasDynamicStoredProperty.x!setter.1.foreign
 // CHECK: unwind
 
+// TESTING-LABEL: sil shared [serialized] @$S11modify_objc24HasDynamicStoredPropertyC1xSivM : $@yield_once @convention(method) (@guaranteed HasDynamicStoredProperty) -> @yields @inout Int
 
 class HasDynamicComputedProperty : ProtocolWithIntProperty {
   @objc dynamic var x: Int { get { } set { } }
 }
 
-// CHECK-LABEL: sil shared [transparent] @$S11modify_objc26HasDynamicComputedPropertyC1xSivM : $@yield_once @convention(method) (@guaranteed HasDynamicComputedProperty) -> @yields @inout Int
+// CHECK-LABEL: sil shared @$S11modify_objc26HasDynamicComputedPropertyC1xSivM : $@yield_once @convention(method) (@guaranteed HasDynamicComputedProperty) -> @yields @inout Int
 // CHECK: objc_method %0 : $HasDynamicComputedProperty, #HasDynamicComputedProperty.x!getter.1.foreign
 // CHECK: yield
 // CHECK: objc_method %0 : $HasDynamicComputedProperty, #HasDynamicComputedProperty.x!setter.1.foreign
@@ -76,6 +78,7 @@ class HasDynamicComputedProperty : ProtocolWithIntProperty {
 // CHECK: objc_method %0 : $HasDynamicComputedProperty, #HasDynamicComputedProperty.x!setter.1.foreign
 // CHECK: unwind
 
+// TESTING-LABEL: sil shared [serialized] @$S11modify_objc26HasDynamicComputedPropertyC1xSivM : $@yield_once @convention(method) (@guaranteed HasDynamicComputedProperty) -> @yields @inout Int
 
 // Make sure 'modify' implementations for public 'dynamic' properties
 // are serialized.
@@ -83,13 +86,29 @@ public class PublicHasDynamicStoredProperty : ProtocolWithIntProperty {
   @objc public dynamic var x: Int = 0
 }
 
-// CHECK-LABEL: sil shared [transparent] [serialized] @$S11modify_objc30PublicHasDynamicStoredPropertyC1xSivM : $@yield_once @convention(method) (@guaranteed PublicHasDynamicStoredProperty) -> @yields @inout Int
-// RESILIENT-LABEL: sil shared @$S11modify_objc30PublicHasDynamicStoredPropertyC1xSivM : $@yield_once @convention(method) (@guaranteed PublicHasDynamicStoredProperty) -> @yields @inout Int
+// CHECK-LABEL: sil shared [serialized] @$S11modify_objc30PublicHasDynamicStoredPropertyC1xSivM : $@yield_once @convention(method) (@guaranteed PublicHasDynamicStoredProperty) -> @yields @inout Int
+// RESILIENT-LABEL: sil shared [serialized] @$S11modify_objc30PublicHasDynamicStoredPropertyC1xSivM : $@yield_once @convention(method) (@guaranteed PublicHasDynamicStoredProperty) -> @yields @inout Int
 
 
 public class PublicHasDynamicComputedProperty : ProtocolWithIntProperty {
   @objc public dynamic var x: Int { get { } set { } }
 }
 
-// CHECK-LABEL: sil shared [transparent] [serialized] @$S11modify_objc32PublicHasDynamicComputedPropertyC1xSivM : $@yield_once @convention(method) (@guaranteed PublicHasDynamicComputedProperty) -> @yields @inout Int
-// RESILIENT-LABEL: sil shared @$S11modify_objc32PublicHasDynamicComputedPropertyC1xSivM : $@yield_once @convention(method) (@guaranteed PublicHasDynamicComputedProperty) -> @yields @inout Int
+// CHECK-LABEL: sil shared [serialized] @$S11modify_objc32PublicHasDynamicComputedPropertyC1xSivM : $@yield_once @convention(method) (@guaranteed PublicHasDynamicComputedProperty) -> @yields @inout Int
+// RESILIENT-LABEL: sil shared [serialized] @$S11modify_objc32PublicHasDynamicComputedPropertyC1xSivM : $@yield_once @convention(method) (@guaranteed PublicHasDynamicComputedProperty) -> @yields @inout Int
+
+
+// ... even if the class inherits NSObject.
+public class NSPublicHasDynamicStoredProperty : NSObject, ProtocolWithIntProperty {
+  @objc public dynamic var x: Int = 0
+}
+
+// CHECK-LABEL: sil shared [serialized] @$S11modify_objc32NSPublicHasDynamicStoredPropertyC1xSivM : $@yield_once @convention(method) (@guaranteed NSPublicHasDynamicStoredProperty) -> @yields @inout Int
+// RESILIENT-LABEL: sil shared [serialized] @$S11modify_objc32NSPublicHasDynamicStoredPropertyC1xSivM : $@yield_once @convention(method) (@guaranteed NSPublicHasDynamicStoredProperty) -> @yields @inout Int
+
+public class NSPublicHasDynamicComputedProperty : NSObject, ProtocolWithIntProperty {
+  @objc public dynamic var x: Int { get { } set { } }
+}
+
+// CHECK-LABEL: sil shared [serialized] @$S11modify_objc34NSPublicHasDynamicComputedPropertyC1xSivM : $@yield_once @convention(method) (@guaranteed NSPublicHasDynamicComputedProperty) -> @yields @inout Int
+// RESILIENT-LABEL: sil shared [serialized] @$S11modify_objc34NSPublicHasDynamicComputedPropertyC1xSivM : $@yield_once @convention(method) (@guaranteed NSPublicHasDynamicComputedProperty) -> @yields @inout Int

--- a/test/SILGen/modify_objc.swift
+++ b/test/SILGen/modify_objc.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -enable-objc-interop -import-objc-header %S/Inputs/modify_objc.h %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -enable-objc-interop -import-objc-header %S/Inputs/modify_objc.h %s -enable-resilience | %FileCheck %s --check-prefix=RESILIENT
 
 // REQUIRES: objc_interop
 
@@ -42,3 +43,53 @@ extension ClassWithBlockProperty : ProtocolWithBlockProperty {}
 
 // CHECK-LABEL: sil shared [serializable] @$SSo22ClassWithBlockPropertyC09dependentC0ySSSgcSgvM :
 // CHECK-SAME:    $@yield_once @convention(method) (@guaranteed ClassWithBlockProperty) -> @yields @inout Optional<@callee_guaranteed (@guaranteed Optional<String>) -> ()>
+
+// Make sure 'modify' implementations for 'dynamic' properties go through
+// accessors.
+public protocol ProtocolWithIntProperty {
+  var x: Int { get set }
+}
+
+
+class HasDynamicStoredProperty : ProtocolWithIntProperty {
+  @objc dynamic var x: Int = 0
+}
+
+// CHECK-LABEL: sil shared [transparent] @$S11modify_objc24HasDynamicStoredPropertyC1xSivM : $@yield_once @convention(method) (@guaranteed HasDynamicStoredProperty) -> @yields @inout Int
+// CHECK: objc_method %0 : $HasDynamicStoredProperty, #HasDynamicStoredProperty.x!getter.1.foreign
+// CHECK: yield
+// CHECK: objc_method %0 : $HasDynamicStoredProperty, #HasDynamicStoredProperty.x!setter.1.foreign
+// CHECK: return
+// CHECK: objc_method %0 : $HasDynamicStoredProperty, #HasDynamicStoredProperty.x!setter.1.foreign
+// CHECK: unwind
+
+
+class HasDynamicComputedProperty : ProtocolWithIntProperty {
+  @objc dynamic var x: Int { get { } set { } }
+}
+
+// CHECK-LABEL: sil shared [transparent] @$S11modify_objc26HasDynamicComputedPropertyC1xSivM : $@yield_once @convention(method) (@guaranteed HasDynamicComputedProperty) -> @yields @inout Int
+// CHECK: objc_method %0 : $HasDynamicComputedProperty, #HasDynamicComputedProperty.x!getter.1.foreign
+// CHECK: yield
+// CHECK: objc_method %0 : $HasDynamicComputedProperty, #HasDynamicComputedProperty.x!setter.1.foreign
+// CHECK: return
+// CHECK: objc_method %0 : $HasDynamicComputedProperty, #HasDynamicComputedProperty.x!setter.1.foreign
+// CHECK: unwind
+
+
+// Make sure 'modify' implementations for public 'dynamic' properties
+// are serialized.
+public class PublicHasDynamicStoredProperty : ProtocolWithIntProperty {
+  @objc public dynamic var x: Int = 0
+}
+
+// CHECK-LABEL: sil shared [transparent] [serialized] @$S11modify_objc30PublicHasDynamicStoredPropertyC1xSivM : $@yield_once @convention(method) (@guaranteed PublicHasDynamicStoredProperty) -> @yields @inout Int
+// RESILIENT-LABEL: sil shared @$S11modify_objc30PublicHasDynamicStoredPropertyC1xSivM : $@yield_once @convention(method) (@guaranteed PublicHasDynamicStoredProperty) -> @yields @inout Int
+
+
+public class PublicHasDynamicComputedProperty : ProtocolWithIntProperty {
+  @objc public dynamic var x: Int { get { } set { } }
+}
+
+// CHECK-LABEL: sil shared [transparent] [serialized] @$S11modify_objc32PublicHasDynamicComputedPropertyC1xSivM : $@yield_once @convention(method) (@guaranteed PublicHasDynamicComputedProperty) -> @yields @inout Int
+// RESILIENT-LABEL: sil shared @$S11modify_objc32PublicHasDynamicComputedPropertyC1xSivM : $@yield_once @convention(method) (@guaranteed PublicHasDynamicComputedProperty) -> @yields @inout Int


### PR DESCRIPTION
The 'modify' coroutine should always call getter and setter methods, and not directly access storage. It should also be marked serialized so that it can be referenced from serialized protocol witness thunks.

Fixes <https://bugs.swift.org/browse/SR-8657> / <rdar://problem/43951732>.