### PR TITLE
Demangling: use `LLVM_BUILTIN_UNREACHABLE` over `llvm_unreachable`

### DIFF
--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -185,7 +185,7 @@ static bool isAliasNode(Demangle::NodePointer Node) {
   default:
     return false;
   }
-  llvm_unreachable("Unhandled node kind!");
+  LLVM_BUILTIN_UNREACHABLE;
 }
 
 bool swift::Demangle::isAlias(llvm::StringRef mangledName) {
@@ -203,7 +203,7 @@ static bool isClassNode(Demangle::NodePointer Node) {
   default:
     return false;
   }
-  llvm_unreachable("Unhandled node kind!");
+  LLVM_BUILTIN_UNREACHABLE;
 }
 
 bool swift::Demangle::isClass(llvm::StringRef mangledName) {
@@ -221,7 +221,7 @@ static bool isEnumNode(Demangle::NodePointer Node) {
   default:
     return false;
   }
-  llvm_unreachable("Unhandled node kind!");
+  LLVM_BUILTIN_UNREACHABLE;
 }
 
 bool swift::Demangle::isEnum(llvm::StringRef mangledName) {
@@ -238,7 +238,7 @@ static bool isProtocolNode(Demangle::NodePointer Node) {
   default:
     return false;
   }
-  llvm_unreachable("Unhandled node kind!");
+  LLVM_BUILTIN_UNREACHABLE;
 }
 
 bool swift::Demangle::isProtocol(llvm::StringRef mangledName) {
@@ -256,7 +256,7 @@ static bool isStructNode(Demangle::NodePointer Node) {
   default:
     return false;
   }
-  llvm_unreachable("Unhandled node kind!");
+  LLVM_BUILTIN_UNREACHABLE;
 }
 
 bool swift::Demangle::isStruct(llvm::StringRef mangledName) {


### PR DESCRIPTION
Avoid a dependency on LLVMSupport at runtime through the `llvm_unreachable`.
This would pull in `llvm_unreachable_internal` in debug builds, which requires a
runtime dependency on LLVMSupport which increases the size of the binary
considerably.  Although we miss the error messages in debug builds, we would
normally lose the error message on a release build so this doesn't make it any
worse.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
