### PR TITLE
XPC Codable support

### DIFF
--- a/stdlib/public/SDK/XPC/CMakeLists.txt
+++ b/stdlib/public/SDK/XPC/CMakeLists.txt
@@ -3,6 +3,15 @@ include("../../../../cmake/modules/StandaloneOverlay.cmake")
 
 add_swift_library(swiftXPC ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
   XPC.swift
+  XPCCodingKey.swift
+  XPCDecoder.swift
+  XPCEncoder.swift
+  XPCKeyedDecodingContainer.swift
+  XPCKeyedEncodingContainer.swift
+  XPCSingleValueDecodingContainer.swift
+  XPCSingleValueEncodingContainer.swift
+  XPCUnkeyedDecodingContainer.swift
+  XPCUnkeyedEncodingContainer.swift
 
   SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"

--- a/stdlib/public/SDK/XPC/XPCCodingKey.swift
+++ b/stdlib/public/SDK/XPC/XPCCodingKey.swift
@@ -17,13 +17,14 @@
 
 
 public struct XPCCodingKey: CodingKey {
-    public var stringValue: String
+    public let stringValue: String
 
     public init?(stringValue: String) {
+        self.intValue = nil
         self.stringValue = stringValue
     }
 
-    public var intValue: Int?
+    public let intValue: Int?
 
     public init?(intValue: Int) {
         self.intValue = intValue
@@ -35,5 +36,5 @@ public struct XPCCodingKey: CodingKey {
         self.stringValue = stringValue
     }
 
-    static let superKey = XPCCodingKey(intValue: 0, stringValue: "super")
+    internal static let superKey = XPCCodingKey(intValue: 0, stringValue: "super")
 }

--- a/stdlib/public/SDK/XPC/XPCCodingKey.swift
+++ b/stdlib/public/SDK/XPC/XPCCodingKey.swift
@@ -9,10 +9,10 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 // -----------------------------------------------------------------------------
-///
-/// This file degines a coding key specific for supporting XPC. This mainly used
-/// for the super key.
-///
+//
+// This file degines a coding key specific for supporting XPC. This mainly used
+// for the super key.
+//
 // -----------------------------------------------------------------------------
 
 

--- a/stdlib/public/SDK/XPC/XPCCodingKey.swift
+++ b/stdlib/public/SDK/XPC/XPCCodingKey.swift
@@ -1,0 +1,39 @@
+// stdlib/public/SDK/XPC/XPCCodingKey.swift - CodingKey Implementation for XPC
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// This file degines a coding key specific for supporting XPC. This mainly used
+/// for the super key.
+///
+// -----------------------------------------------------------------------------
+
+
+public struct XPCCodingKey: CodingKey {
+    public var stringValue: String
+
+    public init?(stringValue: String) {
+        self.stringValue = stringValue
+    }
+
+    public var intValue: Int?
+
+    public init?(intValue: Int) {
+        self.intValue = intValue
+        self.stringValue = String(intValue)
+    }
+
+    public init(intValue: Int, stringValue: String) {
+        self.intValue = intValue
+        self.stringValue = stringValue
+    }
+
+    static let superKey = XPCCodingKey(intValue: 0, stringValue: "super")
+}

--- a/stdlib/public/SDK/XPC/XPCDecoder.swift
+++ b/stdlib/public/SDK/XPC/XPCDecoder.swift
@@ -86,7 +86,7 @@ extension xpc_object_t {
         return to.init(xpc_uint64_get_value(self))
     }
 
-    func decodeFloatingPointNumber<F>(_ to: F.Type, at codingPath: [CodingKey]) throws -> F where F: BinaryFloatingPoint{
+    func decodeFloatingPointNumber<F: BinaryFloatingPoint>(_ to: F.Type, at codingPath: [CodingKey]) throws -> F {
         guard xpc_get_type(self) == XPC_TYPE_DOUBLE else {
             throw DecodingError.typeMismatch(to.self,
                                              DecodingError.Context(codingPath: codingPath,

--- a/stdlib/public/SDK/XPC/XPCDecoder.swift
+++ b/stdlib/public/SDK/XPC/XPCDecoder.swift
@@ -46,65 +46,65 @@ open class XPCDecoder: Decoder {
     }
 }
 
-struct XPCDecodingHelpers {
-    static func decodeNil(from xpcObject: xpc_object_t, at codingPath: [CodingKey]) -> Bool {
+extension xpc_object_t {
+    func decodeNil(at codingPath: [CodingKey]) -> Bool {
         let nullSingleton = xpc_null_create()
 
-        return xpcObject === nullSingleton
+        return self === nullSingleton
     }
 
-    static func decodeBool(from xpcObject: xpc_object_t, at codingPath: [CodingKey]) throws -> Bool {
-        guard xpc_get_type(xpcObject) == XPC_TYPE_BOOL else {
+    func decodeBool(at codingPath: [CodingKey]) throws -> Bool {
+        guard xpc_get_type(self) == XPC_TYPE_BOOL else {
             throw DecodingError.typeMismatch(Bool.self,
                                              DecodingError.Context(codingPath: codingPath,
                                                                    debugDescription: "Type mismatch.",
                                                                    underlyingError: nil))
         }
 
-        return xpcObject === XPC_BOOL_TRUE
+        return self === XPC_BOOL_TRUE
     }
 
-    static func decodeSignedInteger<I: SignedInteger>(_ to: I.Type, from xpcObject: xpc_object_t, at codingPath: [CodingKey]) throws -> I {
-        guard xpc_get_type(xpcObject) == XPC_TYPE_INT64 else {
+    func decodeSignedInteger<I: SignedInteger>(_ to: I.Type, at codingPath: [CodingKey]) throws -> I {
+        guard xpc_get_type(self) == XPC_TYPE_INT64 else {
             throw DecodingError.typeMismatch(to.self,
                                              DecodingError.Context(codingPath: codingPath,
                                                                    debugDescription: "Type mismatch.",
                                                                    underlyingError: nil))
         }
 
-        return to.init(exactly: xpc_int64_get_value(xpcObject))!
+        return to.init(xpc_int64_get_value(self))
     }
 
-    static func decodeUnsignedInteger<U: UnsignedInteger>(_ to: U.Type, from xpcObject: xpc_object_t, at codingPath: [CodingKey]) throws -> U {
-        guard xpc_get_type(xpcObject) == XPC_TYPE_UINT64 else {
+    func decodeUnsignedInteger<U: UnsignedInteger>(_ to: U.Type, at codingPath: [CodingKey]) throws -> U {
+        guard xpc_get_type(self) == XPC_TYPE_UINT64 else {
             throw DecodingError.typeMismatch(to.self,
                                              DecodingError.Context(codingPath: codingPath,
                                                                    debugDescription: "Type mismatch.",
                                                                    underlyingError: nil))
         }
 
-        return to.init(exactly: xpc_uint64_get_value(xpcObject))!
+        return to.init(xpc_uint64_get_value(self))
     }
 
-    static func decodeFloatingPointNumber<F>(_ to: F.Type, from xpcObject: xpc_object_t, at codingPath: [CodingKey]) throws -> F where F: BinaryFloatingPoint{
-        guard xpc_get_type(xpcObject) == XPC_TYPE_DOUBLE else {
+    func decodeFloatingPointNumber<F>(_ to: F.Type, at codingPath: [CodingKey]) throws -> F where F: BinaryFloatingPoint{
+        guard xpc_get_type(self) == XPC_TYPE_DOUBLE else {
             throw DecodingError.typeMismatch(to.self,
                                              DecodingError.Context(codingPath: codingPath,
                                                                    debugDescription: "Type mismatch.",
                                                                    underlyingError: nil))
         }
 
-        return to.init(xpc_double_get_value(xpcObject))
+        return to.init(xpc_double_get_value(self))
     }
 
-    static func decodeString(from xpcObject: xpc_object_t, at codingPath: [CodingKey]) throws -> String {
-        guard xpc_get_type(xpcObject) == XPC_TYPE_STRING else {
+    func decodeString(at codingPath: [CodingKey]) throws -> String {
+        guard xpc_get_type(self) == XPC_TYPE_STRING else {
             throw DecodingError.typeMismatch(String.self,
                                              DecodingError.Context(codingPath: codingPath,
                                                                    debugDescription: "Type mismatch.",
                                                                    underlyingError: nil))
         }
 
-        return String(cString: xpc_string_get_string_ptr(xpcObject)!)
+        return String(cString: xpc_string_get_string_ptr(self)!)
     }
 }

--- a/stdlib/public/SDK/XPC/XPCDecoder.swift
+++ b/stdlib/public/SDK/XPC/XPCDecoder.swift
@@ -16,14 +16,6 @@
 ///
 // -----------------------------------------------------------------------------//
 
-public enum XPCParsingError: Error {
-    case invalidXPCObjectType
-    case keyDoesNotExist
-    case typeMismatch
-    case reachedArrayEnd
-    case notYetImplemented
-}
-
 open class XPCDecoder: Decoder {
     private let underlyingMessage: xpc_object_t
 
@@ -55,47 +47,62 @@ open class XPCDecoder: Decoder {
 }
 
 struct XPCDecodingHelpers {
-    static func decodeNil(from xpcObject: xpc_object_t) -> Bool {
+    static func decodeNil(from xpcObject: xpc_object_t, at codingPath: [CodingKey]) -> Bool {
         let nullSingleton = xpc_null_create()
 
         return xpcObject === nullSingleton
     }
 
-    static func decodeBool(from xpcObject: xpc_object_t) throws -> Bool {
+    static func decodeBool(from xpcObject: xpc_object_t, at codingPath: [CodingKey]) throws -> Bool {
         guard xpc_get_type(xpcObject) == XPC_TYPE_BOOL else {
-            throw XPCParsingError.typeMismatch
+            throw DecodingError.typeMismatch(Bool.self,
+                                             DecodingError.Context(codingPath: codingPath,
+                                                                   debugDescription: "Type mismatch.",
+                                                                   underlyingError: nil))
         }
 
         return xpcObject === XPC_BOOL_TRUE
     }
 
-    static func decodeSignedInteger<I: SignedInteger>(_ to: I.Type, from xpcObject: xpc_object_t) throws -> I {
+    static func decodeSignedInteger<I: SignedInteger>(_ to: I.Type, from xpcObject: xpc_object_t, at codingPath: [CodingKey]) throws -> I {
         guard xpc_get_type(xpcObject) == XPC_TYPE_INT64 else {
-            throw XPCParsingError.typeMismatch
+            throw DecodingError.typeMismatch(to.self,
+                                             DecodingError.Context(codingPath: codingPath,
+                                                                   debugDescription: "Type mismatch.",
+                                                                   underlyingError: nil))
         }
 
         return to.init(exactly: xpc_int64_get_value(xpcObject))!
     }
 
-    static func decodeUnsignedInteger<I: UnsignedInteger>(_ to: I.Type, from xpcObject: xpc_object_t) throws -> I {
+    static func decodeUnsignedInteger<U: UnsignedInteger>(_ to: U.Type, from xpcObject: xpc_object_t, at codingPath: [CodingKey]) throws -> U {
         guard xpc_get_type(xpcObject) == XPC_TYPE_UINT64 else {
-            throw XPCParsingError.typeMismatch
+            throw DecodingError.typeMismatch(to.self,
+                                             DecodingError.Context(codingPath: codingPath,
+                                                                   debugDescription: "Type mismatch.",
+                                                                   underlyingError: nil))
         }
 
         return to.init(exactly: xpc_uint64_get_value(xpcObject))!
     }
 
-    static func decodeFloatingPointNumber<F>(_ to: F.Type, from xpcObject: xpc_object_t) throws -> F where F: BinaryFloatingPoint{
+    static func decodeFloatingPointNumber<F>(_ to: F.Type, from xpcObject: xpc_object_t, at codingPath: [CodingKey]) throws -> F where F: BinaryFloatingPoint{
         guard xpc_get_type(xpcObject) == XPC_TYPE_DOUBLE else {
-            throw XPCParsingError.typeMismatch
+            throw DecodingError.typeMismatch(to.self,
+                                             DecodingError.Context(codingPath: codingPath,
+                                                                   debugDescription: "Type mismatch.",
+                                                                   underlyingError: nil))
         }
 
         return to.init(xpc_double_get_value(xpcObject))
     }
 
-    static func decodeString(from xpcObject: xpc_object_t) throws -> String {
+    static func decodeString(from xpcObject: xpc_object_t, at codingPath: [CodingKey]) throws -> String {
         guard xpc_get_type(xpcObject) == XPC_TYPE_STRING else {
-            throw XPCParsingError.typeMismatch
+            throw DecodingError.typeMismatch(String.self,
+                                             DecodingError.Context(codingPath: codingPath,
+                                                                   debugDescription: "Type mismatch.",
+                                                                   underlyingError: nil))
         }
 
         return String(cString: xpc_string_get_string_ptr(xpcObject)!)

--- a/stdlib/public/SDK/XPC/XPCDecoder.swift
+++ b/stdlib/public/SDK/XPC/XPCDecoder.swift
@@ -64,7 +64,7 @@ extension xpc_object_t {
         return self === XPC_BOOL_TRUE
     }
 
-    func decodeSignedInteger<I: SignedInteger>(_ to: I.Type, at codingPath: [CodingKey]) throws -> I {
+    func decodeSignedInteger<I: SignedInteger & FixedWidthInteger>(_ to: I.Type, at codingPath: [CodingKey]) throws -> I {
         guard xpc_get_type(self) == XPC_TYPE_INT64 else {
             throw DecodingError.typeMismatch(to.self,
                                              DecodingError.Context(codingPath: codingPath,
@@ -75,7 +75,7 @@ extension xpc_object_t {
         return to.init(xpc_int64_get_value(self))
     }
 
-    func decodeUnsignedInteger<U: UnsignedInteger>(_ to: U.Type, at codingPath: [CodingKey]) throws -> U {
+    func decodeUnsignedInteger<U: UnsignedInteger & FixedWidthInteger>(_ to: U.Type, at codingPath: [CodingKey]) throws -> U {
         guard xpc_get_type(self) == XPC_TYPE_UINT64 else {
             throw DecodingError.typeMismatch(to.self,
                                              DecodingError.Context(codingPath: codingPath,

--- a/stdlib/public/SDK/XPC/XPCDecoder.swift
+++ b/stdlib/public/SDK/XPC/XPCDecoder.swift
@@ -9,11 +9,11 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 // -----------------------------------------------------------------------------
-///
-/// This file contains an implementation of a Decoder for xpc_object_t types, as
-/// well as generic utility functions for decoding primitives that are reused by
-/// all the decoding containers.
-///
+//
+// This file contains an implementation of a Decoder for xpc_object_t types, as
+// well as generic utility functions for decoding primitives that are reused by
+// all the decoding containers.
+//
 // -----------------------------------------------------------------------------//
 
 open class XPCDecoder: Decoder {

--- a/stdlib/public/SDK/XPC/XPCDecoder.swift
+++ b/stdlib/public/SDK/XPC/XPCDecoder.swift
@@ -1,0 +1,103 @@
+// stdlib/public/SDK/XPC/XPCDecoder.swift - Decoder impelementation for XPC
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// This file contains an implementation of a Decoder for xpc_object_t types, as
+/// well as generic utility functions for decoding primitives that are reused by
+/// all the decoding containers.
+///
+// -----------------------------------------------------------------------------//
+
+public enum XPCParsingError: Error {
+    case invalidXPCObjectType
+    case keyDoesNotExist
+    case typeMismatch
+    case reachedArrayEnd
+    case notYetImplemented
+}
+
+open class XPCDecoder: Decoder {
+    private let underlyingMessage: xpc_object_t
+
+    public var codingPath: [CodingKey]
+
+    public var userInfo: [CodingUserInfoKey : Any] = [:]
+
+    public init(withUnderlyingMessage message: xpc_object_t, at codingPath: [CodingKey] = []) {
+        self.underlyingMessage = message
+        self.codingPath = codingPath
+    }
+
+    public func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key : CodingKey {
+        let container = try XPCKeyedDecodingContainer<Key>(referencing: self, wrapping: self.underlyingMessage)
+        return KeyedDecodingContainer(container)
+    }
+
+    public func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+        return try XPCUnkeyedDecodingContainer(referencing: self, wrapping: self.underlyingMessage)
+    }
+
+    public func singleValueContainer() throws -> SingleValueDecodingContainer {
+        return XPCSingleValueDecodingContainer(referencing: self, wrapping: self.underlyingMessage)
+    }
+
+    public static func decode<T: Decodable>(_ type: T.Type, message xpcObject: xpc_object_t) throws -> T {
+        return try T(from: XPCDecoder(withUnderlyingMessage: xpcObject))
+    }
+}
+
+struct XPCDecodingHelpers {
+    static func decodeNil(from xpcObject: xpc_object_t) -> Bool {
+        let nullSingleton = xpc_null_create()
+
+        return xpcObject === nullSingleton
+    }
+
+    static func decodeBool(from xpcObject: xpc_object_t) throws -> Bool {
+        guard xpc_get_type(xpcObject) == XPC_TYPE_BOOL else {
+            throw XPCParsingError.typeMismatch
+        }
+
+        return xpcObject === XPC_BOOL_TRUE
+    }
+
+    static func decodeSignedInteger<I: SignedInteger>(_ to: I.Type, from xpcObject: xpc_object_t) throws -> I {
+        guard xpc_get_type(xpcObject) == XPC_TYPE_INT64 else {
+            throw XPCParsingError.typeMismatch
+        }
+
+        return to.init(exactly: xpc_int64_get_value(xpcObject))!
+    }
+
+    static func decodeUnsignedInteger<I: UnsignedInteger>(_ to: I.Type, from xpcObject: xpc_object_t) throws -> I {
+        guard xpc_get_type(xpcObject) == XPC_TYPE_UINT64 else {
+            throw XPCParsingError.typeMismatch
+        }
+
+        return to.init(exactly: xpc_uint64_get_value(xpcObject))!
+    }
+
+    static func decodeFloatingPointNumber<F>(_ to: F.Type, from xpcObject: xpc_object_t) throws -> F where F: BinaryFloatingPoint{
+        guard xpc_get_type(xpcObject) == XPC_TYPE_DOUBLE else {
+            throw XPCParsingError.typeMismatch
+        }
+
+        return to.init(xpc_double_get_value(xpcObject))
+    }
+
+    static func decodeString(from xpcObject: xpc_object_t) throws -> String {
+        guard xpc_get_type(xpcObject) == XPC_TYPE_STRING else {
+            throw XPCParsingError.typeMismatch
+        }
+
+        return String(cString: xpc_string_get_string_ptr(xpcObject)!)
+    }
+}

--- a/stdlib/public/SDK/XPC/XPCEncoder.swift
+++ b/stdlib/public/SDK/XPC/XPCEncoder.swift
@@ -97,11 +97,11 @@ enum XPCEncodingHelpers {
     }
 
     static func encodeSignedInteger<I: SignedInteger & FixedWidthInteger>(_ value: I) -> xpc_object_t {
-        return xpc_int64_create(Int64(exactly: value)!)
+        return xpc_int64_create(Int64(value))
     }
 
     static func encodeUnsignedInteger<U: UnsignedInteger & FixedWidthInteger>(_ value: U) -> xpc_object_t {
-        return xpc_uint64_create(UInt64(exactly: value)!)
+        return xpc_uint64_create(UInt64(value))
     }
 
     static func encodeDouble(_ value: Double) -> xpc_object_t {

--- a/stdlib/public/SDK/XPC/XPCEncoder.swift
+++ b/stdlib/public/SDK/XPC/XPCEncoder.swift
@@ -75,9 +75,9 @@ public class XPCEncoder: Encoder {
             preconditionFailure("This encoder already has a container of kind \(self.containerKind)")
         }
 
-        let inserter = XPCSingleValueEncoderInserter(into: self)
-
-        return XPCSingleValueEncodingContainer(referencing: self, inserter: inserter)
+        return XPCSingleValueEncodingContainer(referencing: self, insertionClosure: {
+            self.topLevelContainer = $0
+        })
     }
 
     public static func encode<T: Encodable>(_ value: T, at codingPath: [CodingKey] = []) throws -> xpc_object_t {

--- a/stdlib/public/SDK/XPC/XPCEncoder.swift
+++ b/stdlib/public/SDK/XPC/XPCEncoder.swift
@@ -9,11 +9,11 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 // -----------------------------------------------------------------------------
-///
-/// This file contains stuff an Encoder implementation for xpc_object_t as well
-/// as generic utility functions for encoding primiives that are reused by the
-/// encoding containers.
-///
+//
+// This file contains stuff an Encoder implementation for xpc_object_t as well
+// as generic utility functions for encoding primiives that are reused by the
+// encoding containers.
+//
 // -----------------------------------------------------------------------------//
 
 public class XPCEncoder: Encoder {

--- a/stdlib/public/SDK/XPC/XPCEncoder.swift
+++ b/stdlib/public/SDK/XPC/XPCEncoder.swift
@@ -96,11 +96,11 @@ enum XPCEncodingHelpers {
         return xpc_bool_create(value)
     }
 
-    static func encodeSignedInteger<I: SignedInteger>(_ value: I) -> xpc_object_t {
+    static func encodeSignedInteger<I: SignedInteger & FixedWidthInteger>(_ value: I) -> xpc_object_t {
         return xpc_int64_create(Int64(exactly: value)!)
     }
 
-    static func encodeUnsignedInteger<U: UnsignedInteger>(_ value: U) -> xpc_object_t {
+    static func encodeUnsignedInteger<U: UnsignedInteger & FixedWidthInteger>(_ value: U) -> xpc_object_t {
         return xpc_uint64_create(UInt64(exactly: value)!)
     }
 

--- a/stdlib/public/SDK/XPC/XPCEncoder.swift
+++ b/stdlib/public/SDK/XPC/XPCEncoder.swift
@@ -16,12 +16,6 @@
 ///
 // -----------------------------------------------------------------------------//
 
-public enum XPCSerializationError: Error {
-    case invalidXPCObjectType
-    case insertionPastEndOfArray
-    case notYetImplemented
-}
-
 public class XPCEncoder: Encoder {
     private enum ContainerKind: String {
         case Keyed
@@ -120,5 +114,12 @@ struct XPCEncodingHelpers {
 
     static func encodeString(_ value: String) -> xpc_object_t {
         return value.withCString({ return xpc_string_create($0) })
+    }
+
+    static func makeEncodingError(_ value: Any, _ codingPath: [CodingKey],
+                                  _ debugDescription: String) -> EncodingError {
+        return EncodingError.invalidValue(value,
+                                          EncodingError.Context(codingPath: codingPath,
+                                                                debugDescription: debugDescription))
     }
 }

--- a/stdlib/public/SDK/XPC/XPCEncoder.swift
+++ b/stdlib/public/SDK/XPC/XPCEncoder.swift
@@ -87,7 +87,7 @@ public class XPCEncoder: Encoder {
     }
 }
 
-struct XPCEncodingHelpers {
+enum XPCEncodingHelpers {
     static func encodeNil() -> xpc_object_t {
         return xpc_null_create()
     }

--- a/stdlib/public/SDK/XPC/XPCEncoder.swift
+++ b/stdlib/public/SDK/XPC/XPCEncoder.swift
@@ -1,0 +1,92 @@
+// stdlib/public/SDK/XPC/XPCEncoder.swift - Encoder implementation for XPC
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// This file contains stuff an Encoder implementation for xpc_object_t as well
+/// as generic utility functions for encoding primiives that are reused by the
+/// encoding containers.
+///
+// -----------------------------------------------------------------------------//
+
+public enum XPCSerializationError: Error {
+    case invalidXPCObjectType
+    case insertionPastEndOfArray
+    case notYetImplemented
+}
+
+open class XPCEncoder: Encoder {
+    public var codingPath: [CodingKey]
+
+    public var userInfo: [CodingUserInfoKey : Any] = [:]
+
+    var topLevelContainer: xpc_object_t?
+
+    public init(at codingPath: [CodingKey] = []) {
+        self.codingPath = codingPath
+    }
+
+    public func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
+        self.topLevelContainer = xpc_dictionary_create(nil, nil, 0)
+
+        // It is OK to force this because we are explicitly passing a dictionary
+        let container = try! XPCKeyedEncodingContainer<Key>(referencing: self, wrapping: self.topLevelContainer!)
+        return KeyedEncodingContainer(container)
+    }
+
+    public func unkeyedContainer() -> UnkeyedEncodingContainer {
+        self.topLevelContainer = xpc_array_create(nil, 0)
+
+        //It is OK to force this through becasue we are explicitly passing an array
+        return try! XPCUnkeyedEncodingContainer(referencing: self, wrapping: self.topLevelContainer!)
+    }
+
+    public func singleValueContainer() -> SingleValueEncodingContainer {
+        let inserter = XPCSingleValueEncoderInserter(into: self)
+
+        return XPCSingleValueEncodingContainer(referencing: self, inserter: inserter)
+    }
+
+    public static func encode<T: Encodable>(_ value: T, at codingPath: [CodingKey] = []) throws -> xpc_object_t {
+        let encoder = XPCEncoder(at: codingPath)
+        try value.encode(to: encoder)
+        return encoder.topLevelContainer!
+    }
+}
+
+struct XPCEncodingHelpers {
+    static func encodeNil() -> xpc_object_t {
+        return xpc_null_create()
+    }
+
+    static func encodeBool(_ value: Bool) -> xpc_object_t {
+        return xpc_bool_create(value)
+    }
+
+    static func encodeSignedInteger<I: SignedInteger>(_ value: I) -> xpc_object_t {
+        return xpc_int64_create(Int64(exactly: value)!)
+    }
+
+    static func encodeUnsignedInteger<U: UnsignedInteger>(_ value: U) -> xpc_object_t {
+        return xpc_uint64_create(UInt64(exactly: value)!)
+    }
+
+    static func encodeDouble(_ value: Double) -> xpc_object_t {
+        return xpc_double_create(Double(value))
+    }
+
+    static func encodeFloat(_ value: Float) -> xpc_object_t {
+        return xpc_double_create(Double(value))
+    }
+
+    static func encodeString(_ value: String) -> xpc_object_t {
+        return value.withCString({ return xpc_string_create($0) })
+    }
+}

--- a/stdlib/public/SDK/XPC/XPCEncoder.swift
+++ b/stdlib/public/SDK/XPC/XPCEncoder.swift
@@ -18,10 +18,10 @@
 
 public class XPCEncoder: Encoder {
     private enum ContainerKind: String {
-        case Keyed
-        case Unkeyed
-        case SingleValue
-        case None
+        case keyed
+        case unkeyed
+        case singleValue
+        case noContainer
     }
 
     public var codingPath: [CodingKey]
@@ -30,7 +30,7 @@ public class XPCEncoder: Encoder {
 
     var topLevelContainer: xpc_object_t?
 
-    private var containerKind: ContainerKind = .None
+    private var containerKind: ContainerKind = .noContainer
 
     public init(at codingPath: [CodingKey] = []) {
         self.codingPath = codingPath
@@ -38,10 +38,10 @@ public class XPCEncoder: Encoder {
 
     public func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
         switch self.containerKind {
-        case .None:
+        case .noContainer:
             self.topLevelContainer = xpc_dictionary_create(nil, nil, 0)
-            self.containerKind = .Keyed
-        case .Keyed:
+            self.containerKind = .keyed
+        case .keyed:
             break
         default:
             preconditionFailure("This encoder already has a container of kind \(self.containerKind)")
@@ -54,10 +54,10 @@ public class XPCEncoder: Encoder {
 
     public func unkeyedContainer() -> UnkeyedEncodingContainer {
         switch self.containerKind {
-        case .None:
+        case .noContainer:
             self.topLevelContainer = xpc_array_create(nil, 0)
-            self.containerKind = .Unkeyed
-        case .Unkeyed:
+            self.containerKind = .unkeyed
+        case .unkeyed:
             break
         default:
             preconditionFailure("This encoder already has a container of kind \(self.containerKind)")
@@ -69,8 +69,8 @@ public class XPCEncoder: Encoder {
 
     public func singleValueContainer() -> SingleValueEncodingContainer {
         switch self.containerKind {
-        case .None:
-            self.containerKind = .SingleValue
+        case .noContainer:
+            self.containerKind = .singleValue
         default:
             preconditionFailure("This encoder already has a container of kind \(self.containerKind)")
         }

--- a/stdlib/public/SDK/XPC/XPCKeyedDecodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCKeyedDecodingContainer.swift
@@ -83,7 +83,7 @@ public struct XPCKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerPro
         get {
             var keys: [Key] = []
             xpc_dictionary_apply(self.underlyingMessage) { (key, _) -> Bool in
-                keys.append(Key(stringValue: String.init(cString: key))!)
+                keys.append(Key(stringValue: String(cString: key))!)
                 return true
             }
             return keys

--- a/stdlib/public/SDK/XPC/XPCKeyedDecodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCKeyedDecodingContainer.swift
@@ -1,0 +1,264 @@
+// stdlib/public/SDK/XPC/XPCKeyedDecodingContainer.swift -
+// KeyedDecodingContainer implementation for XPC
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// This file contains a KeyedDecodingContainer implementation for xpc_object_t.
+///
+// -----------------------------------------------------------------------------//
+
+public struct XPCKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol {
+    public typealias Key = K
+
+    // MARK: - Properties
+
+    /// A reference to the decoder we're reading from.
+    private let decoder: XPCDecoder
+
+    /// The path of coding keys taken to get to this point in decoding.
+    public var codingPath: [CodingKey] {
+        get {
+            return self.decoder.codingPath
+        }
+    }
+
+    private let underlyingMessage: xpc_object_t
+
+    // MARK: - Initialization
+
+    /// Initializes `self` by referencing the given decoder and container.
+    init(referencing decoder: XPCDecoder, wrapping underlyingMessage: xpc_object_t) throws {
+        guard xpc_get_type(underlyingMessage) == XPC_TYPE_DICTIONARY else {
+            throw XPCParsingError.invalidXPCObjectType
+        }
+        self.decoder = decoder
+        self.underlyingMessage = underlyingMessage
+    }
+
+    // MARK: - Helpers
+    private func decodeIntegerType<I: SignedInteger>(_ type: I.Type, forKey key: Key) throws -> I {
+        let foundValue = try getXPCObjectForKey(from: key)
+
+        return try XPCDecodingHelpers.decodeSignedInteger(type.self, from: foundValue)
+    }
+
+    private func decodeIntegerType<I: UnsignedInteger>(_ type: I.Type, forKey key: Key) throws -> I {
+        let foundValue = try getXPCObjectForKey(from: key)
+
+        return try XPCDecodingHelpers.decodeUnsignedInteger(type.self, from: foundValue)
+    }
+
+    private func decodeFloatingPointType<F: BinaryFloatingPoint>(_ type: F.Type, forKey key: Key) throws -> F {
+        let foundValue = try getXPCObjectForKey(from: key)
+
+        return try XPCDecodingHelpers.decodeFloatingPointNumber(type.self, from: foundValue)
+    }
+
+    private func getXPCObjectForKey(from key: CodingKey) throws -> xpc_object_t {
+        guard let foundValue = key.stringValue.withCString({
+            return xpc_dictionary_get_value(self.underlyingMessage, $0)
+        }) else {
+            throw XPCParsingError.keyDoesNotExist
+        }
+
+        return foundValue
+    }
+
+    // MARK: - KeyedDecodingContainerProtocol Methods
+
+    /// You shouldn't rely on this because this is slow
+    public var allKeys: [Key] {
+        get {
+            var keys: [Key] = []
+            xpc_dictionary_apply(self.underlyingMessage) { (key, _) -> Bool in
+                keys.append(Key(stringValue: String.init(cString: key))!)
+                return true
+            }
+            return keys
+        }
+    }
+
+    public func contains(_ key: Key) -> Bool {
+        do {
+            let _ = try getXPCObjectForKey(from: key)
+        } catch {
+            return false
+        }
+        return true
+    }
+
+    public func decodeNil(forKey key: Key) throws -> Bool {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+        let foundValue = try getXPCObjectForKey(from: key)
+
+        return XPCDecodingHelpers.decodeNil(from: foundValue)
+    }
+
+    public func decode(_ type: Bool.Type, forKey key: Key) throws -> Bool {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        let foundValue = try getXPCObjectForKey(from: key)
+
+        return try XPCDecodingHelpers.decodeBool(from: foundValue)
+    }
+
+
+    public func decode(_ type: Int.Type, forKey key: Key) throws -> Int {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        return try decodeIntegerType(type, forKey: key)
+    }
+
+    public func decode(_ type: Int8.Type, forKey key: Key) throws -> Int8 {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        return try decodeIntegerType(type, forKey: key)
+    }
+
+    public func decode(_ type: Int16.Type, forKey key: Key) throws -> Int16 {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        return try decodeIntegerType(type, forKey: key)
+    }
+
+    public func decode(_ type: Int32.Type, forKey key: Key) throws -> Int32 {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        return try decodeIntegerType(type, forKey: key)
+    }
+
+    public func decode(_ type: Int64.Type, forKey key: Key) throws -> Int64 {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        return try decodeIntegerType(type, forKey: key)
+    }
+
+    public func decode(_ type: UInt.Type, forKey key: Key) throws -> UInt {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        return try decodeIntegerType(type, forKey: key)
+    }
+
+    public func decode(_ type: UInt8.Type, forKey key: Key) throws -> UInt8 {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        return try decodeIntegerType(type, forKey: key)
+    }
+
+    public func decode(_ type: UInt16.Type, forKey key: Key) throws -> UInt16 {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        return try decodeIntegerType(type, forKey: key)
+    }
+
+    public func decode(_ type: UInt32.Type, forKey key: Key) throws -> UInt32 {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        return try decodeIntegerType(type, forKey: key)
+    }
+
+    public func decode(_ type: UInt64.Type, forKey key: Key) throws -> UInt64 {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        return try decodeIntegerType(type, forKey: key)
+    }
+
+    public func decode(_ type: Float.Type, forKey key: Key) throws -> Float {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        return try decodeFloatingPointType(type, forKey: key)
+    }
+
+    public func decode(_ type: Double.Type, forKey key: Key) throws -> Double {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        return try decodeFloatingPointType(type, forKey: key)
+    }
+
+    public func decode(_ type: String.Type, forKey key: Key) throws -> String {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        let foundValue = try getXPCObjectForKey(from: key)
+
+        return try XPCDecodingHelpers.decodeString(from: foundValue)
+    }
+
+    public func decode<T: Decodable>(_ type: T.Type, forKey key: Key) throws -> T {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        let foundValue = try getXPCObjectForKey(from: key)
+
+        return try T(from: XPCDecoder(withUnderlyingMessage: foundValue, at: self.decoder.codingPath))
+    }
+
+    public func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        let foundValue = try getXPCObjectForKey(from: key)
+
+        let container = try XPCKeyedDecodingContainer<NestedKey>(referencing: decoder, wrapping: foundValue)
+        return KeyedDecodingContainer<NestedKey>(container)
+    }
+
+    public func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        let foundValue = try getXPCObjectForKey(from: key)
+
+        return try XPCUnkeyedDecodingContainer(referencing: decoder, wrapping: foundValue)
+    }
+
+    private func _superDecoder(forKey key: CodingKey) throws -> Decoder {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        let foundValue = try getXPCObjectForKey(from: key)
+
+        return XPCDecoder(withUnderlyingMessage: foundValue, at: self.decoder.codingPath)
+    }
+
+    public func superDecoder() throws -> Decoder {
+        self.decoder.codingPath.append(XPCCodingKey.superKey)
+        defer { self.decoder.codingPath.removeLast() }
+
+        let foundValue = try getXPCObjectForKey(from: XPCCodingKey.superKey)
+
+        return XPCDecoder(withUnderlyingMessage: foundValue, at: self.decoder.codingPath)
+    }
+
+    public func superDecoder(forKey key: Key) throws -> Decoder {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+
+        let foundValue = try getXPCObjectForKey(from: key)
+
+        return XPCDecoder(withUnderlyingMessage: foundValue, at: self.decoder.codingPath)
+    }
+}
+

--- a/stdlib/public/SDK/XPC/XPCKeyedDecodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCKeyedDecodingContainer.swift
@@ -10,9 +10,9 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 // -----------------------------------------------------------------------------
-///
-/// This file contains a KeyedDecodingContainer implementation for xpc_object_t.
-///
+//
+// This file contains a KeyedDecodingContainer implementation for xpc_object_t.
+//
 // -----------------------------------------------------------------------------//
 
 public struct XPCKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerProtocol {

--- a/stdlib/public/SDK/XPC/XPCKeyedDecodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCKeyedDecodingContainer.swift
@@ -48,19 +48,19 @@ public struct XPCKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerPro
     private func decodeIntegerType<I: SignedInteger>(_ type: I.Type, forKey key: Key) throws -> I {
         let foundValue = try getXPCObjectForKey(from: key)
 
-        return try XPCDecodingHelpers.decodeSignedInteger(type.self, from: foundValue, at: self.codingPath)
+        return try foundValue.decodeSignedInteger(type.self, at: self.codingPath)
     }
 
     private func decodeIntegerType<I: UnsignedInteger>(_ type: I.Type, forKey key: Key) throws -> I {
         let foundValue = try getXPCObjectForKey(from: key)
 
-        return try XPCDecodingHelpers.decodeUnsignedInteger(type.self, from: foundValue, at: self.codingPath)
+        return try foundValue.decodeUnsignedInteger(type.self, at: self.codingPath)
     }
 
     private func decodeFloatingPointType<F: BinaryFloatingPoint>(_ type: F.Type, forKey key: Key) throws -> F {
         let foundValue = try getXPCObjectForKey(from: key)
 
-        return try XPCDecodingHelpers.decodeFloatingPointNumber(type.self, from: foundValue, at: self.codingPath)
+        return try foundValue.decodeFloatingPointNumber(type.self, at: self.codingPath)
     }
 
     private func getXPCObjectForKey(from key: CodingKey) throws -> xpc_object_t {
@@ -104,7 +104,7 @@ public struct XPCKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerPro
         defer { self.decoder.codingPath.removeLast() }
         let foundValue = try getXPCObjectForKey(from: key)
 
-        return XPCDecodingHelpers.decodeNil(from: foundValue, at: self.codingPath)
+        return foundValue.decodeNil(at: self.codingPath)
     }
 
     public func decode(_ type: Bool.Type, forKey key: Key) throws -> Bool {
@@ -113,7 +113,7 @@ public struct XPCKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerPro
 
         let foundValue = try getXPCObjectForKey(from: key)
 
-        return try XPCDecodingHelpers.decodeBool(from: foundValue, at: self.codingPath)
+        return try foundValue.decodeBool(at: self.codingPath)
     }
 
 
@@ -207,7 +207,7 @@ public struct XPCKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerPro
 
         let foundValue = try getXPCObjectForKey(from: key)
 
-        return try XPCDecodingHelpers.decodeString(from: foundValue, at: self.codingPath)
+        return try foundValue.decodeString(at: self.codingPath)
     }
 
     public func decode<T: Decodable>(_ type: T.Type, forKey key: Key) throws -> T {

--- a/stdlib/public/SDK/XPC/XPCKeyedDecodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCKeyedDecodingContainer.swift
@@ -46,24 +46,24 @@ public struct XPCKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerPro
 
     // MARK: - Helpers
     private func decodeIntegerType<I: SignedInteger & FixedWidthInteger>(_ type: I.Type, forKey key: Key) throws -> I {
-        let foundValue = try getXPCObjectForKey(from: key)
+        let foundValue = try getXPCObject(for: key)
 
         return try foundValue.decodeSignedInteger(type.self, at: self.codingPath)
     }
 
     private func decodeIntegerType<I: UnsignedInteger & FixedWidthInteger>(_ type: I.Type, forKey key: Key) throws -> I {
-        let foundValue = try getXPCObjectForKey(from: key)
+        let foundValue = try getXPCObject(for: key)
 
         return try foundValue.decodeUnsignedInteger(type.self, at: self.codingPath)
     }
 
     private func decodeFloatingPointType<F: BinaryFloatingPoint>(_ type: F.Type, forKey key: Key) throws -> F {
-        let foundValue = try getXPCObjectForKey(from: key)
+        let foundValue = try getXPCObject(for: key)
 
         return try foundValue.decodeFloatingPointNumber(type.self, at: self.codingPath)
     }
 
-    private func getXPCObjectForKey(from key: CodingKey) throws -> xpc_object_t {
+    private func getXPCObject(for key: CodingKey) throws -> xpc_object_t {
         guard let foundValue = key.stringValue.withCString({
             return xpc_dictionary_get_value(self.underlyingMessage, $0)
         }) else {
@@ -92,7 +92,7 @@ public struct XPCKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerPro
 
     public func contains(_ key: Key) -> Bool {
         do {
-            let _ = try getXPCObjectForKey(from: key)
+            let _ = try getXPCObject(for: key)
         } catch {
             return false
         }
@@ -102,7 +102,7 @@ public struct XPCKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerPro
     public func decodeNil(forKey key: Key) throws -> Bool {
         self.decoder.codingPath.append(key)
         defer { self.decoder.codingPath.removeLast() }
-        let foundValue = try getXPCObjectForKey(from: key)
+        let foundValue = try getXPCObject(for: key)
 
         return foundValue.decodeNil(at: self.codingPath)
     }
@@ -111,7 +111,7 @@ public struct XPCKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerPro
         self.decoder.codingPath.append(key)
         defer { self.decoder.codingPath.removeLast() }
 
-        let foundValue = try getXPCObjectForKey(from: key)
+        let foundValue = try getXPCObject(for: key)
 
         return try foundValue.decodeBool(at: self.codingPath)
     }
@@ -205,7 +205,7 @@ public struct XPCKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerPro
         self.decoder.codingPath.append(key)
         defer { self.decoder.codingPath.removeLast() }
 
-        let foundValue = try getXPCObjectForKey(from: key)
+        let foundValue = try getXPCObject(for: key)
 
         return try foundValue.decodeString(at: self.codingPath)
     }
@@ -214,7 +214,7 @@ public struct XPCKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerPro
         self.decoder.codingPath.append(key)
         defer { self.decoder.codingPath.removeLast() }
 
-        let foundValue = try getXPCObjectForKey(from: key)
+        let foundValue = try getXPCObject(for: key)
 
         return try T(from: XPCDecoder(withUnderlyingMessage: foundValue, at: self.decoder.codingPath))
     }
@@ -223,7 +223,7 @@ public struct XPCKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerPro
         self.decoder.codingPath.append(key)
         defer { self.decoder.codingPath.removeLast() }
 
-        let foundValue = try getXPCObjectForKey(from: key)
+        let foundValue = try getXPCObject(for: key)
 
         let container = try XPCKeyedDecodingContainer<NestedKey>(referencing: decoder, wrapping: foundValue)
         return KeyedDecodingContainer<NestedKey>(container)
@@ -233,7 +233,7 @@ public struct XPCKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerPro
         self.decoder.codingPath.append(key)
         defer { self.decoder.codingPath.removeLast() }
 
-        let foundValue = try getXPCObjectForKey(from: key)
+        let foundValue = try getXPCObject(for: key)
 
         return try XPCUnkeyedDecodingContainer(referencing: decoder, wrapping: foundValue)
     }
@@ -242,7 +242,7 @@ public struct XPCKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerPro
         self.decoder.codingPath.append(key)
         defer { self.decoder.codingPath.removeLast() }
 
-        let foundValue = try getXPCObjectForKey(from: key)
+        let foundValue = try getXPCObject(for: key)
 
         return XPCDecoder(withUnderlyingMessage: foundValue, at: self.decoder.codingPath)
     }
@@ -251,7 +251,7 @@ public struct XPCKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerPro
         self.decoder.codingPath.append(XPCCodingKey.superKey)
         defer { self.decoder.codingPath.removeLast() }
 
-        let foundValue = try getXPCObjectForKey(from: XPCCodingKey.superKey)
+        let foundValue = try getXPCObject(for: XPCCodingKey.superKey)
 
         return XPCDecoder(withUnderlyingMessage: foundValue, at: self.decoder.codingPath)
     }
@@ -260,7 +260,7 @@ public struct XPCKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerPro
         self.decoder.codingPath.append(key)
         defer { self.decoder.codingPath.removeLast() }
 
-        let foundValue = try getXPCObjectForKey(from: key)
+        let foundValue = try getXPCObject(for: key)
 
         return XPCDecoder(withUnderlyingMessage: foundValue, at: self.decoder.codingPath)
     }

--- a/stdlib/public/SDK/XPC/XPCKeyedDecodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCKeyedDecodingContainer.swift
@@ -238,15 +238,6 @@ public struct XPCKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerPro
         return try XPCUnkeyedDecodingContainer(referencing: decoder, wrapping: foundValue)
     }
 
-    private func _superDecoder(forKey key: CodingKey) throws -> Decoder {
-        self.decoder.codingPath.append(key)
-        defer { self.decoder.codingPath.removeLast() }
-
-        let foundValue = try getXPCObject(for: key)
-
-        return XPCDecoder(withUnderlyingMessage: foundValue, at: self.decoder.codingPath)
-    }
-
     public func superDecoder() throws -> Decoder {
         self.decoder.codingPath.append(XPCCodingKey.superKey)
         defer { self.decoder.codingPath.removeLast() }

--- a/stdlib/public/SDK/XPC/XPCKeyedDecodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCKeyedDecodingContainer.swift
@@ -45,13 +45,13 @@ public struct XPCKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerPro
     }
 
     // MARK: - Helpers
-    private func decodeIntegerType<I: SignedInteger>(_ type: I.Type, forKey key: Key) throws -> I {
+    private func decodeIntegerType<I: SignedInteger & FixedWidthInteger>(_ type: I.Type, forKey key: Key) throws -> I {
         let foundValue = try getXPCObjectForKey(from: key)
 
         return try foundValue.decodeSignedInteger(type.self, at: self.codingPath)
     }
 
-    private func decodeIntegerType<I: UnsignedInteger>(_ type: I.Type, forKey key: Key) throws -> I {
+    private func decodeIntegerType<I: UnsignedInteger & FixedWidthInteger>(_ type: I.Type, forKey key: Key) throws -> I {
         let foundValue = try getXPCObjectForKey(from: key)
 
         return try foundValue.decodeUnsignedInteger(type.self, at: self.codingPath)

--- a/stdlib/public/SDK/XPC/XPCKeyedEncodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCKeyedEncodingContainer.swift
@@ -1,0 +1,231 @@
+// stdlib/public/SDK/XPC/XPCKeyedEncodingContainer.swift -
+// KeyedEncodingContainer implementation for XPC
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// This file contains a KeyedEncodingContainer implementation for xpc_object_t.
+/// This includes a specialization of the XPCEncoder for handling the super
+/// class case, as we don't know what container type is going to be needed to
+/// handle it.
+///
+// -----------------------------------------------------------------------------//
+
+public struct XPCKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
+    public typealias Key = K
+
+    // MARK: - Properties
+
+    /// A reference to the encoder we're writing to.
+    private let encoder: XPCEncoder
+
+    private let underlyingMesage: xpc_object_t
+
+    /// The path of coding keys taken to get to this point in encoding.
+    public var codingPath: [CodingKey] {
+        get {
+            return self.encoder.codingPath
+        }
+    }
+
+    // MARK: - Initialization
+
+    /// Initializes `self` with the given references.
+    init(referencing encoder: XPCEncoder, wrapping dictionary: xpc_object_t) throws {
+        self.encoder = encoder
+        guard xpc_get_type(dictionary) == XPC_TYPE_DICTIONARY else {
+            throw XPCSerializationError.invalidXPCObjectType
+        }
+        self.underlyingMesage = dictionary
+    }
+
+    // MARK: - KeyedEncodingContainerProtocol Methods
+
+    public mutating func encodeNil(forKey key: Key) throws {
+        self.encoder.codingPath.append(key)
+        defer { self.encoder.codingPath.removeLast() }
+
+        key.stringValue.withCString({ xpc_dictionary_set_value(self.underlyingMesage, $0, XPCEncodingHelpers.encodeNil())})
+    }
+
+    public mutating func encode(_ value: Bool, forKey key: Key) throws {
+        self.encoder.codingPath.append(key)
+        defer { self.encoder.codingPath.removeLast() }
+
+        key.stringValue.withCString({ xpc_dictionary_set_bool(self.underlyingMesage, $0, value) })
+    }
+
+    public mutating func encode(_ value: Int, forKey key: Key) throws {
+        self.encoder.codingPath.append(key)
+        defer { self.encoder.codingPath.removeLast() }
+
+        key.stringValue.withCString({ xpc_dictionary_set_value(self.underlyingMesage, $0, XPCEncodingHelpers.encodeSignedInteger(value)) })
+    }
+
+    public mutating func encode(_ value: Int8, forKey key: Key) throws {
+        self.encoder.codingPath.append(key)
+        defer { self.encoder.codingPath.removeLast() }
+
+        key.stringValue.withCString({ xpc_dictionary_set_value(self.underlyingMesage, $0, XPCEncodingHelpers.encodeSignedInteger(value)) })
+    }
+
+    public mutating func encode(_ value: Int16, forKey key: Key) throws {
+        self.encoder.codingPath.append(key)
+        defer { self.encoder.codingPath.removeLast() }
+
+        key.stringValue.withCString({ xpc_dictionary_set_value(self.underlyingMesage, $0, XPCEncodingHelpers.encodeSignedInteger(value)) })
+    }
+
+    public mutating func encode(_ value: Int32, forKey key: Key) throws {
+        self.encoder.codingPath.append(key)
+        defer { self.encoder.codingPath.removeLast() }
+
+        key.stringValue.withCString({ xpc_dictionary_set_value(self.underlyingMesage, $0, XPCEncodingHelpers.encodeSignedInteger(value)) })
+    }
+
+    public mutating func encode(_ value: Int64, forKey key: Key) throws {
+        self.encoder.codingPath.append(key)
+        defer { self.encoder.codingPath.removeLast() }
+
+        key.stringValue.withCString({ xpc_dictionary_set_value(self.underlyingMesage, $0, XPCEncodingHelpers.encodeSignedInteger(value)) })
+    }
+
+    public mutating func encode(_ value: UInt, forKey key: Key) throws {
+        self.encoder.codingPath.append(key)
+        defer { self.encoder.codingPath.removeLast() }
+
+        key.stringValue.withCString({ xpc_dictionary_set_value(self.underlyingMesage, $0, XPCEncodingHelpers.encodeUnsignedInteger(value)) })
+    }
+
+    public mutating func encode(_ value: UInt8, forKey key: Key) throws {
+        self.encoder.codingPath.append(key)
+        defer { self.encoder.codingPath.removeLast() }
+
+        key.stringValue.withCString({ xpc_dictionary_set_value(self.underlyingMesage, $0, XPCEncodingHelpers.encodeUnsignedInteger(value)) })
+    }
+
+    public mutating func encode(_ value: UInt16, forKey key: Key) throws {
+        self.encoder.codingPath.append(key)
+        defer { self.encoder.codingPath.removeLast() }
+
+        key.stringValue.withCString({ xpc_dictionary_set_value(self.underlyingMesage, $0, XPCEncodingHelpers.encodeUnsignedInteger(value)) })
+    }
+
+    public mutating func encode(_ value: UInt32, forKey key: Key) throws {
+        self.encoder.codingPath.append(key)
+        defer { self.encoder.codingPath.removeLast() }
+
+        key.stringValue.withCString({ xpc_dictionary_set_value(self.underlyingMesage, $0, XPCEncodingHelpers.encodeUnsignedInteger(value)) })
+    }
+
+    public mutating func encode(_ value: UInt64, forKey key: Key) throws {
+        self.encoder.codingPath.append(key)
+        defer { self.encoder.codingPath.removeLast() }
+
+        key.stringValue.withCString({ xpc_dictionary_set_value(self.underlyingMesage, $0, XPCEncodingHelpers.encodeUnsignedInteger(value)) })
+    }
+
+    public mutating func encode(_ value: String, forKey key: Key) throws {
+        self.encoder.codingPath.append(key)
+        defer { self.encoder.codingPath.removeLast() }
+
+        key.stringValue.withCString({ xpc_dictionary_set_value(self.underlyingMesage, $0, XPCEncodingHelpers.encodeString(value)) })
+    }
+
+    public mutating func encode(_ value: Float, forKey key: Key) throws {
+        self.encoder.codingPath.append(key)
+        defer { self.encoder.codingPath.removeLast() }
+
+        key.stringValue.withCString({ xpc_dictionary_set_value(self.underlyingMesage, $0, XPCEncodingHelpers.encodeFloat(value)) })
+    }
+
+    public mutating func encode(_ value: Double, forKey key: Key) throws {
+        self.encoder.codingPath.append(key)
+        defer { self.encoder.codingPath.removeLast() }
+
+        key.stringValue.withCString({ xpc_dictionary_set_value(self.underlyingMesage, $0, XPCEncodingHelpers.encodeDouble(value)) })
+    }
+
+    public mutating func encode<T : Encodable>(_ value: T, forKey key: Key) throws {
+        self.encoder.codingPath.append(key)
+        defer { self.encoder.codingPath.removeLast() }
+
+        let xpcObject = try XPCEncoder.encode(value, at: self.encoder.codingPath)
+        key.stringValue.withCString({ xpc_dictionary_set_value(self.underlyingMesage, $0, xpcObject) })
+    }
+
+    public mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
+        self.encoder.codingPath.append(key)
+        defer { self.encoder.codingPath.removeLast() }
+
+        let xpcDictionary = xpc_dictionary_create(nil, nil, 0)
+        key.stringValue.withCString({ xpc_dictionary_set_value(self.underlyingMesage, $0, xpcDictionary) })
+        // It is OK to force this through because we know we are providing a dictionary
+        let container = try! XPCKeyedEncodingContainer<NestedKey>(referencing: self.encoder, wrapping: xpcDictionary)
+        return KeyedEncodingContainer(container)
+    }
+
+    public mutating func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
+        fatalError("NYP")
+    }
+
+    public mutating func superEncoder() -> Encoder {
+        self.encoder.codingPath.append(XPCCodingKey.superKey)
+        defer { self.encoder.codingPath.removeLast() }
+
+        return XPCDictionaryReferencingEncoder(at: self.encoder.codingPath, wrapping: self.underlyingMesage, forKey: XPCCodingKey.superKey)
+    }
+
+    public mutating func superEncoder(forKey key: Key) -> Encoder {
+        self.encoder.codingPath.append(key)
+        defer { self.encoder.codingPath.removeLast() }
+
+        return XPCDictionaryReferencingEncoder(at: self.encoder.codingPath, wrapping: self.underlyingMesage, forKey: key)
+    }
+}
+
+// This is used for encoding super classes, we don't know yet what kind of
+// container the caller will request so we can not prepoluate in superEncoder().
+// To overcome this we alias the encoder, the underlying dictionary, and the key
+// to use, this way we can insert the key-value pair upon request and use the
+// encoder to maintain the encoding state
+fileprivate class XPCDictionaryReferencingEncoder: XPCEncoder {
+    let xpcDictionary: xpc_object_t
+    let key: CodingKey
+
+    init(at codingPath: [CodingKey], wrapping dictionary: xpc_object_t, forKey key: CodingKey) {
+        self.xpcDictionary = dictionary
+        self.key = key
+        super.init(at: codingPath)
+    }
+
+    override func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
+        let newDictionary = xpc_dictionary_create(nil, nil, 0)
+        self.key.stringValue.withCString({ xpc_dictionary_set_value(self.xpcDictionary, $0, newDictionary) })
+
+        // It is OK to force this through because we are explicitly passing a dictionary
+        let container = try! XPCKeyedEncodingContainer<Key>(referencing: self, wrapping: newDictionary)
+        return KeyedEncodingContainer(container)
+    }
+
+    override func unkeyedContainer() -> UnkeyedEncodingContainer {
+        let newArray = xpc_array_create(nil, 0)
+        self.key.stringValue.withCString({ xpc_dictionary_set_value(self.xpcDictionary, $0, newArray) })
+
+        // It is OK to force this through because we are explicitly passing an array
+        return try! XPCUnkeyedEncodingContainer(referencing: self, wrapping: newArray)
+    }
+
+    override func singleValueContainer() -> SingleValueEncodingContainer {
+        // It is OK to force this through because we are explicitly passing a dictionary
+        let inserter = try! XPCSingleValueDictionaryInserter(into: self.xpcDictionary, at: self.key)
+        return XPCSingleValueEncodingContainer(referencing: self, inserter: inserter)
+    }
+}

--- a/stdlib/public/SDK/XPC/XPCKeyedEncodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCKeyedEncodingContainer.swift
@@ -10,12 +10,12 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 // -----------------------------------------------------------------------------
-///
-/// This file contains a KeyedEncodingContainer implementation for xpc_object_t.
-/// This includes a specialization of the XPCEncoder for handling the super
-/// class case, as we don't know what container type is going to be needed to
-/// handle it.
-///
+//
+// This file contains a KeyedEncodingContainer implementation for xpc_object_t.
+// This includes a specialization of the XPCEncoder for handling the super
+// class case, as we don't know what container type is going to be needed to
+// handle it.
+//
 // -----------------------------------------------------------------------------//
 
 public struct XPCKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProtocol {

--- a/stdlib/public/SDK/XPC/XPCKeyedEncodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCKeyedEncodingContainer.swift
@@ -237,7 +237,9 @@ fileprivate class XPCDictionaryReferencingEncoder: XPCEncoder {
 
     override func singleValueContainer() -> SingleValueEncodingContainer {
         // It is OK to force this through because we are explicitly passing a dictionary
-        let inserter = try! XPCSingleValueDictionaryInserter(into: self.xpcDictionary, at: self.key)
-        return XPCSingleValueEncodingContainer(referencing: self, inserter: inserter)
+        return XPCSingleValueEncodingContainer(referencing: self, insertionClosure: {
+            value in
+                self.key.stringValue.withCString({ xpc_dictionary_set_value(self.xpcDictionary, $0, value)})
+        })
     }
 }

--- a/stdlib/public/SDK/XPC/XPCSingleValueDecodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCSingleValueDecodingContainer.swift
@@ -93,7 +93,7 @@ public struct XPCSingleValueDecodingContainer: SingleValueDecodingContainer {
         return try self.underlyingMessage.decodeUnsignedInteger(UInt64.self, at: self.codingPath)
     }
 
-    public func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
+    public func decode<T: Decodable>(_ type: T.Type) throws -> T {
         return try T(from: XPCDecoder(withUnderlyingMessage: self.underlyingMessage, at: self.decoder.codingPath))
     }
 }

--- a/stdlib/public/SDK/XPC/XPCSingleValueDecodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCSingleValueDecodingContainer.swift
@@ -10,10 +10,10 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 // -----------------------------------------------------------------------------
-///
-/// This file contains a SingleValueDecodingContainer implementation for
-/// xpc_object_t.
-///
+//
+// This file contains a SingleValueDecodingContainer implementation for
+// xpc_object_t.
+//
 // -----------------------------------------------------------------------------//
 
 public struct XPCSingleValueDecodingContainer: SingleValueDecodingContainer {

--- a/stdlib/public/SDK/XPC/XPCSingleValueDecodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCSingleValueDecodingContainer.swift
@@ -34,63 +34,63 @@ public struct XPCSingleValueDecodingContainer: SingleValueDecodingContainer {
     }
 
     public func decodeNil() -> Bool {
-        return XPCDecodingHelpers.decodeNil(from: self.underlyingMessage)
+        return XPCDecodingHelpers.decodeNil(from: self.underlyingMessage, at: self.codingPath)
     }
 
     public func decode(_ type: Bool.Type) throws -> Bool {
-        return try XPCDecodingHelpers.decodeBool(from: self.underlyingMessage)
+        return try XPCDecodingHelpers.decodeBool(from: self.underlyingMessage, at: self.codingPath)
     }
 
     public func decode(_ type: String.Type) throws -> String {
-        return try XPCDecodingHelpers.decodeString(from: self.underlyingMessage)
+        return try XPCDecodingHelpers.decodeString(from: self.underlyingMessage, at: self.codingPath)
     }
 
     public func decode(_ type: Double.Type) throws -> Double {
-        return try XPCDecodingHelpers.decodeFloatingPointNumber(Double.self, from: self.underlyingMessage)
+        return try XPCDecodingHelpers.decodeFloatingPointNumber(Double.self, from: self.underlyingMessage, at: self.codingPath)
     }
 
     public func decode(_ type: Float.Type) throws -> Float {
-        return try XPCDecodingHelpers.decodeFloatingPointNumber(Float.self, from: self.underlyingMessage)
+        return try XPCDecodingHelpers.decodeFloatingPointNumber(Float.self, from: self.underlyingMessage, at: self.codingPath)
     }
 
     public func decode(_ type: Int.Type) throws -> Int {
-        return try XPCDecodingHelpers.decodeSignedInteger(Int.self, from: self.underlyingMessage)
+        return try XPCDecodingHelpers.decodeSignedInteger(Int.self, from: self.underlyingMessage, at: self.codingPath)
     }
 
     public func decode(_ type: Int8.Type) throws -> Int8 {
-        return try XPCDecodingHelpers.decodeSignedInteger(Int8.self, from: self.underlyingMessage)
+        return try XPCDecodingHelpers.decodeSignedInteger(Int8.self, from: self.underlyingMessage, at: self.codingPath)
     }
 
     public func decode(_ type: Int16.Type) throws -> Int16 {
-        return try XPCDecodingHelpers.decodeSignedInteger(Int16.self, from: self.underlyingMessage)
+        return try XPCDecodingHelpers.decodeSignedInteger(Int16.self, from: self.underlyingMessage, at: self.codingPath)
     }
 
     public func decode(_ type: Int32.Type) throws -> Int32 {
-        return try XPCDecodingHelpers.decodeSignedInteger(Int32.self, from: self.underlyingMessage)
+        return try XPCDecodingHelpers.decodeSignedInteger(Int32.self, from: self.underlyingMessage, at: self.codingPath)
     }
 
     public func decode(_ type: Int64.Type) throws -> Int64 {
-        return try XPCDecodingHelpers.decodeSignedInteger(Int64.self, from: self.underlyingMessage)
+        return try XPCDecodingHelpers.decodeSignedInteger(Int64.self, from: self.underlyingMessage, at: self.codingPath)
     }
 
     public func decode(_ type: UInt.Type) throws -> UInt {
-        return try XPCDecodingHelpers.decodeUnsignedInteger(UInt.self, from: self.underlyingMessage)
+        return try XPCDecodingHelpers.decodeUnsignedInteger(UInt.self, from: self.underlyingMessage, at: self.codingPath)
     }
 
     public func decode(_ type: UInt8.Type) throws -> UInt8 {
-        return try XPCDecodingHelpers.decodeUnsignedInteger(UInt8.self, from: self.underlyingMessage)
+        return try XPCDecodingHelpers.decodeUnsignedInteger(UInt8.self, from: self.underlyingMessage, at: self.codingPath)
     }
 
     public func decode(_ type: UInt16.Type) throws -> UInt16 {
-        return try XPCDecodingHelpers.decodeUnsignedInteger(UInt16.self, from: self.underlyingMessage)
+        return try XPCDecodingHelpers.decodeUnsignedInteger(UInt16.self, from: self.underlyingMessage, at: self.codingPath)
     }
 
     public func decode(_ type: UInt32.Type) throws -> UInt32 {
-        return try XPCDecodingHelpers.decodeUnsignedInteger(UInt32.self, from: self.underlyingMessage)
+        return try XPCDecodingHelpers.decodeUnsignedInteger(UInt32.self, from: self.underlyingMessage, at: self.codingPath)
     }
 
     public func decode(_ type: UInt64.Type) throws -> UInt64 {
-        return try XPCDecodingHelpers.decodeUnsignedInteger(UInt64.self, from: self.underlyingMessage)
+        return try XPCDecodingHelpers.decodeUnsignedInteger(UInt64.self, from: self.underlyingMessage, at: self.codingPath)
     }
 
     public func decode<T>(_ type: T.Type) throws -> T where T : Decodable {

--- a/stdlib/public/SDK/XPC/XPCSingleValueDecodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCSingleValueDecodingContainer.swift
@@ -1,0 +1,99 @@
+// stdlib/public/SDK/XPC/XPCSingleValueDecodingContainer.swift -
+// SingleValueDecodingContainer for XPC
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// This file contains a SingleValueDecodingContainer implementation for
+/// xpc_object_t.
+///
+// -----------------------------------------------------------------------------//
+
+public struct XPCSingleValueDecodingContainer: SingleValueDecodingContainer {
+    // MARK: - Properties
+    public var codingPath: [CodingKey] {
+        get {
+            return self.decoder.codingPath
+        }
+    }
+
+    private let decoder: XPCDecoder
+    private let underlyingMessage: xpc_object_t
+
+    // MARK: - Initialization
+    init(referencing decoder: XPCDecoder, wrapping xpcObject: xpc_object_t) {
+        self.decoder = decoder
+        self.underlyingMessage = xpcObject
+    }
+
+    public func decodeNil() -> Bool {
+        return XPCDecodingHelpers.decodeNil(from: self.underlyingMessage)
+    }
+
+    public func decode(_ type: Bool.Type) throws -> Bool {
+        return try XPCDecodingHelpers.decodeBool(from: self.underlyingMessage)
+    }
+
+    public func decode(_ type: String.Type) throws -> String {
+        return try XPCDecodingHelpers.decodeString(from: self.underlyingMessage)
+    }
+
+    public func decode(_ type: Double.Type) throws -> Double {
+        return try XPCDecodingHelpers.decodeFloatingPointNumber(Double.self, from: self.underlyingMessage)
+    }
+
+    public func decode(_ type: Float.Type) throws -> Float {
+        return try XPCDecodingHelpers.decodeFloatingPointNumber(Float.self, from: self.underlyingMessage)
+    }
+
+    public func decode(_ type: Int.Type) throws -> Int {
+        return try XPCDecodingHelpers.decodeSignedInteger(Int.self, from: self.underlyingMessage)
+    }
+
+    public func decode(_ type: Int8.Type) throws -> Int8 {
+        return try XPCDecodingHelpers.decodeSignedInteger(Int8.self, from: self.underlyingMessage)
+    }
+
+    public func decode(_ type: Int16.Type) throws -> Int16 {
+        return try XPCDecodingHelpers.decodeSignedInteger(Int16.self, from: self.underlyingMessage)
+    }
+
+    public func decode(_ type: Int32.Type) throws -> Int32 {
+        return try XPCDecodingHelpers.decodeSignedInteger(Int32.self, from: self.underlyingMessage)
+    }
+
+    public func decode(_ type: Int64.Type) throws -> Int64 {
+        return try XPCDecodingHelpers.decodeSignedInteger(Int64.self, from: self.underlyingMessage)
+    }
+
+    public func decode(_ type: UInt.Type) throws -> UInt {
+        return try XPCDecodingHelpers.decodeUnsignedInteger(UInt.self, from: self.underlyingMessage)
+    }
+
+    public func decode(_ type: UInt8.Type) throws -> UInt8 {
+        return try XPCDecodingHelpers.decodeUnsignedInteger(UInt8.self, from: self.underlyingMessage)
+    }
+
+    public func decode(_ type: UInt16.Type) throws -> UInt16 {
+        return try XPCDecodingHelpers.decodeUnsignedInteger(UInt16.self, from: self.underlyingMessage)
+    }
+
+    public func decode(_ type: UInt32.Type) throws -> UInt32 {
+        return try XPCDecodingHelpers.decodeUnsignedInteger(UInt32.self, from: self.underlyingMessage)
+    }
+
+    public func decode(_ type: UInt64.Type) throws -> UInt64 {
+        return try XPCDecodingHelpers.decodeUnsignedInteger(UInt64.self, from: self.underlyingMessage)
+    }
+
+    public func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
+        return try T(from: XPCDecoder(withUnderlyingMessage: self.underlyingMessage, at: self.decoder.codingPath))
+    }
+}

--- a/stdlib/public/SDK/XPC/XPCSingleValueDecodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCSingleValueDecodingContainer.swift
@@ -34,63 +34,63 @@ public struct XPCSingleValueDecodingContainer: SingleValueDecodingContainer {
     }
 
     public func decodeNil() -> Bool {
-        return XPCDecodingHelpers.decodeNil(from: self.underlyingMessage, at: self.codingPath)
+        return self.underlyingMessage.decodeNil(at: self.codingPath)
     }
 
     public func decode(_ type: Bool.Type) throws -> Bool {
-        return try XPCDecodingHelpers.decodeBool(from: self.underlyingMessage, at: self.codingPath)
+        return try self.underlyingMessage.decodeBool(at: self.codingPath)
     }
 
     public func decode(_ type: String.Type) throws -> String {
-        return try XPCDecodingHelpers.decodeString(from: self.underlyingMessage, at: self.codingPath)
+        return try self.underlyingMessage.decodeString(at: self.codingPath)
     }
 
     public func decode(_ type: Double.Type) throws -> Double {
-        return try XPCDecodingHelpers.decodeFloatingPointNumber(Double.self, from: self.underlyingMessage, at: self.codingPath)
+        return try self.underlyingMessage.decodeFloatingPointNumber(Double.self, at: self.codingPath)
     }
 
     public func decode(_ type: Float.Type) throws -> Float {
-        return try XPCDecodingHelpers.decodeFloatingPointNumber(Float.self, from: self.underlyingMessage, at: self.codingPath)
+        return try self.underlyingMessage.decodeFloatingPointNumber(Float.self, at: self.codingPath)
     }
 
     public func decode(_ type: Int.Type) throws -> Int {
-        return try XPCDecodingHelpers.decodeSignedInteger(Int.self, from: self.underlyingMessage, at: self.codingPath)
+        return try self.underlyingMessage.decodeSignedInteger(Int.self, at: self.codingPath)
     }
 
     public func decode(_ type: Int8.Type) throws -> Int8 {
-        return try XPCDecodingHelpers.decodeSignedInteger(Int8.self, from: self.underlyingMessage, at: self.codingPath)
+        return try self.underlyingMessage.decodeSignedInteger(Int8.self, at: self.codingPath)
     }
 
     public func decode(_ type: Int16.Type) throws -> Int16 {
-        return try XPCDecodingHelpers.decodeSignedInteger(Int16.self, from: self.underlyingMessage, at: self.codingPath)
+        return try self.underlyingMessage.decodeSignedInteger(Int16.self, at: self.codingPath)
     }
 
     public func decode(_ type: Int32.Type) throws -> Int32 {
-        return try XPCDecodingHelpers.decodeSignedInteger(Int32.self, from: self.underlyingMessage, at: self.codingPath)
+        return try self.underlyingMessage.decodeSignedInteger(Int32.self, at: self.codingPath)
     }
 
     public func decode(_ type: Int64.Type) throws -> Int64 {
-        return try XPCDecodingHelpers.decodeSignedInteger(Int64.self, from: self.underlyingMessage, at: self.codingPath)
+        return try self.underlyingMessage.decodeSignedInteger(Int64.self, at: self.codingPath)
     }
 
     public func decode(_ type: UInt.Type) throws -> UInt {
-        return try XPCDecodingHelpers.decodeUnsignedInteger(UInt.self, from: self.underlyingMessage, at: self.codingPath)
+        return try self.underlyingMessage.decodeUnsignedInteger(UInt.self, at: self.codingPath)
     }
 
     public func decode(_ type: UInt8.Type) throws -> UInt8 {
-        return try XPCDecodingHelpers.decodeUnsignedInteger(UInt8.self, from: self.underlyingMessage, at: self.codingPath)
+        return try self.underlyingMessage.decodeUnsignedInteger(UInt8.self, at: self.codingPath)
     }
 
     public func decode(_ type: UInt16.Type) throws -> UInt16 {
-        return try XPCDecodingHelpers.decodeUnsignedInteger(UInt16.self, from: self.underlyingMessage, at: self.codingPath)
+        return try self.underlyingMessage.decodeUnsignedInteger(UInt16.self, at: self.codingPath)
     }
 
     public func decode(_ type: UInt32.Type) throws -> UInt32 {
-        return try XPCDecodingHelpers.decodeUnsignedInteger(UInt32.self, from: self.underlyingMessage, at: self.codingPath)
+        return try self.underlyingMessage.decodeUnsignedInteger(UInt32.self, at: self.codingPath)
     }
 
     public func decode(_ type: UInt64.Type) throws -> UInt64 {
-        return try XPCDecodingHelpers.decodeUnsignedInteger(UInt64.self, from: self.underlyingMessage, at: self.codingPath)
+        return try self.underlyingMessage.decodeUnsignedInteger(UInt64.self, at: self.codingPath)
     }
 
     public func decode<T>(_ type: T.Type) throws -> T where T : Decodable {

--- a/stdlib/public/SDK/XPC/XPCSingleValueEncodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCSingleValueEncodingContainer.swift
@@ -1,0 +1,154 @@
+// stdlib/public/SDK/XPC/XPCSingleValueEncodingContainer.swift -
+// SingleValueEncodingContainer for XPC
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// This file contains a SincludeValueEncodingContainer implementation for
+/// xpc_object_t.
+///
+// -----------------------------------------------------------------------------//
+
+protocol SingleValueEncodingContainerInsertion {
+    mutating func insert(_ value: xpc_object_t) throws
+}
+
+struct XPCSingleValueDictionaryInserter: SingleValueEncodingContainerInsertion {
+    private let dictionary: xpc_object_t
+    private let key: CodingKey
+
+    init(into dictionary: xpc_object_t, at key: CodingKey) throws {
+        guard xpc_get_type(dictionary) == XPC_TYPE_DICTIONARY else {
+            throw XPCSerializationError.invalidXPCObjectType
+        }
+        self.dictionary = dictionary
+        self.key = key
+    }
+
+    mutating func insert(_ value: xpc_object_t) {
+        self.key.stringValue.withCString({ xpc_dictionary_set_value(self.dictionary, $0, value)})
+    }
+}
+
+struct XPCSingleValueArrayInserter: SingleValueEncodingContainerInsertion {
+    private let array: xpc_object_t
+    private let index: Int
+
+    init(into array: xpc_object_t, at index: Int) throws {
+        guard xpc_get_type(array) == XPC_TYPE_ARRAY else {
+            throw XPCSerializationError.invalidXPCObjectType
+        }
+        self.array = array
+        self.index = index
+    }
+
+    mutating func insert(_ value: xpc_object_t) throws {
+        guard self.index < xpc_array_get_count(self.array) else {
+            throw XPCSerializationError.insertionPastEndOfArray
+        }
+        xpc_array_set_value(self.array, self.index, value)
+    }
+}
+
+struct XPCSingleValueEncoderInserter: SingleValueEncodingContainerInsertion {
+    private let encoder: XPCEncoder
+
+    init(into encoder: XPCEncoder) {
+        self.encoder = encoder
+    }
+
+    mutating func insert(_ value: xpc_object_t) throws {
+        self.encoder.topLevelContainer = value
+    }
+}
+
+public struct XPCSingleValueEncodingContainer: SingleValueEncodingContainer {
+    // MARK: - Properties
+    public var codingPath: [CodingKey] {
+        get {
+            return self.encoder.codingPath
+        }
+    }
+
+    private let encoder: XPCEncoder
+    private var inserter: SingleValueEncodingContainerInsertion
+
+    // MARK: - Initialization
+    init(referencing encoder: XPCEncoder, inserter: SingleValueEncodingContainerInsertion) {
+        self.encoder = encoder
+        self.inserter = inserter
+    }
+
+    // MARK: - SingleValueEncodingContainer protocol methods
+    public mutating func encodeNil() throws {
+        try self.inserter.insert(XPCEncodingHelpers.encodeNil())
+    }
+
+    public mutating func encode(_ value: Bool) throws {
+        try self.inserter.insert(XPCEncodingHelpers.encodeBool(value))
+    }
+
+    public mutating func encode(_ value: String) throws {
+        try self.inserter.insert(XPCEncodingHelpers.encodeString(value))
+    }
+
+    public mutating func encode(_ value: Double) throws {
+        try self.inserter.insert(XPCEncodingHelpers.encodeDouble(value))
+    }
+
+    public mutating func encode(_ value: Float) throws {
+        try self.inserter.insert(XPCEncodingHelpers.encodeFloat(value))
+    }
+
+    public mutating func encode(_ value: Int) throws {
+        try self.inserter.insert(XPCEncodingHelpers.encodeSignedInteger(value))
+    }
+
+    public mutating func encode(_ value: Int8) throws {
+        try self.inserter.insert(XPCEncodingHelpers.encodeSignedInteger(value))
+    }
+
+    public mutating func encode(_ value: Int16) throws {
+        try self.inserter.insert(XPCEncodingHelpers.encodeSignedInteger(value))
+    }
+
+    public mutating func encode(_ value: Int32) throws {
+        try self.inserter.insert(XPCEncodingHelpers.encodeSignedInteger(value))
+    }
+
+    public mutating func encode(_ value: Int64) throws {
+        try self.inserter.insert(XPCEncodingHelpers.encodeSignedInteger(value))
+    }
+
+    public mutating func encode(_ value: UInt) throws {
+        try self.inserter.insert(XPCEncodingHelpers.encodeUnsignedInteger(value))
+    }
+
+    public mutating func encode(_ value: UInt8) throws {
+        try self.inserter.insert(XPCEncodingHelpers.encodeUnsignedInteger(value))
+    }
+
+    public mutating func encode(_ value: UInt16) throws {
+        try self.inserter.insert(XPCEncodingHelpers.encodeUnsignedInteger(value))
+    }
+
+    public mutating func encode(_ value: UInt32) throws {
+        try self.inserter.insert(XPCEncodingHelpers.encodeUnsignedInteger(value))
+    }
+
+    public mutating func encode(_ value: UInt64) throws {
+        try self.inserter.insert(XPCEncodingHelpers.encodeUnsignedInteger(value))
+    }
+
+    public mutating func encode<T>(_ value: T) throws where T : Encodable {
+        let xpcObject = try XPCEncoder.encode(value, at: self.encoder.codingPath)
+        try self.inserter.insert(xpcObject)
+    }
+}

--- a/stdlib/public/SDK/XPC/XPCSingleValueEncodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCSingleValueEncodingContainer.swift
@@ -10,10 +10,10 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 // -----------------------------------------------------------------------------
-///
-/// This file contains a SincludeValueEncodingContainer implementation for
-/// xpc_object_t.
-///
+//
+// This file contains a SincludeValueEncodingContainer implementation for
+// xpc_object_t.
+//
 // -----------------------------------------------------------------------------//
 
 public struct XPCSingleValueEncodingContainer: SingleValueEncodingContainer {

--- a/stdlib/public/SDK/XPC/XPCSingleValueEncodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCSingleValueEncodingContainer.swift
@@ -16,59 +16,6 @@
 ///
 // -----------------------------------------------------------------------------//
 
-protocol SingleValueEncodingContainerInsertion {
-    mutating func insert(_ value: xpc_object_t) throws
-}
-
-struct XPCSingleValueDictionaryInserter: SingleValueEncodingContainerInsertion {
-    private let dictionary: xpc_object_t
-    private let key: CodingKey
-
-    init(into dictionary: xpc_object_t, at key: CodingKey) throws {
-        guard xpc_get_type(dictionary) == XPC_TYPE_DICTIONARY else {
-            throw XPCEncodingHelpers.makeEncodingError(dictionary, [], "Internal error")
-        }
-        self.dictionary = dictionary
-        self.key = key
-    }
-
-    mutating func insert(_ value: xpc_object_t) {
-        self.key.stringValue.withCString({ xpc_dictionary_set_value(self.dictionary, $0, value)})
-    }
-}
-
-struct XPCSingleValueArrayInserter: SingleValueEncodingContainerInsertion {
-    private let array: xpc_object_t
-    private let index: Int
-
-    init(into array: xpc_object_t, at index: Int) throws {
-        guard xpc_get_type(array) == XPC_TYPE_ARRAY else {
-            throw XPCEncodingHelpers.makeEncodingError(array, [], "Internal error")
-        }
-        self.array = array
-        self.index = index
-    }
-
-    mutating func insert(_ value: xpc_object_t) throws {
-        guard self.index < xpc_array_get_count(self.array) else {
-            throw XPCEncodingHelpers.makeEncodingError(value, [], "Internal Error")
-        }
-        xpc_array_set_value(self.array, self.index, value)
-    }
-}
-
-struct XPCSingleValueEncoderInserter: SingleValueEncodingContainerInsertion {
-    private let encoder: XPCEncoder
-
-    init(into encoder: XPCEncoder) {
-        self.encoder = encoder
-    }
-
-    mutating func insert(_ value: xpc_object_t) throws {
-        self.encoder.topLevelContainer = value
-    }
-}
-
 public struct XPCSingleValueEncodingContainer: SingleValueEncodingContainer {
     // MARK: - Properties
     public var codingPath: [CodingKey] {
@@ -78,77 +25,77 @@ public struct XPCSingleValueEncodingContainer: SingleValueEncodingContainer {
     }
 
     private let encoder: XPCEncoder
-    private var inserter: SingleValueEncodingContainerInsertion
+    private let insertionClosure: (_ value: xpc_object_t) throws -> ()
 
     // MARK: - Initialization
-    init(referencing encoder: XPCEncoder, inserter: SingleValueEncodingContainerInsertion) {
+    init(referencing encoder: XPCEncoder, insertionClosure: @escaping (_ value: xpc_object_t) throws -> ()) {
         self.encoder = encoder
-        self.inserter = inserter
+        self.insertionClosure = insertionClosure
     }
 
     // MARK: - SingleValueEncodingContainer protocol methods
     public mutating func encodeNil() throws {
-        try self.inserter.insert(XPCEncodingHelpers.encodeNil())
+        try self.insertionClosure(XPCEncodingHelpers.encodeNil())
     }
 
     public mutating func encode(_ value: Bool) throws {
-        try self.inserter.insert(XPCEncodingHelpers.encodeBool(value))
+        try self.insertionClosure(XPCEncodingHelpers.encodeBool(value))
     }
 
     public mutating func encode(_ value: String) throws {
-        try self.inserter.insert(XPCEncodingHelpers.encodeString(value))
+        try self.insertionClosure(XPCEncodingHelpers.encodeString(value))
     }
 
     public mutating func encode(_ value: Double) throws {
-        try self.inserter.insert(XPCEncodingHelpers.encodeDouble(value))
+        try self.insertionClosure(XPCEncodingHelpers.encodeDouble(value))
     }
 
     public mutating func encode(_ value: Float) throws {
-        try self.inserter.insert(XPCEncodingHelpers.encodeFloat(value))
+        try self.insertionClosure(XPCEncodingHelpers.encodeFloat(value))
     }
 
     public mutating func encode(_ value: Int) throws {
-        try self.inserter.insert(XPCEncodingHelpers.encodeSignedInteger(value))
+        try self.insertionClosure(XPCEncodingHelpers.encodeSignedInteger(value))
     }
 
     public mutating func encode(_ value: Int8) throws {
-        try self.inserter.insert(XPCEncodingHelpers.encodeSignedInteger(value))
+        try self.insertionClosure(XPCEncodingHelpers.encodeSignedInteger(value))
     }
 
     public mutating func encode(_ value: Int16) throws {
-        try self.inserter.insert(XPCEncodingHelpers.encodeSignedInteger(value))
+        try self.insertionClosure(XPCEncodingHelpers.encodeSignedInteger(value))
     }
 
     public mutating func encode(_ value: Int32) throws {
-        try self.inserter.insert(XPCEncodingHelpers.encodeSignedInteger(value))
+        try self.insertionClosure(XPCEncodingHelpers.encodeSignedInteger(value))
     }
 
     public mutating func encode(_ value: Int64) throws {
-        try self.inserter.insert(XPCEncodingHelpers.encodeSignedInteger(value))
+        try self.insertionClosure(XPCEncodingHelpers.encodeSignedInteger(value))
     }
 
     public mutating func encode(_ value: UInt) throws {
-        try self.inserter.insert(XPCEncodingHelpers.encodeUnsignedInteger(value))
+        try self.insertionClosure(XPCEncodingHelpers.encodeUnsignedInteger(value))
     }
 
     public mutating func encode(_ value: UInt8) throws {
-        try self.inserter.insert(XPCEncodingHelpers.encodeUnsignedInteger(value))
+        try self.insertionClosure(XPCEncodingHelpers.encodeUnsignedInteger(value))
     }
 
     public mutating func encode(_ value: UInt16) throws {
-        try self.inserter.insert(XPCEncodingHelpers.encodeUnsignedInteger(value))
+        try self.insertionClosure(XPCEncodingHelpers.encodeUnsignedInteger(value))
     }
 
     public mutating func encode(_ value: UInt32) throws {
-        try self.inserter.insert(XPCEncodingHelpers.encodeUnsignedInteger(value))
+        try self.insertionClosure(XPCEncodingHelpers.encodeUnsignedInteger(value))
     }
 
     public mutating func encode(_ value: UInt64) throws {
-        try self.inserter.insert(XPCEncodingHelpers.encodeUnsignedInteger(value))
+        try self.insertionClosure(XPCEncodingHelpers.encodeUnsignedInteger(value))
     }
 
     public mutating func encode<T>(_ value: T) throws where T : Encodable {
         let xpcObject = try XPCEncoder.encode(value, at: self.encoder.codingPath)
-        try self.inserter.insert(xpcObject)
+        try self.insertionClosure(xpcObject)
     }
 }

--- a/stdlib/public/SDK/XPC/XPCSingleValueEncodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCSingleValueEncodingContainer.swift
@@ -26,7 +26,7 @@ struct XPCSingleValueDictionaryInserter: SingleValueEncodingContainerInsertion {
 
     init(into dictionary: xpc_object_t, at key: CodingKey) throws {
         guard xpc_get_type(dictionary) == XPC_TYPE_DICTIONARY else {
-            throw XPCSerializationError.invalidXPCObjectType
+            throw XPCEncodingHelpers.makeEncodingError(dictionary, [], "Internal error")
         }
         self.dictionary = dictionary
         self.key = key
@@ -43,7 +43,7 @@ struct XPCSingleValueArrayInserter: SingleValueEncodingContainerInsertion {
 
     init(into array: xpc_object_t, at index: Int) throws {
         guard xpc_get_type(array) == XPC_TYPE_ARRAY else {
-            throw XPCSerializationError.invalidXPCObjectType
+            throw XPCEncodingHelpers.makeEncodingError(array, [], "Internal error")
         }
         self.array = array
         self.index = index
@@ -51,7 +51,7 @@ struct XPCSingleValueArrayInserter: SingleValueEncodingContainerInsertion {
 
     mutating func insert(_ value: xpc_object_t) throws {
         guard self.index < xpc_array_get_count(self.array) else {
-            throw XPCSerializationError.insertionPastEndOfArray
+            throw XPCEncodingHelpers.makeEncodingError(value, [], "Internal Error")
         }
         xpc_array_set_value(self.array, self.index, value)
     }

--- a/stdlib/public/SDK/XPC/XPCSingleValueEncodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCSingleValueEncodingContainer.swift
@@ -94,7 +94,7 @@ public struct XPCSingleValueEncodingContainer: SingleValueEncodingContainer {
         try self.insertionClosure(XPCEncodingHelpers.encodeUnsignedInteger(value))
     }
 
-    public mutating func encode<T>(_ value: T) throws where T : Encodable {
+    public mutating func encode<T: Encodable>(_ value: T) throws {
         let xpcObject = try XPCEncoder.encode(value, at: self.encoder.codingPath)
         try self.insertionClosure(xpcObject)
     }

--- a/stdlib/public/SDK/XPC/XPCUnkeyedDecodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCUnkeyedDecodingContainer.swift
@@ -53,7 +53,7 @@ public struct XPCUnkeyedDecodingContainer: UnkeyedDecodingContainer {
     }
 
     // MARK: - Helpers
-    private mutating func decodeIntegerType<I: SignedInteger>(_ type: I.Type) throws -> I {
+    private mutating func decodeIntegerType<I: SignedInteger & FixedWidthInteger>(_ type: I.Type) throws -> I {
         guard !self.isAtEnd else {
             throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath,
                                                                     debugDescription: "Reached end of unkeyed container."))
@@ -68,7 +68,7 @@ public struct XPCUnkeyedDecodingContainer: UnkeyedDecodingContainer {
         return integer
     }
 
-    private mutating func decodeIntegerType<I: UnsignedInteger>(_ type: I.Type) throws -> I {
+    private mutating func decodeIntegerType<I: UnsignedInteger & FixedWidthInteger>(_ type: I.Type) throws -> I {
         guard !self.isAtEnd else {
             throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath,
                                                                     debugDescription: "Reached end of unkeyed container."))

--- a/stdlib/public/SDK/XPC/XPCUnkeyedDecodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCUnkeyedDecodingContainer.swift
@@ -1,0 +1,222 @@
+// stdlib/public/SDK/XPC/XPCUnkeyedDecodingContainer.swift -
+// UnkeyedDecodingContainer for XPC
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// This file contains a UnkeyedDecodingContainer implementation for
+/// xpc_object_t.
+///
+// -----------------------------------------------------------------------------//
+
+public struct XPCUnkeyedDecodingContainer: UnkeyedDecodingContainer {
+
+    // MARK: - Properties
+    public var codingPath: [CodingKey] {
+        get {
+            return self.decoder.codingPath
+        }
+    }
+
+    public var count: Int?
+
+    public var isAtEnd: Bool {
+        get {
+            return self.currentIndex >= self.count!
+        }
+    }
+
+    public var currentIndex: Int
+
+    private let underlyingMessage: xpc_object_t
+
+    private let decoder: XPCDecoder
+
+    // MARK: - Initilization
+    init(referencing decoder: XPCDecoder, wrapping: xpc_object_t) throws {
+        guard xpc_get_type(wrapping) == XPC_TYPE_ARRAY else {
+            throw XPCParsingError.typeMismatch
+        }
+
+        self.underlyingMessage = wrapping
+        self.decoder = decoder
+        self.count = xpc_array_get_count(self.underlyingMessage)
+        self.currentIndex = 0
+    }
+
+    // MARK: - Helpers
+    private mutating func decodeIntegerType<I: SignedInteger>(_ type: I.Type) throws -> I {
+        guard !self.isAtEnd else { throw XPCParsingError.reachedArrayEnd }
+        self.decoder.codingPath.append(XPCCodingKey(intValue: self.currentIndex)!)
+        defer { self.decoder.codingPath.removeLast() }
+
+        let foundValue = xpc_array_get_value(self.underlyingMessage, self.currentIndex)
+
+        let integer: I = try XPCDecodingHelpers.decodeSignedInteger(type.self, from: foundValue)
+        self.currentIndex += 1
+        return integer
+    }
+
+    private mutating func decodeIntegerType<I: UnsignedInteger>(_ type: I.Type) throws -> I {
+        guard !self.isAtEnd else { throw XPCParsingError.reachedArrayEnd }
+        self.decoder.codingPath.append(XPCCodingKey(intValue: self.currentIndex)!)
+        defer { self.decoder.codingPath.removeLast() }
+
+        let foundValue = xpc_array_get_value(self.underlyingMessage, self.currentIndex)
+
+        let integer: I = try XPCDecodingHelpers.decodeUnsignedInteger(type.self, from: foundValue)
+        self.currentIndex += 1
+        return integer
+    }
+
+    private mutating func decodeFloatingPointType<F: BinaryFloatingPoint>(_ type: F.Type) throws -> F {
+        guard !self.isAtEnd else { throw XPCParsingError.reachedArrayEnd }
+        self.decoder.codingPath.append(XPCCodingKey(intValue: self.currentIndex)!)
+        defer { self.decoder.codingPath.removeLast() }
+
+        let foundValue = xpc_array_get_value(self.underlyingMessage, self.currentIndex)
+
+        let float: F = try XPCDecodingHelpers.decodeFloatingPointNumber(type.self, from: foundValue)
+        self.currentIndex += 1
+        return float
+    }
+
+    // MARK: - UnkeyedDecodingContainer protocol methods
+    public mutating func decodeNil() throws -> Bool {
+        guard !self.isAtEnd else { throw XPCParsingError.reachedArrayEnd }
+
+        let foundValue = xpc_array_get_value(self.underlyingMessage, self.currentIndex)
+
+
+        if XPCDecodingHelpers.decodeNil(from: foundValue) {
+            self.currentIndex += 1
+            return true
+        }
+        return false
+    }
+
+    public mutating func decode(_ type: Bool.Type) throws -> Bool {
+        guard !self.isAtEnd else { throw XPCParsingError.reachedArrayEnd }
+        self.decoder.codingPath.append(XPCCodingKey(intValue: self.currentIndex)!)
+        defer { self.decoder.codingPath.removeLast() }
+
+        let foundValue = xpc_array_get_value(self.underlyingMessage, self.currentIndex)
+
+        let boolean = try XPCDecodingHelpers.decodeBool(from: foundValue)
+        self.currentIndex += 1
+        return boolean
+    }
+
+    public mutating func decode(_ type: String.Type) throws -> String {
+        guard !self.isAtEnd else { throw XPCParsingError.reachedArrayEnd }
+        self.decoder.codingPath.append(XPCCodingKey(intValue: self.currentIndex)!)
+        defer { self.decoder.codingPath.removeLast() }
+
+        let foundValue = xpc_array_get_value(self.underlyingMessage, self.currentIndex)
+
+        let string = try XPCDecodingHelpers.decodeString(from: foundValue)
+        self.currentIndex += 1
+        return string
+    }
+
+    public mutating func decode(_ type: Double.Type) throws -> Double {
+        return try decodeFloatingPointType(type)
+    }
+
+    public mutating func decode(_ type: Float.Type) throws -> Float {
+        return try decodeFloatingPointType(type)
+    }
+
+    public mutating func decode(_ type: Int.Type) throws -> Int {
+        return try decodeIntegerType(type)
+    }
+
+    public mutating func decode(_ type: Int8.Type) throws -> Int8 {
+        return try decodeIntegerType(type)
+    }
+
+    public mutating func decode(_ type: Int16.Type) throws -> Int16 {
+        return try decodeIntegerType(type)
+    }
+
+    public mutating func decode(_ type: Int32.Type) throws -> Int32 {
+        return try decodeIntegerType(type)
+    }
+
+    public mutating func decode(_ type: Int64.Type) throws -> Int64 {
+        return try decodeIntegerType(type)
+    }
+
+    public mutating func decode(_ type: UInt.Type) throws -> UInt {
+        return try decodeIntegerType(type)
+    }
+
+    public mutating func decode(_ type: UInt8.Type) throws -> UInt8 {
+        return try decodeIntegerType(type)
+    }
+
+    public mutating func decode(_ type: UInt16.Type) throws -> UInt16 {
+        return try decodeIntegerType(type)
+    }
+
+    public mutating func decode(_ type: UInt32.Type) throws -> UInt32 {
+        return try decodeIntegerType(type)
+    }
+
+    public mutating func decode(_ type: UInt64.Type) throws -> UInt64 {
+        return try decodeIntegerType(type)
+    }
+
+    public mutating func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
+        guard !isAtEnd else { throw XPCParsingError.reachedArrayEnd }
+        self.decoder.codingPath.append(XPCCodingKey(intValue: self.currentIndex)!)
+        defer { self.decoder.codingPath.removeLast() }
+
+        let foundValue = xpc_array_get_value(self.underlyingMessage, self.currentIndex)
+
+        let constructedValue = try T(from: XPCDecoder(withUnderlyingMessage: foundValue, at: self.decoder.codingPath))
+        self.currentIndex += 1
+        return constructedValue
+    }
+
+    public mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
+        guard !self.isAtEnd else { throw XPCParsingError.reachedArrayEnd }
+        self.decoder.codingPath.append(XPCCodingKey(intValue: self.currentIndex)!)
+        defer { self.decoder.codingPath.removeLast() }
+
+        let foundValue = xpc_array_get_value(self.underlyingMessage, self.currentIndex)
+
+        let container = try XPCKeyedDecodingContainer<NestedKey>(referencing: self.decoder, wrapping: foundValue)
+        self.currentIndex += 1
+        return KeyedDecodingContainer(container)
+    }
+
+    public mutating func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
+        guard !self.isAtEnd else { throw XPCParsingError.reachedArrayEnd }
+        self.decoder.codingPath.append(XPCCodingKey(intValue: self.currentIndex)!)
+        defer { self.decoder.codingPath.removeLast() }
+
+        let foundValue = xpc_array_get_value(self.underlyingMessage, self.currentIndex)
+
+        let container = try XPCUnkeyedDecodingContainer(referencing: self.decoder, wrapping: foundValue)
+        self.currentIndex += 1
+        return container
+    }
+
+    public mutating func superDecoder() throws -> Decoder {
+        guard !self.isAtEnd else { throw XPCParsingError.reachedArrayEnd }
+        self.decoder.codingPath.append(XPCCodingKey(intValue: self.currentIndex)!)
+        defer { self.decoder.codingPath.removeLast() }
+
+        let foundValue = xpc_array_get_value(self.underlyingMessage, self.currentIndex)
+        self.currentIndex += 1
+        return XPCDecoder(withUnderlyingMessage: foundValue, at: self.decoder.codingPath)
+    }
+}

--- a/stdlib/public/SDK/XPC/XPCUnkeyedDecodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCUnkeyedDecodingContainer.swift
@@ -63,7 +63,7 @@ public struct XPCUnkeyedDecodingContainer: UnkeyedDecodingContainer {
 
         let foundValue = xpc_array_get_value(self.underlyingMessage, self.currentIndex)
 
-        let integer: I = try XPCDecodingHelpers.decodeSignedInteger(type.self, from: foundValue, at: self.codingPath)
+        let integer: I = try foundValue.decodeSignedInteger(type.self, at: self.codingPath)
         self.currentIndex += 1
         return integer
     }
@@ -78,7 +78,7 @@ public struct XPCUnkeyedDecodingContainer: UnkeyedDecodingContainer {
 
         let foundValue = xpc_array_get_value(self.underlyingMessage, self.currentIndex)
 
-        let integer: I = try XPCDecodingHelpers.decodeUnsignedInteger(type.self, from: foundValue, at: self.codingPath)
+        let integer: I = try foundValue.decodeUnsignedInteger(type.self, at: self.codingPath)
         self.currentIndex += 1
         return integer
     }
@@ -93,7 +93,7 @@ public struct XPCUnkeyedDecodingContainer: UnkeyedDecodingContainer {
 
         let foundValue = xpc_array_get_value(self.underlyingMessage, self.currentIndex)
 
-        let float: F = try XPCDecodingHelpers.decodeFloatingPointNumber(type.self, from: foundValue, at: self.codingPath)
+        let float: F = try foundValue.decodeFloatingPointNumber(type.self, at: self.codingPath)
         self.currentIndex += 1
         return float
     }
@@ -109,7 +109,7 @@ public struct XPCUnkeyedDecodingContainer: UnkeyedDecodingContainer {
 
         let foundValue = xpc_array_get_value(self.underlyingMessage, self.currentIndex)
 
-        if XPCDecodingHelpers.decodeNil(from: foundValue, at: self.codingPath) {
+        if foundValue.decodeNil(at: self.codingPath) {
             self.currentIndex += 1
             return true
         }
@@ -126,7 +126,7 @@ public struct XPCUnkeyedDecodingContainer: UnkeyedDecodingContainer {
 
         let foundValue = xpc_array_get_value(self.underlyingMessage, self.currentIndex)
 
-        let boolean = try XPCDecodingHelpers.decodeBool(from: foundValue, at: self.codingPath)
+        let boolean = try foundValue.decodeBool(at: self.codingPath)
         self.currentIndex += 1
         return boolean
     }
@@ -141,7 +141,7 @@ public struct XPCUnkeyedDecodingContainer: UnkeyedDecodingContainer {
 
         let foundValue = xpc_array_get_value(self.underlyingMessage, self.currentIndex)
 
-        let string = try XPCDecodingHelpers.decodeString(from: foundValue, at: self.codingPath)
+        let string = try foundValue.decodeString(at: self.codingPath)
         self.currentIndex += 1
         return string
     }

--- a/stdlib/public/SDK/XPC/XPCUnkeyedDecodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCUnkeyedDecodingContainer.swift
@@ -25,7 +25,11 @@ public struct XPCUnkeyedDecodingContainer: UnkeyedDecodingContainer {
         }
     }
 
-    public var count: Int?
+    public var count: Int? {
+        get {
+            return xpc_array_get_count(self.underlyingMessage)
+        }
+    }
 
     public var isAtEnd: Bool {
         get {
@@ -48,7 +52,6 @@ public struct XPCUnkeyedDecodingContainer: UnkeyedDecodingContainer {
 
         self.underlyingMessage = wrapping
         self.decoder = decoder
-        self.count = xpc_array_get_count(self.underlyingMessage)
         self.currentIndex = 0
     }
 

--- a/stdlib/public/SDK/XPC/XPCUnkeyedDecodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCUnkeyedDecodingContainer.swift
@@ -197,7 +197,7 @@ public struct XPCUnkeyedDecodingContainer: UnkeyedDecodingContainer {
         return try decodeIntegerType(type)
     }
 
-    public mutating func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
+    public mutating func decode<T: Decodable>(_ type: T.Type) throws -> T {
         guard !self.isAtEnd else {
             throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath,
                                                                     debugDescription: "Reached end of unkeyed container."))

--- a/stdlib/public/SDK/XPC/XPCUnkeyedDecodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCUnkeyedDecodingContainer.swift
@@ -10,10 +10,10 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 // -----------------------------------------------------------------------------
-///
-/// This file contains a UnkeyedDecodingContainer implementation for
-/// xpc_object_t.
-///
+//
+// This file contains a UnkeyedDecodingContainer implementation for
+// xpc_object_t.
+//
 // -----------------------------------------------------------------------------//
 
 public struct XPCUnkeyedDecodingContainer: UnkeyedDecodingContainer {

--- a/stdlib/public/SDK/XPC/XPCUnkeyedDecodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCUnkeyedDecodingContainer.swift
@@ -33,7 +33,7 @@ public struct XPCUnkeyedDecodingContainer: UnkeyedDecodingContainer {
         }
     }
 
-    public var currentIndex: Int
+    public private(set) var currentIndex: Int
 
     private let underlyingMessage: xpc_object_t
 

--- a/stdlib/public/SDK/XPC/XPCUnkeyedEncodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCUnkeyedEncodingContainer.swift
@@ -248,7 +248,12 @@ private class XPCArrayReferencingEncoder: XPCEncoder {
 
     override func singleValueContainer() -> SingleValueEncodingContainer {
         // It is OK to force this through because we are explictly passing an array
-        let inserter = try! XPCSingleValueArrayInserter(into: self.xpcArray, at: self.index)
-        return XPCSingleValueEncodingContainer(referencing: self, inserter: inserter)
+        return XPCSingleValueEncodingContainer(referencing: self, insertionClosure: {
+            value in
+                guard self.index < xpc_array_get_count(self.xpcArray) else {
+                    throw XPCEncodingHelpers.makeEncodingError(value, [], "Internal Error")
+                }
+                xpc_array_set_value(self.xpcArray, self.index, value)
+        })
     }
 }

--- a/stdlib/public/SDK/XPC/XPCUnkeyedEncodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCUnkeyedEncodingContainer.swift
@@ -1,0 +1,248 @@
+// stdlib/public/SDK/XPC/XPCUnkeyedEncodingContainer.swift -
+// UnkeyedEncodingContainer for XPC
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// This file contains a UnkeyedEncodingContainer implementation for
+/// xpc_object_t. It also includes a specialization of XPCEncoder for handling
+/// the super class case as we don't know what kind of object is going to be
+/// needed and we need to maitain a reference to the underlying array.
+///
+// -----------------------------------------------------------------------------//
+
+public struct XPCUnkeyedEncodingContainer: UnkeyedEncodingContainer {
+    // MARK: - Properties
+    public var codingPath: [CodingKey] {
+        get {
+            return self.encoder.codingPath
+        }
+    }
+
+    public var count: Int {
+        get {
+            return xpc_array_get_count(underlyingMessage)
+        }
+    }
+
+    private let encoder: XPCEncoder
+
+    private let underlyingMessage: xpc_object_t
+
+    // MARK: - Initialization
+    init(referencing encoder: XPCEncoder, wrapping underlyingMessage: xpc_object_t) throws {
+        self.encoder = encoder
+
+        guard xpc_get_type(underlyingMessage) == XPC_TYPE_ARRAY else {
+            throw XPCSerializationError.invalidXPCObjectType
+        }
+
+        self.underlyingMessage = underlyingMessage
+    }
+
+    // MARK: - UnkeyedEncodingContainer protocol methods
+    public mutating func encode(_ value: Bool) throws {
+        self.encoder.codingPath.append(XPCCodingKey(intValue: self.count - 1)!)
+        defer { self.encoder.codingPath.removeLast() }
+
+        let boolValue = XPCEncodingHelpers.encodeBool(value)
+        xpc_array_append_value(self.underlyingMessage, boolValue)
+    }
+
+    public mutating func encodeNil() throws {
+        self.encoder.codingPath.append(XPCCodingKey(intValue: self.count - 1)!)
+        defer { self.encoder.codingPath.removeLast() }
+
+        let nilValue = XPCEncodingHelpers.encodeNil()
+        xpc_array_append_value(self.underlyingMessage, nilValue)
+    }
+
+    public mutating func encode(_ value: String) throws {
+        self.encoder.codingPath.append(XPCCodingKey(intValue: self.count - 1)!)
+        defer { self.encoder.codingPath.removeLast() }
+
+        let stringValue = XPCEncodingHelpers.encodeString(value)
+        xpc_array_append_value(self.underlyingMessage, stringValue)
+    }
+
+    public mutating func encode(_ value: Double) throws {
+        self.encoder.codingPath.append(XPCCodingKey(intValue: self.count - 1)!)
+        defer { self.encoder.codingPath.removeLast() }
+
+        let doubleValue = XPCEncodingHelpers.encodeDouble(value)
+        xpc_array_append_value(self.underlyingMessage, doubleValue)
+    }
+
+    public mutating func encode(_ value: Float) throws {
+        self.encoder.codingPath.append(XPCCodingKey(intValue: self.count - 1)!)
+        defer { self.encoder.codingPath.removeLast() }
+
+        let floatValue = XPCEncodingHelpers.encodeFloat(value)
+        xpc_array_append_value(self.underlyingMessage, floatValue)
+    }
+
+    public mutating func encode(_ value: Int) throws {
+        self.encoder.codingPath.append(XPCCodingKey(intValue: self.count - 1)!)
+        defer { self.encoder.codingPath.removeLast() }
+
+        let intValue = XPCEncodingHelpers.encodeSignedInteger(value)
+        xpc_array_append_value(self.underlyingMessage, intValue)
+    }
+
+    public mutating func encode(_ value: Int8) throws {
+        self.encoder.codingPath.append(XPCCodingKey(intValue: self.count - 1)!)
+        defer { self.encoder.codingPath.removeLast() }
+
+        let intValue = XPCEncodingHelpers.encodeSignedInteger(value)
+        xpc_array_append_value(self.underlyingMessage, intValue)
+    }
+
+    public mutating func encode(_ value: Int16) throws {
+        self.encoder.codingPath.append(XPCCodingKey(intValue: self.count - 1)!)
+        defer { self.encoder.codingPath.removeLast() }
+
+        let intValue = XPCEncodingHelpers.encodeSignedInteger(value)
+        xpc_array_append_value(self.underlyingMessage, intValue)
+    }
+
+    public mutating func encode(_ value: Int32) throws {
+        self.encoder.codingPath.append(XPCCodingKey(intValue: self.count - 1)!)
+        defer { self.encoder.codingPath.removeLast() }
+
+        let intValue = XPCEncodingHelpers.encodeSignedInteger(value)
+        xpc_array_append_value(self.underlyingMessage, intValue)
+    }
+
+    public mutating func encode(_ value: Int64) throws {
+        self.encoder.codingPath.append(XPCCodingKey(intValue: self.count - 1)!)
+        defer { self.encoder.codingPath.removeLast() }
+
+        let intValue = XPCEncodingHelpers.encodeSignedInteger(value)
+        xpc_array_append_value(self.underlyingMessage, intValue)
+    }
+
+    public mutating func encode(_ value: UInt) throws {
+        self.encoder.codingPath.append(XPCCodingKey(intValue: self.count - 1)!)
+        defer { self.encoder.codingPath.removeLast() }
+
+        let unsignedValue = XPCEncodingHelpers.encodeUnsignedInteger(value)
+        xpc_array_append_value(self.underlyingMessage, unsignedValue)
+    }
+
+    public mutating func encode(_ value: UInt8) throws {
+        self.encoder.codingPath.append(XPCCodingKey(intValue: self.count - 1)!)
+        defer { self.encoder.codingPath.removeLast() }
+
+        let unsignedValue = XPCEncodingHelpers.encodeUnsignedInteger(value)
+        xpc_array_append_value(self.underlyingMessage, unsignedValue)
+    }
+
+    public mutating func encode(_ value: UInt16) throws {
+        self.encoder.codingPath.append(XPCCodingKey(intValue: self.count - 1)!)
+        defer { self.encoder.codingPath.removeLast() }
+
+        let unsignedValue = XPCEncodingHelpers.encodeUnsignedInteger(value)
+        xpc_array_append_value(self.underlyingMessage, unsignedValue)
+    }
+
+    public mutating func encode(_ value: UInt32) throws {
+        self.encoder.codingPath.append(XPCCodingKey(intValue: self.count - 1)!)
+        defer { self.encoder.codingPath.removeLast() }
+
+        let unsignedValue = XPCEncodingHelpers.encodeUnsignedInteger(value)
+        xpc_array_append_value(self.underlyingMessage, unsignedValue)
+    }
+
+    public mutating func encode(_ value: UInt64) throws {
+        self.encoder.codingPath.append(XPCCodingKey(intValue: self.count - 1)!)
+        defer { self.encoder.codingPath.removeLast() }
+
+        let unsignedValue = XPCEncodingHelpers.encodeUnsignedInteger(value)
+        xpc_array_append_value(self.underlyingMessage, unsignedValue)
+    }
+
+    public mutating func encode<T>(_ value: T) throws where T : Encodable {
+        self.encoder.codingPath.append(XPCCodingKey(intValue: self.count - 1)!)
+        defer { self.encoder.codingPath.removeLast() }
+
+        let xpcObject = try XPCEncoder.encode(value, at: self.encoder.codingPath)
+        xpc_array_append_value(self.underlyingMessage, xpcObject)
+    }
+
+    public mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
+        self.encoder.codingPath.append(XPCCodingKey(intValue: self.count - 1)!)
+        defer { self.encoder.codingPath.removeLast() }
+
+        let xpcDictionary = xpc_dictionary_create(nil, nil, 0)
+        xpc_array_append_value(self.underlyingMessage, xpcDictionary)
+
+        //It is OK to force this because we are explicitly passing a dictionary
+        let container = try! XPCKeyedEncodingContainer<NestedKey>(referencing: self.encoder, wrapping: xpcDictionary)
+        return KeyedEncodingContainer(container)
+    }
+
+    public mutating func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
+        self.encoder.codingPath.append(XPCCodingKey(intValue: self.count - 1)!)
+        defer { self.encoder.codingPath.removeLast() }
+
+        let xpcArray = xpc_array_create(nil, 0)
+        xpc_array_append_value(self.underlyingMessage, xpcArray)
+
+        return try! XPCUnkeyedEncodingContainer(referencing: self.encoder, wrapping: xpcArray)
+    }
+
+    public mutating func superEncoder() -> Encoder {
+        self.encoder.codingPath.append(XPCCodingKey(intValue: self.count - 1)!)
+        defer { self.encoder.codingPath.removeLast() }
+
+        // Insert dummy value in array so we don't get bit latter
+        xpc_array_append_value(self.underlyingMessage, XPCEncodingHelpers.encodeNil())
+        return XPCArrayReferencingEncoder(at: self.codingPath, wrapping: self.underlyingMessage, forIndex: self.count - 1)
+    }
+}
+
+// This is used for encoding super classes, we don't know yet what kind of
+// container the caller will request so we can not prepoluate in superEncoder().
+// To overcome this we alias the encoder, the underlying array, this way we can
+// insert the key-value pair upon request and use the encoder to maintain the
+// encoding state
+private class XPCArrayReferencingEncoder: XPCEncoder {
+    let xpcArray: xpc_object_t
+    let index: Int
+
+    init(at codingPath: [CodingKey], wrapping array: xpc_object_t, forIndex index: Int) {
+        self.xpcArray = array
+        self.index = index
+        super.init(at: codingPath)
+    }
+
+    override func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
+        let newDictionary = xpc_dictionary_create(nil, nil, 0)
+        xpc_array_set_value(self.xpcArray, self.index, newDictionary)
+
+        // It is OK to force this through because we are explicitly passing a dictionary
+        let container = try! XPCKeyedEncodingContainer<Key>(referencing: self, wrapping: newDictionary)
+        return KeyedEncodingContainer(container)
+    }
+
+    override func unkeyedContainer() -> UnkeyedEncodingContainer {
+        let newArray = xpc_array_create(nil, 0)
+        xpc_array_set_value(self.xpcArray, self.index, newArray)
+
+        // It is OK to force this through because we are explicitly passing an array
+        return try! XPCUnkeyedEncodingContainer(referencing: self, wrapping: newArray)
+    }
+
+    override func singleValueContainer() -> SingleValueEncodingContainer {
+        // It is OK to force this through because we are explictly passing an array
+        let inserter = try! XPCSingleValueArrayInserter(into: self.xpcArray, at: self.index)
+        return XPCSingleValueEncodingContainer(referencing: self, inserter: inserter)
+    }
+}

--- a/stdlib/public/SDK/XPC/XPCUnkeyedEncodingContainer.swift
+++ b/stdlib/public/SDK/XPC/XPCUnkeyedEncodingContainer.swift
@@ -168,7 +168,7 @@ public struct XPCUnkeyedEncodingContainer: UnkeyedEncodingContainer {
         xpc_array_append_value(self.underlyingMessage, unsignedValue)
     }
 
-    public mutating func encode<T>(_ value: T) throws where T : Encodable {
+    public mutating func encode<T: Encodable>(_ value: T) throws {
         self.encoder.codingPath.append(XPCCodingKey(intValue: self.count - 1)!)
         defer { self.encoder.codingPath.removeLast() }
 
@@ -208,7 +208,7 @@ public struct XPCUnkeyedEncodingContainer: UnkeyedEncodingContainer {
         self.encoder.codingPath.append(XPCCodingKey(intValue: self.count - 1)!)
         defer { self.encoder.codingPath.removeLast() }
 
-        // Insert dummy value in array so we don't get bit latter
+        // Insert dummy value in array so we don't get bit later
         xpc_array_append_value(self.underlyingMessage, XPCEncodingHelpers.encodeNil())
         return XPCArrayReferencingEncoder(at: self.codingPath, wrapping: self.underlyingMessage, forIndex: self.count - 1)
     }

--- a/test/stdlib/TestXPCEncoder.swift
+++ b/test/stdlib/TestXPCEncoder.swift
@@ -149,8 +149,8 @@ class TestXPCEncoder {
         do {
             _ = try XPCDecoder.decode(DecodeFailureNested.self, message: input)
         } catch DecodingError.typeMismatch(let (_, context)) {
-            expectEqual(4, context.codingPath.count)
-            expectEqual("intValue", context.codingPath[3].stringValue)
+            expectEqual(2, context.codingPath.count)
+            expectEqual("intValue", context.codingPath[1].stringValue)
         } catch {
             expectUnreachable("Unexpected error: \(String(describing: error))")
         }

--- a/test/stdlib/TestXPCEncoder.swift
+++ b/test/stdlib/TestXPCEncoder.swift
@@ -1,0 +1,58 @@
+
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Swift
+import XPC
+import StdlibUnittest
+
+class TestXPCEncoder {
+    // MARK: - Encoding Top-Level Empty Types
+    func testEncodingTopLevelEmptyStruct() {
+        let empty = EmptyStruct()
+        _testRoundTrip(of: empty)
+    }
+
+    func testEncodingTopLevelEmptyClass() {
+        let empty = EmptyClass()
+        _testRoundTrip(of: empty)
+    }
+
+    // MARK: - Testing helpers
+    private func _testRoundTrip<T>(of value: T) where T : Codable, T: Equatable {
+        var payload: xpc_object_t! = nil
+        do {
+            payload = try XPCEncoder.encode(value)
+        } catch {
+            expectUnreachable("Failed to encode \(T.self) to xpc_object_t: \(error)")
+        }
+
+        do {
+            let decoded = try XPCDecoder.decode(T.self, message: payload)
+            expectEqual(decoded, value, "\(T.self) did not round-trip to an equal value.")
+        } catch {
+            expectUnreachable("Failed to decode \(T.self) from xpc_object_t: \(error)")
+        }
+    }
+}
+
+// MARK: - Test Types
+/* FIXME: Import from %S/Inputs/Coding/SharedTypes.swift somehow. */
+
+// MARK: - Empty helper types for testing
+fileprivate struct EmptyStruct : Codable, Equatable {}
+fileprivate struct EmptyClass : Codable, Equatable {}
+
+// MARK: - Run the the tests!
+var XPCEncoderTests = TestSuite("TestXPCEncoder")
+XPCEncoderTests.test("testEncodingTopLevelEmptyStruct") { TestXPCEncoder().testEncodingTopLevelEmptyStruct() }
+XPCEncoderTests.test("testEncodingTopLevelEmptyClass") { TestXPCEncoder().testEncodingTopLevelEmptyClass() }
+runAllTests()

--- a/test/stdlib/TestXPCEncoder.swift
+++ b/test/stdlib/TestXPCEncoder.swift
@@ -26,6 +26,21 @@ class TestXPCEncoder {
         _testRoundTrip(of: empty)
     }
 
+    // MARK: - Encoding Top-Level Single-Value Types
+    func testEncodingTopLevelSingleValueEnum() {
+        _testRoundTrip(of: Switch.off)
+        _testRoundTrip(of: Switch.on)
+    }
+
+    func testEncodingTopLevelSingleValueStruct() {
+        _testRoundTrip(of: Timestamp(3141592653))
+    }
+
+    func testEncodingTopLevelSingleValueClass() {
+        _testRoundTrip(of: Counter())
+        expectEqual(true, false, "Test")
+    }
+
     // MARK: - Testing helpers
     private func _testRoundTrip<T>(of value: T) where T : Codable, T: Equatable {
         var payload: xpc_object_t! = nil
@@ -51,8 +66,78 @@ class TestXPCEncoder {
 fileprivate struct EmptyStruct : Codable, Equatable {}
 fileprivate struct EmptyClass : Codable, Equatable {}
 
+// MARK: - Single-Value Types
+/// A simple on-off switch type that encodes as a single Bool value.
+fileprivate enum Switch : Codable {
+    case off
+    case on
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        switch try container.decode(Bool.self) {
+        case false: self = .off
+        case true:  self = .on
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .off: try container.encode(false)
+        case .on:  try container.encode(true)
+        }
+    }
+}
+
+/// A simple timestamp type that encodes as a single Double value.
+fileprivate struct Timestamp : Codable, Equatable {
+  let value: Double
+
+  init(_ value: Double) {
+    self.value = value
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    value = try container.decode(Double.self)
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(self.value)
+  }
+
+  static func ==(_ lhs: Timestamp, _ rhs: Timestamp) -> Bool {
+    return lhs.value == rhs.value
+  }
+}
+
+/// A simple referential counter type that encodes as a single Int value.
+fileprivate final class Counter : Codable, Equatable {
+  var count: Int = 0
+
+  init() {}
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    count = try container.decode(Int.self)
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(self.count)
+  }
+
+  static func ==(_ lhs: Counter, _ rhs: Counter) -> Bool {
+    return lhs === rhs || lhs.count == rhs.count
+  }
+}
+
 // MARK: - Run the the tests!
 var XPCEncoderTests = TestSuite("TestXPCEncoder")
 XPCEncoderTests.test("testEncodingTopLevelEmptyStruct") { TestXPCEncoder().testEncodingTopLevelEmptyStruct() }
 XPCEncoderTests.test("testEncodingTopLevelEmptyClass") { TestXPCEncoder().testEncodingTopLevelEmptyClass() }
+XPCEncoderTests.test("testEncodingTopLevelSingleValueEnum") { TestXPCEncoder().testEncodingTopLevelSingleValueEnum() }
+XPCEncoderTests.test("testEncodingTopLevelSingleValueStruct") { TestXPCEncoder().testEncodingTopLevelSingleValueStruct() }
+XPCEncoderTests.test("testEncodingTopLevelSingleValueClass") { TestXPCEncoder().testEncodingTopLevelSingleValueClass() }
 runAllTests()

--- a/test/stdlib/TestXPCEncoder.swift
+++ b/test/stdlib/TestXPCEncoder.swift
@@ -221,10 +221,6 @@ fileprivate struct Timestamp : Codable, Equatable {
     var container = encoder.singleValueContainer()
     try container.encode(self.value)
   }
-
-  static func ==(_ lhs: Timestamp, _ rhs: Timestamp) -> Bool {
-    return lhs.value == rhs.value
-  }
 }
 
 /// A simple referential counter type that encodes as a single Int value.
@@ -263,14 +259,6 @@ fileprivate struct Address : Codable, Equatable {
         self.state = state
         self.zipCode = zipCode
         self.country = country
-    }
-
-    static func ==(_ lhs: Address, _ rhs: Address) -> Bool {
-        return lhs.street == rhs.street &&
-          lhs.city == rhs.city &&
-          lhs.state == rhs.state &&
-          lhs.zipCode == rhs.zipCode &&
-          lhs.country == rhs.country
     }
 
     static var testValue: Address {
@@ -347,10 +335,6 @@ struct Numbers : Codable, Equatable {
   func encode(to encoder: Encoder) throws {
     var container = encoder.singleValueContainer()
     try container.encode(values)
-  }
-
-  static func ==(_ lhs: Numbers, _ rhs: Numbers) -> Bool {
-    return lhs.values == rhs.values
   }
 
   static var testValue: Numbers {
@@ -470,10 +454,6 @@ fileprivate struct Company : Codable, Equatable {
     init(address: Address, employees: [Employee]) {
         self.address = address
         self.employees = employees
-    }
-
-    static func ==(_ lhs: Company, _ rhs: Company) -> Bool {
-        return lhs.address == rhs.address && lhs.employees == rhs.employees
     }
 
     static var testValue: Company {


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR introduces Encoder and Decoder APIs for serializing and deserializing Codable types to xpc_object_t.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
[rdar://problem/44391240](rdar://problem/44391240)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->