### PR TITLE
[Serialization] Handful of cleanups and possibly memory usage improvements

### DIFF
--- a/include/swift/SIL/SILDefaultWitnessTable.h
+++ b/include/swift/SIL/SILDefaultWitnessTable.h
@@ -119,7 +119,11 @@ public:
                                         const ProtocolDecl *Protocol,
                                         ArrayRef<Entry> entries);
 
-  Identifier getIdentifier() const;
+  /// Get a name that uniquely identifies this default witness table.
+  ///
+  /// Note that this is /not/ valid as a symbol name; it is only guaranteed to
+  /// be unique among default witness tables, not all symbols.
+  std::string getUniqueName() const;
 
   /// Get the linkage of the default witness table.
   SILLinkage getLinkage() const { return Linkage; }

--- a/include/swift/SIL/SILWitnessTable.h
+++ b/include/swift/SIL/SILWitnessTable.h
@@ -226,10 +226,6 @@ public:
   /// object file level.
   StringRef getName() const { return Name; }
 
-  /// Return the symbol name of the witness table that will be propagated to the
-  /// object file as an Identifier.
-  Identifier getIdentifier() const;
-
   /// Returns true if this witness table is a declaration.
   bool isDeclaration() const { return IsDeclaration; }
 

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -314,11 +314,11 @@ private:
 
   /// Represents an identifier that may or may not have been deserialized yet.
   ///
-  /// If \c Offset is non-zero, the identifier has not been loaded yet.
+  /// If \c Ident is empty, the identifier has not been loaded yet.
   class SerializedIdentifier {
   public:
     Identifier Ident;
-    serialization::BitOffset Offset;
+    unsigned Offset;
 
     template <typename IntTy>
     /*implicit*/ SerializedIdentifier(IntTy rawOffset)
@@ -792,6 +792,11 @@ public:
   /// Convenience method to retrieve the identifier backing the name with
   /// given ID. Asserts that the name with this ID is not special.
   Identifier getIdentifier(serialization::IdentifierID IID);
+
+  /// Convenience method to retrieve the text of the name with the given ID.
+  /// This can be used if the result doesn't need to be uniqued in the
+  /// ASTContext. Asserts that the name with this ID is not special.
+  StringRef getIdentifierText(serialization::IdentifierID IID);
 
   /// Returns the decl with the given ID, deserializing it if needed.
   ///

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -241,7 +241,7 @@ public:
     T Value;
 
     /// The offset.
-    serialization::BitOffset Offset;
+    unsigned Offset : 31;
 
     unsigned IsFullyDeserialized : 1;
 

--- a/lib/SIL/SILDefaultWitnessTable.cpp
+++ b/lib/SIL/SILDefaultWitnessTable.cpp
@@ -95,10 +95,9 @@ convertToDefinition(ArrayRef<Entry> entries) {
   }
 }
 
