### PR TITLE
[stdlib] Switch ManagedBuffer.header to use _modify

### DIFF
--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -244,8 +244,8 @@ public struct ManagedBufferPointer<Header, Element> : Equatable {
     addressWithNativeOwner {
       return (UnsafePointer(_headerPointer), _nativeBuffer)
     }
-    mutableAddressWithNativeOwner {
-      return (_headerPointer, _nativeBuffer)
+    _modify {
+      yield &_headerPointer.pointee
     }
   }
 


### PR DESCRIPTION
First go at trying this with a property rather than a subscript...