### PR TITLE
NFC: Moved GraphOperationInfo related code into a separate translation unit

### DIFF
--- a/include/swift/SIL/GraphOperationInfo.h
+++ b/include/swift/SIL/GraphOperationInfo.h
@@ -1,0 +1,146 @@
+//===--- GraphOperationInfo.h - GraphOperationInst Parse Logic --*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the parsing logic for a GraphOperationInst, in particular
+// decoding the mangled inst name string for the operands and attributes.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_GRAPH_OPERATION_INFO_H
+#define SWIFT_AST_GRAPH_OPERATION_INFO_H
+
+#include "swift/AST/Identifier.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace swift {
+class GraphOperationInst;
+
+namespace tf {
+/// Holds information about a TensorFlow operation as represented in SIL
+/// as GraphOperationInst.
+struct GraphOperationInfo {
+  /// One of these records exists for every operand that the BuiltinInst has,
+  /// classifying the operand into a couple of buckets.  The most coarse grain
+  /// classification is "input" vs "attribute": the inputs come first,
+  /// followed by the attributes.  However, we need to be able to model the
+  /// fact that some input arguments are aggregated together into a single
+  /// input that is an array of tensors.  An integer attribute may be either
+  /// a Tensor value or an integer-encoded DType, etc.
+  enum class OperandClass {
+    /// Indicates one of the following:
+    /// 1) A normal tensor input: the value is a TensorHandle.
+    /// 2) An normal attribute (without modifier).
+    /// 3) A tensor or shape attribute (need a modifier for proper lowering).
+    /// 4) An array attribute (needed for parsing tfop, and dropped before graph
+    ///    lowering).
+    Input,
+
+    /// No modifier.
+    Normal,
+
+    /// Indicates that the array or scalar should be turned into a TF_Tensor.
+    Tensor,
+
+    /// Indicates that the array of integers should be interpreted as a shape.
+    Shape,
+
+    /// Indicates the metatype of a TensorFlow value type or an aggregate of
+    /// TensorFlow value types should be turned into a list of unknown shapes.
+    UnknownShapeList,
+
+    /// Indicates that the operand should be interpreted as an array. When
+    /// applied to the metatype of a TensorFlow value type or an aggregate of
+    /// TensorFlow value types, it will be flattened into an array of dtypes of
+    /// each TensorFlow value type as a Normal operand.
+    Array,
+
+    /// An operand specifying the address where an indirect output should be
+    /// stored.  This occurs when the tfop exists in a context where its output
+    /// is address-only.  Deabstraction eliminates Out operands before forming
+    /// graph_ops, by rewriting the tfop to return the value directly.  This
+    /// rewriting is possible because tfop outputs must always be loadable in
+    /// deabstraction scopes.
+    Out,
+  };
+
+  /// Return the string suffix for the specified attribute modifier.
+  static const char *
+  getOperandClassSuffix(GraphOperationInfo::OperandClass opClass);
+
+  /// Return the operand class of the specified string form like "tensor"
+  static llvm::Optional<GraphOperationInfo::OperandClass>
+  getOperandClass(StringRef suffix);
+
+  /// The instruction being analyzed.
+  GraphOperationInst *inst;
+
+  explicit GraphOperationInfo(GraphOperationInst *inst) : inst(inst) {}
+
+  /// Return the device attribute associated with `inst`, which is required to
+  /// exist.
+  // StringRef getDeviceString() const;
+
+  // /// Return the device type for this instruction.
+  // DeviceType getDeviceType() const {
+  //   return getOpDeviceType(getDeviceString());
+  // }
+
+  enum InputMarker {
+    /// Scalar input, used by tfc.scalarToTensor only.
+    IM_Scalar,
+    /// Normal tensor, variant or resource input.
+    IM_Normal,
+    /// Marker for the start of an input list, has no corresponding operand.
+    IM_InputList,
+    /// Element of an input list.
+    IM_InputListElt,
+  };
+
+  /// Return a comma and letter identifier whose letter corresponds to the
+  /// specified InputMarker.
+  static const char *getInputMarker(InputMarker kind) {
+    switch (kind) {
+    case IM_Scalar:
+      return ",s";
+    case IM_Normal:
+      return ",i";
+    case IM_InputList:
+      return ",L";
+    case IM_InputListElt:
+      return ",e";
+    }
+  }
+
+  /// Decode the name of a graph_op into its TensorFlow op name and a list of
+  /// information about the operands.
+  llvm::StringRef decodeName(llvm::SmallVectorImpl<InputMarker> &inputInfo);
+
+  /// Given an attribute name like foo$tensor, decode the name and the class.
+  /// If there is no modifier specified, this defaults to
+  /// OperandClass::Normal.
+  static std::pair<llvm::StringRef, OperandClass>
+  decodeAttributeName(Identifier name);
+
+  /// Get an int-typed attribute at `attrIdx`, which must have `attrName`.
+  int64_t getIntAttr(unsigned attrIdx, llvm::StringRef attrName) const;
+
+  /// Get a string-typed attribute at `attrIdx`, which must have `attrName`.
+  std::string getStringAttr(unsigned attrIdx, llvm::StringRef attrName) const;
+  // /// Get a float-typed attribute at `attrIdx`, which must have `attrName`.
+  // float getFloatAttr(unsigned attrIdx, llvm::StringRef attrName) const;
+
+  void assertWithDump(bool cond, const char *assertMsg) const;
+};
+} // end namespace tf
+} // end namespace swift
+#endif // SWIFT_AST_GRAPH_OPERATION_INFO_H

