### PR TITLE
SILOptimizer: use `LLVM_ATTRIBUTE_USED`

### DIFF
--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -247,7 +247,7 @@ public:
     return {NewValue, SubElementNumber, InsertionPoints};
   }
 
-  void dump() const __attribute__((used));
+  void dump() const LLVM_ATTRIBUTE_USED;
   void print(llvm::raw_ostream &os) const;
 
 private:
@@ -379,7 +379,7 @@ public:
   SILValue aggregateValues(SILType LoadTy, SILValue Address, unsigned FirstElt);
 
   void print(llvm::raw_ostream &os) const;
-  void dump() const __attribute__((used));
+  void dump() const LLVM_ATTRIBUTE_USED;
 
 private:
   SILValue aggregateFullyAvailableValue(SILType LoadTy, unsigned FirstElt);


### PR DESCRIPTION
This makes the use of the unused attribute more portable.
`__attribute__((__unused__))` is not accepted by Visual Studio, but LLVM
conveniently provides the helpful macro `LLVM_ATTRIBUTE_UNUSED` to enable this.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
