### PR TITLE
(SR-8699) make @differentiable work on methods

### DIFF
--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -101,6 +101,11 @@ struct SILReverseAutoDiffIndices {
 
   bool operator==(const SILReverseAutoDiffIndices &other) const;
 
+  bool isWrtParameter(unsigned parameterIndex) const {
+    return parameterIndex < parameters.size() &&
+           parameters.test(parameterIndex);
+  }
+
   void print(llvm::raw_ostream &s = llvm::outs()) const {
     s << "(source=" << source << " parameters=(";
     interleave(parameters.set_bits(),

--- a/include/swift/AST/AutoDiff.h
+++ b/include/swift/AST/AutoDiff.h
@@ -101,6 +101,8 @@ struct SILReverseAutoDiffIndices {
 
   bool operator==(const SILReverseAutoDiffIndices &other) const;
 
+  /// Queries whether the function's parameter with index `parameterIndex` is
+  /// one of the parameters to differentiate with respect to.
   bool isWrtParameter(unsigned parameterIndex) const {
     return parameterIndex < parameters.size() &&
            parameters.test(parameterIndex);

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -725,18 +725,25 @@ static llvm::SmallBitVector getLoweredAutoDiffParameterIndices(
     const DifferentiableAttr *DA) {
   auto *fnTy =
     AFD->getInterfaceType()->getCanonicalType()->getAs<AnyFunctionType>();
-  auto silFnTy = SGM.getLoweredType(fnTy).castTo<SILFunctionType>();
-  llvm::SmallBitVector indices(silFnTy->getNumParameters());
-  // We don't diff wrt `self` unless it is explicitly specified, therefore
-  // dropping the last SIL parameter if it's a method.
+  // If the function has a self parameter, then its signature is
+  //   (Self) -> ...
+  // Strip off the (Self) parameter list so that indexing can index into the
+  // next parameter list.
   if (AFD->getImplicitSelfDecl())
     fnTy = fnTy->getResult()->getAs<AnyFunctionType>();
-  // If no parameters are specified, add all parameter indices.
-  if (DA->getParameters().empty())
-    indices.set();
+
+  llvm::SmallBitVector indices(F->getLoweredFunctionType()->getNumParameters());
+  // If no parameters are specified, add all parameter indices except the self
+  // parameter.
+  if (DA->getParameters().empty()) {
+    if (F->hasSelfParam())
+      // 'self' is always the last SIL parameter.
+      indices.set(0, indices.size() - 1);
+    else
+      indices.set();
+  }
   // Otherwise, convert differentiation parameters.
   else {
-    bool hasSelf = false;
     for (auto param : DA->getParameters()) {
       switch (param.getKind()) {
       // Normal index maps directly to a SIL parameter index.
@@ -749,16 +756,13 @@ static llvm::SmallBitVector getLoweredAutoDiffParameterIndices(
           indices.set(paramIdxRange.front(), paramIdxRange.back());
         break;
       }
-      // 'self' is always the last SIL parameter.
       case AutoDiffParameter::Kind::Self:
         // Sema guarantees this case to occur at most once.
-        hasSelf = true;
+        // 'self' is always the last SIL parameter.
+        indices.set(indices.size() - 1);
         break;
       }
     }
-    // The last SIL parameter is `self`, if needed.
-    if (hasSelf)
-      indices.set(silFnTy->getNumParameters() - 1);
   }
   return indices;
 }

--- a/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDifferentiation.cpp
@@ -2894,10 +2894,18 @@ SILFunction *AdjointGen::createEmptyAdjoint(DifferentiationTask *task) {
   SmallVector<SILResultInfo, 8> adjResults;
   auto origTy = original->getLoweredFunctionType();
   auto origParams = origTy->getParameters();
-  for (auto &param : origParams)
+  assert((!origTy->hasSelfParam() ||
+          origParams.back() == origTy->getSelfParameter()) &&
+         "self argument should be the last one");
+  auto origParamsWithoutSelf = origTy->hasSelfParam() ?
+      origParams.slice(0, origParams.size() - 1) : origParams;
+
+  // Add adjoint parameters for the original non-self parameters. If there is a
+  // self parameter, we'll push it later as the last adjoint parameter, because
+  // Swift's method convention always has self last.
+  for (auto &param : origParamsWithoutSelf)
     adjParams.push_back(param);
-  for (auto i : task->getIndices().parameters.set_bits())
-    adjResults.push_back(getFormalResultInfo(origParams[i].getType(), module));
+
   // If there's a generated primal, accept a primal value struct in the adjoint
   // parameter list.
   if (auto *pi = task->getPrimalInfo()) {
@@ -2906,12 +2914,33 @@ SILFunction *AdjointGen::createEmptyAdjoint(DifferentiationTask *task) {
                       ->getCanonicalType();
     adjParams.push_back(getFormalParameterInfo(pvType, module));
   }
-  // Add parameter types.
+
+  // Add adjoint parameters for the original results.
   for (auto &origRes : origTy->getResults())
     adjParams.push_back(getFormalParameterInfo(origRes.getType(), module));
-  // Add seed type.
+
+  // Add adjoint parameter for the seed.
   adjParams.push_back(getFormalParameterInfo(
       origTy->getResults()[task->getIndices().source].getType(), module));
+
+  // Add adjoint parameter for the original self parameter, if applicable.
+  if (origTy->hasSelfParam())
+    adjParams.push_back(origTy->getSelfParameter());
+
+  // Add adjoint result for the wrt self parameter, if it was requested.
+  auto selfParamIndex = origParams.size() - 1;
+  if (origTy->hasSelfParam() &&
+      task->getIndices().isWrtParameter(selfParamIndex))
+    adjResults.push_back(getFormalResultInfo(
+        origParams[selfParamIndex].getType(), module));
+
+  // Add adjoint results for the requested non-self wrt parameters.
+  for (auto i : task->getIndices().parameters.set_bits()) {
+    if (origTy->hasSelfParam() && i == selfParamIndex)
+      continue;
+    adjResults.push_back(getFormalResultInfo(origParams[i].getType(), module));
+  }
+
   auto adjName = "AD__" + original->getName().str() + "__adjoint_" +
                  mangleADIndices(task->getIndices());
   auto adjType = SILFunctionType::get(
@@ -3187,7 +3216,7 @@ private:
   DenseMap<SILBasicBlock *, SILBasicBlock *> adjointBBMap;
 
   /// The range of original parameters in the adjoint function.
-  ArrayRef<SILArgument *> originalParametersInAdj;
+  SmallVector<SILArgument *, 8> originalParametersInAdj;
 
   /// The primal value aggregate passed to the adjoint function.
   SILArgument *primalValueAggregateInAdj = nullptr;
@@ -3312,18 +3341,30 @@ public:
     // `originalResults` and `seed`.
     auto adjParamArgs = getAdjoint().getArgumentsWithoutIndirectResults();
     auto origNumParams = origConv.getNumParameters();
+    auto origNumParamsWithoutSelf = origTy->hasSelfParam() ? origNumParams - 1
+                                                           : origNumParams;
     auto origNumResults = origTy->getNumResults();
     // The adjoint function has type
-    //   (arg0, ..., argn, pv0, ..., pvn, origres, seed) -> (arg0, ..., argn).
+    //   (arg0, ..., argn, pv0, ..., pvn, origres, seed, [self])
+    //       -> ([self], [arg0], ..., [argn]).
+    // Square brackets denote [] elements that are not always in the signature:
+    //   * "self" is present in the argument list when it's present in the
+    //      original's argument list.
+    //   * Results are present when the adjoint is with respect to the
+    //     corresponding original argument.
+    //
     // We get each range of arguments by shifting the `paramArgsData` pointer.
     auto *paramArgsData = adjParamArgs.data();
-    originalParametersInAdj = {paramArgsData, origNumParams};
-    paramArgsData += origNumParams;
+    originalParametersInAdj.reserve(origNumParams);
+    for (unsigned i = 0; i < origNumParamsWithoutSelf; i++)
+      originalParametersInAdj.push_back(*paramArgsData++);
     primalValueAggregateInAdj = *paramArgsData++;
     originalResultsInAdj = {paramArgsData, origNumResults};
     paramArgsData += origNumResults;
-    seed = *paramArgsData;
-    assert(seed == adjParamArgs.back());
+    seed = *paramArgsData++;
+    if (origTy->hasSelfParam())
+      originalParametersInAdj.push_back(*paramArgsData++);
+    assert(paramArgsData == adjParamArgs.data() + adjParamArgs.size());
 
     // Map the original's parameters to the adjoint's corresponding "original
     // parameters".
@@ -3364,15 +3405,28 @@ public:
     getBuilder().setInsertionPoint(adjointEntry);
 
     SmallVector<SILValue, 8> retElts;
-    auto origParamArgs = original.getArgumentsWithoutIndirectResults();
-    for (auto i : task->getIndices().parameters.set_bits()) {
-      auto origParam = origParamArgs[i];
-      auto adjParam = originalParametersInAdj[i];
+    auto origParams = original.getArgumentsWithoutIndirectResults();
+    auto addRetElt = [&](unsigned parameterIndex) -> void {
+      auto origParam = origParams[parameterIndex];
+      auto adjParam = originalParametersInAdj[parameterIndex];
       auto adjVal = getAdjointValue(origParam);
       if (adjParam->getType().isObject())
         retElts.push_back(materializeAdjointDirect(adjVal, adjLoc));
       else
         materializeAdjointIndirect(adjVal, adjParam);
+    };
+    // The original's self parameter, if present, is the last parameter. But we
+    // want its gradient, if present, to be the first return element.
+    auto selfParamIndex = origParams.size() - 1;
+    if (origTy->hasSelfParam() &&
+        task->getIndices().isWrtParameter(selfParamIndex))
+      addRetElt(selfParamIndex);
+    for (auto i : task->getIndices().parameters.set_bits()) {
+      // Do not add the self parameter because we have already added it at the
+      // beginning.
+      if (origTy->hasSelfParam() && i == selfParamIndex)
+        continue;
+      addRetElt(i);
     }
     getBuilder().createReturn(adjLoc, joinElements(retElts, builder, adjLoc));
     return errorOccurred;
@@ -3524,10 +3578,19 @@ public:
       args.push_back(buf);
       allocsToCleanUp.push_back(buf);
     }
-    // For each original parameter, push the mapped parameter.
-    SILFunctionConventions origConv(origTy, getModule());
-    for (auto param : ai->getArgumentsWithoutIndirectResults())
+
+    // For each non-self original parameter, push the mapped parameter. If
+    // there is a self parameter, we'll push it later as the last argument,
+    // because Swift's method convention always has self last.
+    auto originalParams = ai->getArgumentsWithoutIndirectResults();
+    assert((!ai->hasSelfArgument() ||
+           originalParams.back() == ai->getSelfArgument()) &&
+           "self argument should be the last one");
+    auto originalParamsWithoutSelf = ai->hasSelfArgument() ?
+        originalParams.slice(0, originalParams.size() - 1) : originalParams;
+    for (auto param : originalParamsWithoutSelf)
       args.push_back(remapValue(param));
+
     // Add nested primal values.
     if (auto nestedPrimValAggr = extractPrimalValueIfAny(ai, /*nested*/ true)) {
       SmallVector<SILValue, 8> nestedPrimVals;
@@ -3555,6 +3618,11 @@ public:
           loc, access, getBufferLOQ(seed.getSwiftType(), getAdjoint())));
       getBuilder().createEndAccess(loc, access, /*aborted*/ false);
     }
+
+    // Push the mapped self parameter, if any.
+    if (ai->hasSelfArgument())
+      args.push_back(remapValue(ai->getSelfArgument()));
+
     // Call the adjoint function.
     auto *adjointRef = getBuilder().createFunctionRef(ai->getLoc(), adjoint);
     auto origFnRef = ai->getCalleeOrigin();
@@ -3585,9 +3653,23 @@ public:
     // Set adjoints for all original parameters.
     auto origNumIndRes = origConvs.getNumIndirectSILResults();
     auto allResultsIt = allResults.begin();
-    for (unsigned i : otherTask->getIndices().parameters.set_bits())
-      addAdjointValue(ai->getArgument(i + origNumIndRes),
+    // If the applied adjoint returns the adjoint of the original self
+    // parameter, then it returns it first. Set the adjoint of the original
+    // self parameter.
+    auto selfParamIndex = originalParams.size() - 1;
+    if (ai->hasSelfArgument() &&
+        otherTask->getIndices().isWrtParameter(selfParamIndex))
+      addAdjointValue(ai->getArgument(origNumIndRes + selfParamIndex),
                       AdjointValue::getMaterialized(*allResultsIt++));
+    // Set adjoints for the remaining non-self original parameters.
+    for (unsigned i : otherTask->getIndices().parameters.set_bits()) {
+      // Do not set the adjoint of the original self parameter because we
+      // already added it at the beginning.
+      if (ai->hasSelfArgument() && i == selfParamIndex)
+        continue;
+      addAdjointValue(ai->getArgument(origNumIndRes + i),
+                      AdjointValue::getMaterialized(*allResultsIt++));
+    }
   }
 
   /// Handle `gradient` instruction.

--- a/test/AutoDiff/method.swift
+++ b/test/AutoDiff/method.swift
@@ -1,0 +1,305 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var MethodTests = TestSuite("Method")
+
+// ==== Tests with generated adjoint ====
+
+struct Parameter : Equatable {
+  let x: Float
+}
+
+extension Parameter {
+  func squared() -> Float {
+    return x * x
+  }
+
+  static func squared(p: Parameter) -> Float {
+    return p.x * p.x
+  }
+
+  func multiplied(with other: Float) -> Float {
+    return x * other
+  }
+
+  static func * (_ a: Parameter, _ b: Parameter) -> Float {
+    return a.x * b.x
+  }
+}
+
+MethodTests.test("instance method with generated adjoint, called from differentated func") {
+  func f(_ p: Parameter) -> Float {
+    return 100 * p.squared()
+  }
+  let dF = #gradient(f)
+  expectEqual(Parameter(x: 4 * 100), dF(Parameter(x: 2)))
+  expectEqual(Parameter(x: 40 * 100), dF(Parameter(x: 20)))
+}
+
+MethodTests.test("instance method with generated adjoint, differentiated directly") {
+  // This is our current syntax for taking gradients of instance methods
+  // directly. If/when we develop nicer syntax for this, change this test.
+  let g = #gradient({ (p: Parameter) in p.squared() })
+  expectEqual(Parameter(x: 4), g(Parameter(x: 2)))
+  expectEqual(Parameter(x: 40), g(Parameter(x: 20)))
+}
+
+MethodTests.test("instance method with generated adjoint, wrt only self") {
+  func f(_ p: Parameter) -> Float {
+    return 100 * p.multiplied(with: 200)
+  }
+  let dF = #gradient(f)
+  expectEqual(Parameter(x: 100 * 200), dF(Parameter(x: 1)))
+  expectEqual(Parameter(x: 100 * 200), dF(Parameter(x: 2)))
+}
+
+MethodTests.test("instance method with generated adjoint, wrt only non-self") {
+  func f(_ other: Float) -> Float {
+    return 100 * Parameter(x: 200).multiplied(with: other)
+  }
+  let dF = #gradient(f)
+  expectEqual(100 * 200, dF(1))
+  expectEqual(100 * 200, dF(2))
+}
+
+MethodTests.test("instance method with generated adjoint, wrt self and non-self") {
+  let g = #gradient({ (p: Parameter, o: Float) in p.multiplied(with: o) })
+  expectEqual((Parameter(x: 100), 200), g(Parameter(x: 200), 100))
+  expectEqual((Parameter(x: 200), 100), g(Parameter(x: 100), 200))
+}
+
+MethodTests.test("static method with generated adjoint, called from differentiated func") {
+  func f(_ p: Parameter) -> Float {
+    return 100 * Parameter.squared(p: p)
+  }
+  let dF = #gradient(f)
+  expectEqual(Parameter(x: 4 * 100), dF(Parameter(x: 2)))
+  expectEqual(Parameter(x: 40 * 100), dF(Parameter(x: 20)))
+}
+
+// TODO(SR-8699): Fix this test.
+// MethodTests.test("static method with generated adjoint, differentiated directly") {
+//   let grad = #gradient(Parameter.squared(p:))
+//   expectEqual(Parameter(x: 4), grad(Parameter(x: 2)))
+//   expectEqual(Parameter(x: 40), grad(Parameter(x: 20)))
+// }
+
+MethodTests.test("static method with generated adjoint, wrt only first param") {
+  func f(_ p: Parameter) -> Float {
+    return 100 * (p * Parameter(x: 200))
+  }
+  let dF = #gradient(f)
+  expectEqual(Parameter(x: 100 * 200), dF(Parameter(x: 1)))
+  expectEqual(Parameter(x: 100 * 200), dF(Parameter(x: 2)))
+}
+
+MethodTests.test("static method with generated adjoint, wrt only second param") {
+  func f(_ p: Parameter) -> Float {
+    return 100 * (Parameter(x: 200) * p)
+  }
+  let dF = #gradient(f)
+  expectEqual(Parameter(x: 100 * 200), dF(Parameter(x: 1)))
+  expectEqual(Parameter(x: 100 * 200), dF(Parameter(x: 2)))
+}
+
+MethodTests.test("static method with generated adjoint, wrt all params") {
+  let g = #gradient({ (a: Parameter, b: Parameter) in a * b })
+  expectEqual((Parameter(x: 100), Parameter(x: 200)),
+              g(Parameter(x: 200), Parameter(x: 100)))
+  expectEqual((Parameter(x: 200), Parameter(x: 100)),
+              g(Parameter(x: 100), Parameter(x: 200)))
+}
+
+// ==== Tests with custom adjoint ====
+
+struct CustomParameter : Equatable {
+  let x: Float
+}
+
+extension Float {
+  func clamped(to limits: ClosedRange<Float>) -> Float {
+    return min(max(self, limits.lowerBound), limits.upperBound)
+  }
+}
+
+extension CustomParameter {
+  @differentiable(reverse, wrt: (self), adjoint: dSquared)
+  func squared() -> Float {
+    return x * x
+  }
+
+  func dSquared(origVal: Float, seed: Float) -> CustomParameter {
+    return CustomParameter(x: (2 * x).clamped(to: -10.0...10.0) * seed)
+  }
+
+  @differentiable(reverse, adjoint: dSquared)
+  static func squared(p: CustomParameter) -> Float {
+    return p.x * p.x
+  }
+
+  static func dSquared(_ p: CustomParameter, origVal: Float, seed: Float)
+      -> CustomParameter {
+     return CustomParameter(x: (2 * p.x).clamped(to: -10.0...10.0) * seed)
+  }
+
+  // There is currently no way to define multiple custom adjoints wrt different
+  // parameters on the same func, so we define a copy of this func per adjoint.
+
+  @differentiable(reverse, wrt: (self, .0), adjoint: dMultiplied_wrtAll)
+  func multiplied(with other: Float) -> Float {
+    return x * other
+  }
+
+  @differentiable(reverse, wrt: (.0), adjoint: dMultiplied_wrtOther)
+  func multiplied_constSelf(with other: Float) -> Float {
+    return x * other
+  }
+
+  @differentiable(reverse, wrt: (self), adjoint: dMultiplied_wrtSelf)
+  func multiplied_constOther(with other: Float) -> Float {
+    return x * other
+  }
+
+  func dMultiplied_wrtAll(with other: Float, origVal: Float, seed: Float)
+      -> (CustomParameter, Float) {
+    return (CustomParameter(x: other.clamped(to: -10.0...10.0) * seed),
+            x.clamped(to: -10.0...10.0) * seed)
+  }
+
+  func dMultiplied_wrtOther(with other: Float, origVal: Float, seed: Float)
+      -> Float {
+    return dMultiplied_wrtAll(with: other, origVal: origVal, seed: seed).1
+  }
+
+  func dMultiplied_wrtSelf(with other: Float, origVal: Float, seed: Float)
+      -> CustomParameter {
+    return dMultiplied_wrtAll(with: other, origVal: origVal, seed: seed).0
+  }
+
+  @differentiable(reverse, adjoint: dMultiply_wrtAll)
+  static func multiply(_ lhs: CustomParameter, _ rhs: CustomParameter)
+      -> Float {
+    return lhs.x * rhs.x
+  }
+
+  @differentiable(reverse, wrt: (.1), adjoint: dMultiply_wrtRhs)
+  static func multiply_constLhs(_ lhs: CustomParameter, _ rhs: CustomParameter)
+      -> Float {
+    return lhs.x * rhs.x
+  }
+
+  @differentiable(reverse, wrt: (.0), adjoint: dMultiply_wrtLhs)
+  static func multiply_constRhs(_ lhs: CustomParameter, _ rhs: CustomParameter)
+      -> Float {
+    return lhs.x * rhs.x
+  }
+
+  static func dMultiply_wrtAll(_ lhs: CustomParameter,_ rhs: CustomParameter,
+                               origValue: Float, seed: Float)
+      -> (CustomParameter, CustomParameter) {
+    return (CustomParameter(x: rhs.x.clamped(to: -10.0...10.0) * seed),
+            CustomParameter(x: lhs.x.clamped(to: -10.0...10.0) * seed))
+  }
+
+  static func dMultiply_wrtLhs(_ lhs: CustomParameter,_ rhs: CustomParameter,
+                               origValue: Float, seed: Float)
+      -> CustomParameter {
+    return dMultiply_wrtAll(lhs, rhs, origValue: origValue, seed: seed).0
+  }
+
+  static func dMultiply_wrtRhs(_ lhs: CustomParameter, _ rhs: CustomParameter,
+                               origValue: Float, seed: Float)
+      -> CustomParameter {
+    return dMultiply_wrtAll(lhs, rhs, origValue: origValue, seed: seed).1
+  }
+}
+
+MethodTests.test("instance method with custom adjoint, called from differentated func") {
+  func f(_ p: CustomParameter) -> Float {
+    return 100 * p.squared()
+  }
+  let dF = #gradient(f)
+  expectEqual(CustomParameter(x: 4 * 100), dF(CustomParameter(x: 2)))
+  expectEqual(CustomParameter(x: 10 * 100), dF(CustomParameter(x: 20)))
+}
+
+MethodTests.test("instance method with generated adjoint, differentated directly") {
+  // This is our current syntax for taking gradients of instance methods
+  // directly. If/when we develop nicer syntax for this, change this test.
+  let g = #gradient({ (p: CustomParameter) in p.squared() })
+  expectEqual(CustomParameter(x: 4), g(CustomParameter(x: 2)))
+  expectEqual(CustomParameter(x: 10), g(CustomParameter(x: 20)))
+}
+
+MethodTests.test("static method with custom adjoint, called from differentated func") {
+  func f(_ p: CustomParameter) -> Float {
+    return 100 * CustomParameter.squared(p: p)
+  }
+  let dF = #gradient(f)
+  expectEqual(CustomParameter(x: 4 * 100), dF(CustomParameter(x: 2)))
+  expectEqual(CustomParameter(x: 10 * 100), dF(CustomParameter(x: 20)))
+}
+
+// TODO(SR-8699): Fix this test.
+// MethodTests.test("static method with custom adjoint, differentiated directly") {
+//   let grad = #gradient(CustomParameter.squared(p:))
+//   expectEqual(CustomParameter(x: 4), grad(CustomParameter(x: 2)))
+//   expectEqual(CustomParameter(x: 10), grad(CustomParameter(x: 20)))
+// }
+
+MethodTests.test("instance method with custom adjoint, wrt only self") {
+  func f(_ p: CustomParameter) -> Float {
+    return 100 * p.multiplied_constOther(with: 200)
+  }
+  let dF = #gradient(f)
+  expectEqual(CustomParameter(x: 100 * 10), dF(CustomParameter(x: 1)))
+  expectEqual(CustomParameter(x: 100 * 10), dF(CustomParameter(x: 2)))
+}
+
+MethodTests.test("instance method with custom adjoint, wrt only non-self") {
+  func f(_ other: Float) -> Float {
+    return 100 * CustomParameter(x: 200).multiplied_constSelf(with: other)
+  }
+  let dF = #gradient(f)
+  expectEqual(100 * 10, dF(1))
+  expectEqual(100 * 10, dF(2))
+}
+
+MethodTests.test("instance method with custom adjoint, wrt self and non-self") {
+  let g = #gradient({ (p: CustomParameter, o: Float) in p.multiplied(with: o) })
+  expectEqual((CustomParameter(x: 5), 10), g(CustomParameter(x: 100), 5))
+  expectEqual((CustomParameter(x: 10), 5), g(CustomParameter(x: 5), 100))
+}
+
+MethodTests.test("static method with custom adjoint, wrt only lhs") {
+  func f(_ p: CustomParameter) -> Float {
+    return 100 * CustomParameter.multiply_constRhs(p, CustomParameter(x: 200))
+  }
+  let dF = #gradient(f)
+  expectEqual(CustomParameter(x: 100 * 10), dF(CustomParameter(x: 1)))
+  expectEqual(CustomParameter(x: 100 * 10), dF(CustomParameter(x: 2)))
+}
+
+MethodTests.test("static method with custom adjoint, wrt only rhs") {
+  func f(_ p: CustomParameter) -> Float {
+    return 100 * CustomParameter.multiply_constLhs(CustomParameter(x: 200), p)
+  }
+  let dF = #gradient(f)
+  expectEqual(CustomParameter(x: 100 * 10), dF(CustomParameter(x: 1)))
+  expectEqual(CustomParameter(x: 100 * 10), dF(CustomParameter(x: 2)))
+}
+
+MethodTests.test("static method with custom adjoint, wrt all") {
+  func f(_ a: CustomParameter, _ b: CustomParameter) -> Float {
+    return CustomParameter.multiply(a, b)
+  }
+  let dF = #gradient(f)
+  expectEqual((CustomParameter(x: 5), CustomParameter(x: 10)),
+              dF(CustomParameter(x: 100), CustomParameter(x: 5)))
+  expectEqual((CustomParameter(x: 10), CustomParameter(x: 5)),
+              dF(CustomParameter(x: 5), CustomParameter(x: 100)))
+}
+
+runAllTests()


### PR DESCRIPTION
Please do not test or submit this until https://github.com/apple/swift/pull/19169 is submitted. The tests will fail.

This PR modifies every location that deals with adjoints to agree that the signature of the adjoint of a method is `(arg0, ..., argn, pv0, ..., pvn, origRes, self) -> ([self], [arg0], ..., [argn])`. (I'm using square brackets [] to denote elements that may or may not be present based on the wrt config). Before this PR, all locations dealing with adjoints were unaware of `self` and therefore thought the signature was `(arg0, ..., argn, self, pv0, ..., pvn, origRes) -> ([arg0], ..., [argn], [self])`. This made it impossible to define custom adjoints with `@differentiable` because that's not the signature that SILGen generates for user-defined methods.

This should make it possible to revert https://github.com/apple/swift/pull/19201, but I want to do that separately to keep this change simple.