### PR TITLE
Add test case for bug 'fixed' by dropping of Swift 3 compatibility

### DIFF
--- a/test/SILGen/default_arguments_generic.swift
+++ b/test/SILGen/default_arguments_generic.swift
@@ -41,6 +41,7 @@ struct InitializableImpl: Initializable {
 // CHECK-LABEL: sil hidden @$S25default_arguments_generic17testInitializableyyF
 func testInitializable() {
   // The ".init" is required to trigger the crash that used to happen.
+  _ = Generic<InitializableImpl>()
   _ = Generic<InitializableImpl>.init()
   // CHECK: function_ref @$S25default_arguments_generic7GenericVyACyxGxcfcfA_ : $@convention(thin) <τ_0_0 where τ_0_0 : Initializable> () -> @out τ_0_0
   // CHECK: [[INIT:%.+]] = function_ref @$S25default_arguments_generic7GenericVyACyxGxcfC


### PR DESCRIPTION
This was <https://bugs.swift.org/browse/SR-3806>.