### PR TITLE
[CSStep] Add `BindingStep` to unify some logic in `TypeVar`, `Disjunction` steps

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1406,8 +1406,8 @@ bool DisjunctionChoice::attempt(ConstraintSystem &cs) const {
   return !cs.failedConstraint && !cs.simplify();
 }
 
-bool DisjunctionChoice::isGenericOp(Constraint *choice) {
-  auto *decl = getOperatorDecl(choice);
+bool DisjunctionChoice::isGenericOperator() const {
+  auto *decl = getOperatorDecl(Choice);
   if (!decl)
     return false;
 
@@ -1415,8 +1415,8 @@ bool DisjunctionChoice::isGenericOp(Constraint *choice) {
   return interfaceType->is<GenericFunctionType>();
 }
 
-bool DisjunctionChoice::isSymmetricOp(Constraint *choice) {
-  auto *decl = getOperatorDecl(choice);
+bool DisjunctionChoice::isSymmetricOperator() const {
+  auto *decl = getOperatorDecl(Choice);
   if (!decl)
     return false;
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3345,89 +3345,34 @@ void simplifyLocator(Expr *&anchor,
 /// null otherwise.
 Expr *simplifyLocatorToAnchor(ConstraintSystem &cs, ConstraintLocator *locator);
 
-enum class TypeBindingFlag {
-  /// The constraint represented by this choice has been
-  /// marked as disabled by the solver.
-  Disabled = 0x01,
-  /// The declaration behind this binding is marked as `@unavailable`
-  Unavailable = 0x02,
-  /// This binding comes from the "defaults to" constraint.
-  Defaultable = 0x04,
-  /// This binding comes from the "defaults to" constraint
-  /// which has associated protocol.
-  HasDefaultedProtocol = 0x08,
-  /// Type of the binding comes from generic operator declaration.
-  GenericOperator = 0x10,
-  /// Type of the binding comes from symmetric operator declaration.
-  SymmetricOperator = 0x20,
-};
-
-using TypeBindingFlags = OptionSet<TypeBindingFlag>;
-
-/// Common interface to encapsulate attempting choices of
-/// different entities, such as type variables (types)
-/// or disjunctions (their choices).
-class TypeBinding {
+class DisjunctionChoice {
   unsigned Index;
-  TypeBindingFlags Flags;
-
-public:
-  TypeBinding(unsigned index, TypeBindingFlags flags)
-      : Index(index), Flags(flags) {}
-
-  virtual ~TypeBinding() {}
-
-  /// Attempt given binding in the constraint system, this is going to
-  /// introduce some new constraints (potentially "bind" constraints)
-  /// to try and associate some type variables with new types.
-  ///
-  /// \returns true if attempt has been accepted by the constraint system,
-  ///          which means that new constraints have been successfully solved.
-  virtual bool attempt(ConstraintSystem &cs) const = 0;
-
-  /// Position of this binding in the chain.
-  unsigned getIndex() const { return Index; }
-
-  bool isDisabled() const { return Flags.contains(TypeBindingFlag::Disabled); }
-
-  bool isUnavailable() const {
-    return Flags.contains(TypeBindingFlag::Unavailable);
-  }
-
-  bool isDefaultable() const {
-    return Flags.contains(TypeBindingFlag::Defaultable);
-  }
-
-  bool hasDefaultedProtocol() const {
-    return Flags.contains(TypeBindingFlag::HasDefaultedProtocol);
-  }
-
-  // FIXME: Both of the accessors below are required to support
-  //        performance optimization hacks in constraint solver.
-
-  bool isGenericOperator() const {
-    return Flags.contains(TypeBindingFlag::GenericOperator);
-  }
-
-  bool isSymmetricOperator() const {
-    return Flags.contains(TypeBindingFlag::SymmetricOperator);
-  }
-
-  virtual void print(llvm::raw_ostream &Out, SourceManager *SM) const = 0;
-};
-
-class DisjunctionChoice : public TypeBinding {
   Constraint *Choice;
   bool ExplicitConversion;
 
 public:
   DisjunctionChoice(unsigned index, Constraint *choice, bool explicitConversion)
-      : TypeBinding(index, computeFlags(choice)), Choice(choice),
-        ExplicitConversion(explicitConversion) {}
+      : Index(index), Choice(choice), ExplicitConversion(explicitConversion) {}
 
-  bool attempt(ConstraintSystem &cs) const override;
+  unsigned getIndex() const { return Index; }
 
-  void print(llvm::raw_ostream &Out, SourceManager *SM) const override {
+  bool attempt(ConstraintSystem &cs) const;
+
+  bool isDisabled() const { return Choice->isDisabled(); }
+
+  bool isUnavailable() const {
+    if (auto *decl = getDecl(Choice))
+      return decl->getAttrs().isUnavailable(decl->getASTContext());
+    return false;
+  }
+
+  // FIXME: Both of the accessors below are required to support
+  //        performance optimization hacks in constraint solver.
+
+  bool isGenericOperator() const;
+  bool isSymmetricOperator() const;
+
+  void print(llvm::raw_ostream &Out, SourceManager *SM) const {
     Choice->print(Out, SM);
   }
 
@@ -3438,15 +3383,6 @@ private:
   /// \brief If associated disjunction is an explicit conversion,
   /// let's try to propagate its type early to prune search space.
   void propagateConversionInfo(ConstraintSystem &cs) const;
-
-  static bool unavailable(Constraint *choice) {
-    if (auto *decl = getDecl(choice))
-      return decl->getAttrs().isUnavailable(decl->getASTContext());
-    return false;
-  }
-
-  static bool isGenericOp(Constraint *choice);
-  static bool isSymmetricOp(Constraint *choice);
 
   static ValueDecl *getOperatorDecl(Constraint *choice) {
     auto *decl = getDecl(choice);
@@ -3466,46 +3402,25 @@ private:
 
     return choice.getDecl();
   }
-
-  static TypeBindingFlags computeFlags(Constraint *choice) {
-    TypeBindingFlags flags;
-    if (choice->isDisabled())
-      flags |= TypeBindingFlag::Disabled;
-    if (unavailable(choice))
-      flags |= TypeBindingFlag::Unavailable;
-    if (isGenericOp(choice))
-      flags |= TypeBindingFlag::GenericOperator;
-    if (isSymmetricOp(choice))
-      flags |= TypeBindingFlag::SymmetricOperator;
-    return flags;
-  }
 };
 
-class TypeVariableBinding : public TypeBinding {
+class TypeVariableBinding {
   TypeVariableType *TypeVar;
   ConstraintSystem::PotentialBinding Binding;
 
 public:
-  TypeVariableBinding(unsigned index, TypeVariableType *typeVar,
+  TypeVariableBinding(TypeVariableType *typeVar,
                       ConstraintSystem::PotentialBinding &binding)
-      : TypeBinding(index, computeFlags(binding)), TypeVar(typeVar),
-        Binding(binding) {}
+      : TypeVar(typeVar), Binding(binding) {}
 
-  bool attempt(ConstraintSystem &cs) const override;
+  bool isDefaultable() const { return Binding.isDefaultableBinding(); }
 
-  void print(llvm::raw_ostream &Out, SourceManager *) const override {
+  bool hasDefaultedProtocol() const { return Binding.DefaultedProtocol; }
+
+  bool attempt(ConstraintSystem &cs) const;
+
+  void print(llvm::raw_ostream &Out, SourceManager *) const {
     Out << TypeVar->getString() << " := " << Binding.BindingType->getString();
-  }
-
-private:
-  static TypeBindingFlags
-  computeFlags(ConstraintSystem::PotentialBinding &binding) {
-    TypeBindingFlags flags;
-    if (binding.isDefaultableBinding())
-      flags |= TypeBindingFlag::Defaultable;
-    if (binding.DefaultedProtocol)
-      flags |= TypeBindingFlag::HasDefaultedProtocol;
-    return flags;
   }
 };
 
@@ -3564,8 +3479,7 @@ public:
     if (needsToComputeNext() && !computeNext())
       return None;
 
-    unsigned currIndex = Index++;
-    return TypeVariableBinding(currIndex, TypeVar, Bindings[currIndex]);
+    return TypeVariableBinding(TypeVar, Bindings[Index++]);
   }
 
   bool needsToComputeNext() const override { return Index >= Bindings.size(); }


### PR DESCRIPTION
Unify `take` implementation and API for type variable
and disjunction via `BindingStep` which accepts a producer.

And remove `TypeBinding` class which is no longer necessary.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
