### PR TITLE
class -> AnyObject

### DIFF
--- a/docs/OptimizationTips.rst
+++ b/docs/OptimizationTips.rst
@@ -540,7 +540,7 @@ protocols as class-only protocols to get better runtime performance.
 
 ::
 
-  protocol Pingable : class { func ping() -> Int }
+  protocol Pingable : AnyObject { func ping() -> Int }
 
 .. https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/Protocols.html
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
[OptimizationTips - advice-mark-protocols-that-are-only-satisfied-by-classes-as-class-protocols](https://github.com/apple/swift/blob/master/docs/OptimizationTips.rst#advice-mark-protocols-that-are-only-satisfied-by-classes-as-class-protocols)
According to the swift guide document, the class only protocol is specified as **AnyObject**.
Although **class is a typealias of AnyObject**, I think it is better to specify it correctly as AnyObject.



<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->