### PR TITLE
Give opaque existential containers extra inhabitants.

### DIFF
--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -109,6 +109,11 @@ namespace {
     Address projectMetadataRef(IRGenFunction &IGF, Address addr) {
       return IGF.Builder.CreateStructGEP(addr, 1, getFixedBufferSize(IGF.IGM));
     }
+    
+    /// Give the offset of the metadata field of an existential object.
+    Size getMetadataRefOffset(IRGenModule &IGM) {
+      return getFixedBufferSize(IGM);
+    }
 
     /// Given the address of an existential object, load its metadata
     /// object.
@@ -810,12 +815,12 @@ class OpaqueExistentialTypeInfo final :
              IndirectTypeInfo<OpaqueExistentialTypeInfo, FixedTypeInfo>>;
   friend super;
 
-  // FIXME: We could get spare bits out of the metadata and/or witness
-  // pointers.
   OpaqueExistentialTypeInfo(ArrayRef<const ProtocolDecl *> protocols,
-                            llvm::Type *ty, Size size, Alignment align)
+                            llvm::Type *ty, Size size,
+                            SpareBitVector &&spareBits,
+                            Alignment align)
     : super(protocols, ty, size,
-            SpareBitVector::getConstant(size.getValueInBits(), false), align,
+            std::move(spareBits), align,
             IsNotPOD, IsBitwiseTakable, IsFixedSize) {}
 
 public:
@@ -901,6 +906,37 @@ public:
     call->setCallingConv(IGF.IGM.DefaultCC);
     call->setDoesNotThrow();
     return;
+  }
+               
+  // Opaque existentials have extra inhabitants and spare bits in their type
+  // metadata pointer, matching those of a standalone thick metatype (which
+  // in turn match those of a heap object).
+  unsigned getFixedExtraInhabitantCount(IRGenModule &IGM) const override {
+    return getHeapObjectExtraInhabitantCount(IGM);
+  }
+  APInt getFixedExtraInhabitantValue(IRGenModule &IGM,
+                                     unsigned bits,
+                                     unsigned index) const override {
+    auto offset = getLayout().getMetadataRefOffset(IGM).getValueInBits();
+    return getHeapObjectFixedExtraInhabitantValue(IGM, bits, index, offset);
+  }
+  APInt getFixedExtraInhabitantMask(IRGenModule &IGM) const override {
+    auto mask = APInt::getAllOnesValue(IGM.getPointerSize().getValueInBits());
+    mask = mask.zext(getFixedSize().getValueInBits());
+    mask = mask.shl(getLayout().getMetadataRefOffset(IGM).getValueInBits());
+    return mask;
+  }
+  llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF,
+                                       Address src, SILType T,
+                                       bool isOutlined) const override {
+    auto type = getLayout().projectMetadataRef(IGF, src);
+    return getHeapObjectExtraInhabitantIndex(IGF, type);
+  }
+  void storeExtraInhabitant(IRGenFunction &IGF, llvm::Value *index,
+                            Address dest, SILType T, bool isOutlined)
+  const override {
+    auto type = getLayout().projectMetadataRef(IGF, dest);
+    return storeHeapObjectExtraInhabitant(IGF, index, type);
   }
 };
 
@@ -1407,7 +1443,27 @@ static const TypeInfo *createExistentialTypeInfo(IRGenModule &IGM, CanType T) {
   OpaqueExistentialLayout opaque(protosWithWitnessTables.size());
   Alignment align = opaque.getAlignment(IGM);
   Size size = opaque.getSize(IGM);
+  // There are spare bits in the metadata pointer and witness table pointers
+  // consistent with a native object reference.
+  SpareBitVector spareBits;
+  spareBits.appendClearBits(size.getValueInBits());
+  /* TODO: There are spare bits we could theoretically use in the type metadata
+     and witness table pointers, but opaque existentials are currently address-
+     only, and we can't soundly take advantage of spare bits for in-memory
+     representations.
+   
+  auto metadataOffset = opaque.getMetadataRefOffset(IGM);
+  spareBits.appendClearBits(metadataOffset.getValueInBits());
+  auto typeSpareBits = IGM.getHeapObjectSpareBits();
+  spareBits.append(typeSpareBits);
+  auto witnessSpareBits =
+    IGM.getWitnessTablePtrSpareBits();
+  for (unsigned i = 0, e = protosWithWitnessTables.size(); i < e; ++i)
+    spareBits.append(witnessSpareBits);
+  assert(spareBits.size() == size.getValueInBits());
+   */
   return OpaqueExistentialTypeInfo::create(protosWithWitnessTables, type, size,
+                                           std::move(spareBits),
                                            align);
 }
 

--- a/lib/IRGen/GenOpaque.cpp
+++ b/lib/IRGen/GenOpaque.cpp
@@ -38,7 +38,7 @@
 using namespace swift;
 using namespace irgen;
 
