### PR TITLE
 [Associated type inference] Never infer a type involving archetypes and interface types

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -2163,8 +2163,7 @@ static void rewriteFunction(StructLoweringState &pass,
       break;
     }
     case SILInstructionKind::WitnessMethodInst: {
-      auto *WMI = dyn_cast<WitnessMethodInst>(instr);
-      assert(WMI && "ValueKind is Witness Method but dyn_cast failed");
+      auto *WMI = cast<WitnessMethodInst>(instr);
       newInstr = methodBuilder.createWitnessMethod(
           loc, WMI->getLookupType(), WMI->getConformance(), member, newSILType);
       break;

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -700,11 +700,11 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitness(ValueDecl *req,
       if (!inferredType->isMaterializable())
         return true;
 
-      // If the type contains both a type parameter and an archetype,
-      // there is nothing we can infer from it.
+      // If the type contains a type parameter, there is nothing we can infer
+      // from it.
       // FIXME: This is a weird state introduced by associated type inference
       // that should not exist.
-      if (inferredType->hasTypeParameter() && inferredType->hasArchetype())
+      if (inferredType->hasTypeParameter())
         return true;
 
       auto proto = Conformance->getProtocol();

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -700,6 +700,13 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitness(ValueDecl *req,
       if (!inferredType->isMaterializable())
         return true;
 
+      // If the type contains both a type parameter and an archetype,
+      // there is nothing we can infer from it.
+      // FIXME: This is a weird state introduced by associated type inference
+      // that should not exist.
+      if (inferredType->hasTypeParameter() && inferredType->hasArchetype())
+        return true;
+
       auto proto = Conformance->getProtocol();
       if (auto assocType = getReferencedAssocTypeOfProtocol(firstDepMember,
                                                             proto)) {

--- a/validation-test/compiler_crashers_2_fixed/0172-rdar-44235762.swift
+++ b/validation-test/compiler_crashers_2_fixed/0172-rdar-44235762.swift
@@ -1,0 +1,20 @@
+// RUN: not %target-swift-frontend -typecheck %s
+
+// Was crashing in associated type inference.
+
+protocol P {
+  associatedtype Assoc
+
+  subscript(i: Int) -> Assoc { get }
+  func f() -> Assoc
+}
+
+struct X<T, U> { }
+
+extension P {
+  subscript<T>(i: T) -> X<T, Self> { return X<T, Self>() }
+  func f<T>() -> X<T, Self> { return X<T, Self> }
+}
+
+struct Y<T>: P { }
+


### PR DESCRIPTION
Works around an oddity of the associated type inference when the
potential witness is generic and returns (e.g.) Self.

Associated type inference needs to move off of archetypes for the
implementation to become sane. For now, this eliminates a crash.

Fixes rdar://problem/43591024.