### PR TITLE
Fix swift-4.1 branch to build with clang r331013 and later

### DIFF
--- a/include/swift/Reflection/TypeRef.h
+++ b/include/swift/Reflection/TypeRef.h
@@ -42,18 +42,23 @@ enum class TypeRefKind {
 // Clang reports an error if we don't use "template"
 #if defined(__clang__) || defined(__GNUC__)
 #define DEPENDENT_TEMPLATE template
+#if __clang_major__ >= 7
+#define DEPENDENT_TEMPLATE2
+#else
+#define DEPENDENT_TEMPLATE2 template
+#endif
 #else
 #define DEPENDENT_TEMPLATE
 #endif
 
 #define FIND_OR_CREATE_TYPEREF(Allocator, TypeRefTy, ...)                      \
   auto ID = Profile(__VA_ARGS__);                                              \
-  const auto Entry = Allocator.DEPENDENT_TEMPLATE TypeRefTy##s.find(ID);       \
-  if (Entry != Allocator.DEPENDENT_TEMPLATE TypeRefTy##s.end())                \
+  const auto Entry = Allocator.DEPENDENT_TEMPLATE2 TypeRefTy##s.find(ID);      \
+  if (Entry != Allocator.DEPENDENT_TEMPLATE2 TypeRefTy##s.end())               \
     return Entry->second;                                                      \
   const auto TR =                                                              \
       Allocator.DEPENDENT_TEMPLATE makeTypeRef<TypeRefTy>(__VA_ARGS__);        \
-  Allocator.DEPENDENT_TEMPLATE TypeRefTy##s.insert({ID, TR});                  \
+  Allocator.DEPENDENT_TEMPLATE2 TypeRefTy##s.insert({ID, TR});                 \
   return TR;
 
 /// An identifier containing the unique bit pattern made up of all of the

--- a/include/swift/Reflection/TypeRef.h
+++ b/include/swift/Reflection/TypeRef.h
@@ -40,15 +40,23 @@ enum class TypeRefKind {
 
 // MSVC reports an error if we use "template"
 // Clang reports an error if we don't use "template"
-#if defined(__clang__) || defined(__GNUC__)
-#define DEPENDENT_TEMPLATE template
-#if __clang_major__ >= 7
-#define DEPENDENT_TEMPLATE2
+#if defined(__APPLE_CC__)
+#  define DEPENDENT_TEMPLATE template
+#  if __APPLE_CC__ >= 7000
+#    define DEPENDENT_TEMPLATE2
+#  else
+#    define DEPENDENT_TEMPLATE2 template
+#  endif
+#elif defined(__clang__) || defined(__GNUC__)
+#  define DEPENDENT_TEMPLATE template
+#  if __clang_major__ >= 7
+#    define DEPENDENT_TEMPLATE2
+#  else
+#    define DEPENDENT_TEMPLATE2 template
+#  endif
 #else
-#define DEPENDENT_TEMPLATE2 template
-#endif
-#else
-#define DEPENDENT_TEMPLATE
+#  define DEPENDENT_TEMPLATE template
+#  define DEPENDENT_TEMPLATE2
 #endif
 
 #define FIND_OR_CREATE_TYPEREF(Allocator, TypeRefTy, ...)                      \

--- a/include/swift/Reflection/TypeRef.h
+++ b/include/swift/Reflection/TypeRef.h
@@ -40,33 +40,20 @@ enum class TypeRefKind {
 
 // MSVC reports an error if we use "template"
 // Clang reports an error if we don't use "template"
-#if defined(__APPLE_CC__)
+#if defined(__clang__) || defined(__GNUC__)
 #  define DEPENDENT_TEMPLATE template
-#  if __APPLE_CC__ >= 7000
-#    define DEPENDENT_TEMPLATE2
-#  else
-#    define DEPENDENT_TEMPLATE2 template
-#  endif
-#elif defined(__clang__) || defined(__GNUC__)
-#  define DEPENDENT_TEMPLATE template
-#  if __clang_major__ >= 7
-#    define DEPENDENT_TEMPLATE2
-#  else
-#    define DEPENDENT_TEMPLATE2 template
-#  endif
 #else
-#  define DEPENDENT_TEMPLATE template
-#  define DEPENDENT_TEMPLATE2
+#  define DEPENDENT_TEMPLATE
 #endif
 
 #define FIND_OR_CREATE_TYPEREF(Allocator, TypeRefTy, ...)                      \
   auto ID = Profile(__VA_ARGS__);                                              \
-  const auto Entry = Allocator.DEPENDENT_TEMPLATE2 TypeRefTy##s.find(ID);      \
-  if (Entry != Allocator.DEPENDENT_TEMPLATE2 TypeRefTy##s.end())               \
+  const auto Entry = Allocator.TypeRefTy##s.find(ID);      \
+  if (Entry != Allocator.TypeRefTy##s.end())               \
     return Entry->second;                                                      \
   const auto TR =                                                              \
       Allocator.DEPENDENT_TEMPLATE makeTypeRef<TypeRefTy>(__VA_ARGS__);        \
-  Allocator.DEPENDENT_TEMPLATE2 TypeRefTy##s.insert({ID, TR});                 \
+  Allocator.TypeRefTy##s.insert({ID, TR});                 \
   return TR;
 
 /// An identifier containing the unique bit pattern made up of all of the


### PR DESCRIPTION
Update the 4.1 branch with changes to allow building with more recent versions of Clang that include r331013, which changed the way the template keyword is interpreted in some contexts.

rdar://problem/43632440