### PR TITLE
[test] Fix mixed-target-using-module.swift autolinking checks

### DIFF
--- a/test/ClangImporter/MixedSource/mixed-target-using-module.swift
+++ b/test/ClangImporter/MixedSource/mixed-target-using-module.swift
@@ -1,9 +1,9 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -F %S/Inputs/mixed-target/ -module-name Mixed -import-underlying-module -typecheck %s -verify -enable-objc-interop -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -F %S/Inputs/mixed-target/ -module-name Mixed -import-underlying-module -enable-objc-interop -emit-ir %S/../../Inputs/empty.swift - | %FileCheck -check-prefix=CHECK-AUTOLINK %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -F %S/Inputs/mixed-target/ -module-name Mixed -import-underlying-module -enable-objc-interop -emit-ir %S/../../Inputs/empty.swift | %FileCheck -check-prefix=CHECK-AUTOLINK %s
 // RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -F %S/Inputs/mixed-target/ -module-name WrongName -import-underlying-module -typecheck %s  -enable-objc-interop -disable-objc-attr-requires-foundation-module 2>&1 | %FileCheck -check-prefix=CHECK-WRONG-NAME %s
 
 // CHECK-AUTOLINK: !llvm.linker.options = !{
-// CHECK-AUTOLINK-NOT: metadata !"-framework", metadata !"Mixed"
+// CHECK-AUTOLINK-NOT: !"-framework"
 
 // CHECK-WRONG-NAME: underlying Objective-C module 'WrongName' not found
 


### PR DESCRIPTION
Negative tests aren't great to begin with, and this one was looking for a pattern that could no longer happen. This particular example doesn't seem to have regressed, but something similar has that I'm still looking into.