### PR TITLE
[Docs] Fix minor typos in the ownership manifesto.

### DIFF
--- a/docs/OwnershipManifesto.md
+++ b/docs/OwnershipManifesto.md
@@ -481,7 +481,7 @@ Properties can be classified into three groups:
 - `static` and `class` properties on any kind of type.
 
 We propose to always treat reference-type and `static` properties
-as independent from one another other, but to treat value-type
+as independent from one another, but to treat value-type
 properties as generally non-independent outside of a specific
 (but important) special case.  That's a potentially significant
 restriction, and it's reasonable to wonder both why it's necessary
@@ -836,7 +836,7 @@ born from a trio of concerns:
   costs for users.  And it's still inevitably necessary
   to sometimes drop down to unsafe code to work around the
   limitations of the ownership system.  Given that a line
-  does have to drawn somewhere, it's not completely settled
+  does have to be drawn somewhere, it's not completely settled
   that lifetime-qualification systems deserve to be on the
   Swift side of the line.
 


### PR DESCRIPTION
Fixed minor typos I came across while reading this manifesto.