### PR TITLE
[TF] Fix macOS build caused by changes to runtime pthread code path

### DIFF
--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -908,7 +908,7 @@ public final class _TensorComputation {
           return nil
         }
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-        var newThread: pthread_t?
+        var newThread: pthread_t!
 #else
         var newThread = pthread_t()
 #endif


### PR DESCRIPTION
macOS build was broken since #19182. Linux and macOS have different `pthread_create` type signatures.