### PR TITLE
Zero-initialize -Onone debug shadow copies for exploded values 

### DIFF
--- a/test/DebugInfo/dbgvalue-insertpt.swift
+++ b/test/DebugInfo/dbgvalue-insertpt.swift
@@ -2,8 +2,8 @@
 // FIXME: This test should be testing a non-shadow-copied value instead.
 for i in 0 ..< 3 {
   // CHECK: %[[ALLOCA:[0-9]+]] = alloca %TSiSg
-  // CHECK: %i.addr = alloca i{{32|64}}
-  // CHECK-NEXT: call void @llvm.dbg.declare(metadata i{{32|64}}* %i.addr,
+  // CHECK: %i.debug = alloca i{{32|64}}
+  // CHECK-NEXT: call void @llvm.dbg.declare(metadata i{{32|64}}* %i.debug,
   // CHECK-SAME:                           metadata ![[I:[0-9]+]],
   // CHECK: call swiftcc{{.*}} @{{.*}}next{{.*}}
   // CHECK: %[[LD:[0-9]+]] = load i{{32|64}}, i{{32|64}}*
@@ -14,6 +14,6 @@ for i in 0 ..< 3 {
   //
   // CHECK: ; <label>:[[NEXT_BB]]:
   // CHECK: %[[PHI_VAL:.*]] = phi i{{32|64}} [ %[[LD]], %[[SUCCESS]] ]
-  // CHECK: store i{{32|64}} %[[PHI_VAL]], i{{32|64}}* %i.addr
+  // CHECK: store i{{32|64}} %[[PHI_VAL]], i{{32|64}}* %i.debug
   // CHECK: ![[I]] = !DILocalVariable(name: "i",
 }

--- a/test/DebugInfo/generic_arg2.swift
+++ b/test/DebugInfo/generic_arg2.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s
 
 // CHECK: define hidden swiftcc void @"$S12generic_arg25ClassC3foo{{.*}}, %swift.type* %U
-// CHECK: call void @llvm.dbg.declare(metadata %swift.opaque** %y.addr, metadata ![[U:.*]], metadata !DIExpression())
+// CHECK: call void @llvm.dbg.declare(metadata %swift.opaque** %y.debug, metadata ![[U:.*]], metadata !DIExpression())
 // Make sure there is no conflicting dbg.value for this variable.x
 // CHECK-NOT: dbg.value{{.*}}metadata ![[U]]
 class Class <T> {

--- a/test/DebugInfo/guard-let.swift
+++ b/test/DebugInfo/guard-let.swift
@@ -1,5 +1,7 @@
-// RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s
-// RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s --check-prefix=CHECK2
+// RUN: %target-swift-frontend %s -c -emit-ir -g -o - | \
+// RUN:   %FileCheck %s --check-prefix=CHECK1
+// RUN: %target-swift-frontend %s -c -emit-ir -g -o - | \
+// RUN:   %FileCheck %s --check-prefix=CHECK2
 
 // UNSUPPORTED: OS=watchos
 
@@ -7,16 +9,18 @@ func use<T>(_ t: T) {}
 
 public func f(_ i : Int?)
 {
-  // CHECK: define {{.*}}@"$S4main1fyySiSgF"
-  // CHECK1: %debug.copy = alloca %TSiSg
-  // CHECK1: @llvm.dbg.declare(metadata %TSiSg* %debug.copy
-  // CHECK1: @llvm.dbg.declare(metadata {{(i32|i64)}}* %val.addr, {{.*}}, !dbg ![[DBG0:.*]]
-  // CHECK1: %5 = bitcast %TSiSg* %debug.copy to i64*, !dbg
-  // CHECK1: store i64 %0, i64* %5, align 8, !dbg
+  // CHECK1-LABEL: define {{.*}}@"$S4main1fyySiSgF"
+  // CHECK1: %i.debug = alloca %TSiSg
+  // CHECK1: @llvm.dbg.declare(metadata %TSiSg* %i.debug
+  // CHECK1: %[[BITCAST:.*]] = bitcast %TSiSg* %i.debug to i8*
+  // CHECK1: call void @llvm.memset{{.*}}(i8* align {{(4|8)}} %[[BITCAST]],
+  // CHECK1-SAME:                         i8 0, i64 {{(5|9)}}, i1 false){{$}}
+  // CHECK1: @llvm.dbg.declare(metadata {{(i32|i64)}}* %val.debug,
+  // CHECK1-SAME:              !dbg ![[DBG0:.*]]
+  // CHECK1-LABEL: define {{.*}}@"$S4main1gyySSSgF"
   // CHECK1: ![[F:.*]] = distinct !DISubprogram(name: "f",
   // CHECK1: ![[BLK:.*]] = distinct !DILexicalBlock(scope: ![[F]],
-  // CHECK1: ![[DBG0]] = !DILocation(line: [[@LINE+2]],
-  // CHECK1: ![[DBG1]] = !DILocation(line: 0, scope: ![[BLK]])
+  // CHECK1: ![[DBG0]] = !DILocation(line: [[@LINE+1]],
   guard let val = i else { return }
   use(val)
 }
@@ -32,13 +36,12 @@ public func f(_ i : Int?)
 public func g(_ s : String?)
 {
   // CHECK2: define {{.*}}@"$S4main1gyySSSgF"
-  // CHECK2: %debug.copy = alloca %TSSSg
+  // CHECK2: %s.debug = alloca %TSSSg
   // CHECK2: @llvm.dbg.declare(metadata %TSSSg*
-  // CHECK2: %debug.copy1 = alloca %TSS
+  // CHECK2: %val.debug = alloca %TSS
   // CHECK2: @llvm.dbg.declare(metadata %TSS*
-  // CHECK2: %4 = bitcast %TSSSg* %debug.copy to {{.*}}*, !dbg
-  // CHECK2: %5 = getelementptr inbounds {{.*}}, {{.*}}* %4, i32 0, i32 0, !dbg
-  // CHECK2: store {{.*}} %0, {{.*}}* %5, align 8, !dbg
+  // CHECK2: %[[BITCAST:.*]] = bitcast %TSS* %val.debug to i8*{{$}}
+  // CHECK2: call void @llvm.memset.{{.*}}(i8* align {{(4|8)}} %[[BITCAST]], i8 0
   // CHECK2: ![[G:.*]] = distinct !DISubprogram(name: "g"
   guard let val = s else { return }
   use(val)

--- a/test/DebugInfo/linetable-codeview.swift
+++ b/test/DebugInfo/linetable-codeview.swift
@@ -47,12 +47,12 @@ func foo() {
   // NOTE: The point of this test is to trigger IRGenSIL::emitShadowCopy()
   //       and IRGenSIL::emitShadowCopyIfNeeded(). It may be worthwhile to
   //       simplify this testcase.
-  // CHECK: store float %0, float* %myArg.addr, {{.*}}, !dbg ![[PROLOGUE:[0-9]+]]
-  // CHECK: store float {{.*}}, float* %debug.copy.myVal1._value, {{.*}}, !dbg ![[PROLOGUE]]
+  // CHECK: store float %0, float* %myArg.debug, {{.*}}, !dbg ![[PROLOGUE:[0-9]+]]
+  // CHECK: store float {{.*}}, float* %self.debug.myVal1._value, {{.*}}, !dbg ![[PROLOGUE]]
 
 // func myLoop() {
   // CHECK: define {{.*}} @"$S4main6myLoopyyF"
-  // CHECK: call void @llvm.dbg.declare(metadata i64* %index.addr, {{.*}}), !dbg ![[FORLOOP:[0-9]+]]
+  // CHECK: call void @llvm.dbg.declare(metadata i64* %index.debug, {{.*}}), !dbg ![[FORLOOP:[0-9]+]]
   // CHECK: phi i64 [ %{{.[0-9]+}}, %{{.[0-9]+}} ], !dbg ![[FORLOOP]]
   // CHECK: call {{.*}} @"$S4main8markUsedyyxlF"{{.*}}, !dbg ![[FORBODY:[0-9]+]]
   // CHECK: ret void

--- a/test/DebugInfo/shadowcopy-linetable.swift
+++ b/test/DebugInfo/shadowcopy-linetable.swift
@@ -8,8 +8,8 @@ func foo(_ x: inout Int64) {
   // not.
   // CHECK: %[[X:.*]] = alloca %Ts5Int64V*, align {{(4|8)}}
   // CHECK-NEXT: call void @llvm.dbg.declare
-  // CHECK-NEXT: [[ZEROED:%[0-9]+]] = bitcast %Ts5Int64V** %[[X]] to %swift.opaque**
-  // CHECK-NEXT: store %swift.opaque* null, %swift.opaque** [[ZEROED]], align {{(4|8)}}
+  // CHECK-NEXT: %[[ZEROED:[0-9]+]] = bitcast %Ts5Int64V** %[[X]] to i8*{{$}}
+  // CHECK-NEXT: call void @llvm.memset.{{.*}}(i8* align {{(4|8)}} %[[ZEROED]], i8 0
   // CHECK: store %Ts5Int64V* %0, %Ts5Int64V** %[[X]], align {{(4|8)}}
   // CHECK-SAME: !dbg ![[LOC0:.*]]
   // CHECK-NEXT: getelementptr inbounds %Ts5Int64V, %Ts5Int64V* %0, i32 0, i32 0,

--- a/test/IRGen/alloc_box.swift
+++ b/test/IRGen/alloc_box.swift
@@ -9,7 +9,7 @@ func f() -> Bool? { return nil }
 })()
 
 // CHECK-LABEL: @"$S9alloc_boxyyXEfU_"
-// CHECK: <label>:8:
+// CHECK: <label>:9:
 // CHECK-NOT: call void @swift_setDeallocating
 // CHECK: call void @swift_deallocUninitializedObject
 

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -748,6 +748,7 @@ func unsafeGuaranteed_test(_ x: Builtin.NativeObject) -> Builtin.NativeObject {
 // CHECK-LABEL: define {{.*}} @{{.*}}unsafeGuaranteedEnd_test
 // CHECK-NEXT: {{.*}}:
 // CHECK-NEXT: alloca
+// CHECK-NEXT: memset
 // CHECK-NEXT: store
 // CHECK-NEXT: ret void
 func unsafeGuaranteedEnd_test(_ x: Builtin.Int8) {

--- a/test/IRGen/class_bounded_generics.swift
+++ b/test/IRGen/class_bounded_generics.swift
@@ -298,7 +298,7 @@ func archetype_with_generic_class_constraint<T, U>(t: T) where T : A<U> {
 
 // CHECK-LABEL: define hidden swiftcc void @"$S22class_bounded_generics029calls_archetype_with_generic_A11_constraint1ayAA1ACyxG_tlF"(%T22class_bounded_generics1AC*) #0 {
 // CHECK:      alloca
-// CHECK:      store
+// CHECK:      memset
 // CHECK:      [[ISA_ADDR:%.*]] = getelementptr inbounds %T22class_bounded_generics1AC, %T22class_bounded_generics1AC* %0, i32 0, i32 0, i32 0
 // CHECK-NEXT: [[ISA:%.*]] = load %swift.type*, %swift.type** [[ISA_ADDR]]
 // CHECK:      [[ISA_PTR:%.*]] = bitcast %swift.type* [[ISA]] to %swift.type**

--- a/test/IRGen/objc.swift
+++ b/test/IRGen/objc.swift
@@ -91,7 +91,7 @@ func test1(_ cell: Blammo) {}
 // CHECK-NEXT:    entry
 // CHECK-NEXT:    alloca
 // CHECK-NEXT:    bitcast
-// CHECK-NEXT:    store
+// CHECK-NEXT:    memset
 // CHECK-NEXT:    store
 // CHECK-NEXT:    ret void
 

--- a/test/IRGen/struct_resilience.swift
+++ b/test/IRGen/struct_resilience.swift
@@ -97,7 +97,7 @@ public func functionWithMyResilientTypesSize(_ s: __owned MySize, f: (__owned My
 // CHECK: bitcast
 // CHECK: llvm.lifetime.start
 // CHECK: bitcast
-// CHECK: [[COPY:%.*]] = bitcast %T17struct_resilience6MySizeV* %4 to i8*
+// CHECK: [[COPY:%.*]] = bitcast %T17struct_resilience6MySizeV* %5 to i8*
 // CHECK: [[ARG:%.*]] = bitcast %T17struct_resilience6MySizeV* %1 to i8*
 // CHECK: call void @llvm.memcpy{{.*}}(i8* align {{4|8}} [[COPY]], i8* align {{4|8}} [[ARG]], {{i32 8|i64 16}}, i1 false)
 // CHECK: [[FN:%.*]] = bitcast i8* %2


### PR DESCRIPTION
and simplify the initialization code by emitting a memset intrinsic.

rdar://problem/43566087
