### PR TITLE
Add support for sending and receiving  resource handles

### DIFF
--- a/stdlib/public/TensorFlow/OpaqueHandles.swift
+++ b/stdlib/public/TensorFlow/OpaqueHandles.swift
@@ -16,31 +16,105 @@
 
 import CTensorFlow
 
-/// `ResourceHandle` is the type used by ops and the `#tfop()` syntax to
-/// represent TensorFlow "resource" values.  It exists only to represent edges
-/// in TensorFlow graphs, and has no host-side representation (and thus no
-/// methods).
-public final class ResourceHandle {
-  private init() {
-    fatalError("ResourceHandle is a marker type that can never be created")
-  }
-}
-
-/// `VariantHandle` is the type used by ops and the `#tfop()` syntax to
-/// represent TensorFlow "variant" values.
-/// TODO: rename this source file as this is no longer "opaque".
-public final class VariantHandle {
-  public let cTensorHandle: CTensorHandle
-
+/// A class that implements common functionality for resource and variant handles.
+public class ResourceVariantHandleBase {
+	public let cTensorHandle: CTensorHandle
+	public let cDataType: TF_DataType
+	
   @usableFromInline
-  init(owning cTensorHandle: CTensorHandle) {
+  init(owning cTensorHandle: CTensorHandle, cDataType : TF_DataType) {
     self.cTensorHandle = cTensorHandle
+		self.cDataType = cDataType
   }
 
   deinit {
     debugLog("De-initializing TensorHandle.")
     TFE_DeleteTensorHandle(cTensorHandle)
-    debugLog("Returning from deinit of VariantHandle.")
+    debugLog("Returning from deinit of handle.")
+  }
+
+	static public func getTFDataTypeName(_ type: TF_DataType) -> String {
+		if type == TF_VARIANT {
+			return "variant"
+		}
+		if type == TF_RESOURCE {
+			return "resource"
+		}
+		return "unknown"
+	}
+	
+	@inlinable
+	static func receiveTensorHandleHelper(
+		_ computation: _TensorComputation,
+    _ tensorID: Int,
+		_ dataType: TF_DataType) -> CTensorHandle {
+		debugLog("Receiving \(ResourceVariantHandleBase.getTFDataTypeName(dataType)) tensor of id \(tensorID).")
+    let status = TF_NewStatus()
+    let context = _ExecutionContext.global
+    let cTensorHandle: CTensorHandle! = TFE_DequeueNamedTensorFromCtx(
+      context.eagerContext, Int32(tensorID), dataType, status)
+    checkOk(status)
+    TF_DeleteStatus(status)
+		return cTensorHandle
+	}
+
+  @inlinable
+  func sendToAcceleratorHelper(_ computation: _TensorComputation,
+                         _ tensorID: Int) {
+    debugLog("Sending \(ResourceVariantHandleBase.getTFDataTypeName(self.cDataType)) tensor of id \(tensorID).")
+    let status = TF_NewStatus()
+    let context = _ExecutionContext.global
+    TFE_EnqueueNamedTensorFromCtx(
+      context.eagerContext, Int32(tensorID), self.cTensorHandle, status)
+    TF_DeleteStatus(status)
+    debugLog("Done sending \(ResourceVariantHandleBase.getTFDataTypeName(self.cDataType)) tensor of id \(tensorID).")
+  }
+}
+
+
+/// `ResourceHandle` is the type used by ops and the `#tfop()` syntax to
+/// represent TensorFlow "resource" values.  
+public final class ResourceHandle : ResourceVariantHandleBase {
+  @usableFromInline
+  init(owning cTensorHandle: CTensorHandle) {
+		super.init(owning: cTensorHandle, cDataType: TF_RESOURCE)
+  }
+}
+
+
+extension ResourceHandle : TensorSendableReceivable {
+  @inlinable
+  static func receiveFromAccelerator(
+    _ computation: _TensorComputation,
+    _ tensorID: Int
+  ) -> ResourceHandle {
+		let receivedTensor = receiveTensorHandleHelper(computation, tensorID, TF_RESOURCE)
+		return ResourceHandle(owning: receivedTensor)
+	}
+
+  @inlinable
+  func sendToAccelerator(_ computation: _TensorComputation,
+    _ tensorID: Int) {
+		self.sendToAcceleratorHelper(computation, tensorID);
+  }
+
+  // TODO: remove this dummy Scalar typealias, currently required in order to
+  // conform to TensorSendableReceivable.
+  typealias Scalar = Float
+  @inlinable
+  static func scalar(_ scalar: Scalar) -> ResourceHandle {
+    fatalError("Unsupported")
+  }
+}
+
+
+/// `VariantHandle` is the type used by ops and the `#tfop()` syntax to
+/// represent TensorFlow "variant" values.
+/// TODO: rename this source file as this is no longer "opaque".
+public final class VariantHandle : ResourceVariantHandleBase {
+  @usableFromInline
+  init(owning cTensorHandle: CTensorHandle) {
+		super.init(owning: cTensorHandle, cDataType: TF_VARIANT)
   }
 }
 
@@ -50,27 +124,14 @@ extension VariantHandle : TensorSendableReceivable {
     _ computation: _TensorComputation,
     _ tensorID: Int
   ) -> VariantHandle {
-    debugLog("Receiving variant tensor of id \(tensorID).")
-    let status = TF_NewStatus()
-    let context = _ExecutionContext.global
-    let cTensorHandle: CTensorHandle! = TFE_DequeueNamedTensorFromCtx(
-      context.eagerContext, Int32(tensorID), TF_VARIANT, status)
-    checkOk(status)
-    TF_DeleteStatus(status)
-    debugLog("Done receiving variant tensor of id \(tensorID).")
-    return VariantHandle(owning: cTensorHandle)    
-  }
+		let receivedTensor = receiveTensorHandleHelper(computation, tensorID, TF_VARIANT)
+		return VariantHandle(owning: receivedTensor)
+	}
 
   @inlinable
   func sendToAccelerator(_ computation: _TensorComputation,
-                         _ tensorID: Int) {
-    debugLog("Sending variant tensor of id \(tensorID).")
-    let status = TF_NewStatus()
-    let context = _ExecutionContext.global
-    TFE_EnqueueNamedTensorFromCtx(
-      context.eagerContext, Int32(tensorID), self.cTensorHandle, status)
-    TF_DeleteStatus(status)
-    debugLog("Done sending variant tensor of id \(tensorID).")
+    _ tensorID: Int) {
+		self.sendToAcceleratorHelper(computation, tensorID);
   }
 
   // TODO: remove this dummy Scalar typealias, currently required in order to

--- a/stdlib/public/TensorFlow/OpaqueHandles.swift
+++ b/stdlib/public/TensorFlow/OpaqueHandles.swift
@@ -17,7 +17,7 @@
 import CTensorFlow
 
 /// `ResourceHandle` is the type used by ops and the `#tfop()` syntax to
-/// represent TensorFlow "variant" values.
+/// represent TensorFlow "resource" values.
 /// TODO: rename this source file as this is no longer "opaque".
 public final class ResourceHandle {
   public let cTensorHandle: CTensorHandle

--- a/test/TensorFlowRuntime/dataset_global.swift
+++ b/test/TensorFlowRuntime/dataset_global.swift
@@ -21,7 +21,6 @@ var DatasetGlobalTests = TestSuite("DatasetGlobal")
 // Global code must turn on eager mode explicitly (until when we change the
 // default mode to eager).
 _RuntimeConfig.usesTFEagerAPI = true
-_RuntimeConfig.printsDebugLog = true
 let scalars = Tensor<Float>([0, 1, 2])
 let dataset = Dataset(elements: scalars)
 var iterator = dataset.makeIterator()
@@ -34,7 +33,6 @@ var iterator = dataset.makeIterator()
 _ = Tensor<Float>(0.0)
 
 DatasetGlobalTests.testCPUOrGPU("DatasetAsGlobalVar") {
-	_RuntimeConfig.printsDebugLog = true
   // This stmt makes sure the load inst from the global var `dataset` does not
   // make dataset an input arg tensor.
   //
@@ -51,7 +49,6 @@ DatasetGlobalTests.testCPUOrGPU("DatasetAsGlobalVar") {
 }
 
 DatasetGlobalTests.testCPUOrGPU("IteratorAsGlobalVar") {
-	_RuntimeConfig.printsDebugLog = true
   // This stmt makes sure the load inst from the global var `iterator` does not
   // make iterator an input arg tensor.
   //


### PR DESCRIPTION
It simply follows the code path for VariantHandle. I just refactored it to avoid code duplication. 

Note: There is still some boiler plate. I was able to get rid of it by using generics and a typealias. However, classifyTensorValue relies on the class names to be ResourceHandle and VariantHandle. Therefore, I had to revert those changes. 