### PR TITLE
[SR-8239][Parse] Fix same-type constraint commutativity

### DIFF
--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -275,8 +275,9 @@ ParserStatus Parser::parseGenericWhereClause(
   bool HasNextReq;
   do {
     SyntaxParsingContext ReqContext(SyntaxContext, SyntaxContextKind::Syntax);
-    // Parse the leading type-identifier.
-    ParserResult<TypeRepr> FirstType = parseTypeIdentifier();
+    // Parse the leading type. It doesn't necessarily have to be just a type
+    // identifier if we're dealing with a same-type constraint.
+    ParserResult<TypeRepr> FirstType = parseType();
 
     if (FirstType.hasCodeCompletion()) {
       Status.setHasCodeCompletion();

--- a/test/Constraints/same_types.swift
+++ b/test/Constraints/same_types.swift
@@ -281,3 +281,29 @@ func test9<T: P6, U: P6>(_ t: T, u: U)
 
 // FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected error produced: generic parameter τ_0_0.Bar.Foo cannot be equal to both 'Y.Foo' (aka 'X') and 'Z'
+
+func testMetatypeSameType<T, U>(_ t: T, _ u: U)
+  where T.Type == U.Type { }
+// expected-error@-1{{same-type requirement makes generic parameters 'T' and 'U' equivalent}}
+
+func testSameTypeCommutativity1<U, T>(_ t: T, _ u: U)
+  where T.Type == U { } // Equivalent to U == T.Type
+// expected-error@-1{{same-type requirement makes generic parameter 'U' non-generic}}
+
+func testSameTypeCommutativity2<U, T: P1>(_ t: T, _ u: U)
+  where U? == T.Assoc { } // Ok, equivalent to T.Assoc == U?
+
+func testSameTypeCommutativity3<U, T: P1>(_ t: T, _ u: U)
+  where (U) -> () == T.Assoc { } // Ok, equivalent to T.Assoc == (U) -> ()
+
+func testSameTypeCommutativity4<U, T>(_ t: T, _ u: U)
+  where (U) -> () == T { } // Equivalent to T == (U) -> ()
+// expected-error@-1{{same-type requirement makes generic parameter 'T' non-generic}}
+
+func testSameTypeCommutativity5<U, T: P1>(_ t: T, _ u: U)
+  where P1 & P2 == T.Assoc { } // Ok, equivalent to T.Assoc == P1 & P2
+
+// FIXME: Error emitted twice.
+func testSameTypeCommutativity6<U, T: P1>(_ t: T, _ u: U)
+  where U & P2 == T.Assoc { } // Equivalent to T.Assoc == U & P2
+// expected-error@-1 2 {{non-protocol, non-class type 'U' cannot be used within a protocol-constrained type}}

--- a/test/Generics/function_defs.swift
+++ b/test/Generics/function_defs.swift
@@ -295,5 +295,23 @@ func badTypeConformance1<T>(_: T) where Int : EqualComparable {} // expected-err
 
 func badTypeConformance2<T>(_: T) where T.Blarg : EqualComparable { } // expected-error{{'Blarg' is not a member type of 'T'}}
 
+func badTypeConformance3<T>(_: T) where (T) -> () : EqualComparable { }
+// expected-error@-1{{type '(T) -> ()' in conformance requirement does not refer to a generic parameter or associated type}}
+
+func badTypeConformance4<T>(_: T) where @escaping (inout T) throws -> () : EqualComparable { }
+// expected-error@-1{{type '(inout T) throws -> ()' in conformance requirement does not refer to a generic parameter or associated type}}
+// expected-error@-2 2 {{@escaping attribute may only be used in function parameter position}}
+
+// FIXME: Error emitted twice.
+func badTypeConformance5<T>(_: T) where T & Sequence : EqualComparable { }
+// expected-error@-1 2 {{non-protocol, non-class type 'T' cannot be used within a protocol-constrained type}}
+// expected-error@-2{{type 'Sequence' in conformance requirement does not refer to a generic parameter or associated type}}
+
+func badTypeConformance6<T>(_: T) where [T] : Collection { }
+// expected-error@-1{{type '[T]' in conformance requirement does not refer to a generic parameter or associated type}}
+
+func badTypeConformance7<T, U>(_: T, _: U) where T? : U { }
+// expected-error@-1{{type 'T?' constrained to non-protocol, non-class type 'U'}}
+
 func badSameType<T, U : GeneratesAnElement, V>(_ : T, _ : U)
   where T == U.Element, U.Element == V {} // expected-error{{same-type requirement makes generic parameters 'T' and 'V' equivalent}}

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -102,7 +102,7 @@ public func requirementOnNonGenericFunction(x: Int, y: Int) {
 public func missingRequirement<X:P, Y>(x: X, y: Y) {
 }
 
-@_specialize(where) // expected-error{{expected identifier for type name}}
+@_specialize(where) // expected-error{{expected type}}
 @_specialize() // expected-error{{expected a parameter label or a where clause in '_specialize' attribute}} expected-error{{expected declaration}}
 public func funcWithEmptySpecializeAttr<X: P, Y>(x: X, y: Y) {
 }


### PR DESCRIPTION
Same-type constraints are not always commutative, i.e. (see SR for more)

``` swift 
protocol P { associatedtype Assoc }
func foo<U, T: P>(...) where T.Assoc == U? { }  // ok

func foo<U, T: P>(...) where U? == T.Assoc { }  // 4 parsing errors
```

Resolves [SR-8239](https://bugs.swift.org/browse/SR-8239).
