### PR TITLE
AST: SFINAE away template'd constructor

### DIFF
--- a/include/swift/AST/AnyRequest.h
+++ b/include/swift/AST/AnyRequest.h
@@ -164,11 +164,19 @@ public:
   AnyRequest(const AnyRequest &&other)
     : storageKind(other.storageKind), stored(other.stored) { }
 
+  // Create a local template typename `ValueType` in the template specialization
+  // so that we can refer to it in the SFINAE condition as well as the body of
+  // the template itself.  The SFINAE condition allows us to remove this
+  // constructor from candidacy when evaluating explicit construction with an
+  // instance of `AnyRequest`.  If we do not do so, we will find ourselves with
+  // ambiguity with this constructor and the defined move constructor above.
   /// Construct a new instance with the given value.
-  template<typename T>
-  explicit AnyRequest(T&& value) : storageKind(StorageKind::Normal) {
-    using ValueType =
-        typename std::remove_cv<typename std::remove_reference<T>::type>::type;
+  template <typename T,
+            typename ValueType = typename std::remove_cv<
+                typename std::remove_reference<T>::type>::type,
+            typename = typename std::enable_if<
+                !std::is_same<ValueType, AnyRequest>::value>::type>
+  explicit AnyRequest(T &&value) : storageKind(StorageKind::Normal) {
     stored = llvm::IntrusiveRefCntPtr<HolderBase>(
         new Holder<ValueType>(std::forward<T>(value)));
   }


### PR DESCRIPTION
Because we cannot explicitly control which constructor is used, and Visual
Studio also instantiates the templated constructor (even with the copy and move
constructors available, we end up with ambiguity in the constructor when trying
to instantiate a `llvm::SetVector<AnyRequest>` in the Evaluator.

```
	swift\include\swift\AST\AnyRequest.h(98): error C2027: use of undefined type 'swift::TypeID<Request>'
		with
		[
		    Request=ValueType
		]
	swift\include\swift\AST\AnyRequest.h(98): note: see declaration of 'swift::TypeID<Request>'
		with
		[
		    Request=ValueType
		]
	swift\include\swift\AST\AnyRequest.h(97): note: while compiling class template member function 'swift::AnyRequest::Holder<ValueType>::Holder(const Request &)'
		with
		[
		    Request=ValueType
		]
	swift\include\swift\AST\AnyRequest.h(167): note: see reference to function template instantiation 'swift::AnyRequest::Holder<ValueType>::Holder(const Request &)' being compiled
		with
		[
		    Request=ValueType
		]
	swift\include\swift\AST\AnyRequest.h(168): note: see reference to class template instantiation 'swift::AnyRequest::Holder<ValueType>' being compiled
	C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Tools\MSVC\14.13.26128\include\xmemory0(917): note: see reference to function template instantiation 'swift::AnyRequest::AnyRequest<T&>(swift::AnyRequest&)' being compiled
		with
		[
		    T=swift::AnyRequest
		]
	C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Tools\MSVC\14.13.26128\include\xmemory(120): note: see reference to function template instantiation 'void std::_Default_allocator_traits<_Alloc>::construct<_Ty,T&>(_Alloc &,_Objty *const ,T &)' being compiled
		with
		[
		    _Alloc=std::allocator<swift::AnyRequest>,
		    _Ty=swift::AnyRequest,
		    T=swift::AnyRequest,
		    _Objty=swift::AnyRequest
		]
	C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Tools\MSVC\14.13.26128\include\xmemory(120): note: see reference to function template instantiation 'void std::_Default_allocator_traits<_Alloc>::construct<_Ty,T&>(_Alloc &,_Objty *const ,T &)' being compiled
		with
		[
		    _Alloc=std::allocator<swift::AnyRequest>,
		    _Ty=swift::AnyRequest,
		    T=swift::AnyRequest,
		    _Objty=swift::AnyRequest
		]
	C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Tools\MSVC\14.13.26128\include\xmemory(153): note: see reference to function template instantiation '_FwdIt std::_Uninitialized_copy_al_unchecked<_Iter,_Iter,_Alloc>(_InIt,_InIt,_FwdIt,_Alloc &,std::_General_ptr_iterator_tag,std::_Any_tag)' being compiled
		with
		[
		    _FwdIt=swift::AnyRequest *,
		    _Iter=swift::AnyRequest *,
		    _Alloc=std::allocator<swift::AnyRequest>,
		    _InIt=swift::AnyRequest *
		]
	C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Tools\MSVC\14.13.26128\include\vector(1939): note: see reference to function template instantiation '_FwdIt *std::_Uninitialized_copy<swift::AnyRequest*,swift::AnyRequest*,std::allocator<_Ty>>(_InIt,_InIt,_FwdIt,_Alloc &)' being compiled
		with
		[
		    _FwdIt=swift::AnyRequest *,
		    _Ty=swift::AnyRequest,
		    _InIt=swift::AnyRequest *,
		    _Alloc=std::allocator<swift::AnyRequest>
		]
	C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Tools\MSVC\14.13.26128\include\vector(1938): note: while compiling class template member function 'void std::vector<T,std::allocator<_Ty>>::_Umove_if_noexcept1(swift::AnyRequest *,swift::AnyRequest *,swift::AnyRequest *,std::false_type)'
		with
		[
		    T=swift::AnyRequest,
		    _Ty=swift::AnyRequest
		]
	C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Tools\MSVC\14.13.26128\include\vector(1944): note: see reference to function template instantiation 'void std::vector<T,std::allocator<_Ty>>::_Umove_if_noexcept1(swift::AnyRequest *,swift::AnyRequest *,swift::AnyRequest *,std::false_type)' being compiled
		with
		[
		    T=swift::AnyRequest,
		    _Ty=swift::AnyRequest
		]
	llvm\include\llvm\ADT\SetVector.h(49): note: see reference to class template instantiation 'std::vector<T,std::allocator<_Ty>>' being compiled
		with
		[
		    T=swift::AnyRequest,
		    _Ty=swift::AnyRequest
		]
	swift\include\swift\AST\Evaluator.h(208): note: see reference to class template instantiation 'llvm::SetVector<swift::AnyRequest,std::vector<T,std::allocator<_Ty>>,llvm::DenseSet<T,llvm::DenseMapInfo<swift::AnyRequest>>>' being compiled
		with
		[
		    T=swift::AnyRequest,
		    _Ty=swift::AnyRequest
		]
	swift\include\swift\AST\AnyRequest.h(97): error C2065: 'value': undeclared identifier
```

Hoist the type alias into the template specialization so that we can use that
in the SFINAE expression rather than duplicating it.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
