### PR TITLE
[awaiting evolution] Allow convenience initializers to reassign self.

### DIFF
--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -697,7 +697,12 @@ private:
 
     bool isInout = false;
     if (auto inoutType = dyn_cast<InOutType>(substType)) {
-      isInout = true;
+      // The `self` parameter of convenience initializers is considered 'inout'
+      // for semantic purposes in the AST, but at the ABI level is always
+      // passed by value in and returned out.
+      if (!forSelf || rep != SILFunctionTypeRepresentation::ObjCMethod) {
+        isInout = true;
+      }
       substType = inoutType.getObjectType();
       origType = origType.getWithoutSpecifierType();
     }

--- a/test/SILGen/objc_convenience_init.swift
+++ b/test/SILGen/objc_convenience_init.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-emit-sil(mock-sdk: %clang-importer-sdk) -swift-version 5 -verify %s
+
+import Foundation
+
+class X: NSObject {
+  override init() {}
+
+  static func foo() -> Self { fatalError() }
+
+  @objc convenience init(x: Int) {
+    self = type(of: self).foo()
+  }
+}

--- a/test/SILOptimizer/definite_init_type_of_self_in_convenience_init.swift
+++ b/test/SILOptimizer/definite_init_type_of_self_in_convenience_init.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-emit-sil -verify %s
+// RUN: %target-swift-emit-sil -swift-version 4 -verify %s
+// RUN: %target-swift-emit-sil -swift-version 5 -verify %s
 
 // Integration test to ensure that `type(of: self)` keeps working in
 // class convenience initializers, even though they are now implemented as

--- a/test/decl/init/convenience_init_assignment_s4.swift
+++ b/test/decl/init/convenience_init_assignment_s4.swift
@@ -1,0 +1,26 @@
+// RUN: %target-typecheck-verify-swift -swift-version 4
+
+final class A {
+  static let a = A()
+  convenience init(a: ()) {
+    self = A.a // expected-error{{immutable}}
+  }
+}
+
+private func _forceCastToSelf<T: AnyObject>(_ object: AnyObject) -> T {
+  return object as! T
+}
+
+class B {
+  static let b = B()
+
+  convenience init(bWrong: ()) {
+    self = B.b // expected-error{{immutable}}
+  }
+
+  convenience init(b: ()) {
+    self = _forceCastToSelf(B.b) // expected-error{{immutable}}
+  }
+}
+
+class C: B { }

--- a/test/decl/init/convenience_init_assignment_s5.swift
+++ b/test/decl/init/convenience_init_assignment_s5.swift
@@ -1,0 +1,39 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5
+
+final class A {
+  static let a = A()
+  convenience init(a: ()) {
+    self = A.a
+  }
+}
+
+private func _forceCastToSelf<T: AnyObject>(_ object: AnyObject) -> T {
+  return object as! T
+}
+
+protocol P {}
+
+extension P {
+  static var selfProperty: Self { fatalError() }
+  static func selfReturningMethod() -> Self { fatalError() }
+  static func selfLaunderingMethod(_: Self) -> Self { fatalError() }
+
+  init(protocolExt: ()) { fatalError() }
+}
+
+class B: P {
+  static let b = B()
+
+  convenience init(otherInstance: B) {
+    self = B.b // expected-error{{cannot assign value of type 'B' to type 'Self'}}
+    self = otherInstance // expected-error{{cannot assign value of type 'B' to type 'Self'}}
+    self = _forceCastToSelf(B.b)
+    self = type(of: self).selfProperty
+    self = type(of: self).selfReturningMethod()
+    self = type(of: self).selfLaunderingMethod(otherInstance) // expected-error{{cannot assign value of type 'B' to type 'Self'}}
+    self = type(of: self).selfLaunderingMethod(type(of: self).selfReturningMethod())
+    self = type(of: self).init(protocolExt: ())
+  }
+}
+
+class C: B { }


### PR DESCRIPTION
Now that convenience initializers are implemented exactly the same as value type delegating initializers, it's straightforward to allow them to assign self to an existing object reference instead of only allowing them to chain to other initializers. Because convenience inits can be inherited, the formal type of self is still the dynamic Self type, however. This was handled unsoundly in Swift 4 mode, and unfortunately we can't fix it without breaking source in Swift 4 mode, so enable this feature only in Swift 5 mode.

Making `self` inout inside convenience inits also changes the code generation of loads from self, so we need to tweak DI's special handling of type(of: self) slightly so that it also recognizes this new pattern.

Proposal: https://github.com/apple/swift-evolution/pull/910