### PR TITLE
[sil-ownership] Tighten up the verification of guaranteed phi arguments.

### DIFF
--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -98,6 +98,8 @@ static bool isOwnershipForwardingValueKind(SILNodeKind K) {
   case SILNodeKind::SelectEnumInst:
   case SILNodeKind::SwitchEnumInst:
   case SILNodeKind::CheckedCastBranchInst:
+  case SILNodeKind::BranchInst:
+  case SILNodeKind::CondBranchInst:
   case SILNodeKind::DestructureStructInst:
   case SILNodeKind::DestructureTupleInst:
     return true;
@@ -795,6 +797,16 @@ OwnershipCompatibilityUseChecker::visitReturnInst(ReturnInst *RI) {
 
 OwnershipUseCheckerResult
 OwnershipCompatibilityUseChecker::visitEndBorrowInst(EndBorrowInst *I) {
+  // If we are checking a subobject, make sure that we are from a guaranteed
+  // basic block argument.
+  if (isCheckingSubObject()) {
+    auto *phiArg = cast<SILPHIArgument>(Op.get());
+    (void)phiArg;
+    assert(phiArg->getOwnershipKind() == ValueOwnershipKind::Guaranteed &&
+           "Expected an end_borrow paired with an argument.");
+    return {true, UseLifetimeConstraint::MustBeLive};
+  }
+
   /// An end_borrow is modeled as invalidating the guaranteed value preventing
   /// any further uses of the value.
   return {compatibleWithOwnership(ValueOwnershipKind::Guaranteed),
@@ -1438,6 +1450,7 @@ void SILValueOwnershipChecker::gatherUsers(
   // users since we verify against our base.
   auto OwnershipKind = Value.getOwnershipKind();
   bool IsGuaranteed = OwnershipKind == ValueOwnershipKind::Guaranteed;
+  bool IsOwned = OwnershipKind == ValueOwnershipKind::Owned;
 
   if (IsGuaranteed && isGuaranteedForwardingValue(Value))
     return;
@@ -1485,26 +1498,36 @@ void SILValueOwnershipChecker::gatherUsers(
       }
     }
 
-    // If our base value is not guaranteed or our intermediate value is not an
-    // ownership forwarding inst, continue. We do not want to visit any
-    // subobjects recursively.
-    if (!IsGuaranteed || !isGuaranteedForwardingInst(User)) {
-      // Do a check if any of our users are begin_borrows. If we find such a
-      // use, then we want to include the end_borrow associated with the
-      // begin_borrow in our NonLifetimeEndingUser lists.
-      //
-      // For correctness reasons we use indices to make sure that we can append
-      // to NonLifetimeEndingUsers without needing to deal with iterator
-      // invalidation.
-      SmallVector<SILInstruction *, 4> endBorrowInsts;
-      for (unsigned i : indices(NonLifetimeEndingUsers)) {
-        if (auto *bbi = dyn_cast<BeginBorrowInst>(
-                NonLifetimeEndingUsers[i].getInst())) {
-          copy(bbi->getEndBorrows(), std::back_inserter(ImplicitRegularUsers));
+    // If our base value is not guaranteed, we do not to try to visit
+    // subobjects.
+    if (!IsGuaranteed) {
+      // But if we are owned, check if we have any end_borrows. We
+      // need to treat these as sub-scope users. We can rely on the
+      // end_borrow to prevent recursion.
+      if (IsOwned) {
+        // Do a check if any of our users are begin_borrows. If we find such a
+        // use, then we want to include the end_borrow associated with the
+        // begin_borrow in our NonLifetimeEndingUser lists.
+        //
+        // For correctness reasons we use indices to make sure that we can
+        // append to NonLifetimeEndingUsers without needing to deal with
+        // iterator invalidation.
+        SmallVector<SILInstruction *, 4> endBorrowInsts;
+        for (unsigned i : indices(NonLifetimeEndingUsers)) {
+          if (auto *bbi = dyn_cast<BeginBorrowInst>(
+                  NonLifetimeEndingUsers[i].getInst())) {
+            copy(bbi->getEndBorrows(),
+                 std::back_inserter(ImplicitRegularUsers));
+          }
         }
       }
       continue;
     }
+
+    // If we are guaranteed, but are not a guaranteed forwarding inst,
+    // just continue. This user is just treated as a normal use.
+    if (!isGuaranteedForwardingInst(User))
+      continue;
 
     // At this point, we know that we must have a forwarded subobject. Since the
     // base type is guaranteed, we know that the subobject is either guaranteed
@@ -1537,9 +1560,8 @@ void SILValueOwnershipChecker::gatherUsers(
     }
 
     // Otherwise if we have a terminator, add any as uses any end_borrow to
-    // ensure that the subscope is completely enclsed within the super
-    // scope. all of the arguments to the work list. We require all of our
-    // arguments to be either trivial or guaranteed.
+    // ensure that the subscope is completely enclsed within the super scope. We
+    // require all of our arguments to be either trivial or guaranteed.
     for (auto &Succ : TI->getSuccessors()) {
       auto *BB = Succ.getBB();
 
@@ -1552,7 +1574,7 @@ void SILValueOwnershipChecker::gatherUsers(
       //
       // TODO: We could ignore this error and emit a more specific error on the
       // actual terminator.
-      for (auto *BBArg : BB->getArguments()) {
+      for (auto *BBArg : BB->getPHIArguments()) {
         // *NOTE* We do not emit an error here since we want to allow for more
         // specific errors to be found during use_verification.
         //
@@ -1569,8 +1591,16 @@ void SILValueOwnershipChecker::gatherUsers(
         if (BBArgOwnershipKind == ValueOwnershipKind::Trivial)
           continue;
 
-        // Otherwise,
-        copy(BBArg->getUses(), std::back_inserter(Users));
+        // Otherwise add all end_borrow users for this BBArg to the
+        // implicit regular user list. We know that BBArg must be
+        // completely joint post-dominated by these users, so we use
+        // them to ensure that all of BBArg's uses are completely
+        // enclosed within the end_borrow of this argument.
+        for (auto *op : BBArg->getUses()) {
+          if (auto *ebi = dyn_cast<EndBorrowInst>(op->getUser())) {
+            ImplicitRegularUsers.push_back(ebi);
+          }
+        }
       }
     }
   }

--- a/test/SIL/ownership-verifier/arguments.sil
+++ b/test/SIL/ownership-verifier/arguments.sil
@@ -1,0 +1,368 @@
+// RUN: %target-sil-opt -module-name Swift -sil-ownership-verifier-enable-testing -enable-sil-ownership -enable-sil-verify-all=0 %s -o /dev/null 2>&1 | %FileCheck %s
+// REQUIRES: asserts
+
+// This is a test that verifies ownership behavior around arguments that should
+// be flagged as failures.
+
+sil_stage canonical
+
+import Builtin
+
+// CHECK-LABEL: Function: 'no_end_borrow_error'
+// CHECK: Non trivial values, non address values, and non guaranteed function args must have at least one lifetime ending use?!
+// CHECK: Value: %2 = argument of bb1 : $Builtin.NativeObject
+//
+// TODO: Better error message here.
+sil @no_end_borrow_error : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject):
+  br bb1(%0 : $Builtin.NativeObject)
+
+bb1(%1 : @guaranteed $Builtin.NativeObject):
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: Function: 'leak_along_path'
+// CHECK-NEXT: Error! Found a leak due to a consuming post-dominance failure!
+// CHECK-NEXT:     Value: %2 = argument of bb1 : $Builtin.NativeObject
+// CHECK-NEXT:     Post Dominating Failure Blocks:
+// CHECK-NEXT:         bb3
+sil @leak_along_path : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject):
+  br bb1(%0 : $Builtin.NativeObject)
+
+bb1(%1 : @guaranteed $Builtin.NativeObject):
+  cond_br undef, bb2, bb3
+
+bb2:
+  end_borrow %1 : $Builtin.NativeObject
+  br bb3
+
+bb3:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Make sure that we only flag the subargument leak and not the parent argument.
+//
+// CHECK-LABEL: Function: 'leak_along_subarg_path'
+// CHECK-NEXT: Error! Found a leak due to a consuming post-dominance failure!
+// CHECK-NEXT:     Value: %5 = argument of bb3 : $Builtin.NativeObject
+// CHECK-NEXT:     Post Dominating Failure Blocks:
+// CHECK-NEXT:         bb5
+
+sil @leak_along_subarg_path : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject):
+  br bb1(%0 : $Builtin.NativeObject)
+
+bb1(%1 : @guaranteed $Builtin.NativeObject):
+  cond_br undef, bb2, bb5
+
+bb2:
+  br bb3(%1 : $Builtin.NativeObject)
+
+bb3(%2 : @guaranteed $Builtin.NativeObject):
+  cond_br undef, bb4, bb5
+
+bb4:
+  end_borrow %2 : $Builtin.NativeObject
+  br bb5
+
+bb5:
+  end_borrow %1 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-NOT: Function: 'good_order'
+sil @good_order : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  cond_br undef, bb1, bb5
+
+bb1:
+  br bb2(%1 : $Builtin.NativeObject)
+
+bb2(%2 : @guaranteed $Builtin.NativeObject):
+  end_borrow %2 : $Builtin.NativeObject
+  end_borrow %1 : $Builtin.NativeObject
+  cond_br undef, bb3, bb4
+
+bb3:
+  br bb4
+
+bb4:
+  destroy_value %0 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+
+bb5:
+  end_borrow %1 : $Builtin.NativeObject
+  br bb4
+}
+
+// Make sure that we only flag the end_borrow "use after free" in bb2.
+//
+// CHECK-LABEL: Function: 'bad_order'
+// CHECK-NEXT: Found use after free?!
+// CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
+// CHECK-NEXT: Consuming User:   end_borrow %1 : $Builtin.NativeObject
+// CHECK-NEXT: Non Consuming User:   end_borrow %4 : $Builtin.NativeObject           // id: %6
+// CHECK-NEXT: Block: bb2
+// CHECK-LABEL: Function: 'bad_order'
+// CHECK-NEXT: Found use after free due to unvisited non lifetime ending uses?!
+// CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
+// CHECK-NEXT:     Remaining Users:
+// CHECK-NEXT: User:  end_borrow %4 : $Builtin.NativeObject
+// CHECK-NEXT: Block: bb2
+// CHECK-NOT: Block: bb1
+sil @bad_order : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  cond_br undef, bb1, bb5
+
+bb1:
+  br bb2(%1 : $Builtin.NativeObject)
+
+bb2(%2 : @guaranteed $Builtin.NativeObject):
+  end_borrow %1 : $Builtin.NativeObject
+  end_borrow %2 : $Builtin.NativeObject
+  cond_br undef, bb3, bb4
+
+bb3:
+  br bb4
+
+bb4:
+  destroy_value %0 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+
+bb5:
+  end_borrow %1 : $Builtin.NativeObject
+  br bb4
+}
+
+// CHECK-LABEL: Function: 'bad_order_add_a_level'
+// CHECK-NEXT: Found use after free?!
+// CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
+// CHECK-NEXT: Consuming User:   end_borrow %1 : $Builtin.NativeObject
+// CHECK-NEXT: Non Consuming User:   end_borrow %4 : $Builtin.NativeObject
+// CHECK-NEXT: Block: bb2
+
+// CHECK-LABEL: Function: 'bad_order_add_a_level'
+// CHECK-NEXT: Found over consume?!
+// CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
+// CHECK-NEXT: User:   end_borrow %1 : $Builtin.NativeObject
+// CHECK-NEXT: Block: bb2
+
+// CHECK-LABEL: Function: 'bad_order_add_a_level'
+// CHECK-NEXT: Found over consume?!
+// CHECK-NEXT: Value: %4 = argument of bb2 : $Builtin.NativeObject
+// CHECK-NEXT: User:   end_borrow %4 : $Builtin.NativeObject
+// CHECK-NEXT: Block: bb2
+
+// CHECK-LABEL: Function: 'bad_order_add_a_level'
+// CHECK-NEXT: Non trivial values, non address values, and non guaranteed function args must have at least one lifetime ending use?!
+// CHECK-NEXT: Value: %9 = argument of bb4 : $Builtin.NativeObject
+
+// NOTE: We use the expected numbered value in the output to make it easier to
+// match the filecheck patterns with the input.
+sil @bad_order_add_a_level : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  cond_br undef, bb1, bb7
+
+bb1:
+  br bb2(%1 : $Builtin.NativeObject)
+
+bb2(%4 : @guaranteed $Builtin.NativeObject):
+  end_borrow %1 : $Builtin.NativeObject
+  end_borrow %4 : $Builtin.NativeObject
+  cond_br undef, bb3, bb5
+
+bb3:
+  br bb4(%4 : $Builtin.NativeObject)
+
+bb4(%9 : @guaranteed $Builtin.NativeObject):
+  br bb6
+
+bb5:
+  end_borrow %4 : $Builtin.NativeObject
+  end_borrow %1 : $Builtin.NativeObject
+  br bb6
+
+bb6:
+  destroy_value %0 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+
+bb7:
+  end_borrow %1 : $Builtin.NativeObject
+  br bb6
+}
+
+// Check that we only add an argument to the use set of its parent argument.
+// This ensures that when checking we do not waste a bunch of compile time by
+// propagating up end_borrows through many arguments. Also make sure that we do
+// properly visit terminators so that we do not erroneously flag them as
+// improper uses.
+//
+//
+// CHECK-LABEL: Function: 'bad_order_add_a_level_2'
+// CHECK-NEXT: Found use after free?!
+// CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
+// CHECK-NEXT: Consuming User:   end_borrow %1 : $Builtin.NativeObject
+// CHECK-NEXT: Non Consuming User:   end_borrow %4 : $Builtin.NativeObject
+// CHECK-NEXT: Block: bb2
+//
+// CHECK-LABEL: Function: 'bad_order_add_a_level_2'
+// CHECK-NEXT: Found use after free?!
+// CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
+// CHECK-NEXT: Consuming User:   end_borrow %1 : $Builtin.NativeObject
+// CHECK-NEXT: Non Consuming User:   end_borrow %4 : $Builtin.NativeObject
+// CHECK-NEXT: Block: bb4
+//
+// CHECK-LABEL: Function: 'bad_order_add_a_level_2'
+// CHECK-NEXT: Found use after free?!
+// CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
+// CHECK-NEXT: Consuming User:   end_borrow %1 : $Builtin.NativeObject
+// CHECK-NEXT: Non Consuming User:   end_borrow %4 : $Builtin.NativeObject
+// CHECK-NEXT: Block: bb5
+//
+// CHECK-LABEL: Function: 'bad_order_add_a_level_2'
+// CHECK-NEXT: Found over consume?!
+// CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
+// CHECK-NEXT: User:   end_borrow %1 : $Builtin.NativeObject
+// CHECK-NEXT: Block: bb2
+//
+// CHECK-LABEL: Function: 'bad_order_add_a_level_2'
+// CHECK-NEXT: Found use after free?!
+// CHECK-NEXT: Value: %4 = argument of bb2 : $Builtin.NativeObject
+// CHECK-NEXT: Consuming User:   end_borrow %4 : $Builtin.NativeObject
+// CHECK-NEXT: Non Consuming User:   end_borrow %9 : $Builtin.NativeObject
+// CHECK-NEXT: Block: bb4
+
+// CHECK-LABEL: Function: 'bad_order_add_a_level_2'
+// CHECK-NEXT: Found over consume?!
+// CHECK-NEXT: Value: %4 = argument of bb2 : $Builtin.NativeObject
+// CHECK-NEXT: User:   end_borrow %4 : $Builtin.NativeObject
+// CHECK-NEXT: Block: bb2
+// CHECK-NOT: Block
+sil @bad_order_add_a_level_2 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  cond_br undef, bb1, bb7
+
+bb1:
+  br bb2(%1 : $Builtin.NativeObject)
+
+bb2(%4 : @guaranteed $Builtin.NativeObject):
+  end_borrow %1 : $Builtin.NativeObject
+  end_borrow %4 : $Builtin.NativeObject
+  cond_br undef, bb3, bb5
+
+bb3:
+  br bb4(%4 : $Builtin.NativeObject)
+
+bb4(%9 : @guaranteed $Builtin.NativeObject):
+  end_borrow %1 : $Builtin.NativeObject
+  end_borrow %4 : $Builtin.NativeObject
+  end_borrow %9 : $Builtin.NativeObject
+  br bb6
+
+bb5:
+  end_borrow %1 : $Builtin.NativeObject
+  end_borrow %4 : $Builtin.NativeObject
+  br bb6
+
+bb6:
+  destroy_value %0 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+
+bb7:
+  end_borrow %1 : $Builtin.NativeObject
+  br bb6
+}
+
+// CHECK-LABEL: Function: 'owned_argument_overuse_br1'
+// CHECK-NEXT: Found over consume?!
+// CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject
+// CHECK-NEXT: User:   br bb1(%0 : $Builtin.NativeObject)
+// CHECK-NEXT: Block: bb0
+
+// CHECK-LABEL: Function: 'owned_argument_overuse_br1'
+// CHECK-NEXT: Error! Found a leaked owned value that was never consumed.
+// CHECK-NEXT: Value: %3 = argument of bb1 : $Builtin.NativeObject
+// CHECK-NOT: Block
+// CHECK-NOT: Function: 'owned_argument_overuse_br1'
+sil @owned_argument_overuse_br1 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  destroy_value %0 : $Builtin.NativeObject
+  br bb1(%0 : $Builtin.NativeObject)
+
+bb1(%1 : @owned $Builtin.NativeObject):
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: Function: 'owned_argument_overuse_br2'
+// CHECK-NEXT: Found over consume?!
+// CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject
+// CHECK-NEXT: User:   br bb1(%0 : $Builtin.NativeObject)
+// CHECK-NEXT: Block: bb0
+// CHECK-NOT: Block
+// CHECK-NOT: Function: 'owned_argument_overuse_br2'
+sil @owned_argument_overuse_br2 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  destroy_value %0 : $Builtin.NativeObject
+  br bb1(%0 : $Builtin.NativeObject)
+
+bb1(%1 : @owned $Builtin.NativeObject):
+  destroy_value %1 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: Function: 'owned_argument_overuse_condbr1'
+// CHECK-NEXT: Found over consume?!
+// CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject
+// CHECK-NEXT: User:   cond_br undef, bb1(%0 : $Builtin.NativeObject), bb2
+// CHECK-NEXT: Block: bb0
+// CHECK-LABEL: Function: 'owned_argument_overuse_condbr1'
+// CHECK-NEXT: Error! Found a leaked owned value that was never consumed.
+// CHECK-NEXT: Value: %3 = argument of bb1 : $Builtin.NativeObject
+// CHECK-NOT: Function: 'owned_argument_overuse_condbr1'
+sil @owned_argument_overuse_condbr1 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  destroy_value %0 : $Builtin.NativeObject
+  cond_br undef, bb1(%0 : $Builtin.NativeObject), bb2
+
+bb1(%1 : @owned $Builtin.NativeObject):
+  br bb2
+
+bb2:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: Function: 'owned_argument_overuse_condbr2'
+// CHECK-NEXT: Found over consume?!
+// CHECK-NEXT: Value: %0 = argument of bb0 : $Builtin.NativeObject
+// CHECK-NEXT: User:   cond_br undef, bb1(%0 : $Builtin.NativeObject), bb2
+// CHECK-NEXT: Block: bb0
+// CHECK-NOT: Block
+// CHECK-NOT: Function: 'owned_argument_overuse_condbr2'
+sil @owned_argument_overuse_condbr2 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  destroy_value %0 : $Builtin.NativeObject
+  cond_br undef, bb1(%0 : $Builtin.NativeObject), bb2
+
+bb1(%1 : @owned $Builtin.NativeObject):
+  destroy_value %1 : $Builtin.NativeObject
+  br bb2
+
+bb2:
+  %9999 = tuple()
+  return %9999 : $()
+}

--- a/test/SIL/ownership-verifier/over_consume.sil
+++ b/test/SIL/ownership-verifier/over_consume.sil
@@ -220,12 +220,12 @@ bb3:
 }
 
 
