### PR TITLE
fix some AD index calculations

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -100,7 +100,10 @@ struct SILReverseAutoDiffIndices {
                                          ArrayRef<unsigned> parameters);
 
   bool operator==(const SILReverseAutoDiffIndices &other) const {
-    return source == other.source && !parameters.test(other.parameters);
+    return source == other.source &&
+        (parameters.size() >= other.parameters.size() ?
+            !parameters.test(other.parameters) :
+            !other.parameters.test(parameters));
   }
 
   void print(llvm::raw_ostream &s = llvm::outs()) const {

--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -2228,11 +2228,13 @@ static void collectMinimalIndicesForFunctionCall(
   // Parameter indices are indices (in the type signature) of parameter
   // arguments that are varied or are arguments.
   unsigned currentParamIdx = 0;
-  for (auto applyArg : ai->getArgumentsWithoutIndirectResults())
+  for (auto applyArg : ai->getArgumentsWithoutIndirectResults()) {
     if (activityInfo.isVaried(applyArg, parentIndices.parameters) ||
         isDifferentiationParameter(dyn_cast<SILArgument>(applyArg),
                                    parentIndices.parameters))
-      paramIndices.push_back(currentParamIdx++);
+      paramIndices.push_back(currentParamIdx);
+    ++currentParamIdx;
+  }
   // Result indices are indices (in the type signature) of results that are
   // useful.
   //


### PR DESCRIPTION
1. SILReverseAutoDiffIndices's `==` was wrong when `other.parameters.size()` was bigger.
2. `currentParamIdx` should be incremented on every loop iteration, because it's supposed to keep track of the index of the argument that the loop is looking at.