### PR TITLE
Add serialization/deserialization support for designated protocols fo…

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6283,6 +6283,12 @@ public:
         DesignatedProtocolName(DesignatedProtocolName),
         DesignatedProtocolNameLoc(DesignatedProtocolNameLoc) {}
 
+  OperatorDecl(DeclKind kind, DeclContext *DC, SourceLoc OperatorLoc,
+               Identifier Name, SourceLoc NameLoc,
+               ProtocolDecl *DesignatedProtocol)
+      : Decl(kind, DC), OperatorLoc(OperatorLoc), NameLoc(NameLoc), name(Name),
+        DesignatedProtocol(DesignatedProtocol) {}
+
   SourceLoc getLoc() const { return NameLoc; }
 
   SourceLoc getOperatorLoc() const { return OperatorLoc; }
@@ -6333,6 +6339,15 @@ public:
         SecondIdentifierLoc(secondIdentifierLoc),
         FirstIdentifier(firstIdentifier), SecondIdentifier(secondIdentifier) {}
 
+  InfixOperatorDecl(DeclContext *DC, SourceLoc operatorLoc, Identifier name,
+                    SourceLoc nameLoc, SourceLoc colonLoc,
+                    Identifier firstIdentifier, SourceLoc firstIdentifierLoc,
+                    ProtocolDecl *designatedProtocol)
+      : OperatorDecl(DeclKind::InfixOperator, DC, operatorLoc, name, nameLoc,
+                     designatedProtocol),
+        ColonLoc(colonLoc), FirstIdentifierLoc(firstIdentifierLoc),
+        FirstIdentifier(firstIdentifier) {}
+
   SourceLoc getEndLoc() const {
     if (!SecondIdentifier.empty())
       return SecondIdentifierLoc;
@@ -6381,6 +6396,11 @@ public:
       : OperatorDecl(DeclKind::PrefixOperator, DC, OperatorLoc, Name, NameLoc,
                      DesignatedProtocolName, DesignatedProtocolNameLoc) {}
 
+  PrefixOperatorDecl(DeclContext *DC, SourceLoc OperatorLoc, Identifier Name,
+                     SourceLoc NameLoc, ProtocolDecl *DesignatedProtocol)
+      : OperatorDecl(DeclKind::PrefixOperator, DC, OperatorLoc, Name, NameLoc,
+                     DesignatedProtocol) {}
+
   SourceRange getSourceRange() const {
     return { getOperatorLoc(), getNameLoc() };
   }
@@ -6409,6 +6429,11 @@ public:
                       SourceLoc DesignatedProtocolNameLoc = SourceLoc())
       : OperatorDecl(DeclKind::PostfixOperator, DC, OperatorLoc, Name, NameLoc,
                      DesignatedProtocolName, DesignatedProtocolNameLoc) {}
+
+  PostfixOperatorDecl(DeclContext *DC, SourceLoc OperatorLoc, Identifier Name,
+                      SourceLoc NameLoc, ProtocolDecl *DesignatedProtocol)
+      : OperatorDecl(DeclKind::PostfixOperator, DC, OperatorLoc, Name, NameLoc,
+                     DesignatedProtocol) {}
 
   SourceRange getSourceRange() const {
     return { getOperatorLoc(), getNameLoc() };

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -55,7 +55,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t VERSION_MINOR = 441; // Last change: remove end_borrow src arg
+const uint16_t VERSION_MINOR = 442; // Last change: operator protocol
 
 using DeclIDField = BCFixed<31>;
 
@@ -1089,8 +1089,9 @@ namespace decls_block {
   template <unsigned Code>
   using UnaryOperatorLayout = BCRecordLayout<
     Code, // ID field
-    IdentifierIDField, // name
-    DeclContextIDField // context decl
+    IdentifierIDField,  // name
+    DeclContextIDField, // context decl
+    DeclIDField         // protocol
   >;
 
   using PrefixOperatorLayout = UnaryOperatorLayout<PREFIX_OPERATOR_DECL>;
@@ -1100,7 +1101,8 @@ namespace decls_block {
     INFIX_OPERATOR_DECL,
     IdentifierIDField, // name
     DeclContextIDField,// context decl
-    DeclIDField        // precedence group
+    DeclIDField,       // precedence group
+    DeclIDField        // protocol
   >;
 
   using PrecedenceGroupLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2819,10 +2819,11 @@ void Serializer::writeDecl(const Decl *D) {
     auto contextID = addDeclContextRef(op->getDeclContext());
     auto nameID = addDeclBaseNameRef(op->getName());
     auto groupID = addDeclRef(op->getPrecedenceGroup());
+    auto protoID = addDeclRef(op->getDesignatedProtocol());
 
     unsigned abbrCode = DeclTypeAbbrCodes[InfixOperatorLayout::Code];
-    InfixOperatorLayout::emitRecord(Out, ScratchRecord, abbrCode,
-                                    nameID, contextID, groupID);
+    InfixOperatorLayout::emitRecord(Out, ScratchRecord, abbrCode, nameID,
+                                    contextID, groupID, protoID);
     break;
   }
 
@@ -2831,11 +2832,12 @@ void Serializer::writeDecl(const Decl *D) {
     verifyAttrSerializable(op);
 
     auto contextID = addDeclContextRef(op->getDeclContext());
+    auto protoID = addDeclRef(op->getDesignatedProtocol());
 
     unsigned abbrCode = DeclTypeAbbrCodes[PrefixOperatorLayout::Code];
     PrefixOperatorLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                      addDeclBaseNameRef(op->getName()),
-                                     contextID);
+                                     contextID, protoID);
     break;
   }
 
@@ -2844,11 +2846,12 @@ void Serializer::writeDecl(const Decl *D) {
     verifyAttrSerializable(op);
 
     auto contextID = addDeclContextRef(op->getDeclContext());
+    auto protoID = addDeclRef(op->getDesignatedProtocol());
 
     unsigned abbrCode = DeclTypeAbbrCodes[PostfixOperatorLayout::Code];
     PostfixOperatorLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                       addDeclBaseNameRef(op->getName()),
-                                      contextID);
+                                      contextID, protoID);
     break;
   }
 


### PR DESCRIPTION
…r operators.

Parsing for these protocols in operator declarations is gated by
-enable-operator-designated-protocols (added in
https://github.com/apple/swift/pull/19145).
