### PR TITLE
Parser: calculating interface hash only for primary files.

### DIFF
--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -128,6 +128,7 @@ void CompilerInstance::recordPrimaryInputBuffer(unsigned BufID) {
 void CompilerInstance::recordPrimarySourceFile(SourceFile *SF) {
   assert(MainModule && "main module not created yet");
   PrimarySourceFiles.push_back(SF);
+  SF->enableInterfaceHash();
   SF->createReferencedNameTracker();
   if (SF->getBufferID().hasValue())
     recordPrimaryInputBuffer(SF->getBufferID().getValue());

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -117,8 +117,8 @@ bool swift::parseIntoSourceFile(SourceFile &SF,
   Parser P(BufferID, SF, SIL ? SIL->Impl.get() : nullptr, PersistentState);
   PrettyStackTraceParser StackTrace(P);
 
-  llvm::SaveAndRestore<bool> S(P.IsParsingInterfaceTokens, true);
-
+  llvm::SaveAndRestore<bool> S(P.IsParsingInterfaceTokens,
+                               SF.hasInterfaceHash());
   if (DelayedParseCB)
     P.setDelayedParsingCallbacks(DelayedParseCB);
 

--- a/test/InterfaceHash/added_function.swift
+++ b/test/InterfaceHash/added_function.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
-// RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/a.swift 2> %t/a.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/b.swift 2> %t/b.hash
 // RUN: not cmp %t/a.hash %t/b.hash
 
 // BEGIN a.swift

--- a/test/InterfaceHash/added_localfunc.swift
+++ b/test/InterfaceHash/added_localfunc.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
-// RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/a.swift 2> %t/a.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/b.swift 2> %t/b.hash
 // RUN: cmp %t/a.hash %t/b.hash
 
 // BEGIN a.swift

--- a/test/InterfaceHash/added_method.swift
+++ b/test/InterfaceHash/added_method.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
-// RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/a.swift 2> %t/a.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/b.swift 2> %t/b.hash
 // RUN: not cmp %t/a.hash %t/b.hash
 
 // BEGIN a.swift

--- a/test/InterfaceHash/added_private_class_private_property.swift
+++ b/test/InterfaceHash/added_private_class_private_property.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
-// RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/a.swift 2> %t/a.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/b.swift 2> %t/b.hash
 // RUN: not cmp %t/a.hash %t/b.hash
 
 // BEGIN a.swift

--- a/test/InterfaceHash/added_private_class_property.swift
+++ b/test/InterfaceHash/added_private_class_property.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
-// RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/a.swift 2> %t/a.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/b.swift 2> %t/b.hash
 // RUN: not cmp %t/a.hash %t/b.hash
 
 // BEGIN a.swift

--- a/test/InterfaceHash/added_private_enum_private_property.swift
+++ b/test/InterfaceHash/added_private_enum_private_property.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
-// RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/a.swift 2> %t/a.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/b.swift 2> %t/b.hash
 // RUN: not cmp %t/a.hash %t/b.hash
 
 // BEGIN a.swift

--- a/test/InterfaceHash/added_private_enum_property.swift
+++ b/test/InterfaceHash/added_private_enum_property.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
-// RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/a.swift 2> %t/a.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/b.swift 2> %t/b.hash
 // RUN: not cmp %t/a.hash %t/b.hash
 
 // BEGIN a.swift

--- a/test/InterfaceHash/added_private_method.swift
+++ b/test/InterfaceHash/added_private_method.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
-// RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/a.swift 2> %t/a.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/b.swift 2> %t/b.hash
 // RUN: not cmp %t/a.hash %t/b.hash
 
 // BEGIN a.swift

--- a/test/InterfaceHash/added_private_method_value_types.swift
+++ b/test/InterfaceHash/added_private_method_value_types.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
-// RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/a.swift 2> %t/a.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/b.swift 2> %t/b.hash
 // RUN: not cmp %t/a.hash %t/b.hash
 
 // BEGIN a.swift

--- a/test/InterfaceHash/added_private_protocol_method.swift
+++ b/test/InterfaceHash/added_private_protocol_method.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
-// RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/a.swift 2> %t/a.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/b.swift 2> %t/b.hash
 // RUN: not cmp %t/a.hash %t/b.hash
 
 // BEGIN a.swift

--- a/test/InterfaceHash/added_private_protocol_property.swift
+++ b/test/InterfaceHash/added_private_protocol_property.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
-// RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/a.swift 2> %t/a.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/b.swift 2> %t/b.hash
 // RUN: not cmp %t/a.hash %t/b.hash
 
 // BEGIN a.swift

--- a/test/InterfaceHash/added_private_struct_private_property.swift
+++ b/test/InterfaceHash/added_private_struct_private_property.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
-// RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/a.swift 2> %t/a.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/b.swift 2> %t/b.hash
 // RUN: not cmp %t/a.hash %t/b.hash
 
 // BEGIN a.swift

--- a/test/InterfaceHash/added_private_struct_property.swift
+++ b/test/InterfaceHash/added_private_struct_property.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
-// RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/a.swift 2> %t/a.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/b.swift 2> %t/b.hash
 // RUN: not cmp %t/a.hash %t/b.hash
 
 // BEGIN a.swift

--- a/test/InterfaceHash/changed_private_var_type.swift
+++ b/test/InterfaceHash/changed_private_var_type.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
-// RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/a.swift 2> %t/a.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/b.swift 2> %t/b.hash
 // RUN: not cmp %t/a.hash %t/b.hash
 
 // BEGIN a.swift

--- a/test/InterfaceHash/changed_var_name.swift
+++ b/test/InterfaceHash/changed_var_name.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
-// RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/a.swift 2> %t/a.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/b.swift 2> %t/b.hash
 // RUN: not cmp %t/a.hash %t/b.hash
 
 // BEGIN a.swift

--- a/test/InterfaceHash/changed_var_type.swift
+++ b/test/InterfaceHash/changed_var_type.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
-// RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/a.swift 2> %t/a.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/b.swift 2> %t/b.hash
 // RUN: not cmp %t/a.hash %t/b.hash
 
 // BEGIN a.swift

--- a/test/InterfaceHash/edited_function_body.swift
+++ b/test/InterfaceHash/edited_function_body.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
-// RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/a.swift 2> %t/a.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/b.swift 2> %t/b.hash
 // RUN: cmp %t/a.hash %t/b.hash
 
 // BEGIN a.swift

--- a/test/InterfaceHash/edited_method_body.swift
+++ b/test/InterfaceHash/edited_method_body.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
-// RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/a.swift 2> %t/a.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/b.swift 2> %t/b.hash
 // RUN: cmp %t/a.hash %t/b.hash
 
 // BEGIN a.swift

--- a/test/InterfaceHash/edited_property_getter.swift
+++ b/test/InterfaceHash/edited_property_getter.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
-// RUN: %target-swift-frontend -dump-interface-hash %t/a.swift 2> %t/a.hash
-// RUN: %target-swift-frontend -dump-interface-hash %t/b.swift 2> %t/b.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/a.swift 2> %t/a.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/b.swift 2> %t/b.hash
 // RUN: cmp %t/a.hash %t/b.hash
 
 // BEGIN a.swift


### PR DESCRIPTION
Per discussion we had in https://github.com/apple/swift/pull/19192, we only need to collect interface hashes for primary files. This change allows parser to consume tokens out of order for non-primary files.