-/// A fixed-size buffer is always 16 bytes and pointer-aligned.
+/// A fixed-size buffer is always three pointers in size and pointer-aligned.
 /// If we align them more, we'll need to introduce padding to
 /// make protocol types work.
 Size irgen::getFixedBufferSize(IRGenModule &IGM) {

--- a/stdlib/public/Reflection/TypeLowering.cpp
+++ b/stdlib/public/Reflection/TypeLowering.cpp
@@ -436,7 +436,10 @@ unsigned RecordTypeInfoBuilder::addField(unsigned fieldSize,
   switch (Kind) {
   // The extra inhabitants of a struct are the same as the extra
   // inhabitants of the field that has the most.
+  // Opaque existentials pick up the extra inhabitants of their type metadata
+  // field.
   case RecordKind::Struct:
+  case RecordKind::OpaqueExistential:
     NumExtraInhabitants = std::max(NumExtraInhabitants, numExtraInhabitants);
     break;
   
@@ -450,7 +453,6 @@ unsigned RecordTypeInfoBuilder::addField(unsigned fieldSize,
   case RecordKind::Invalid:
   case RecordKind::MultiPayloadEnum:
   case RecordKind::NoPayloadEnum:
-  case RecordKind::OpaqueExistential:
   case RecordKind::SinglePayloadEnum:
   case RecordKind::ThickFunction:
   case RecordKind::Tuple:

--- a/stdlib/public/runtime/ExistentialMetadataImpl.h
+++ b/stdlib/public/runtime/ExistentialMetadataImpl.h
@@ -328,7 +328,18 @@ struct LLVM_LIBRARY_VISIBILITY OpaqueExistentialBox
   static constexpr size_t stride = sizeof(Container);
   static constexpr size_t isPOD = false;
   static constexpr bool isBitwiseTakable = true;
-  static constexpr unsigned numExtraInhabitants = 0;
+  static constexpr unsigned numExtraInhabitants =
+    swift_getHeapObjectExtraInhabitantCount();
+  
+  static void storeExtraInhabitant(Container *dest, int index) {
+    swift_storeHeapObjectExtraInhabitant((HeapObject**)&dest->Header.Type,
+                                         index);
+  }
+
+  static int getExtraInhabitantIndex(const Container *src) {
+    return swift_getHeapObjectExtraInhabitantIndex(
+                                        (HeapObject* const *)&src->Header.Type);
+  }
 };
 
 /// A non-fixed box implementation class for an opaque existential
@@ -371,7 +382,18 @@ struct LLVM_LIBRARY_VISIBILITY NonFixedOpaqueExistentialBox
   };
 
   using type = Container;
-  static constexpr unsigned numExtraInhabitants = 0;
+  static constexpr unsigned numExtraInhabitants =
+    swift_getHeapObjectExtraInhabitantCount();
+  
+  static void storeExtraInhabitant(Container *dest, int index) {
+    swift_storeHeapObjectExtraInhabitant((HeapObject**)&dest->Header.Type,
+                                         index);
+  }
+
+  static int getExtraInhabitantIndex(const Container *src) {
+    return swift_getHeapObjectExtraInhabitantIndex(
+                                  (HeapObject* const *)&src->Header.Type);
+  }
 };
 
 /// A common base class for fixed and non-fixed class-existential box

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2741,7 +2741,7 @@ public:
 
 class OpaqueExistentialValueWitnessTableCacheEntry {
 public:
-  ValueWitnessTable Data;
+  ExtraInhabitantsValueWitnessTable Data;
 
   OpaqueExistentialValueWitnessTableCacheEntry(unsigned numTables);
 
@@ -2798,9 +2798,11 @@ public:
 /// The uniquing structure for existential type metadata.
 static SimpleGlobalCache<ExistentialCacheEntry> ExistentialTypes;
 
-static const ValueWitnessTable OpaqueExistentialValueWitnesses_0 =
+static const ExtraInhabitantsValueWitnessTable
+OpaqueExistentialValueWitnesses_0 =
   ValueWitnessTableForBox<OpaqueExistentialBox<0>>::table;
-static const ValueWitnessTable OpaqueExistentialValueWitnesses_1 =
+static const ExtraInhabitantsValueWitnessTable
+OpaqueExistentialValueWitnesses_1 =
   ValueWitnessTableForBox<OpaqueExistentialBox<1>>::table;
 
 /// The standard metadata for Any.
@@ -2855,7 +2857,6 @@ OpaqueExistentialValueWitnessTableCacheEntry::
 OpaqueExistentialValueWitnessTableCacheEntry(unsigned numWitnessTables) {
   using Box = NonFixedOpaqueExistentialBox;
   using Witnesses = NonFixedValueWitnesses<Box, /*known allocated*/ true>;
-  static_assert(!Witnesses::hasExtraInhabitants, "no extra inhabitants");
 
 #define WANT_ONLY_REQUIRED_VALUE_WITNESSES
 #define VALUE_WITNESS(LOWER_ID, UPPER_ID) \
@@ -2869,8 +2870,13 @@ OpaqueExistentialValueWitnessTableCacheEntry(unsigned numWitnessTables) {
     .withPOD(false)
     .withBitwiseTakable(true)
     .withInlineStorage(false)
-    .withExtraInhabitants(false);
+    .withExtraInhabitants(true);
   Data.stride = Box::Container::getStride(numWitnessTables);
+  
+  // Extra inhabitant behavior does not change with the number of witnesses.
+  Data.extraInhabitantFlags = Witnesses::extraInhabitantFlags;
+  Data.getExtraInhabitantIndex = Witnesses::getExtraInhabitantIndex;
+  Data.storeExtraInhabitant = Witnesses::storeExtraInhabitant;
 
   assert(getNumWitnessTables() == numWitnessTables);
 }

--- a/stdlib/public/runtime/MetadataImpl.h
+++ b/stdlib/public/runtime/MetadataImpl.h
@@ -918,13 +918,12 @@ struct NonFixedValueWitnesses :
 
   static void storeExtraInhabitant(OpaqueValue *dest, int index,
                                    const Metadata *self) {
-    Box::storeExtraInhabitant((typename Box::type*) dest, index, self);
+    Box::storeExtraInhabitant((typename Box::type*) dest, index);
   }
 
   static int getExtraInhabitantIndex(const OpaqueValue *src,
                                      const Metadata *self) {
-    return Box::getExtraInhabitantIndex((typename Box::type const *) src,
-                                        self);
+    return Box::getExtraInhabitantIndex((typename Box::type const *) src);
   }
 };
 

--- a/test/IRGen/existentials.sil
+++ b/test/IRGen/existentials.sil
@@ -8,8 +8,8 @@ import Swift
 protocol P {}
 
 // NonBitwiseTakableBit = 0x00100000. This struct is bitwise takable because
-// 0x30007 = 196615.
-// CHECK: @"$S12existentials14BitwiseTakableVWV" = internal constant [11 x i8*] {{.*}} i8* inttoptr (i64 196615 to i8*)
+// 0x70007 = 458759
+// CHECK: @"$S12existentials14BitwiseTakableVWV" = internal constant [14 x i8*] {{.*}} i8* inttoptr (i64 458759 to i8*)
 struct BitwiseTakable {
   var p: P
 }

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -514,66 +514,66 @@
 
 12TypeLowering17ExistentialStructV
 // CHECK-64:      (struct TypeLowering.ExistentialStruct)
-// CHECK-64-NEXT: (struct size=464 alignment=8 stride=464 num_extra_inhabitants=[[PTR_XI]]
+// CHECK-64-NEXT: (struct size=440 alignment=8 stride=440 num_extra_inhabitants=[[PTR_XI]]
 // CHECK-64-NEXT:   (field name=any offset=0
-// CHECK-64-NEXT:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=0
+// CHECK-64-NEXT:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=[[PTR_XI]]
 // CHECK-64-NEXT:       (field name=metadata offset=24
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]]))))
 // CHECK-64-NEXT:   (field name=optionalAny offset=32
