### PR TITLE
Generalize extra inhabitants of tuples.

### DIFF
--- a/foo.swift
+++ b/foo.swift
@@ -1,0 +1,25 @@
+
+enum SinglePayloadGenericEnumWithDefaultMirror<T, U> {
+  case Well
+  case Faucet
+  case Pipe(T, U)
+}
+
+func foo(x: Int, y: [Int], out: (SinglePayloadGenericEnumWithDefaultMirror<Int, [Int]>) -> ()) {
+  out(.Well)
+  out(.Faucet)
+  out(.Pipe(x, y))
+}
+
+func bar<T, U>(_ x: SinglePayloadGenericEnumWithDefaultMirror<T, U>) {
+  switch x {
+  case .Well:
+    print("well")
+  case .Faucet:
+    print("faucet")
+  case .Pipe:
+    print("pipe")
+  }
+}
+
+foo(x: 1, y: [1,2,3], out: bar)

--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -1443,7 +1443,7 @@ struct TargetTupleTypeMetadata : public TargetMetadata<Runtime> {
   using StoredSize = typename Runtime::StoredSize;
   TargetTupleTypeMetadata() = default;
   constexpr TargetTupleTypeMetadata(const TargetMetadata<Runtime> &base,
-                                    StoredSize numElements,
+                                    uint32_t numElements,
                                     TargetPointer<Runtime, const char> labels)
     : TargetMetadata<Runtime>(base),
       NumElements(numElements),
@@ -1487,14 +1487,19 @@ struct TargetTupleTypeMetadata : public TargetMetadata<Runtime> {
     return getElements()[i];
   }
 
-  static constexpr StoredSize OffsetToNumElements = sizeof(TargetMetadata<Runtime>);
-
+  static constexpr StoredSize getOffsetToNumElements();
   static bool classof(const TargetMetadata<Runtime> *metadata) {
     return metadata->getKind() == MetadataKind::Tuple;
   }
 };
 using TupleTypeMetadata = TargetTupleTypeMetadata<InProcess>;
   
+template <typename Runtime>
+constexpr inline auto
+TargetTupleTypeMetadata<Runtime>::getOffsetToNumElements() -> StoredSize {
+  return offsetof(TargetTupleTypeMetadata<Runtime>, NumElements);
+}
+
 template <typename Runtime> struct TargetProtocolDescriptor;
 
 #if SWIFT_OBJC_INTEROP

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -244,7 +244,6 @@ public:
 
 public:
   constexpr TargetExtraInhabitantFlags() : Data(0) {}
