### PR TITLE
SwiftDemangle: link against LLVMSupport

### DIFF
--- a/lib/Demangling/CMakeLists.txt
+++ b/lib/Demangling/CMakeLists.txt
@@ -1,13 +1,15 @@
-add_swift_library(swiftDemangling STATIC
-  Demangler.cpp
-  Context.cpp
-  ManglingUtils.cpp
-  NodeDumper.cpp
-  NodePrinter.cpp
-  OldDemangler.cpp
-  OldRemangler.cpp
-  Punycode.cpp
-  Remangler.cpp
-  TypeDecoder.cpp
-  )
+add_swift_library(swiftDemangling
+                  STATIC
+                    Demangler.cpp
+                    Context.cpp
+                    ManglingUtils.cpp
+                    NodeDumper.cpp
+                    NodePrinter.cpp
+                    OldDemangler.cpp
+                    OldRemangler.cpp
+                    Punycode.cpp
+                    Remangler.cpp
+                    TypeDecoder.cpp
+                  C_COMPILE_FLAGS
+                    -DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1)
 

--- a/lib/SwiftDemangle/CMakeLists.txt
+++ b/lib/SwiftDemangle/CMakeLists.txt
@@ -1,7 +1,11 @@
-add_swift_library(swiftDemangle SHARED
-  SwiftDemangle.cpp
-  MangleHack.cpp
-  LINK_LIBRARIES swiftDemangling)
+add_swift_library(swiftDemangle
+                  SHARED
+                    SwiftDemangle.cpp
+                    MangleHack.cpp
+                  LINK_LIBRARIES
+                    swiftDemangling
+                  C_COMPILE_FLAGS
+                    -DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1)
 
 swift_install_in_component(compiler
     TARGETS swiftDemangle


### PR DESCRIPTION
Since this library uses ADT headers, it will pull in a dependency for
LLVMSupport (Error.cpp has the necessary variable declaration for ABI breaking
checks).  Ensure that the dependency is fulfilled.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