-// CHECK-64-NEXT:     (single_payload_enum size=33 alignment=8 stride=40 num_extra_inhabitants=0
+// CHECK-64-NEXT:     (single_payload_enum size=32 alignment=8 stride=32 num_extra_inhabitants=[[PTR_XI_SUB_1]]
 // CHECK-64-NEXT:       (field name=some offset=0
-// CHECK-64-NEXT:         (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=0
+// CHECK-64-NEXT:         (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=[[PTR_XI]]
 // CHECK-64-NEXT:           (field name=metadata offset=24
 // CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]]))))))
-// CHECK-64-NEXT:   (field name=anyObject offset=72
+// CHECK-64-NEXT:   (field name=anyObject offset=64
 // CHECK-64-NEXT:     (class_existential size=8 alignment=8 stride=8
 // CHECK-64-NEXT:       (field name=object offset=0
 // CHECK-64-NEXT:         (reference kind=strong refcounting=unknown))))
-// CHECK-64-NEXT:   (field name=optionalAnyObject offset=80
+// CHECK-64-NEXT:   (field name=optionalAnyObject offset=72
 // CHECK-64-NEXT:     (single_payload_enum size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI_SUB_1]]
 // CHECK-64-NEXT:       (field name=some offset=0
 // CHECK-64-NEXT:         (class_existential size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]]
 // CHECK-64-NEXT:           (field name=object offset=0
 // CHECK-64-NEXT:             (reference kind=strong refcounting=unknown))))))
-// CHECK-64-NEXT:   (field name=anyProto offset=88
-// CHECK-64-NEXT:     (opaque_existential size=40 alignment=8 stride=40 num_extra_inhabitants=0
+// CHECK-64-NEXT:   (field name=anyProto offset=80
+// CHECK-64-NEXT:     (opaque_existential size=40 alignment=8 stride=40 num_extra_inhabitants=[[PTR_XI]]
 // CHECK-64-NEXT:       (field name=metadata offset=24
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]]))
 // CHECK-64-NEXT:       (field name=wtable offset=32
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))))
-// CHECK-64-NEXT:   (field name=optionalAnyProto offset=128
-// CHECK-64-NEXT:     (single_payload_enum size=41 alignment=8 stride=48 num_extra_inhabitants=0
+// CHECK-64-NEXT:   (field name=optionalAnyProto offset=120
+// CHECK-64-NEXT:     (single_payload_enum size=40 alignment=8 stride=40 num_extra_inhabitants=[[PTR_XI_SUB_1]]
 // CHECK-64-NEXT:       (field name=some offset=0
-// CHECK-64-NEXT:         (opaque_existential size=40 alignment=8 stride=40 num_extra_inhabitants=0
+// CHECK-64-NEXT:         (opaque_existential size=40 alignment=8 stride=40 num_extra_inhabitants=[[PTR_XI]]
 // CHECK-64-NEXT:           (field name=metadata offset=24
 // CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]]))
 // CHECK-64-NEXT:           (field name=wtable offset=32
 // CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))))))
