### PR TITLE
AST: fully qualify the friended complete template specialization

### DIFF
--- a/include/swift/AST/AccessRequests.h
+++ b/include/swift/AST/AccessRequests.h
@@ -39,7 +39,7 @@ public:
   using SimpleRequest::SimpleRequest;
 
 private:
-  friend class SimpleRequest;
+  friend SimpleRequest;
 
   // Evaluation.
   llvm::Expected<AccessLevel> evaluate(Evaluator &evaluator,
@@ -68,7 +68,7 @@ public:
   using SimpleRequest::SimpleRequest;
 
 private:
-  friend class SimpleRequest;
+  friend SimpleRequest;
 
   // Evaluation.
   llvm::Expected<AccessLevel>
@@ -95,7 +95,7 @@ public:
   using SimpleRequest::SimpleRequest;
   using DefaultAndMax = std::pair<AccessLevel, AccessLevel>;
 private:
-  friend class SimpleRequest;
+  friend SimpleRequest;
 
   // Evaluation.
   llvm::Expected<DefaultAndMax>

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -68,7 +68,7 @@ public:
   using SimpleRequest::SimpleRequest;
 
 private:
-  friend class SimpleRequest;
+  friend SimpleRequest;
 
   // Evaluation.
   DirectlyReferencedTypeDecls evaluate(
@@ -114,7 +114,7 @@ public:
   using SimpleRequest::SimpleRequest;
 
 private:
-  friend class SimpleRequest;
+  friend SimpleRequest;
 
   // Evaluation.
   DirectlyReferencedTypeDecls evaluate(
@@ -140,7 +140,7 @@ public:
   using SimpleRequest::SimpleRequest;
 
 private:
-  friend class SimpleRequest;
+  friend SimpleRequest;
 
   // Evaluation.
   llvm::Expected<ClassDecl *>
@@ -165,7 +165,7 @@ public:
   using SimpleRequest::SimpleRequest;
 
 private:
-  friend class SimpleRequest;
+  friend SimpleRequest;
 
   // Evaluation.
   llvm::Expected<NominalTypeDecl *>
@@ -193,7 +193,7 @@ public:
   using SimpleRequest::SimpleRequest;
 
 private:
-  friend class SimpleRequest;
+  friend SimpleRequest;
 
   // Evaluation.
   llvm::TinyPtrVector<NominalTypeDecl *> evaluate(Evaluator &evaluator,
@@ -218,7 +218,7 @@ public:
   using SimpleRequest::SimpleRequest;
 
 private:
-  friend class SimpleRequest;
+  friend SimpleRequest;
 
   // Evaluation.
   DirectlyReferencedTypeDecls evaluate(Evaluator &evaluator,

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -55,7 +55,7 @@ public:
   using SimpleRequest::SimpleRequest;
 
 private:
-  friend class SimpleRequest;
+  friend SimpleRequest;
 
   // Evaluation.
   llvm::Expected<Type>
@@ -86,7 +86,7 @@ public:
   using SimpleRequest::SimpleRequest;
 
 private:
-  friend class SimpleRequest;
+  friend SimpleRequest;
 
   // Evaluation.
   llvm::Expected<Type>
@@ -115,7 +115,7 @@ public:
   using SimpleRequest::SimpleRequest;
 
 private:
-  friend class SimpleRequest;
+  friend SimpleRequest;
 
   // Evaluation.
   llvm::Expected<Type>
@@ -144,7 +144,7 @@ public:
   using SimpleRequest::SimpleRequest;
 
 private:
-  friend class SimpleRequest;
+  friend SimpleRequest;
 
   // Evaluation.
   llvm::Expected<llvm::TinyPtrVector<ValueDecl *>>
@@ -171,7 +171,7 @@ public:
   using SimpleRequest::SimpleRequest;
 
 private:
-  friend class SimpleRequest;
+  friend SimpleRequest;
 
   // Evaluation.
   llvm::Expected<bool> evaluate(Evaluator &evaluator, ValueDecl *decl) const;
@@ -197,7 +197,7 @@ public:
   using SimpleRequest::SimpleRequest;
 
 private:
-  friend class SimpleRequest;
+  friend SimpleRequest;
 
   // Evaluation.
   llvm::Expected<bool> evaluate(Evaluator &evaluator, ValueDecl *decl) const;
@@ -275,7 +275,7 @@ public:
       llvm::function_ref<bool(Requirement, RequirementRepr*)> callback);
 
 private:
-  friend class SimpleRequest;
+  friend SimpleRequest;
 
   /// Retrieve the requirement this request operates on.
   RequirementRepr &getRequirement() const;
@@ -308,7 +308,7 @@ public:
   using SimpleRequest::SimpleRequest;
 
 private:
-  friend class SimpleRequest;
+  friend SimpleRequest;
 
   // Evaluation.
   llvm::Expected<std::string> evaluate(Evaluator &eval, const ValueDecl* d) const;


### PR DESCRIPTION
When building with Visual Studio, the following error is identified:

  'SimpleRequest': non-class template has already been declared as a class template
  note: see declaration of 'SimpleRequest'

Change the friend declarations to friend the complete template specialization
that we derive from to ensure that the templated class is friended
appropriately.  This repairs the build with Visual Studio and ensures that the
friending is more strictly checked.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
