### PR TITLE
Refactoring ArgumentSource and PreparedArguments

### DIFF
--- a/lib/SILGen/ArgumentSource.cpp
+++ b/lib/SILGen/ArgumentSource.cpp
@@ -275,7 +275,7 @@ void ArgumentSource::dump(raw_ostream &out, unsigned indent) const {
 }
 
 void PreparedArguments::emplaceEmptyArgumentList(SILGenFunction &SGF) {
-  emplace(CanType(TupleType::getEmpty(SGF.getASTContext())), /*scalar*/ false);
+  emplace({}, /*scalar*/ false);
   assert(isValid());
 }
 
@@ -284,7 +284,7 @@ PreparedArguments::copy(SILGenFunction &SGF, SILLocation loc) const {
   if (isNull()) return PreparedArguments();
 
   assert(isValid());
-  PreparedArguments result(getFormalType(), isScalar());
+  PreparedArguments result(getParams(), isScalar());
   for (auto &elt : Arguments) {
     assert(elt.isRValue());
     result.add(elt.getKnownRValueLocation(),
@@ -332,7 +332,7 @@ PreparedArguments PreparedArguments::copyForDiagnostics() const {
     return PreparedArguments();
 
   assert(isValid());
-  PreparedArguments result(getFormalType(), isScalar());
+  PreparedArguments result(getParams(), isScalar());
   for (auto &arg : Arguments) {
     result.Arguments.push_back(arg.copyForDiagnostics());
   }

--- a/lib/SILGen/ArgumentSource.cpp
+++ b/lib/SILGen/ArgumentSource.cpp
@@ -33,8 +33,6 @@ void ArgumentSource::rewriteType(CanType newType) & {
     llvm_unreachable("argument source is invalid");
   case Kind::LValue:
     llvm_unreachable("cannot rewrite type of l-value");
-  case Kind::Tuple:
-    llvm_unreachable("cannot rewrite type of tuple");
   case Kind::RValue:
     Storage.get<RValueStorage>(StoredKind).Value.rewriteType(newType);
     return;
@@ -70,7 +68,6 @@ bool ArgumentSource::isShuffle() const {
     llvm_unreachable("argument source is invalid");
   case Kind::RValue:
   case Kind::LValue:
-  case Kind::Tuple:
     return false;
   case Kind::Expr:
     // FIXME: TupleShuffleExprs come in two flavors:
@@ -102,44 +99,8 @@ RValue ArgumentSource::getAsRValue(SILGenFunction &SGF, SGFContext C) && {
     return std::move(*this).asKnownRValue(SGF);
   case Kind::Expr:
     return SGF.emitRValue(std::move(*this).asKnownExpr(), C);
-  case Kind::Tuple:
-    return std::move(*this).getKnownTupleAsRValue(SGF, C);
   }
   llvm_unreachable("bad kind");
-}
-
-RValue
-ArgumentSource::getKnownTupleAsRValue(SILGenFunction &SGF, SGFContext C) && {
-
-  return std::move(*this).withKnownTupleElementSources<RValue>(
-                            [&](SILLocation loc, CanTupleType type,
-                                MutableArrayRef<ArgumentSource> elements) {
-    // If there's a target initialization, and we can split it, do so.
-    if (auto init = C.getEmitInto()) {
-      if (init->canSplitIntoTupleElements()) {
-        // Split the tuple.
-        SmallVector<InitializationPtr, 4> scratch;
-        auto eltInits = init->splitIntoTupleElements(SGF, loc, type, scratch);
-
-        // Emit each element into the corresponding element initialization.
-        for (auto i : indices(eltInits)) {
-          std::move(elements[i]).forwardInto(SGF, eltInits[i].get());
-        }
-
-        // Finish initialization.
-        init->finishInitialization(SGF);
-
-        return RValue::forInContext();
-      }
-    }
-
-    // Otherwise, emit all of the elements into a single big r-value.
-    RValue result(type);
-    for (auto &element : elements) {
-      result.addElement(std::move(element).getAsRValue(SGF));
-    }
-    return result;
-  });
 }
 
 ManagedValue ArgumentSource::getAsSingleValue(SILGenFunction &SGF,
@@ -172,13 +133,6 @@ ManagedValue ArgumentSource::getAsSingleValue(SILGenFunction &SGF,
       return SGF.emitRValueAsSingleValue(e, C);
     }
   }
-  case Kind::Tuple: {
-    auto loc = getKnownTupleLocation();
-    auto rvalue = std::move(*this).getKnownTupleAsRValue(SGF, C);
-    if (rvalue.isInContext())
-      return ManagedValue::forInContext();
-    return std::move(rvalue).getAsSingleValue(SGF, loc);
-  }
   }
   llvm_unreachable("bad kind");
 }
@@ -202,7 +156,6 @@ ManagedValue ArgumentSource::getConverted(SILGenFunction &SGF,
     llvm_unreachable("cannot get converted l-value");
   case Kind::RValue:
   case Kind::Expr:
-  case Kind::Tuple:
     return SGF.emitConvertedRValue(getLocation(), conversion, C,
                 [&](SILGenFunction &SGF, SILLocation loc, SGFContext C) {
       return std::move(*this).getAsSingleValue(SGF, C);
@@ -227,13 +180,6 @@ void ArgumentSource::forwardInto(SILGenFunction &SGF, Initialization *dest) && {
     SGF.emitExprInto(e, dest);
     return;
   }
-  case Kind::Tuple: {
-    auto loc = getKnownTupleLocation();
-    auto rvalue = std::move(*this).getKnownTupleAsRValue(SGF, SGFContext(dest));
-    if (!rvalue.isInContext())
-      std::move(rvalue).ensurePlusOne(SGF, loc).forwardInto(SGF, loc, dest);
-    return;
-  }
   }
   llvm_unreachable("bad kind");
 }
@@ -256,10 +202,6 @@ ArgumentSource ArgumentSource::borrow(SILGenFunction &SGF) const & {
   }
   case Kind::Expr: {
     llvm_unreachable("cannot borrow an expression");
-  }
-  case Kind::Tuple: {
-    // FIXME: We can if we check the sub argument sources.
-    llvm_unreachable("cannot borrow a tuple");
   }
   }
   llvm_unreachable("bad kind");
@@ -355,16 +297,6 @@ void ArgumentSource::dump(raw_ostream &out, unsigned indent) const {
     out << "LValue\n";
     Storage.get<LValueStorage>(StoredKind).Value.dump(out, indent + 2);
     return;
-  case Kind::Tuple: {
-    out << "Tuple\n";
-    auto &storage = Storage.get<TupleStorage>(StoredKind);
-    storage.SubstType.dump(out, indent + 2);
-    for (auto &elt : storage.Elements) {
-      elt.dump(out, indent + 2);
-      out << '\n';
-    }
-    return;
-  }
   case Kind::RValue:
     out << "RValue\n";
     Storage.get<RValueStorage>(StoredKind).Value.dump(out, indent + 2);
@@ -426,17 +358,6 @@ bool ArgumentSource::isObviouslyEqual(const ArgumentSource &other) const {
     return false; // TODO?
   case Kind::Expr:
     return false; // TODO?
-  case Kind::Tuple: {
-    auto &selfTuple = Storage.get<TupleStorage>(StoredKind);
-    auto &otherTuple = other.Storage.get<TupleStorage>(other.StoredKind);
-    if (selfTuple.Elements.size() != otherTuple.Elements.size())
-      return false;
-    for (auto i : indices(selfTuple.Elements)) {
-      if (!selfTuple.Elements[i].isObviouslyEqual(otherTuple.Elements[i]))
-        return false;
-    }
-    return true;
-  }
   }
   llvm_unreachable("bad kind");
 }
@@ -464,14 +385,6 @@ ArgumentSource ArgumentSource::copyForDiagnostics() const {
     return {getKnownRValueLocation(), asKnownRValue().copyForDiagnostics()};
   case Kind::Expr:
     return asKnownExpr();
-  case Kind::Tuple: {
-    auto &tuple = Storage.get<TupleStorage>(StoredKind);
-    SmallVector<ArgumentSource, 4> copiedElements;
-    for (auto &elt : tuple.Elements) {
-      copiedElements.push_back(elt.copyForDiagnostics());
-    }
-    return {tuple.Loc, tuple.SubstType, copiedElements};
-  }
   }
   llvm_unreachable("bad kind");
 }

--- a/lib/SILGen/ArgumentSource.cpp
+++ b/lib/SILGen/ArgumentSource.cpp
@@ -27,41 +27,6 @@ RValue &ArgumentSource::peekRValue() & {
   return Storage.get<RValueStorage>(StoredKind).Value;
 }
 
-void ArgumentSource::rewriteType(CanType newType) & {
-  switch (StoredKind) {
-  case Kind::Invalid:
-    llvm_unreachable("argument source is invalid");
-  case Kind::LValue:
-    llvm_unreachable("cannot rewrite type of l-value");
-  case Kind::RValue:
-    Storage.get<RValueStorage>(StoredKind).Value.rewriteType(newType);
-    return;
-  case Kind::Expr:
-    Expr *&expr = Storage.get<Expr*>(StoredKind);
-    CanType oldType = expr->getType()->getCanonicalType();
-
-    // Usually nothing is required.
-    if (oldType == newType) return;
-
-    // Sometimes we need to wrap the expression in a single-element tuple.
-    // This is only necessary because we don't break down the argument list
-    // when dealing with SILGenApply.
-    if (auto newTuple = dyn_cast<TupleType>(newType)) {
-      if (newTuple->getNumElements() == 1 &&
-          newTuple.getElementType(0) == oldType) {
-        expr = TupleExpr::create(newType->getASTContext(),
-                                 SourceLoc(), expr, {}, {}, SourceLoc(),
-                                 /*trailing closure*/ false,
-                                 /*implicit*/ true, newType);
-        return;
-      }
-    }
-
-    llvm_unreachable("unimplemented! hope it doesn't happen");
-  }
-  llvm_unreachable("bad kind");
-}
-
 bool ArgumentSource::isShuffle() const {
   switch (StoredKind) {
   case Kind::Invalid:

--- a/lib/SILGen/ArgumentSource.h
+++ b/lib/SILGen/ArgumentSource.h
@@ -238,9 +238,6 @@ public:
                            AbstractionPattern origFormalType,
                            SILType expectedType = SILType()) &&;
 
-  // This is a hack and should be avoided.
-  void rewriteType(CanType newType) &;
-
   /// Whether this argument source is a TupleShuffleExpr.
   bool isShuffle() const;
 

--- a/lib/SILGen/ArgumentSource.h
+++ b/lib/SILGen/ArgumentSource.h
@@ -292,8 +292,8 @@ public:
   // This is a hack and should be avoided.
   void rewriteType(CanType newType) &;
 
-  /// Whether this argument source requires the callee to evaluate.
-  bool requiresCalleeToEvaluate() const;
+  /// Whether this argument source is a TupleShuffleExpr.
+  bool isShuffle() const;
 
   bool isObviouslyEqual(const ArgumentSource &other) const;
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -2647,19 +2647,6 @@ private:
       return;
     }
 
-    // If we're working with a tuple source, expand it.
-    if (arg.isTuple()) {
-      (void) std::move(arg).withKnownTupleElementSources<int>(
-                          [&](SILLocation loc, CanTupleType type,
-                              MutableArrayRef<ArgumentSource> elts) {
-        for (auto i : indices(elts)) {
-          emit(std::move(elts[i]), origParamType.getTupleElementType(i));
-        }
-        return 0; // We need a fake return value because <void> won't compile.
-      });
-      return;
-    }
-
     // Otherwise, we're working with an expression.
     Expr *e = std::move(arg).asKnownExpr();
     e = e->getSemanticsProvidingExpr();

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -2526,24 +2526,6 @@ private:
         emitExpanded(std::move(arg), origParamType);
         return;
       }
-
-      // Otherwise, if the substituted type is a tuple, then we should
-      // emit the tuple in its most general form, because there's a
-      // substitution of an opaque archetype to a tuple or function
-      // type in play.  The most general convention is generally to
-      // pass the entire tuple indirectly, but if it's not
-      // materializable, the convention is actually to break it up
-      // into materializable chunks.  See the comment in SILType.cpp.
-      //
-      // FIXME: Once -swift-version 3 code generation goes away, we
-      // can simplify this.
-      if (auto substTupleType = dyn_cast<TupleType>(substArgType)) {
-        if (shouldExpandTupleType(substTupleType)) {
-          assert(origParamType.isTypeParameter());
-          emitExpanded(std::move(arg), origParamType);
-          return;
-        }
-      }
     }
 
     // Okay, everything else will be passed as a single value, one

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2808,20 +2808,23 @@ loadIndexValuesForKeyPathComponent(SILGenFunction &SGF, SILLocation loc,
   if (!isa<SubscriptDecl>(storage))
     return PreparedArguments();
 
-  SmallVector<TupleTypeElt, 2> indexElts;
+  SmallVector<AnyFunctionType::Param, 8> indexParams;
   for (auto &elt : indexes) {
-    indexElts.push_back(SGF.F.mapTypeIntoContext(elt.first));
+    // FIXME: Varargs?
+    indexParams.emplace_back(SGF.F.mapTypeIntoContext(elt.first));
   }
   
-  auto indexTupleTy = TupleType::get(indexElts, SGF.getASTContext())
-                        ->getCanonicalType();
-  PreparedArguments indexValues(indexTupleTy, /*scalar*/ indexes.size() == 1);
+  PreparedArguments indexValues(indexParams, /*scalar*/ indexes.size() == 1);
   if (indexes.empty()) {
     assert(indexValues.isValid());
     return indexValues;
   }
 
-  auto indexLoweredTy = SGF.getLoweredType(indexTupleTy);
+  auto indexLoweredTy =
+    SGF.getLoweredType(
+      AnyFunctionType::composeInput(SGF.getASTContext(), indexParams,
+                                    /*canonicalVararg=*/false));
+
   auto addr = SGF.B.createPointerToAddress(loc, pointer,
                                            indexLoweredTy.getAddressType(),
                                            /*isStrict*/ false);


### PR DESCRIPTION
Pushing usages of `AbstractionPattern::getFunctionInput()` down. Getting close, but as you can see they're still there.