-// CHECK-64-NEXT:   (field name=anyProtoComposition offset=176
-// CHECK-64-NEXT:     (opaque_existential size=48 alignment=8 stride=48 num_extra_inhabitants=0
+// CHECK-64-NEXT:   (field name=anyProtoComposition offset=160
+// CHECK-64-NEXT:     (opaque_existential size=48 alignment=8 stride=48 num_extra_inhabitants=[[PTR_XI]]
 // CHECK-64-NEXT:       (field name=metadata offset=24
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]]))
 // CHECK-64-NEXT:       (field name=wtable offset=32
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
 // CHECK-64-NEXT:       (field name=wtable offset=40
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))))
-// CHECK-64-NEXT:   (field name=optionalAnyProtoComposition offset=224
-// CHECK-64-NEXT:     (single_payload_enum size=49 alignment=8 stride=56 num_extra_inhabitants=0
+// CHECK-64-NEXT:   (field name=optionalAnyProtoComposition offset=208
+// CHECK-64-NEXT:     (single_payload_enum size=48 alignment=8 stride=48 num_extra_inhabitants=[[PTR_XI_SUB_1]]
 // CHECK-64-NEXT:       (field name=some offset=0
-// CHECK-64-NEXT:         (opaque_existential size=48 alignment=8 stride=48 num_extra_inhabitants=0
+// CHECK-64-NEXT:         (opaque_existential size=48 alignment=8 stride=48 num_extra_inhabitants=[[PTR_XI]]
 // CHECK-64-NEXT:           (field name=metadata offset=24
 // CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[PTR_XI]]))
 // CHECK-64-NEXT:           (field name=wtable offset=32
 // CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
 // CHECK-64-NEXT:           (field name=wtable offset=40
 // CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))))))
-// CHECK-64-NEXT:   (field name=anyClassBoundProto1 offset=280
+// CHECK-64-NEXT:   (field name=anyClassBoundProto1 offset=256
 // CHECK-64-NEXT:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]]
 // CHECK-64-NEXT:       (field name=object offset=0
 // CHECK-64-NEXT:         (reference kind=strong refcounting=unknown))
 // CHECK-64-NEXT:       (field name=wtable offset=8
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))))
-// CHECK-64-NEXT:   (field name=optionalAnyClassBoundProto1 offset=296
+// CHECK-64-NEXT:   (field name=optionalAnyClassBoundProto1 offset=272
 // CHECK-64-NEXT:     (single_payload_enum size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI_SUB_1]]
 // CHECK-64-NEXT:       (field name=some offset=0
 // CHECK-64-NEXT:         (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]]
@@ -581,13 +581,13 @@
 // CHECK-64-NEXT:             (reference kind=strong refcounting=unknown))
 // CHECK-64-NEXT:           (field name=wtable offset=8
 // CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))))))
-// CHECK-64-NEXT:   (field name=anyClassBoundProto2 offset=312
+// CHECK-64-NEXT:   (field name=anyClassBoundProto2 offset=288
 // CHECK-64-NEXT:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]]
 // CHECK-64-NEXT:       (field name=object offset=0
 // CHECK-64-NEXT:         (reference kind=strong refcounting=unknown))
 // CHECK-64-NEXT:       (field name=wtable offset=8
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))))
-// CHECK-64-NEXT:   (field name=optionalAnyClassBoundProto2 offset=328
+// CHECK-64-NEXT:   (field name=optionalAnyClassBoundProto2 offset=304
 // CHECK-64-NEXT:     (single_payload_enum size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI_SUB_1]]
 // CHECK-64-NEXT:       (field name=some offset=0
 // CHECK-64-NEXT:         (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]]
@@ -595,13 +595,13 @@
 // CHECK-64-NEXT:             (reference kind=strong refcounting=unknown))
 // CHECK-64-NEXT:           (field name=wtable offset=8
 // CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))))))
-// CHECK-64-NEXT:   (field name=anyClassBoundProtoComposition1 offset=344
+// CHECK-64-NEXT:   (field name=anyClassBoundProtoComposition1 offset=320
 // CHECK-64-NEXT:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]]
 // CHECK-64-NEXT:       (field name=object offset=0
 // CHECK-64-NEXT:         (reference kind=strong refcounting=unknown))
 // CHECK-64-NEXT:       (field name=wtable offset=8
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))))
-// CHECK-64-NEXT:   (field name=optionalAnyClassBoundProtoComposition1 offset=360
+// CHECK-64-NEXT:   (field name=optionalAnyClassBoundProtoComposition1 offset=336
 // CHECK-64-NEXT:     (single_payload_enum size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI_SUB_1]]
 // CHECK-64-NEXT:       (field name=some offset=0
 // CHECK-64-NEXT:         (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]]
@@ -609,7 +609,7 @@
 // CHECK-64-NEXT:             (reference kind=strong refcounting=unknown))
 // CHECK-64-NEXT:           (field name=wtable offset=8
 // CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))))))
