### PR TITLE
[ConstraintSystem] Infer empty closures as returning () more eagerly.

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3653,6 +3653,9 @@ public:
   /// its body; it can only update that expression.
   void setSingleExpressionBody(Expr *NewBody);
 
+  /// \brief Is this a completely empty closure?
+  bool hasEmptyBody() const;
+
   static bool classof(const Expr *E) {
     return E->getKind() == ExprKind::Closure;
   }

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1855,6 +1855,10 @@ void ClosureExpr::setSingleExpressionBody(Expr *NewBody) {
   getBody()->setElement(0, NewBody);
 }
 
+bool ClosureExpr::hasEmptyBody() const {
+  return getBody()->getNumElements() == 0;
+}
+
 FORWARD_SOURCE_LOCS_TO(AutoClosureExpr, Body)
 
 void AutoClosureExpr::setBody(Expr *E) {

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -749,3 +749,51 @@ func f20371273() {
   let y: UInt = 4
   _ = x.filter { ($0 + y)  > 42 } // expected-error {{'+' is unavailable}}
 }
+
+// rdar://problem/42337247
+
+func overloaded(_ handler: () -> Int) {} // expected-note {{found this candidate}}
+func overloaded(_ handler: () -> Void) {} // expected-note {{found this candidate}}
+
+overloaded { } // empty body => inferred as returning ()
+
+overloaded { print("hi") } // single-expression closure => typechecked with body
+
+overloaded { print("hi"); print("bye") } // multiple expression closure without explicit returns; can default to any return type
+// expected-error@-1 {{ambiguous use of 'overloaded'}}
+
+func not_overloaded(_ handler: () -> Int) {}
+
+not_overloaded { } // empty body
+// expected-error@-1 {{cannot convert value of type '() -> ()' to expected argument type '() -> Int'}}
+
+not_overloaded { print("hi") } // single-expression closure
+// expected-error@-1 {{cannot convert value of type '()' to closure result type 'Int'}}
+
+// no error in -typecheck, but dataflow diagnostics will complain about missing return
+not_overloaded { print("hi"); print("bye") } // multiple expression closure
+
+func apply(_ fn: (Int) throws -> Int) rethrows -> Int {
+  return try fn(0)
+}
+
+enum E : Error {
+  case E
+}
+
+func test() -> Int? {
+  return try? apply({ _ in throw E.E })
+}
+
+var fn: () -> [Int] = {}
+// expected-error@-1 {{cannot convert value of type '() -> ()' to specified type '() -> [Int]'}}
+
+fn = {}
+// expected-error@-1 {{cannot assign value of type '() -> ()' to type '() -> [Int]'}}
+
+func test<Instances : Collection>(
+  _ instances: Instances,
+  _ fn: (Instances.Index, Instances.Index) -> Bool
+) { fatalError() }
+
+test([1]) { _, _ in fatalError(); () }

--- a/test/SILGen/objc_blocks_bridging.swift
+++ b/test/SILGen/objc_blocks_bridging.swift
@@ -154,7 +154,7 @@ class Test: NSObject {
 // CHECK:         return [[RESULT]]
 
 func clearDraggingItemImageComponentsProvider(_ x: NSDraggingItem) {
-  x.imageComponentsProvider = {}
+  x.imageComponentsProvider = { [] }
 }
 // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @$SSayypGIego_So7NSArrayCSgIeyBa_TR
 // CHECK:         [[CONVERT:%.*]] = function_ref @$SSa10FoundationE19_bridgeToObjectiveCSo7NSArrayCyF

--- a/test/decl/func/default-values-swift4.swift
+++ b/test/decl/func/default-values-swift4.swift
@@ -109,4 +109,5 @@ public func evilCode(
       versionedFunction()
       // expected-error@-1 {{global function 'versionedFunction()' is internal and cannot be referenced from a default argument value}}
     }
+    return 0
   }()) {}

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -252,6 +252,7 @@ func rdar19179412() -> (Int) -> Int {
     class A {
       let d : Int = 0
     }
+    return 0
   }
 }
 


### PR DESCRIPTION
We previously allowed these closures to default to (), but be inferred
as other types as well, which means that we will find some expressions
to be ambiguous because we end up finding multiple viable solutions
where there is really only one reasonable solution.

Fixes: rdar://problem/42337247
