### PR TITLE
[CMake] Stop compiling API notes files to a binary format

### DIFF
--- a/apinotes/README.md
+++ b/apinotes/README.md
@@ -6,75 +6,12 @@ original Objective-C headers. This semantic information can then be
 used by the Swift compiler when importing the corresponding Objective-C
 module to provide a better mapping of Objective-C APIs into Swift.
 
-API notes are organized into a set of `.apinotes` files. Each
-`.apinotes` file contains annotations for a single Objective-C module,
-written in YAML (FIXME: to be) described below. These YAML sources
-must be manually compiled into a binary representation (`.apinotesc`)
-that the Swift compiler will lazily load when it builds code, also
+API notes are organized into a set of `.apinotes` files. Each `.apinotes` file
+contains annotations for a single Objective-C module, written in YAML (FIXME:
+to be) described in the Clang repository. These YAML sources are lazily loaded
+by the Swift compiler when it imports the corresponding framework, also
 described below.
-
-# API Notes YAML Format
-
-TBD...
-
-# Compiling API notes
-
-The Swift compiler lazily loads API notes from compiled API notes
-files (`.apinotesc` files) and uses these annotations to affect the
-Swift signatures of imported Objective-C APIs. Compiled API notes
-files reside in the Swift module directory, i.e., the same directory
-where the `.swiftmodule` file would reside for the Swift overlay of
-that module. For system modules, the path depends on the platform
-and architecture.
-
-Platform  | Path
-:------------- | :-------------
-  macOS | `$SWIFT_EXEC/lib/swift/macosx/`
-  iOS (32-bit) | `$SWIFT_EXEC/lib/swift/iphoneos/32`
-  iOS (64-bit) | `$SWIFT_EXEC/lib/swift/iphoneos`
-  iOS Simulator (32-bit) | `$SWIFT_EXEC/lib/swift/iphonesimulator/32`
-  iOS Simulator (64-bit) | `$SWIFT_EXEC/lib/swift/iphonesimulator`
-
-where `$SWIFT_EXEC/bin/swift` is the path to the Swift compiler
-executable.
-
-When updating API notes for a system module, recompile the API notes
-and place the result in the appropriate directories listed above. The
-Swift compiler itself need not be recompiled except in rare cases
-where the changes affect how the SDK overlays are built. To recompile
-API notes for a given module `$MODULE` and place them into their
-
-### macOS
-```
-xcrun swift -apinotes -yaml-to-binary -target x86_64-apple-macosx10.10 -o $SWIFT_EXEC/lib/swift/macosx/$MODULE.apinotesc $MODULE.apinotes
-```
-
-### iOS (32-bit)
-```
-xcrun swift -apinotes -yaml-to-binary -target armv7-apple-ios7.0 -o $SWIFT_EXEC/lib/swift/iphoneos/32/$MODULE.apinotesc $MODULE.apinotes
-```
-
-### iOS (64-bit)
-```
-xcrun swift -apinotes -yaml-to-binary -target arm64-apple-ios7.0 -o $SWIFT_EXEC/lib/swift/iphoneos/$MODULE.apinotesc $MODULE.apinotes
-```
-
-### iOS Simulator (32-bit)
-```
-xcrun swift -apinotes -yaml-to-binary -target i386-apple-ios7.0 -o $SWIFT_EXEC/lib/swift/iphonesimulator/32/$MODULE.apinotesc $MODULE.apinotes
-```
-
-### iOS Simulator (64-bit)
-```
-xcrun swift -apinotes -yaml-to-binary -target x86_64-apple-ios7.0 -o $SWIFT_EXEC/lib/swift/iphonesimulator/$MODULE.apinotesc $MODULE.apinotes
-```
 
 To add API notes for a system module `$MODULE` that does not have them yet,
 create a new source file `$MODULE.apinotes` and update CMakeLists.txt.
 Updated API notes will be found by the build system during the next build.
-
-Note that Swift provides decompilation of binary API notes files via
-the `-apinotes -binary-to-yaml` option, which allows one to inspect
-the information the compiler is using internally. The order of the
-entities in the original YAML input is not preserved, so all entities
-in the resulting YAML output are sorted alphabetically.

--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -354,16 +354,14 @@ function(_compile_swift_files
   set(apinote_files)
 
   foreach(apinote_module ${SWIFTFILE_API_NOTES})
-    set(apinote_file "${module_dir}/${apinote_module}.apinotesc")
+    set(apinote_file "${module_dir}/${apinote_module}.apinotes")
     set(apinote_input_file
       "${SWIFT_API_NOTES_PATH}/${apinote_module}.apinotes")
 
     list(APPEND command_create_apinotes
       COMMAND
-      "${swift_compiler_tool}" "-apinotes" "-yaml-to-binary"
-      "-o" "${apinote_file}"
-      "-target" "${SWIFT_SDK_${SWIFTFILE_SDK}_ARCH_${SWIFTFILE_ARCHITECTURE}_TRIPLE}"
-      "${apinote_input_file}")
+      "${CMAKE_COMMAND}" "-E" "copy_if_different"
+      "${apinote_input_file}" "${apinote_file}")
     list(APPEND depends_create_apinotes "${apinote_input_file}")
 
     list(APPEND apinote_files "${apinote_file}")
@@ -447,10 +445,9 @@ function(_compile_swift_files
         COMMAND ""
         OUTPUT ${apinotes_outputs}
         DEPENDS
-          ${swift_compiler_tool_dep}
           ${depends_create_apinotes}
           ${obj_dirs_dependency_target}
-        COMMENT "Generating API notes ${first_output}")
+        COMMENT "Copying API notes for ${first_output}")
   endif()
 
   # Then we can compile both the object files and the swiftmodule files


### PR DESCRIPTION
Clang's been able to read the textual format for a long time, and indeed that's what's used in the SDK. This isn't even really a performance win because the information is cached in PCMs.

rdar://problem/34293901