-// TEMP-DISABLED-CHECK-LABEL: Function: 'switch_enum_guaranteed_arg_outlives_original_value'
-// TEMP-DISABLED-CHECK: Found use after free?!
-// TEMP-DISABLED-CHECK: Value:   %1 = begin_borrow %0 : $Optional<Builtin.NativeObject>
-// TEMP-DISABLED-CHECK: Consuming User:   end_borrow %1 : $Optional<Builtin.NativeObject>
-// TEMP-DISABLED-CHECK: Non Consuming User:   end_borrow %3 : $Builtin.NativeObject
-// TEMP-DISABLED-CHECK: Block: bb1
+// CHECK-LABEL: Function: 'switch_enum_guaranteed_arg_outlives_original_value'
+// CHECK: Found use after free?!
+// CHECK: Value:   %1 = begin_borrow %0 : $Optional<Builtin.NativeObject>
+// CHECK: Consuming User:   end_borrow %1 : $Optional<Builtin.NativeObject>
+// CHECK: Non Consuming User:   end_borrow %3 : $Builtin.NativeObject
+// CHECK: Block: bb1
 sil @switch_enum_guaranteed_arg_outlives_original_value : $@convention(thin) (@owned Optional<Builtin.NativeObject>) -> () {
 bb0(%0 : @owned $Optional<Builtin.NativeObject>):
   %1 = begin_borrow %0 : $Optional<Builtin.NativeObject>
@@ -398,12 +398,12 @@ bb3:
   return %9999 : $()
 }
 
