### PR TITLE
[Batch Mode] Very simple and safe fix for batch mode diagnostic suppression bug. Includes tests.

### DIFF
--- a/include/swift/AST/DiagnosticConsumer.h
+++ b/include/swift/AST/DiagnosticConsumer.h
@@ -187,6 +187,7 @@ private:
       ConsumerSpecificInfoForSubsequentNotes = None;
 
   bool HasAnErrorBeenConsumed = false;
+  bool HasAnErrorWithNoConsumerSpecificInfoBeenConsumed = false;
 
 public:
   /// Takes ownership of the DiagnosticConsumers specified in \p consumers.

--- a/test/ClangImporter/diags_from_header.swift
+++ b/test/ClangImporter/diags_from_header.swift
@@ -1,6 +1,16 @@
-// RUN: not %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/diags_from_header.h 2>&1 | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-WARN
+// RUN: not %target-swift-frontend -typecheck %s -enable-objc-interop -import-objc-header %S/Inputs/diags_from_header.h -serialize-diagnostics-path %t.dia 2>&1 | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-WARN
+// RUN: test -s %t.dia
+// RUN: c-index-test -read-diagnostics %t.dia 2>&1 | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-WARN
+  
+// Also check batch mode (multiple primary files).
+// RUN: not %target-swift-frontend -typecheck -primary-file %s -primary-file %S/../Inputs/empty.swift -enable-objc-interop -import-objc-header %S/Inputs/diags_from_header.h -serialize-diagnostics-path %t.1.dia -serialize-diagnostics-path %t.2.dia 2>&1 | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-WARN
+// RUN: test -s %t.1.dia
+// RUN: c-index-test -read-diagnostics %t.1.dia 2>&1 | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-WARN
+// RUN: test -s %t.2.dia
+// RUN: c-index-test -read-diagnostics %t.2.dia 2>&1 | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-WARN
 
-// RUN: not %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/diags_from_header.h -Xcc -Wno-#warnings 2>&1 | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-NO-WARN
+// Verify that -Wno-* options are applied.
+// RUN: not %target-swift-frontend -typecheck %s -enable-objc-interop -import-objc-header %S/Inputs/diags_from_header.h -Xcc -Wno-#warnings 2>&1 | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-NO-WARN
 
 // CHECK-WARN: diags_from_header.h:{{.*}}:2: warning: "here is some warning about something"
 // CHECK-NO-WARN-NOT: warning about something

--- a/test/ClangImporter/diags_from_module.swift
+++ b/test/ClangImporter/diags_from_module.swift
@@ -29,8 +29,6 @@
 
 // RUN: %target-swift-frontend -module-cache-path %t -enable-objc-interop -typecheck %s -F %S/Inputs/frameworks -Xcc -Wno-#warnings 2>&1 | %FileCheck -check-prefix CHECK-NO-WARN -allow-empty %s
 
-// XFAIL: linux
-
 import Module
 
 // CHECK: Another.h:2:4: error: Module should have been built without -DFOO

