### PR TITLE
[Sema] Warn for a function value in string interpolation

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3026,11 +3026,11 @@ NOTE(force_optional_to_any,none,
 NOTE(silence_optional_to_any,none,
      "explicitly cast to %0 with '%1' to silence this warning",
      (Type, StringRef))
-WARNING(optional_in_string_interpolation_segment,none,
-        "string interpolation produces a debug description for an optional "
+WARNING(debug_description_in_string_interpolation_segment,none,
+        "string interpolation produces a debug description for %select{an optional|a function}0 "
         "value; did you mean to make this explicit?",
-        ())
-NOTE(silence_optional_in_interpolation_segment_call,none,
+        (bool))
+NOTE(silence_debug_description_in_interpolation_segment_call,none,
      "use 'String(describing:)' to silence this warning", ())
 
 ERROR(invalid_noescape_use,none,

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3779,7 +3779,7 @@ static void diagnoseUnintendedOptionalBehavior(TypeChecker &TC, const Expr *E,
           .fixItInsert(segment->getEndLoc(), ")");
 
         // Suggest inserting a default value about an optional.
-        if(isOptional)
+        if (isOptional)
             TC.diagnose(segment->getLoc(), diag::default_optional_to_any)
               .highlight(segment->getSourceRange())
               .fixItInsert(segment->getEndLoc(), " ?? <#default value#>");

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3752,33 +3752,37 @@ static void diagnoseUnintendedOptionalBehavior(TypeChecker &TC, const Expr *E,
     }
 
     void visitInterpolatedStringLiteralExpr(InterpolatedStringLiteralExpr *E) {
-      // Warn about interpolated segments that contain optionals.
+      // Warn about interpolated segments that contain optionals or function.
       for (auto &segment : E->getSegments()) {
         // Allow explicit casts.
         if (auto paren = dyn_cast<ParenExpr>(segment))
           if (isa<ExplicitCastExpr>(paren->getSubExpr()))
             continue;
 
-        // Bail out if we don't have an optional.
-        if (!segment->getType()->getRValueType()->getOptionalObjectType())
+        bool isOptional = !!segment->getType()->getRValueType()->getOptionalObjectType();
+        bool isFunction = segment->getType()->getRValueType()->is<AnyFunctionType>();
+
+        // Bail out if we don't have an optional and a function.
+        if (!isOptional && !isFunction)
           continue;
 
         TC.diagnose(segment->getStartLoc(),
-                    diag::optional_in_string_interpolation_segment)
+                    diag::debug_description_in_string_interpolation_segment, isFunction)
           .highlight(segment->getSourceRange());
 
         // Suggest 'String(describing: <expr>)'.
         auto segmentStart = segment->getStartLoc().getAdvancedLoc(1);
         TC.diagnose(segment->getLoc(),
-                    diag::silence_optional_in_interpolation_segment_call)
+                    diag::silence_debug_description_in_interpolation_segment_call)
           .highlight(segment->getSourceRange())
           .fixItInsert(segmentStart, "String(describing: ")
           .fixItInsert(segment->getEndLoc(), ")");
 
-        // Suggest inserting a default value.
-        TC.diagnose(segment->getLoc(), diag::default_optional_to_any)
-          .highlight(segment->getSourceRange())
-          .fixItInsert(segment->getEndLoc(), " ?? <#default value#>");
+        // Suggest inserting a default value about an optional.
+        if(isOptional)
+            TC.diagnose(segment->getLoc(), diag::default_optional_to_any)
+              .highlight(segment->getSourceRange())
+              .fixItInsert(segment->getEndLoc(), " ?? <#default value#>");
       }
     }
 

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3759,7 +3759,7 @@ static void diagnoseUnintendedOptionalBehavior(TypeChecker &TC, const Expr *E,
           if (isa<ExplicitCastExpr>(paren->getSubExpr()))
             continue;
 
-        bool isOptional = !!segment->getType()->getRValueType()->getOptionalObjectType();
+        bool isOptional = bool(segment->getType()->getRValueType()->getOptionalObjectType());
         bool isFunction = segment->getType()->getRValueType()->is<AnyFunctionType>();
 
         // Bail out if we don't have an optional and a function.

--- a/test/Sema/diag_function_in_string_interpolation.swift
+++ b/test/Sema/diag_function_in_string_interpolation.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift
+
+func f() {
+}
+
+print("\(f)")
+// expected-warning@-1 {{string interpolation produces a debug description for a function value; did you mean to make this explicit?}}
+// expected-note@-2 {{use 'String(describing:)' to silence this warning}} {{10-10=String(describing: }} {{11-11=)}}
+
+print("\(String(describing: f))") // No warning


### PR DESCRIPTION
Resolves https://bugs.swift.org/browse/SR-8464.

Warn about a function in string interpolation like this.

```swift
func f() {
}

print("\(f)")
// => string interpolation produces a debug description for a function value; did you mean to make this explicit?
// => use 'String(describing:)' to silence this warning
```

Because a printing function is useless in a most case, this warn would help developers.