### PR TITLE
[Parse] 2nd attempt at multiline attribute messages (SE-200)

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1296,8 +1296,6 @@ ERROR(swift_native_objc_runtime_base_must_be_identifier,none,
 
 ERROR(attr_interpolated_string,none,
 "'%0' cannot be an interpolated string literal", (StringRef))
-ERROR(attr_multiline_string,none,
-"'%0' cannot be a multiline string literal", (StringRef))
 ERROR(attr_extended_escaping_string,none,
 "'%0' cannot be an extended escaping string literal", (StringRef))
 

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -426,15 +426,19 @@ public:
   /// If a copy needs to be made, it will be allocated out of the provided
   /// \p Buffer.
   static StringRef getEncodedStringSegment(StringRef Str,
-                                           SmallVectorImpl<char> &Buffer) {
+                                           SmallVectorImpl<char> &Buffer,
+                                           bool IsFirstSegment = false,
+                                           bool IsLastSegment = false,
+                                           unsigned IndentToStrip = 0,
+                                           unsigned CustomDelimiterLen = 0) {
     SmallString<128> TerminatedStrBuf(Str);
     TerminatedStrBuf.push_back('\0');
     StringRef TerminatedStr = StringRef(TerminatedStrBuf).drop_back();
     StringRef Result = getEncodedStringSegmentImpl(TerminatedStr, Buffer,
-                                                   /*IsFirstSegment*/false,
-                                                   /*IsLastSegment*/false,
-                                                   /*IndentToStrip*/0,
-                                                   /*CustomDelimiterLen*/0);
+                                                   IsFirstSegment,
+                                                   IsLastSegment,
+                                                   IndentToStrip,
+                                                   CustomDelimiterLen);
     if (Result == TerminatedStr)
       return Str;
     assert(Result.data() == Buffer.data());

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -307,13 +307,9 @@ bool Parser::parseTopLevel() {
 static Optional<StringRef>
 getStringLiteralIfNotInterpolated(Parser &P, SourceLoc Loc, const Token &Tok,
                                   StringRef DiagText) {
-  // FIXME: Support extended escaping / multiline string literal.
+  // FIXME: Support extended escaping string literal.
   if (Tok.getCustomDelimiterLen()) {
     P.diagnose(Loc, diag::attr_extended_escaping_string, DiagText);
-    return None;
-  }
-  if (Tok.isMultilineString()) {
-    P.diagnose(Loc, diag::attr_multiline_string, DiagText);
     return None;
   }
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -2160,7 +2160,7 @@ class EncodedDiagnosticMessage {
 public:
   /// \param S A string with an encoded message
   EncodedDiagnosticMessage(StringRef S)
-      : Message(Lexer::getEncodedStringSegment(S, Buf)) {}
+      : Message(Lexer::getEncodedStringSegment(S, Buf, true, true, ~0U)) {}
 
   /// The unescaped message to display to the user.
   const StringRef Message;

--- a/test/Parse/diagnose_availability.swift
+++ b/test/Parse/diagnose_availability.swift
@@ -66,11 +66,19 @@ func swiftMessage() {}
 // expected-error@-1{{'message' cannot be an interpolated string literal}}
 func interpolatedMessage() {}
 
-// expected-error@+1{{'message' cannot be a multiline string literal}}
 @available(*, unavailable, message: """
   foobar message.
   """)
 func multilineMessage() {}
+multilineMessage()
+// expected-error@-1{{'multilineMessage()' is unavailable: foobar message.}}
+// expected-note@-3{{'multilineMessage()' has been explicitly marked unavailable here}}
+
+@available(*, unavailable, message: " ")
+func emptyMessage() {}
+emptyMessage()
+// expected-error@-1{{'emptyMessage()' is unavailable:  }}
+// expected-note@-3{{'emptyMessage()' has been explicitly marked unavailable here}}
 
 // expected-error@+1{{'message' cannot be an extended escaping string literal}}
 @available(*, unavailable, message: #"""


### PR DESCRIPTION
This is a follow up on https://github.com/apple/swift/pull/19170 and the subsequent revert https://github.com/apple/swift/pull/19206 by @rintaro of some dubious code by me which attempted to support modified escaping and multiline literals for attribute messages and caused ASAN failures. Reworked to try to at least get multiline strings working which might be useful as messages for attributes (for example a detailed “unavailable” annotation) minus the code which read off the start of the StringRef buffer.

Please ASAN test before merging.

Resolves [SR-8724](https://bugs.swift.org/browse/SR-8724).