### PR TITLE
AST: re-order copy constructor, remove extra copy constructor

### DIFF
--- a/include/swift/AST/AnyRequest.h
+++ b/include/swift/AST/AnyRequest.h
@@ -158,12 +158,6 @@ public:
     return *this;
   }
 
-  AnyRequest(AnyRequest &other)
-    : storageKind(other.storageKind), stored(other.stored) { }
-
-  AnyRequest(const AnyRequest &&other)
-    : storageKind(other.storageKind), stored(other.stored) { }
-
   // Create a local template typename `ValueType` in the template specialization
   // so that we can refer to it in the SFINAE condition as well as the body of
   // the template itself.  The SFINAE condition allows us to remove this


### PR DESCRIPTION
Visual Studio objects with the following:

  ```
  AST/AnyRequest.h(243): error: C2580: 'swift::AnyRequest::AnyRequest(const swift::AnyRequest &)': multiple versions of a defaulted special member functions are not allowed
  AST/AnyRequest(243): warning C4521: 'swift::AnyRequest': multiple copy constructors specified
  ```

Remove the non-const implementation, the default'ed definition should be
sufficient.  Additionally, re-order to keep the const and non-const r-value ref
versions next to each other.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