-// CHECK-64-NEXT:   (field name=anyClassBoundProtoComposition2 offset=376
+// CHECK-64-NEXT:   (field name=anyClassBoundProtoComposition2 offset=352
 // CHECK-64-NEXT:     (class_existential size=24 alignment=8 stride=24 num_extra_inhabitants=[[PTR_XI]]
 // CHECK-64-NEXT:       (field name=object offset=0
 // CHECK-64-NEXT:         (reference kind=strong refcounting=unknown))
@@ -617,7 +617,7 @@
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
 // CHECK-64-NEXT:       (field name=wtable offset=16
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))))
-// CHECK-64-NEXT:   (field name=optionalAnyClassBoundProtoComposition2 offset=400
+// CHECK-64-NEXT:   (field name=optionalAnyClassBoundProtoComposition2 offset=376
 // CHECK-64-NEXT:     (single_payload_enum size=24 alignment=8 stride=24 num_extra_inhabitants=[[PTR_XI_SUB_1]]
 // CHECK-64-NEXT:       (field name=some offset=0
 // CHECK-64-NEXT:         (class_existential size=24 alignment=8 stride=24 num_extra_inhabitants=[[PTR_XI]]
@@ -627,17 +627,17 @@
 // CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))
 // CHECK-64-NEXT:           (field name=wtable offset=16
 // CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))))))
-// CHECK-64-NEXT:   (field name=weakAnyObject offset=424
+// CHECK-64-NEXT:   (field name=weakAnyObject offset=400
 // CHECK-64-NEXT:     (class_existential size=8 alignment=8 stride=8
 // CHECK-64-NEXT:       (field name=object offset=0
 // CHECK-64-NEXT:         (reference kind=weak refcounting=unknown))))
-// CHECK-64-NEXT:   (field name=weakAnyClassBoundProto offset=432
+// CHECK-64-NEXT:   (field name=weakAnyClassBoundProto offset=408
 // CHECK-64-NEXT:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]]
 // CHECK-64-NEXT:       (field name=object offset=0
 // CHECK-64-NEXT:         (reference kind=weak refcounting=unknown))
 // CHECK-64-NEXT:       (field name=wtable offset=8
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))))
-// CHECK-64-NEXT:   (field name=classConstrainedP1 offset=448
+// CHECK-64-NEXT:   (field name=classConstrainedP1 offset=424
 // CHECK-64-NEXT:     (class_existential size=16 alignment=8 stride=16 num_extra_inhabitants=[[PTR_XI]]
 // CHECK-64-NEXT:       (field name=object offset=0
 // CHECK-64-NEXT:         (reference kind=strong refcounting=native))
@@ -645,66 +645,66 @@
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1)))))
 
 // CHECK-32: (struct TypeLowering.ExistentialStruct)
-// CHECK-32-NEXT: (struct size=232 alignment=4 stride=232 num_extra_inhabitants=4096
+// CHECK-32-NEXT: (struct size=220 alignment=4 stride=220 num_extra_inhabitants=4096
 // CHECK-32-NEXT:   (field name=any offset=0
-// CHECK-32-NEXT:     (opaque_existential size=16 alignment=4 stride=16 num_extra_inhabitants=0
+// CHECK-32-NEXT:     (opaque_existential size=16 alignment=4 stride=16 num_extra_inhabitants=4096
 // CHECK-32-NEXT:       (field name=metadata offset=12
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096))))
 // CHECK-32-NEXT:   (field name=optionalAny offset=16
-// CHECK-32-NEXT:     (single_payload_enum size=17 alignment=4 stride=20 num_extra_inhabitants=0
+// CHECK-32-NEXT:     (single_payload_enum size=16 alignment=4 stride=16 num_extra_inhabitants=4095
 // CHECK-32-NEXT:       (field name=some offset=0
-// CHECK-32-NEXT:         (opaque_existential size=16 alignment=4 stride=16 num_extra_inhabitants=0
+// CHECK-32-NEXT:         (opaque_existential size=16 alignment=4 stride=16 num_extra_inhabitants=4096
 // CHECK-32-NEXT:           (field name=metadata offset=12
 // CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096))))))
-// CHECK-32-NEXT:   (field name=anyObject offset=36
+// CHECK-32-NEXT:   (field name=anyObject offset=32
 // CHECK-32-NEXT:     (class_existential size=4 alignment=4 stride=4 num_extra_inhabitants=4096
 // CHECK-32-NEXT:       (field name=object offset=0
 // CHECK-32-NEXT:         (reference kind=strong refcounting=unknown))))
-// CHECK-32-NEXT:   (field name=optionalAnyObject offset=40
+// CHECK-32-NEXT:   (field name=optionalAnyObject offset=36
 // CHECK-32-NEXT:     (single_payload_enum size=4 alignment=4 stride=4 num_extra_inhabitants=4095
 // CHECK-32-NEXT:       (field name=some offset=0
 // CHECK-32-NEXT:         (class_existential size=4 alignment=4 stride=4 num_extra_inhabitants=4096
 // CHECK-32-NEXT:           (field name=object offset=0
 // CHECK-32-NEXT:             (reference kind=strong refcounting=unknown))))))
