### PR TITLE
 Reserve the spare bits in closure context pointers.

### DIFF
--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -573,7 +573,11 @@ const TypeInfo *TypeConverter::convertFunctionType(SILFunctionType *T) {
   case SILFunctionType::Representation::Thick: {
     SpareBitVector spareBits;
     spareBits.append(IGM.getFunctionPointerSpareBits());
-    spareBits.append(IGM.getHeapObjectSpareBits());
+    // Although the context pointer of a closure (at least, an escaping one)
+    // is a refcounted pointer, we'd like to reserve the right to pack small
+    // contexts into the pointer value, so let's not take any spare bits from
+    // it.
+    spareBits.appendClearBits(IGM.getPointerSize().getValueInBits());
     
     if (T->isNoEscape()) {
       // @noescape thick functions are trivial types.


### PR DESCRIPTION
Although this is a refcounted pointer (for escaping closures, at least), we'd like to eventually take advantage of the ability to bit pack arbitrary payloads into refcountable fields on 64-bit platforms. For nonescaping closures, the context ought to be a trivial arbitrary word as well, so we shouldn't be looking for spare bits to begin with.