-Identifier SILDefaultWitnessTable::getIdentifier() const {
+std::string SILDefaultWitnessTable::getUniqueName() const {
   Mangle::ASTMangler Mangler;
-  std::string name = Mangler.mangleTypeAsUSR(getProtocol()->getDeclaredType());
-  return Mod.getASTContext().getIdentifier(name);
+  return Mangler.mangleTypeAsUSR(getProtocol()->getDeclaredType());
 }
 
 SILDefaultWitnessTable::~SILDefaultWitnessTable() {

--- a/lib/SIL/SILWitnessTable.cpp
+++ b/lib/SIL/SILWitnessTable.cpp
@@ -151,10 +151,6 @@ void SILWitnessTable::convertToDefinition(
   }
 }
 
-Identifier SILWitnessTable::getIdentifier() const {
-  return Mod.getASTContext().getIdentifier(Name);
-}
-
 bool SILWitnessTable::conformanceIsSerialized(ProtocolConformance *conformance) {
   // Serialize witness tables for conformances synthesized by
   // the ClangImporter.

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -182,7 +182,7 @@ SILDeserializer::SILDeserializer(
       DefaultWitnessTableList = readFuncTable(scratch, blobData);
     else if (kind == sil_index_block::SIL_PROPERTY_OFFSETS) {
       // No matching 'names' block for property descriptors needed yet.
-      Properties.assign(scratch.begin(), scratch.end());
+      MF->allocateBuffer(Properties, scratch);
       return;
     }
 
@@ -195,27 +195,27 @@ SILDeserializer::SILDeserializer(
       assert((next.Kind == llvm::BitstreamEntry::Record &&
               offKind == sil_index_block::SIL_FUNC_OFFSETS) &&
              "Expect a SIL_FUNC_OFFSETS record.");
-      Funcs.assign(scratch.begin(), scratch.end());
+      MF->allocateBuffer(Funcs, scratch);
     } else if (kind == sil_index_block::SIL_VTABLE_NAMES) {
       assert((next.Kind == llvm::BitstreamEntry::Record &&
               offKind == sil_index_block::SIL_VTABLE_OFFSETS) &&
              "Expect a SIL_VTABLE_OFFSETS record.");
-      VTables.assign(scratch.begin(), scratch.end());
+      MF->allocateBuffer(VTables, scratch);
     } else if (kind == sil_index_block::SIL_GLOBALVAR_NAMES) {
       assert((next.Kind == llvm::BitstreamEntry::Record &&
               offKind == sil_index_block::SIL_GLOBALVAR_OFFSETS) &&
              "Expect a SIL_GLOBALVAR_OFFSETS record.");
-      GlobalVars.assign(scratch.begin(), scratch.end());
+      MF->allocateBuffer(GlobalVars, scratch);
     } else if (kind == sil_index_block::SIL_WITNESS_TABLE_NAMES) {
       assert((next.Kind == llvm::BitstreamEntry::Record &&
               offKind == sil_index_block::SIL_WITNESS_TABLE_OFFSETS) &&
              "Expect a SIL_WITNESS_TABLE_OFFSETS record.");
-      WitnessTables.assign(scratch.begin(), scratch.end());
+      MF->allocateBuffer(WitnessTables, scratch);
     } else if (kind == sil_index_block::SIL_DEFAULT_WITNESS_TABLE_NAMES) {
       assert((next.Kind == llvm::BitstreamEntry::Record &&
               offKind == sil_index_block::SIL_DEFAULT_WITNESS_TABLE_OFFSETS) &&
              "Expect a SIL_DEFAULT_WITNESS_TABLE_OFFSETS record.");
-      DefaultWitnessTables.assign(scratch.begin(), scratch.end());
+      MF->allocateBuffer(DefaultWitnessTables, scratch);
     }
   }
 }

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -3130,7 +3130,7 @@ SILDeserializer::lookupDefaultWitnessTable(SILDefaultWitnessTable *existingWt) {
 
   // Use the mangled name of the protocol to lookup the partially
   // deserialized value from the default witness table list.
-  auto iter = DefaultWitnessTableList->find(existingWt->getIdentifier().str());
+  auto iter = DefaultWitnessTableList->find(existingWt->getUniqueName());
   if (iter == DefaultWitnessTableList->end())
     return nullptr;
 

--- a/lib/Serialization/DeserializeSIL.h
+++ b/lib/Serialization/DeserializeSIL.h
@@ -39,23 +39,23 @@ namespace swift {
       llvm::OnDiskIterableChainedHashTable<FuncTableInfo>;
 
     std::unique_ptr<SerializedFuncTable> FuncTable;
-    std::vector<ModuleFile::PartiallySerialized<SILFunction*>> Funcs;
+    MutableArrayRef<ModuleFile::PartiallySerialized<SILFunction*>> Funcs;
 
     std::unique_ptr<SerializedFuncTable> VTableList;
-    std::vector<ModuleFile::Serialized<SILVTable*>> VTables;
+    MutableArrayRef<ModuleFile::Serialized<SILVTable*>> VTables;
 
     std::unique_ptr<SerializedFuncTable> GlobalVarList;
-    std::vector<ModuleFile::Serialized<SILGlobalVariable*>> GlobalVars;
+    MutableArrayRef<ModuleFile::Serialized<SILGlobalVariable*>> GlobalVars;
 
     std::unique_ptr<SerializedFuncTable> WitnessTableList;
-    std::vector<ModuleFile::PartiallySerialized<SILWitnessTable *>>
+    MutableArrayRef<ModuleFile::PartiallySerialized<SILWitnessTable *>>
     WitnessTables;
 
     std::unique_ptr<SerializedFuncTable> DefaultWitnessTableList;
-    std::vector<ModuleFile::PartiallySerialized<SILDefaultWitnessTable *>>
+    MutableArrayRef<ModuleFile::PartiallySerialized<SILDefaultWitnessTable *>>
     DefaultWitnessTables;
 
-    std::vector<ModuleFile::PartiallySerialized<SILProperty *>>
+    MutableArrayRef<ModuleFile::PartiallySerialized<SILProperty *>>
     Properties;
 
     /// A declaration will only

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -796,19 +796,19 @@ bool ModuleFile::readIndexBlock(llvm::BitstreamCursor &cursor) {
       switch (kind) {
       case index_block::DECL_OFFSETS:
         assert(blobData.empty());
-        Decls.assign(scratch.begin(), scratch.end());
+        allocateBuffer(Decls, scratch);
         break;
       case index_block::DECL_CONTEXT_OFFSETS:
         assert(blobData.empty());
-        DeclContexts.assign(scratch.begin(), scratch.end());
+        allocateBuffer(DeclContexts, scratch);
         break;
       case index_block::TYPE_OFFSETS:
         assert(blobData.empty());
-        Types.assign(scratch.begin(), scratch.end());
+        allocateBuffer(Types, scratch);
         break;
       case index_block::IDENTIFIER_OFFSETS:
         assert(blobData.empty());
-        Identifiers.assign(scratch.begin(), scratch.end());
+        allocateBuffer(Identifiers, scratch);
         break;
       case index_block::TOP_LEVEL_DECLS:
         TopLevelDecls = readDeclTable(scratch, blobData);
@@ -836,7 +836,7 @@ bool ModuleFile::readIndexBlock(llvm::BitstreamCursor &cursor) {
         setEntryPointClassID(scratch.front());
         break;
       case index_block::ORDERED_TOP_LEVEL_DECLS:
-        OrderedTopLevelDecls.assign(scratch.begin(), scratch.end());
+        allocateBuffer(OrderedTopLevelDecls, scratch);
         break;
       case index_block::LOCAL_TYPE_DECLS:
         LocalTypeDecls = readLocalDeclTable(scratch, blobData);
@@ -849,27 +849,27 @@ bool ModuleFile::readIndexBlock(llvm::BitstreamCursor &cursor) {
         break;
       case index_block::LOCAL_DECL_CONTEXT_OFFSETS:
         assert(blobData.empty());
-        LocalDeclContexts.assign(scratch.begin(), scratch.end());
+        allocateBuffer(LocalDeclContexts, scratch);
         break;
       case index_block::GENERIC_SIGNATURE_OFFSETS:
         assert(blobData.empty());
-        GenericSignatures.assign(scratch.begin(), scratch.end());
+        allocateBuffer(GenericSignatures, scratch);
         break;
       case index_block::GENERIC_ENVIRONMENT_OFFSETS:
         assert(blobData.empty());
-        GenericEnvironments.assign(scratch.begin(), scratch.end());
+        allocateBuffer(GenericEnvironments, scratch);
         break;
       case index_block::SUBSTITUTION_MAP_OFFSETS:
         assert(blobData.empty());
-        SubstitutionMaps.assign(scratch.begin(), scratch.end());
+        allocateBuffer(SubstitutionMaps, scratch);
         break;
       case index_block::NORMAL_CONFORMANCE_OFFSETS:
         assert(blobData.empty());
-        NormalConformances.assign(scratch.begin(), scratch.end());
+        allocateBuffer(NormalConformances, scratch);
         break;
       case index_block::SIL_LAYOUT_OFFSETS:
         assert(blobData.empty());
-        SILLayouts.assign(scratch.begin(), scratch.end());
+        allocateBuffer(SILLayouts, scratch);
         break;
 
       default:

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -703,9 +703,9 @@ IdentifierID Serializer::addDeclBaseNameRef(DeclBaseName ident) {
   }
 }
 
-IdentifierID Serializer::addUniquedStringRef(StringRef str) {
+std::pair<StringRef, IdentifierID> Serializer::addUniquedString(StringRef str) {
   if (str.empty())
-    return 0;
+    return {str, 0};
 
   decltype(UniquedStringIDs)::iterator iter;
   bool isNew;
@@ -713,11 +713,12 @@ IdentifierID Serializer::addUniquedStringRef(StringRef str) {
       UniquedStringIDs.insert({str, LastUniquedStringID + 1});
 
   if (!isNew)
-    return iter->getValue();
+    return {iter->getKey(), iter->getValue()};
 
+  ++LastUniquedStringID;
   // Note that we use the string data stored in the StringMap.
   StringsToWrite.push_back(iter->getKey());
-  return ++LastUniquedStringID;
+  return {iter->getKey(), LastUniquedStringID};
 }
 
 IdentifierID Serializer::addModuleRef(const ModuleDecl *M) {

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -87,7 +87,17 @@ private:
   /// A map from Types and Decls to their serialized IDs.
   llvm::DenseMap<DeclTypeUnion, DeclID> DeclAndTypeIDs;
 
+  /// A map from non-identifier uniqued strings to their serialized IDs.
+  ///
+  /// Since we never remove items from this map, we can use a BumpPtrAllocator
+  /// to back the entries.
+  llvm::StringMap<IdentifierID, llvm::BumpPtrAllocator> UniquedStringIDs;
+
   /// A map from Identifiers to their serialized IDs.
+  ///
+  /// This is stored separately from \p UniquedStringIDs because it's faster
+  /// to do lookups in, even though that may lead to some duplication between
+  /// identifier and non-identifier strings.
   llvm::DenseMap<Identifier, IdentifierID> IdentifierIDs;
 
   /// A map from DeclContexts to their serialized IDs.
@@ -185,8 +195,9 @@ private:
   /// SILLayouts that need to be serialized.
   std::queue<SILLayout *> SILLayoutsToWrite;
 
-  /// All identifiers that need to be serialized.
-  std::vector<Identifier> IdentifiersToWrite;
+  /// All uniqued strings that need to be serialized (identifiers and
+  /// non-identifiers).
+  std::vector<StringRef> StringsToWrite;
 
   /// The abbreviation code for each record in the "decls-and-types" block.
   ///
@@ -252,11 +263,11 @@ private:
   /// The last assigned DeclID for types from this module.
   uint32_t /*TypeID*/ LastTypeID = 0;
 
-  /// The last assigned IdentifierID for types from this module.
+  /// The last assigned IdentifierID for uniqued strings from this module.
   ///
   /// Note that special module IDs and IDs of special names must not be valid
   /// IdentifierIDs, except that 0 will always represent the empty identifier.
-  uint32_t /*IdentifierID*/ LastIdentifierID =
+  uint32_t /*IdentifierID*/ LastUniquedStringID =
       serialization::NUM_SPECIAL_IDS - 1;
 
   /// The last assigned GenericSignatureID for generic signature from this
@@ -452,6 +463,12 @@ public:
   ///
   /// \returns The ID for the given DeclBaseName in this module.
   IdentifierID addDeclBaseNameRef(DeclBaseName ident);
+
+  /// Records the use of the given string, which will only be stored once in
+  /// the resulting module file.
+  ///
+  /// \returns The ID for the given string in this module.
+  IdentifierID addUniquedStringRef(StringRef str);
 
   /// Records the use of the given Decl.
   ///

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -467,8 +467,19 @@ public:
   /// Records the use of the given string, which will only be stored once in
   /// the resulting module file.
   ///
+  /// \returns A pair containing the copy of the string now owned by the
+  /// Serializer and the ID for the string in this module.
+  /// \sa addUniquedStringRef
+  std::pair<StringRef, IdentifierID> addUniquedString(StringRef str);
+
+  /// Records the use of the given string, which will only be stored once in
+  /// the resulting module file.
+  ///
   /// \returns The ID for the given string in this module.
-  IdentifierID addUniquedStringRef(StringRef str);
+  /// \sa addUniquedString
+  IdentifierID addUniquedStringRef(StringRef str) {
+    return addUniquedString(str).second;
+  }
 
   /// Records the use of the given Decl.
   ///


### PR DESCRIPTION
Tweak serialization and a few SIL structures for lower memory usage. In particular:
- Compact some types.
- Allow non-Identifiers to go in the string table, so that those strings don't get uniqued in the ASTContext too.

This is probably easiest to look at commit-by-commit.