-// CHECK-32-NEXT:   (field name=anyProto offset=44
-// CHECK-32-NEXT:     (opaque_existential size=20 alignment=4 stride=20 num_extra_inhabitants=0
+// CHECK-32-NEXT:   (field name=anyProto offset=40
+// CHECK-32-NEXT:     (opaque_existential size=20 alignment=4 stride=20 num_extra_inhabitants=4096
 // CHECK-32-NEXT:       (field name=metadata offset=12
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096))
 // CHECK-32-NEXT:       (field name=wtable offset=16
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))))
-// CHECK-32-NEXT:   (field name=optionalAnyProto offset=64
-// CHECK-32-NEXT:     (single_payload_enum size=21 alignment=4 stride=24 num_extra_inhabitants=0
+// CHECK-32-NEXT:   (field name=optionalAnyProto offset=60
+// CHECK-32-NEXT:     (single_payload_enum size=20 alignment=4 stride=20 num_extra_inhabitants=4095
 // CHECK-32-NEXT:       (field name=some offset=0
-// CHECK-32-NEXT:         (opaque_existential size=20 alignment=4 stride=20 num_extra_inhabitants=0
+// CHECK-32-NEXT:         (opaque_existential size=20 alignment=4 stride=20 num_extra_inhabitants=4096
 // CHECK-32-NEXT:           (field name=metadata offset=12
 // CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096))
 // CHECK-32-NEXT:           (field name=wtable offset=16
 // CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))))))
-// CHECK-32-NEXT:   (field name=anyProtoComposition offset=88
-// CHECK-32-NEXT:     (opaque_existential size=24 alignment=4 stride=24 num_extra_inhabitants=0
+// CHECK-32-NEXT:   (field name=anyProtoComposition offset=80
+// CHECK-32-NEXT:     (opaque_existential size=24 alignment=4 stride=24 num_extra_inhabitants=4096
 // CHECK-32-NEXT:       (field name=metadata offset=12
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096))
 // CHECK-32-NEXT:       (field name=wtable offset=16
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
 // CHECK-32-NEXT:       (field name=wtable offset=20
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))))
-// CHECK-32-NEXT:   (field name=optionalAnyProtoComposition offset=112
-// CHECK-32-NEXT:     (single_payload_enum size=25 alignment=4 stride=28 num_extra_inhabitants=0
+// CHECK-32-NEXT:   (field name=optionalAnyProtoComposition offset=104
+// CHECK-32-NEXT:     (single_payload_enum size=24 alignment=4 stride=24 num_extra_inhabitants=4095
 // CHECK-32-NEXT:       (field name=some offset=0
-// CHECK-32-NEXT:         (opaque_existential size=24 alignment=4 stride=24 num_extra_inhabitants=0
+// CHECK-32-NEXT:         (opaque_existential size=24 alignment=4 stride=24 num_extra_inhabitants=4096
 // CHECK-32-NEXT:           (field name=metadata offset=12
 // CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096))
 // CHECK-32-NEXT:           (field name=wtable offset=16
 // CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
 // CHECK-32-NEXT:           (field name=wtable offset=20
 // CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))))))
-// CHECK-32-NEXT:   (field name=anyClassBoundProto1 offset=140
+// CHECK-32-NEXT:   (field name=anyClassBoundProto1 offset=128
 // CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096
 // CHECK-32-NEXT:       (field name=object offset=0
 // CHECK-32-NEXT:         (reference kind=strong refcounting=unknown))
 // CHECK-32-NEXT:       (field name=wtable offset=4
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))))
-// CHECK-32-NEXT:   (field name=optionalAnyClassBoundProto1 offset=148
+// CHECK-32-NEXT:   (field name=optionalAnyClassBoundProto1 offset=136
 // CHECK-32-NEXT:     (single_payload_enum size=8 alignment=4 stride=8 num_extra_inhabitants=4095
 // CHECK-32-NEXT:       (field name=some offset=0
 // CHECK-32-NEXT:         (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096
@@ -712,13 +712,13 @@
 // CHECK-32-NEXT:             (reference kind=strong refcounting=unknown))
 // CHECK-32-NEXT:           (field name=wtable offset=4
 // CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))))))
-// CHECK-32-NEXT:   (field name=anyClassBoundProto2 offset=156
+// CHECK-32-NEXT:   (field name=anyClassBoundProto2 offset=144
 // CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096
 // CHECK-32-NEXT:       (field name=object offset=0
 // CHECK-32-NEXT:         (reference kind=strong refcounting=unknown))
 // CHECK-32-NEXT:       (field name=wtable offset=4
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))))
-// CHECK-32-NEXT:   (field name=optionalAnyClassBoundProto2 offset=164
+// CHECK-32-NEXT:   (field name=optionalAnyClassBoundProto2 offset=152
 // CHECK-32-NEXT:     (single_payload_enum size=8 alignment=4 stride=8 num_extra_inhabitants=4095
 // CHECK-32-NEXT:       (field name=some offset=0
 // CHECK-32-NEXT:         (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096
@@ -726,13 +726,13 @@
 // CHECK-32-NEXT:             (reference kind=strong refcounting=unknown))
 // CHECK-32-NEXT:           (field name=wtable offset=4
 // CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))))))
