### PR TITLE
[test] Sorting 2**21 arrays is probably not necessary

### DIFF
--- a/validation-test/stdlib/Algorithm.swift
+++ b/validation-test/stdlib/Algorithm.swift
@@ -284,7 +284,7 @@ Algorithm.test("heapSort") {
   } // addOne end.
 
   // Test binary number size.
-  let numberLength = 21
+  let numberLength = 11
   var binaryNumber = [Int](repeating: 0, count: numberLength)
 
   // We are testing sort on all permutations off 0-1s of size `numberLength`


### PR DESCRIPTION
Addresses: <rdar://problem/44152615>

This caused test timeouts in https://ci.swift.org/job/oss-swift_tools-RA_stdlib-DA_test-simulator/
