### PR TITLE
SILGen: Fix crash when emitting foreign-to-native thunk for allocating init in -swift-version 5

### DIFF
--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1613,7 +1613,8 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
   Type allocatorSelfType;
   if (thunk.kind == SILDeclRef::Kind::Allocator) {
     auto *selfDecl = fd->getImplicitSelfDecl();
-    allocatorSelfType = F.mapTypeIntoContext(selfDecl->getInterfaceType());
+    allocatorSelfType = F.mapTypeIntoContext(
+      fd->getDeclContext()->getSelfInterfaceType());
 
     auto selfMetatype =
       CanMetatypeType::get(allocatorSelfType->getCanonicalType());

--- a/test/SILGen/Inputs/usr/include/Gizmo.h
+++ b/test/SILGen/Inputs/usr/include/Gizmo.h
@@ -39,6 +39,7 @@ typedef long NSInteger;
 - (Gizmo*) init OBJC_DESIGNATED_INITIALIZER;
 - (Gizmo*) initWithBellsOn:(NSInteger)x OBJC_DESIGNATED_INITIALIZER;
 - (instancetype) initWithoutBells:(NSInteger)x;
++ (instancetype) gizmoWithWhistles:(NSInteger)x;
 - (void) fork NS_CONSUMES_SELF;
 - (void) enumerateSubGizmos: (void (^ _Nullable)(Gizmo*))f;
 + (void) consume: (NS_CONSUMED Gizmo*) gizmo;

--- a/test/SILGen/objc_thunks.swift
+++ b/test/SILGen/objc_thunks.swift
@@ -1,5 +1,6 @@
 
 // RUN: %target-swift-emit-silgen -module-name objc_thunks -Xllvm -sil-full-demangle -Xllvm -sil-print-debuginfo -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -emit-verbose-sil -enable-sil-ownership | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name objc_thunks -Xllvm -sil-full-demangle -Xllvm -sil-print-debuginfo -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -emit-verbose-sil -enable-sil-ownership -swift-version 5 | %FileCheck %s
 
 // REQUIRES: objc_interop
 
@@ -592,3 +593,12 @@ func testObjCNoescapeThunk() {
 // CHECK-NEXT:  [[T4:%.*]] = tuple ()
 // CHECK-NEXT:  end_borrow [[T2]]
 // CHECK-NEXT:  return [[T4]]
+
+// Call a convenience initializer
+func buildGizmo1() -> Gizmo {
+  return Gizmo(outBells: 10)
+}
+
+func buildGizmo2() -> Gizmo {
+  return Gizmo(whistles: 10)
+}


### PR DESCRIPTION
This comes up when we import a static factory method as a convenience init.
The thunk was using DynamicSelfType as the type of a basic block argument,
because that was the type of the 'self' parameter in -swift-version 5.

Fixes <rdar://problem/44242156>.