### PR TITLE
[test/lit.cfg] Use absolute imports

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -18,6 +18,7 @@
 #
 # -----------------------------------------------------------------------------
 
+from __future__ import absolute_import
 import os
 import platform
 import re


### PR DESCRIPTION
This fixes an issue when using Docker on OSX, 'import shutil' in 'lit.cfg' ends up finding lit.ShUtil instead of the module from the standard library.
Switching to absolute imports ensures that the module from the standard library will be used.