### PR TITLE
[stdlib] Switch Dictionary.subscript(_:default:) to use _modify

### DIFF
--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -926,11 +926,11 @@ extension Dictionary {
     get {
       return _variant.maybeGet(key) ?? defaultValue()
     }
-    mutableAddressWithNativeOwner {
+    _modify {
       let (_, address) = _variant.pointerToValue(
         forKey: key,
         insertingDefault: defaultValue)
-      return (address, Builtin.castToNativeObject(_variant.asNative._storage))
+      yield &address.pointee
     }
   }
 


### PR DESCRIPTION
Getting rid of another addressor.