### PR TITLE
Fix response file quote bug, add flag for testing, add tests.

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -120,6 +120,10 @@ def driver_force_one_batch_repartition : Flag<["-"], "driver-force-one-batch-rep
   InternalDebugOpt,
   HelpText<"Force one batch repartitioning for testing">;
 
+def driver_force_response_files : Flag<["-"], "driver-force-response-files">,
+  InternalDebugOpt,
+  HelpText<"Force the use of response files for testing">;
+
 def driver_always_rebuild_dependents :
   Flag<["-"], "driver-always-rebuild-dependents">, InternalDebugOpt,
   HelpText<"Always rebuild dependents of files that have been modified">;

--- a/lib/Driver/Job.cpp
+++ b/lib/Driver/Job.cpp
@@ -425,9 +425,8 @@ bool Job::writeArgsToResponseFile() const {
     return true;
   }
   for (const char *arg : Arguments) {
-    OS << "\"";
     escapeAndPrintString(OS, arg);
-    OS << "\" ";
+    OS << " ";
   }
   OS.flush();
   return false;

--- a/lib/Driver/ToolChain.cpp
+++ b/lib/Driver/ToolChain.cpp
@@ -120,9 +120,15 @@ ToolChain::constructJob(const JobAction &JA,
 
   const char *responseFilePath = nullptr;
   const char *responseFileArg = nullptr;
-  if (invocationInfo.allowsResponseFiles &&
-      !llvm::sys::commandLineFitsWithinSystemLimits(
-          executablePath, invocationInfo.Arguments)) {
+
+  const bool forceResponseFiles =
+      C.getArgs().hasArg(options::OPT_driver_force_response_files);
+  assert((invocationInfo.allowsResponseFiles || !forceResponseFiles) &&
+         "Cannot force response file if platform does not allow it");
+
+  if (forceResponseFiles || (invocationInfo.allowsResponseFiles &&
+                             !llvm::sys::commandLineFitsWithinSystemLimits(
+                                 executablePath, invocationInfo.Arguments))) {
     responseFilePath = context.getTemporaryFilePath("arguments", "resp");
     responseFileArg = C.getArgs().MakeArgString(Twine("@") + responseFilePath);
   }

--- a/lib/Driver/ToolChain.cpp
+++ b/lib/Driver/ToolChain.cpp
@@ -21,6 +21,7 @@
 #include "swift/Driver/Compilation.h"
 #include "swift/Driver/Driver.h"
 #include "swift/Driver/Job.h"
+#include "swift/Option/Options.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Option/ArgList.h"

--- a/test/Driver/force-response-files.swift
+++ b/test/Driver/force-response-files.swift
@@ -1,0 +1,6 @@
+// Ensure that -driver-force-response-files works.
+
+
+// RUN: %swiftc_driver -driver-force-response-files -typecheck %S/../Inputs/empty.swift -### 2>&1 | %FileCheck %s
+// CHECK: @
+// CHECK: .resp

--- a/test/Driver/response-files-with-spaces-in-filenames.swift
+++ b/test/Driver/response-files-with-spaces-in-filenames.swift
@@ -1,0 +1,4 @@
+// RUN: %empty-directory(%t)
+// RUN: touch "%t/f i l e.swift"
+//
+// RUN: %target-build-swift -driver-force-response-files -parse  "%t/f i l e.swift"


### PR DESCRIPTION
<!-- What's in this pull request? -->
Explanation: Fixes response file bug when spaces are in file paths.
Scope of issue: Build breakage when paths are too long and contain spaces.
Origination: Typo when written, as near as I can tell.
Risk: Minimal. I can't see how getting the quotes right could introduce a bug.
Reviewed by: Jordan Rose
Testing: Normal regression tests.
Radar: rdar://44142091

Details: 

Recently, response files were added to the compiler. If the project is located in a path that is long enough, so that the arguments to a tool (frontend, linker) might be too long, the driver passes them in a file instead, called a "response file". In order for the tool to accurately reparse the reponse file contents into a sequence of arguments, each argument in the response file must be enclosed in quotes in case that argument contains a space character.

However, when the response file mechanism was added, extra quotes were mistakenly used. For instance, the argument <part1 part2.swift> gets written to the response file as <""part1 part2.swift"">.
The effect is to cause projects using response files to break.

This PR:
- fixes the bug,
- adds a flag to make it possible to test the fix: -driver-force-response-files,
- adds tests for the flag, and the bug fix.

It combines PRs from master:
https://github.com/apple/swift/pull/19316
https://github.com/apple/swift/pull/19314
https://github.com/apple/swift/pull/19313