### PR TITLE
tapi: make it build on Windows

### DIFF
--- a/lib/TBDGen/tapi/Defines.h
+++ b/lib/TBDGen/tapi/Defines.h
@@ -22,7 +22,11 @@
 #define TAPI_NAMESPACE_V1_BEGIN namespace tapi { inline namespace v1 {
 #define TAPI_NAMESPACE_V1_END } }
 
+#if defined(_WIN32)
+#define TAPI_PUBLIC
+#else
 #define TAPI_PUBLIC __attribute__((visibility ("default")))
+#endif
 
 #endif // TAPI_DEFINES_H
 


### PR DESCRIPTION
Since TAPI is currently built statically, just define away `TAPI_PUBLIC` on
Windows.  If tapi is to be built dynamic, we would need to annotate dllstorage
on the public interfaces.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
