### PR TITLE
SIL: hoist CFGState out of the function scope

### DIFF
--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -4424,20 +4424,21 @@ public:
             "have at least one argument for self.");
   }
 
+  enum CFGState {
+    /// No special rules are in play.
+    Normal,
+    /// We've followed the resume edge of a yield in a yield_once coroutine.
+    YieldOnceResume,
+    /// We've followed the unwind edge of a yield.
+    YieldUnwind
+  };
+
   /// Verify the various control-flow-sensitive rules of SIL:
   ///
   /// - stack allocations and deallocations must obey a stack discipline
   /// - accesses must be uniquely ended
   /// - flow-sensitive states must be equivalent on all paths into a block
   void verifyFlowSensitiveRules(SILFunction *F) {
-    enum CFGState {
-      /// No special rules are in play.
-      Normal,
-      /// We've followed the resume edge of a yield in a yield_once coroutine.
-      YieldOnceResume,
-      /// We've followed the unwind edge of a yield.
-      YieldUnwind
-    };
     struct BBState {
       std::vector<SingleValueInstruction*> Stack;
 


### PR DESCRIPTION
Visual Studio objects to the existing construct with:

  ```
  lib\SIL\SILVerifier.cpp(4448): error C2065: 'Normal': undeclared identifier
  lib\SIL\SILVerifier.cpp(4448): note: This diagnostic occurred in the compiler generated function '`anonymous-namespace'::SILVerifier::verifyFlowSensitiveRules::BBState::BBState(void)'
  llvm\ADT\DenseMap.h(292): note: see reference to function template instantiation 'BucketT *llvm::DenseMapBase<llvm::DenseMap<swift::SILBasicBlock *,`anonymous-namespace'::SILVerifier::verifyFlowSensitiveRules::BBState,llvm::DenseMapInfo<KeyT>,BucketT>,KeyT,ValueT,KeyInfoT,BucketT>::InsertIntoBucket<const KeyT&,>(BucketT *,KeyArg)' being compiled
        with
        [
            BucketT=llvm::detail::DenseMapPair<swift::SILBasicBlock *,`anonymous-namespace'::SILVerifier::verifyFlowSensitiveRules::BBState>,
            KeyT=swift::SILBasicBlock *,
            ValueT=`anonymous-namespace'::SILVerifier::verifyFlowSensitiveRules::BBState,
            KeyInfoT=llvm::DenseMapInfo<swift::SILBasicBlock *>,
            KeyArg=swift::SILBasicBlock *const &
        ]
  ```

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
