### PR TITLE
enable named operands in graph_op

### DIFF
--- a/include/swift/SIL/GraphOperationInfo.h
+++ b/include/swift/SIL/GraphOperationInfo.h
@@ -118,17 +118,23 @@ struct GraphOperationInfo {
     ///   ,([iL][^,]*)|(se)
     StringRef MangledName;
 
-    OperandMarker(StringRef MangledName, const GraphOperationInfo &info);
+    OperandMarker(StringRef MangledName);
 
   public:
-    OperandMarkerKind getKind() const;
+    OperandMarkerKind getKind() const {
+      return Kind;
+    }
 
     // The name of the marked operand or list.
-    StringRef getName() const;
+    StringRef getName() const {
+      return MangledName.drop_front(2);
+    }
 
     /// A mangled string describing this OperandMarker, suitable for appending
     /// to a mangled graph_op name.
-    StringRef getMangledName() const;
+    StringRef getMangledName() const {
+      return MangledName;
+    }
 
     /// Appends an OperandMarker with `kind` and `name` to the passed-in
     /// `mangledOpName`. `name` must be empty for OMK_Scalar and

--- a/include/swift/SIL/GraphOperationInfo.h
+++ b/include/swift/SIL/GraphOperationInfo.h
@@ -95,35 +95,53 @@ struct GraphOperationInfo {
   //   return getOpDeviceType(getDeviceString());
   // }
 
-  enum InputMarker {
-    /// Scalar input, used by tfc.scalarToTensor only.
-    IM_Scalar,
-    /// Normal tensor, variant or resource input.
-    IM_Normal,
-    /// Marker for the start of an input list, has no corresponding operand.
-    IM_InputList,
-    /// Element of an input list.
-    IM_InputListElt,
+  enum OperandMarkerKind {
+    /// Scalar input, used by tfc.scalarToTensor only. Cannot have name.
+    OMK_Scalar,
+    /// Operand that is not in a list. Might have name.
+    OMK_Normal,
+    /// Marker for the start of a list, has no corresponding operand. Might have
+    /// name.
+    OMK_InputList,
+    /// Element of a list. Cannot have name.
+    OMK_InputListElt,
   };
 
-  /// Return a comma and letter identifier whose letter corresponds to the
-  /// specified InputMarker.
-  static const char *getInputMarker(InputMarker kind) {
-    switch (kind) {
-    case IM_Scalar:
-      return ",s";
-    case IM_Normal:
-      return ",i";
-    case IM_InputList:
-      return ",L";
-    case IM_InputListElt:
-      return ",e";
-    }
-  }
+  /// The operands to a GraphOperationInst may be named and/or grouped into
+  /// rank-1 lists. OperandMarkers encode this naming and structure.
+  class OperandMarker {
+    friend struct GraphOperationInfo;
+
+    OperandMarkerKind Kind;
+
+    /// The mangled name as it appears in the graph_op. Matches regexp:
+    ///   ,([iL][^,]*)|(se)
+    StringRef MangledName;
+
+    OperandMarker(StringRef MangledName, const GraphOperationInfo &info);
+
+  public:
+    OperandMarkerKind getKind() const;
+
+    // The name of the marked operand or list.
+    StringRef getName() const;
+
+    /// A mangled string describing this OperandMarker, suitable for appending
+    /// to a mangled graph_op name.
+    StringRef getMangledName() const;
+
+    /// Appends an OperandMarker with `kind` and `name` to the passed-in
+    /// `mangledOpName`. `name` must be empty for OMK_Scalar and
+    /// OMK_InputListElt.
+    static void
+    appendTo(std::string &mangledOpName, OperandMarkerKind kind,
+             StringRef name = StringRef());
+  };
 
   /// Decode the name of a graph_op into its TensorFlow op name and a list of
   /// information about the operands.
-  llvm::StringRef decodeName(llvm::SmallVectorImpl<InputMarker> &inputInfo);
+  llvm::StringRef
+  decodeName(llvm::SmallVectorImpl<OperandMarker> &operandMarkers) const;
 
   /// Given an attribute name like foo$tensor, decode the name and the class.
   /// If there is no modifier specified, this defaults to

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -52,6 +52,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/SaveAndRestore.h"
 #include "llvm/Transforms/Utils/Local.h"
+#include "swift/SIL/GraphOperationInfo.h"
 
 #include "CallEmission.h"
 #include "Explosion.h"
@@ -1877,7 +1878,17 @@ void IRGenSILFunction::visitGraphOperationInst(GraphOperationInst *i) {
   auto &llvmModule = IGM.Module;
   auto &llvmContext = llvmModule.getContext();
 
-  // TODO: refactor GraphOperationInfo and use that to decode `i`.
+  tf::GraphOperationInfo opInfo(i);
+  SmallVector<tf::GraphOperationInfo::OperandMarker, 4> operandMarkers;
+  auto opName = opInfo.decodeName(operandMarkers);
+
+  // TODO: Remove these. They are a temporary way of testing that dynamic
+  // attributes make it here.
+  llvm::dbgs() << "IRGen for graph_op: " << opName << "\n";
+  for (auto oi : operandMarkers) {
+    llvm::dbgs() << "  operand: " << oi.getMangledName() << "\n";
+  }
+  llvm::dbgs() << "end operands\n";
 
   // The overall workflow is:
   // 1. Prepare the input tensor handles and attributes

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1884,11 +1884,11 @@ void IRGenSILFunction::visitGraphOperationInst(GraphOperationInst *i) {
 
   // TODO: Remove these. They are a temporary way of testing that dynamic
   // attributes make it here.
-  llvm::dbgs() << "IRGen for graph_op: " << opName << "\n";
+  LLVM_DEBUG(llvm::dbgs() << "IRGen for graph_op: " << opName << "\n");
   for (auto oi : operandMarkers) {
-    llvm::dbgs() << "  operand: " << oi.getMangledName() << "\n";
+    LLVM_DEBUG(llvm::dbgs() << "  operand: " << oi.getMangledName() << "\n");
   }
-  llvm::dbgs() << "end operands\n";
+  LLVM_DEBUG(llvm::dbgs() << "end operands\n");
 
   // The overall workflow is:
   // 1. Prepare the input tensor handles and attributes

--- a/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
+++ b/lib/SILOptimizer/Mandatory/TFCanonicalizeCFG.cpp
@@ -727,10 +727,10 @@ SILBasicBlock *SingleExitLoopTransformer::createNewExitBlockWithDemux(
 
     // Create a condition to compare exitIndex to a constant
     std::string equalOpName("Equal");
-    equalOpName +=
-        GraphOperationInfo::getInputMarker(GraphOperationInfo::IM_Normal);
-    equalOpName +=
-        GraphOperationInfo::getInputMarker(GraphOperationInfo::IM_Normal);
+    GraphOperationInfo::OperandMarker::appendTo(
+        equalOpName, GraphOperationInfo::OMK_Normal);
+    GraphOperationInfo::OperandMarker::appendTo(
+        equalOpName, GraphOperationInfo::OMK_Normal);
     SmallVector<GraphOperationAttribute, 2> attributes;
     deviceInfo->handleDevicePlacement(
         equalOpName, /*opDevice*/ getDeviceString(DeviceType::ALL),

--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -52,10 +52,6 @@ static llvm::cl::opt<bool> TFPromoteGlobalVariables(
         "If enabled, promote global variables into SSA with a best "
         "effort to minimize sends/recvs. This is a performance optimization."));
 
-namespace llvm {
-  extern cl::opt<bool> TFDynamicCompilation;
-}
-
 template<typename...T, typename...U>
 static InFlightDiagnostic
 diagnose(ASTContext &Context, SourceLoc loc, Diag<T...> diag, U &&...args) {

--- a/lib/SILOptimizer/Mandatory/TFDevicePartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDevicePartition.cpp
@@ -333,11 +333,11 @@ class DevicePartitionCloner
 
 void DevicePartitionCloner::visitGraphOperationInst(GraphOperationInst *inst) {
   GraphOperationInfo decoder(inst);
-  SmallVector<GraphOperationInfo::InputMarker, 4> inputInfos;
-  auto opName = decoder.decodeName(inputInfos);
+  SmallVector<GraphOperationInfo::OperandMarker, 4> operandMarkers;
+  auto opName = decoder.decodeName(operandMarkers);
   if (opName == "tfc.TensorTransfer") {
-    assert(inputInfos.size() == 1);
-    assert(inputInfos[0] == GraphOperationInfo::IM_Normal);
+    assert(operandMarkers.size() == 1);
+    assert(operandMarkers[0].getKind() == GraphOperationInfo::OMK_Normal);
     visitTensorTransferInst(decoder);
     return;
   }
@@ -385,8 +385,8 @@ void DevicePartitionCloner::addD2DSend(GraphOperationInfo &graphOpInfo,
 
   // Insert a send inst, with type <T> (T) {int, str, str} -> ()
   std::string newInstName = "tfc.D2DTensorSend";
-  newInstName +=
-      GraphOperationInfo::getInputMarker(GraphOperationInfo::IM_Normal);
+  GraphOperationInfo::OperandMarker::appendTo(newInstName,
+                                              GraphOperationInfo::OMK_Normal);
 
   auto &allocator = ctx.getAllocator();
   SmallVector<GraphOperationAttribute, 4> attributes;
@@ -809,8 +809,8 @@ public:
       // above is placed on the primary device), we rely on the backend graph
       // compiler (e.g. grappler) to optimize away this extraneous identity op.
       std::string identityOpName = "Identity";
-      identityOpName +=
-          GraphOperationInfo::getInputMarker(GraphOperationInfo::IM_Normal);
+      GraphOperationInfo::OperandMarker::appendTo(
+          identityOpName, GraphOperationInfo::OMK_Normal);
 
       // insert this new inst at the beginning of the function.
       SILBuilder B(&srcFn.front().front());
@@ -870,8 +870,8 @@ public:
       // <T> (T) {transferId$int, srcDevice$str, destDevice$str} -> T
       // Optionally, it also has a shape array attribute (needed for TPU).
       auto newInstName = std::string("tfc.TensorTransfer");
-      newInstName +=
-          GraphOperationInfo::getInputMarker(GraphOperationInfo::IM_Normal);
+      GraphOperationInfo::OperandMarker::appendTo(
+          newInstName, GraphOperationInfo::OMK_Normal);
 
       auto loc = inst->getLoc();
       // Insert the transfer right after the operandInst.

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -70,20 +70,6 @@ static llvm::cl::opt<bool> TFSendRecvOpaqueHandle(
     llvm::cl::desc("When true, variant and resource handles can be sent via "
                    "eager API as tensor handles."));
 
-// The flag below is referenced in multiple translation units.
-namespace llvm {
-// This flag is used as a crutch to develop and test IRGen code that handles
-// graph_op insts.
-// TODO: Fold this flag into -Onone mode.
-llvm::cl::opt<bool> TFDynamicCompilation(
-    "tf-dynamic-compilation", llvm::cl::init(false),
-    llvm::cl::desc(
-        "When true, skip the partitioning and lowering pass, so that graph_op "
-        "instructions flow to IRGen. This flag should not be turned on by end "
-        "users, due to many restrictions (e.g. it will not work with "
-        "tensorflow convention functions)."));
-} // namespace llvm
-
 template <typename... T, typename... U>
 static InFlightDiagnostic diagnose(ASTContext &Context, SourceLoc loc,
                                    Diag<T...> diag, U &&... args) {

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -2538,8 +2538,10 @@ void PartitionCloner::visitScalarInst(SingleValueInstruction *inst) {
     assert(0 && "Handled above");
   case PromotedScalarKind::Binary:
   case PromotedScalarKind::OverflowingBinary:
-    opName += GraphOperationInfo::getInputMarker(GraphOperationInfo::IM_Normal);
-    opName += GraphOperationInfo::getInputMarker(GraphOperationInfo::IM_Normal);
+    GraphOperationInfo::OperandMarker::appendTo(
+        opName, GraphOperationInfo::OMK_Normal);
+    GraphOperationInfo::OperandMarker::appendTo(
+        opName, GraphOperationInfo::OMK_Normal);
     break;
   case PromotedScalarKind::Literal: {
     SymbolicValue constVal;
@@ -2569,7 +2571,8 @@ void PartitionCloner::visitScalarInst(SingleValueInstruction *inst) {
   }
   case PromotedScalarKind::Conversion: {
     // Conversions get an attribute specifying the result dtype, named "DstT".
-    opName += GraphOperationInfo::getInputMarker(GraphOperationInfo::IM_Normal);
+    GraphOperationInfo::OperandMarker::appendTo(
+        opName, GraphOperationInfo::OMK_Normal);
     attributes.push_back(
         {ctx.getIdentifier("DstT"),
          SymbolicValue::getMetatype(
@@ -2781,7 +2784,8 @@ void createAcceleratorSend(SILBuilder &B, SILLocation loc, SILValue value,
   auto voidTy = B.getModule().Types.getEmptyTupleType();
   auto opType = "tfc.SendToHost";
   std::string instName = opType;
-  instName += GraphOperationInfo::getInputMarker(GraphOperationInfo::IM_Normal);
+  GraphOperationInfo::OperandMarker::appendTo(instName,
+                                              GraphOperationInfo::OMK_Normal);
   SmallVector<GraphOperationAttribute, 2> attributes;
   attributes.push_back(
       {ctx.getIdentifier("tensorId"), SymbolicValue::getInteger(idNumber, 32)});
@@ -3093,10 +3097,10 @@ void PartitionCloner::handleSendRecvForTerminator(TermInst *inst) {
       // Omit the metatype attr T for simplicity, and TF graphDef compiler can
       // infer the type.
       std::string equalOpName = "Equal";
-      equalOpName +=
-          GraphOperationInfo::getInputMarker(GraphOperationInfo::IM_Normal);
-      equalOpName +=
-          GraphOperationInfo::getInputMarker(GraphOperationInfo::IM_Normal);
+      GraphOperationInfo::OperandMarker::appendTo(
+          equalOpName, GraphOperationInfo::OMK_Normal);
+      GraphOperationInfo::OperandMarker::appendTo(
+          equalOpName, GraphOperationInfo::OMK_Normal);
 
       auto boolFieldSILType =
           extractBuiltinTypeFromStdlibNumericType(ctx.getBoolDecl());

--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -47,6 +47,20 @@ static llvm::cl::opt<bool> TFDumpIntermediatesToTmp(
     llvm::cl::desc("Dump intermediate results in "
                    "TensorFlow passes to files in /tmp"));
 
+// The flag below is referenced in multiple translation units.
+namespace llvm {
+// This flag is used as a crutch to develop and test IRGen code that handles
+// graph_op insts.
+// TODO: Fold this flag into -Onone mode.
+llvm::cl::opt<bool> TFDynamicCompilation(
+    "tf-dynamic-compilation", llvm::cl::init(false),
+    llvm::cl::desc(
+        "When true, skip the partitioning and lowering pass, so that graph_op "
+        "instructions flow to IRGen. This flag should not be turned on by end "
+        "users, due to many restrictions (e.g. it will not work with "
+        "tensorflow convention functions)."));
+} // namespace llvm
+
 static raw_ostream &getTmpLoggingStream() {
   // If we are supposed to dump the intermediates into /tmp, set that up now.
   SmallString<64> resultPath;

--- a/lib/SILOptimizer/Mandatory/TFUtilities.h
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.h
@@ -23,9 +23,14 @@
 #include "swift/SIL/GraphOperationInfo.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILFunction.h"
+#include "llvm/Support/CommandLine.h"
 #ifdef SWIFT_ENABLE_TENSORFLOW
 #include "tensorflow/c/c_api.h"
 #endif
+
+namespace llvm {
+extern cl::opt<bool> TFDynamicCompilation;
+}
 
 namespace swift {
 namespace tf {

--- a/test/TensorFlow/dynamic_compilation_irgen.swift
+++ b/test/TensorFlow/dynamic_compilation_irgen.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -emit-ir -Xllvm -tf-dynamic-compilation %s 2>&1 | %FileCheck %s
+
+import TensorFlow
+
+class Dynamic {
+  static let float = 1.0
+}
+
+public func unknownAttribute() {
+  let x: TensorHandle<Float> = #tfop("Dummy1", value$tensor: Dynamic.float)
+  _hostOp(x)
+  // CHECK-LABEL: IRGen for graph_op: Dummy1
+  // CHECK-NEXT: ,ivalue$tensor
+  // CHECK-NEXT: end operands
+}
+
+public func knownAttribute() {
+  let x: TensorHandle<Float> = #tfop("Dummy2", value$tensor: 1.0)
+  _hostOp(x)
+  // CHECK-LABEL: IRGen for graph_op: Dummy2
+  // CHECK-NEXT: end operands
+}

--- a/test/TensorFlow/dynamic_compilation_irgen.swift
+++ b/test/TensorFlow/dynamic_compilation_irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -Xllvm -tf-dynamic-compilation %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -Xllvm -tf-dynamic-compilation -Xllvm -debug -Xllvm -debug-only -Xllvm irgensil %s 2>&1 | %FileCheck %s
 
 import TensorFlow
 
@@ -10,7 +10,7 @@ public func unknownAttribute() {
   let x: TensorHandle<Float> = #tfop("Dummy1", value$tensor: Dynamic.float)
   _hostOp(x)
   // CHECK-LABEL: IRGen for graph_op: Dummy1
-  // CHECK-NEXT: ,ivalue$tensor
+  // CHECK-NEXT: operand: ,ivalue$tensor
   // CHECK-NEXT: end operands
 }
 


### PR DESCRIPTION
* Enables named operands in graph_op, by extending graph_op's existing name mangling to handle named operands.
* Makes tfdeabstraction emit named operands for unknown attributes, when -tf-dynamic-compilation is on.
* Adds a dummy test to make sure that the named operand is getting all the way into the dynamic compilation IRGen.

Future work, for which I have just filed JIRAs, includes:
1. Make the textual SIL nicer: e.g. `graph_op "Foo"(%0 : $Tensor<Float>, [ %1 : $Tensor<Float>, %2 : $Tensor<Float> ], value$tensor %3 : Float` instead of `graph_op "Foo,i,L,e,e,ivalue$tensor" (%0 : $Tensor<Float>, %1 : $Tensor<Float>, %2 : $Tensor<Float>, %3 : Float)`. (https://bugs.swift.org/browse/SR-8783)
2. Make a nicer C++ interface to GraphOperationInst so that we don't have to deal with the mangling everywhere. (https://bugs.swift.org/browse/SR-8784)
3. Nested lists of `graph_op` operands. Do we need this? (https://bugs.swift.org/browse/SR-8785)
4. Make SILGen generate `graph_op`s directly, and delete "__tfop" builtins. Change `formGraphOp` into a `graph_op` -> `graph_op` transformation. (https://bugs.swift.org/browse/SR-8786)