### PR TITLE
litter the tree with `llvm_unreachable`

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1289,6 +1289,7 @@ public:
     case Kind::NSErrorWrapperAnon:
       return "E";
     }
+    llvm_unreachable("unhandled kind");
   }
 
   static bool classof(const DeclAttribute *DA) {

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4624,6 +4624,7 @@ public:
     case Specifier::InOut:
       return false;
     }
+    llvm_unreachable("unhandled specifier");
   }
   /// Is this an immutable 'let' property?
   bool isLet() const { return getSpecifier() == Specifier::Let; }
@@ -4645,6 +4646,7 @@ public:
     case Specifier::Owned:
       return ValueOwnership::Owned;
     }
+    llvm_unreachable("unhandled specifier");
   }
 
   /// Is this an element in a capture list?

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4925,11 +4925,11 @@ public:
     bool isValid() const {
       return getKind() != Kind::Invalid;
     }
-    
+
     bool isResolved() const {
       if (!getComponentType())
         return false;
-      
+
       switch (getKind()) {
       case Kind::Subscript:
       case Kind::OptionalChain:
@@ -4937,20 +4937,21 @@ public:
       case Kind::OptionalForce:
       case Kind::Property:
         return true;
-      
+
       case Kind::UnresolvedSubscript:
       case Kind::UnresolvedProperty:
       case Kind::Invalid:
         return false;
       }
+      llvm_unreachable("unhandled kind");
     }
-    
+
     Expr *getIndexExpr() const {
       switch (getKind()) {
       case Kind::Subscript:
       case Kind::UnresolvedSubscript:
         return SubscriptIndexExprAndKind.getPointer();
-        
+
       case Kind::Invalid:
       case Kind::OptionalChain:
       case Kind::OptionalWrap:
@@ -4959,6 +4960,7 @@ public:
       case Kind::Property:
         return nullptr;
       }
+      llvm_unreachable("unhandled kind");
     }
 
     ArrayRef<Identifier> getSubscriptLabels() const {
@@ -4966,7 +4968,7 @@ public:
       case Kind::Subscript:
       case Kind::UnresolvedSubscript:
         return SubscriptLabels;
-        
+
       case Kind::Invalid:
       case Kind::OptionalChain:
       case Kind::OptionalWrap:
@@ -4975,14 +4977,15 @@ public:
       case Kind::Property:
         llvm_unreachable("no subscript labels for this kind");
       }
+      llvm_unreachable("unhandled kind");
     }
-    
+
     ArrayRef<ProtocolConformanceRef>
     getSubscriptIndexHashableConformances() const {
       switch (getKind()) {
       case Kind::Subscript:
         return SubscriptHashableConformances;
-        
+
       case Kind::UnresolvedSubscript:
       case Kind::Invalid:
       case Kind::OptionalChain:
@@ -4992,8 +4995,9 @@ public:
       case Kind::Property:
         return {};
       }
+      llvm_unreachable("unhandled kind");
     }
-    
+
     void setSubscriptIndexHashableConformances(
       ArrayRef<ProtocolConformanceRef> hashables);
 
@@ -5011,8 +5015,9 @@ public:
       case Kind::Property:
         llvm_unreachable("no unresolved name for this kind");
       }
+      llvm_unreachable("unhandled kind");
     }
-    
+
     ConcreteDeclRef getDeclRef() const {
       switch (getKind()) {
       case Kind::Property:
@@ -5027,8 +5032,9 @@ public:
       case Kind::OptionalForce:
         llvm_unreachable("no decl ref for this kind");
       }
+      llvm_unreachable("unhandled kind");
     }
-    
+
     Type getComponentType() const {
       return ComponentType;
     }

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -1732,6 +1732,7 @@ inline bool isErrorResult(GenericSignatureBuilder::ConstraintResult result) {
   case GenericSignatureBuilder::ConstraintResult::Unresolved:
     return false;
   }
+  llvm_unreachable("unhandled result");
 }
 
 /// Canonical ordering for dependent types.

--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -297,6 +297,7 @@ public:
     case Kind::Destructor:
       return "deinit";
     }
+    llvm_unreachable("unhandled kind");
   }
 
   int compare(DeclBaseName other) const {

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -237,6 +237,7 @@ public:
     case Class:
       return objProj == other.objProj;
     }
+    llvm_unreachable("unhandled kind");
   }
 
   /// Return true if the storage is guaranteed local.
@@ -253,6 +254,7 @@ public:
     case Unidentified:
       return false;
     }
+    llvm_unreachable("unhandled kind");
   }
 
   bool isUniquelyIdentified() const {
@@ -268,6 +270,7 @@ public:
     case Unidentified:
       return false;
     }
+    llvm_unreachable("unhandled kind");
   }
 
   bool isDistinctFrom(const AccessedStorage &other) const {

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -2411,8 +2411,9 @@ public:
     case Unpacked:
       return (Kind)((uintptr_t)ValueAndKind.getPointer() >> KindPackingBits);
     }
+    llvm_unreachable("unhandled kind");
   }
-  
+
   CanType getComponentType() const {
     return ComponentType;
   }
@@ -2430,7 +2431,7 @@ public:
     }
     llvm_unreachable("unhandled kind");
   }
-  
+
   ComputedPropertyId getComputedPropertyId() const {
     switch (getKind()) {
     case Kind::StoredProperty:
@@ -2445,7 +2446,7 @@ public:
     }
     llvm_unreachable("unhandled kind");
   }
-  
+
   SILFunction *getComputedPropertyGetter() const {
     switch (getKind()) {
     case Kind::StoredProperty:
@@ -2473,7 +2474,7 @@ public:
     }
     llvm_unreachable("unhandled kind");
   }
-  
+
   ArrayRef<Index> getSubscriptIndices() const {
     switch (getKind()) {
     case Kind::StoredProperty:
@@ -2485,8 +2486,9 @@ public:
     case Kind::SettableProperty:
       return Indices;
     }
+    llvm_unreachable("unhandled kind");
   }
