### PR TITLE
[ModuleInterface] Don't print setter access twice

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -125,7 +125,8 @@ PrintOptions PrintOptions::printTextualInterfaceFile() {
   // the default to 'public' and mark the 'internal' things.
   result.PrintAccess = true;
 
-  result.ExcludeAttrList = {DAK_ImplicitlyUnwrappedOptional, DAK_AccessControl};
+  result.ExcludeAttrList = {DAK_ImplicitlyUnwrappedOptional, DAK_AccessControl,
+                            DAK_SetterAccess};
 
   return result;
 }
@@ -527,6 +528,9 @@ class PrintAST : public ASTVisitor<PrintAST> {
   }
 
   void printAccess(const ValueDecl *D) {
+    assert(!llvm::is_contained(Options.ExcludeAttrList, DAK_AccessControl) ||
+           llvm::is_contained(Options.ExcludeAttrList, DAK_SetterAccess));
+
     if (!Options.PrintAccess || isa<ProtocolDecl>(D->getDeclContext()))
       return;
     if (D->getAttrs().hasAttribute<AccessControlAttr>() &&

--- a/test/ModuleInterface/access-filter.swift
+++ b/test/ModuleInterface/access-filter.swift
@@ -96,3 +96,9 @@ extension UFIProto {
   // CHECK-NEXT: internal func ufiMethod(){{$}}
   @usableFromInline internal func ufiMethod() {}
 } // CHECK: {{^[}]$}}
+
+// CHECK: extension PublicStruct {{[{]$}}
+extension PublicStruct {
+  // CHECK: public private(set) static var secretlySettable: Int{{$}}
+  public private(set) static var secretlySettable: Int = 0
+} // CHECK: {{^[}]$}}


### PR DESCRIPTION
And assert from now on that people don't exclude DAK_AccessControl without also excluding DAK_SetterAccess.