### PR TITLE
@differentiable typechecking fixes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2645,6 +2645,8 @@ ERROR(differentiable_attr_no_parameters,none,
       "%0 has no parameters to differentiate with respect to", (DeclName))
 ERROR(differentiable_attr_void_result,none,
       "cannot differentiate void function %0", (DeclName))
+ERROR(differentiable_attr_wrt_nothing,none,
+      "specify at least one parameter to differentiate with respect to", (DeclName))
 ERROR(differentiable_attr_primal_overload_not_found,none,
       "%0 does not have expected parameters' type %1", (DeclName, Type))
 ERROR(differentiable_attr_adjoint_overload_not_found,none,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2238,8 +2238,9 @@ checkAndDiagnoseWrtType(TypeChecker &TC, SourceLoc loc, Type type) {
   return false;
 }
 
-// If the self type of `method`, appends the corresponding return type
-// to `retElts` and returns false. Otherwise, returns true and diagnoses.
+// If the self type of `method` is allowed as a wrt param, appends the
+// corresponding return type to `retElts` and returns false. Otherwise,
+// returns true and diagnoses.
 static bool
 addWrtSelfRetTyOrDiagnose(TypeChecker &TC, SourceLoc loc,
                           const FuncDecl *method,

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -93,7 +93,7 @@ func dPlus(_ x: Int, _ y: S, _ primal: S, _ seed: S) -> (Int, S) {
 }
 
 struct C {
-  @differentiable(reverse, wrt: (.0), adjoint: adjoint)
+  @differentiable(reverse, adjoint: adjoint)
   func primal(x: Float) -> Float {
     return x
   }
@@ -104,7 +104,7 @@ struct C {
 }
 
 struct S {
-  @differentiable(reverse, adjoint: dmeow1_out_of_S(_:_:_:_:)) // expected-error {{'dmeow1_out_of_S' is not defined in the current type context}}
+  @differentiable(reverse, wrt: (self, .0), adjoint: dmeow1_out_of_S(_:_:_:_:)) // expected-error {{'dmeow1_out_of_S' is not defined in the current type context}}
   func meow1(_ x: Float) -> Float {
     return x + 1
   }
@@ -148,7 +148,7 @@ struct S {
     return rhs
   }
 
-  @differentiable(reverse, adjoint: dIdentity_wrt_self) // ok
+  @differentiable(reverse, adjoint: dIdentity_wrt_self) // expected-error {{specify at least one parameter to differentiate with respect to}}
   func identity() -> S {
     return self
   }
@@ -198,7 +198,7 @@ func dmeow2(_ x: Float, _: Float, _: Float, _: Float, _: Float) -> (Float, Float
 
 // Original function in struct definition, adjoint in extension.
 struct E1 {
-  @differentiable(reverse, wrt: (.0), adjoint: adjoint)
+  @differentiable(reverse, adjoint: adjoint)
   func original(x: Float) -> Float {
     return x
   }
@@ -212,7 +212,7 @@ extension E1 {
 // Original function and adjoint in separate struct extensions.
 struct E2 {}
 extension E2 {
-  @differentiable(reverse, wrt: (.0), adjoint: adjoint)
+  @differentiable(reverse, adjoint: adjoint)
   func original(x: Float) -> Float {
     return x
   }
@@ -227,7 +227,7 @@ extension E2 {
 // generic constraints.
 struct E3<T> {}
 extension E3 where T == Float {
-  @differentiable(reverse, wrt: (.0), adjoint: adjoint_same_constraint)
+  @differentiable(reverse, adjoint: adjoint_same_constraint)
   func original(x: Float) -> Float {
     return x
   }
@@ -240,7 +240,7 @@ extension E3 where T == Float {
 
 struct E4<T> {}
 extension E4 {
-  @differentiable(reverse, wrt: (.0), adjoint: adjoint_no_constraint)
+  @differentiable(reverse, adjoint: adjoint_no_constraint)
   func original(x: Float) -> Float {
     return x
   }
@@ -255,7 +255,7 @@ extension E4 {
 // non-matching generic constraints.
 struct E5<T> {}
 extension E5 {
-  @differentiable(reverse, wrt: (.0), adjoint: adjoint_diff_constraint)
+  @differentiable(reverse, adjoint: adjoint_diff_constraint)
   // expected-error @-1 {{'adjoint_diff_constraint' does not have expected type '<T> (E5<T>) -> (Float, Float, Float) -> Float'}}
   func original(x: Float) -> Float {
     return x
@@ -417,15 +417,9 @@ func dProtocolParameter(_: ParamProtocol, _: Float, seed: Float) -> ParamProtoco
 }
 
 class ClassWithDifferentiableMethods {
-  @differentiable(reverse, adjoint: dMethod)
-  // expected-error @-1 {{class objects and protocol existentials ('ClassWithDifferentiableMethods') cannot be differentiated with respect to}}
-  func method1() -> Float {
-    return 1
-  }
-
   @differentiable(reverse, wrt: (self), adjoint: dMethod)
   // expected-error @-1 {{class objects and protocol existentials ('ClassWithDifferentiableMethods') cannot be differentiated with respect to}}
-  func method2() -> Float {
+  func method() -> Float {
     return 1
   }
 


### PR DESCRIPTION
While making my way through code related to [SR-8699](https://bugs.swift.org/browse/SR-8699), I found and fixed two issues. (This does not fix anything directly related to SR-8699 though).

1. *edited*: There is an assertion failure when you put `@differentiable` with no wrt list on an instance method with no parameters. So I added a diagnostic to catch this.
   - (*original, outdated*: If you add a `@differentiable` attribute without a `wrt:` list to an instance method, it does not include `self` as a wrt param. I think including `self` is the most consistent thing to do, so I made it include `self`.)
2. If you add a `@differentiable` attribute without a `wrt:` list to any function, it does not reject class objects and existentials. So I made it reject them.

This PR also factors the classobject/existential checks out into functions because a lot of different places are doing them now.