### PR TITLE
SILOptimizer: make a conversion operation explicit

### DIFF
--- a/include/swift/SILOptimizer/Analysis/ARCAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/ARCAnalysis.h
@@ -230,7 +230,7 @@ private:
     Optional<ArrayRef<SILInstruction *>> getFullyPostDomReleases() const {
       if (releases.empty() || foundSomeButNotAllReleases())
         return None;
-      return {releases};
+      return ArrayRef<SILInstruction *>{releases};
     }
 
     /// If we were able to find a set of releases for this argument, but those


### PR DESCRIPTION
Visual Studio objects to the existing construct with:

  ```
  swift/SILOptimizer/Analysis/ARCAnalysis.h(233): warning C4927: illegal conversion; more than one user-defined conversion has been implicitly applied
  swift/SILOptimizer/Analysis/ARCAnalysis.h(233): note: while calling the constructor 'llvm::Optional<llvm::ArrayRef<swift::SILInstruction *>>::Optiona(T &&)'
	with
	[
	  T=llvm::ArrayRef<swift::SILInstruction *>
	]
  llvm/ADT/Optional.h(143): note: see declaration of 'llvm::Optional<llvm::ArrayRef<swift::SILInstruction *>>::Optional'
  ```

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
