### PR TITLE
do not hoist tensorStartPoint above itself

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -1548,6 +1548,10 @@ static bool hoistValueAboveStartPoint(SILInstruction *inst,
   if (DI.properlyDominates(inst, tensorStartPoint))
     return true;
 
+  // It doesn't make sense to hoist the start point above itself.
+  if (inst == tensorStartPoint)
+    return false;
+
   // In general, we need to check to see if we have a chain of side-effect free
   // instructions whose ultimate inputs dominate the start point.
   if (canMoveInstruction(inst, /*plusZeroTensorOperand*/ nullptr)) {


### PR DESCRIPTION
This fixes `test/TensorFlowRuntime/sese_loop_canonicalization.swift` in piper.

I can make the test fail in the opensource build by putting `public` in front of `func natSumWithBreak`. Perhaps some configuration difference is causing the piper build to partition `natSumWithBreak` even without `public`. Anyways, here's what's happening:

Right before TFPartition starts marking `natSumWithBreak`, it looks like this:
```
// natSumWithBreak(_:)
sil @$S4sese15natSumWithBreaky10TensorFlow0F0Vys5Int32VGAGF : $@convention(thin) (Int32) -> @owned Tensor<Int32> {
// %0                                             // users: %4, %1
bb0(%0 : $Int32):
  debug_value %0 : $Int32, let, name "breakIndex", argno 1 // id: %1
  %2 = integer_literal $Builtin.Int32, 1          // users: %9, %14, %5, %17
  [TENSOR START POINT] %3 = graph_op "Const"() {dtype: $Int32, value$tensor: i32 0, __device: "ALL_DEVICES"} : $TensorHandle<Int32> // users: %8, %6
  %4 = struct_extract %0 : $Int32, #Int32._value  // users: %9, %28
  %5 = graph_op "tfc.scalarToTensor,s"(%2 : $Builtin.Int32) {__device: "/device:CPU:0"} : $TensorHandle<Int32> // users: %7, %6
  %6 = graph_op "Add,i,i"(%3 : $TensorHandle<Int32>, %5 : $TensorHandle<Int32>) {T: $Int32, __device: "/device:CPU:0"} : $TensorHandle<Int32> // users: %11, %14
  strong_release %5 : $TensorHandle<Int32>        // id: %7
  strong_release %3 : $TensorHandle<Int32>        // id: %8
  %9 = builtin "cmp_eq_Int32"(%4 : $Builtin.Int32, %2 : $Builtin.Int32) : $Builtin.Int1 // user: %10
  cond_br %9, bb1, bb2                            // id: %10
...
```

Now, `sinkValueIntoRegionForPromotion` sinks `%2 = integer_literal`, which makes `%2 = integer_literal` the new start point.

Eventually, `hoistValueAboveStartPoint` tries to recursively hoist `%9 = builtin "cmp_eq_Int32"` and its operands above the start point. Unfortunately, one of the operands is the start point. `hoistValueAboveStartPoint` does not handle hoisting the start point above itself correctly, so it creates the following result where `builtin "cmp_eq_Int32"` takes an operand that comes after it:
```
// natSumWithBreak(_:)
sil @$S4sese15natSumWithBreaky10TensorFlow0F0Vys5Int32VGAGF : $@convention(thin) (Int32) -> @owned Tensor<Int32> {
// %0                                             // users: %2, %1
bb0(%0 : $Int32):
  debug_value %0 : $Int32, let, name "breakIndex", argno 1 // id: %1
  %2 = struct_extract %0 : $Int32, #Int32._value  // users: %3, %28
  %3 = builtin "cmp_eq_Int32"(%2 : $Builtin.Int32, %5 : $Builtin.Int32) : $Builtin.Int1 // user: %11
  %4 = integer_literal $Builtin.Int32, 100        // user: %21
  %5 = integer_literal $Builtin.Int32, 1          // users: %3, %14, %7, %17
  %6 = graph_op "Const"() {dtype: $Int32, value$tensor: i32 0, __device: "ALL_DEVICES"} : $TensorHandle<Int32> // users: %10, %8
  %7 = graph_op "tfc.scalarToTensor,s"(%5 : $Builtin.Int32) {__device: "/device:CPU:0"} : $TensorHandle<Int32> // users: %9, %8
  %8 = graph_op "Add,i,i"(%6 : $TensorHandle<Int32>, %7 : $TensorHandle<Int32>) {T: $Int32, __device: "/device:CPU:0"} : $TensorHandle<Int32> // users: %12, %14
  strong_release %7 : $TensorHandle<Int32>        // id: %9
  strong_release %6 : $TensorHandle<Int32>        // id: %10
  cond_br %3, bb1, bb2                            // id: %11
...
```