### PR TITLE
Point the 'sort3/simple' test back at sort3

### DIFF
--- a/validation-test/stdlib/Algorithm.swift
+++ b/validation-test/stdlib/Algorithm.swift
@@ -227,7 +227,7 @@ Algorithm.test("sort3/simple")
     [1, 2, 3], [1, 3, 2], [2, 1, 3], [2, 3, 1], [3, 1, 2], [3, 2, 1]
   ]) {
     var input = $0
-    input.sort()
+    input._sort3(0, 1, 2, by: <)
     expectEqual([1, 2, 3], input)
 }
 


### PR DESCRIPTION
This test is for `_sort3`, which only gets called as part of partitioning, so it isn't exercised in the general sort for arrays this small.