### PR TITLE
[ModuleInterface] Don't include 'import Builtin' for the stdlib

### DIFF
--- a/lib/FrontendTool/TextualInterfaceGeneration.cpp
+++ b/lib/FrontendTool/TextualInterfaceGeneration.cpp
@@ -57,7 +57,8 @@ static void printImports(raw_ostream &out, ModuleDecl *M) {
 
   for (auto import : allImports) {
     if (import.second->isStdlibModule() ||
-        import.second->isOnoneSupportModule()) {
+        import.second->isOnoneSupportModule() ||
+        import.second->isBuiltinModule()) {
       continue;
     }
 

--- a/test/ModuleInterface/stdlib.swift
+++ b/test/ModuleInterface/stdlib.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -emit-interface-path - -emit-module -o /dev/null -parse-stdlib %s | %FileCheck %s
+
+// CHECK-NOT: import Builtin
+
+// CHECK: func test() {
+// CHECK-NEXT: Builtin.sizeof
+// CHECK-NEXT: {{^}$}}
+@inlinable public func test() {
+  Builtin.sizeof(Builtin.Int8.self)
+}


### PR DESCRIPTION
The special 'Builtin' module is implicitly imported via -parse-stdlib, and can't be found via normal import resolution, so we shouldn't print it in a textual interface.