### PR TITLE
move some tensor ops out of extensions

### DIFF
--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -49,38 +49,40 @@
 // Elementwise binary
 //===----------------------------------------------------------------------===//
 
-extension Tensor where Scalar : Numeric {
-  @inlinable
-  static func _adjointAdd(
-    _ x: Tensor, _ y: Tensor, originalValue: Tensor, seed: Tensor
-  ) -> (Tensor, Tensor) {
-    let seed = seed.broadcast(like: originalValue)
-    return (seed.unbroadcast(like: x), seed.unbroadcast(like: y))
-  }
+/// TODO(SR-8699): Move this back into an extension of Tensor.
+@inlinable
+func _adjointAdd<T: Numeric>(
+  _ x: Tensor<T>, _ y: Tensor<T>, originalValue: Tensor<T>, seed: Tensor<T>
+) -> (Tensor<T>, Tensor<T>) {
+  let seed = seed.broadcast(like: originalValue)
+  return (seed.unbroadcast(like: x), seed.unbroadcast(like: y))
+}
 
-  @inlinable
-  static func _adjointSubtract(
-    _ x: Tensor, _ y: Tensor, originalValue: Tensor, seed: Tensor
-  ) -> (Tensor, Tensor) {
-    let seed = seed.broadcast(like: originalValue)
-    return (seed.unbroadcast(like: x), 0 - seed.unbroadcast(like: y))
-  }
+/// TODO(SR-8699): Move this back into an extension of Tensor.
+@inlinable
+func _adjointSubtract<T: Numeric>(
+  _ x: Tensor<T>, _ y: Tensor<T>, originalValue: Tensor<T>, seed: Tensor<T>
+) -> (Tensor<T>, Tensor<T>) {
+  let seed = seed.broadcast(like: originalValue)
+  return (seed.unbroadcast(like: x), 0 - seed.unbroadcast(like: y))
+}
 
-  @inlinable
-  static func _adjointMultiply(
-    _ x: Tensor, _ y: Tensor, originalValue: Tensor, seed: Tensor
-  ) -> (Tensor, Tensor) {
-    return ((y * seed).unbroadcast(like: x),
-            (x * seed).unbroadcast(like: y))
-  }
+/// TODO(SR-8699): Move this back into an extension of Tensor.
+@inlinable
+func _adjointMultiply<T: Numeric>(
+  _ x: Tensor<T>, _ y: Tensor<T>, originalValue: Tensor<T>, seed: Tensor<T>
+) -> (Tensor<T>, Tensor<T>) {
+  return ((y * seed).unbroadcast(like: x),
+          (x * seed).unbroadcast(like: y))
+}
 
-  @inlinable
-  static func _adjointDivide(
-    _ x: Tensor, _ y: Tensor, originalValue: Tensor, seed: Tensor
-  ) -> (Tensor, Tensor) {
-    return ((seed / y).unbroadcast(like: x),
-            ((0 - x) / y.squared() * seed).unbroadcast(like: y))
-  }
+/// TODO(SR-8699): Move this back into an extension of Tensor.
+@inlinable
+func _adjointDivide<T: Numeric>(
+  _ x: Tensor<T>, _ y: Tensor<T>, originalValue: Tensor<T>, seed: Tensor<T>
+) -> (Tensor<T>, Tensor<T>) {
+  return ((seed / y).unbroadcast(like: x),
+          ((0 - x) / y.squared() * seed).unbroadcast(like: y))
 }
 
 @inlinable
@@ -105,13 +107,12 @@ func _adjointPow<T : BinaryFloatingPoint>(
 // Elementwise unary
 //===----------------------------------------------------------------------===//
 
-extension Tensor where Scalar : SignedNumeric {
-  @inlinable
-  static func _adjointNegate(
-    _ x: Tensor, originalValue: Tensor, seed: Tensor
-  ) -> Tensor {
-    return -seed.broadcast(like: originalValue)
-  }
+/// TODO(SR-8699): Move this back into an extension of Tensor.
+@inlinable
+func _adjointNegate<T: SignedNumeric>(
+  _ x: Tensor<T>, originalValue: Tensor<T>, seed: Tensor<T>
+) -> Tensor<T> {
+  return -seed.broadcast(like: originalValue)
 }
 
 @inlinable

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -65,7 +65,7 @@ public extension Tensor where Scalar : Numeric {
 /// TODO(SR-8699): Move this back into the extension.
 @inlinable @inline(__always)
 @differentiable(reverse, adjoint: _adjointAdd(_:_:originalValue:seed:))
-public func +<T: Numeric> (lhs: Tensor<T>, rhs: Tensor<T>) -> Tensor<T> {
+public func + <T: Numeric> (lhs: Tensor<T>, rhs: Tensor<T>) -> Tensor<T> {
   return Raw.add(lhs, rhs)
 }
 
@@ -74,7 +74,7 @@ public func +<T: Numeric> (lhs: Tensor<T>, rhs: Tensor<T>) -> Tensor<T> {
 /// TODO(SR-8699): Move this back into the extension.
 @inlinable @inline(__always)
 @differentiable(reverse, adjoint: _adjointSubtract(_:_:originalValue:seed:))
-public func -<T: Numeric> (lhs: Tensor<T>, rhs: Tensor<T>) -> Tensor<T> {
+public func - <T: Numeric> (lhs: Tensor<T>, rhs: Tensor<T>) -> Tensor<T> {
   return Raw.sub(lhs, rhs)
 }
 
@@ -83,7 +83,7 @@ public func -<T: Numeric> (lhs: Tensor<T>, rhs: Tensor<T>) -> Tensor<T> {
 /// TODO(SR-8699): Move this back into the extension.
 @inlinable @inline(__always)
 @differentiable(reverse, adjoint: _adjointMultiply(_:_:originalValue:seed:))
-public func *<T: Numeric> (lhs: Tensor<T>, rhs: Tensor<T>) -> Tensor<T> {
+public func * <T: Numeric> (lhs: Tensor<T>, rhs: Tensor<T>) -> Tensor<T> {
   return Raw.mul(lhs, rhs)
 }
 
@@ -148,7 +148,7 @@ extension Tensor : DifferentiableVectorNumeric
 /// TODO(SR-8699): Move this back into the extension.
 @inlinable @inline(__always)
 @differentiable(reverse, adjoint: _adjointDivide(_:_:originalValue:seed:))
-public func /<T: Numeric> (lhs: Tensor<T>, rhs: Tensor<T>) -> Tensor<T> {
+public func / <T: Numeric> (lhs: Tensor<T>, rhs: Tensor<T>) -> Tensor<T> {
   return Raw.div(lhs, rhs)
 }
 
@@ -282,7 +282,7 @@ infix operator • : MultiplicationPrecedence
 /// TODO(SR-8699): Move this back into an extension of Tensor.
 @inlinable @inline(__always)
 @differentiable(reverse, adjoint: _adjointMatmul(_:_:originalValue:seed:))
-public func •<T: Numeric> (lhs: Tensor<T>, rhs: Tensor<T>) -> Tensor<T> {
+public func • <T: Numeric> (lhs: Tensor<T>, rhs: Tensor<T>) -> Tensor<T> {
   return matmul(lhs, rhs)
 }
 
@@ -587,7 +587,7 @@ public extension Tensor {
 /// TODO(SR-8699): Move this back into an extension of Tensor.
 @inlinable @inline(__always)
 @differentiable(reverse, adjoint: _adjointNegate(_:originalValue:seed:))
-public prefix func -<T: SignedNumeric> (rhs: Tensor<T>) -> Tensor<T> {
+public prefix func - <T: SignedNumeric> (rhs: Tensor<T>) -> Tensor<T> {
   return Raw.neg(rhs)
 }
 

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -60,6 +60,33 @@ public extension Tensor where Scalar : Numeric {
 // Vector numeric properties and element-wise arithmetics
 //===----------------------------------------------------------------------===//
 
+/// Adds two tensors and produces their sum.
+/// - Note: `+` supports broadcasting.
+/// TODO(SR-8699): Move this back into the extension.
+@inlinable @inline(__always)
+@differentiable(reverse, adjoint: _adjointAdd(_:_:originalValue:seed:))
+public func +<T: Numeric> (lhs: Tensor<T>, rhs: Tensor<T>) -> Tensor<T> {
+  return Raw.add(lhs, rhs)
+}
+
+/// Subtracts one tensor from another and produces their difference.
+/// - Note: `-` supports broadcasting.
+/// TODO(SR-8699): Move this back into the extension.
+@inlinable @inline(__always)
+@differentiable(reverse, adjoint: _adjointSubtract(_:_:originalValue:seed:))
+public func -<T: Numeric> (lhs: Tensor<T>, rhs: Tensor<T>) -> Tensor<T> {
+  return Raw.sub(lhs, rhs)
+}
+
+/// Multiplies two tensors and produces their product.
+/// - Note: `*` supports broadcasting.
+/// TODO(SR-8699): Move this back into the extension.
+@inlinable @inline(__always)
+@differentiable(reverse, adjoint: _adjointMultiply(_:_:originalValue:seed:))
+public func *<T: Numeric> (lhs: Tensor<T>, rhs: Tensor<T>) -> Tensor<T> {
+  return Raw.mul(lhs, rhs)
+}
+
 extension Tensor : VectorNumeric where Scalar : Numeric {
   public typealias ScalarElement = Scalar
   public typealias Dimensionality = TensorShape
@@ -67,30 +94,6 @@ extension Tensor : VectorNumeric where Scalar : Numeric {
   @inlinable @inline(__always)
   public init(dimensionality: TensorShape, repeating repeatedValue: Scalar) {
     self.init(shape: dimensionality, repeating: repeatedValue)
-  }
-
-  /// Adds two tensors and produces their sum.
-  /// - Note: `+` supports broadcasting.
-  @inlinable @inline(__always)
-  @differentiable(reverse, adjoint: _adjointAdd(_:_:originalValue:seed:))
-  public static func + (lhs: Tensor, rhs: Tensor) -> Tensor {
-    return Raw.add(lhs, rhs)
-  }
-
-  /// Subtracts one tensor from another and produces their difference.
-  /// - Note: `-` supports broadcasting.
-  @inlinable @inline(__always)
-  @differentiable(reverse, adjoint: _adjointSubtract(_:_:originalValue:seed:))
-  public static func - (lhs: Tensor, rhs: Tensor) -> Tensor {
-    return Raw.sub(lhs, rhs)
-  }
-
-  /// Multiplies two tensors and produces their product.
-  /// - Note: `*` supports broadcasting.
-  @inlinable @inline(__always)
-  @differentiable(reverse, adjoint: _adjointMultiply(_:_:originalValue:seed:))
-  public static func * (lhs: Tensor, rhs: Tensor) -> Tensor {
-    return Raw.mul(lhs, rhs)
   }
 
   /// Adds the scalar to every scalar of the tensor and produces the sum.
@@ -140,6 +143,15 @@ extension Tensor : DifferentiableVectorNumeric
   public typealias Cotangent = Tensor
 }
 
+/// Returns the quotient of dividing the first tensor by the second.
+/// - Note: `/` supports broadcasting.
+/// TODO(SR-8699): Move this back into the extension.
+@inlinable @inline(__always)
+@differentiable(reverse, adjoint: _adjointDivide(_:_:originalValue:seed:))
+public func /<T: Numeric> (lhs: Tensor<T>, rhs: Tensor<T>) -> Tensor<T> {
+  return Raw.div(lhs, rhs)
+}
+
 public extension Tensor where Scalar : Numeric {
   /// Adds two tensors and stores the result in the left-hand-side variable.
   /// - Note: `+=` supports broadcasting.
@@ -183,14 +195,6 @@ public extension Tensor where Scalar : Numeric {
   @inlinable @inline(__always)
   static func *= (lhs: inout Tensor, rhs: Scalar) {
     lhs = lhs * rhs
-  }
-
-  /// Returns the quotient of dividing the first tensor by the second.
-  /// - Note: `/` supports broadcasting.
-  @inlinable @inline(__always)
-  @differentiable(reverse, adjoint: _adjointDivide(_:_:originalValue:seed:))
-  static func / (lhs: Tensor, rhs: Tensor) -> Tensor {
-    return Raw.div(lhs, rhs)
   }
 
   /// Returns the quotient of dividing the scalar by the tensor, broadcasting
@@ -273,13 +277,13 @@ public func matmul<Scalar : Numeric>(
 
 infix operator • : MultiplicationPrecedence
 
-public extension Tensor where Scalar : Numeric {
-  /// Performs matrix multiplication between two tensors and produces the
-  /// result.
-  @inlinable @inline(__always)
-  static func • (lhs: Tensor, rhs: Tensor) -> Tensor {
-    return matmul(lhs, rhs)
-  }
+/// Performs matrix multiplication between two tensors and produces the
+/// result.
+/// TODO(SR-8699): Move this back into an extension of Tensor.
+@inlinable @inline(__always)
+@differentiable(reverse, adjoint: _adjointMatmul(_:_:originalValue:seed:))
+public func •<T: Numeric> (lhs: Tensor<T>, rhs: Tensor<T>) -> Tensor<T> {
+  return matmul(lhs, rhs)
 }
 
 //===----------------------------------------------------------------------===//
@@ -579,13 +583,12 @@ public extension Tensor {
 @_exported import func Glibc.powf
 #endif
 
-public extension Tensor where Scalar : SignedNumeric {
-  /// Computes the negation of the specified tensor element-wise.
-  @inlinable @inline(__always)
-  @differentiable(reverse, adjoint: _adjointNegate(_:originalValue:seed:))
-  static prefix func - (rhs: Tensor) -> Tensor {
-    return Raw.neg(rhs)
-  }
+/// Computes the negation of the specified tensor element-wise.
+/// TODO(SR-8699): Move this back into an extension of Tensor.
+@inlinable @inline(__always)
+@differentiable(reverse, adjoint: _adjointNegate(_:originalValue:seed:))
+public prefix func -<T: SignedNumeric> (rhs: Tensor<T>) -> Tensor<T> {
+  return Raw.neg(rhs)
 }
 
 /// Computes the absolute value of the specified tensor element-wise.

--- a/test/TensorFlow/adjoint_expr_type_checking.swift
+++ b/test/TensorFlow/adjoint_expr_type_checking.swift
@@ -9,9 +9,10 @@ func testSpecialized(_ t: Tensor<Float>) {
   _ = #adjoint(relu)(t, originalValue: t, seed: t)
   _ = #adjoint(sin)(t, originalValue: t, seed: t)
 
-  _ = #adjoint(Tensor<Float>.+)
-  let _: (Tensor<Float>, Tensor<Float>, Tensor<Float>, Tensor<Float>) -> (Tensor<Float>, Tensor<Float>)
-    = #adjoint(Tensor.+)
+  // TODO(SR-8699): Uncomment these.
+  // _ = #adjoint(Tensor<Float>.+)
+  // let _: (Tensor<Float>, Tensor<Float>, Tensor<Float>, Tensor<Float>) -> (Tensor<Float>, Tensor<Float>)
+  //   = #adjoint(Tensor.+)
 
   _ = #adjoint(Tensor<Float>.convolved2D)
   let _: (Tensor<Float>) -> (Tensor<Float>, (Int32, Int32, Int32, Int32), Padding, Tensor<Float>, Tensor<Float>) -> (Tensor<Float>, Tensor<Float>)
@@ -22,9 +23,10 @@ func testGeneric<T : BinaryFloatingPoint>( _ t: Tensor<T>) {
   let _ = #adjoint(relu)(t, originalValue: t, seed: t)
   let _ = #adjoint(sin)(t, originalValue: t, seed: t)
 
-  _ = #adjoint(Tensor<T>.+)
-  let _: (Tensor<T>, Tensor<T>, Tensor<T>, Tensor<T>) -> (Tensor<T>, Tensor<T>)
-    = #adjoint(Tensor.+)
+  // TODO(SR-8699): Uncomment these.
+  // _ = #adjoint(Tensor<T>.+)
+  // let _: (Tensor<T>, Tensor<T>, Tensor<T>, Tensor<T>) -> (Tensor<T>, Tensor<T>)
+  //   = #adjoint(Tensor.+)
 
   _ = #adjoint(Tensor<T>.convolved2D)
   let _: (Tensor<T>) -> (Tensor<T>, (Int32, Int32, Int32, Int32), Padding, Tensor<T>, Tensor<T>) -> (Tensor<T>, Tensor<T>)
@@ -36,7 +38,8 @@ func testLabels<T : BinaryFloatingPoint>(_ t: Tensor<T>) {
   // necessary.
   // This matches the behavior for normal function application.
   _ = #adjoint(matmul)(t, t, originalValue: t, seed: t)
-  _ = #adjoint(Tensor.+)(t, t, originalValue: t, seed: t)
+  // TODO(SR-8699): Uncomment this.
+  // _ = #adjoint(Tensor.+)(t, t, originalValue: t, seed: t)
   _ = #adjoint(Tensor.batchNormalized)(t)(
     alongAxis: 0, offset: 0, scale: 0, epsilon: 0, originalValue: t, seed: t
   )
@@ -46,8 +49,9 @@ func testLabels<T : BinaryFloatingPoint>(_ t: Tensor<T>) {
   let dMatmul: (Tensor<T>, Tensor<T>, Tensor<T>, Tensor<T>) -> (Tensor<T>, Tensor<T>)
     = #adjoint(matmul)
   _ = dMatmul(t, t, t, t)
-  let dAdd = #adjoint(Tensor<T>.+)
-  _ = dAdd(t, t, t, t)
+  // TODO(SR-8699): Uncomment these.
+  // let dAdd = #adjoint(Tensor<T>.+)
+  // _ = dAdd(t, t, t, t)
   let dBatchNorm = #adjoint(Tensor<T>.batchNormalized)
   _ = dBatchNorm(t)(0, 0, 0, 0, t, t)
 }

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -11,9 +11,14 @@ import TensorFlowUnittest
 var TensorADTests = TestSuite("TensorAD")
 
 TensorADTests.testAllBackends("SimpleAdjointCall") {
-  let adjPlus = #adjoint(Tensor<Float>.+)
-  let x = Tensor<Float>(1)
-  let (d0, d1) = adjPlus(x, x, x + x, x)
+  let adjMatmul: (
+    Tensor<Float>,
+    Tensor<Float>,
+    Tensor<Float>,
+    Tensor<Float>
+  ) -> (Tensor<Float>, Tensor<Float>) = #adjoint(matmul)
+  let x = Tensor<Float>([[1]])
+  let (d0, d1) = adjMatmul(x, x, x, x)
   expectNearlyEqual(1, d0.scalarized())
   expectNearlyEqual(1, d1.scalarized())
 }


### PR DESCRIPTION
This lets AD differentiate functions containing these ops before we fix SR-8699.

This only moves the static differentiable functions out of the extensions. Rewriting the few nonstatic differentiable functions (e.g. `transposed`, `convolved2D`) sounds like a bunch of throwaway work, so I did not do that.