### PR TITLE
[AST] Don't coalesce @available(swift 5) with @available(iOS 5, *)

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -203,6 +203,7 @@ void DeclAttributes::dump(const Decl *D) const {
 /// attribute (e.g., as @available(iOS 8.0, *). The presentation requires an
 /// introduction version and does not support deprecation, obsoletion, or
 /// messages.
+LLVM_READONLY
 static bool isShortAvailable(const DeclAttribute *DA) {
   auto *AvailAttr = dyn_cast<AvailableAttr>(DA);
   if (!AvailAttr)
@@ -223,9 +224,15 @@ static bool isShortAvailable(const DeclAttribute *DA) {
   if (!AvailAttr->Rename.empty())
     return false;
 
-  if (AvailAttr->PlatformAgnostic != PlatformAgnosticAvailabilityKind::None &&
-      !AvailAttr->isLanguageVersionSpecific())
+  switch (AvailAttr->PlatformAgnostic) {
+  case PlatformAgnosticAvailabilityKind::Deprecated:
+  case PlatformAgnosticAvailabilityKind::Unavailable:
+  case PlatformAgnosticAvailabilityKind::UnavailableInSwift:
     return false;
+  case PlatformAgnosticAvailabilityKind::None:
+  case PlatformAgnosticAvailabilityKind::SwiftVersionSpecific:
+    return true;
+  }
 
   return true;
 }
@@ -243,7 +250,7 @@ static void printShortFormAvailable(ArrayRef<const DeclAttribute *> Attrs,
   assert(!Attrs.empty());
 
   Printer << "@available(";
-  auto FirstAvail = dyn_cast<AvailableAttr>(Attrs[0]);
+  auto FirstAvail = cast<AvailableAttr>(Attrs.front());
   if (Attrs.size() == 1 &&
       FirstAvail->isLanguageVersionSpecific()) {
     assert(FirstAvail->Introduced.hasValue());
@@ -273,6 +280,7 @@ void DeclAttributes::print(ASTPrinter &Printer, const PrintOptions &Options,
 
   // Process attributes in passes.
   AttributeVector shortAvailableAttributes;
+  const DeclAttribute *swiftVersionAvailableAttribute = nullptr;
   AttributeVector longAttributes;
   AttributeVector attributes;
   AttributeVector modifiers;
@@ -286,6 +294,16 @@ void DeclAttributes::print(ASTPrinter &Printer, const PrintOptions &Options,
     if (Options.excludeAttrKind(DA->getKind()))
       continue;
 
+    // Be careful not to coalesce `@available(swift 5)` with other short
+    // `available' attributes.
+    if (auto *availableAttr = dyn_cast<AvailableAttr>(DA)) {
+      if (availableAttr->isLanguageVersionSpecific() &&
+          isShortAvailable(availableAttr)) {
+        swiftVersionAvailableAttribute = availableAttr;
+        continue;
+      }
+    }
+
     AttributeVector &which = DA->isDeclModifier() ? modifiers :
                              isShortAvailable(DA) ? shortAvailableAttributes :
                              DA->isLongAttribute() ? longAttributes :
@@ -293,9 +311,10 @@ void DeclAttributes::print(ASTPrinter &Printer, const PrintOptions &Options,
     which.push_back(DA);
   }
 
-  if (!shortAvailableAttributes.empty()) {
+  if (swiftVersionAvailableAttribute)
+    printShortFormAvailable(swiftVersionAvailableAttribute, Printer, Options);
+  if (!shortAvailableAttributes.empty())
     printShortFormAvailable(shortAvailableAttributes, Printer, Options);
-  }
 
   for (auto DA : longAttributes)
     DA->print(Printer, Options, D);

--- a/test/attr/Inputs/OldAndNew.swift
+++ b/test/attr/Inputs/OldAndNew.swift
@@ -1,9 +1,31 @@
-@available(swift, introduced: 3.0, obsoleted: 4.0)
-public func threeOnly() -> Int {
-  return 3
-}
-
+// CHECK: @available(swift 4.0)
+// CHECK-NEXT: func fourOnly() -> Int
 @available(swift, introduced: 4.0)
 public func fourOnly() -> Int {
   return 4
+}
+
+// CHECK: @available(swift 4.0)
+// CHECK-NEXT: @available(OSX 10.1, *)
+// CHECK-NEXT: func fourOnlyWithMac() -> Int
+@available(swift, introduced: 4.0)
+@available(macOS, introduced: 10.1)
+public func fourOnlyWithMac() -> Int {
+  return 4
+}
+
+// CHECK: @available(swift 4.0)
+// CHECK-NEXT: @available(OSX 10.1, *)
+// CHECK-NEXT: func fourOnlyWithMac2() -> Int
+@available(macOS, introduced: 10.1)
+@available(swift, introduced: 4.0)
+public func fourOnlyWithMac2() -> Int {
+  return 4
+}
+
+// CHECK: @available(swift, introduced: 3.0, obsoleted: 4.0)
+// CHECK-NEXT: func threeOnly() -> Int
+@available(swift, introduced: 3.0, obsoleted: 4.0)
+public func threeOnly() -> Int {
+  return 3
 }

--- a/test/attr/attr_availability_swift_deserialize.swift
+++ b/test/attr/attr_availability_swift_deserialize.swift
@@ -2,6 +2,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/OldAndNew.swiftmodule -module-name OldAndNew %S/Inputs/OldAndNew.swift 
 // RUN: not %target-swift-frontend -typecheck -I %t -swift-version 3 %s 2>&1 | %FileCheck -check-prefix THREE %s
 // RUN: not %target-swift-frontend -typecheck -I %t -swift-version 4 %s 2>&1 | %FileCheck -check-prefix FOUR %s
+// RUN: %target-swift-ide-test -print-module -module-to-print OldAndNew -source-filename x -I %t | %FileCheck %S/Inputs/OldAndNew.swift
 
 import OldAndNew
 


### PR DESCRIPTION
Doing so was leading to nonsense attribute forms like

```
@available(* 5, iOS 5, *)
```