### PR TITLE
Rdar 44142091 fix without test

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -120,6 +120,10 @@ def driver_force_one_batch_repartition : Flag<["-"], "driver-force-one-batch-rep
   InternalDebugOpt,
   HelpText<"Force one batch repartitioning for testing">;
 
+def driver_force_response_files : Flag<["-"], "driver-force-response-files">,
+  InternalDebugOpt,
+  HelpText<"Force the use of response files for testing">;
+
 def driver_always_rebuild_dependents :
   Flag<["-"], "driver-always-rebuild-dependents">, InternalDebugOpt,
   HelpText<"Always rebuild dependents of files that have been modified">;

--- a/lib/Driver/Job.cpp
+++ b/lib/Driver/Job.cpp
@@ -425,9 +425,8 @@ bool Job::writeArgsToResponseFile() const {
     return true;
   }
   for (const char *arg : Arguments) {
-    OS << "\"";
     escapeAndPrintString(OS, arg);
-    OS << "\" ";
+    OS << " ";
   }
   OS.flush();
   return false;

--- a/lib/Driver/ToolChain.cpp
+++ b/lib/Driver/ToolChain.cpp
@@ -116,9 +116,15 @@ std::unique_ptr<Job> ToolChain::constructJob(
 
   const char *responseFilePath = nullptr;
   const char *responseFileArg = nullptr;
-  if (invocationInfo.allowsResponseFiles &&
-      !llvm::sys::commandLineFitsWithinSystemLimits(
-          executablePath, invocationInfo.Arguments)) {
+
+  const bool forceResponseFiles =
+      C.getArgs().hasArg(options::OPT_driver_force_response_files);
+  assert((invocationInfo.allowsResponseFiles || !forceResponseFiles) &&
+         "Cannot force response file if platform does not allow it");
+
+  if (forceResponseFiles || (invocationInfo.allowsResponseFiles &&
+                             !llvm::sys::commandLineFitsWithinSystemLimits(
+                                 executablePath, invocationInfo.Arguments))) {
     responseFilePath = context.getTemporaryFilePath("arguments", "resp");
     responseFileArg = C.getArgs().MakeArgString(Twine("@") + responseFilePath);
   }

--- a/test/Driver/force-response-files.swift
+++ b/test/Driver/force-response-files.swift
@@ -1,0 +1,6 @@
+// Ensure that -driver-force-response-files works.
+
+
+// RUN: %swiftc_driver -driver-force-response-files -typecheck %S/../Inputs/empty.swift -### 2>&1 | %FileCheck %s
+// CHECK: @
+// CHECK: .resp


### PR DESCRIPTION
<!-- What's in this pull request? -->
Today, response files include extra, bogus quotes, for example: ""foo.swift"". This PR removes the superfluous and harmful extra quotes, so that spaces in file names in response files work.
It fixes rdar://44142091, but cannot be tested easily until https://github.com/apple/swift/pull/19313 lands. At that point, I will submit another PR with the test, which I have already written:
```
// RUN: %empty-directory(%t)
// RUN: touch "%t/f i l e.swift"
//
// RUN: %swiftc_driver -driver-force-response-files -typecheck  "%t/f i l e.swift"
```
Or, if preferred, PR 19313 can land first, then I can add the test to this PR.
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->