-// CHECK-32-NEXT:   (field name=anyClassBoundProtoComposition1 offset=172
+// CHECK-32-NEXT:   (field name=anyClassBoundProtoComposition1 offset=160
 // CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096
 // CHECK-32-NEXT:       (field name=object offset=0
 // CHECK-32-NEXT:         (reference kind=strong refcounting=unknown))
 // CHECK-32-NEXT:       (field name=wtable offset=4
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))))
-// CHECK-32-NEXT:   (field name=optionalAnyClassBoundProtoComposition1 offset=180
+// CHECK-32-NEXT:   (field name=optionalAnyClassBoundProtoComposition1 offset=168
 // CHECK-32-NEXT:     (single_payload_enum size=8 alignment=4 stride=8 num_extra_inhabitants=4095
 // CHECK-32-NEXT:       (field name=some offset=0
 // CHECK-32-NEXT:         (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096
@@ -740,7 +740,7 @@
 // CHECK-32-NEXT:             (reference kind=strong refcounting=unknown))
 // CHECK-32-NEXT:           (field name=wtable offset=4
 // CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))))))
-// CHECK-32-NEXT:   (field name=anyClassBoundProtoComposition2 offset=188
+// CHECK-32-NEXT:   (field name=anyClassBoundProtoComposition2 offset=176
 // CHECK-32-NEXT:     (class_existential size=12 alignment=4 stride=12 num_extra_inhabitants=4096
 // CHECK-32-NEXT:       (field name=object offset=0
 // CHECK-32-NEXT:         (reference kind=strong refcounting=unknown))
@@ -748,7 +748,7 @@
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
 // CHECK-32-NEXT:       (field name=wtable offset=8
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))))
-// CHECK-32-NEXT:   (field name=optionalAnyClassBoundProtoComposition2 offset=200
+// CHECK-32-NEXT:   (field name=optionalAnyClassBoundProtoComposition2 offset=188
 // CHECK-32-NEXT:     (single_payload_enum size=12 alignment=4 stride=12 num_extra_inhabitants=4095
 // CHECK-32-NEXT:       (field name=some offset=0
 // CHECK-32-NEXT:         (class_existential size=12 alignment=4 stride=12 num_extra_inhabitants=4096
@@ -758,17 +758,17 @@
 // CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))
 // CHECK-32-NEXT:           (field name=wtable offset=8
 // CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))))))
-// CHECK-32-NEXT:   (field name=weakAnyObject offset=212
+// CHECK-32-NEXT:   (field name=weakAnyObject offset=200
 // CHECK-32-NEXT:     (class_existential size=4 alignment=4 stride=4 num_extra_inhabitants=4096
 // CHECK-32-NEXT:       (field name=object offset=0
 // CHECK-32-NEXT:         (reference kind=weak refcounting=unknown))))
-// CHECK-32-NEXT:   (field name=weakAnyClassBoundProto offset=216
+// CHECK-32-NEXT:   (field name=weakAnyClassBoundProto offset=204
 // CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096
 // CHECK-32-NEXT:       (field name=object offset=0
 // CHECK-32-NEXT:         (reference kind=weak refcounting=unknown))
 // CHECK-32-NEXT:       (field name=wtable offset=4
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))))
-// CHECK-32-NEXT:   (field name=classConstrainedP1 offset=224
+// CHECK-32-NEXT:   (field name=classConstrainedP1 offset=212
 // CHECK-32-NEXT:     (class_existential size=8 alignment=4 stride=8 num_extra_inhabitants=4096
 // CHECK-32-NEXT:       (field name=object offset=0
 // CHECK-32-NEXT:         (reference kind=strong refcounting=native))

--- a/validation-test/Reflection/existentials.swift
+++ b/validation-test/Reflection/existentials.swift
@@ -269,7 +269,7 @@ reflect(any: he)
 // CHECK-64-NEXT:       (field name=error offset=0
 // CHECK-64-NEXT:         (reference kind=strong refcounting=unknown))))
 // CHECK-64-NEXT:   (field name=errorInComposition offset=8
-// CHECK-64-NEXT:     (opaque_existential size=48 alignment=8 stride=48 num_extra_inhabitants=0
+// CHECK-64-NEXT:     (opaque_existential size=48 alignment=8 stride=48 num_extra_inhabitants=2147483647
 // CHECK-64-NEXT:       (field name=metadata offset=24
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647))
 // CHECK-64-NEXT:       (field name=wtable offset=32
@@ -277,13 +277,13 @@ reflect(any: he)
 // CHECK-64-NEXT:       (field name=wtable offset=40
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))))
 // CHECK-64-NEXT:   (field name=customError offset=56
-// CHECK-64-NEXT:     (opaque_existential size=40 alignment=8 stride=40 num_extra_inhabitants=0
+// CHECK-64-NEXT:     (opaque_existential size=40 alignment=8 stride=40 num_extra_inhabitants=2147483647
 // CHECK-64-NEXT:       (field name=metadata offset=24
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647))
 // CHECK-64-NEXT:       (field name=wtable offset=32
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1))))
 // CHECK-64-NEXT:   (field name=customErrorInComposition offset=96
-// CHECK-64-NEXT:     (opaque_existential size=48 alignment=8 stride=48 num_extra_inhabitants=0
+// CHECK-64-NEXT:     (opaque_existential size=48 alignment=8 stride=48 num_extra_inhabitants=2147483647
 // CHECK-64-NEXT:       (field name=metadata offset=24
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647))
 // CHECK-64-NEXT:       (field name=wtable offset=32
