### PR TITLE
[docs] Add "WIP" and "DNM" to Lexicon.rst

### DIFF
--- a/docs/Lexicon.rst
+++ b/docs/Lexicon.rst
@@ -104,6 +104,10 @@ source code, tests, and commit messages. See also the `LLVM lexicon`_.
 
     __ https://developer.apple.com/swift/blog/?id=28
 
+  DNM
+    "Do not merge". Placed in PR titles where discussion or analysis is still
+    ongoing.
+
   dup
     From "duplicate". As a noun, refers to another filed issue that describes
     the same bug ("I have a dup of this"); as a verb, the act of marking a bug
@@ -401,6 +405,10 @@ source code, tests, and commit messages. See also the `LLVM lexicon`_.
     overridable method in the class. Unlike an Objective-C method table,
     vtable keys are just offsets, making lookup much simpler at the cost of
     dynamism and duplicated information about *non*-overridden methods.
+
+  WIP
+    "Work-in-progress". Placed in PR titles to indicate that the PR is not ready
+    for review or merging.
 
   witness
     The value or type that satisfies a protocol requirement.


### PR DESCRIPTION
"WIP" is hardly unique to Swift, but it is a three-letter acronym that someone might not have encountered before. "DNM" seems to have arisen organically over the last few weeks.