### PR TITLE
remove unnecessary "import TensorFlow" from AutoDiff test

### DIFF
--- a/test/AutoDiff/primalgen.swift
+++ b/test/AutoDiff/primalgen.swift
@@ -1,7 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s
 
-import TensorFlow
-
 @inline(never)
 func print<T>(_ x: T) {
   Swift.print(x)


### PR DESCRIPTION
It's causing a test failure in Piper because the BUILD file for AutoDiff tests isn't set up to import TensorFlow stuff.