@@ -303,7 +303,7 @@ reflect(any: he)
 // CHECK-32-NEXT:       (field name=error offset=0
 // CHECK-32-NEXT:         (reference kind=strong refcounting=unknown))))
 // CHECK-32-NEXT:   (field name=errorInComposition offset=4
-// CHECK-32-NEXT:     (opaque_existential size=24 alignment=4 stride=24 num_extra_inhabitants=0
+// CHECK-32-NEXT:     (opaque_existential size=24 alignment=4 stride=24 num_extra_inhabitants=4096
 // CHECK-32-NEXT:       (field name=metadata offset=12
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096))
 // CHECK-32-NEXT:       (field name=wtable offset=16
@@ -311,13 +311,13 @@ reflect(any: he)
 // CHECK-32-NEXT:       (field name=wtable offset=20
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))))
 // CHECK-32-NEXT:   (field name=customError offset=28
-// CHECK-32-NEXT:     (opaque_existential size=20 alignment=4 stride=20 num_extra_inhabitants=0
+// CHECK-32-NEXT:     (opaque_existential size=20 alignment=4 stride=20 num_extra_inhabitants=4096
 // CHECK-32-NEXT:       (field name=metadata offset=12
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096))
 // CHECK-32-NEXT:       (field name=wtable offset=16
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1))))
 // CHECK-32-NEXT:   (field name=customErrorInComposition offset=48
-// CHECK-32-NEXT:     (opaque_existential size=24 alignment=4 stride=24 num_extra_inhabitants=0
+// CHECK-32-NEXT:     (opaque_existential size=24 alignment=4 stride=24 num_extra_inhabitants=4096
 // CHECK-32-NEXT:       (field name=metadata offset=12
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096))
 // CHECK-32-NEXT:       (field name=wtable offset=16

--- a/validation-test/Reflection/functions.swift
+++ b/validation-test/Reflection/functions.swift
@@ -49,14 +49,14 @@ func concrete(x: Int, y: Any) {
 // CHECK-32:      Type info:
 // CHECK-32-NEXT: (closure_context size=24 alignment=4 stride=24
 // CHECK-32-NEXT:   (field offset=8
-// CHECK-32-NEXT:     (opaque_existential size=16 alignment=4 stride=16 num_extra_inhabitants=0
+// CHECK-32-NEXT:     (opaque_existential size=16 alignment=4 stride=16 num_extra_inhabitants=4096
 // CHECK-32-NEXT:       (field name=metadata offset=12
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096)))))
 
 // CHECK-64:      Type info:
 // CHECK-64-NEXT: (closure_context size=48 alignment=8 stride=48
 // CHECK-64-NEXT:   (field offset=16
-// CHECK-64-NEXT:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=0
+// CHECK-64-NEXT:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=2147483647
 // CHECK-64-NEXT:       (field name=metadata offset=24
 // CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647)))))
 }

--- a/validation-test/Reflection/reflect_existential.swift
+++ b/validation-test/Reflection/reflect_existential.swift
@@ -31,7 +31,7 @@ reflect(object: TestGeneric(D() as Any))
 // CHECK-64: Type info:
 // CHECK-64: (class_instance size=48 alignment=8 stride=48 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=0
+// CHECK-64:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=2147483647
 // CHECK-64:       (field name=metadata offset=24
 // CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647)))))
 
@@ -42,7 +42,7 @@ reflect(object: TestGeneric(D() as Any))
 // CHECK-32: Type info:
 // CHECK-32: (class_instance size=24 alignment=4 stride=24 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=8
-// CHECK-32:     (opaque_existential size=16 alignment=4 stride=16 num_extra_inhabitants=0
+// CHECK-32:     (opaque_existential size=16 alignment=4 stride=16 num_extra_inhabitants=4096
 // CHECK-32:       (field name=metadata offset=12
 // CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096)))))
 
@@ -56,7 +56,7 @@ reflect(object: TestGeneric(D() as P))
 // CHECK-64: Type info:
 // CHECK-64: (class_instance size=56 alignment=8 stride=56 num_extra_inhabitants=0
 // CHECK-64:   (field name=t offset=16
-// CHECK-64:     (opaque_existential size=40 alignment=8 stride=40 num_extra_inhabitants=0
+// CHECK-64:     (opaque_existential size=40 alignment=8 stride=40 num_extra_inhabitants=2147483647
 // CHECK-64:       (field name=metadata offset=24
 // CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647))
 // CHECK-64:       (field name=wtable offset=32
@@ -70,7 +70,7 @@ reflect(object: TestGeneric(D() as P))
 // CHECK-32: Type info:
 // CHECK-32: (class_instance size=28 alignment=4 stride=28 num_extra_inhabitants=0
 // CHECK-32:   (field name=t offset=8
-// CHECK-32:     (opaque_existential size=20 alignment=4 stride=20 num_extra_inhabitants=0
+// CHECK-32:     (opaque_existential size=20 alignment=4 stride=20 num_extra_inhabitants=4096
 // CHECK-32:       (field name=metadata offset=12
 // CHECK-32:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096))
 // CHECK-32:       (field name=wtable offset=16


### PR DESCRIPTION
We can use the extra inhabitants of the type metadata field as extra inhabitants of the entire
existential container, allowing `Any?` and similar types to be the same size as non-optional
existentials.