-  
+
   SILFunction *getSubscriptIndexEquals() const {
     switch (getKind()) {
     case Kind::StoredProperty:
@@ -2498,6 +2500,7 @@ public:
     case Kind::SettableProperty:
       return IndexEquality.Equal;
     }
+    llvm_unreachable("unhandled kind");
   }
   SILFunction *getSubscriptIndexHash() const {
     switch (getKind()) {
@@ -2510,8 +2513,9 @@ public:
     case Kind::SettableProperty:
       return IndexEquality.Hash;
     }
+    llvm_unreachable("unhandled kind");
   }
-  
+
   bool isComputedSettablePropertyMutating() const;
   
   static KeyPathPatternComponent forStoredProperty(VarDecl *property,
@@ -2530,8 +2534,9 @@ public:
     case Kind::SettableProperty:
       return ExternalStorage;
     }
+    llvm_unreachable("unhandled kind");
   }
-  
+
   SubstitutionMap getExternalSubstitutions() const {
     switch (getKind()) {
     case Kind::StoredProperty:
@@ -2543,6 +2548,7 @@ public:
     case Kind::SettableProperty:
       return ExternalSubstitutions;
     }
+    llvm_unreachable("unhandled kind");
   }
 
   static KeyPathPatternComponent

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -496,6 +496,7 @@ public:
     case TypeExpansionKind::MostDerivedDescendents:
       return emitLoweredCopyValueMostDerivedDescendents(B, loc, value);
     }
+    llvm_unreachable("unhandled style");
   }
 
   /// Allocate a new TypeLowering using the TypeConverter's allocator.

--- a/include/swift/Syntax/Serialization/SyntaxSerialization.h
+++ b/include/swift/Syntax/Serialization/SyntaxSerialization.h
@@ -47,6 +47,7 @@ struct ScalarReferenceTraits<syntax::SourcePresence> {
     case syntax::SourcePresence::Missing:
       return "\"Missing\"";
     }
+    llvm_unreachable("unhandled presence");
   }
 
   static bool mustQuote(StringRef) {
@@ -243,6 +244,7 @@ template <>
     case syntax::SourcePresence::Missing: return 0;
     case syntax::SourcePresence::Present: return 1;
     }
+    llvm_unreachable("unhandled presence");
   }
 
   static void write(ByteTreeWriter &Writer,
@@ -330,12 +332,14 @@ struct ObjectTraits<syntax::RawSyntax> {
       case Layout: return 6;
       case Omitted: return 2;
       }
+      llvm_unreachable("unhandled kind");
     } else {
       switch (nodeKind(Syntax, UserInfo)) {
       case Token: return 6;
       case Layout: return 5;
       case Omitted: return 2;
       }
+      llvm_unreachable("unhandled kind");
     }
   }
 

--- a/include/swift/Syntax/SyntaxKind.h.gyb
+++ b/include/swift/Syntax/SyntaxKind.h.gyb
@@ -96,6 +96,7 @@ struct WrapperTypeTraits<syntax::SyntaxKind> {
 %   end
 % end
     }
+    llvm_unreachable("unhandled kind");
   }
 
   static void write(ByteTreeWriter &Writer, const syntax::SyntaxKind &Kind,
@@ -122,6 +123,7 @@ struct ScalarReferenceTraits<syntax::SyntaxKind> {
         return "\"${node.syntax_kind}\"";
 % end
     }
+    llvm_unreachable("unhandled kind");
   }
 
   static bool mustQuote(StringRef) {

--- a/include/swift/Syntax/Trivia.h.gyb
+++ b/include/swift/Syntax/Trivia.h.gyb
@@ -171,6 +171,7 @@ public:
 %   end
 % end
     }
+    llvm_unreachable("unhandled kind");
   }
 
   bool isComment() const;
@@ -384,6 +385,7 @@ struct WrapperTypeTraits<syntax::TriviaKind> {
   case syntax::TriviaKind::${trivia.name}: return ${trivia.serialization_code};
 % end
     }
+    llvm_unreachable("unhandled kind");
   }
 
   static void write(ByteTreeWriter &Writer, const syntax::TriviaKind &Kind,
@@ -459,6 +461,7 @@ struct ScalarReferenceTraits<syntax::TriviaKind> {
       return "\"${trivia.name}\"";
 % end
     }
+    llvm_unreachable("unhandled kind");
   }
 
   static bool mustQuote(StringRef) {

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -501,6 +501,7 @@ public:
 
         return false;
       }
+      llvm_unreachable("unhandled kind");
     }
 
     // Default cases for cleaning up as we exit a node.

--- a/lib/AST/AccessRequests.cpp
+++ b/lib/AST/AccessRequests.cpp
@@ -119,6 +119,7 @@ AccessLevelRequest::evaluate(Evaluator &evaluator, ValueDecl *D) const {
   case DeclContextKind::ExtensionDecl:
     return cast<ExtensionDecl>(DC)->getDefaultAccessLevel();
   }
+  llvm_unreachable("unhandled kind");
 }
 
 void AccessLevelRequest::diagnoseCycle(DiagnosticEngine &diags) const {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4857,6 +4857,7 @@ ParamDecl::getDefaultValueStringRepresentation(
   case DefaultArgumentKind::EmptyArray: return "[]";
   case DefaultArgumentKind::EmptyDictionary: return "[:]";
   }
+  llvm_unreachable("unhandled kind");
 }
 
 void

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -186,6 +186,7 @@ static unsigned getRequirementKindOrder(RequirementKind kind) {
   case RequirementKind::SameType: return 3;
   case RequirementKind::Layout: return 1;
   }
+  llvm_unreachable("unhandled kind");
 }
 #endif
 
@@ -585,6 +586,7 @@ bool GenericSignature::isRequirementSatisfied(Requirement requirement) {
     return true;
   }
   }
+  llvm_unreachable("unhandled kind");
 }
 
 SmallVector<Requirement, 4> GenericSignature::requirementsNotSatisfiedBy(

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -1066,6 +1066,7 @@ const RequirementSource *RequirementSource::getMinimalConformanceSource(
       rootType = parentType;
       return false;
     }
+    llvm_unreachable("unhandled kind");
   }).isNull();
 
   // If we didn't already find a redundancy, check our end state.
