### PR TITLE
IRGen: qualify the base template type

### DIFF
--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -150,8 +150,9 @@ namespace {
     create(ArrayRef<const ProtocolDecl *> protocols, As &&...args)
     {
       void *buffer = operator new(
-          ExistentialTypeInfoBase::template totalSizeToAlloc<
-            const ProtocolDecl *>(protocols.size()));
+          llvm::TrailingObjects<Derived, const ProtocolDecl *>::
+              template totalSizeToAlloc<const ProtocolDecl *>(
+                  protocols.size()));
       return new (buffer) Derived(protocols, std::forward<As>(args)...);
     }
 


### PR DESCRIPTION
Visual Studio is unable to follow the inheritance to find the method and objects
    with:

  ```
      lib\IRGen\GenExistential.cpp(153): error C2903: 'totalSizeToAlloc': symbol is neither a class template nor a function template
      lib\IRGen\GenExistential.cpp(153): note: This diagnostic occurred in the compiler generated function 'const Derived *`anonymous-namespace'::ExistentialTypeInfoBase<Derived,Base>::create(llvm::ArrayRef<T>,As &&...)'
            with
            [
                T=const swift::ProtocolDecl *
            ]
      lib\IRGen\GenExistential.cpp(202): note: see reference to class template instantiation '`anonymous-namespace'::ExistentialTypeInfoBase<Derived,Base>' being compiled
      lib\IRGen\GenExistential.cpp(154): error C2760: syntax error: unexpected token 'const', expected 'expression'
      lib\IRGen\GenExistential.cpp(154): note: This diagnostic occurred in the compiler generated function 'const Derived *`anonymous-namespace'::ExistentialTypeInfoBase<Derived,Base>::create(llvm::ArrayRef<T>,As &&...)'
            with
            [
                T=const swift::ProtocolDecl *
            ]
  ```

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
