### PR TITLE
[stdlib] Switch Dictionary.Values.subscript to use _modify

### DIFF
--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1442,9 +1442,9 @@ extension Dictionary {
       get {
         return _variant.assertingGet(at: position).value
       }
-      mutableAddressWithNativeOwner {
+      _modify {
         let address = _variant.pointerToValue(at: position)
-        return (address, Builtin.castToNativeObject(_variant.asNative._storage))
+        yield &address.pointee
       }
     }
 


### PR DESCRIPTION
Benchmarks are a bit scant for this type but we do have [one](https://github.com/apple/swift/blob/master/benchmark/single-source/DictionarySwap.swift#L63) that should see this change.