### PR TITLE
Enable debug info for inlined generics by default. It works now.

### DIFF
--- a/test/DebugInfo/inlined-generics-basic.swift
+++ b/test/DebugInfo/inlined-generics-basic.swift
@@ -4,7 +4,7 @@
 // RUN:    | %FileCheck %s --check-prefix=SIL
 // IR.
 // RUN: %target-swift-frontend -parse-as-library -module-name A \
-// RUN:      -Xllvm -debug-info-inlined-generics %s -g -O -o - -emit-ir \
+// RUN:      %s -g -O -o - -emit-ir \
 // RUN:      | %FileCheck %s --check-prefix=IR
 
 import StdlibUnittest


### PR DESCRIPTION
(For some reason I thought I already did this 2 months ago...)