### PR TITLE
fix AutoDiff indices again

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -99,12 +99,7 @@ struct SILReverseAutoDiffIndices {
   /*implicit*/ SILReverseAutoDiffIndices(unsigned source,
                                          ArrayRef<unsigned> parameters);
 
-  bool operator==(const SILReverseAutoDiffIndices &other) const {
-    return source == other.source &&
-        (parameters.size() >= other.parameters.size() ?
-            !parameters.test(other.parameters) :
-            !other.parameters.test(parameters));
-  }
+  bool operator==(const SILReverseAutoDiffIndices &other) const;
 
   void print(llvm::raw_ostream &s = llvm::outs()) const {
     s << "(source=" << source << " parameters=(";

--- a/lib/AST/AutoDiff.cpp
+++ b/lib/AST/AutoDiff.cpp
@@ -17,6 +17,9 @@ using namespace swift;
 
 SILReverseAutoDiffIndices::SILReverseAutoDiffIndices(
     unsigned source, ArrayRef<unsigned> parameters) : source(source) {
+  if (parameters.empty())
+    return;
+
   auto max = *std::max_element(parameters.begin(), parameters.end());
   this->parameters.resize(max + 1);
   int last = -1;
@@ -25,4 +28,18 @@ SILReverseAutoDiffIndices::SILReverseAutoDiffIndices(
     last = paramIdx;
     this->parameters.set(paramIdx);
   }
+}
+
+bool SILReverseAutoDiffIndices::operator==(
+    const SILReverseAutoDiffIndices &other) const {
+  if (source != other.source)
+    return false;
+
+  // The parameters are the same when they have exactly the same set bit
+  // indices, even if they have different sizes.
+  llvm::SmallBitVector buffer(std::max(parameters.size(),
+                                       other.parameters.size()));
+  buffer ^= parameters;
+  buffer ^= other.parameters;
+  return buffer.none();
 }

--- a/unittests/AST/CMakeLists.txt
+++ b/unittests/AST/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_swift_unittest(SwiftASTTests
   ArithmeticEvaluator.cpp
-  SILReverseAutoDiffIndices.cpp
   DiagnosticConsumerTests.cpp
+  SILReverseAutoDiffIndices.cpp
   SourceLocTests.cpp
   TestContext.cpp
   TypeMatchTests.cpp

--- a/unittests/AST/CMakeLists.txt
+++ b/unittests/AST/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_swift_unittest(SwiftASTTests
   ArithmeticEvaluator.cpp
+  SILReverseAutoDiffIndices.cpp
   DiagnosticConsumerTests.cpp
   SourceLocTests.cpp
   TestContext.cpp

--- a/unittests/AST/CMakeLists.txt
+++ b/unittests/AST/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_swift_unittest(SwiftASTTests
   ArithmeticEvaluator.cpp
   DiagnosticConsumerTests.cpp
+  # SWIFT_ENABLE_TENSORFLOW
   SILReverseAutoDiffIndices.cpp
   SourceLocTests.cpp
   TestContext.cpp

--- a/unittests/AST/SILReverseAutoDiffIndices.cpp
+++ b/unittests/AST/SILReverseAutoDiffIndices.cpp
@@ -1,0 +1,67 @@
+//===--- SILReverseAutoDiffIndices.cpp - Tests SILReverseAutoDiffIndices --===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/AutoDiff.h"
+#include "gtest/gtest.h"
+#include "llvm/Support/Debug.h"
+
+using namespace swift;
+
+TEST(SILReverseAutoDiffIndices, Equality) {
+  std::array<unsigned, 0> empty;
+  // Each example is distinct.
+  SILReverseAutoDiffIndices examples[] = {
+    {0, empty},
+    {1, empty},
+    {0, {0}},
+    {0, {0, 1}},
+    {0, {1}},
+    {0, {1, 2}},
+    {0, {100}},
+    {0, {0, 100}},
+    {0, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}}
+  };
+  size_t exampleCount = std::extent<decltype(examples)>::value;
+  for (size_t i = 0; i < exampleCount; ++i) {
+    auto example1 = examples[i];
+    auto grownExample1 = example1;
+    grownExample1.parameters.resize(grownExample1.parameters.size() + 1);
+
+    // Make sure that the grown example is actually grown.
+    EXPECT_TRUE(example1.parameters.size() < grownExample1.parameters.size());
+
+    // Test that the example is equal to itself and to the grown version of
+    // itself.
+    EXPECT_TRUE(example1 == example1);
+    EXPECT_TRUE(example1 == grownExample1);
+    EXPECT_TRUE(grownExample1 == example1);
+
+    // Test that the example is not equal to any of the others.
+    for (size_t j = i + 1; j < exampleCount; ++j) {
+      auto example2 = examples[j];
+      auto grownExample2 = example2;
+      grownExample2.parameters.resize(grownExample2.parameters.size() + 1);
+
+      // Make sure that the grown example is actually grown.
+      EXPECT_TRUE(example2.parameters.size() < grownExample2.parameters.size());
+
+      EXPECT_FALSE(example1 == example2);
+      EXPECT_FALSE(example2 == example1);
+
+      EXPECT_FALSE(example1 == grownExample2);
+      EXPECT_FALSE(grownExample2 == example1);
+
+      EXPECT_FALSE(example2 == grownExample1);
+      EXPECT_FALSE(grownExample1 == example2);
+    }
+  }
+}

--- a/unittests/AST/SILReverseAutoDiffIndices.cpp
+++ b/unittests/AST/SILReverseAutoDiffIndices.cpp
@@ -9,6 +9,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+// SWIFT_ENABLE_TENSORFLOW
 
 #include "swift/AST/AutoDiff.h"
 #include "gtest/gtest.h"

--- a/unittests/AST/SILReverseAutoDiffIndices.cpp
+++ b/unittests/AST/SILReverseAutoDiffIndices.cpp
@@ -12,7 +12,6 @@
 
 #include "swift/AST/AutoDiff.h"
 #include "gtest/gtest.h"
-#include "llvm/Support/Debug.h"
 
 using namespace swift;
 


### PR DESCRIPTION
My previous `operator==` fix in https://github.com/apple/swift/pull/19165 was wrong. Since it's so tricky, I added a unit test for it. The unit test caught a bug in a constructor, so I fixed that too.