### PR TITLE
Imported modules only import the stdlib if it exists.

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3082,7 +3082,8 @@ void ClangModuleUnit::getImportedModules(
   switch (filter) {
   case ModuleDecl::ImportFilter::All:
   case ModuleDecl::ImportFilter::Private:
-    imports.push_back({ModuleDecl::AccessPathTy(), owner.getStdlibModule()});
+    if (auto stdlib = owner.getStdlibModule())
+      imports.push_back({ModuleDecl::AccessPathTy(), stdlib});
     break;
   case ModuleDecl::ImportFilter::Public:
     break;


### PR DESCRIPTION
Any configuration where the stdlib doesn't exist is an atypical one, but being more permissive here lets us successfully import many kinds of declarations even without a stdlib.  That in turn makes it possible to write IRGen tests that need foreign types and exercise a specific target without restricting the test to only run when building that target.