@@ -1327,6 +1328,7 @@ const RequirementSource *RequirementSource::withoutRedundantSubpath(
     return parent->withoutRedundantSubpath(builder, start, end)
       ->viaSuperclass(builder, getProtocolConformance());
   }
+  llvm_unreachable("unhandled kind");
 }
 
 const RequirementSource *RequirementSource::getRoot() const {
@@ -1401,6 +1403,7 @@ RequirementSource::visitPotentialArchetypesAlongPath(
     return replaceSelfWithType(parentType, getStoredType());
   }
   }
+  llvm_unreachable("unhandled kind");
 }
 
 Type RequirementSource::getStoredType() const {
@@ -1752,6 +1755,7 @@ bool FloatingRequirementSource::isExplicit() const {
       return false;
     }
   }
+  llvm_unreachable("unhandled kind");
 }
 
 
@@ -1771,6 +1775,7 @@ FloatingRequirementSource FloatingRequirementSource::asInferred(
                                   protocolReq.protocol, typeRepr,
                                   /*inferred=*/true);
   }
+  llvm_unreachable("unhandled kind");
 }
 
 bool FloatingRequirementSource::isRecursive(
@@ -2586,6 +2591,7 @@ ConstraintResult GenericSignatureBuilder::handleUnresolvedRequirement(
   case UnresolvedHandlingKind::GenerateUnresolved:
     return ConstraintResult::Unresolved;
   }
+  llvm_unreachable("unhandled handling");
 }
 
 bool GenericSignatureBuilder::addConditionalRequirements(

--- a/lib/AST/LayoutConstraint.cpp
+++ b/lib/AST/LayoutConstraint.cpp
@@ -334,6 +334,7 @@ LayoutConstraint::getLayoutConstraint(LayoutConstraintKind Kind) {
   case LayoutConstraintKind::TrivialOfExactSize:
     llvm_unreachable("Wrong layout constraint kind");
   }
+  llvm_unreachable("unhandled kind");
 }
 
 LayoutConstraint LayoutConstraint::getUnknownLayout() {

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1467,6 +1467,7 @@ bool SourceFile::shouldCollectToken() const {
   case SourceFileKind::SIL:
     return false;
   }
+  llvm_unreachable("unhandled kind");
 }
 
 bool SourceFile::shouldBuildSyntaxTree() const {
@@ -1479,6 +1480,7 @@ bool SourceFile::shouldBuildSyntaxTree() const {
   case SourceFileKind::SIL:
     return false;
   }
+  llvm_unreachable("unhandled kind");
 }
 
 bool FileUnit::walk(ASTWalker &walker) {

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2416,6 +2416,7 @@ directReferencesForTypeRepr(Evaluator &evaluator,
   case TypeReprKind::ImplicitlyUnwrappedOptional:
     return { 1, ctx.getOptionalDecl() };
   }
+  llvm_unreachable("unhandled kind");
 }
 
 static DirectlyReferencedTypeDecls directReferencesForType(Type type) {

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -256,6 +256,7 @@ ValueDecl *ProtocolConformance::getWitnessDecl(ValueDecl *requirement,
     return cast<SpecializedProtocolConformance>(this)
       ->getGenericConformance()->getWitnessDecl(requirement, resolver);
   }
+  llvm_unreachable("unhandled kind");
 }
 
 /// Determine whether the witness for the given requirement

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -389,6 +389,7 @@ Optional<Requirement> RequirementRequest::getCachedResult() const {
     return Requirement(RequirementKind::Layout, reqRepr.getSubject(),
                        reqRepr.getLayoutConstraint());
   }
+  llvm_unreachable("unhandled kind");
 }
 
 void RequirementRequest::cacheResult(Requirement value) const {

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -90,6 +90,7 @@ DarwinPlatformKind swift::getNonSimulatorPlatform(DarwinPlatformKind platform) {
   case DarwinPlatformKind::WatchOSSimulator:
     return DarwinPlatformKind::WatchOS;
   }
+  llvm_unreachable("Unsupported Darwin platform");
 }
 
 static StringRef getPlatformNameForDarwin(const DarwinPlatformKind platform) {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -783,6 +783,7 @@ bool ClangImporter::canReadPCH(StringRef PCHFilename) {
     assert(0 && "unexpected ASTReader failure for PCH validation");
     return false;
   }
+  llvm_unreachable("unhandled result");
 }
 
 Optional<std::string>

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2821,6 +2821,7 @@ namespace {
           // Assume this is a context other than the enum.
           return false;
         }
+        llvm_unreachable("unhandled kind");
       };
 
       for (auto constant : decl->enumerators()) {

--- a/lib/ClangImporter/ImportEnumInfo.h
+++ b/lib/ClangImporter/ImportEnumInfo.h
@@ -88,6 +88,7 @@ public:
     case EnumKind::Constants:
       return false;
     }
+    llvm_unreachable("unhandled kind");
   }
 
   /// For this error enum, extract the name of the error domain constant

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -147,6 +147,7 @@ DeclBaseName SerializedSwiftName::toDeclBaseName(ASTContext &Context) const {
   case DeclBaseName::Kind::Destructor:
     return DeclBaseName::createDestructor();
   }
+  llvm_unreachable("unhandled kind");
 }
 
 bool SwiftLookupTable::contextRequiresName(ContextKind kind) {

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -88,6 +88,7 @@ struct SerializedSwiftName {
     case DeclBaseName::Kind::Destructor:
       return "deinit";
     }
+    llvm_unreachable("unhandled kind");
   }
 
   bool operator<(SerializedSwiftName RHS) const {
@@ -255,6 +256,7 @@ public:
     case UnresolvedContext:
       return getUnresolvedName() == other.getUnresolvedName();
     }
+    llvm_unreachable("unhandled kind");
   }
 };
 

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -3005,4 +3005,5 @@ bool OutputInfo::mightHaveExplicitPrimaryInputs(
   case Mode::REPL:
     llvm_unreachable("REPL and immediate modes handled elsewhere");
   }
+  llvm_unreachable("unhandled mode");
 }

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -441,6 +441,7 @@ const char *ToolChain::JobContext::computeFrontendModeForCompile() const {
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID");
   }
