### PR TITLE
[Parse] Fix minor bug in #sourceLocation on lex error

### DIFF
--- a/test/Parse/line-directive.swift
+++ b/test/Parse/line-directive.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift
+// RUN: not %target-swift-frontend -c %s 2>&1 | %FileCheck %s
 
 let x = 0 // We need this because of the #sourceLocation-ends-with-a-newline requirement.
 
@@ -53,3 +54,9 @@ enum E {
     case C, D
 #sourceLocation()
 }
+
+#sourceLocation(file: "sr8772.swift", line: 400)
+2., 3
+// CHECK: sr8772.swift:400:2: error: expected member name following '.'
+// CHECK: sr8772.swift:400:3: error: consecutive statements on a line must be separated by ';'
+// CHECK: sr8772.swift:400:3: error: expected expression


### PR DESCRIPTION
There seems to be a minor bug in the implementation of #sourceLocation when the directive is succeeded by token that gives an error during lexing. The error will be reported with the wrong location. This is because lexing of the next token occurs immediately on consuming the last token of the directive which is before the virtual file is set up to have the location take effect.

Resolved by moving consumption of directives last token to the end of the function.

Resolves [SR-8772](https://bugs.swift.org/browse/SR-8772).