--- a/include/swift/SIL/GraphOperationInfo.h
+++ b/include/swift/SIL/GraphOperationInfo.h
@@ -15,8 +15,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_AST_GRAPH_OPERATION_INFO_H
-#define SWIFT_AST_GRAPH_OPERATION_INFO_H
+#ifndef SWIFT_SIL_GRAPH_OPERATION_INFO_H
+#define SWIFT_SIL_GRAPH_OPERATION_INFO_H
 
 #include "swift/AST/Identifier.h"
 #include "llvm/ADT/SmallVector.h"
@@ -143,4 +143,4 @@ struct GraphOperationInfo {
 };
 } // end namespace tf
 } // end namespace swift
-#endif // SWIFT_AST_GRAPH_OPERATION_INFO_H
+#endif // SWIFT_SIL_GRAPH_OPERATION_INFO_H

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -36,6 +36,8 @@ add_swift_library(swiftAST STATIC
   GenericEnvironment.cpp
   GenericSignature.cpp
   GenericSignatureBuilder.cpp
+  # SWIFT_ENABLE_TENSORFLOW
+  GraphOperationInfo.cpp
   Identifier.cpp
   LayoutConstraint.cpp
   LookupVisibleDecls.cpp

--- a/lib/AST/GraphOperationInfo.cpp
+++ b/lib/AST/GraphOperationInfo.cpp
@@ -1,0 +1,150 @@
+//===--- GraphOperationInfo.cpp - GraphOperationInst Parse Logic ----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SIL/GraphOperationInfo.h"
+#include "swift/SIL/SILConstants.h"
+#include "swift/SIL/SILInstruction.h"
+
+using llvm::SmallVectorImpl;
+using llvm::StringRef;
+using namespace swift;
+using namespace tf;
+typedef GraphOperationInfo::OperandClass OperandClass;
+
+/// Return the string suffix for the specified attribute modifier.
+const char *GraphOperationInfo::getOperandClassSuffix(OperandClass opClass) {
+  switch (opClass) {
+  case OperandClass::Input:
+    return "$in";
+  case OperandClass::Normal:
+    return "";
+  case OperandClass::Tensor:
+    return "$tensor";
+  case OperandClass::Shape:
+    return "$shape";
+  case OperandClass::UnknownShapeList:
+    return "$unknownShapeList";
+  case OperandClass::Array:
+    return "$array";
+  case OperandClass::Out:
+    return "$out";
+  }
+}
+
+/// Return the operand class of the specified string form like "tensor"
+llvm::Optional<OperandClass>
+GraphOperationInfo::getOperandClass(StringRef suffix) {
+  return llvm::StringSwitch<llvm::Optional<OperandClass>>(suffix)
+      .Case("in", OperandClass::Input)
+      .Case("", OperandClass::Normal)
+      .Case("tensor", OperandClass::Tensor)
+      .Case("shape", OperandClass::Shape)
+      .Case("unknownShapeList", OperandClass::UnknownShapeList)
+      .Case("array", OperandClass::Array)
+      .Case("out", OperandClass::Out)
+      .Default(None);
+}
+
+/// Return the device attribute associated with `inst`, which is required to
+/// exist.
+// StringRef GraphOperationInfo::getDeviceString() const {
+//   auto attr = inst->getAttributeNamed(DEVICE_ATTR);
+//   assertWithDump(attr.hasValue(), "Tensor op instruction has no device
+//   string"); return attr.getValue().getStringValue();
+// }
+
+void GraphOperationInfo::assertWithDump(bool cond,
+                                        const char *assertMsg) const {
+#ifndef NDEBUG
+  if (cond)
+    return;
+  inst->dump();
+  llvm_unreachable(assertMsg);
+#endif // NDEBUG
+}
+
+/// Decode the name of a graph_op into its TensorFlow op name and a list of
+/// information about the operands.
+StringRef
+GraphOperationInfo::decodeName(SmallVectorImpl<InputMarker> &inputInfo) {
+  auto name = inst->getName().str();
+  auto pos = name.find(',');
+  auto opName = name.substr(0, pos);
+
+  while (pos != StringRef::npos) {
+    name = name.drop_front(pos + 1);
+    pos = name.find(',');
+    auto letter = name.substr(0, pos);
+    assertWithDump(letter.size() == 1, "malformed graph_op instruction");
+    InputMarker kind;
+    switch (letter[0]) {
+    case 's':
+      kind = InputMarker::IM_Scalar;
+      break;
+    case 'i':
+      kind = InputMarker::IM_Normal;
+      break;
+    case 'L':
+      kind = InputMarker::IM_InputList;
+      break;
+    case 'e':
+      kind = InputMarker::IM_InputListElt;
+      break;
+    default:
+      assertWithDump(false, "malformed graph_op instruction");
+    }
+    inputInfo.push_back(kind);
+  }
+
+  return opName;
+}
+
+/// Given an attribute name like foo$tensor, decode the name and the class.  If
+/// there is no modifier specified, this defaults to OperandClass::Normal.
+std::pair<StringRef, GraphOperationInfo::OperandClass>
+GraphOperationInfo::decodeAttributeName(Identifier name) {
+  auto nameStr = name.str();
+  // Figure out what the suffix is (if any).
+  auto dollarLoc = nameStr.find('$');
+
+  auto opClass = OperandClass::Normal;
+  if (dollarLoc != StringRef::npos) {
+    auto suffix = nameStr.drop_front(dollarLoc + 1);
+    if (auto res = getOperandClass(suffix))
+      opClass = res.getValue();
+    else {
+      std::string msg = "invalid attribute modifier '" + name.str().str() + "'";
+      llvm_unreachable(msg.c_str());
+    }
+  }
+
+  // Slice the suffix off the attribute name and add the decoded version.
+  return {nameStr.substr(0, dollarLoc), opClass};
+}
+
+int64_t GraphOperationInfo::getIntAttr(unsigned attrIdx,
+                                       StringRef attrName) const {
+  auto attr = inst->getAttribute(attrIdx);
+  auto attrInfo = GraphOperationInfo::decodeAttributeName(attr.name);
+  assert(attrInfo.first == attrName);
+  auto attrValue = attr.value;
+  return attrValue.getIntegerValue().getLimitedValue();
+}
+
+std::string GraphOperationInfo::getStringAttr(unsigned attrIdx,
+                                              StringRef attrName) const {
+  auto attr = inst->getAttribute(attrIdx);
+  auto attrInfo = GraphOperationInfo::decodeAttributeName(attr.name);
+  assert(attrInfo.first == attrName);
+  auto attrValue = attr.value;
+  return attrValue.getStringValue().str();
+}

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1888,7 +1888,8 @@ void IRGenSILFunction::visitGraphOperationInst(GraphOperationInst *i) {
   // maps to void* in the Swift-C calling convention.
   auto getContextFn = llvmModule.getOrInsertFunction(
       "_swift_tfc_GetGlobalEagerContext",
-      llvm::TypeBuilder<void *(), false>::get(llvmContext));
+      llvm::TypeBuilder<void *(), /*cross_compilable=*/false>::get(
+          llvmContext));
   auto eagerContext = Builder.CreateCall(getContextFn, {});
 
   // The true function type is TFE_Context* -> TFE_TensorHandle*.

--- a/lib/SILOptimizer/Mandatory/TFDeviceSupport.h
+++ b/lib/SILOptimizer/Mandatory/TFDeviceSupport.h
@@ -45,6 +45,7 @@ enum class DeviceType {
 static const int NUM_DEVICE_TYPES = 5;
 
 class DevicePartitionerImpl;
+struct GraphOperationInfo;
 
 static const char DEFAULT_CPU_DEVICE[] = "/device:CPU:0";
 static const char DEFAULT_GPU_DEVICE[] = "/device:GPU:0";
@@ -63,7 +64,7 @@ static const char DEVICE_ATTR[] = "__device";
 // other TF ops (e.g. a "Const" op).
 static const char SHAPE_ARRAY_ATTR[] = "__shapes";
 
-static DeviceType getOpDeviceType(llvm::StringRef device) {
+static inline DeviceType getOpDeviceType(llvm::StringRef device) {
   if (device.str() == DEFAULT_CPU_DEVICE)
     return DeviceType::CPU;
   if (device.str() == DEFAULT_GPU_DEVICE)
@@ -93,6 +94,10 @@ static inline std::string getDeviceString(DeviceType deviceType) {
     llvm_unreachable("Unsupported device type");
   }
 }
+
+StringRef getDeviceString(const GraphOperationInfo &graphOpInfo);
+
+DeviceType getDeviceType(const GraphOperationInfo &graphOpInfo);
 
 /// The returned string can be used to construct SIL function names.
 static inline std::string getDeviceShortName(DeviceType deviceType) {

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -2055,7 +2055,7 @@ bool TFFunctionPartition::markFunction(bool &hasTensorOps) {
       tensorOps.push_back(inst);
       tensorOpsSet.insert(inst);
 
-      auto opDevice = GraphOperationInfo(graphOp).getDeviceType();
+      auto opDevice = getDeviceType(GraphOperationInfo(graphOp));
       deviceInfo.markDeviceUsed(opDevice);
     }
   }


### PR DESCRIPTION
This is in preparation for its new use in IRgen for decoding graph_op insts.

Elevated it from SILOptimizer/ to SIL/, so that IRGen can depend on it.
