### PR TITLE
Revert "Serialization: Fix deserialization of generic typealiases"

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t VERSION_MINOR = 443; // Last change: serialize unsubstituted type alias type
+const uint16_t VERSION_MINOR = 442; // Last change: operator protocol
 
 using DeclIDField = BCFixed<31>;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3625,14 +3625,13 @@ void Serializer::writeType(Type ty) {
   case TypeKind::NameAlias: {
     auto alias = cast<NameAliasType>(ty.getPointer());
     const TypeAliasDecl *typeAlias = alias->getDecl();
-    auto underlyingType = typeAlias->getUnderlyingTypeLoc().getType();
 
     unsigned abbrCode = DeclTypeAbbrCodes[NameAliasTypeLayout::Code];
     NameAliasTypeLayout::emitRecord(
                            Out, ScratchRecord, abbrCode,
                            addDeclRef(typeAlias, /*allowTypeAliasXRef*/true),
                            addTypeRef(alias->getParent()),
-                           addTypeRef(underlyingType),
+                           addTypeRef(alias->getSinglyDesugaredType()),
                            addSubstitutionMapRef(alias->getSubstitutionMap()));
     break;
   }

--- a/test/IDE/print_swift_module.swift
+++ b/test/IDE/print_swift_module.swift
@@ -4,43 +4,22 @@
 // RUN: %FileCheck %s -check-prefix=CHECK1 < %t.syn.txt
 
 public protocol P1 {
-  /// foo1 comment from P1
-  func foo1()
-  /// foo2 comment from P1
-  func foo2()
+	/// foo1 comment from P1
+	func foo1()
+	/// foo2 comment from P1
+	func foo2()
 }
 public class C1 : P1 {
-  public func foo1() {
-  }
-  /// foo2 comment from C1
-  public func foo2() {
-  }
+	public func foo1() {
+	}
+	/// foo2 comment from C1
+	public func foo2() {
+	}
 }
 
-/// Alias comment
-public typealias Alias<T> = (T, T)
-
-/// returnsAlias() comment
-public func returnsAlias() -> Alias<Int> {
-  return (0, 0)
-}
-
-// CHECK1:      /// Alias comment
-// CHECK1-NEXT: typealias Alias<T> = (T, T)
-
-// CHECK1:      public class C1 : P1 {
-// CHECK1-NEXT:   /// foo1 comment from P1
-// CHECK1-NEXT:   public func foo1()
-// CHECK1-NEXT:   /// foo2 comment from C1
-// CHECK1-NEXT:   public func foo2()
+// CHECK1: 			public class C1 : P1 {
+// CHECK1-NEXT:		/// foo1 comment from P1
+// CHECK1-NEXT:  	public func foo1()
+// CHECK1-NEXT:  	/// foo2 comment from C1
+// CHECK1-NEXT:  	public func foo2()
 // CHECK1-NEXT: }
-
-// CHECK1:      public protocol P1 {
-// CHECK1-NEXT:   /// foo1 comment from P1
-// CHECK1-NEXT:   func foo1()
-// CHECK1-NEXT:   /// foo2 comment from P1
-// CHECK1-NEXT:   func foo2()
-// CHECK1-NEXT: }
-
-// CHECK1:      /// returnsAlias() comment
-// CHECK1-NEXT: func returnsAlias() -> Alias<Int>

--- a/test/Serialization/Recovery/types-4-to-5.swift
+++ b/test/Serialization/Recovery/types-4-to-5.swift
@@ -49,7 +49,11 @@ public func A_renameAllTheThings(
 
 // CHECK-4-LABEL: func A_renameAllTheThings(
 // CHECK-4-SAME: a: Swift4RenamedClass?
-// CHECK-4-SAME: b: Swift4RenamedGenericClass<AnyObject>?
+
+// FIXME: An issue not specific to the importer where generic typealiases are
+// not preserved when provided arguments.
+// CHECK-4-SAME: b: RenamedGenericClass<AnyObject>?
+
 // CHECK-4-SAME: c: Swift4RenamedTypedef
 // CHECK-4-SAME: d: Swift4RenamedStruct
 // CHECK-4-SAME: e: Swift4RenamedEnum

--- a/test/api-digester/source-stability.swift.expected
+++ b/test/api-digester/source-stability.swift.expected
@@ -1,6 +1,5 @@
 
 /* Generic Signature Changes */
-Func Substring.replaceSubrange(_:with:) has generic signature change from <C where C : Collection, C.Element == Character> to <C where C : Collection, C.Element == Substring.Iterator.Element>
 Protocol BinaryInteger has generic signature change from <Self : CustomStringConvertible, Self : Hashable, Self : Numeric, Self : Strideable, Self.Magnitude : BinaryInteger, Self.Magnitude == Self.Magnitude.Magnitude, Self.Words : Sequence, Self.Words.Element == UInt> to <Self : CustomStringConvertible, Self : Hashable, Self : Numeric, Self : Strideable, Self.Magnitude : BinaryInteger, Self.Magnitude == Self.Magnitude.Magnitude, Self.Words : RandomAccessCollection, Self.Words.Element == UInt, Self.Words.Index == Int>
 /* RawRepresentable Changes */
 


### PR DESCRIPTION
Reverts apple/swift#19253. Internal testing uncovered an issue and this fix needs more work.