+  llvm_unreachable("unhandled output type");
 }
 
 void ToolChain::JobContext::addFrontendInputAndOutputArguments(

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -299,6 +299,7 @@ static bool shouldTreatSingleInputAsMain(InputFileKind inputKind) {
   case InputFileKind::None:
     return false;
   }
+  llvm_unreachable("unhandled input kind");
 }
 
 bool CompilerInstance::setUpInputs() {

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -192,6 +192,7 @@ FrontendOptions::formatForPrincipalOutputFileForAction(ActionType action) {
   case ActionType::EmitImportedModules:
     return TY_ImportedModules;
   }
+  llvm_unreachable("unhandled action");
 }
 
 bool FrontendOptions::canActionEmitDependencies(ActionType action) {
@@ -225,6 +226,7 @@ bool FrontendOptions::canActionEmitDependencies(ActionType action) {
   case ActionType::EmitImportedModules:
     return true;
   }
+  llvm_unreachable("unhandled action");
 }
 
 bool FrontendOptions::canActionEmitReferenceDependencies(ActionType action) {
@@ -258,6 +260,7 @@ bool FrontendOptions::canActionEmitReferenceDependencies(ActionType action) {
   case ActionType::EmitImportedModules:
     return true;
   }
+  llvm_unreachable("unhandled action");
 }
 
 bool FrontendOptions::canActionEmitObjCHeader(ActionType action) {
@@ -291,6 +294,7 @@ bool FrontendOptions::canActionEmitObjCHeader(ActionType action) {
   case ActionType::EmitImportedModules:
     return true;
   }
+  llvm_unreachable("unhandled action");
 }
 
 bool FrontendOptions::canActionEmitLoadedModuleTrace(ActionType action) {
@@ -324,6 +328,7 @@ bool FrontendOptions::canActionEmitLoadedModuleTrace(ActionType action) {
   case ActionType::EmitImportedModules:
     return true;
   }
+  llvm_unreachable("unhandled action");
 }
 
 bool FrontendOptions::canActionEmitModule(ActionType action) {
@@ -357,6 +362,7 @@ bool FrontendOptions::canActionEmitModule(ActionType action) {
   case ActionType::EmitImportedModules:
     return true;
   }
+  llvm_unreachable("unhandled action");
 }
 
 bool FrontendOptions::canActionEmitModuleDoc(ActionType action) {
@@ -394,6 +400,7 @@ bool FrontendOptions::canActionEmitInterface(ActionType action) {
   case ActionType::EmitObject:
     return true;
   }
+  llvm_unreachable("unhandled action");
 }
 
 bool FrontendOptions::doesActionProduceOutput(ActionType action) {
@@ -463,6 +470,7 @@ bool FrontendOptions::doesActionProduceTextualOutput(ActionType action) {
   case ActionType::DumpTypeInfo:
     return true;
   }
+  llvm_unreachable("unhandled action");
 }
 
 bool FrontendOptions::doesActionGenerateSIL(ActionType action) {
@@ -496,6 +504,7 @@ bool FrontendOptions::doesActionGenerateSIL(ActionType action) {
   case ActionType::DumpTypeInfo:
     return true;
   }
+  llvm_unreachable("unhandled action");
 }
 
 

--- a/lib/FrontendTool/TBD.cpp
+++ b/lib/FrontendTool/TBD.cpp
@@ -69,6 +69,7 @@ bool swift::inputFileKindCanHaveTBDValidated(InputFileKind kind) {
   case InputFileKind::LLVM:
     return false;
   }
+  llvm_unreachable("unhandled kind");
 }
 
 static bool validateSymbolSet(DiagnosticEngine &diags,

--- a/lib/IDE/APIDigesterData.cpp
+++ b/lib/IDE/APIDigesterData.cpp
@@ -282,6 +282,7 @@ bool APIDiffItem::operator==(const APIDiffItem &Other) const {
   case APIDiffItemKind::ADK_SpecialCaseDiffItem:
     return true;
   }
+  llvm_unreachable("unhandled kind");
 }
 
 namespace {
@@ -295,6 +296,7 @@ static const char* getKeyContent(DiffItemKeyKind KK) {
 #define DIFF_ITEM_KEY_KIND(NAME) case DiffItemKeyKind::KK_##NAME: return #NAME;
 #include "swift/IDE/DigesterEnums.def"
   }
+  llvm_unreachable("unhandled kind");
 }
 
 static DiffItemKeyKind parseKeyKind(StringRef Content) {
@@ -367,6 +369,7 @@ serializeDiffItem(llvm::BumpPtrAllocator &Alloc,
       SpecialCaseDiffItem(Usr, SpecialCaseId);
   }
   }
+  llvm_unreachable("unhandled kind");
 }
 } // end anonymous namespace
 

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -963,6 +963,7 @@ isApplicable(ResolvedRangeInfo Info, DiagnosticEngine &Diag) {
       success({CannotExtractReason::VoidType});
   }
   }
+  llvm_unreachable("unhandled kind");
 }
 
 static StringRef correctNameInternal(ASTContext &Ctx, StringRef Name,
@@ -1492,6 +1493,7 @@ isApplicable(ResolvedRangeInfo Info, DiagnosticEngine &Diag) {
     case RangeKind::Invalid:
       return false;
   }
+  llvm_unreachable("unhandled kind");
 }
 
 bool RefactoringActionExtractExpr::performChange() {
@@ -1514,6 +1516,7 @@ isApplicable(ResolvedRangeInfo Info, DiagnosticEngine &Diag) {
     case RangeKind::Invalid:
       return false;
   }
+  llvm_unreachable("unhandled kind");
 }
 bool RefactoringActionExtractRepeatedExpr::performChange() {
   return RefactoringActionExtractExprBase(TheFile, RangeInfo,
@@ -1573,6 +1576,7 @@ bool RefactoringActionMoveMembersToExtension::isApplicable(
   case RangeKind::Invalid:
     return false;
   }
+  llvm_unreachable("unhandled kind");
 }
 
 bool RefactoringActionMoveMembersToExtension::performChange() {
@@ -1643,6 +1647,7 @@ bool RefactoringActionReplaceBodiesWithFatalError::isApplicable(
   case RangeKind::Invalid:
     return false;
   }
+  llvm_unreachable("unhandled kind");
 }
 
 bool RefactoringActionReplaceBodiesWithFatalError::performChange() {
@@ -2966,6 +2971,7 @@ static bool rangeStartMayNeedRename(ResolvedRangeInfo Info) {
     case RangeKind::Invalid:
       return false;
   }
+  llvm_unreachable("unhandled kind");
 }
 }// end of anonymous namespace
 
