### PR TITLE
IRGen: Refuse to compute witness table layouts of resilient protocols

### DIFF
--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -943,47 +943,25 @@ emitKeyPathComponent(IRGenModule &IGM,
 
         auto dc = declRef.getDecl()->getDeclContext();
 
-        // If the method context is resilient, use the dispatch thunk as a
-        // stable identifier for the storage.
-        if (IGM.isResilient(cast<NominalTypeDecl>(dc),
+        // We can use a method descriptor if we have a class or resilient
+        // protocol.
+        if (isa<ClassDecl>(dc) ||
+            IGM.isResilient(cast<NominalTypeDecl>(dc),
                             ResilienceExpansion::Minimal)) {
           idKind = KeyPathComponentHeader::Pointer;
-          idValue = IGM.getAddrOfDispatchThunk(declRef, NotForDefinition);
+          idValue = IGM.getAddrOfMethodDescriptor(declRef, NotForDefinition);
           idResolved = true;
           break;
         }
       
         idKind = KeyPathComponentHeader::VTableOffset;
-        if (isa<ClassDecl>(dc) && !cast<ClassDecl>(dc)->isForeign()) {
-          auto declaringClass =
-            cast<ClassDecl>(declRef.getDecl()->getDeclContext());
-          auto &metadataLayout = IGM.getClassMetadataLayout(declaringClass);
-
-          // For a class method, we don't necessarily need the absolute offset,
-          // only an offset that's unique to this method. For a class with
-          // resilient ancestry, all of the superclass methods will be
-          // identified by their dispatch thunk (see above), so we can use
-          // relative offsets from the dynamic base offset to identify the local
-          // class's own methods.
-          auto methodInfo = metadataLayout.getMethodOffsetInfo(declRef);
-          Size offset;
-          if (methodInfo.isStatic())
-            offset = methodInfo.getStaticOffset();
-          else
-            offset = methodInfo.getRelativeOffset();
-
-          idValue = llvm::ConstantInt::get(IGM.SizeTy, offset.getValue());
-          idResolved = true;
-        } else if (auto methodProto = dyn_cast<ProtocolDecl>(dc)) {
-          auto &protoInfo = IGM.getProtocolInfo(methodProto,
-                                                ProtocolInfoKind::Full);
-          auto index = protoInfo.getFunctionIndex(
-                               cast<AbstractFunctionDecl>(declRef.getDecl()));
-          idValue = llvm::ConstantInt::get(IGM.SizeTy, -index.getValue());
-          idResolved = true;
-        } else {
-          llvm_unreachable("neither a class nor protocol dynamic method?");
-        }
+        auto methodProto = cast<ProtocolDecl>(dc);
+        auto &protoInfo = IGM.getProtocolInfo(methodProto,
+                                              ProtocolInfoKind::Full);
+        auto index = protoInfo.getFunctionIndex(
+                             cast<AbstractFunctionDecl>(declRef.getDecl()));
+        idValue = llvm::ConstantInt::get(IGM.SizeTy, -index.getValue());
+        idResolved = true;
       }
       break;
     }

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1207,7 +1207,7 @@ llvm::Value *uniqueForeignWitnessTableRef(IRGenFunction &IGF,
     ArrayRef<SILWitnessTable::Entry> SILEntries;
     ArrayRef<SILWitnessTable::ConditionalConformance>
         SILConditionalConformances;
-    const ProtocolInfo &PI;
+
     Optional<FulfillmentMap> Fulfillments;
     SmallVector<std::pair<size_t, const ConformanceInfo *>, 4>
       SpecializedBaseConformances;
@@ -1217,8 +1217,10 @@ llvm::Value *uniqueForeignWitnessTableRef(IRGenFunction &IGF,
     // Conditional conformances and metadata caches are stored at negative
     // offsets, with conditional conformances closest to 0.
     unsigned NextPrivateDataIndex = 0;
+    bool ResilientConformance;
     bool RequiresSpecialization = false;
-    bool ResilientConformance = false;
+
+    const ProtocolInfo &PI;
 
   public:
     WitnessTableBuilder(IRGenModule &IGM, ConstantArrayBuilder &table,
@@ -1234,13 +1236,14 @@ llvm::Value *uniqueForeignWitnessTableRef(IRGenFunction &IGF,
                                                          Conformance.getDeclContext())),
           SILEntries(SILWT->getEntries()),
           SILConditionalConformances(SILWT->getConditionalConformances()),
+          ResilientConformance(isResilientConformance(&Conformance)),
           PI(IGM.getProtocolInfo(SILWT->getConformance()->getProtocol(),
-                                 ProtocolInfoKind::Full)) {
+                                 (ResilientConformance
+                                  ? ProtocolInfoKind::RequirementSignature
+                                  : ProtocolInfoKind::Full))) {
       // If the conformance is resilient, we require runtime instantiation.
-      if (isResilientConformance(&Conformance)) {
+      if (ResilientConformance)
         RequiresSpecialization = true;
-        ResilientConformance = true;
-      }
     }
 
     /// The top-level entry point.
@@ -2107,6 +2110,10 @@ void IRGenModule::ensureRelativeSymbolCollocation(SILWitnessTable &wt) {
 /// Do a memoized witness-table layout for a protocol.
 const ProtocolInfo &IRGenModule::getProtocolInfo(ProtocolDecl *protocol,
                                                  ProtocolInfoKind kind) {
+  // If the protocol is resilient, we cannot know the full witness table layout.
+  assert(!isResilient(protocol, ResilienceExpansion::Maximal) ||
+         kind == ProtocolInfoKind::RequirementSignature);
+
   return Types.getProtocolInfo(protocol, kind);
 }
 

--- a/lib/IRGen/GenThunk.cpp
+++ b/lib/IRGen/GenThunk.cpp
@@ -120,3 +120,13 @@ llvm::GlobalValue *IRGenModule::defineMethodDescriptor(SILDeclRef declRef,
   auto entity = LinkEntity::forMethodDescriptor(declRef);
   return defineAlias(entity, definition);
 }
+
+/// Get or create a method descriptor variable.
+llvm::Constant *
+IRGenModule::getAddrOfMethodDescriptor(SILDeclRef declRef,
+                                       ForDefinition_t forDefinition) {
+  assert(forDefinition == NotForDefinition);
+  LinkEntity entity = LinkEntity::forMethodDescriptor(declRef);
+  return getAddrOfLLVMVariable(entity, Alignment(4), forDefinition,
+                               MethodDescriptorStructTy, DebugTypeInfo());
+}

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1153,7 +1153,8 @@ public:
   llvm::GlobalValue *defineMethodDescriptor(SILDeclRef declRef,
                                             NominalTypeDecl *nominalDecl,
                                             llvm::Constant *definition);
-
+  llvm::Constant *getAddrOfMethodDescriptor(SILDeclRef declRef,
+                                            ForDefinition_t forDefinition);
 
   Address getAddrOfEnumCase(EnumElementDecl *Case,
                             ForDefinition_t forDefinition);

--- a/lib/IRGen/MetadataLayout.cpp
+++ b/lib/IRGen/MetadataLayout.cpp
@@ -399,16 +399,6 @@ ClassMetadataLayout::getMethodInfo(IRGenFunction &IGF, SILDeclRef method) const{
   return MethodInfo(offset);
 }
 
-MetadataLayout::StoredOffset
-ClassMetadataLayout::getMethodOffsetInfo(SILDeclRef method) const {
-  return getStoredMethodInfo(method).TheOffset;
-}
-
-Offset
-ClassMetadataLayout::getVTableOffset(IRGenFunction &IGF) const {
-  return emitOffset(IGF, VTableOffset);
-}
-
 Offset ClassMetadataLayout::getFieldOffset(IRGenFunction &IGF,
                                            VarDecl *field) const {
   return emitOffset(IGF, getStoredFieldOffset(field));

--- a/lib/IRGen/MetadataLayout.h
+++ b/lib/IRGen/MetadataLayout.h
@@ -239,19 +239,7 @@ public:
 
   Size getInstanceAlignMaskOffset() const;
 
-  /// Returns the start of the vtable in the class metadata.
-  Offset getVTableOffset(IRGenFunction &IGF) const;
-
-  /// Returns the size of the vtable, in words.
-  unsigned getVTableSize() const {
-    return MethodInfos.size();
-  }
-
   MethodInfo getMethodInfo(IRGenFunction &IGF, SILDeclRef method) const;
-
-  /// Return the information necessary to compute the offset of a method's
-  /// vtable entry in the class object.
-  StoredOffset getMethodOffsetInfo(SILDeclRef method) const;
 
   Offset getFieldOffset(IRGenFunction &IGF, VarDecl *field) const;
 

--- a/test/IRGen/class_resilience.swift
+++ b/test/IRGen/class_resilience.swift
@@ -397,20 +397,6 @@ extension ResilientGenericOutsideParent {
 // CHECK:       ret %swift.type* [[GENERIC_PARAM]]
 
 
-// ResilientChild.field getter dispatch thunk
-
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @"$S16class_resilience14ResilientChildC5fields5Int32VvgTj"(%T16class_resilience14ResilientChildC* swiftself)
-// CHECK:      [[ISA_ADDR:%.*]] = getelementptr inbounds %T16class_resilience14ResilientChildC, %T16class_resilience14ResilientChildC* %0, i32 0, i32 0, i32 0
-// CHECK-NEXT: [[ISA:%.*]] = load %swift.type*, %swift.type** [[ISA_ADDR]]
-// CHECK-NEXT: [[BASE:%.*]] = load [[INT]], [[INT]]* getelementptr inbounds ([[BOUNDS]], [[BOUNDS]]* @"$S16class_resilience14ResilientChildCMo", i32 0, i32 0)
-// CHECK-NEXT: [[METADATA_BYTES:%.*]] = bitcast %swift.type* [[ISA]] to i8*
-// CHECK-NEXT: [[VTABLE_OFFSET_TMP:%.*]] = getelementptr inbounds i8, i8* [[METADATA_BYTES]], [[INT]] [[BASE]]
-// CHECK-NEXT: [[VTABLE_OFFSET_ADDR:%.*]] = bitcast i8* [[VTABLE_OFFSET_TMP]] to i32 (%T16class_resilience14ResilientChildC*)**
-// CHECK-NEXT: [[METHOD:%.*]] = load i32 (%T16class_resilience14ResilientChildC*)*, i32 (%T16class_resilience14ResilientChildC*)** [[VTABLE_OFFSET_ADDR]]
-// CHECK-NEXT: [[RESULT:%.*]] = call swiftcc i32 [[METHOD]](%T16class_resilience14ResilientChildC* swiftself %0)
-// CHECK-NEXT: ret i32 [[RESULT]]
-
-
 // ClassWithResilientProperty metadata initialization function
 
 // CHECK-LABEL: define internal swiftcc %swift.metadata_response @"$S16class_resilience26ClassWithResilientPropertyCMr"(%swift.type*, i8*, i8**)
@@ -439,7 +425,7 @@ extension ResilientGenericOutsideParent {
 // CHECK-native:      [[FIELD_OFFSET:%.*]] = load [[INT]], [[INT]]* {{.*}}
 // CHECK-native-NEXT: store [[INT]] [[FIELD_OFFSET]], [[INT]]* @"$S16class_resilience26ClassWithResilientPropertyC5colors5Int32VvpWvd"
 
-// CHECK: br label %metadata-dependencies.cont
+// CHECK:      br label %metadata-dependencies.cont
 
 // CHECK: metadata-dependencies.cont:
 
@@ -514,6 +500,20 @@ extension ResilientGenericOutsideParent {
 // CHECK-NEXT: [[T0:%.*]] = insertvalue %swift.metadata_response undef, %swift.type* [[PENDING_METADATA]], 0
 // CHECK-NEXT: [[T1:%.*]] = insertvalue %swift.metadata_response [[T0]], [[INT]] [[NEW_STATUS]], 1
 // CHECK-NEXT: ret %swift.metadata_response [[T1]]
+
+
+// ResilientChild.field getter dispatch thunk
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @"$S16class_resilience14ResilientChildC5fields5Int32VvgTj"(%T16class_resilience14ResilientChildC* swiftself)
+// CHECK:      [[ISA_ADDR:%.*]] = getelementptr inbounds %T16class_resilience14ResilientChildC, %T16class_resilience14ResilientChildC* %0, i32 0, i32 0, i32 0
+// CHECK-NEXT: [[ISA:%.*]] = load %swift.type*, %swift.type** [[ISA_ADDR]]
+// CHECK-NEXT: [[BASE:%.*]] = load [[INT]], [[INT]]* getelementptr inbounds ([[BOUNDS]], [[BOUNDS]]* @"$S16class_resilience14ResilientChildCMo", i32 0, i32 0)
+// CHECK-NEXT: [[METADATA_BYTES:%.*]] = bitcast %swift.type* [[ISA]] to i8*
+// CHECK-NEXT: [[VTABLE_OFFSET_TMP:%.*]] = getelementptr inbounds i8, i8* [[METADATA_BYTES]], [[INT]] [[BASE]]
+// CHECK-NEXT: [[VTABLE_OFFSET_ADDR:%.*]] = bitcast i8* [[VTABLE_OFFSET_TMP]] to i32 (%T16class_resilience14ResilientChildC*)**
+// CHECK-NEXT: [[METHOD:%.*]] = load i32 (%T16class_resilience14ResilientChildC*)*, i32 (%T16class_resilience14ResilientChildC*)** [[VTABLE_OFFSET_ADDR]]
+// CHECK-NEXT: [[RESULT:%.*]] = call swiftcc i32 [[METHOD]](%T16class_resilience14ResilientChildC* swiftself %0)
+// CHECK-NEXT: ret i32 [[RESULT]]
 
 
 // ResilientChild.field setter dispatch thunk

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -171,10 +171,10 @@ sil_vtable C {}
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
 //              -- instantiable in-line, size 16
 // CHECK-32-SAME: <i32 0x8000_0010>,
-// -- computed, settable, nonmutating, identified by vtable, no args
-// CHECK-SAME: <i32 0x0250_0000>,
+// -- computed, settable, nonmutating, identified by pointer, no args
+// CHECK-SAME: <i32 0x0240_0000>,
 // CHECK-64-SAME: [4 x i8] zeroinitializer,
-// CHECK-SAME: [[WORD]]
+// CHECK-SAME: %swift.method_descriptor* getelementptr inbounds (<{{.*}}>, <{{.*}}>* @"$S8keypaths1CCMn", i32 0, i32 13),
 // CHECK-SAME: void (%TSi*, %T8keypaths1CC**)* @l_get,
 // CHECK-SAME: void (%TSi*, %T8keypaths1CC**)* @l_set }>
 


### PR DESCRIPTION
It's not correct to depend on the order of entries in a witness table
if the protocol is resilient, so don't even try.