### PR TITLE
Enforce that a fixed-contents struct has usable-from-inline fields

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1333,6 +1333,7 @@ WARNING(pattern_type_access_inferred_warn,none,
         "because its type %6 uses "
         "%select{a private|a fileprivate|an internal|%error|%error}5 type",
         (bool, bool, bool, AccessLevel, bool, AccessLevel, Type))
+
 ERROR(pattern_type_not_usable_from_inline,none,
       "type referenced from a '@usableFromInline' "
       "%select{%select{variable|constant}0|property}1 "
@@ -1343,6 +1344,10 @@ WARNING(pattern_type_not_usable_from_inline_warn,none,
         "%select{%select{variable|constant}0|property}1 "
         "should be '@usableFromInline' or public",
         (bool, bool))
+ERROR(pattern_type_not_usable_from_inline_fixed_layout,none,
+      "type referenced from a stored property in a @_fixed_layout struct must "
+      "be '@usableFromInline' or public",
+      (/*ignored*/bool, /*ignored*/bool))
 ERROR(pattern_type_not_usable_from_inline_inferred,none,
       "type referenced from a '@usableFromInline' "
       "%select{%select{variable|constant}0|property}1 "
@@ -1355,6 +1360,11 @@ WARNING(pattern_type_not_usable_from_inline_inferred_warn,none,
         "with inferred type %2 "
         "should be '@usableFromInline' or public",
         (bool, bool, Type))
+ERROR(pattern_type_not_usable_from_inline_inferred_fixed_layout,none,
+      "type referenced from a stored property with inferred type %2 in a "
+      "@_fixed_layout struct must be '@usableFromInline' or public",
+      (/*ignored*/bool, /*ignored*/bool, Type))
+
 ERROR(pattern_binds_no_variables,none,
       "%select{property|global variable}0 declaration does not bind any "
       "variables",

--- a/stdlib/public/core/Hasher.swift
+++ b/stdlib/public/core/Hasher.swift
@@ -16,6 +16,9 @@
 
 import SwiftShims
 
+// FIXME: Remove @usableFromInline once Hasher is resilient.
+// rdar://problem/38549901
+@usableFromInline
 internal protocol _HasherCore {
   init(seed: (UInt64, UInt64))
   mutating func compress(_ value: UInt64)
@@ -74,6 +77,9 @@ internal func _loadPartialUnalignedUInt64LE(
 /// trailing bytes, while the most significant 8 bits hold the count of bytes
 /// appended so far, modulo 256. The count of bytes currently stored in the
 /// buffer is in the lower three bits of the byte count.)
+// FIXME: Remove @usableFromInline and @_fixed_layout once Hasher is resilient.
+// rdar://problem/38549901
+@usableFromInline @_fixed_layout
 internal struct _HasherTailBuffer {
   // msb                                                             lsb
   // +---------+-------+-------+-------+-------+-------+-------+-------+
@@ -146,6 +152,9 @@ internal struct _HasherTailBuffer {
   }
 }
 
+// FIXME: Remove @usableFromInline and @_fixed_layout once Hasher is resilient.
+// rdar://problem/38549901
+@usableFromInline @_fixed_layout
 internal struct _BufferingHasher<Core: _HasherCore> {
   private var _buffer: _HasherTailBuffer
   private var _core: Core
@@ -278,7 +287,13 @@ internal struct _BufferingHasher<Core: _HasherCore> {
 ///   versions of the standard library.
 @_fixed_layout // FIXME: Should be resilient (rdar://problem/38549901)
 public struct Hasher {
+  // FIXME: Remove @usableFromInline once Hasher is resilient.
+  // rdar://problem/38549901
+  @usableFromInline
   internal typealias RawCore = _SipHash13Core
+  // FIXME: Remove @usableFromInline once Hasher is resilient.
+  // rdar://problem/38549901
+  @usableFromInline
   internal typealias Core = _BufferingHasher<RawCore>
 
   internal var _core: Core

--- a/stdlib/public/core/SipHash.swift
+++ b/stdlib/public/core/SipHash.swift
@@ -19,7 +19,10 @@
 /// * Daniel J. Bernstein <djb@cr.yp.to>
 //===----------------------------------------------------------------------===//
 
-private struct _SipHashState {
+// FIXME: Remove @usableFromInline and @_fixed_layout once Hasher is resilient.
+// rdar://problem/38549901
+@usableFromInline @_fixed_layout
+internal struct _SipHashState {
   // "somepseudorandomlygeneratedbytes"
   fileprivate var v0: UInt64 = 0x736f6d6570736575
   fileprivate var v1: UInt64 = 0x646f72616e646f6d
@@ -69,6 +72,9 @@ private struct _SipHashState {
   }
 }
 
+// FIXME: Remove @usableFromInline and @_fixed_layout once Hasher is resilient.
+// rdar://problem/38549901
+@usableFromInline @_fixed_layout
 internal struct _SipHash13Core: _HasherCore {
   private var _state: _SipHashState
 


### PR DESCRIPTION
That is, a stored instance property of a fixed-contents struct in a resilient module must have a type that's public or `@usableFromInline`, so that it can be manipulated from outside the module without having to use the struct's value witness table.

This actually tripped on some declarations in the implementation of Hasher.