@@ -2977,6 +2983,7 @@ getDescriptiveRefactoringKindName(RefactoringKind Kind) {
 #define REFACTORING(KIND, NAME, ID) case RefactoringKind::KIND: return NAME;
 #include "swift/IDE/RefactoringKinds.def"
     }
+    llvm_unreachable("unhandled kind");
   }
 
   StringRef swift::ide::
@@ -2995,6 +3002,7 @@ getDescriptiveRefactoringKindName(RefactoringKind Kind) {
       case RenameAvailableKind::Unavailable_decl_from_clang:
         return "cannot rename a Clang symbol from its Swift reference";
     }
+    llvm_unreachable("unhandled kind");
   }
 
 SourceLoc swift::ide::RangeConfig::getStart(SourceManager &SM) {
@@ -3030,6 +3038,7 @@ struct swift::ide::FindRenameRangesAnnotatingConsumer::Implementation {
       case RefactoringRangeKind::SelectorArgumentLabel:
         return "sel";
     }
+    llvm_unreachable("unhandled kind");
   }
   void accept(SourceManager &SM, const RenameRangeDetail &Range) {
     std::string NewText;
@@ -3212,6 +3221,7 @@ case RefactoringKind::KIND: {                                                  \
     case RefactoringKind::None:
       llvm_unreachable("should not enter here.");
   }
+  llvm_unreachable("unhandled kind");
 }
 
 static std::vector<ResolvedLoc>

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -1005,6 +1005,7 @@ private:
       return {VoidTy, ExitState::Negative};
     }
     }
+    llvm_unreachable("unhandled kind");
   }
 
   ResolvedRangeInfo getSingleNodeKind(ASTNode Node) {

--- a/lib/IRGen/Fulfillment.cpp
+++ b/lib/IRGen/Fulfillment.cpp
@@ -330,6 +330,7 @@ static StringRef getStateName(MetadataState state) {
   case MetadataState::LayoutComplete: return "layout-complete";
   case MetadataState::Abstract: return "abstract";
   }
+  llvm_unreachable("unhandled state");
 }
 
 void FulfillmentMap::dump() const {

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -606,6 +606,7 @@ irgen::tryEmitConstantClassFragilePhysicalMemberOffset(IRGenModule &IGM,
   case FieldAccess::ConstantIndirect:
     return nullptr;
   }
+  llvm_unreachable("unhandled access");
 }
 
 FieldAccess

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -820,6 +820,7 @@ IRGenModule::getAddrOfParentContextDescriptor(DeclContext *from) {
     return {getAddrOfModuleContextDescriptor(cast<ModuleDecl>(parent)),
             ConstantReference::Direct};
   }
+  llvm_unreachable("unhandled kind");
 }
 
 /// Add the given global value to @llvm.used.

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -706,6 +706,7 @@ static CanType getArgumentLoweringType(CanType type,
   case ParameterConvention::Indirect_InoutAliasable:
     return CanInOutType::get(type);
   }
+  llvm_unreachable("unhandled convention");
 }
 
 static bool isABIIgnoredParameterWithoutStorage(IRGenModule &IGM,

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -1876,6 +1876,7 @@ llvm::Value *irgen::emitDynamicTypeOfHeapObject(IRGenFunction &IGF,
     // ObjC classes.
     return emitDynamicTypeOfOpaqueHeapObject(IGF, object, repr);
   }
+  llvm_unreachable("unhandled ISA encoding");
 }
 
 static ClassDecl *getRootClass(ClassDecl *theClass) {

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -661,6 +661,7 @@ Callee irgen::getObjCMethodCallee(IRGenFunction &IGF,
       case ObjCMessageKind::Super:
         return IGF.IGM.getObjCMsgSendSuperStret2Fn();
       }
+      llvm_unreachable("unhandled kind");
     } else {
       switch (kind) {
       case ObjCMessageKind::Normal:
@@ -672,6 +673,7 @@ Callee irgen::getObjCMethodCallee(IRGenFunction &IGF,
       case ObjCMessageKind::Super:
         return IGF.IGM.getObjCMsgSendSuper2Fn();
       }
+      llvm_unreachable("unhandled kind");
     }
   }();
 

--- a/lib/IRGen/MetadataLayout.h
+++ b/lib/IRGen/MetadataLayout.h
@@ -160,6 +160,7 @@ public:
     case MetadataLayout::Kind::ForeignClass:
       return false;
     }
+    llvm_unreachable("unhandled kind");
   }
 };
 

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -722,6 +722,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
       return false;
     }
     }
+    llvm_unreachable("unhandled case");
   }
 
   bool handleTypeHoist(ValueDecl *FD, CallExpr* Call, Expr *Arg) {
@@ -809,6 +810,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
       Editor.remove(Arg->getEndLoc());
       return true;
     }