-// TEMP-DISABLED-CHECK-LABEL: Function: 'checked_cast_br_guaranteed_arg_outlives_original_value'
-// TEMP-DISABLED-CHECK: Found use after free?!
-// TEMP-DISABLED-CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
-// TEMP-DISABLED-CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject
-// TEMP-DISABLED-CHECK: Non Consuming User:   end_borrow %7 : $Builtin.NativeObject
-// TEMP-DISABLED-CHECK: Block: bb2
+// CHECK-LABEL: Function: 'checked_cast_br_guaranteed_arg_outlives_original_value'
+// CHECK: Found use after free?!
+// CHECK: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject
+// CHECK: Consuming User:   end_borrow %1 : $Builtin.NativeObject
+// CHECK: Non Consuming User:   end_borrow %7 : $Builtin.NativeObject
+// CHECK: Block: bb2
 sil @checked_cast_br_guaranteed_arg_outlives_original_value : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject

--- a/test/SIL/ownership-verifier/use_verifier.sil
+++ b/test/SIL/ownership-verifier/use_verifier.sil
@@ -448,6 +448,85 @@ bb3:
   return %9999 : $()
 }
 
+// Make sure that we can properly handle a guaranteed switch_enum.
+sil @switch_enum_guaranteed_arg_test : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject):
+  %1 = enum $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1, %0 : $Builtin.NativeObject
+  switch_enum %1 : $Optional<Builtin.NativeObject>, case #Optional.some!enumelt.1: bb1, case #Optional.none!enumelt: bb2
+
+bb1(%2 : @guaranteed $Builtin.NativeObject):
+  end_borrow %2 : $Builtin.NativeObject
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil @switch_enum_guaranteed_beginborrow_test_1a : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  %2 = enum $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1, %1 : $Builtin.NativeObject
+  switch_enum %2 : $Optional<Builtin.NativeObject>, case #Optional.some!enumelt.1: bb1, case #Optional.none!enumelt: bb2
+
+bb1(%3 : @guaranteed $Builtin.NativeObject):
+  end_borrow %3 : $Builtin.NativeObject
+  end_borrow %1 : $Builtin.NativeObject
+  br bb3
+
+bb2:
+  end_borrow %1 : $Builtin.NativeObject
+  br bb3
+
+bb3:
+  destroy_value %0 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil @switch_enum_guaranteed_beginborrow_test_1b : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = begin_borrow %0 : $Builtin.NativeObject
+  %2 = enum $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1, %1 : $Builtin.NativeObject
+  switch_enum %2 : $Optional<Builtin.NativeObject>, case #Optional.some!enumelt.1: bb1, case #Optional.none!enumelt: bb2
+
+bb1(%3 : @guaranteed $Builtin.NativeObject):
+  end_borrow %3 : $Builtin.NativeObject
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  end_borrow %1 : $Builtin.NativeObject
+  destroy_value %0 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil @switch_enum_guaranteed_beginborrow_test_2 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %1 = enum $Optional<Builtin.NativeObject>, #Optional.some!enumelt.1, %0 : $Builtin.NativeObject
+  %2 = begin_borrow %1 : $Optional<Builtin.NativeObject>
+  switch_enum %2 : $Optional<Builtin.NativeObject>, case #Optional.some!enumelt.1: bb1, case #Optional.none!enumelt: bb2
+
+bb1(%3 : @guaranteed $Builtin.NativeObject):
+  end_borrow %3 : $Builtin.NativeObject
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  end_borrow %2 : $Optional<Builtin.NativeObject>
+  destroy_value %1 : $Optional<Builtin.NativeObject>
+  %9999 = tuple()
+  return %9999 : $()
+}
+
 // Make sure that we can properly handle a switch enum case where the input
 // argument is an enum, but the final argument is trivial.
 sil @switch_enum_no_payload_test : $@convention(thin) () -> () {
@@ -611,6 +690,45 @@ bb50:
   br bb51
 
 bb51:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We check first for objects, then for metatypes, then for guaranteed values
+sil @checked_cast_br_test : $@convention(thin) (@owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject, %6 : @guaranteed $Builtin.NativeObject):
+  checked_cast_br %0 : $Builtin.NativeObject to $SuperKlass, bb1, bb2
+
+bb1(%1 : @owned $SuperKlass):
+  destroy_value %1 : $SuperKlass
+  br bb3
+
+bb2(%2 : @owned $Builtin.NativeObject):
+  destroy_value %2 : $Builtin.NativeObject
+  br bb3
+
+bb3:
+  %3 = metatype $@thick SuperKlass.Type
+  checked_cast_br %3 : $@thick SuperKlass.Type to $@thick SubKlass.Type, bb4, bb5
+
+bb4(%4 : @trivial $@thick SubKlass.Type):
+  br bb6
+
+bb5(%5 : @trivial $@thick SuperKlass.Type):
+  br bb6
+
+bb6:
+  checked_cast_br %6 : $Builtin.NativeObject to $SuperKlass, bb7, bb8
+
+bb7(%7 : @guaranteed $SuperKlass):
+  end_borrow %7 : $SuperKlass
+  br bb9
+
+bb8(%8 : @guaranteed $Builtin.NativeObject):
+  end_borrow %8 : $Builtin.NativeObject
+  br bb9
+
+bb9:
   %9999 = tuple()
   return %9999 : $()
 }


### PR DESCRIPTION
Now we properly enforce that all guaranteed phi arguments's lifetime is
completely enclosed by the lifetimes of the phi argument's inputs. This is
implemented by inserting an "implicit" regular use into the use stream of the
phi argument's inputs. This is nice since it ensures that when we are verifying
ownership of a specific argument, we will not walk through all
subarguments... instead we just need to verify that the end_borrow is completely
enclosed within the lifetime of the input guaranteed value.

I also fixed a case where we were bailing early out of the SIL Ownership
Verifier causing us to emit an incorrect error. This error would only occur if
we already diagnosed an error.

I also re-added all of the tests that I removed when I replaced
end_borrow_argument with end_borrow.

rdar://33440767