-
   /// The number of extra inhabitants in the type's representation.
   int getNumExtraInhabitants() const { return Data & NumExtraInhabitantsMask; }
 

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -1087,8 +1087,8 @@ protected:
         return _readMetadata<TargetStructMetadata>(address);
       case MetadataKind::Tuple: {
         auto numElementsAddress = address +
-          TargetTupleTypeMetadata<Runtime>::OffsetToNumElements;
-        StoredSize numElements;
+          TargetTupleTypeMetadata<Runtime>::getOffsetToNumElements();
+        uint32_t numElements;
         if (!Reader->readInteger(RemoteAddress(numElementsAddress),
                                  &numElements))
           return nullptr;

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -108,8 +108,6 @@ namespace {
   class StructTypeInfoBase :
      public RecordTypeInfo<Impl, Base, FieldInfoType> {
     using super = RecordTypeInfo<Impl, Base, FieldInfoType>;
-   mutable Optional<const FieldInfoType *> ExtraInhabitantProvidingField;
-   mutable Optional<bool> MayHaveExtraInhabitants;
   protected:
     template <class... As>
     StructTypeInfoBase(StructTypeInfoKind kind, As &&...args)
@@ -145,9 +143,18 @@ namespace {
       auto elements = in.getRange(fieldRange.first, fieldRange.second);
       out.add(elements);
     }
+       
+    /// Given the address of a struct value, project out the address of a
+    /// single field.
+    Address projectFieldAddress(IRGenFunction &IGF,
+                                Address addr,
+                                SILType T,
+                                const FieldInfoType &field) const {
+      return asImpl().projectFieldAddress(IGF, addr, T, field.Field);
+    }
 
-    /// Given the address of a tuple, project out the address of a
-    /// single element.
+    /// Given the address of a struct value, project out the address of a
+    /// single field.
     Address projectFieldAddress(IRGenFunction &IGF,
                                 Address addr,
                                 SILType T,
@@ -202,216 +209,6 @@ namespace {
       return fieldInfo.getStructIndex();
     }
 
-    bool mayHaveExtraInhabitants(IRGenModule &IGM) const override {
-      if (!MayHaveExtraInhabitants.hasValue()) {
-        MayHaveExtraInhabitants = false;
-        for (auto &field : asImpl().getFields())
-          if (field.getTypeInfo().mayHaveExtraInhabitants(IGM)) {
-            MayHaveExtraInhabitants = true;
-            break;
-          }
-      }
-      return *MayHaveExtraInhabitants;
-    }
-
-    // This is dead code in NonFixedStructTypeInfo.
-    unsigned getFixedExtraInhabitantCount(IRGenModule &IGM) const {
-      if (auto field = asImpl().getFixedExtraInhabitantProvidingField(IGM)) {
-        auto &fieldTI = cast<FixedTypeInfo>(field->getTypeInfo());
-        return fieldTI.getFixedExtraInhabitantCount(IGM);
-      }
-      
-      return 0;
-    }
-
-    // This is dead code in NonFixedStructTypeInfo.
-    APInt getFixedExtraInhabitantValue(IRGenModule &IGM,
-                                       unsigned bits,
-                                       unsigned index) const {
-      // We are only called if the type is known statically to have extra
-      // inhabitants.
-      auto &field = *asImpl().getFixedExtraInhabitantProvidingField(IGM);
-      auto &fieldTI = cast<FixedTypeInfo>(field.getTypeInfo());
-      APInt fieldValue = fieldTI.getFixedExtraInhabitantValue(IGM, bits, index);
-      return fieldValue.shl(field.getFixedByteOffset().getValueInBits());
-    }
-
-    // This is dead code in NonFixedStructTypeInfo.
-    APInt getFixedExtraInhabitantMask(IRGenModule &IGM) const {
-      auto field = asImpl().getFixedExtraInhabitantProvidingField(IGM);
-      if (!field)
-        return APInt();
-      
-      const FixedTypeInfo &fieldTI
-        = cast<FixedTypeInfo>(field->getTypeInfo());
-      auto targetSize = asImpl().getFixedSize().getValueInBits();
-      
-      if (fieldTI.isKnownEmpty(ResilienceExpansion::Maximal))
-        return APInt(targetSize, 0);
-      
-      APInt fieldMask = fieldTI.getFixedExtraInhabitantMask(IGM);
-      if (targetSize > fieldMask.getBitWidth())
-        fieldMask = fieldMask.zext(targetSize);
-      fieldMask = fieldMask.shl(field->getFixedByteOffset().getValueInBits());
-      return fieldMask;
-    }
-    
-    // Perform an operation using the field that provides extra inhabitants for
-    // the aggregate, whether that field is known statically or dynamically.
-    llvm::Value *withExtraInhabitantProvidingField(IRGenFunction &IGF,
-           Address structAddr,
-           SILType structType,
-           bool isOutlined,
-           llvm::Type *resultTy,
-           llvm::function_ref<llvm::Value* (const FieldInfoType &field)> body,
-           llvm::function_ref<llvm::Value* ()> outline) const {
-      // If we know one field consistently provides extra inhabitants, delegate
-      // to that field.
-      if (auto field = asImpl().getFixedExtraInhabitantProvidingField(IGF.IGM)){
-        return body(*field);
-      }
-      
-      // Otherwise, we have to figure out which field at runtime.
-      // The decision tree could be rather large, so invoke the value witness
-      // unless we're emitting the value witness.
-      if (!isOutlined)
-        return outline();
-
-      // The number of extra inhabitants the instantiated type has can be used
-      // to figure out which field the runtime chose. The runtime uses the same
-      // algorithm as above--use the field with the most extra inhabitants,
-      // favoring the earliest field in a tie. If we test the number of extra
-      // inhabitants in the struct against each field type's, then the first
-      // match should indicate which field we chose.
-      //
-      // We can reduce the decision space somewhat if there are fixed-layout
-      // fields, since we know the only possible runtime choices are
-      // either the fixed field with the most extra inhabitants (if any), or
-      // one of the unknown-layout fields.
-      //
-      // See whether we have a fixed candidate.
-      const FieldInfoType *fixedCandidate = nullptr;
-      unsigned fixedCount = 0;
-      for (auto &field : asImpl().getFields()) {
-        if (!field.getTypeInfo().mayHaveExtraInhabitants(IGF.IGM))
-          continue;
-        
-        if (const FixedTypeInfo *fixed =
-              dyn_cast<FixedTypeInfo>(&field.getTypeInfo())) {
-          auto fieldCount = fixed->getFixedExtraInhabitantCount(IGF.IGM);
-          if (fieldCount > fixedCount) {
-            fixedCandidate = &field;
-            fixedCount = fieldCount;
-          }
-        }
-      }
-      
-      // Loop through checking to see whether we picked the fixed candidate
-      // (if any) or one of the unknown-layout fields.
-      llvm::Value *instantiatedCount
-        = emitLoadOfExtraInhabitantCount(IGF, structType);
-      
-      auto contBB = IGF.createBasicBlock("chose_field_for_xi");
-      llvm::PHINode *contPhi = nullptr;
-      if (resultTy != IGF.IGM.VoidTy)
-        contPhi = llvm::PHINode::Create(resultTy,
-                                        asImpl().getFields().size());
-      
-      // If two fields have the same type, they have the same extra inhabitant
-      // count, and we'll pick the first. We don't have to check both.
-      SmallPtrSet<SILType, 4> visitedTypes;
-      
-      for (auto &field : asImpl().getFields()) {
-        if (!field.getTypeInfo().mayHaveExtraInhabitants(IGF.IGM))
-          continue;
-
-        ConditionalDominanceScope condition(IGF);
-
-        llvm::Value *fieldCount;
-        if (isa<FixedTypeInfo>(field.getTypeInfo())) {
-          // Skip fixed fields except for the candidate with the most known
-          // extra inhabitants we picked above.
-          if (&field != fixedCandidate)
-            continue;
-          
-          fieldCount = llvm::ConstantInt::get(IGF.IGM.SizeTy, fixedCount);
-        } else {
-          auto fieldTy = field.getType(IGF.IGM, structType);
-          // If this field has the same type as a field we already tested,
-          // we'll never pick this one, since they both have the same count.
-          if (!visitedTypes.insert(fieldTy).second)
-            continue;
-        
-          fieldCount = emitLoadOfExtraInhabitantCount(IGF, fieldTy);
-        }
-        auto equalsCount = IGF.Builder.CreateICmpEQ(instantiatedCount,
-                                                    fieldCount);
-        
-        auto yesBB = IGF.createBasicBlock("");
-        auto noBB = IGF.createBasicBlock("");
-        
-        IGF.Builder.CreateCondBr(equalsCount, yesBB, noBB);
-        
-        IGF.Builder.emitBlock(yesBB);
-        auto value = body(field);
-        if (contPhi)
-          contPhi->addIncoming(value, IGF.Builder.GetInsertBlock());
-        IGF.Builder.CreateBr(contBB);
-        
-        IGF.Builder.emitBlock(noBB);
-      }
-      
-      // We shouldn't have picked a number of extra inhabitants inconsistent
-      // with any individual field.
-      IGF.Builder.CreateUnreachable();
-      
-      IGF.Builder.emitBlock(contBB);
-      if (contPhi)
-        IGF.Builder.Insert(contPhi);
-     
-      return contPhi;
-    }
-
-    llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF,
-                                         Address structAddr,
-                                         SILType structType,
-                                         bool isOutlined) const override {
-      return withExtraInhabitantProvidingField(IGF, structAddr, structType,
-                                               isOutlined,
-                                               IGF.IGM.Int32Ty,
-        [&](const FieldInfoType &field) -> llvm::Value* {
-          Address fieldAddr = asImpl().projectFieldAddress(
-                                     IGF, structAddr, structType, field.Field);
-          return field.getTypeInfo().getExtraInhabitantIndex(IGF, fieldAddr,
-                                           field.getType(IGF.IGM, structType),
-                                           false /*not outlined for field*/);
-        },
-        [&]() -> llvm::Value * {
-          return emitGetExtraInhabitantIndexCall(IGF, structType, structAddr);
-        });
-    }
-
-    void storeExtraInhabitant(IRGenFunction &IGF,
-                              llvm::Value *index,
-                              Address structAddr,
-                              SILType structType,
-                              bool isOutlined) const override {
-      withExtraInhabitantProvidingField(IGF, structAddr, structType, isOutlined,
-                                        IGF.IGM.VoidTy,
-        [&](const FieldInfoType &field) -> llvm::Value* {
-          Address fieldAddr = asImpl().projectFieldAddress(
-                                     IGF, structAddr, structType, field.Field);
-          field.getTypeInfo().storeExtraInhabitant(IGF, index, fieldAddr,
-                                           field.getType(IGF.IGM, structType),
-                                           false /*not outlined for field*/);
-          return nullptr;
-        },
-        [&]() -> llvm::Value * {
-          emitStoreExtraInhabitantCall(IGF, structType, index, structAddr);
-          return nullptr;
-        });
-    }
-       
     bool isSingleRetainablePointer(ResilienceExpansion expansion,
                                    ReferenceCounting *rc) const override {
       auto fields = asImpl().getFields();
@@ -487,68 +284,6 @@ namespace {
           continue;
         }
       }
-    }
-       
-    const FieldInfoType *
-    getFixedExtraInhabitantProvidingField(IRGenModule &IGM) const {
-      if (!ExtraInhabitantProvidingField.hasValue()) {
-        unsigned mostExtraInhabitants = 0;
-        const FieldInfoType *fieldWithMost = nullptr;
-        const FieldInfoType *singleNonFixedField = nullptr;
-
-        // TODO: If two fields have the same type, they have the same extra
-        // inhabitant count, and we'll pick the first. We don't have to check
-        // both. However, we don't always have access to the substituted struct
-        // type from this context, which would be necessary to make that
-        // judgment reliably.
-        
-        for (auto &field : asImpl().getFields()) {
-          auto &ti = field.getTypeInfo();
-          if (!ti.mayHaveExtraInhabitants(IGM))
-            continue;
-          
-          auto *fixed = dyn_cast<FixedTypeInfo>(&field.getTypeInfo());
-          // If any field is non-fixed, we can't definitively pick a best one,
-          // unless it happens to be the only non-fixed field and none of the
-          // other fields have extra inhabitants.
-          if (!fixed) {
-            // If we already saw a non-fixed field, then we can't pick one
-            // at compile time.
-            if (singleNonFixedField) {
-              singleNonFixedField = fieldWithMost = nullptr;
-              break;
-            }
-            
-            // Otherwise, note this field for later. If we have no fixed
-            // candidates, it may be the only choice for extra inhabitants.
-            singleNonFixedField = &field;
-            continue;
-          }
-          
-          unsigned count = fixed->getFixedExtraInhabitantCount(IGM);
-          if (count > mostExtraInhabitants) {
-            mostExtraInhabitants = count;
-            fieldWithMost = &field;
-          }
-        }
-        
-        if (fieldWithMost) {
-          if (singleNonFixedField) {
-            // If we have a non-fixed and fixed candidate, we can't know for
-            // sure now.
-            ExtraInhabitantProvidingField = nullptr;
-          } else {
-            // If we had all fixed fields, pick the one with the most extra
-            // inhabitants.
-            ExtraInhabitantProvidingField = fieldWithMost;
-          }
-        } else {
-          // If there were no fixed candidates, but we had a single non-fixed
-          // field with potential extra inhabitants, then it's our only choice.
-          ExtraInhabitantProvidingField = singleNonFixedField;
-        }
-      }
-      return *ExtraInhabitantProvidingField;
     }
   };
   

--- a/lib/IRGen/GenTuple.cpp
+++ b/lib/IRGen/GenTuple.cpp
@@ -122,6 +122,15 @@ namespace {
 
     /// Given the address of a tuple, project out the address of a
     /// single element.
+    Address projectFieldAddress(IRGenFunction &IGF,
+                                Address addr,
+                                SILType T,
+                                const TupleFieldInfo &field) const {
+      return asImpl().projectElementAddress(IGF, addr, T, field.Index);
+    }
+
+    /// Given the address of a tuple, project out the address of a
+    /// single element.
     Address projectElementAddress(IRGenFunction &IGF,
                                   Address tuple,
                                   SILType T,
@@ -162,69 +171,6 @@ namespace {
                               Address src, SILType T,
                               bool isOutlined) const override {
       llvm_unreachable("unexploded tuple as argument?");
-    }
-
-    // For now, just use extra inhabitants from the first element.
-    // FIXME: generalize
-    bool mayHaveExtraInhabitants(IRGenModule &IGM) const override {
-      if (asImpl().getFields().empty()) return false;
-      return asImpl().getFields()[0].getTypeInfo().mayHaveExtraInhabitants(IGM);
-    }
-
-    // This is dead code in NonFixedTupleTypeInfo.
-    unsigned getFixedExtraInhabitantCount(IRGenModule &IGM) const {
-      if (asImpl().getFields().empty()) return 0;
-      auto &eltTI = cast<FixedTypeInfo>(asImpl().getFields()[0].getTypeInfo());
-      return eltTI.getFixedExtraInhabitantCount(IGM);
-    }
-
-    // This is dead code in NonFixedTupleTypeInfo.
-    APInt getFixedExtraInhabitantValue(IRGenModule &IGM,
-                                       unsigned bits,
-                                       unsigned index) const {
-      auto &eltTI = cast<FixedTypeInfo>(asImpl().getFields()[0].getTypeInfo());
-      return eltTI.getFixedExtraInhabitantValue(IGM, bits, index);
-    }
-        
-    // This is dead code in NonFixedTupleTypeInfo.
-    APInt getFixedExtraInhabitantMask(IRGenModule &IGM) const {
-      if (asImpl().getFields().empty())
-        return APInt();
-      
-      const FixedTypeInfo &fieldTI
-        = cast<FixedTypeInfo>(asImpl().getFields()[0].getTypeInfo());
-      auto size = asImpl().getFixedSize().getValueInBits();
-      
-      if (fieldTI.isKnownEmpty(ResilienceExpansion::Maximal))
-        return APInt(size, 0);
-      
-      APInt firstMask = fieldTI.getFixedExtraInhabitantMask(IGM);
-      return firstMask.zextOrTrunc(size);
-    }
-
-    llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF,
-                                         Address tupleAddr,
-                                         SILType tupleType,
-                                         bool isOutlined) const override {
-      Address eltAddr =
-        asImpl().projectElementAddress(IGF, tupleAddr, tupleType, 0);
-      auto &elt = asImpl().getFields()[0];
-      return elt.getTypeInfo().getExtraInhabitantIndex(IGF, eltAddr,
-                                             elt.getType(IGF.IGM, tupleType),
-                                             false /*not outlined for field*/);
-    }
-  
-    void storeExtraInhabitant(IRGenFunction &IGF,
-                              llvm::Value *index,
-                              Address tupleAddr,
-                              SILType tupleType,
-                              bool isOutlined) const override {
-      Address eltAddr =
-        asImpl().projectElementAddress(IGF, tupleAddr, tupleType, 0);
-      auto &elt = asImpl().getFields()[0];
-      elt.getTypeInfo().storeExtraInhabitant(IGF, index, eltAddr,
-                                             elt.getType(IGF.IGM, tupleType),
-                                             false /*not outlined for field*/);
     }
     
     void verify(IRGenTypeVerifierFunction &IGF,

--- a/stdlib/public/Reflection/TypeLowering.cpp
+++ b/stdlib/public/Reflection/TypeLowering.cpp
@@ -434,12 +434,13 @@ unsigned RecordTypeInfoBuilder::addField(unsigned fieldSize,
   Alignment = std::max(Alignment, fieldAlignment);
 
   switch (Kind) {
-  // The extra inhabitants of a struct are the same as the extra
+  // The extra inhabitants of a struct or tuple are the same as the extra
   // inhabitants of the field that has the most.
   // Opaque existentials pick up the extra inhabitants of their type metadata
   // field.
   case RecordKind::Struct:
   case RecordKind::OpaqueExistential:
+  case RecordKind::Tuple:
     NumExtraInhabitants = std::max(NumExtraInhabitants, numExtraInhabitants);
     break;
   
@@ -455,7 +456,6 @@ unsigned RecordTypeInfoBuilder::addField(unsigned fieldSize,
   case RecordKind::NoPayloadEnum:
   case RecordKind::SinglePayloadEnum:
   case RecordKind::ThickFunction:
-  case RecordKind::Tuple:
     if (Empty) {
       NumExtraInhabitants = numExtraInhabitants;
     }

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -950,6 +950,7 @@ public:
 
   // NOTE: if you change the layout of this type, you'll also need
   // to update tuple_getValueWitnesses().
+  unsigned ExtraInhabitantProvidingElement;
   ExtraInhabitantsValueWitnessTable Witnesses;
   FullMetadata<TupleTypeMetadata> Data;
 
@@ -994,7 +995,7 @@ public:
     // Order by the cheaper comparisons first:
 
     // The number of elements.
-    if (auto result = compareIntegers(key.NumElements, Data.NumElements))
+    if (auto result = compareIntegers(key.NumElements,(size_t)Data.NumElements))
       return result;
 
     // The element types.
@@ -1220,15 +1221,41 @@ static OpaqueValue *tuple_initializeBufferWithCopyOfBuffer(ValueBuffer *dest,
   return tuple_projectBuffer<IsPOD, IsInline>(dest, metatype);
 }
 
+static void tuple_storeExtraInhabitant(OpaqueValue *tuple,
+                                       int index,
+                                       const Metadata *_metatype) {
+  auto &metatype = *(const TupleTypeMetadata*) _metatype;
+  auto cacheEntry = TupleCacheStorage::resolveExistingEntry(&metatype);
+  auto &eltInfo =
+    metatype.getElement(cacheEntry->ExtraInhabitantProvidingElement);
+
+  auto *elt = (OpaqueValue*)((uintptr_t)tuple + eltInfo.Offset);
+
+  eltInfo.Type->vw_storeExtraInhabitant(elt, index);
+}
+
+static int tuple_getExtraInhabitantIndex(const OpaqueValue *tuple,
+                                         const Metadata *_metatype) {
+  auto &metatype = *(const TupleTypeMetadata*) _metatype;
+
+  auto cacheEntry = TupleCacheStorage::resolveExistingEntry(&metatype);
+  auto &eltInfo =
+    metatype.getElement(cacheEntry->ExtraInhabitantProvidingElement);
+
+  auto *elt = (const OpaqueValue*)((uintptr_t)tuple + eltInfo.Offset);
+  return eltInfo.Type->vw_getExtraInhabitantIndex(elt);
+}
+
 template <bool IsPOD, bool IsInline>
 static unsigned tuple_getEnumTagSinglePayload(const OpaqueValue *enumAddr,
                                               unsigned numEmptyCases,
                                               const Metadata *self) {
-  auto *witnesses = self->getValueWitnesses();
+  
+  auto *witnesses = tuple_getValueWitnesses(self);
   auto size = witnesses->getSize();
   auto numExtraInhabitants = witnesses->getNumExtraInhabitants();
-  auto EIVWT = dyn_cast<ExtraInhabitantsValueWitnessTable>(witnesses);
-  auto getExtraInhabitantIndex = EIVWT ? EIVWT->getExtraInhabitantIndex : nullptr;
+  auto getExtraInhabitantIndex = numExtraInhabitants > 0
+    ? tuple_getExtraInhabitantIndex : nullptr;
 
   return getEnumTagSinglePayloadImpl(enumAddr, numEmptyCases, self, size,
                                      numExtraInhabitants,
@@ -1239,37 +1266,14 @@ template <bool IsPOD, bool IsInline>
 static void
 tuple_storeEnumTagSinglePayload(OpaqueValue *enumAddr, unsigned whichCase,
                                 unsigned numEmptyCases, const Metadata *self) {
-  auto *witnesses = self->getValueWitnesses();
+  auto *witnesses = tuple_getValueWitnesses(self);
   auto size = witnesses->getSize();
   auto numExtraInhabitants = witnesses->getNumExtraInhabitants();
-  auto EIVWT = dyn_cast<ExtraInhabitantsValueWitnessTable>(witnesses);
-  auto storeExtraInhabitant = EIVWT ? EIVWT->storeExtraInhabitant : nullptr;
+  auto storeExtraInhabitant = numExtraInhabitants > 0
+    ? tuple_storeExtraInhabitant : nullptr;
 
   storeEnumTagSinglePayloadImpl(enumAddr, whichCase, numEmptyCases, self, size,
                                 numExtraInhabitants, storeExtraInhabitant);
-}
-
-static void tuple_storeExtraInhabitant(OpaqueValue *tuple,
-                                       int index,
-                                       const Metadata *_metatype) {
-  auto &metatype = *(const TupleTypeMetadata*) _metatype;
-  auto &eltInfo = metatype.getElement(0);
-
-  assert(eltInfo.Offset == 0);
-  OpaqueValue *elt = tuple;
-
-  eltInfo.Type->vw_storeExtraInhabitant(elt, index);
-}
-
-static int tuple_getExtraInhabitantIndex(const OpaqueValue *tuple,
-                                         const Metadata *_metatype) {
-  auto &metatype = *(const TupleTypeMetadata*) _metatype;
-  auto &eltInfo = metatype.getElement(0);
-
-  assert(eltInfo.Offset == 0);
-  const OpaqueValue *elt = tuple;
-
-  return eltInfo.Type->vw_getExtraInhabitantIndex(elt);
 }
 
 /// Various standard witness table for tuples.
@@ -1400,12 +1404,24 @@ void swift::swift_getTupleTypeLayout(TypeLayout *result,
                                      TupleTypeFlags flags,
                                      const TypeLayout * const *elements) {
   *result = TypeLayout();
+  unsigned numExtraInhabitants = 0;
   performBasicLayout(*result, elements, flags.getNumElements(),
     [](const TypeLayout *elt) { return elt; },
-    [elementOffsets](size_t i, const TypeLayout *elt, size_t offset) {
+    [elementOffsets, &numExtraInhabitants]
+    (size_t i, const TypeLayout *elt, size_t offset) {
       if (elementOffsets)
         elementOffsets[i] = uint32_t(offset);
+      numExtraInhabitants = std::max(numExtraInhabitants,
+                                     elt->getNumExtraInhabitants());
     });
+  
+  if (numExtraInhabitants > 0) {
+    *result = TypeLayout(result->size,
+                         result->flags.withExtraInhabitants(true),
+                         result->stride,
+                         ExtraInhabitantFlags()
+                           .withNumExtraInhabitants(numExtraInhabitants));
+  }
 }
 
 MetadataResponse
@@ -1540,14 +1556,25 @@ TupleCacheEntry::tryInitialize(Metadata *metadata,
   Witnesses.flags = layout.flags;
   Witnesses.stride = layout.stride;
 
-  // We have extra inhabitants if the first element does.
-  // FIXME: generalize this.
-  bool hasExtraInhabitants = false;
-  if (auto firstEltEIVWT = dyn_cast<ExtraInhabitantsValueWitnessTable>(
-                                Data.getElement(0).Type->getValueWitnesses())) {
-    hasExtraInhabitants = true;
+  // We have extra inhabitants if any element does.
+  // Pick the element with the most, favoring the earliest element in a tie.
+  unsigned extraInhabitantProvidingElement = ~0u;
+  unsigned numExtraInhabitants = 0;
+  for (unsigned i = 0, e = Data.NumElements; i < e; ++i) {
+    if (auto eltEIVWI = dyn_cast<ExtraInhabitantsValueWitnessTable>(
+                                Data.getElement(i).Type->getValueWitnesses())) {
+      unsigned eltEI = eltEIVWI->extraInhabitantFlags.getNumExtraInhabitants();
+      if (eltEI > numExtraInhabitants) {
+        extraInhabitantProvidingElement = i;
+        numExtraInhabitants = eltEI;
+      }
+    }
+  }
+  if (numExtraInhabitants > 0) {
+    ExtraInhabitantProvidingElement = extraInhabitantProvidingElement;
     Witnesses.flags = Witnesses.flags.withExtraInhabitants(true);
-    Witnesses.extraInhabitantFlags = firstEltEIVWT->extraInhabitantFlags;
+    Witnesses.extraInhabitantFlags = ExtraInhabitantFlags()
+      .withNumExtraInhabitants(numExtraInhabitants);
     Witnesses.storeExtraInhabitant = tuple_storeExtraInhabitant;
     Witnesses.getExtraInhabitantIndex = tuple_getExtraInhabitantIndex;
   }
@@ -1557,13 +1584,19 @@ TupleCacheEntry::tryInitialize(Metadata *metadata,
   if (!proposedWitnesses) {
     // Try to pattern-match into something better than the generic witnesses.
     if (layout.flags.isInlineStorage() && layout.flags.isPOD()) {
-      if (!hasExtraInhabitants && layout.size == 8 && layout.flags.getAlignmentMask() == 7)
+      if (numExtraInhabitants == 0
+          && layout.size == 8
+          && layout.flags.getAlignmentMask() == 7)
         proposedWitnesses = &VALUE_WITNESS_SYM(Bi64_);
-      else if (!hasExtraInhabitants && layout.size == 4 && layout.flags.getAlignmentMask() == 3)
+      else if (numExtraInhabitants == 0
+               && layout.size == 4
+               && layout.flags.getAlignmentMask() == 3)
         proposedWitnesses = &VALUE_WITNESS_SYM(Bi32_);
-      else if (!hasExtraInhabitants && layout.size == 2 && layout.flags.getAlignmentMask() == 1)
+      else if (numExtraInhabitants == 0
+               && layout.size == 2
+               && layout.flags.getAlignmentMask() == 1)
         proposedWitnesses = &VALUE_WITNESS_SYM(Bi16_);
-      else if (!hasExtraInhabitants && layout.size == 1)
+      else if (numExtraInhabitants == 0 && layout.size == 1)
         proposedWitnesses = &VALUE_WITNESS_SYM(Bi8_);
       else
         proposedWitnesses = &tuple_witnesses_pod_inline;

--- a/validation-test/Reflection/functions.swift
+++ b/validation-test/Reflection/functions.swift
@@ -234,7 +234,7 @@ class CapturingClass {
   // CHECK-64:      Type info:
   // CHECK-64:      (closure_context size=32 alignment=8 stride=32
   // CHECK-64-NEXT: (field offset=16
-  // CHECK-64-NEXT:   (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=0
+  // CHECK-64-NEXT:   (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=2147483647
   // CHECK-64-NEXT:     (field offset=0
   // CHECK-64-NEXT:       (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0
   // CHECK-64-NEXT:         (field name=_value offset=0
@@ -249,7 +249,7 @@ class CapturingClass {
   // CHECK-32:        Type info:
   // CHECK-32:        (closure_context size=16 alignment=4 stride=16
   // CHECK-32-NEXT:   (field offset=8
-  // CHECK-32-NEXT:     (tuple size=8 alignment=4 stride=8 num_extra_inhabitants=0
+  // CHECK-32-NEXT:     (tuple size=8 alignment=4 stride=8 num_extra_inhabitants=4096
   // CHECK-32-NEXT:       (field offset=0
   // CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0
   // CHECK-32-NEXT:           (field name=_value offset=0


### PR DESCRIPTION
Like we did for structs, make it so that tuple types can also get extra inhabitants from whichever element with the most, not only the first. This lets us move all of the extra inhabitant handling functionality between structs and tuples in IRGen up to the common RecordTypeInfo CRTP base.