+    llvm_unreachable("unhandled subkind");
   }
 
   void handleFunctionCallToPropertyChange(ValueDecl *FD, Expr* FuncRefContainer,

--- a/lib/SIL/MemAccessUtils.cpp
+++ b/lib/SIL/MemAccessUtils.cpp
@@ -135,6 +135,7 @@ const ValueDecl *AccessedStorage::getDecl(SILFunction *F) const {
   case Unidentified:
     return nullptr;
   }
+  llvm_unreachable("unhandled kind");
 }
 
 const char *AccessedStorage::getKindName(AccessedStorage::Kind k) {
@@ -156,6 +157,7 @@ const char *AccessedStorage::getKindName(AccessedStorage::Kind k) {
   case Class:
     return "Class";
   }
+  llvm_unreachable("unhandled kind");
 }
 
 void AccessedStorage::print(raw_ostream &os) const {

--- a/lib/SIL/Projection.cpp
+++ b/lib/SIL/Projection.cpp
@@ -862,6 +862,7 @@ static bool isSupportedProjection(const Projection &p) {
   case ProjectionKind::Index:
     return false;
   }
+  llvm_unreachable("unhandled kind");
 }
 
 void

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -361,6 +361,7 @@ SILLinkage SILDeclRef::getLinkage(ForDefinition_t forDefinition) const {
       return maybeAddExternal(SILLinkage::Hidden);
     return maybeAddExternal(SILLinkage::Public);
   }
+  llvm_unreachable("unhandled access");
 }
 
 SILDeclRef SILDeclRef::getDefaultArgGenerator(Loc loc,

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -286,6 +286,7 @@ public:
     case ValueOwnership::Owned:
       return ParameterConvention::Indirect_In;
     }
+    llvm_unreachable("unhandled ownership");
   }
 
   ParameterConvention getDirect(ValueOwnership ownership, bool forSelf,
@@ -303,6 +304,7 @@ public:
     case ValueOwnership::Owned:
       return ParameterConvention::Direct_Owned;
     }
+    llvm_unreachable("unhandled ownership");
   }
 };
 
@@ -820,6 +822,7 @@ static std::pair<AbstractionPattern, CanType> updateResultTypeForForeignError(
   case ForeignErrorConvention::NonNilError:
     return {origResultType, substFormalResultType};
   }
+  llvm_unreachable("unhandled kind");
 }
 
 /// Lower any/all capture context parameters.

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -2001,6 +2001,7 @@ bool KeyPathPatternComponent::isComputedSettablePropertyMutating() const {
        == ParameterConvention::Indirect_Inout;
   }
   }
+  llvm_unreachable("unhandled kind");
 }
 
 static void

--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -965,6 +965,7 @@ visitFullApply(FullApplySite apply) {
   case ParameterConvention::Indirect_InoutAliasable:
     llvm_unreachable("Unexpected non-trivial parameter convention.");
   }
+  llvm_unreachable("unhandled convension");
 }
 
 OwnershipUseCheckerResult
@@ -1020,6 +1021,7 @@ OwnershipCompatibilityUseChecker::visitYieldInst(YieldInst *I) {
   case ParameterConvention::Indirect_InoutAliasable:
     llvm_unreachable("Unexpected non-trivial parameter convention.");
   }
+  llvm_unreachable("unhandled convension");
 }
 
 OwnershipUseCheckerResult

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1220,6 +1220,7 @@ TypeConverter::canStorageUseStoredKeyPathComponent(AbstractStorageDecl *decl) {
   case AccessStrategy::BehaviorStorage:
     llvm_unreachable("should not occur");
   }
+  llvm_unreachable("unhandled strategy");
 }
 
 static bool canStorageUseTrivialDescriptor(SILModule &M,
@@ -1265,6 +1266,7 @@ static bool canStorageUseTrivialDescriptor(SILModule &M,
       && decl->getSetter() == nullptr;
   }
   }
+  llvm_unreachable("unhandled strategy");
 }
 
 void SILGenModule::tryEmitPropertyDescriptor(AbstractStorageDecl *decl) {

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -650,6 +650,7 @@ public:
       return ManagedValue::forUnmanaged(fn);
     }
     }
+    llvm_unreachable("unhandled kind");
   }
 
   CalleeTypeInfo getTypeInfo(SILGenFunction &SGF, bool isCurried) const & {
@@ -698,6 +699,7 @@ public:
       return createCalleeTypeInfo(SGF, constant, formalType);
     }
     }
+    llvm_unreachable("unhandled kind");
   }
 
   SubstitutionMap getSubstitutions() const {

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -3449,6 +3449,7 @@ static SILValue emitLoadOfSemanticRValue(SILGenFunction &SGF,
 #include "swift/AST/ReferenceStorage.def"
 #undef ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE_HELPER
   }
+  llvm_unreachable("unhandled ownership");
 }
 
 /// Given that the type-of-rvalue differs from the type-of-storage,

--- a/lib/SILOptimizer/Analysis/AccessedStorageAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AccessedStorageAnalysis.cpp
@@ -293,6 +293,7 @@ transformCalleeStorage(const StorageAccessInfo &storage,
     // because we don't have any better placeholder for a callee-defined object.
     return storage;
   }
+  llvm_unreachable("unhandled kind");
 }
 
 bool FunctionAccessedStorage::mergeFromApply(

--- a/lib/SILOptimizer/Mandatory/AccessMarkerElimination.cpp
+++ b/lib/SILOptimizer/Mandatory/AccessMarkerElimination.cpp
@@ -81,6 +81,7 @@ bool AccessMarkerElimination::shouldPreserveAccess(
   case SILAccessEnforcement::Dynamic:
     return Mod->getOptions().EnforceExclusivityDynamic;
   }
+  llvm_unreachable("unhandled enforcement");
 }
 
 // Check if the instruction is a marker that should be eliminated. If so, delete

--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -108,6 +108,7 @@ public:
       case RecordedAccessKind::NoescapeClosureCapture:
         return ClosureAccessKind;
     };
+    llvm_unreachable("unhandled kind");
   }
 
   SILLocation getAccessLoc() const {
@@ -117,6 +118,7 @@ public:
       case RecordedAccessKind::NoescapeClosureCapture:
         return ClosureAccessLoc;
     };
+    llvm_unreachable("unhandled kind");
   }
 
   const IndexTrieNode *getSubPath() const {

--- a/lib/SILOptimizer/Transforms/AccessEnforcementWMO.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementWMO.cpp
@@ -89,6 +89,7 @@ VarDecl *getDisjointAccessLocation(const AccessedStorage &storage) {
   case AccessedStorage::Nested:
     llvm_unreachable("Unexpected Nested access.");
   }
+  llvm_unreachable("unhandled kind");
 }
 
 namespace {

--- a/lib/SILOptimizer/Transforms/Outliner.cpp
+++ b/lib/SILOptimizer/Transforms/Outliner.cpp
@@ -79,6 +79,7 @@ private:
     case BridgedMethod:
       return 'm';
     }
