### PR TITLE
Make primal, adjoint and gradient have non_abi linkage.

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -2800,8 +2800,11 @@ PrimalGen::createEmptyPrimal(DifferentiationTask *task) {
       originalTy->getParameters(), originalTy->getYields(), results,
       originalTy->getOptionalErrorResult(), context.getASTContext());
   SILFunctionBuilder FB(module);
+  auto linkage = original->getLinkage();
+  if (linkage == SILLinkage::Public)
+    linkage = SILLinkage::PublicNonABI;
   auto *primal = FB.getOrCreateFunction(
-      original->getLocation(), primalName, original->getLinkage(), primalTy,
+      original->getLocation(), primalName, linkage, primalTy,
       original->isBare(), original->isTransparent(), original->isSerialized());
   primal->setUnqualifiedOwnership();
   LLVM_DEBUG(getADDebugStream() << "Primal function created \n"
@@ -2916,8 +2919,10 @@ SILFunction *AdjointGen::createEmptyAdjoint(DifferentiationTask *task) {
       origTy->getCoroutineKind(), origTy->getCalleeConvention(), adjParams, {},
       adjResults, None, original->getASTContext());
   SILFunctionBuilder FB(module);
-  auto *adjoint = FB.createFunction(
-      original->getLinkage(), adjName, adjType,
+  auto linkage = original->getLinkage();
+  if (linkage == SILLinkage::Public)
+    linkage = SILLinkage::PublicNonABI;
+  auto *adjoint = FB.createFunction(linkage, adjName, adjType,
       original->getGenericEnvironment(), original->getLocation(),
       original->isBare(), original->isTransparent(), original->isSerialized());
   adjoint->setUnqualifiedOwnership();
@@ -4199,8 +4204,11 @@ static SILFunction *lookupOrSynthesizeGradient(ADContext &context,
         "AD__" + original->getName().str() + "__" + mangleADConfig(config);
     auto gradNameId = astCtx.getIdentifier(gradName);
     SILFunctionBuilder FB(module);
+    auto linkage = original->getLinkage();
+    if (linkage == SILLinkage::Public)
+      linkage = SILLinkage::PublicNonABI;
     auto *gradFn =
-        FB.createFunction(original->getLinkage(), gradNameId.str(), gradType,
+        FB.createFunction(linkage, gradNameId.str(), gradType,
                           original->getGenericEnvironment(),
                           original->getLocation(), original->isBare(),
                           original->isTransparent(), original->isSerialized());

--- a/test/AutoDiff/autodiff_e2e_basic.swift
+++ b/test/AutoDiff/autodiff_e2e_basic.swift
@@ -44,3 +44,14 @@ print(x * z)
 // CHECK: @{{.*}}sigmoid{{.*}}__grad_src_0_wrt_0
 // CHECK: @{{.*}}sigmoid{{.*}}__grad_src_0_wrt_0_s_p
 // CHECK: @{{.*}}sigmoid{{.*}}__grad_src_0_wrt_0_p
+
+
+public func publicFunc(_ x: Float) -> Float {
+  return x + x
+}
+_ = #gradient(publicFunc)
+
+// CHECK: sil non_abi @{{.*}}publicFunc{{.*}}__grad_src_0_wrt_0
+// CHECK: sil non_abi @{{.*}}publicFunc{{.*}}__primal_src_0_wrt_0
+// CHECK: sil non_abi @{{.*}}publicFunc{{.*}}__adjoint_src_0_wrt_0
+

--- a/test/AutoDiff/builtin_math.sil
+++ b/test/AutoDiff/builtin_math.sil
@@ -105,7 +105,7 @@ bb0(%0 : @trivial $Builtin.FPIEEE32):
 // CHECK:   return %4 : $(AD__simple_mul__Type__src_0_wrt_0_1, Builtin.FPIEEE32)
 // CHECK: }
 
-// CHECK-LABEL: sil @AD__chain_rule__primal_src_0_wrt_0_1
+// CHECK-LABEL: @AD__chain_rule__primal_src_0_wrt_0_1
 // CHECK: bb0(%0 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32):
 // CHECK:   %2 = builtin "fneg_FPIEEE32"(%0 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32
 // CHECK:   %3 = builtin "fmul_FPIEEE32"(%1 : $Builtin.FPIEEE32, %2 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32


### PR DESCRIPTION
Resolves https://bugs.swift.org/browse/SR-8723.