### PR TITLE
[ModuleInterface] Print imports (including '@_exported')

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -260,6 +260,10 @@ ERROR(error_invalid_debug_prefix_map, none,
 ERROR(invalid_vfs_overlay_file,none,
       "invalid virtual overlay file '%0'", (StringRef))
 
+WARNING(textual_interface_scoped_import_unsupported,none,
+        "scoped imports are not yet supported in textual module interfaces",
+        ())
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -460,6 +460,9 @@ public:
   /// \returns true if this module is the "builtin" module.
   bool isBuiltinModule() const;
 
+  /// \returns true if this module is the "SwiftOnoneSupport" module;
+  bool isOnoneSupportModule() const;
+
   /// \returns true if this module is a system module; note that the StdLib is
   /// considered a system module.
   bool isSystemModule() const;

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -373,6 +373,12 @@ public:
   void
   getImportedModulesForLookup(SmallVectorImpl<ImportedModule> &imports) const;
 
+  /// Uniques the items in \p imports, ignoring the source locations of the
+  /// access paths.
+  ///
+  /// The order of items in \p imports is \e not preserved.
+  static void removeDuplicateImports(SmallVectorImpl<ImportedModule> &imports);
+
   /// Finds all top-level decls of this module.
   ///
   /// This does a simple local lookup, not recursively looking through imports.

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -380,9 +380,6 @@ public:
     return wholeModule;
   }
 
-  /// Returns true if it is the OnoneSupport module.
-  bool isOnoneSupportModule() const;
-
   /// Returns true if it is the optimized OnoneSupport module.
   bool isOptimizedOnoneSupportModule() const;
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -36,6 +36,7 @@
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/Statistic.h"
 #include "swift/Parse/Token.h"
+#include "swift/Strings.h"
 #include "swift/Syntax/SyntaxNodes.h"
 #include "clang/Basic/Module.h"
 #include "llvm/ADT/DenseMap.h"
