### PR TITLE
[SE-0211] Emoji properties require ICU 57 or later

### DIFF
--- a/stdlib/public/core/UnicodeScalarProperties.swift
+++ b/stdlib/public/core/UnicodeScalarProperties.swift
@@ -623,6 +623,7 @@ extension Unicode.Scalar.Properties {
   ///
   /// This property corresponds to the `Emoji` property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
+  @available(macOS 10.12.2, iOS 10.2, tvOS 10.1, watchOS 3.1.1, *)
   public var isEmoji: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_EMOJI)
   }
@@ -639,6 +640,7 @@ extension Unicode.Scalar.Properties {
   ///
   /// This property corresponds to the `Emoji_Presentation` property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
+  @available(macOS 10.12.2, iOS 10.2, tvOS 10.1, watchOS 3.1.1, *)
   public var isEmojiPresentation: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_EMOJI_PRESENTATION)
   }
@@ -652,6 +654,7 @@ extension Unicode.Scalar.Properties {
   ///
   /// This property corresponds to the `Emoji_Modifier` property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
+  @available(macOS 10.12.2, iOS 10.2, tvOS 10.1, watchOS 3.1.1, *)
   public var isEmojiModifier: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_EMOJI_MODIFIER)
   }
@@ -661,6 +664,7 @@ extension Unicode.Scalar.Properties {
   ///
   /// This property corresponds to the `Emoji_Modifier_Base` property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
+  @available(macOS 10.12.2, iOS 10.2, tvOS 10.1, watchOS 3.1.1, *)
   public var isEmojiModifierBase: Bool {
     return _hasBinaryProperty(__swift_stdlib_UCHAR_EMOJI_MODIFIER_BASE)
   }

--- a/test/stdlib/UnicodeScalarPropertiesTests.swift
+++ b/test/stdlib/UnicodeScalarPropertiesTests.swift
@@ -83,7 +83,7 @@ UnicodeScalarPropertiesTests.test("properties.booleanProperties") {
   expectBooleanProperty(\.changesWhenNFKCCaseFolded, trueFor: "A", falseFor: "!")
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-  if #available(iOS 10.2, *) {
+  if #available(macOS 10.12.2, iOS 10.2, tvOS 10.1, watchOS 3.1.1, *) {
     // U+2708 AIRPLANE
     expectBooleanProperty(\.isEmoji, trueFor: "\u{2708}", falseFor: "A")
     // U+231A WATCH


### PR DESCRIPTION
Availability of emoji properties should be platform versions which have a `/usr/lib/libicucore.dylib` derived from ICU 57 or later.

|  ICU |   macOS |  iOS | tvOS | watchOS |
| ---: | ------: | ---: | ---: | ------: |
|  55  |  10.11  |   9  |   9  |      2  |
| *57* | *10.12* | *10* | *10* |     *3* |
|  59  |  10.13  |  11  |  11  |      4  |

These platform versions are based on the `unicode/uchar.h` and `unicode/uvernum.h` headers of:

- the macOS ICU projects at <https://opensource.apple.com/>;
- the iOS, tvOS, and watchOS SDKs.

(I didn't check as far back as macOS 10.9 or iOS 7).

This pull request is a follow-up to:

- <https://github.com/apple/swift/pull/15593/commits/b454e8d0f4df76ac3564af97c9f7f431f36a33c6>
- <https://github.com/apple/swift/pull/17992>