+    llvm_unreachable("unhandled kind");
   }
 };
 } // end anonymous namespace.

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -318,6 +318,7 @@ bool MissingForcedDowncastFailure::diagnoseAsError() {
         .fixItReplace(coerceExpr->getLoc(), "as!");
     return true;
   }
+  llvm_unreachable("unhandled cast kind");
 }
 
 bool MissingAddressOfFailure::diagnoseAsError() {

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3208,6 +3208,7 @@ namespace {
         return MetatypeType::get(ctx.TheAnyType)->getCanonicalType();
       }
       }
+      llvm_unreachable("unhandled operation");
     }
   };
 
@@ -3756,6 +3757,7 @@ getMemberDecls(InterestedMemberKind Kind) {
   case InterestedMemberKind::All:
     return Result;
   }
+  llvm_unreachable("unhandled kind");
 }
 
 ResolvedMemberResult

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2464,6 +2464,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       case SolutionKind::Unsolved:
         return getTypeMatchAmbiguous();
     }
+    llvm_unreachable("unhandled kind");
   };
 
   // Handle restrictions.
@@ -4294,6 +4295,7 @@ ConstraintSystem::simplifyKeyPathApplicationConstraint(
       case SolutionKind::Unsolved:
         llvm_unreachable("should have generated constraints");
       }
+      llvm_unreachable("unhandled match");
     };
 
     if (bgt->getDecl() == getASTContext().getPartialKeyPathDecl()) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2050,6 +2050,7 @@ bool OverloadChoice::isImplicitlyUnwrappedValueOrReturnValue() const {
   case FunctionRefKind::DoubleApply:
     return true;
   }
+  llvm_unreachable("unhandled kind");
 }
 
 bool ConstraintSystem::salvage(SmallVectorImpl<Solution> &viable, Expr *expr) {

--- a/lib/Sema/NameBinding.cpp
+++ b/lib/Sema/NameBinding.cpp
@@ -131,6 +131,7 @@ static bool isNominalImportKind(ImportKind kind) {
   case ImportKind::Func:
     return false;
   }
+  llvm_unreachable("unhandled kind");
 }
 
 static const char *getImportKindString(ImportKind kind) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1649,6 +1649,7 @@ static Requirement getCanonicalRequirement(const Requirement &req) {
     return Requirement(req.getKind(), req.getFirstType()->getCanonicalType(),
                        req.getLayoutConstraint());
   }
+  llvm_unreachable("unhandled kind");
 }
 
 /// Require that the given type either not involve type parameters or be

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2305,6 +2305,7 @@ static void checkProtocolSelfRequirements(ProtocolDecl *proto,
         case RequirementKind::SameType:
           return false;
         }
+        llvm_unreachable("unhandled kind");
       });
 }
 

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -53,6 +53,7 @@ bool swift::shouldDiagnoseObjCReason(ObjCReason reason, ASTContext &ctx) {
   case ObjCReason::Accessor:
     return false;
   }
+  llvm_unreachable("unhandled reason");
 }
 
 unsigned swift::getObjCDiagnosticAttrKind(ObjCReason reason) {
@@ -78,6 +79,7 @@ unsigned swift::getObjCDiagnosticAttrKind(ObjCReason reason) {
   case ObjCReason::Accessor:
     llvm_unreachable("should not diagnose this @objc reason");
   }
+  llvm_unreachable("unhandled reason");
 }
 
 /// Emit an additional diagnostic describing why we are applying @objc to the

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -1038,4 +1038,5 @@ RequirementRequest::evaluate(Evaluator &evaluator,
                        resolveType(reqRepr.getSubjectLoc()),
                        reqRepr.getLayoutConstraint());
   }
+  llvm_unreachable("unhandled kind");
 }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -240,6 +240,7 @@ static bool checkMutating(FuncDecl *requirement, FuncDecl *witness,
       case ReadImplKind::Get:
         llvm_unreachable("should have a getter");
       }
+      llvm_unreachable("unhandled kind");
     };
 
     auto isStoredSetterMutating = [&] {
@@ -263,6 +264,7 @@ static bool checkMutating(FuncDecl *requirement, FuncDecl *witness,
       case WriteImplKind::InheritedWithObservers:
         llvm_unreachable("should have a setter");
       }
+      llvm_unreachable("unhandled kind");
     };
 
     auto isReadWriteMutating = [&] {
@@ -278,6 +280,7 @@ static bool checkMutating(FuncDecl *requirement, FuncDecl *witness,
       case ReadWriteImplKind::Immutable:
         llvm_unreachable("asking for setter for immutable storage");
       }
+      llvm_unreachable("unhandled kind");
     };
 
     switch (reqtAsAccessor->getAccessorKind()) {

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1182,6 +1182,7 @@ bool AssociatedTypeInference::checkConstrainedExtension(ExtensionDecl *ext) {
   case RequirementCheckResult::Failure:
     return true;
   }
+  llvm_unreachable("unhandled result");
 }
 
 void AssociatedTypeInference::findSolutions(

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -184,6 +184,7 @@ namespace {
           return acc;
         }
         }
+        llvm_unreachable("unhandled kind");
       }
 
       explicit Space(Type T, Identifier NameForPrinting)
@@ -858,6 +859,7 @@ namespace {
           return result;
         }
         }
+        llvm_unreachable("unhandled kind");
       }
     };
 
@@ -1595,6 +1597,7 @@ namespace {
                                      conArgSpace);
       }
       }
+      llvm_unreachable("unhandled kind");
     }
   };
 } // end anonymous namespace

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -105,6 +105,7 @@ GenericSignature *TypeResolution::getGenericSignature() const {
   case TypeResolutionStage::Structural:
     return nullptr;
   }
