### PR TITLE
[Stats] Teach process-stats-dir.py to render organized sets of flamegraphs.

### DIFF
--- a/utils/jobstats/__init__.py
+++ b/utils/jobstats/__init__.py
@@ -20,4 +20,4 @@ __email__ = 'ghoare@apple.com'
 __versioninfo__ = (0, 1, 0)
 __version__ = '.'.join(str(v) for v in __versioninfo__)
 
-from .jobstats import JobStats, load_stats_dir, merge_all_jobstats # noqa
+from .jobstats import JobStats, JobProfs, load_stats_dir, merge_all_jobstats, list_stats_dir_profiles # noqa


### PR DESCRIPTION
This adds a new mode to process-stats-dir.py called `--render-profiles` (with a sub-mode if you're sitting at a workstation: `--browse-profiles`). This scans a `--stats-output-dir` directory for profiles generated by either `--profile-stats-events` or `--profile-stats-entities` and then runs them all through `flamegraph.pl` (either found in your path or specified on command line) with appropriate titles explaining what each is, and writes a nice summary HTML index of them all hyperlinked together for convenient browsing.

If you pass `--browse-profiles` it'll even open a web browser pointing at the newly-generated page, from which you can navigate to the profiles. Works with --select-stat and --select-module, as usual.