### PR TITLE
Refactor the preheader subst map computation in SESE canonicalization. 

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
+++ b/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
@@ -324,7 +324,7 @@ private:
   getPreheaderSubstMap(const SmallPtrSetImpl<SILValue> &values) const;
 
   /// Compute escaping values and what values to use as arguments at preheader.
-  llvm::DenseMap<SILValue, SILValue> computeEscapingValues() const;
+  llvm::DenseMap<SILValue, SILValue> computeEscapingValuesSubstMap() const;
 
   /// Create a new header for the loop and return a pair consisting of
   /// the new block and the phi argument corresponding to the exitIndex.
@@ -418,11 +418,11 @@ void SingleExitLoopTransformer::initialize() {
     }
   }
 
-  escapingValueSubstMap = computeEscapingValues();
+  escapingValueSubstMap = computeEscapingValuesSubstMap();
 }
 
 llvm::DenseMap<SILValue, SILValue>
-SingleExitLoopTransformer::computeEscapingValues() const {
+SingleExitLoopTransformer::computeEscapingValuesSubstMap() const {
   llvm::SmallPtrSet<SILValue, 8> escapingValues;
   for (const SILBasicBlock *bb : loop->getBlocks()) {
     // Save the values that are escaping this loop in result set.

--- a/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
+++ b/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
@@ -318,7 +318,7 @@ private:
 
   /// Return a map that captures information about what SILValue should be
   /// used at the pre-header of the loop for every SILValue in the given
-  /// `values` set. If it cannnot find a suitable SILValue for an entry in
+  /// `values` set. If it cannot find a suitable SILValue for an entry in
   /// `values`, the corresponding will be mapped to an undef.
   llvm::DenseMap<SILValue, SILValue>
   getPreheaderSubstMap(const SmallPtrSetImpl<SILValue> &values) const;
@@ -454,7 +454,7 @@ SingleExitLoopTransformer::getPreheaderSubstMap(
     result[value] = getUndef(value->getType());
   }
   // Do not eliminate undefs unless requested for.
-  if (!TFNoUndefsInSESE)  return result;
+  if (!TFNoUndefsInSESE) return result;
 
   // Replace undef with an equivalent value that is available at preheader.
   for (auto &kv : result) {


### PR DESCRIPTION
Refactoring some code that I find useful for subsequent PRs. 