### PR TITLE
[Stats] Add SWIFTC_MAXIMUM_DETERMINISM to inhibit parallelism everywhere.

### DIFF
--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -17,8 +17,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if !(defined(DIAG) || (defined(ERROR) && defined(WARNING) && defined(NOTE)))
-#  error Must define either DIAG or the set {ERROR,WARNING,NOTE}
+#if !(defined(DIAG) || (defined(ERROR) && defined(WARNING) && defined(NOTE) && defined(REMARK)))
+#  error Must define either DIAG or the set {ERROR,WARNING,NOTE,REMARK}
 #endif
 
 #ifndef ERROR
@@ -34,6 +34,11 @@
 #ifndef NOTE
 #  define NOTE(ID,Options,Text,Signature) \
   DIAG(NOTE,ID,Options,Text,Signature)
+#endif
+
+#ifndef REMARK
+#  define REMARK(ID,Options,Text,Signature) \
+  DIAG(REMARK,ID,Options,Text,Signature)
 #endif
 
 ERROR(invalid_diagnostic,none,
@@ -58,6 +63,9 @@ NOTE(brace_stmt_suggest_do,none,
 NOTE(while_parsing_as_left_angle_bracket,none,
      "while parsing this '<' as a type parameter bracket", ())
 
+// Generic determinism-forcing override.
+REMARK(remark_max_determinism_overriding,none,
+         "SWIFTC_MAXIMUM_DETERMINISM overriding %0", (StringRef))
 
 // FIXME: This is used both as a parse error (a literal "super" outside a
 // method) and a type-checker error ("super" in a method of a non-class type).

--- a/include/swift/Basic/Statistic.h
+++ b/include/swift/Basic/Statistic.h
@@ -68,6 +68,16 @@ class SourceManager;
 class Stmt;
 class TypeRepr;
 
+// There are a handful of cases where the swift compiler can introduce
+// counter-measurement noise via nondeterminism, especially via
+// parallelism; inhibiting all such cases reliably using existing avenues
+// is a bit tricky and depends both on delicate build-setting management
+// and some build-system support that is still pending (see
+// rdar://39528362); in the meantime we support an environment variable
+// ourselves to request blanket suppression of parallelism (and anything
+// else nondeterministic we find).
+bool environmentVariableRequestedMaximumDeterminism();
+
 class UnifiedStatsReporter {
 
 public:

--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -50,6 +50,12 @@ namespace swift {
 using namespace llvm;
 using namespace llvm::sys;
 
+bool environmentVariableRequestedMaximumDeterminism() {
+  if (const char *S = ::getenv("SWIFTC_MAXIMUM_DETERMINISM"))
+    return (S[0] != '\0');
+  return false;
+}
+
 static int64_t
 getChildrenMaxResidentSetSize() {
 #if defined(HAVE_GETRUSAGE) && !defined(__HAIKU__)

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -297,6 +297,11 @@ std::unique_ptr<sys::TaskQueue> Driver::buildTaskQueue(const Compilation &C) {
       return nullptr;
     }
   }
+  if (environmentVariableRequestedMaximumDeterminism()) {
+      NumberOfParallelCommands = 1;
+      Diags.diagnose(SourceLoc(), diag::remark_max_determinism_overriding,
+                     "-j");
+  }
 
   const bool DriverSkipExecution =
     ArgList.hasArg(options::OPT_driver_skip_execution,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -614,8 +614,13 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
                      A->getAsString(Args), A->getValue());
       return true;
     }
+    if (environmentVariableRequestedMaximumDeterminism()) {
+      Opts.NumThreads = 1;
+      Diags.diagnose(SourceLoc(), diag::remark_max_determinism_overriding,
+                     "-num-threads");
+    }
   }
-  
+
   if (Args.hasArg(OPT_sil_merge_partial_modules))
     Opts.MergePartialModules = true;
 

--- a/test/Misc/stats_max_determinism.swift
+++ b/test/Misc/stats_max_determinism.swift
@@ -1,0 +1,6 @@
+// RUN: %empty-directory(%t)
+// RUN: env SWIFTC_MAXIMUM_DETERMINISM=1 %target-swiftc_driver -j 4 -num-threads 10 -c -o %t/out.o %s >%t/out.txt 2>&1
+// RUN: %FileCheck -input-file %t/out.txt %s
+// CHECK: remark: SWIFTC_MAXIMUM_DETERMINISM overriding -j
+// CHECK: remark: SWIFTC_MAXIMUM_DETERMINISM overriding -num-threads
+print(1)


### PR DESCRIPTION
As penance for daring to suggest compilers are at all deterministic, I've spent the past week hunting sources of it in our builds (where we're now measuring instruction counts). Parallelism in the driver and frontend remain among the cases to iron out, and it's not as easy to ensure they wind up set to a given number in a given build scenario as we'd like. So for the meantime, I'm proposing Yet Another Override via an env var. Unsupported, undocumented, just for testing.