### PR TITLE
[Type checker] Move accessor creation out of validateDecl().

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -17,6 +17,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "ConstraintSystem.h"
+#include "CodeSynthesis.h"
 #include "CSDiagnostics.h"
 #include "MiscDiagnostics.h"
 #include "TypeCheckProtocol.h"
@@ -4112,6 +4113,7 @@ namespace {
         method = func;
       } else if (auto var = dyn_cast<VarDecl>(foundDecl)) {
         // Properties.
+        maybeAddAccessorsToStorage(tc, var);
 
         // If this isn't a property on a type, complain.
         if (!var->getDeclContext()->isTypeContext()) {

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1786,6 +1786,7 @@ static bool wouldBeCircularSynthesis(AbstractStorageDecl *storage,
 void swift::triggerAccessorSynthesis(TypeChecker &TC,
                                      AbstractStorageDecl *storage) {
   auto VD = dyn_cast<VarDecl>(storage);
+  maybeAddAccessorsToStorage(TC, storage);
 
   // Synthesize accessors for lazy, all checking already been performed.
   bool lazy = false;

--- a/test/CircularReferences/objc.swift
+++ b/test/CircularReferences/objc.swift
@@ -10,3 +10,16 @@
 class A {
   @objc func foo() { }
 }
+
+
+@objc class B {
+  @objc dynamic subscript(i: Int) -> B {
+    return self
+  }
+}
+
+class C: B {
+  override subscript(i: Int) -> B {
+    return super[i]
+  }
+}


### PR DESCRIPTION
Creating accessors for a storage declaration within validateDecl() caused
circular dependencies detected by the request-evaluator. Separate out
accessor creation to break the dependency.

Fixes SR-8656 / rdar://problem/43951634.
