### PR TITLE
Parser: disallow delayed decl member parsing if interface hash is requested.

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1401,7 +1401,7 @@ public:
   ParserResult<LanguageVersionConstraintAvailabilitySpec>
   parseLanguageVersionConstraintSpec();
 
-  bool canDelayBodyParsing();
+  bool canDelayMemberDeclParsing();
 };
 
 /// Describes a parsed declaration name.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -184,6 +184,8 @@ void PersistentParserState::parseMembers(IterableDeclContext *IDC) {
   if (!hasDelayedDeclList(IDC))
     return;
   SourceFile &SF = *IDC->getDecl()->getDeclContext()->getParentSourceFile();
+  assert(!SF.hasInterfaceHash() &&
+    "Cannot delay parsing if we care about the interface hash.");
   unsigned BufferID = *SF.getBufferID();
   // MarkedPos is not useful for delayed parsing because we know where we should
   // jump the parser to. However, we should recover the MarkedPos here in case
@@ -3347,6 +3349,9 @@ bool Parser::parseDeclList(SourceLoc LBLoc, SourceLoc &RBLoc,
 }
 
 bool Parser::canDelayBodyParsing() {
+  // Calculating interface hash requires tokens consumed in the original order.
+  if (SF.hasInterfaceHash())
+    return false;
   if (SF.Kind == SourceFileKind::REPL)
     return false;
   // We always collect the entire syntax tree for IDE uses.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3348,7 +3348,7 @@ bool Parser::parseDeclList(SourceLoc LBLoc, SourceLoc &RBLoc,
   return !RBLoc.isValid();
 }
 
-bool Parser::canDelayBodyParsing() {
+bool Parser::canDelayMemberDeclParsing() {
   // Calculating interface hash requires tokens consumed in the original order.
   if (SF.hasInterfaceHash())
     return false;
@@ -3438,7 +3438,7 @@ Parser::parseDeclExtension(ParseDeclOptions Flags, DeclAttributes &Attributes) {
     ContextChange CC(*this, ext);
     Scope S(this, ScopeKind::Extension);
     ParseDeclOptions Options(PD_HasContainerType | PD_InExtension);
-    if (canDelayBodyParsing()) {
+    if (canDelayMemberDeclParsing()) {
       if (Tok.is(tok::r_brace)) {
         RBLoc = consumeToken();
       } else {
@@ -5555,7 +5555,7 @@ ParserResult<EnumDecl> Parser::parseDeclEnum(ParseDeclOptions Flags,
   } else {
     Scope S(this, ScopeKind::ClassBody);
     ParseDeclOptions Options(PD_HasContainerType | PD_AllowEnumElement | PD_InEnum);
-    if (canDelayBodyParsing()) {
+    if (canDelayMemberDeclParsing()) {
       if (Tok.is(tok::r_brace)) {
         RBLoc = consumeToken();
       } else {


### PR DESCRIPTION
Calculating interface hash requires tokens being consumed at a deterministic
order; thus we should disable delayed decl member parsing here.