### PR TITLE
stdlib: adjust the shims for MSVC mode compilation

### DIFF
--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -1406,11 +1406,20 @@ typedef swift::InlineRefCounts InlineRefCounts;
 #endif
 
 // These assertions apply to both the C and the C++ declarations.
+#if defined(_MSC_VER) && !defined(__clang__)
+static_assert(sizeof(InlineRefCounts) == sizeof(InlineRefCountsPlaceholder),
+              "InlineRefCounts and InlineRefCountsPlaceholder must match");
+static_assert(sizeof(InlineRefCounts) == sizeof(__swift_uintptr_t),
+              "InlineRefCounts must be pointer-sized");
+static_assert(__alignof(InlineRefCounts) == __alignof(__swift_uintptr_t),
+              "InlineRefCounts must be pointer-aligned");
+#else
 _Static_assert(sizeof(InlineRefCounts) == sizeof(InlineRefCountsPlaceholder),
   "InlineRefCounts and InlineRefCountsPlaceholder must match");
 _Static_assert(sizeof(InlineRefCounts) == sizeof(__swift_uintptr_t),
   "InlineRefCounts must be pointer-sized");
 _Static_assert(_Alignof(InlineRefCounts) == _Alignof(__swift_uintptr_t),
   "InlineRefCounts must be pointer-aligned");
+#endif
 
 #endif

--- a/stdlib/public/SwiftShims/SwiftStdint.h
+++ b/stdlib/public/SwiftShims/SwiftStdint.h
@@ -70,8 +70,20 @@ typedef unsigned __INT8_TYPE__ __swift_uint8_t;
 #define __swift_intn_t(n) __swift_join3(__swift_int, n, _t)
 #define __swift_uintn_t(n) __swift_join3(__swift_uint, n, _t)
 
+#if defined(_MSC_VER) && !defined(__clang__)
+#if defined(_WIN32)
+typedef __swift_int32_t __swift_intptr_t;
+typedef __swift_uint32_t __swift_uintptr_t;
+#elif defined(_WIN64)
+typedef __swift_int64_t __swift_intptr_t;
+typedef __swift_uint64_t __swift_uintptr_t;
+#else
+#error unknown windows pointer width
+#endif
+#else
 typedef __swift_intn_t(__INTPTR_WIDTH__) __swift_intptr_t;
 typedef __swift_uintn_t(__INTPTR_WIDTH__) __swift_uintptr_t;
+#endif
 #endif
 
 #endif // SWIFT_STDLIB_SHIMS_SWIFT_STDINT_H


### PR DESCRIPTION
The SwiftStdint.h header is used in the compiler as well.  The compiler may be
built with cl (Visual Studio) on Windows, which does not define
`__INTPTR_TYPE__` nor does it define `__INTPTR_WIDTH__`.  Simply define the
`__swift_{,u}intptr_t` typedefs as Microsoft does on that platform when building
with Visual Studio.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