@@ -1032,6 +1033,10 @@ bool ModuleDecl::isStdlibModule() const {
 
 bool ModuleDecl::isSwiftShimsModule() const {
   return !getParent() && getName() == getASTContext().SwiftShimsModuleName;
+}
+
+bool ModuleDecl::isOnoneSupportModule() const {
+  return !getParent() && getName().str() == SWIFT_ONONE_SUPPORT;
 }
 
 bool ModuleDecl::isBuiltinModule() const {

--- a/lib/FrontendTool/TextualInterfaceGeneration.cpp
+++ b/lib/FrontendTool/TextualInterfaceGeneration.cpp
@@ -12,12 +12,81 @@
 
 #include "TextualInterfaceGeneration.h"
 
+#include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/AST/Module.h"
+#include "clang/Basic/Module.h"
 
 using namespace swift;
 
+/// Diagnose any scoped imports in \p imports, i.e. those with a non-empty
+/// access path. These are not yet supported by textual interfaces, since the
+/// information about the declaration kind is not preserved through the binary
+/// serialization that happens as an intermediate step in non-whole-module
+/// builds.
+///
+/// These come from declarations like `import class FooKit.MainFooController`.
+static void diagnoseScopedImports(DiagnosticEngine &diags,
+                                  ArrayRef<ModuleDecl::ImportedModule> imports){
+  for (const ModuleDecl::ImportedModule &importPair : imports) {
+    if (importPair.first.empty())
+      continue;
+    diags.diagnose(importPair.first.front().second,
+                   diag::textual_interface_scoped_import_unsupported);
+  }
+}
+
+/// Prints the imported modules in \p M to \p out in the form of \c import
+/// source declarations.
+static void printImports(raw_ostream &out, ModuleDecl *M) {
+  // FIXME: This is very similar to what's in Serializer::writeInputBlock, but
+  // it's not obvious what higher-level optimization would be factored out here.
+  SmallVector<ModuleDecl::ImportedModule, 8> allImports;
+  M->getImportedModules(allImports, ModuleDecl::ImportFilter::All);
+  ModuleDecl::removeDuplicateImports(allImports);
+  diagnoseScopedImports(M->getASTContext().Diags, allImports);
+
+  // Collect the public imports as a subset so that we can mark them with
+  // '@_exported'.
+  SmallVector<ModuleDecl::ImportedModule, 8> publicImports;
+  M->getImportedModules(publicImports, ModuleDecl::ImportFilter::Public);
+  llvm::SmallSet<ModuleDecl::ImportedModule, 8,
+                 ModuleDecl::OrderImportedModules> publicImportSet;
+  publicImportSet.insert(publicImports.begin(), publicImports.end());
+
+  for (auto import : allImports) {
+    if (import.second->isStdlibModule() ||
+        import.second->isOnoneSupportModule()) {
+      continue;
+    }
+
+    if (publicImportSet.count(import))
+      out << "@_exported ";
+    out << "import ";
+    if (auto *clangModule = import.second->findUnderlyingClangModule())
+      out << clangModule->getFullModuleName();
+    else
+      out << import.second->getName();
+
+    // Write the access path we should be honoring but aren't.
+    // (See diagnoseScopedImports above.)
+    if (!import.first.empty()) {
+      out << "/*";
+      for (const auto &accessPathElem : import.first)
+        out << "." << accessPathElem.first;
+      out << "*/";
+    }
+
+    out << "\n";
+  }
+}
+
 bool swift::emitModuleInterface(raw_ostream &out, ModuleDecl *M) {
+  assert(M);
+
+  printImports(out, M);
+
   const PrintOptions printOptions = PrintOptions::printTextualInterfaceFile();
   SmallVector<Decl *, 16> topLevelDecls;
   M->getTopLevelDecls(topLevelDecls);

--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -23,7 +23,6 @@
 #include "swift/AST/ModuleLoader.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/Index/Index.h"
-#include "swift/Strings.h"
 #include "clang/Basic/FileManager.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Index/IndexingAction.h"
@@ -402,7 +401,7 @@ static void addModuleDependencies(ArrayRef<ModuleDecl::ImportedModule> imports,
 
   for (auto &import : imports) {
     ModuleDecl *mod = import.second;
-    if (mod->getNameStr() == SWIFT_ONONE_SUPPORT)
+    if (mod->isOnoneSupportModule())
       continue; // ignore the Onone support library.
     if (mod->isSwiftShimsModule())
       continue;

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -22,7 +22,6 @@
 #include "swift/SIL/SILValue.h"
 #include "swift/SIL/SILVisitor.h"
 #include "swift/Serialization/SerializedSILLoader.h"
-#include "swift/Strings.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/Statistic.h"
@@ -634,14 +633,10 @@ shouldSerializeEntitiesAssociatedWithDeclContext(const DeclContext *DC) const {
   return false;
 }
 
-/// Returns true if it is the OnoneSupport module.
-bool SILModule::isOnoneSupportModule() const {
-  return getSwiftModule()->getName().str() == SWIFT_ONONE_SUPPORT;
-}
-
 /// Returns true if it is the optimized OnoneSupport module.
 bool SILModule::isOptimizedOnoneSupportModule() const {
-  return getOptions().shouldOptimize() && isOnoneSupportModule();
+  return getOptions().shouldOptimize() &&
+         getSwiftModule()->isOnoneSupportModule();
 }
 
 void SILModule::setSerializeSILAction(SILModule::ActionCallback Action) {

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -20,7 +20,6 @@
 #include "swift/SILOptimizer/Utils/Generics.h"
 #include "swift/SILOptimizer/Utils/PerformanceInlinerUtils.h"
 #include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
-#include "swift/Strings.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
@@ -492,9 +491,9 @@ static Optional<bool> shouldInlineGeneric(FullApplySite AI) {
   // Do not inline @_semantics functions when compiling the stdlib,
   // because they need to be preserved, so that the optimizer
   // can properly optimize a user code later.
-  auto ModuleName = Callee->getModule().getSwiftModule()->getName().str();
+  ModuleDecl *SwiftModule = Callee->getModule().getSwiftModule();
   if (Callee->hasSemanticsAttrThatStartsWith("array.") &&
-      (ModuleName == STDLIB_NAME || ModuleName == SWIFT_ONONE_SUPPORT))
+      (SwiftModule->isStdlibModule() || SwiftModule->isOnoneSupportModule()))
     return false;
 
   // Do not inline into thunks.

--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -10,9 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/AST/Module.h"
 #include "swift/SILOptimizer/Utils/PerformanceInlinerUtils.h"
-#include "swift/Strings.h"
+#include "swift/AST/Module.h"
 
 //===----------------------------------------------------------------------===//
 //                               ConstantTracker
@@ -666,8 +665,9 @@ SILFunction *swift::getEligibleFunction(FullApplySite AI,
   if (!SILInliner::canInline(AI))
     return nullptr;
 
-  auto ModuleName = Callee->getModule().getSwiftModule()->getName().str();
-  bool IsInStdlib = (ModuleName == STDLIB_NAME || ModuleName == SWIFT_ONONE_SUPPORT);
+  ModuleDecl *SwiftModule = Callee->getModule().getSwiftModule();
+  bool IsInStdlib = (SwiftModule->isStdlibModule() ||
+                     SwiftModule->isOnoneSupportModule());
 
   // Don't inline functions that are marked with the @_semantics or @_effects
   // attribute if the inliner is asked not to inline them.

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1029,33 +1029,6 @@ void Serializer::writeDocHeader() {
   }
 }
 
-static void
-removeDuplicateImports(SmallVectorImpl<ModuleDecl::ImportedModule> &imports) {
-  std::sort(imports.begin(), imports.end(),
-            [](const ModuleDecl::ImportedModule &lhs,
-               const ModuleDecl::ImportedModule &rhs) -> bool {
-    // Arbitrarily sort by name to get a deterministic order.
-    // FIXME: Submodules don't get sorted properly here.
-    if (lhs.second != rhs.second)
-      return lhs.second->getName().str() < rhs.second->getName().str();
-    using AccessPathElem = std::pair<Identifier, SourceLoc>;
-    return std::lexicographical_compare(lhs.first.begin(), lhs.first.end(),
-                                        rhs.first.begin(), rhs.first.end(),
-                                        [](const AccessPathElem &lElem,
-                                           const AccessPathElem &rElem) {
-      return lElem.first.str() < rElem.first.str();
-    });
-  });
-  auto last = std::unique(imports.begin(), imports.end(),
-                          [](const ModuleDecl::ImportedModule &lhs,
-                             const ModuleDecl::ImportedModule &rhs) -> bool {
-    if (lhs.second != rhs.second)
-      return false;
-    return ModuleDecl::isSameAccessPath(lhs.first, rhs.first);
-  });
-  imports.erase(last, imports.end());
-}
-
 using ImportPathBlob = llvm::SmallString<64>;
 static void flattenImportPath(const ModuleDecl::ImportedModule &import,
                               ImportPathBlob &out) {
@@ -1104,20 +1077,17 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
       SearchPath.emit(ScratchRecord, /*framework=*/false, /*system=*/false, path);
   }
 
-  // FIXME: Having to deal with private imports as a superset of public imports
-  // is inefficient.
-  SmallVector<ModuleDecl::ImportedModule, 8> publicImports;
   SmallVector<ModuleDecl::ImportedModule, 8> allImports;
-  for (auto file : M->getFiles()) {
-    file->getImportedModules(publicImports, ModuleDecl::ImportFilter::Public);
-    file->getImportedModules(allImports, ModuleDecl::ImportFilter::All);
-  }
+  M->getImportedModules(allImports, ModuleDecl::ImportFilter::All);
+  ModuleDecl::removeDuplicateImports(allImports);
 
-  llvm::SmallSet<ModuleDecl::ImportedModule, 8, ModuleDecl::OrderImportedModules>
-    publicImportSet;
+  // Collect the public imports as a subset so that we can mark them with an
+  // extra flag.
+  SmallVector<ModuleDecl::ImportedModule, 8> publicImports;
+  M->getImportedModules(publicImports, ModuleDecl::ImportFilter::Public);
+  llvm::SmallSet<ModuleDecl::ImportedModule, 8,
+                 ModuleDecl::OrderImportedModules> publicImportSet;
   publicImportSet.insert(publicImports.begin(), publicImports.end());
-
-  removeDuplicateImports(allImports);
 
   auto clangImporter =
     static_cast<ClangImporter *>(M->getASTContext().getClangModuleLoader());

--- a/test/ModuleInterface/Inputs/imports-clang-modules/A.h
+++ b/test/ModuleInterface/Inputs/imports-clang-modules/A.h
@@ -1,0 +1,1 @@
+void a(void);

--- a/test/ModuleInterface/Inputs/imports-clang-modules/B1.h
+++ b/test/ModuleInterface/Inputs/imports-clang-modules/B1.h
@@ -1,0 +1,1 @@
+void b1(void);

--- a/test/ModuleInterface/Inputs/imports-clang-modules/B2.h
+++ b/test/ModuleInterface/Inputs/imports-clang-modules/B2.h
@@ -1,0 +1,1 @@
+void b2(void);

--- a/test/ModuleInterface/Inputs/imports-clang-modules/B3.h
+++ b/test/ModuleInterface/Inputs/imports-clang-modules/B3.h
@@ -1,0 +1,1 @@
+void b2(void);

--- a/test/ModuleInterface/Inputs/imports-clang-modules/C.h
+++ b/test/ModuleInterface/Inputs/imports-clang-modules/C.h
@@ -1,0 +1,1 @@
+void c(void);

--- a/test/ModuleInterface/Inputs/imports-clang-modules/D.h
+++ b/test/ModuleInterface/Inputs/imports-clang-modules/D.h
@@ -1,0 +1,1 @@
+void d(void);

--- a/test/ModuleInterface/Inputs/imports-clang-modules/module.modulemap
+++ b/test/ModuleInterface/Inputs/imports-clang-modules/module.modulemap
@@ -1,0 +1,8 @@
+module A { header "A.h" }
+module B {
+  explicit module B1 { header "B1.h" }
+  explicit module B2 { header "B2.h" }
+  explicit module B3 { header "B3.h" }
+}
+module C { header "C.h" }
+module D { header "D.h" }

--- a/test/ModuleInterface/Inputs/imports-other.swift
+++ b/test/ModuleInterface/Inputs/imports-other.swift
@@ -1,0 +1,3 @@
+import A
+import B.B3
+import D

--- a/test/ModuleInterface/imports.swift
+++ b/test/ModuleInterface/imports.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t/empty.swiftmodule %S/../Inputs/empty.swift
+// RUN: %target-swift-frontend -emit-interface-path - -emit-module -o /dev/null %s %S/Inputs/imports-other.swift -I %S/Inputs/imports-clang-modules/ -I %t -verify | %FileCheck %s
+
+
+@_exported import empty
+import B.B2
+import func C.c // expected-warning {{scoped imports are not yet supported in textual module interfaces}}
+import D
+
+// CHECK-NOT: import
+// CHECK: {{^}}import A{{$}}
+// CHECK-NEXT: {{^}}import B{{$}}
+// CHECK-NEXT: {{^}}import B.B2{{$}}
+// CHECK-NEXT: {{^}}import B.B3{{$}}
+// CHECK-NEXT: {{^}}import C/*.c*/{{$}}
+// CHECK-NEXT: {{^}}import D{{$}}
+// CHECK-NEXT: {{^}}@_exported import empty{{$}}
+// CHECK-NOT: import


### PR DESCRIPTION
Part of preserving enough information to reconstitute a textual interface back to a binary module.