+  llvm_unreachable("unhandled stage");
 }
 
 bool TypeResolution::usesArchetypes() const {
@@ -116,6 +117,7 @@ bool TypeResolution::usesArchetypes() const {
   case TypeResolutionStage::Contextual:
     return true;
   }
+  llvm_unreachable("unhandled stage");
 }
 
 Type TypeResolution::mapTypeIntoContext(Type type) const {
@@ -127,6 +129,7 @@ Type TypeResolution::mapTypeIntoContext(Type type) const {
   case TypeResolutionStage::Contextual:
     return GenericEnvironment::mapTypeIntoContext(genericEnv, type);
   }
+  llvm_unreachable("unhandled stage");
 }
 
 Type TypeResolution::resolveDependentMemberType(

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -212,6 +212,7 @@ public:
     case Context::AbstractFunctionDecl:
       return false;
     }
+    llvm_unreachable("unhandled kind");
   }
 
   /// Determine whether all of the given options are set.

--- a/lib/Serialization/DeserializationErrors.h
+++ b/lib/Serialization/DeserializationErrors.h
@@ -70,6 +70,7 @@ class XRefTracePath {
       case Kind::Unknown:
         return Identifier();
       }
+      llvm_unreachable("unhandled kind");
     }
 
     void print(raw_ostream &os) const {

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -830,6 +830,7 @@ SILDeserializer::readKeyPathComponent(ArrayRef<uint64_t> ListOfValues,
       return getSILDeclRef(MF, ListOfValues, nextValue);
     }
     }
+    llvm_unreachable("unhandled kind");
   };
 
   ArrayRef<KeyPathPatternComponent::Index> indices;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -106,6 +106,7 @@ namespace {
         case DeclBaseName::Kind::Destructor:
           return static_cast<uint8_t>(DeclNameKind::Destructor);
       }
+      llvm_unreachable("unhandled kind");
     }
 
     std::pair<unsigned, unsigned> EmitKeyDataLength(raw_ostream &out,
@@ -335,6 +336,7 @@ namespace {
       case DeclBaseName::Kind::Destructor:
         return static_cast<uint8_t>(DeclNameKind::Destructor);
       }
+      llvm_unreachable("unhandled kind");
     }
 
     std::pair<unsigned, unsigned> EmitKeyDataLength(raw_ostream &out,
@@ -701,6 +703,7 @@ IdentifierID Serializer::addDeclBaseNameRef(DeclBaseName ident) {
   case DeclBaseName::Kind::Destructor:
     return DESTRUCTOR_ID;
   }
+  llvm_unreachable("unhandled kind");
 }
 
 IdentifierID Serializer::addModuleRef(const ModuleDecl *M) {
@@ -1183,6 +1186,7 @@ static uint8_t getRawStableResilienceExpansion(swift::ResilienceExpansion e) {
   case swift::ResilienceExpansion::Maximal:
     return uint8_t(serialization::ResilienceExpansion::Maximal);
   }
+  llvm_unreachable("unhandled expansion");
 }
 
 void Serializer::writeParameterList(const ParameterList *PL) {

--- a/lib/Syntax/SyntaxSerialization.cpp.gyb
+++ b/lib/Syntax/SyntaxSerialization.cpp.gyb
@@ -58,6 +58,7 @@ uint8_t WrapperTypeTraits<tok>::numericValue(const tok &Value) {
     case tok::NUM_TOKENS:
       llvm_unreachable("Should not get serialized in a syntax tree");
   }
+  llvm_unreachable("unhandled token");
 }
 } // namespace byteTree
 } // namespace swift

--- a/lib/Syntax/Trivia.cpp.gyb
+++ b/lib/Syntax/Trivia.cpp.gyb
@@ -55,6 +55,7 @@ bool TriviaPiece::isComment() const {
 % end
 % end
   }
+  llvm_unreachable("unknown kind");
 }
 
 void TriviaPiece::accumulateAbsolutePosition(AbsolutePosition &Pos) const {
@@ -86,6 +87,7 @@ bool TriviaPiece::trySquash(const TriviaPiece &Next) {
 % end
 % end
   }
+  llvm_unreachable("unknown kind");
 }
 
 void TriviaPiece::print(llvm::raw_ostream &OS) const {

--- a/lib/TBDGen/tapi/Architecture.cpp
+++ b/lib/TBDGen/tapi/Architecture.cpp
@@ -53,6 +53,7 @@ StringRef getArchName(Architecture arch) {
   case Architecture::unknown:
     return "unknown";
   }
+  llvm_unreachable("unknown architecutre");
 }
 
 std::pair<uint32_t, uint32_t> getCPUType(Architecture arch) {
@@ -65,6 +66,7 @@ std::pair<uint32_t, uint32_t> getCPUType(Architecture arch) {
   case Architecture::unknown:
     return std::make_pair(0, 0);
   }
+  llvm_unreachable("unknown architecture");
 }
 
 raw_ostream &operator<<(raw_ostream &os, Architecture arch) {

--- a/lib/TBDGen/tapi/Platform.cpp
+++ b/lib/TBDGen/tapi/Platform.cpp
@@ -96,6 +96,7 @@ StringRef getPlatformName(Platform platform) {
   case Platform::bridgeOS:
     return "bridgeOS";
   }
+  llvm_unreachable("unknown platform");
 }
 
 std::string getOSAndEnvironmentName(Platform platform, std::string version) {
@@ -119,6 +120,7 @@ std::string getOSAndEnvironmentName(Platform platform, std::string version) {
   case Platform::bridgeOS:
     return "bridgeos" + version;
   }
+  llvm_unreachable("unknown platform");
 }
 
 raw_ostream &operator<<(raw_ostream &os, Platform platform) {

--- a/lib/TBDGen/tapi/XPI.cpp
+++ b/lib/TBDGen/tapi/XPI.cpp
@@ -99,6 +99,7 @@ std::string XPI::getAnnotatedName(bool demangle) const {
   case XPIKind::ObjCProtocol:
     return name + "(ObjC Protocol) " + _name.str();
   }
+  llvm_unreachable("unknown kind");
 }
 
 void XPI::print(raw_ostream &os) const {


### PR DESCRIPTION
This silences the instances of the warning from Visual Studio about not all
codepaths returning a value.  This makes the output more readable and less
likely to lose useful warnings.  NFC.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
