### PR TITLE
Removed the RK_Inst enum type and associated code from SymbolicValue.

### DIFF
--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -86,11 +86,6 @@ private:
     /// function_ref directly, or a devirtualized method reference.
     RK_Function,
 
-    /// This value is a constant, and tracked by the "inst" member of the
-    /// value union.  This could be an integer, floating point, string, or
-    /// metatype value.
-    RK_Inst,
-
     /// This value is represented with a bump-pointer allocated APInt.
     RK_Integer,
 
@@ -313,20 +308,6 @@ public:
   SILFunction *getFunctionValue() const {
     assert(getKind() == Function);
     return value.function;
-  }
-
-  static SymbolicValue getConstantInst(SingleValueInstruction *inst) {
-    assert(inst && "inst value must be present");
-    SymbolicValue result;
-    result.representationKind = RK_Inst;
-    result.value.inst = inst;
-    return result;
-  }
-
-  // TODO: Remove this, it is just needed because deabstraction has no SIL
-  // instruction of its own.
-  SingleValueInstruction *getConstantInstIfPresent() const {
-    return representationKind == RK_Inst ? value.inst : nullptr;
   }
 
   static SymbolicValue getInteger(int64_t value, unsigned bitWidth);

--- a/lib/SIL/SILConstants.cpp
+++ b/lib/SIL/SILConstants.cpp
@@ -52,10 +52,6 @@ void SymbolicValue::print(llvm::raw_ostream &os, unsigned indent) const {
     os << "\n";
     return;
   }
-  case RK_Inst:
-    os << "inst: ";
-    value.inst->dump();
-    return;
   case RK_Integer:
   case RK_IntegerInline:
     os << "int: " << getIntegerValue() << "\n";
@@ -171,14 +167,6 @@ SymbolicValue::Kind SymbolicValue::getKind() const {
   case RK_Array:
   case RK_ArrayAddress:
     return Array;
-  case RK_Inst:
-    auto *inst = value.inst;
-    if (isa<IntegerLiteralInst>(inst))
-      return Integer;
-    if (isa<FloatLiteralInst>(inst))
-      return Float;
-    assert(isa<StringLiteralInst>(inst) && "Unknown ConstantInst kind");
-    return String;
   }
 }
 
@@ -187,22 +175,7 @@ SymbolicValue::Kind SymbolicValue::getKind() const {
 SymbolicValue
 SymbolicValue::cloneInto(llvm::BumpPtrAllocator &allocator) const {
   auto thisRK = representationKind;
-  // If this is an instruction kind, map onto the thing that will cause a copy.
-  if (thisRK == RK_Inst) {
-    auto *inst = value.inst;
-    if (isa<IntegerLiteralInst>(inst))
-      thisRK = RK_Integer;
-    else if (isa<FloatLiteralInst>(inst))
-      thisRK = RK_Float;
-    else {
-      assert(isa<StringLiteralInst>(inst) && "Unknown ConstantInst kind");
-      thisRK = RK_String;
-    }
-  }
-
   switch (thisRK) {
-  case RK_Inst:
-    assert(0 && "should be remapped above");
   case RK_UninitMemory:
   case RK_Unknown:
   case RK_Metatype:
@@ -300,24 +273,17 @@ APInt SymbolicValue::getIntegerValue() const {
     return APInt(numBits, value.integerInline);
   }
 
-  if (representationKind == RK_Integer) {
-    auto numBits = aux.integer_bitwidth;
-    auto numWords = (numBits + 63) / 64;
-    return APInt(numBits, {value.integer, numWords});
-  }
-
-  assert(representationKind == RK_Inst);
-  return cast<IntegerLiteralInst>(value.inst)->getValue();
+  assert(representationKind == RK_Integer);
+  auto numBits = aux.integer_bitwidth;
+  auto numWords = (numBits + 63) / 64;
+  return APInt(numBits, {value.integer, numWords});
 }
 
 unsigned SymbolicValue::getIntegerValueBitWidth() const {
   assert(getKind() == Integer);
-  if (representationKind == RK_IntegerInline ||
-      representationKind == RK_Integer)
-    return aux.integer_bitwidth;
-
-  assert(representationKind == RK_Inst);
-  return cast<IntegerLiteralInst>(value.inst)->getValue().getBitWidth();
+  assert (representationKind == RK_IntegerInline ||
+          representationKind == RK_Integer);
+  return aux.integer_bitwidth;
 }
 
 //===----------------------------------------------------------------------===//
@@ -407,11 +373,8 @@ APFloat SymbolicValue::getFloatValue() const {
   if (representationKind == RK_Float64)
     return APFloat(value.float64);
 
-  if (representationKind == RK_Float)
-    return value.floatingPoint->getValue();
-
-  assert(representationKind == RK_Inst);
-  return cast<FloatLiteralInst>(value.inst)->getValue();
+  assert(representationKind == RK_Float);
+  return value.floatingPoint->getValue();
 }
 
 const llvm::fltSemantics *SymbolicValue::getFloatValueSemantics() const {
@@ -422,11 +385,8 @@ const llvm::fltSemantics *SymbolicValue::getFloatValueSemantics() const {
   if (representationKind == RK_Float64)
     return &APFloat::IEEEdouble();
 
-  if (representationKind == RK_Float)
-    return &value.floatingPoint->semantics;
-
-  assert(representationKind == RK_Inst);
-  return &getFloatValue().getSemantics();
+  assert (representationKind == RK_Float);
+  return &value.floatingPoint->semantics;
 }
 
 //===----------------------------------------------------------------------===//
@@ -453,11 +413,8 @@ SymbolicValue SymbolicValue::getString(StringRef string,
 StringRef SymbolicValue::getStringValue() const {
   assert(getKind() == String);
 
-  if (representationKind == RK_String)
-    return StringRef(value.string, aux.string_numBytes);
-
-  assert(representationKind == RK_Inst);
-  return cast<StringLiteralInst>(value.inst)->getValue();
+  assert(representationKind == RK_String);
+  return StringRef(value.string, aux.string_numBytes);
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This is a follow-up to https://github.com/apple/swift/pull/19040.
