### PR TITLE
Parser: Ignore and recover marked parse position during on-demand member parsing.

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -185,6 +185,11 @@ void PersistentParserState::parseMembers(IterableDeclContext *IDC) {
     return;
   SourceFile &SF = *IDC->getDecl()->getDeclContext()->getParentSourceFile();
   unsigned BufferID = *SF.getBufferID();
+  // MarkedPos is not useful for delayed parsing because we know where we should
+  // jump the parser to. However, we should recover the MarkedPos here in case
+  // the PersistentParserState will be used to continuously parse the rest of
+  // the file linearly.
+  llvm::SaveAndRestore<ParserPosition> Pos(MarkedPos, ParserPosition());
   Parser TheParser(BufferID, SF, nullptr, this);
   // Disable libSyntax creation in the delayed parsing.
   TheParser.SyntaxContext->disable();

--- a/test/Parse/delayed_extension.swift
+++ b/test/Parse/delayed_extension.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift -swift-version 4
+
+extension X { } // expected-error {{use of undeclared type 'X'}}
+_ = 1
+f() // expected-error {{use of unresolved identifier 'f'}}


### PR DESCRIPTION
New construction of a parser instance will reset the marked parser
position in PersistentParserState. We should recover the marked parser
position during on-demand parsing in case the marked position will be
later used to create another parser instance to continue parsing
linearly.

This patch fixes an infinite loop error found by @DougGregor .