### PR TITLE
Extended swift compiler and stdlib to support sending/receiving a VariantHandle (e.g. DataSet).

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -2717,9 +2717,8 @@ static SILValue createHostReceive(SILBuilder &B, SILLocation loc,
   // %4 = apply %2<Float>(..., %1, %3)
   auto tensorId = createIntValue(idNumber, B, loc);
 
-  LLVM_DEBUG(llvm::dbgs() << "Creating host receive with valueTy: ");
-  LLVM_DEBUG(valueTy.print(llvm::dbgs()));
-  LLVM_DEBUG(llvm::dbgs() << "\n");
+  LLVM_DEBUG(llvm::dbgs() << "Creating host receive with valueTy: " << valueTy
+                          << "\n");
 
   auto scalarType = getTensorHandleElementType(valueTy.getASTType());
   SubstitutionMap subMap;
@@ -2735,9 +2734,8 @@ static SILValue createHostReceive(SILBuilder &B, SILLocation loc,
   // The type can also be VariantHandle.
   auto tensorflowValueType =
       convertElementTypeToTensorValueType(valueTy).getASTType();
-  LLVM_DEBUG(llvm::dbgs() << "The created tensor type is: ");
-  LLVM_DEBUG(tensorflowValueType.print(llvm::dbgs()));
-  LLVM_DEBUG(llvm::dbgs() << "\n");
+  LLVM_DEBUG(llvm::dbgs() << "The created tensor type is: "
+                          << tensorflowValueType << "\n");
 
   auto metatypeType =
       MetatypeType::get(tensorflowValueType, MetatypeRepresentation::Thick)
@@ -2855,23 +2853,19 @@ static SILValue createHostSend(SILBuilder &B, SILLocation loc, SILValue value,
   auto &ctx = B.getASTContext();
   SubstitutionMap subMap;
   if (isOpaqueHandle(value->getType().getASTType())) {
-    LLVM_DEBUG(llvm::dbgs() << "Sending a variant typed tensor: ");
-    LLVM_DEBUG(value->print(llvm::dbgs()));
-    LLVM_DEBUG(llvm::dbgs() << "\n");
+    LLVM_DEBUG(llvm::dbgs()
+               << "Sending a variant typed tensor: " << value << "\n");
     // `subMap` should remain empty.
   } else if (isTensorHandle(value->getType().getASTType())) {
-    LLVM_DEBUG(llvm::dbgs() << "Sending a tensor handle typed tensor: ");
-    LLVM_DEBUG(value->print(llvm::dbgs()));
-    LLVM_DEBUG(llvm::dbgs() << "\n");
+    LLVM_DEBUG(llvm::dbgs()
+               << "Sending a tensor handle typed tensor: " << value << "\n");
 
     auto tensorValueTy = value->getType().getASTType();
     auto scalarValueTy = getTensorHandleElementType(tensorValueTy);
     subMap = getSingleSubstitutionMapForElementType(scalarValueTy,
                                                     B.getASTContext());
   } else {
-    LLVM_DEBUG(llvm::dbgs() << "Sending a scalar tensor: ");
-    LLVM_DEBUG(value->print(llvm::dbgs()));
-    LLVM_DEBUG(llvm::dbgs() << "\n");
+    LLVM_DEBUG(llvm::dbgs() << "Sending a scalar tensor: " << value << "\n");
 
     assert(createScalarTensorFn);
     // Here scalar type is something like $Builtin.FPIEEE32 -- convert it to an
@@ -2947,9 +2941,7 @@ SILFunction *PartitionCloner::lookupSendReceiveFunction(StringRef fnName,
                                                         SILType type,
                                                         SILLocation loc) {
   LLVM_DEBUG(llvm::dbgs() << "Looking up send/recv func " << fnName
-                          << " with type ");
-  LLVM_DEBUG(type.print(llvm::dbgs()));
-  LLVM_DEBUG(llvm::dbgs() << "\n");
+                          << " with type " << type << "\n");
 
   auto &ctx = FP.hostFn.getASTContext();
   // If `value` is not receivable, reject the program with diagnostics.

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -535,10 +535,10 @@ private class TFEState {
     let entryFunctionBaseName = String(cString: entryFunctionBaseNameAddress)
     debugLog("Looking up op(s) from func base name \(entryFunctionBaseName).")
     for i in 0...helperFunctionCount {
-      /// Also look up in the TensorFlow program a function name (op type) based
-      /// on the op name. e.g. given op name "tfc_func_S4mainyycfU_.tf", return
-      /// op type "S4mainyycfU_.tf_CPU.device_partition". TFE ops are created by
-      /// the op types.
+      // Also look up in the TensorFlow program a function name (op type) based
+      // on the op name. e.g. given op name "tfc_func_S4mainyycfU_.tf", return
+      // op type "S4mainyycfU_.tf_CPU.device_partition". TFE ops are created by
+      // the op types.
       var opName = "tfc_func_" + entryFunctionBaseName;
       if i > 0 {
         opName += "_helper_\(i-1)"
@@ -786,11 +786,11 @@ public final class _TensorComputation {
   /// The data structure to pass into pthread creation API.
   /// We cannot have the ThreadBody closure below close over on `threadIndex`,
   /// because ThreadBody is of C convention.
-  class ThreadParam {
-    public let computation: _TensorComputation
-    public let threadIndex: Int
-    
-    public init(computation: _TensorComputation, threadIndex: Int) {
+  private class ThreadParam {
+    let computation: _TensorComputation
+    let threadIndex: Int
+
+    init(computation: _TensorComputation, threadIndex: Int) {
       self.computation = computation
       self.threadIndex = threadIndex
     }

--- a/stdlib/public/TensorFlow/OpaqueHandles.swift
+++ b/stdlib/public/TensorFlow/OpaqueHandles.swift
@@ -52,8 +52,8 @@ extension VariantHandle : TensorSendableReceivable {
     debugLog("Receiving variant tensor of id \(tensorID).")
     let status = TF_NewStatus()
     let context = _ExecutionContext.global
-    let cTensorHandle! = TFE_DequeueVariantTensor(
-      context.eagerContext, Int32(tensorID), status)
+    let cTensorHandle: CTensorHandle! = TFE_DequeueNamedTensorFromCtx(
+      context.eagerContext, Int32(tensorID), TF_VARIANT, status)
     checkOk(status)
     TF_DeleteStatus(status)
     debugLog("Done receiving variant tensor of id \(tensorID).")
@@ -66,7 +66,7 @@ extension VariantHandle : TensorSendableReceivable {
     debugLog("Sending variant tensor of id \(tensorID).")
     let status = TF_NewStatus()
     let context = _ExecutionContext.global
-    TFE_EnqueueVariantTensor(
+    TFE_EnqueueNamedTensorFromCtx(
       context.eagerContext, Int32(tensorID), self.cTensorHandle, status)
     TF_DeleteStatus(status)
     debugLog("Done sending variant tensor of id \(tensorID).")

--- a/stdlib/public/TensorFlow/OpaqueHandles.swift
+++ b/stdlib/public/TensorFlow/OpaqueHandles.swift
@@ -14,6 +14,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import CTensorFlow
+
 /// `ResourceHandle` is the type used by ops and the `#tfop()` syntax to
 /// represent TensorFlow "resource" values.  It exists only to represent edges
 /// in TensorFlow graphs, and has no host-side representation (and thus no
@@ -25,11 +27,56 @@ public final class ResourceHandle {
 }
 
 /// `VariantHandle` is the type used by ops and the `#tfop()` syntax to
-/// represent TensorFlow "variant" values.  It exists only to represent edges
-/// in TensorFlow graphs, and has no host-side representation (and thus no
-/// methods).
+/// represent TensorFlow "variant" values.
+/// TODO: rename this source file as this is no longer "opaque".
 public final class VariantHandle {
-  private init() {
-    fatalError("VariantHandle is a marker type that can never be created")
+  public let cTensorHandle: CTensorHandle
+
+  @usableFromInline
+  init(owning cTensorHandle: CTensorHandle) {
+    self.cTensorHandle = cTensorHandle
+  }
+
+  deinit {
+    debugLog("De-initializing TensorHandle.")
+    TFE_DeleteTensorHandle(cTensorHandle)
+    debugLog("Returning from deinit of VariantHandle.")
+  }
+}
+
+extension VariantHandle : TensorSendableReceivable {
+  @inlinable
+  static func receiveFromAccelerator(_ computation: _TensorComputation,
+                                     _ tensorID: Int
+  ) -> VariantHandle {
+    debugLog("Receiving variant tensor of id \(tensorID).")
+    let status = TF_NewStatus()
+    let context = _ExecutionContext.global
+    let cTensorHandle! = TFE_DequeueVariantTensor(
+      context.eagerContext, Int32(tensorID), status)
+    checkOk(status)
+    TF_DeleteStatus(status)
+    debugLog("Done receiving variant tensor of id \(tensorID).")
+    return VariantHandle(owning: cTensorHandle)    
+  }
+
+  @inlinable
+  func sendToAccelerator(_ computation: _TensorComputation,
+                         _ tensorID: Int) {
+    debugLog("Sending variant tensor of id \(tensorID).")
+    let status = TF_NewStatus()
+    let context = _ExecutionContext.global
+    TFE_EnqueueVariantTensor(
+      context.eagerContext, Int32(tensorID), self.cTensorHandle, status)
+    TF_DeleteStatus(status)
+    debugLog("Done sending variant tensor of id \(tensorID).")
+  }
+
+  // TODO: remove this dummy Scalar typealias, currently required in order to
+  // conform to TensorSendableReceivable.
+  typealias Scalar = Float
+  @inlinable
+  static func scalar(_ scalar: Scalar) -> VariantHandle {
+    fatalError("Unsupported");
   }
 }

--- a/stdlib/public/TensorFlow/OpaqueHandles.swift
+++ b/stdlib/public/TensorFlow/OpaqueHandles.swift
@@ -46,8 +46,9 @@ public final class VariantHandle {
 
 extension VariantHandle : TensorSendableReceivable {
   @inlinable
-  static func receiveFromAccelerator(_ computation: _TensorComputation,
-                                     _ tensorID: Int
+  static func receiveFromAccelerator(
+    _ computation: _TensorComputation,
+    _ tensorID: Int
   ) -> VariantHandle {
     debugLog("Receiving variant tensor of id \(tensorID).")
     let status = TF_NewStatus()
@@ -77,6 +78,6 @@ extension VariantHandle : TensorSendableReceivable {
   typealias Scalar = Float
   @inlinable
   static func scalar(_ scalar: Scalar) -> VariantHandle {
-    fatalError("Unsupported");
+    fatalError("Unsupported")
   }
 }

--- a/test/TensorFlowRuntime/dataset_global.swift
+++ b/test/TensorFlowRuntime/dataset_global.swift
@@ -1,0 +1,41 @@
+// TODO: Revert to %target-run-simple-swift once we complete send/recv support for resource/variant tensors.
+// RUN: %target-run-send-recv-handle-swift
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize
+
+// This file contains testing over a dataset as a global variable. This requires
+// sends/recvs support for variant handles.
+
+import TensorFlow
+import TensorFlowUnittest
+import StdlibUnittest
+
+var DatasetGlobalTests = TestSuite("DatasetGlobal")
+
+let scalars = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1)
+let dataset = Dataset(elements: scalars)
+
+// This stmt makes sure the store inst into the global var `dataset` does not
+// make dataset a return tensor.
+//
+// It can be removed when we convert return tensors to TF->Swift tensor
+// transfers.
+_ = Tensor<Float>(0.0)
+
+DatasetGlobalTests.testCPUOrGPU("DataSetAsGlobalVar") {
+  // This stmt makes sure the load inst from the global var `dataset` does not
+  // make dataset an input arg tensor.
+  //
+  // It can be removed when we convert arg tensors to Swift->TF tensor
+  // transfers.
+  _ = scalars + scalars
+
+  var expectedVal: Float = 0.0
+  for item in dataset {
+    _hostOp(item)
+    expectNearlyEqualWithScalarTensor(expectedVal, item)
+    expectedVal += 1.0
+  }
+}
+
+runAllTests()

--- a/test/TensorFlowRuntime/dataset_global.swift
+++ b/test/TensorFlowRuntime/dataset_global.swift
@@ -31,7 +31,7 @@ let dataset = Dataset(elements: scalars)
 // transfers.
 _ = Tensor<Float>(0.0)
 
-DatasetGlobalTests.testCPUOrGPU("DataSetAsGlobalVar") {
+DatasetGlobalTests.testCPUOrGPU("DatasetAsGlobalVar") {
   // This stmt makes sure the load inst from the global var `dataset` does not
   // make dataset an input arg tensor.
   //

--- a/test/TensorFlowRuntime/dataset_global.swift
+++ b/test/TensorFlowRuntime/dataset_global.swift
@@ -12,7 +12,16 @@ import StdlibUnittest
 
 var DatasetGlobalTests = TestSuite("DatasetGlobal")
 
-let scalars = Tensor<Float>(rangeFrom: 0, to: 5, stride: 1)
+// TODO: add GPU support -- in device partitioning, maybe sure we do not do tensor
+// transfer for variant / resource ops.
+// The current error is:
+// Fatal error: No unary variant device copy function found for direction: 1 and Variant type_name: tensorflow::DatasetVariantWrapper
+#if !CUDA
+
+// Global code must turn on eager mode explicitly (until when we change the
+// default mode to eager).
+_RuntimeConfig.usesTFEagerAPI = true
+let scalars = Tensor<Float>([0, 1, 2])
 let dataset = Dataset(elements: scalars)
 
 // This stmt makes sure the store inst into the global var `dataset` does not
@@ -37,5 +46,7 @@ DatasetGlobalTests.testCPUOrGPU("DataSetAsGlobalVar") {
     expectedVal += 1.0
   }
 }
+
+#endif // !CUDA
 
 runAllTests()

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -724,6 +724,8 @@ if run_vendor == 'apple':
             config.target_run_simple_swift = (
                 "%s %%s" % (target_run_base))
             # SWIFT_ENABLE_TENSORFLOW
+            config.target_run_simple_swift_send_recv_handle = (
+                "%s %%s -Xllvm -tf-send-recv-opaque-handle" % (target_run_base))
             config.target_run_simple_swift_sese_loops = (
                 "%s %%s -Xllvm -tf-ensure-single-loop-exit" % (target_run_base))
             config.target_run_simple_swiftgyb = (
@@ -844,6 +846,8 @@ elif run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'wi
         config.target_run_simple_swift = (
             '%s %%s' % (target_run_base))
         # SWIFT_ENABLE_TENSORFLOW
+        config.target_run_simple_swift_send_recv_handle = (
+            "%s %%s -Xllvm -tf-send-recv-opaque-handle" % (target_run_base))
         config.target_run_simple_swift_sese_loops = (
             '%s %%s -Xllvm -tf-ensure-single-loop-exit' % (target_run_base))
         config.target_run_simple_swiftgyb = (
@@ -1023,6 +1027,12 @@ if not getattr(config, 'target_run_simple_swift', None):
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
     # SWIFT_ENABLE_TENSORFLOW
+    config.target_run_simple_swift_send_recv_handle = (
+        '%%empty-directory(%%t) && '
+        '%s %s %%s -Xllvm -tf-send-recv-opaque-handle -o %%t/a.out -module-name main %s && '
+        '%s %%t/a.out &&'
+        '%s %%t/a.out'
+        % (config.target_build_swift, mcp_opt, swift_tensorflow_extra_options, config.target_codesign, config.target_run))
     config.target_run_simple_swift_sese_loops = (
         '%%empty-directory(%%t) && '
         '%s %s %%s -Xllvm -tf-ensure-single-loop-exit -o %%t/a.out -module-name main %s && '
@@ -1166,6 +1176,7 @@ config.substitutions.append(('%target-run-simple-swiftgyb', config.target_run_si
 config.substitutions.append(('%target-run-simple-swift-swift3', config.target_run_simple_swift_swift3))
 config.substitutions.append(('%target-run-simple-swift', config.target_run_simple_swift))
 # SWIFT_ENABLE_TENSORFLOW
+config.substitutions.append(('%target-run-send-recv-handle-swift', config.target_run_simple_swift_send_recv_handle))
 config.substitutions.append(('%target-run-sese-loops-swift', config.target_run_simple_swift_sese_loops))
 config.substitutions.append(('%target-run-simple-opt-O-swift', config.target_run_simple_opt_O_swift))
 config.substitutions.append(('%target-run-simple-opt-Osize-swift', config.target_run_simple_opt_Osize_swift))


### PR DESCRIPTION
This is done by using eager API to send/receive tensor handles. Variant (and
resource) handles can be enqueued / dequeued via a fifo queue, but cannot be
fetched (e.g. cannot retrieve the value via TF_SessionRun()). Fetching the
their pointers via TFE_Execute() however works.

Added a temp commandline flag to enable this new feature, so that the work on
migrating existing unit tests can be scoped out of this PR.

Also, sends/recvs support of resource handles will be added in a later PR.

Also addressed additional feedback from rxwei@ on the prior PR https://github.com/apple/swift/pull/19182.