--- a/test/ClangImporter/diags_from_module.swift
+++ b/test/ClangImporter/diags_from_module.swift
@@ -1,11 +1,33 @@
-// RUN: not %target-swift-frontend -typecheck %s -F %S/Inputs/frameworks -Xcc -D -Xcc FOO 2> %t.err.txt
-// RUN: %FileCheck -input-file=%t.err.txt %s
+// RUN: %empty-directory(%t)
+// RUN: not %target-swift-frontend -module-cache-path %t -enable-objc-interop -typecheck %s -F %S/Inputs/frameworks -serialize-diagnostics-path %t.dia -Xcc -D -Xcc FOO 2>&1 | %FileCheck %s
+// RUN: test -s %t.dia
+// RUN: c-index-test -read-diagnostics %t.dia 2>&1 | %FileCheck %s
+  
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -module-cache-path %t -enable-objc-interop -typecheck %s -F %S/Inputs/frameworks -serialize-diagnostics-path %t.warn.dia 2>&1 | %FileCheck %s -check-prefix CHECK-WARN
+// RUN: test -s %t.warn.dia
+// RUN: c-index-test -read-diagnostics %t.warn.dia 2>&1 | %FileCheck %s -check-prefix CHECK-WARN
+  
+// Also check batch mode (multiple primary files).
+// RUN: %empty-directory(%t)
+// RUN: not %target-swift-frontend -module-cache-path %t -enable-objc-interop -typecheck -primary-file %s -primary-file %S/../Inputs/empty.swift -F %S/Inputs/frameworks -serialize-diagnostics-path %t.1.dia -serialize-diagnostics-path %t.2.dia -Xcc -D -Xcc FOO 2>&1 | %FileCheck %s
+// RUN: test -s %t.1.dia
+// RUN: c-index-test -read-diagnostics %t.1.dia 2>&1 | %FileCheck %s
+// RUN: c-index-test -read-diagnostics %t.1.dia 2>&1 | %FileCheck %s -check-prefix CHECK-PRIMARY
+// RUN: test -s %t.2.dia
+// RUN: c-index-test -read-diagnostics %t.2.dia 2>&1 | %FileCheck %s
 
-// RUN: %target-swift-frontend -typecheck %s -F %S/Inputs/frameworks 2> %t.warn.txt
-// RUN: %FileCheck -input-file=%t.warn.txt %s -check-prefix=CHECK-WARN
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -module-cache-path %t -enable-objc-interop -typecheck -primary-file %s -primary-file %S/../Inputs/empty.swift -F %S/Inputs/frameworks -serialize-diagnostics-path %t.warn.1.dia -serialize-diagnostics-path %t.warn.2.dia 2>&1 | %FileCheck %s -check-prefix CHECK-WARN
+// RUN: test -s %t.1.dia
+// RUN: c-index-test -read-diagnostics %t.warn.1.dia 2>&1 | %FileCheck %s -check-prefix=CHECK-WARN
+// RUN: test -s %t.2.dia
+// RUN: c-index-test -read-diagnostics %t.warn.2.dia 2>&1 | %FileCheck %s -check-prefix=CHECK-WARN
 
-// RUN: %target-swift-frontend -typecheck %s -F %S/Inputs/frameworks -Xcc -Wno-#warnings 2> %t.nowarn.txt
-// RUN: %FileCheck -input-file=%t.nowarn.txt %s -check-prefix=CHECK-NO-WARN -allow-empty
+// Verify that -Wno-* options are applied.
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -module-cache-path %t -enable-objc-interop -typecheck %s -F %S/Inputs/frameworks -Xcc -Wno-#warnings 2>&1 | %FileCheck -check-prefix CHECK-NO-WARN -allow-empty %s
 
 // XFAIL: linux
 
@@ -13,7 +35,7 @@ import Module
 
 // CHECK: Another.h:2:4: error: Module should have been built without -DFOO
 // CHECK: Sub2.h:2:9: error: could not build module 'Another'
-// CHECK: diags_from_module.swift:[[@LINE-4]]:8: error: could not build Objective-C module 'Module'
+// CHECK-PRIMARY: diags_from_module.swift:[[@LINE-4]]:8: error: could not build Objective-C module 'Module'
 
 // CHECK-WARN: Sub2.h:7:2: warning: here is some warning about something
 // FIXME: show the clang warning: <module-includes>:1:1: warning: umbrella header for module 'Module' does not include header 'NotInModule.h' [-Wincomplete-umbrella]


### PR DESCRIPTION
<!-- What's in this pull request? -->
A much smaller and safer fix for the batch mode bug where all diagnostic outputs could be truncated, leaving the user with no diagnostics.

Scope of issue: User gets no diagnostics when all errors are present in non-primaries, e.g. an Objective-C module import error.
Origination: Initial implementation of batch mode.
Risk: Very very small. Adds one flag, set in one place, tested in one place right where the bad behavior would otherwise occur.
Reviewed by: Jordan Rose informally, will get a formal review from him.
Testing: Normal regression tests.
Radar: rdar://43033749, clone of rdar://42314665.

rdar://44362180