### PR TITLE
[4.2][NameLookup] Swift 4 compatibility hack for cross-module var overloads in generic type extensions

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -239,10 +239,24 @@ bool swift::removeShadowedDecls(SmallVectorImpl<ValueDecl*> &decls,
          firstIdx != n; ++firstIdx) {
       auto firstDecl = collidingDecls.second[firstIdx];
       auto firstModule = firstDecl->getModuleContext();
+      auto firstSig = firstDecl->getOverloadSignature();
       for (unsigned secondIdx = firstIdx + 1; secondIdx != n; ++secondIdx) {
         // Determine whether one module takes precedence over another.
         auto secondDecl = collidingDecls.second[secondIdx];
         auto secondModule = secondDecl->getModuleContext();
+
+        // Swift 4 compatibility hack: Don't shadow properties defined in
+        // extensions of generic types with properties defined elsewhere.
+        // This is due to the fact that in Swift 4, we only gave custom overload
+        // types to properties in extensions of generic types, otherwise we
+        // used the null type.
+        if (!ctx.isSwiftVersionAtLeast(5)) {
+          auto secondSig = secondDecl->getOverloadSignature();
+          if (firstSig.IsVariable && secondSig.IsVariable)
+            if (firstSig.InExtensionOfGenericType !=
+                secondSig.InExtensionOfGenericType)
+              continue;
+        }
 
         // If one declaration is in a protocol or extension thereof and the
         // other is not, prefer the one that is not.

--- a/test/Constraints/dynamic_lookup.swift
+++ b/test/Constraints/dynamic_lookup.swift
@@ -336,3 +336,51 @@ func testOverloadedWithUnavailable(ao: AnyObject) {
   ao.overloadedWithUnavailableB()
 }
 
+// Test that we correctly diagnose ambiguity for different typed members available
+// through dynamic lookup.
+@objc protocol P3 {
+  var ambiguousProperty: String { get } // expected-note {{found this candidate}}
+  var unambiguousProperty: Int { get }
+
+  func ambiguousMethod() -> String // expected-note 2{{found this candidate}}
+  func unambiguousMethod() -> Int
+
+  func ambiguousMethodParam(_ x: String) // expected-note {{found this candidate}}
+  func unambiguousMethodParam(_ x: Int)
+
+  subscript(ambiguousSubscript _: Int) -> String { get } // expected-note {{found this candidate}}
+  subscript(unambiguousSubscript _: String) -> Int { get } // expected-note {{found this candidate}}
+}
+
+class C1 {
+  @objc var ambiguousProperty: Int { return 0 } // expected-note {{found this candidate}}
+  @objc var unambiguousProperty: Int { return 0 }
+
+  @objc func ambiguousMethod() -> Int { return 0 } // expected-note 2{{found this candidate}}
+  @objc func unambiguousMethod() -> Int { return 0 }
+
+  @objc func ambiguousMethodParam(_ x: Int) {} // expected-note {{found this candidate}}
+  @objc func unambiguousMethodParam(_ x: Int) {}
+
+  @objc subscript(ambiguousSubscript _: Int) -> Int { return 0 } // expected-note {{found this candidate}}
+  @objc subscript(unambiguousSubscript _: String) -> Int { return 0 } // expected-note {{found this candidate}}
+}
+
+func testAnyObjectAmbiguity(_ x: AnyObject) {
+  _ = x.ambiguousProperty // expected-error {{ambiguous use of 'ambiguousProperty'}}
+  _ = x.unambiguousProperty
+
+  _ = x.ambiguousMethod() // expected-error {{ambiguous use of 'ambiguousMethod()'}}
+  _ = x.unambiguousMethod()
+
+  _ = x.ambiguousMethod // expected-error {{ambiguous use of 'ambiguousMethod()'}}
+  _ = x.unambiguousMethod
+
+  _ = x.ambiguousMethodParam // expected-error {{ambiguous use of 'ambiguousMethodParam'}}
+  _ = x.unambiguousMethodParam
+
+  _ = x[ambiguousSubscript: 0] // expected-error {{ambiguous use of 'subscript(ambiguousSubscript:)'}}
+
+  // FIX-ME(SR-8611): This is currently ambiguous but shouldn't be.
+  _ = x[unambiguousSubscript: ""] // expected-error {{ambiguous use of 'subscript(unambiguousSubscript:)'}}
+}

--- a/test/IDE/Inputs/complete_import_overloads.swift
+++ b/test/IDE/Inputs/complete_import_overloads.swift
@@ -1,0 +1,16 @@
+
+public struct HasFooGeneric<T> {
+  public var foo: Int = 0
+}
+
+extension HasFooGeneric {
+  public var bar: Int { return 0 }
+}
+
+public class HasFooNonGeneric {
+  public var foo: Int = 0
+}
+
+extension HasFooNonGeneric {
+  public var bar: Int { return 0 }
+}

--- a/test/IDE/complete_import_overloads.swift
+++ b/test/IDE/complete_import_overloads.swift
@@ -1,0 +1,66 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -emit-module -o %t -module-name=library %S/Inputs/complete_import_overloads.swift
+
+// RUN: %target-swift-ide-test -code-completion -swift-version 4 -source-filename %s -code-completion-token=SELF_DOT_1 -I %t | %FileCheck %s -check-prefix=SWIFT4_SELF_DOT_1
+// RUN: %target-swift-ide-test -code-completion -swift-version 4 -source-filename %s -code-completion-token=SELF_DOT_2 -I %t | %FileCheck %s -check-prefix=SWIFT4_SELF_DOT_2
+
+// RUN: %target-swift-ide-test -code-completion -swift-version 5 -source-filename %s -code-completion-token=SELF_DOT_1 -I %t | %FileCheck %s -check-prefix=SWIFT5_SELF_DOT_1
+// RUN: %target-swift-ide-test -code-completion -swift-version 5 -source-filename %s -code-completion-token=SELF_DOT_2 -I %t | %FileCheck %s -check-prefix=SWIFT5_SELF_DOT_2
+
+import library
+
+// Ensure we maintain compatibility with Swift 4's overload signature rules.
+// Variables defined in extensions of generic types had different overload
+// signatures to other variables, so allow overloading in such cases (SR-7341).
+extension HasFooGeneric {
+  var foo: String { return "" } // foo isn't defined in a generic extension in the other module, so allow overloading in Swift 4 mode.
+  var bar: String { return "" } // bar is defined in a generic extension in the other module, so `bar: String` always shadows it.
+  func baz() {
+    self.#^SELF_DOT_1^#
+  }
+}
+
+// SWIFT4_SELF_DOT_1: Begin completions
+// SWIFT4_SELF_DOT_1-DAG: Decl[InstanceVar]/CurrNominal:      foo[#Int#]; name=foo
+// SWIFT4_SELF_DOT_1-DAG: Decl[InstanceVar]/CurrNominal:      foo[#String#]; name=foo
+// SWIFT4_SELF_DOT_1-NOT: Decl[InstanceVar]/CurrNominal:      bar[#Int#]; name=bar
+// SWIFT4_SELF_DOT_1-DAG: Decl[InstanceVar]/CurrNominal:      bar[#String#]; name=bar
+// SWIFT4_SELF_DOT_1: End completions
+
+// But in Swift 5 mode, properties from this module currently always shadow
+// properties from the other module – therefore meaning that the properties from
+// the other module never show up in the overload set.
+// FIX-ME: It seems reasonable for both to show up in the overload set.
+// SWIFT5_SELF_DOT_1: Begin completions
+// SWIFT5_SELF_DOT_1-NOT: Decl[InstanceVar]/CurrNominal:      foo[#Int#]; name=foo
+// SWIFT5_SELF_DOT_1-DAG: Decl[InstanceVar]/CurrNominal:      foo[#String#]; name=foo
+// SWIFT5_SELF_DOT_1-NOT: Decl[InstanceVar]/CurrNominal:      bar[#Int#]; name=bar
+// SWIFT5_SELF_DOT_1-DAG: Decl[InstanceVar]/CurrNominal:      bar[#String#]; name=bar
+// SWIFT5_SELF_DOT_1: End completions
+
+// For non-generic types, the variable overload signature was always the
+// null type, so `foo/bar: String` shadows `foo/bar: Int`.
+extension HasFooNonGeneric {
+  var foo: String { return "" }
+  var bar: String { return "" }
+  func baz() {
+    self.#^SELF_DOT_2^#
+  }
+}
+
+// SWIFT4_SELF_DOT_2: Begin completions
+// SWIFT4_SELF_DOT_2-NOT: Decl[InstanceVar]/CurrNominal:      foo[#Int#]; name=foo
+// SWIFT4_SELF_DOT_2-DAG: Decl[InstanceVar]/CurrNominal:      foo[#String#]; name=foo
+// SWIFT4_SELF_DOT_2-NOT: Decl[InstanceVar]/CurrNominal:      bar[#Int#]; name=bar
+// SWIFT4_SELF_DOT_2-DAG: Decl[InstanceVar]/CurrNominal:      bar[#String#]; name=bar
+// SWIFT4_SELF_DOT_2: End completions
+
+// Again, in Swift 5 mode, we currently consistently shadow the properties from
+// the other module.
+// FIX-ME: It seems reasonable to not shadow them.
+// SWIFT5_SELF_DOT_2: Begin completions
+// SWIFT5_SELF_DOT_2-NOT: Decl[InstanceVar]/CurrNominal:      foo[#Int#]; name=foo
+// SWIFT5_SELF_DOT_2-DAG: Decl[InstanceVar]/CurrNominal:      foo[#String#]; name=foo
+// SWIFT5_SELF_DOT_2-NOT: Decl[InstanceVar]/CurrNominal:      bar[#Int#]; name=bar
+// SWIFT5_SELF_DOT_2-DAG: Decl[InstanceVar]/CurrNominal:      bar[#String#]; name=bar
+// SWIFT5_SELF_DOT_2: End completions

--- a/test/NameBinding/Inputs/overload_vars.swift
+++ b/test/NameBinding/Inputs/overload_vars.swift
@@ -14,3 +14,19 @@ public protocol HasFoo {
 public protocol HasBar {
   var bar: Int { get }
 }
+
+public class HasFooGeneric<T> {
+  public var foo: Int = 0
+}
+
+extension HasFooGeneric {
+  public var bar: Int { return 0 }
+}
+
+public class HasFooNonGeneric {
+  public var foo: Int = 0
+}
+
+extension HasFooNonGeneric {
+  public var bar: Int { return 0 }
+}

--- a/test/NameBinding/import-resolution-overload_swift4.swift
+++ b/test/NameBinding/import-resolution-overload_swift4.swift
@@ -1,0 +1,53 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/overload_vars.swift
+// RUN: %target-typecheck-verify-swift -swift-version 4 -I %t
+
+import overload_vars
+
+func useString(_ str: String) {}
+
+// Ensure we maintain compatibility with Swift 4's overload signature rules.
+// Variables defined in extensions of generic types had different overload
+// signatures to other variables, so allow overloading in such cases (SR-7341).
+extension HasFooGeneric {
+  var foo: String { return "" } // `foo` isn't defined in a generic extension in the other module, so allow overloading in Swift 4 mode.
+  var bar: String { return "" } // `bar` is defined in a generic extension in the other module, so `bar: String` always shadows it.
+
+  func baz() {
+    let x1: Int = foo // Make sure `foo: Int` is in the overload set.
+    _ = x1
+
+    let x2: String = foo // Make sure `foo: String` is in the overload set.
+    _ = x2
+
+    let y1 = bar // No ambiguity error.
+    useString(y1) // Make sure we resolved to `bar: String`.
+
+    // Make sure `bar: Int` is not in the overload set.
+    let y2: Int = bar // expected-error {{cannot convert}}
+    _ = y2
+  }
+}
+
+// But for non-generic types, the variable overload signature was always the
+// null type, so `foo/bar: String` shadows `foo/bar: Int`.
+extension HasFooNonGeneric {
+  var foo: String { return "" }
+  var bar: String { return "" }
+
+  func baz() {
+    let x1 = foo // No ambiguity error.
+    useString(x1) // Make sure we resolved to `foo: String`.
+
+    // Make sure `foo: Int` is not in the overload set.
+    let x2: Int = foo // expected-error {{cannot convert}}
+    _ = x2
+
+    let y1 = bar // No ambiguity error.
+    useString(y1) // Make sure we resolved to `bar: String`.
+
+    // Make sure `bar: Int` is not in the overload set.
+    let y2: Int = bar // expected-error {{cannot convert}}
+    _ = y2
+  }
+}

--- a/test/NameBinding/import-resolution-overload_swift5.swift
+++ b/test/NameBinding/import-resolution-overload_swift5.swift
@@ -1,0 +1,54 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/overload_vars.swift
+// RUN: %target-typecheck-verify-swift -swift-version 5 -I %t
+
+import overload_vars
+
+func useString(_ str: String) {}
+
+// In Swift 5, properties from this module currently always shadow properties
+// from the other module – therefore meaning that the properties from the other
+// module never show up in the overload set.
+// FIX-ME: It seems reasonable for both to show up in the overload set.
+
+extension HasFooGeneric {
+  var foo: String { return "" }
+  var bar: String { return "" }
+
+  func baz() {
+    let x1 = foo // No ambiguity error.
+    useString(x1) // Make sure we resolved to `foo: String`.
+
+    // Make sure `foo: Int` is not in the overload set.
+    let x2: Int = foo // expected-error {{cannot convert}}
+    _ = x2
+
+    let y1 = bar // No ambiguity error.
+    useString(y1) // Make sure we resolved to `bar: String`.
+
+    // Make sure `bar: Int` is not in the overload set.
+    let y2: Int = bar // expected-error {{cannot convert}}
+    _ = y2
+  }
+}
+
+extension HasFooNonGeneric {
+  var foo: String { return "" }
+  var bar: String { return "" }
+
+  func baz() {
+    let x1 = foo // No ambiguity error.
+    useString(x1) // Make sure we resolved to `foo: String`.
+
+    // Make sure `foo: Int` is not in the overload set.
+    let x2: Int = foo // expected-error {{cannot convert}}
+    _ = x2
+
+    let y1 = bar // No ambiguity error.
+    useString(y1) // Make sure we resolved to `bar: String`.
+
+    // Make sure `bar: Int` is not in the overload set.
+    let y2: Int = bar // expected-error {{cannot convert}}
+    _ = y2
+  }
+}


### PR DESCRIPTION
*(4.2 cherry-pick of #18488 + expanded test-case for dynamic overload ranking from #18952)*

- Explanation: Across modules, a property declared in an extension of a generic type would shadow another property declared elsewhere, causing the one in the other module to be inaccessible.

- Scope: Resolves a 4.2 source compatibility regression.

- SR Issue: [SR-7341](https://bugs.swift.org/browse/SR-7341).

- Risk: Moderately low – the added logic is fairly narrow and matches existing compatibility logic in [`swift::conflicting`](https://github.com/apple/swift/blob/2032969ee2bc0901a929b47f1f3ebe3e50ece89c/lib/AST/Decl.cpp#L1925).

- Testing: Added tests for Swift 4 and 5 cross-module property overloading behaviour, Test suite, Compatibility suite.

- Reviewers: @slavapestov, @DougGregor.