### PR TITLE
Reflection: Update extra inhabitants logic for structs.

### DIFF
--- a/stdlib/public/Reflection/TypeLowering.cpp
+++ b/stdlib/public/Reflection/TypeLowering.cpp
@@ -433,12 +433,33 @@ unsigned RecordTypeInfoBuilder::addField(unsigned fieldSize,
   // Update the aggregate alignment
   Alignment = std::max(Alignment, fieldAlignment);
 
-  // The extra inhabitants of a record are the same as the extra
-  // inhabitants of the first field of the record.
-  if (Empty) {
-    NumExtraInhabitants = numExtraInhabitants;
-    Empty = false;
+  switch (Kind) {
+  // The extra inhabitants of a struct are the same as the extra
+  // inhabitants of the field that has the most.
+  case RecordKind::Struct:
+    NumExtraInhabitants = std::max(NumExtraInhabitants, numExtraInhabitants);
+    break;
+  
+  // For other kinds of records, we only use the extra inhabitants of the
+  // first field.
+  case RecordKind::ClassExistential:
+  case RecordKind::ClassInstance:
+  case RecordKind::ClosureContext:
+  case RecordKind::ErrorExistential:
+  case RecordKind::ExistentialMetatype:
+  case RecordKind::Invalid:
+  case RecordKind::MultiPayloadEnum:
+  case RecordKind::NoPayloadEnum:
+  case RecordKind::OpaqueExistential:
+  case RecordKind::SinglePayloadEnum:
+  case RecordKind::ThickFunction:
+  case RecordKind::Tuple:
+    if (Empty) {
+      NumExtraInhabitants = numExtraInhabitants;
+    }
+    break;
   }
+  Empty = false;
 
   return offset;
 }

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -514,7 +514,7 @@
 
 12TypeLowering17ExistentialStructV
 // CHECK-64:      (struct TypeLowering.ExistentialStruct)
-// CHECK-64-NEXT: (struct size=464 alignment=8 stride=464 num_extra_inhabitants=0
+// CHECK-64-NEXT: (struct size=464 alignment=8 stride=464 num_extra_inhabitants=[[PTR_XI]]
 // CHECK-64-NEXT:   (field name=any offset=0
 // CHECK-64-NEXT:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=0
 // CHECK-64-NEXT:       (field name=metadata offset=24
@@ -645,7 +645,7 @@
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1)))))
 
 // CHECK-32: (struct TypeLowering.ExistentialStruct)
-// CHECK-32-NEXT: (struct size=232 alignment=4 stride=232 num_extra_inhabitants=0
+// CHECK-32-NEXT: (struct size=232 alignment=4 stride=232 num_extra_inhabitants=4096
 // CHECK-32-NEXT:   (field name=any offset=0
 // CHECK-32-NEXT:     (opaque_existential size=16 alignment=4 stride=16 num_extra_inhabitants=0
 // CHECK-32-NEXT:       (field name=metadata offset=12
@@ -924,7 +924,7 @@
 
 12TypeLowering10EnumStructV
 // CHECK-64: (struct TypeLowering.EnumStruct)
-// CHECK-64-NEXT: (struct size=81 alignment=8 stride=88 num_extra_inhabitants=0
+// CHECK-64-NEXT: (struct size=81 alignment=8 stride=88 num_extra_inhabitants=[[PTR_XI]]
 // CHECK-64-NEXT:   (field name=empty offset=0
 // CHECK-64-NEXT:     (no_payload_enum size=0 alignment=1 stride=1 num_extra_inhabitants=0))
 // CHECK-64-NEXT:   (field name=noPayload offset=0

--- a/test/Reflection/typeref_lowering_objc.swift
+++ b/test/Reflection/typeref_lowering_objc.swift
@@ -20,7 +20,7 @@
 // CHECK-NEXT: (reference kind=strong refcounting=unknown)
 
 12TypeLowering11HasObjCEnumV
-// CHECK: (struct size=24 alignment=8 stride=24 num_extra_inhabitants=0
+// CHECK: (struct size=24 alignment=8 stride=24 num_extra_inhabitants=2147483647
 // CHECK-NEXT:   (field name=optionalEnum offset=0
 // CHECK-NEXT:     (single_payload_enum size=9 alignment=8 stride=16 num_extra_inhabitants=0
 // CHECK-NEXT:       (field name=some offset=0


### PR DESCRIPTION
Structs now use extra inhabitants from whichever field has the most, not only the first field. rdar://problem/44239246