### PR TITLE
[Sema] Suppress deprecation warnings in synthesized code

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1937,6 +1937,12 @@ void TypeChecker::diagnoseIfDeprecated(SourceRange ReferenceRange,
   if (!Attr)
     return;
 
+  // We don't want deprecated declarations to trigger warnings
+  // in synthesized code.
+  if (ReferenceRange.isInvalid() &&
+      isInsideImplicitFunction(ReferenceRange, ReferenceDC)) {
+    return;
+  }
   // We match the behavior of clang to not report deprecation warnings
   // inside declarations that are themselves deprecated on all deployment
   // targets.

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -1028,3 +1028,16 @@ struct UnavailableAccessors {
     other[alsoUnavailable: 0] += 1 // expected-error {{'subscript(alsoUnavailable:)' is unavailable: bad subscript!}} {{none}}
   }
 }
+
+// Should produce no warnings.
+enum SR8634_Enum: Int {
+  case a
+  @available(*, deprecated, message: "I must not be raised in synthesized code")
+  case b
+  case c
+}
+
+struct SR8634_Struct: Equatable {
+  @available(*, deprecated, message: "I must not be raised in synthesized code", renamed: "x")
+  let a: Int
+}

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -1029,6 +1029,14 @@ struct UnavailableAccessors {
   }
 }
 
+class BaseDeprecatedInit {
+  @available(*, deprecated) init(bad: Int) { }
+}
+
+class SubInheritedDeprecatedInit: BaseDeprecatedInit { }
+
+_ = SubInheritedDeprecatedInit(bad: 0) // expected-warning {{'init(bad:)' is deprecated}}
+
 // Should produce no warnings.
 enum SR8634_Enum: Int {
   case a


### PR DESCRIPTION
Resolves [SR-8634](https://bugs.swift.org/browse/SR-8634).

