### PR TITLE
Revert "SILOptimizer: make a conversion operation explicit"

### DIFF
--- a/include/swift/SILOptimizer/Analysis/ARCAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/ARCAnalysis.h
@@ -230,7 +230,7 @@ private:
     Optional<ArrayRef<SILInstruction *>> getFullyPostDomReleases() const {
       if (releases.empty() || foundSomeButNotAllReleases())
         return None;
-      return ArrayRef<SILInstruction *>{releases};
+      return {releases};
     }
 
     /// If we were able to find a set of releases for this argument, but those


### PR DESCRIPTION
Reverts apple/swift#19300

This failed to build on Ubuntu 14.04:
https://ci.swift.org/job/oss-swift-package-linux-ubuntu-14_04/2187/
https://ci.swift.org/job/oss-swift-incremental-RA-linux-ubuntu-14_04-long-test/4947/
etc.