### PR TITLE
[Serialization] Bump module format for b1f3a1d0e

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t VERSION_MINOR = 443; // Last change: serialize unsubstituted type alias type
+const uint16_t VERSION_MINOR = 444; // Last change: SIL lookup tables use identifier table
 
 using DeclIDField = BCFixed<31>;
 


### PR DESCRIPTION
See #19290. I forgot to do this because it didn't directly change a record. Oops!