### PR TITLE
stdlib: repair the Windows runtime build

### DIFF
--- a/stdlib/public/runtime/ThreadLocalStorage.h
+++ b/stdlib/public/runtime/ThreadLocalStorage.h
@@ -88,19 +88,6 @@ typedef unsigned long __swift_thread_key_t;
 static_assert(std::is_same<__swift_thread_key_t, DWORD>::value,
               "__swift_thread_key_t is not a DWORD");
 
-#  if defined(_M_IX86)
-typedef stdcall void (*__swift_thread_key_destructor)(void *)
-#  else
-typedef void (*__swift_thread_key_destructor)(void *)
-#  endif
-
-static inline
-_stdlib_thread_key_create(__swift_thread_key_t * _Nonnull key,
-                          __swift_thread_key_destructor _Nullable destructor) {
-  *key = FlsAlloc(destroyTLS_CCAdjustmentThunk);
-  return *key != FLS_OUT_OF_INDEXES;
-}
-
 #  define SWIFT_THREAD_KEY_CREATE _stdlib_thread_key_create
 #  define SWIFT_THREAD_GETSPECIFIC FlsGetValue
 #  define SWIFT_THREAD_SETSPECIFIC(key, value) (FlsSetValue(key, value) == TRUE)


### PR DESCRIPTION
Fix syntactic issues in the swift runtime build from the recent TLS changes.
Move the helper definitions into the TLS stubs rather than emitting them
everywhere.  This allows the runtime to build again on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
