### PR TITLE
 [Type checker] Make sure we have a generic signature when inheriting initializers.

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5536,6 +5536,8 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
       }
 
       // We have a designated initializer. Create an override of it.
+      // FIXME: Validation makes sure we get a generic signature here.
+      validateDecl(classDecl);
       if (auto ctor = createDesignatedInitOverride(
                         *this, classDecl, superclassCtor, kind)) {
         Context.addSynthesizedDecl(ctor);

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1106,7 +1106,7 @@ bool swift::checkOverrides(ValueDecl *decl) {
       return false;
     }
 
-    // Try to match with the
+    // Try to match with this attempt kind.
     matches = matcher.match(attempt);
     if (!matches.empty())
       break;

--- a/test/multifile/Inputs/inherited-inits-other.swift
+++ b/test/multifile/Inputs/inherited-inits-other.swift
@@ -1,0 +1,7 @@
+class A {
+  init(foo: Int) { }
+  init(other: Int) { }
+}
+
+
+class B<T>: A { }

--- a/test/multifile/inherited-inits.swift
+++ b/test/multifile/inherited-inits.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -typecheck -primary-file %s %S/Inputs/inherited-inits-other.swift -verify
+
+// expected-no-diagnostics
+
+// Test that we get the generic signature right (which is needed for the
+// super.init to properly type-check) when it comes from another source
+// file (rdar://problem/44235762).
+class C: B<Int> {
+  override init(foo: Int) {
+    super.init(foo: foo)
+  }
+}


### PR DESCRIPTION
Before adding implicit initializers synthesizes a new initializer, make sure that
we’ve validated the current class declaration to determine it’s generic signature.

Fixes rdar://problem/44235762.