### PR TITLE
Sema: qualify the `flags` member

### DIFF
--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -141,8 +141,9 @@ class TypeResolutionOptions {
   Context context = Context::None;
   // TypeResolutionFlags
   uint16_t flags = 0;
-  static_assert(sizeof(flags) == sizeof(TypeResolutionFlags),
-      "Flags size error");
+  static_assert(sizeof(TypeResolutionOptions::flags) ==
+                    sizeof(TypeResolutionFlags),
+                "Flags size error");
 
 public:
   ~TypeResolutionOptions() = default;


### PR DESCRIPTION
When building with Visual Studio, the flags member would not be found.  Qualify
the member with the scope (class name) to resolve the ambiguity.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
