### PR TITLE
[SILGen] Cope with protocol requirement overrides for keypaths.

### DIFF
--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -359,6 +359,11 @@ struct SILDeclRef {
   /// entry overridden by this method.
   SILDeclRef getOverriddenWitnessTableEntry() const;
 
+  /// Return the original protocol requirement that introduced the witness table
+  /// entry overridden by this method.
+  static AbstractFunctionDecl *getOverriddenWitnessTableEntry(
+                                                    AbstractFunctionDecl *func);
+
   /// True if the referenced entity is some kind of thunk.
   bool isThunk() const;
 

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -940,6 +940,8 @@ emitKeyPathComponent(IRGenModule &IGM,
       } else {
         if (auto overridden = declRef.getOverriddenVTableEntry())
           declRef = overridden;
+        if (auto overridden = declRef.getOverriddenWitnessTableEntry())
+          declRef = overridden;
 
         auto dc = declRef.getDecl()->getDeclContext();
 

--- a/lib/IRGen/GenThunk.cpp
+++ b/lib/IRGen/GenThunk.cpp
@@ -126,6 +126,8 @@ llvm::Constant *
 IRGenModule::getAddrOfMethodDescriptor(SILDeclRef declRef,
                                        ForDefinition_t forDefinition) {
   assert(forDefinition == NotForDefinition);
+  assert(declRef.getOverriddenWitnessTableEntry() == declRef &&
+         "Overriding protocol requirements do not have method descriptors");
   LinkEntity entity = LinkEntity::forMethodDescriptor(declRef);
   return getAddrOfLLVMVariable(entity, Alignment(4), forDefinition,
                                MethodDescriptorStructTy, DebugTypeInfo());

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -782,12 +782,19 @@ SILDeclRef SILDeclRef::getNextOverriddenVTableEntry() const {
 }
 
 SILDeclRef SILDeclRef::getOverriddenWitnessTableEntry() const {
-  ValueDecl *bestOverridden = nullptr;
+  auto bestOverridden =
+    getOverriddenWitnessTableEntry(cast<AbstractFunctionDecl>(getDecl()));
+  return SILDeclRef(bestOverridden, kind, isCurried);
+}
 
-  SmallVector<ValueDecl *, 4> stack;
-  SmallPtrSet<ValueDecl *, 4> visited;
-  stack.push_back(getDecl());
-  visited.insert(getDecl());
+AbstractFunctionDecl *SILDeclRef::getOverriddenWitnessTableEntry(
+                                                 AbstractFunctionDecl *func) {
+  AbstractFunctionDecl *bestOverridden = nullptr;
+
+  SmallVector<AbstractFunctionDecl *, 4> stack;
+  SmallPtrSet<AbstractFunctionDecl *, 4> visited;
+  stack.push_back(func);
+  visited.insert(func);
 
   while (!stack.empty()) {
     auto current = stack.back();
@@ -802,7 +809,7 @@ SILDeclRef SILDeclRef::getOverriddenWitnessTableEntry() const {
                         cast<ProtocolDecl>(current->getDeclContext()),
                         cast<ProtocolDecl>(bestOverridden->getDeclContext()))
             < 0) {
-        bestOverridden = current;
+        bestOverridden = cast<AbstractFunctionDecl>(current);
       }
 
       continue;
@@ -810,12 +817,13 @@ SILDeclRef SILDeclRef::getOverriddenWitnessTableEntry() const {
 
     // Add overridden declarations to the stack.
     for (auto overridden : overriddenDecls) {
-      if (visited.insert(overridden).second)
-        stack.push_back(overridden);
+      auto overriddenFunc = cast<AbstractFunctionDecl>(overridden);
+      if (visited.insert(overriddenFunc).second)
+        stack.push_back(overriddenFunc);
     }
   }
 
-  return SILDeclRef(bestOverridden, kind, isCurried);
+  return bestOverridden;
 }
 
 SILDeclRef SILDeclRef::getOverriddenVTableEntry() const {

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -789,6 +789,9 @@ SILDeclRef SILDeclRef::getOverriddenWitnessTableEntry() const {
 
 AbstractFunctionDecl *SILDeclRef::getOverriddenWitnessTableEntry(
                                                  AbstractFunctionDecl *func) {
+  if (!isa<ProtocolDecl>(func->getDeclContext()))
+    return func;
+
   AbstractFunctionDecl *bestOverridden = nullptr;
 
   SmallVector<AbstractFunctionDecl *, 4> stack;

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -442,6 +442,13 @@ public:
   SubstitutionMap
   getNonMemberVarDeclSubstitutions(VarDecl *var);
 
+  /// Map the substitutions for the original declaration to substitutions for
+  /// the overridden declaration.
+  static SubstitutionMap mapSubstitutionsForWitnessOverride(
+                                               AbstractFunctionDecl *original,
+                                               AbstractFunctionDecl *overridden,
+                                               SubstitutionMap subs);
+
   /// Emit a property descriptor for the given storage decl if it needs one.
   void tryEmitPropertyDescriptor(AbstractStorageDecl *decl);
 

--- a/test/IRGen/keypath_witness_overrides.swift
+++ b/test/IRGen/keypath_witness_overrides.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -module-name protocol_overrides -emit-module -enable-sil-ownership -enable-resilience -emit-module-path=%t/protocol_overrides.swiftmodule %S/../SILGen/Inputs/protocol_overrides.swift
+// RUN: %target-swift-frontend -module-name keypath_witness_overrides -emit-ir %s -I %t | %FileCheck %s
+
+import protocol_overrides
+
+// CHECK: @keypath = private global
+// CHECK-SAME: %swift.method_descriptor* @"$S18protocol_overrides14OriginalGetterPy7ElementQz5IndexQzcigTq"
+public func getWritableKeyPath<OS: OverridesSetter>(_ c: OS, index: OS.Index) -> AnyKeyPath
+where OS.Index: Hashable {
+  let keypath = \OS.[index]
+  return keypath
+}

--- a/test/SILGen/Inputs/protocol_overrides.swift
+++ b/test/SILGen/Inputs/protocol_overrides.swift
@@ -1,0 +1,19 @@
+public protocol OriginalGetter {
+  associatedtype Index
+  associatedtype Element
+  
+  subscript (index: Index) -> Element { get }
+}
+
+public protocol OverridesGetter: OriginalGetter {
+  override subscript (index: Index) -> Element { get }
+}
+
+public protocol AddsSetter: OverridesGetter {
+  override subscript (index: Index) -> Element { get set }
+}
+
+public protocol OverridesSetter: AddsSetter {
+  override subscript (index: Index) -> Element { get set }
+}
+

--- a/test/SILGen/keypath_witness_overrides.swift
+++ b/test/SILGen/keypath_witness_overrides.swift
@@ -6,7 +6,6 @@
 // table entry for a protocol requirement is introduced.
 import protocol_overrides
 
-
 // CHECK-LABEL: sil hidden @$S25keypath_witness_overrides18getWritableKeyPath_5indexs03AnyfG0Cx_5IndexQzt09protocol_C015OverridesSetterRzSHAGRQlF
 func getWritableKeyPath<OS: OverridesSetter>(_ c: OS, index: OS.Index) -> AnyKeyPath
 where OS.Index: Hashable {
@@ -15,7 +14,7 @@ where OS.Index: Hashable {
   // CHECK-SAME: getter @$S18protocol_overrides14OriginalGetterPy7ElementQz5IndexQzcipAA15OverridesSetterRzSHAGRQlxxTK
   // CHECK-SAME: setter @$S18protocol_overrides10AddsSetterPy7ElementQz5IndexQzcipAA09OverridesD0RzSHAGRQlxxTk
   // CHECK-SAME: indices_equals @$S5Index18protocol_overrides14OriginalGetterPQzAB15OverridesSetterRzSHAERQlTH
-  // CHECK-SAMEL :indices_hash @$S5Index18protocol_overrides14OriginalGetterPQzAB15OverridesSetterRzSHAERQlTh
+  // CHECK-SAME: indices_hash @$S5Index18protocol_overrides14OriginalGetterPQzAB15OverridesSetterRzSHAERQlTh
   let keypath = \OS.[index]
   return keypath
 }

--- a/test/SILGen/keypath_witness_overrides.swift
+++ b/test/SILGen/keypath_witness_overrides.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -module-name protocol_overrides -emit-module -enable-sil-ownership -enable-resilience -emit-module-path=%t/protocol_overrides.swiftmodule %S/Inputs/protocol_overrides.swift
+// RUN: %target-swift-emit-silgen %s -I %t | %FileCheck %s
+
+// Check that keypath formation properly records the point at which the witness
+// table entry for a protocol requirement is introduced.
+import protocol_overrides
+
+
+// CHECK-LABEL: sil hidden @$S25keypath_witness_overrides18getWritableKeyPath_5indexs03AnyfG0Cx_5IndexQzt09protocol_C015OverridesSetterRzSHAGRQlF
+func getWritableKeyPath<OS: OverridesSetter>(_ c: OS, index: OS.Index) -> AnyKeyPath
+where OS.Index: Hashable {
+  // CHECK: keypath $WritableKeyPath<OS, OS.Element>,
+  // CHECK-SAME: id #OverridesSetter.subscript!getter.1
+  // CHECK-SAME: getter @$S18protocol_overrides14OriginalGetterPy7ElementQz5IndexQzcipAA15OverridesSetterRzSHAGRQlxxTK
+  // CHECK-SAME: setter @$S18protocol_overrides10AddsSetterPy7ElementQz5IndexQzcipAA09OverridesD0RzSHAGRQlxxTk
+  // CHECK-SAME: indices_equals @$S5Index18protocol_overrides14OriginalGetterPQzAB15OverridesSetterRzSHAERQlTH
+  // CHECK-SAMEL :indices_hash @$S5Index18protocol_overrides14OriginalGetterPQzAB15OverridesSetterRzSHAERQlTh
+  let keypath = \OS.[index]
+  return keypath
+}
+
+// CHECK-LABEL: sil shared [thunk] @$S18protocol_overrides14OriginalGetterPy7ElementQz5IndexQzcipAA15OverridesSetterRzSHAGRQlxxTK
+// CHECK: witness_method $OS, #OriginalGetter.subscript!getter.1
+
+// CHECK-LABEL: sil shared [thunk] @$S18protocol_overrides10AddsSetterPy7ElementQz5IndexQzcipAA09OverridesD0RzSHAGRQlxxTk
+// CHECK-LABEL: witness_method $OS, #AddsSetter.subscript!setter.1


### PR DESCRIPTION
When emitting accessor calls for keypaths, make sure that we reference
protocol requirements that introduce witness table entries. Other
protocol requirements don't have the necessary dispatch thunks,
resulting in linker errors.

Fixes rdar://problem/44187969.
