### PR TITLE
[CMake] Install swiftinterface files alongside swiftmodules

### DIFF
--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -333,12 +333,9 @@ function(_compile_swift_files
     endif()
   endif()
 
-  # If we want to build a single overlay, don't install the swiftmodule and swiftdoc files.
-  if(NOT BUILD_STANDALONE)
-    swift_install_in_component("${SWIFTFILE_INSTALL_IN_COMPONENT}"
-        FILES "${module_file}" "${module_doc_file}"
-        DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/${library_subdir}")
-  endif()
+  swift_install_in_component("${SWIFTFILE_INSTALL_IN_COMPONENT}"
+    FILES "${module_file}" "${module_doc_file}"
+    DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/${library_subdir}")
 
   set(line_directive_tool "${SWIFT_SOURCE_DIR}/utils/line-directive")
   set(swift_compiler_tool "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/swiftc")

--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -334,7 +334,7 @@ function(_compile_swift_files
   endif()
 
   swift_install_in_component("${SWIFTFILE_INSTALL_IN_COMPONENT}"
-    FILES "${module_file}" "${module_doc_file}"
+    FILES "${module_file}" "${module_doc_file}" "${interface_file}"
     DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/${library_subdir}")
 
   set(line_directive_tool "${SWIFT_SOURCE_DIR}/utils/line-directive")


### PR DESCRIPTION
This may not be their final destination, but at least this will get them into built toolchains, which means it'll be easier to do integration testing once all the other pieces are in place.

rdar://problem/43823937