### PR TITLE
Add trailing space that was accidentally removed in the previous change.

### DIFF
--- a/test/PrintAsObjC/lit.local.cfg
+++ b/test/PrintAsObjC/lit.local.cfg
@@ -5,7 +5,7 @@ config.substitutions.insert(0, ('%check-in-clang',
   '%%clang -fsyntax-only -x objective-c-header -fobjc-arc -fmodules '
   '-fmodules-validate-system-headers '
   '-Weverything -Werror -Wno-unused-macros -Wno-incomplete-module '
-  '-Wno-auto-import -Wno-objc-property-assign-on-object-type'
+  '-Wno-auto-import -Wno-objc-property-assign-on-object-type '
   '-F %%clang-importer-sdk-path/frameworks '
   '-I %%clang-include-dir '
   '-isysroot %r/Inputs/clang-importer-sdk' % config.test_source_root) )


### PR DESCRIPTION
We need a trailing space after the warning options to separate them from
the following arguments.

rdar://problem/44228136